### PR TITLE
[CIR] Fix function signature mismatch on redirected calls

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1266,19 +1266,43 @@ RValue CIRGenFunction::emitCall(const CIRGenFunctionInfo &funcInfo,
                              attrs, argAttrs, retAttrs, callingConv, sideEffect,
                              /*attrOnCallSite=*/true, /*isThunk=*/false);
 
+  auto resolvedFuncOpFromGlobal = [&](mlir::Operation *op) -> cir::FuncOp {
+    if (auto fnOp = dyn_cast<cir::FuncOp>(op))
+      return fnOp;
+    if (auto getGlobalOp = dyn_cast<cir::GetGlobalOp>(op)) {
+      // FIXME(cir): This peephole optimization avoids indirect calls for
+      // builtins. This should be fixed in the builtin declaration instead by
+      // not emitting an unecessary get_global in the first place. However,
+      // this is also used for no-prototype functions.
+      mlir::Operation *globalOp = cgm.getGlobalValue(getGlobalOp.getName());
+      assert(globalOp && "undefined global function");
+      return cast<cir::FuncOp>(globalOp);
+    }
+    return nullptr;
+  };
+
   cir::FuncType indirectFuncTy;
   mlir::Value indirectFuncVal;
   cir::FuncOp directFuncOp;
-  if (auto fnOp = dyn_cast<cir::FuncOp>(calleePtr)) {
-    directFuncOp = fnOp;
-  } else if (auto getGlobalOp = mlir::dyn_cast<cir::GetGlobalOp>(calleePtr)) {
-    // FIXME(cir): This peephole optimization avoids indirect calls for
-    // builtins. This should be fixed in the builtin declaration instead by
-    // not emitting an unecessary get_global in the first place.
-    // However, this is also used for no-prototype functions.
-    mlir::Operation *globalOp = cgm.getGlobalValue(getGlobalOp.getName());
-    assert(globalOp && "undefined global function");
-    directFuncOp = mlir::cast<cir::FuncOp>(globalOp);
+
+  // If the callee resolves to a FuncOp whose stored signature differs from
+  // this call site's expected signature, the CIR verifier would reject the
+  // mismatched types. This happens, for example, when two declarations share a
+  // mangled name via __asm__ renaming (glibc's __REDIRECT_NTH pattern) but
+  // disagree about a struct argument type. If that happens, we demote the
+  // direct call to an indirect call through a function-pointer bitcast typed
+  // at the call site.
+  if (cir::FuncOp candidate = resolvedFuncOpFromGlobal(calleePtr)) {
+    if (candidate.getFunctionType() == cirFuncTy) {
+      directFuncOp = candidate;
+    } else {
+      mlir::Value addr = cir::GetGlobalOp::create(
+          builder, loc, cir::PointerType::get(candidate.getFunctionType()),
+          candidate.getSymName());
+      indirectFuncTy = cirFuncTy;
+      indirectFuncVal =
+          builder.createBitcast(addr, cir::PointerType::get(cirFuncTy));
+    }
   } else {
     [[maybe_unused]] mlir::ValueTypeRange<mlir::ResultRange> resultTypes =
         calleePtr->getResultTypes();

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2285,39 +2285,27 @@ RValue CIRGenFunction::emitCall(clang::QualType calleeTy,
   // unprototyped function type works like a *non-variadic* call. The way we
   // make this work is to cast to the exxact type fo the promoted arguments.
   //
-  // We can also have a function type mismatch when the callee's stored
-  // signature differs from what this call site expects despite both being
-  // prototyped if the called function is redirected (such as with asm renaming)
-  // to a function with a different signature. This happens with the GNU
-  // __REDIRECT/__REDIRECT_NTH macros in older glibc headers. Because we use
-  // typed pointers in CIR, we need to update the call site to avoid a mismatch.
-  cir::FuncType calleeFnTy = getTypes().getFunctionType(funcInfo);
-  bool isNoProto = isa<FunctionNoProtoType>(fnType);
-  if (isNoProto) {
-    // Treat a no-prototype callee as non-variadic.
-    calleeFnTy = cir::FuncType::get(calleeFnTy.getInputs(),
-                                    calleeFnTy.getReturnType(), false);
-  }
-
-  mlir::Operation *fn = callee.getFunctionPointer();
-  auto calleeFuncOp = mlir::dyn_cast_or_null<cir::FuncOp>(fn);
-  // No-prototype FuncOps are handled by the call verifier (it skips operand
-  // type checking when the callee is marked no_proto), so a mismatch there
-  // doesn't actually require a bitcast.
-  bool prototypeMismatch = calleeFuncOp && !calleeFuncOp.getNoProto() &&
-                           calleeFuncOp.getFunctionType() != calleeFnTy;
-
-  if (isNoProto || prototypeMismatch) {
+  // The redirected-callee case (two declarations sharing a mangled name via
+  // __asm__ renaming, e.g. glibc's __REDIRECT_NTH pattern, where the existing
+  // FuncOp's signature differs from this call site's expected signature) is
+  // handled in CIRGenFunction::emitCall (the funcInfo workhorse below) by
+  // demoting a direct call to an indirect call when the FuncOp signature
+  // doesn't match cirFuncTy.
+  if (isa<FunctionNoProtoType>(fnType)) {
     assert(!cir::MissingFeatures::opCallChain());
     assert(!cir::MissingFeatures::addressSpace());
-    auto calleePtrTy = cir::PointerType::get(calleeFnTy);
+    cir::FuncType calleeTy = getTypes().getFunctionType(funcInfo);
+    // get non-variadic function type
+    calleeTy = cir::FuncType::get(calleeTy.getInputs(),
+                                  calleeTy.getReturnType(), false);
+    auto calleePtrTy = cir::PointerType::get(calleeTy);
 
+    mlir::Operation *fn = callee.getFunctionPointer();
     mlir::Value addr;
-    if (calleeFuncOp) {
+    if (auto funcOp = mlir::dyn_cast<cir::FuncOp>(fn)) {
       addr = cir::GetGlobalOp::create(
           builder, getLoc(e->getSourceRange()),
-          cir::PointerType::get(calleeFuncOp.getFunctionType()),
-          calleeFuncOp.getSymName());
+          cir::PointerType::get(funcOp.getFunctionType()), funcOp.getSymName());
     } else {
       addr = fn->getResult(0);
     }

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2284,13 +2284,6 @@ RValue CIRGenFunction::emitCall(clang::QualType calleeTy,
   // That is, in the general case, we should assume that a call through an
   // unprototyped function type works like a *non-variadic* call. The way we
   // make this work is to cast to the exxact type fo the promoted arguments.
-  //
-  // The redirected-callee case (two declarations sharing a mangled name via
-  // __asm__ renaming, e.g. glibc's __REDIRECT_NTH pattern, where the existing
-  // FuncOp's signature differs from this call site's expected signature) is
-  // handled in CIRGenFunction::emitCall (the funcInfo workhorse below) by
-  // demoting a direct call to an indirect call when the FuncOp signature
-  // doesn't match cirFuncTy.
   if (isa<FunctionNoProtoType>(fnType)) {
     assert(!cir::MissingFeatures::opCallChain());
     assert(!cir::MissingFeatures::addressSpace());

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2284,21 +2284,40 @@ RValue CIRGenFunction::emitCall(clang::QualType calleeTy,
   // That is, in the general case, we should assume that a call through an
   // unprototyped function type works like a *non-variadic* call. The way we
   // make this work is to cast to the exxact type fo the promoted arguments.
-  if (isa<FunctionNoProtoType>(fnType)) {
+  //
+  // We can also have a function type mismatch when the callee's stored
+  // signature differs from what this call site expects despite both being
+  // prototyped if the called function is redirected (such as with asm renaming)
+  // to a function with a different signature. This happens with the GNU
+  // __REDIRECT/__REDIRECT_NTH macros in older glibc headers. Because we use
+  // typed pointers in CIR, we need to update the call site to avoid a mismatch.
+  cir::FuncType calleeFnTy = getTypes().getFunctionType(funcInfo);
+  bool isNoProto = isa<FunctionNoProtoType>(fnType);
+  if (isNoProto) {
+    // Treat a no-prototype callee as non-variadic.
+    calleeFnTy = cir::FuncType::get(calleeFnTy.getInputs(),
+                                    calleeFnTy.getReturnType(), false);
+  }
+
+  mlir::Operation *fn = callee.getFunctionPointer();
+  auto calleeFuncOp = mlir::dyn_cast_or_null<cir::FuncOp>(fn);
+  // No-prototype FuncOps are handled by the call verifier (it skips operand
+  // type checking when the callee is marked no_proto), so a mismatch there
+  // doesn't actually require a bitcast.
+  bool prototypeMismatch = calleeFuncOp && !calleeFuncOp.getNoProto() &&
+                           calleeFuncOp.getFunctionType() != calleeFnTy;
+
+  if (isNoProto || prototypeMismatch) {
     assert(!cir::MissingFeatures::opCallChain());
     assert(!cir::MissingFeatures::addressSpace());
-    cir::FuncType calleeTy = getTypes().getFunctionType(funcInfo);
-    // get non-variadic function type
-    calleeTy = cir::FuncType::get(calleeTy.getInputs(),
-                                  calleeTy.getReturnType(), false);
-    auto calleePtrTy = cir::PointerType::get(calleeTy);
+    auto calleePtrTy = cir::PointerType::get(calleeFnTy);
 
-    mlir::Operation *fn = callee.getFunctionPointer();
     mlir::Value addr;
-    if (auto funcOp = mlir::dyn_cast<cir::FuncOp>(fn)) {
+    if (calleeFuncOp) {
       addr = cir::GetGlobalOp::create(
           builder, getLoc(e->getSourceRange()),
-          cir::PointerType::get(funcOp.getFunctionType()), funcOp.getSymName());
+          cir::PointerType::get(calleeFuncOp.getFunctionType()),
+          calleeFuncOp.getSymName());
     } else {
       addr = fn->getResult(0);
     }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1937,8 +1937,45 @@ void CIRGenModule::replaceUsesOfNonProtoTypeWithRealFunction(
       builder.setInsertionPoint(noProtoCallOp);
 
       // Patch call type with the real function type.
-      cir::CallOp realCallOp = builder.createCallOp(
-          noProtoCallOp.getLoc(), newFn, noProtoCallOp.getOperands());
+      cir::FuncType newFnType = newFn.getFunctionType();
+      mlir::OperandRange callOperands = noProtoCallOp.getOperands();
+      bool returnTypeMatches =
+          newFnType.hasVoidReturn()
+              ? noProtoCallOp.getNumResults() == 0
+              : noProtoCallOp.getNumResults() == 1 &&
+                    noProtoCallOp.getResultTypes().front() ==
+                        newFnType.getReturnType();
+      bool typesMatch = !newFn.getNoProto() && returnTypeMatches &&
+                        callOperands.size() == newFnType.getNumInputs();
+      for (unsigned i = 0, e = newFnType.getNumInputs(); typesMatch && i != e;
+           ++i) {
+        if (callOperands[i].getType() != newFnType.getInput(i))
+          typesMatch = false;
+      }
+
+      cir::CallOp realCallOp;
+      if (typesMatch) {
+        // Patch call type with the real function type.
+        realCallOp =
+            builder.createCallOp(noProtoCallOp.getLoc(), newFn, callOperands);
+      } else {
+        // Build an indirect call whose function-pointer signature matches
+        // the existing call site.
+        cir::FuncType origFnType = oldFn.getFunctionType();
+        cir::FuncType callFnType =
+            origFnType.isVarArg()
+                ? cir::FuncType::get(origFnType.getInputs(),
+                                     origFnType.getReturnType(),
+                                     /*isVarArg=*/false)
+                : origFnType;
+        mlir::Value addr = cir::GetGlobalOp::create(
+            builder, noProtoCallOp.getLoc(), cir::PointerType::get(newFnType),
+            newFn.getSymName());
+        mlir::Value casted =
+            builder.createBitcast(addr, cir::PointerType::get(callFnType));
+        realCallOp = builder.createIndirectCallOp(
+            noProtoCallOp.getLoc(), casted, callFnType, callOperands);
+      }
 
       // Replace old no proto call with fixed call.
       noProtoCallOp.replaceAllUsesWith(realCallOp);

--- a/clang/test/CIR/CodeGen/asm-label-redirect-inline.c
+++ b/clang/test/CIR/CodeGen/asm-label-redirect-inline.c
@@ -1,0 +1,67 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -disable-llvm-passes -o %t.cir %s
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -disable-llvm-passes -o %t-cir.ll %s
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -disable-llvm-passes -o %t.ll %s
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+// This test mirrors what older glibc headers (e.g. GCC 8.5 / glibc 2.27 era)
+// expand to with -D_FILE_OFFSET_BITS=64. There are two declarations sharing
+// the same mangled symbol "real_impl":
+//
+//   1. `my_stat` is declared with `struct my_stat *` and asm-renamed to
+//      "real_impl" - this is the GNU __REDIRECT_NTH pattern.
+//   2. `real_impl` is declared with `struct my_stat64 *` and additionally
+//      provided as an `extern __inline __gnu_inline__` definition with a
+//      body - this is the FORTIFY/__extern_inline wrapper pattern.
+//
+// CIR materializes the FuncOp for "real_impl" lazily on first use. When
+// `test` calls `my_stat(p, &s)`, the FuncOp gets created with the
+// `(ptr, ptr<my_stat>) -> i32` signature. Later, `real_impl`'s inline body
+// is materialized: this triggers `replaceUsesOfNonProtoTypeWithRealFunction`
+// which retroactively rewires the existing call site onto the new FuncOp,
+// whose signature is `(ptr, ptr<my_stat64>) -> i32`. Without special
+// handling, the rewired direct call would carry mismatching operand types.
+// The rewrite must instead fall back to an indirect call through a
+// function-pointer bitcast, the same shape used at initial call emission
+// time.
+
+struct my_stat   { int  legacy_field; };
+struct my_stat64 { long modern_field; };
+
+extern int xreal_impl(const char *path, struct my_stat64 *buf);
+
+extern __inline __attribute__((__always_inline__))
+__attribute__((__gnu_inline__)) int
+real_impl(const char *path, struct my_stat64 *buf) {
+  return xreal_impl(path, buf);
+}
+
+extern int my_stat(const char *path, struct my_stat *buf) __asm__("real_impl");
+
+int test(const char *p) {
+  struct my_stat s;
+  return my_stat(p, &s);
+}
+
+// CIR-LABEL: cir.func {{.*}} @test(
+//
+// After `real_impl`'s body is materialized, the FuncOp's signature is
+// updated to `(ptr, ptr<my_stat64>) -> i32`. The pre-existing call site
+// in `test` (which still has `(ptr, ptr<my_stat>)` operand types) gets
+// rewritten to an indirect call through a function-pointer bitcast.
+// CIR:         %[[GLOBAL:.+]] = cir.get_global @real_impl : !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat64>) -> !s32i>>
+// CIR-NEXT:    %[[PTR:.+]] = cir.cast bitcast %[[GLOBAL]] : !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat64>) -> !s32i>> -> !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat>) -> !s32i>>
+// CIR-NEXT:    cir.call %[[PTR]](%{{.+}}, %{{.+}}) : (!cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat>) -> !s32i>>, !cir.ptr<!s8i>, !cir.ptr<!rec_my_stat>) -> !s32i
+
+// The inline definition of `real_impl` is emitted with `available_externally`
+// linkage, taking `struct my_stat64 *`.
+// CIR:       cir.func {{.*}} available_externally @real_impl(%{{.+}}: !cir.ptr<!s8i>{{.*}}, %{{.+}}: !cir.ptr<!rec_my_stat64>{{.*}}) -> !s32i
+
+// LLVM-LABEL: define dso_local i32 @test(
+// LLVM:         %{{.+}} = call i32 @real_impl(ptr {{.*}}%{{.+}}, ptr {{.*}}%{{.+}})
+// LLVM:       define {{.*}}available_externally i32 @real_impl(
+
+// OGCG-LABEL: define dso_local i32 @test(
+// OGCG:         %{{.+}} = call i32 @real_impl(ptr {{.*}}%{{.+}}, ptr {{.*}}%{{.+}})
+// OGCG:       define {{.*}}available_externally i32 @real_impl(

--- a/clang/test/CIR/CodeGen/asm-label-redirect.c
+++ b/clang/test/CIR/CodeGen/asm-label-redirect.c
@@ -1,0 +1,59 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -disable-llvm-passes -o %t.cir %s
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -disable-llvm-passes -o %t-cir.ll %s
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm -disable-llvm-passes -o %t.ll %s
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+// This test simulates the GNU __REDIRECT_NTH pattern from older glibc headers.
+
+struct my_stat   { int  legacy_field; };
+struct my_stat64 { long modern_field; };
+
+extern int my_stat(const char *path, struct my_stat *buf) __asm__("real_impl");
+extern int real_impl(const char *path, struct my_stat64 *buf);
+
+int test(const char *p) {
+  struct my_stat   s_old;
+  struct my_stat64 s_new;
+  int r1 = my_stat(p, &s_old);
+  int r2 = real_impl(p, &s_new);
+  return r1 + r2;
+}
+
+// Both declarations are mangled to the same symbol "real_impl". CIR
+// materializes a single FuncOp whose signature is whichever declaration
+// it sees first - here, the my_stat declaration.
+//
+// CIR-LABEL: cir.func private @real_impl(
+// CIR-SAME:    !cir.ptr<!s8i> {{.*}},
+// CIR-SAME:    !cir.ptr<!rec_my_stat> {{.*}}) -> !s32i
+
+// CIR-LABEL: cir.func {{.*}} @test(
+//
+// The first call site uses `struct my_stat *`, which matches the FuncOp's
+// stored signature, so it lowers to a direct call.
+// CIR:         %[[R1:.*]] = cir.call @real_impl(%{{.+}}, %{{.+}}) :
+// CIR-SAME:      (!cir.ptr<!s8i> {{.*}}, !cir.ptr<!rec_my_stat> {{.*}}) -> !s32i
+//
+// The second call site uses `struct my_stat64 *`. The FuncOp's stored
+// signature does not match, so the function pointer is bitcast to the
+// call site's expected signature and the call becomes indirect.
+// CIR:         %[[GLOBAL:.*]] = cir.get_global @real_impl :
+// CIR-SAME:      !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat>) -> !s32i>>
+// CIR-NEXT:    %[[PTR:.*]] = cir.cast bitcast %[[GLOBAL]] :
+// CIR-SAME:      !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat>) -> !s32i>>
+// CIR-SAME:      -> !cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat64>) -> !s32i>>
+// CIR-NEXT:    %[[R2:.*]] = cir.call %[[PTR]](%{{.+}}, %{{.+}}) :
+// CIR-SAME:      (!cir.ptr<!cir.func<(!cir.ptr<!s8i>, !cir.ptr<!rec_my_stat64>) -> !s32i>>,
+// CIR-SAME:       !cir.ptr<!s8i> {{.*}}, !cir.ptr<!rec_my_stat64> {{.*}}) -> !s32i
+
+// LLVM:        declare i32 @real_impl(ptr {{[^,]*}}, ptr {{.*}})
+// LLVM-LABEL:  define dso_local i32 @test(
+// LLVM:          %{{.+}} = call i32 @real_impl(ptr {{.*}}%{{.+}}, ptr {{.*}}%{{.+}})
+// LLVM:          %{{.+}} = call i32 @real_impl(ptr {{.*}}%{{.+}}, ptr {{.*}}%{{.+}})
+
+// OGCG-LABEL:  define dso_local i32 @test(
+// OGCG:          %{{.+}} = call i32 @real_impl(ptr {{.*}}%{{.+}}, ptr {{.*}}%{{.+}})
+// OGCG:          %{{.+}} = call i32 @real_impl(ptr {{.*}}%{{.+}}, ptr {{.*}}%{{.+}})
+// OGCG:        declare i32 @real_impl(ptr {{[^,]*}}, ptr {{.*}})


### PR DESCRIPTION
We were running into CIR verification errors ("error: 'cir.call' op operand type mismatch") when compiling with some older versions of the GLIBC headers that used a macro to redirect system library calls to a function that used different, but compatible, arguments.

This change fixes the problem by detecting the mismatch at the callsite and bitcasting the arguments.

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh