### PR TITLE
[RISCV] Use the nhs.lea.h/w/d instead of nhs.lea.h/w/d.ze with Sh1AddPat.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXAndes.td
@@ -838,9 +838,9 @@ let Predicates = [HasVendorXAndesPerf, IsRV64] in {
   defm : Sh2Add_UWPat<NDS_LEA_W_ZE>;
   defm : Sh3Add_UWPat<NDS_LEA_D_ZE>;
 
-  def : Sh1AddPat<NDS_LEA_H_ZE>;
-  def : Sh2AddPat<NDS_LEA_W_ZE>;
-  def : Sh3AddPat<NDS_LEA_D_ZE>;
+  def : Sh1AddPat<NDS_LEA_H>;
+  def : Sh2AddPat<NDS_LEA_W>;
+  def : Sh3AddPat<NDS_LEA_D>;
 } // Predicates = [HasVendorXAndesPerf, IsRV64]
 
 let Predicates = [HasVendorXAndesPerf] in {

--- a/llvm/test/CodeGen/RISCV/rv64zba.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zba.ll
@@ -2937,7 +2937,7 @@ define signext i16 @srliw_1_sh1add(ptr %0, i32 signext %1) {
 ; RV64XANDESPERF-LABEL: srliw_1_sh1add:
 ; RV64XANDESPERF:       # %bb.0:
 ; RV64XANDESPERF-NEXT:    srliw a1, a1, 1
-; RV64XANDESPERF-NEXT:    nds.lea.h.ze a0, a0, a1
+; RV64XANDESPERF-NEXT:    nds.lea.h a0, a0, a1
 ; RV64XANDESPERF-NEXT:    lh a0, 0(a0)
 ; RV64XANDESPERF-NEXT:    ret
   %3 = lshr i32 %1, 1
@@ -3004,7 +3004,7 @@ define signext i32 @srliw_2_sh2add(ptr %0, i32 signext %1) {
 ; RV64XANDESPERF-LABEL: srliw_2_sh2add:
 ; RV64XANDESPERF:       # %bb.0:
 ; RV64XANDESPERF-NEXT:    srliw a1, a1, 2
-; RV64XANDESPERF-NEXT:    nds.lea.w.ze a0, a0, a1
+; RV64XANDESPERF-NEXT:    nds.lea.w a0, a0, a1
 ; RV64XANDESPERF-NEXT:    lw a0, 0(a0)
 ; RV64XANDESPERF-NEXT:    ret
   %3 = lshr i32 %1, 2
@@ -3033,7 +3033,7 @@ define i64 @srliw_3_sh3add(ptr %0, i32 signext %1) {
 ; RV64XANDESPERF-LABEL: srliw_3_sh3add:
 ; RV64XANDESPERF:       # %bb.0:
 ; RV64XANDESPERF-NEXT:    srliw a1, a1, 3
-; RV64XANDESPERF-NEXT:    nds.lea.d.ze a0, a0, a1
+; RV64XANDESPERF-NEXT:    nds.lea.d a0, a0, a1
 ; RV64XANDESPERF-NEXT:    ld a0, 0(a0)
 ; RV64XANDESPERF-NEXT:    ret
   %3 = lshr i32 %1, 3


### PR DESCRIPTION
The srliw already took care of zeroing the upper bits. Using the non-.ze form is consistent with the Zba version of this pattern.