### PR TITLE
Revert "[BOLT] Fix EH data encoding checks in relocateEHFrameSection (#195691)"

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2162,10 +2162,13 @@ void RewriteInstance::relocateEHFrameSection() {
       return;
 
     // Only fix references that are relative to other locations.
-    if ((DwarfType & 0xf0) != dwarf::DW_EH_PE_pcrel &&
-        (DwarfType & 0xf0) != dwarf::DW_EH_PE_textrel &&
-        (DwarfType & 0xf0) != dwarf::DW_EH_PE_funcrel &&
-        (DwarfType & 0xf0) != dwarf::DW_EH_PE_datarel)
+    if (!(DwarfType & dwarf::DW_EH_PE_pcrel) &&
+        !(DwarfType & dwarf::DW_EH_PE_textrel) &&
+        !(DwarfType & dwarf::DW_EH_PE_funcrel) &&
+        !(DwarfType & dwarf::DW_EH_PE_datarel))
+      return;
+
+    if (!(DwarfType & dwarf::DW_EH_PE_sdata4))
       return;
 
     uint32_t RelType;


### PR DESCRIPTION
This reverts commit 7ab26d7c3a160e1dc166f2673644baa396703ee5.

There is test failure in bolt-tests::exceptions-split-strip.test.