### PR TITLE
[ARM] shouldOutlineFromFunctionByDefault should work regardless of class of CPU

### DIFF
--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -6484,7 +6484,7 @@ MachineBasicBlock::iterator ARMBaseInstrInfo::insertOutlinedCall(
 
 bool ARMBaseInstrInfo::shouldOutlineFromFunctionByDefault(
     MachineFunction &MF) const {
-  return Subtarget.isMClass() && MF.getFunction().hasMinSize();
+  return MF.getFunction().hasMinSize();
 }
 
 bool ARMBaseInstrInfo::isReMaterializableImpl(


### PR DESCRIPTION
This was always meant to be temporary as to see if there were any issues before expanding it. We can expand it given its specific to minsize. 