### PR TITLE
[CI] Ignore TidyFastChecks.inc for formatter CI. NFC.

### DIFF
--- a/clang-tools-extra/clangd/.clang-format-ignore
+++ b/clang-tools-extra/clangd/.clang-format-ignore
@@ -1,0 +1,2 @@
+# Keep these entries unformatted.
+TidyFastChecks.inc


### PR DESCRIPTION
`TidyFastChecks.inc` is generated and its contents should not be checked by clang-format CI workflow. Add a local `.clang-format-ignore` entry so the PR formatting check does not report diffs for this file.

Related run: https://github.com/llvm/llvm-project/pull/194516#issuecomment-4332061836