### PR TITLE
[mlir][AMDGPU] Add, unify verification of memref index counts

### DIFF
--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
@@ -1637,9 +1637,6 @@ class AMDGPU_DmaBaseOp<string mnemonic, Type outType> :
                    Variadic<Index>:$lds_indices)>,
     Results<(outs outType: $base)> {
 
-  // TODO:
-  // * Add verifiers to make sure that the number of indices do not exceed the number of dimensions.
-
   let assemblyFormat = [{
     $global `[` $global_indices `]` `,` $lds `[` $lds_indices `]` attr-dict `:` type($global) `,` type($lds) `->` type(results)
   }];

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -958,8 +958,8 @@ LogicalResult GatherToLDSOp::verify() {
   MemRefType srcType = cast<MemRefType>(getSrc().getType());
   MemRefType dstType = cast<MemRefType>(getDst().getType());
 
-  if (failed(verifyIndexCount(*this, "source", srcType,
-                              getSrcIndices().size())) ||
+  if (failed(
+          verifyIndexCount(*this, "source", srcType, getSrcIndices().size())) ||
       failed(verifyIndexCount(*this, "destination", dstType,
                               getDstIndices().size())))
     return failure();
@@ -1036,8 +1036,8 @@ LogicalResult GlobalLoadAsyncToLDSOp::verify() {
   MemRefType srcType = cast<MemRefType>(getSrc().getType());
   MemRefType dstType = cast<MemRefType>(getDst().getType());
 
-  if (failed(verifyIndexCount(*this, "source", srcType,
-                              getSrcIndices().size())) ||
+  if (failed(
+          verifyIndexCount(*this, "source", srcType, getSrcIndices().size())) ||
       failed(verifyIndexCount(*this, "destination", dstType,
                               getDstIndices().size())))
     return failure();
@@ -1238,8 +1238,7 @@ static LogicalResult verifyDescriptorOp(DescriptorOp op) {
   if (Value atomicBarrierAddress = op.getAtomicBarrierAddress()) {
     auto atomicBarrierAddressType =
         cast<MemRefType>(atomicBarrierAddress.getType());
-    if (failed(verifyIndexCount(op, "atomic barrier",
-                                atomicBarrierAddressType,
+    if (failed(verifyIndexCount(op, "atomic barrier", atomicBarrierAddressType,
                                 op.getAtomicBarrierIndices().size())))
       return failure();
 

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -38,6 +38,19 @@
 using namespace mlir;
 using namespace mlir::amdgpu;
 
+/// Verifies that the number of indices matches the rank of the indexed memref,
+/// emitting an op error mentioning `indexName` on mismatch.
+template <typename OpTy>
+static LogicalResult verifyIndexCount(OpTy op, StringRef indexName,
+                                      MemRefType memrefType,
+                                      int64_t numIndices) {
+  int64_t rank = memrefType.getRank();
+  if (rank != numIndices)
+    return op.emitOpError("expected ")
+           << rank << " " << indexName << " indices, got " << numIndices;
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // 8-bit float ops
 //===----------------------------------------------------------------------===//
@@ -177,14 +190,11 @@ static LogicalResult verifyRawBufferOp(T &op) {
 
   if (!isGlobal)
     return op.emitOpError(
-        "Buffer ops must operate on a memref in global memory");
+        "buffer ops must operate on a memref in global memory");
   if (!bufferType.hasRank())
     return op.emitOpError(
-        "Cannot meaningfully buffer_store to an unranked memref");
-  if (static_cast<int64_t>(op.getIndices().size()) != bufferType.getRank())
-    return op.emitOpError("Expected " + Twine(bufferType.getRank()) +
-                          " indices to memref");
-  return success();
+        "cannot meaningfully buffer_store to an unranked memref");
+  return verifyIndexCount(op, "buffer", bufferType, op.getIndices().size());
 }
 
 LogicalResult RawBufferLoadOp::verify() { return verifyRawBufferOp(*this); }
@@ -948,6 +958,12 @@ LogicalResult GatherToLDSOp::verify() {
   MemRefType srcType = cast<MemRefType>(getSrc().getType());
   MemRefType dstType = cast<MemRefType>(getDst().getType());
 
+  if (failed(verifyIndexCount(*this, "source", srcType,
+                              getSrcIndices().size())) ||
+      failed(verifyIndexCount(*this, "destination", dstType,
+                              getDstIndices().size())))
+    return failure();
+
   if (dstType.getRank() > 0 && !dstType.areTrailingDimsContiguous(1))
     return emitOpError("destination type inner most dim must be contiguous");
 
@@ -1020,6 +1036,12 @@ LogicalResult GlobalLoadAsyncToLDSOp::verify() {
   MemRefType srcType = cast<MemRefType>(getSrc().getType());
   MemRefType dstType = cast<MemRefType>(getDst().getType());
 
+  if (failed(verifyIndexCount(*this, "source", srcType,
+                              getSrcIndices().size())) ||
+      failed(verifyIndexCount(*this, "destination", dstType,
+                              getDstIndices().size())))
+    return failure();
+
   if (srcType.getElementType() != dstType.getElementType())
     return emitOpError("source and destination element types must match");
 
@@ -1049,6 +1071,10 @@ LogicalResult GlobalLoadAsyncToLDSOp::verify() {
 
 LogicalResult TransposeLoadOp::verify() {
   MemRefType srcType = cast<MemRefType>(getSrc().getType());
+
+  if (failed(
+          verifyIndexCount(*this, "source", srcType, getSrcIndices().size())))
+    return failure();
 
   if (!hasWorkgroupMemorySpace(srcType.getMemorySpace()))
     return emitOpError("source memory address space must be Workgroup");
@@ -1085,6 +1111,10 @@ LogicalResult TransposeLoadOp::verify() {
 
 LogicalResult GlobalTransposeLoadOp::verify() {
   MemRefType srcType = cast<MemRefType>(getSrc().getType());
+
+  if (failed(
+          verifyIndexCount(*this, "source", srcType, getSrcIndices().size())))
+    return failure();
 
   if (!hasGlobalMemorySpace(srcType.getMemorySpace()))
     return emitOpError("source memory address space must be Global");
@@ -1124,6 +1154,11 @@ template <typename BaseOp>
 static LogicalResult verifyBase(BaseOp op) {
   auto ldsType = cast<MemRefType>(op.getLds().getType());
   auto globalType = cast<MemRefType>(op.getGlobal().getType());
+  if (failed(verifyIndexCount(op, "global", globalType,
+                              op.getGlobalIndices().size())) ||
+      failed(verifyIndexCount(op, "lds", ldsType, op.getLdsIndices().size())))
+    return failure();
+
   if (!hasWorkgroupMemorySpace(ldsType.getMemorySpace()))
     return op.emitOpError(
         "lds memref must have workgroup address space attribute.");
@@ -1196,9 +1231,18 @@ static LogicalResult verifyDescriptorOp(DescriptorOp op) {
                "element type width must be 1, 2, 4 or 8 bytes, but was ")
            << elementTypeWidth << " bits long";
 
+  if (!op.getAtomicBarrierAddress() && !op.getAtomicBarrierIndices().empty())
+    return op.emitOpError(
+        "atomic barrier indices require an atomic barrier address");
+
   if (Value atomicBarrierAddress = op.getAtomicBarrierAddress()) {
     auto atomicBarrierAddressType =
         cast<MemRefType>(atomicBarrierAddress.getType());
+    if (failed(verifyIndexCount(op, "atomic barrier",
+                                atomicBarrierAddressType,
+                                op.getAtomicBarrierIndices().size())))
+      return failure();
+
     bool barrierInLDS =
         hasWorkgroupMemorySpace(atomicBarrierAddressType.getMemorySpace());
     if (!barrierInLDS)
@@ -1417,6 +1461,10 @@ void ScaledMFMAOp::getCanonicalizationPatterns(RewritePatternSet &results,
 template <typename T>
 static LogicalResult verifyDsBarrierOpCommon(T &op) {
   MemRefType memrefType = llvm::cast<MemRefType>(op.getBase().getType());
+  if (failed(
+          verifyIndexCount(op, "barrier", memrefType, op.getIndices().size())))
+    return failure();
+
   if (!hasWorkgroupMemorySpace(memrefType.getMemorySpace()))
     return op.emitOpError("barrier must be in workgroup (LDS) memory");
 
@@ -1446,17 +1494,14 @@ LogicalResult DsBarrierArriveOp::verify() {
 LogicalResult GlobalPrefetchOp::verify() {
   auto src = cast<MemRefType>(getSrc().getType());
 
+  if (failed(verifyIndexCount(*this, "source", src, getIndices().size())))
+    return failure();
+
   Attribute memSpace = src.getMemorySpace();
   if (!memSpace)
     return this->emitOpError("the source must have address space attribute");
   if (!hasGlobalMemorySpace(memSpace))
     return this->emitOpError("the source must reside in global address space");
-
-  ArrayRef<int64_t> srcShape = src.getShape();
-  const size_t numIndices = getIndices().size();
-  if (srcShape.size() != numIndices)
-    return this->emitOpError(
-        "the number of indices must match the source shape size");
 
   const LoadTemporalHint temporalHint = getTemporalHint();
   const Scope scope = getCacheScope();

--- a/mlir/test/Dialect/AMDGPU/invalid.mlir
+++ b/mlir/test/Dialect/AMDGPU/invalid.mlir
@@ -245,6 +245,14 @@ func.func @fat_raw_buffer_cast_stripping_offset_affine_map(%m: memref<8xi32, aff
 
 // -----
 
+func.func @raw_buffer_load_wrong_num_indices(%src: memref<4x4xf32>, %idx: i32) -> f32 {
+  // expected-error@+1 {{'amdgpu.raw_buffer_load' op expected 2 buffer indices, got 1}}
+  %0 = amdgpu.raw_buffer_load %src[%idx] : memref<4x4xf32>, i32 -> f32
+  func.return %0 : f32
+}
+
+// -----
+
 func.func @swizzle_invalid_type(%arg0 : si32) -> si32 {
   // expected-error@+1 {{'amdgpu.swizzle_bitmode' op operand #0 must be Integer or Float or fixed-length vector of Integer or Float values of ranks 1}}
   %0 = amdgpu.swizzle_bitmode %arg0 1 2 4 : si32
@@ -317,11 +325,27 @@ func.func @transpose_load_vector_size_i8(%idx1 : index, %idx2 : index, %mem : me
 
 // -----
 
+func.func @transpose_load_wrong_num_indices(%idx : index, %mem : memref<128x32xf16, #gpu.address_space<workgroup>>) -> vector<4xf16> {
+  // expected-error@+1 {{'amdgpu.transpose_load' op expected 2 source indices, got 1}}
+  %0 = amdgpu.transpose_load %mem[%idx] : memref<128x32xf16, #gpu.address_space<workgroup>> -> vector<4xf16>
+  func.return %0 : vector<4xf16>
+}
+
+// -----
+
 func.func @global_transpose_load_wrong_addrspace(%i : index, %j : index,
     %src : memref<128x256xf16, 3>) -> vector<8xf16> {
   // expected-error@+1 {{'amdgpu.global_transpose_load' op source memory address space must be Global}}
   %0 = amdgpu.global_transpose_load %src[%i, %j]
          : memref<128x256xf16, 3> -> vector<8xf16>
+  func.return %0 : vector<8xf16>
+}
+
+// -----
+
+func.func @global_transpose_load_wrong_num_indices(%idx : index, %mem : memref<128x32xf16, #gpu.address_space<global>>) -> vector<8xf16> {
+  // expected-error@+1 {{'amdgpu.global_transpose_load' op expected 2 source indices, got 1}}
+  %0 = amdgpu.global_transpose_load %mem[%idx] : memref<128x32xf16, #gpu.address_space<global>> -> vector<8xf16>
   func.return %0 : vector<8xf16>
 }
 
@@ -338,6 +362,16 @@ func.func @gather_to_lds_non_lds(%idx1 : index, %mem1 : memref<32xf16>, %mem2 : 
 func.func @gather_to_lds_non_lds(%idx1 : index, %mem1 : memref<32xf16>, %mem2 : memref<32xf16, strided<[?]>, #gpu.address_space<workgroup>>) {
   // expected-error@+1 {{'amdgpu.gather_to_lds' op destination type inner most dim must be contiguous}}
   amdgpu.gather_to_lds %mem1[%idx1], %mem2[%idx1] : vector<2xf16>, memref<32xf16>, memref<32xf16, strided<[?]>, #gpu.address_space<workgroup>>
+  func.return
+}
+
+// -----
+
+func.func @gather_to_lds_wrong_num_indices(%idx : index,
+    %src : memref<32x32xf16, #gpu.address_space<global>>,
+    %dst : memref<32x32xf16, #gpu.address_space<workgroup>>) {
+  // expected-error@+1 {{'amdgpu.gather_to_lds' op expected 2 source indices, got 1}}
+  amdgpu.gather_to_lds %src[%idx], %dst[%idx, %idx] : vector<2xf16>, memref<32x32xf16, #gpu.address_space<global>>, memref<32x32xf16, #gpu.address_space<workgroup>>
   func.return
 }
 
@@ -373,6 +407,18 @@ func.func @global_load_async_to_lds_src_not_global(%idx1 : index,
   amdgpu.global_load_async_to_lds %mem1[%idx1], %mem2[%idx1]
     : f32, memref<32xf32, #gpu.address_space<workgroup>>,
       memref<32xf32, #gpu.address_space<workgroup>>
+  func.return
+}
+
+// -----
+
+func.func @global_load_async_to_lds_wrong_num_indices(%idx : index,
+    %src : memref<32x32xf32, #gpu.address_space<global>>,
+    %dst : memref<32x32xf32, #gpu.address_space<workgroup>>) {
+  // expected-error@+1 {{'amdgpu.global_load_async_to_lds' op expected 2 destination indices, got 1}}
+  amdgpu.global_load_async_to_lds %src[%idx, %idx], %dst[%idx]
+    : f32, memref<32x32xf32, #gpu.address_space<global>>,
+      memref<32x32xf32, #gpu.address_space<workgroup>>
   func.return
 }
 
@@ -441,9 +487,56 @@ func.func @make_gather_dma_base_invalid_addressspace(%idx: index, %smem : memref
 
 // -----
 
+func.func @make_dma_base_wrong_num_indices(%idx: index,
+    %global: memref<8x8xi32, #gpu.address_space<global>>,
+    %lds: memref<8x8xi32, #gpu.address_space<workgroup>>) {
+  // expected-error@+1 {{'amdgpu.make_dma_base' op expected 2 global indices, got 1}}
+  amdgpu.make_dma_base %global[%idx], %lds[%idx, %idx] : memref<8x8xi32, #gpu.address_space<global>>, memref<8x8xi32, #gpu.address_space<workgroup>> -> !amdgpu.tdm_base<i32>
+  return
+}
+
+// -----
+
+func.func @make_gather_dma_base_wrong_num_indices(%idx: index,
+    %global: memref<8x8xi32, #gpu.address_space<global>>,
+    %lds: memref<8x8xi32, #gpu.address_space<workgroup>>) {
+  // expected-error@+1 {{'amdgpu.make_gather_dma_base' op expected 2 lds indices, got 1}}
+  amdgpu.make_gather_dma_base %global[%idx, %idx], %lds[%idx] : memref<8x8xi32, #gpu.address_space<global>>, memref<8x8xi32, #gpu.address_space<workgroup>> -> !amdgpu.tdm_gather_base<i32, i16>
+  return
+}
+
+// -----
+
 func.func @make_dma_base_invalid_barrier(%base: !amdgpu.tdm_base<i32>, %barrier: memref<8x!amdgpu.ds_barrier_state>, %idx: index) {
   // expected-error@+1 {{'amdgpu.make_dma_descriptor' op atomic barrier address must be in LDS.}}
   amdgpu.make_dma_descriptor %base globalSize [64, 64] globalStride [64, 1] sharedSize [64, 64] atomicBarrier(%barrier[%idx] : memref<8x!amdgpu.ds_barrier_state>) : !amdgpu.tdm_base<i32> -> !amdgpu.tdm_descriptor
+  return
+}
+
+// -----
+
+func.func @make_dma_descriptor_barrier_wrong_num_indices(%base: !amdgpu.tdm_base<i32>,
+    %barrier: memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>,
+    %idx: index) {
+  // expected-error@+1 {{'amdgpu.make_dma_descriptor' op expected 2 atomic barrier indices, got 1}}
+  amdgpu.make_dma_descriptor %base
+    globalSize [64, 64] globalStride [64, 1] sharedSize [64, 64]
+    atomicBarrier(%barrier[%idx] : memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>)
+    : !amdgpu.tdm_base<i32> -> !amdgpu.tdm_descriptor
+  return
+}
+
+// -----
+
+func.func @make_dma_descriptor_barrier_indices_without_address(
+    %base: !amdgpu.tdm_base<i32>, %idx: index) {
+  // expected-error@+1 {{'amdgpu.make_dma_descriptor' op atomic barrier indices require an atomic barrier address}}
+  %0 = "amdgpu.make_dma_descriptor"(%base, %idx) <{
+    global_static_sizes = array<i64: 64, 64>,
+    global_static_strides = array<i64: 64, 1>,
+    operandSegmentSizes = array<i32: 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0>,
+    shared_static_sizes = array<i64: 64, 64>
+  }> : (!amdgpu.tdm_base<i32>, index) -> !amdgpu.tdm_descriptor
   return
 }
 
@@ -495,6 +588,35 @@ func.func @make_dma_descriptor_invalid_shared_and_global_rank(%base: !amdgpu.tdm
 func.func @make_gather_dma_descriptor_invalid_index_types(%base: !amdgpu.tdm_gather_base<i32, i16>, %indices: vector<8xi32>) {
   // expected-error@+1 {{'amdgpu.make_gather_dma_descriptor' op indices' element type must match base's element type.}}
   amdgpu.make_gather_dma_descriptor %base[%indices] globalSize [4, 4] globalStride [1, 1] sharedSize [1, 2] : !amdgpu.tdm_gather_base<i32, i16>, vector<8xi32> -> !amdgpu.tdm_descriptor
+  func.return
+}
+
+// -----
+
+func.func @make_gather_dma_descriptor_barrier_wrong_num_indices(%base: !amdgpu.tdm_gather_base<i32, i16>,
+    %indices: vector<8xi16>,
+    %barrier: memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>,
+    %idx: index) {
+  // expected-error@+1 {{'amdgpu.make_gather_dma_descriptor' op expected 2 atomic barrier indices, got 1}}
+  amdgpu.make_gather_dma_descriptor %base[%indices]
+    globalSize [4, 4] globalStride [4, 1] sharedSize [1, 2]
+    atomicBarrier(%barrier[%idx] : memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>)
+    : !amdgpu.tdm_gather_base<i32, i16>, vector<8xi16> -> !amdgpu.tdm_descriptor
+  func.return
+}
+
+// -----
+
+func.func @make_gather_dma_descriptor_barrier_indices_without_address(
+    %base: !amdgpu.tdm_gather_base<i32, i16>, %indices: vector<8xi16>,
+    %idx: index) {
+  // expected-error@+1 {{'amdgpu.make_gather_dma_descriptor' op atomic barrier indices require an atomic barrier address}}
+  %0 = "amdgpu.make_gather_dma_descriptor"(%base, %indices, %idx) <{
+    global_static_sizes = array<i64: 4, 4>,
+    global_static_strides = array<i64: 4, 1>,
+    operandSegmentSizes = array<i32: 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0>,
+    shared_static_sizes = array<i64: 1, 2>
+  }> : (!amdgpu.tdm_gather_base<i32, i16>, vector<8xi16>, index) -> !amdgpu.tdm_descriptor
   func.return
 }
 
@@ -620,6 +742,15 @@ func.func @ds_barrier_init_non_workgroup(%barrier: memref<!amdgpu.ds_barrier_sta
 
 // -----
 
+func.func @ds_barrier_init_wrong_num_indices(%barrier: memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>,
+    %idx: index, %participants: i32) {
+  // expected-error@+1 {{'amdgpu.ds_barrier_init' op expected 2 barrier indices, got 1}}
+  amdgpu.ds_barrier_init %barrier[%idx], %participants : memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>, i32
+  func.return
+}
+
+// -----
+
 func.func @ds_barrier_poll_state_non_workgroup(%barrier: memref<!amdgpu.ds_barrier_state, #gpu.address_space<global>>) -> !amdgpu.ds_barrier_state {
   // expected-error@+1 {{'amdgpu.ds_barrier_poll_state' op barrier must be in workgroup (LDS) memory}}
   %state = amdgpu.ds_barrier_poll_state %barrier[] : memref<!amdgpu.ds_barrier_state, #gpu.address_space<global>> -> !amdgpu.ds_barrier_state
@@ -628,9 +759,36 @@ func.func @ds_barrier_poll_state_non_workgroup(%barrier: memref<!amdgpu.ds_barri
 
 // -----
 
+func.func @ds_barrier_poll_state_wrong_num_indices(%barrier: memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>,
+    %idx: index) -> !amdgpu.ds_barrier_state {
+  // expected-error@+1 {{'amdgpu.ds_barrier_poll_state' op expected 2 barrier indices, got 1}}
+  %state = amdgpu.ds_barrier_poll_state %barrier[%idx] : memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>> -> !amdgpu.ds_barrier_state
+  func.return %state : !amdgpu.ds_barrier_state
+}
+
+// -----
+
+func.func @ds_async_barrier_arrive_wrong_num_indices(%barrier: memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>,
+    %idx: index) {
+  // expected-error@+1 {{'amdgpu.ds_async_barrier_arrive' op expected 2 barrier indices, got 1}}
+  amdgpu.ds_async_barrier_arrive %barrier[%idx] : memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>
+  func.return
+}
+
+// -----
+
 func.func @ds_barrier_arrive_non_workgroup(%barrier: memref<!amdgpu.ds_barrier_state, #amdgpu.address_space<fat_raw_buffer>>, %count: i64) -> !amdgpu.ds_barrier_state {
   // expected-error@+1 {{'amdgpu.ds_barrier_arrive' op barrier must be in workgroup (LDS) memory}}
   %old_state = amdgpu.ds_barrier_arrive %barrier[], %count : memref<!amdgpu.ds_barrier_state, #amdgpu.address_space<fat_raw_buffer>>, i64 -> !amdgpu.ds_barrier_state
+  func.return %old_state : !amdgpu.ds_barrier_state
+}
+
+// -----
+
+func.func @ds_barrier_arrive_wrong_num_indices(%barrier: memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>,
+    %idx: index, %count: i64) -> !amdgpu.ds_barrier_state {
+  // expected-error@+1 {{'amdgpu.ds_barrier_arrive' op expected 2 barrier indices, got 1}}
+  %old_state = amdgpu.ds_barrier_arrive %barrier[%idx], %count : memref<8x8x!amdgpu.ds_barrier_state, #gpu.address_space<workgroup>>, i64 -> !amdgpu.ds_barrier_state
   func.return %old_state : !amdgpu.ds_barrier_state
 }
 
@@ -778,7 +936,7 @@ func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, #gpu.addres
 
 // GlobalPrefetchOp: number of indices must match source shape rank
 func.func @global_prefetch_wrong_num_indices(%src: memref<64x64xf16, #gpu.address_space<global>>, %i: i64) {
-  // expected-error@+1 {{'amdgpu.global_prefetch' op the number of indices must match the source shape size}}
+  // expected-error@+1 {{'amdgpu.global_prefetch' op expected 2 source indices, got 1}}
   amdgpu.global_prefetch %src[%i] RT DEV : memref<64x64xf16, #gpu.address_space<global>>
   func.return
 }


### PR DESCRIPTION
This PR verifies that, on operations that have
`%memref[%idx0, %idx1, ...]` arguments, the number of indices matches the rank of the memref being passed in.

While we're here, fixes capitalization for certain verification error messages.

Assisted-by: Codex 5.5 (handled much of the implementation)