### PR TITLE
[clang] Don't warn on __COUNTER__ in system macros

### DIFF
--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -93,10 +93,10 @@ def err_conflict_marker : Error<"version control conflict marker in file">;
 def err_counter_overflow : Error<
   "'__COUNTER__' value cannot exceed 2'147'483'647">;
 def ext_counter : Extension<
-  "'__COUNTER__' is a C2y extension">, InGroup<C2y>;
+  "'__COUNTER__' is a C2y extension">, InGroup<C2y>, SuppressInSystemMacro;
 def warn_counter : Warning<
   "'__COUNTER__' is incompatible with standards before C2y">,
-  InGroup<CPre2yCompat>, DefaultIgnore;
+  InGroup<CPre2yCompat>, DefaultIgnore, SuppressInSystemMacro;
 
 def err_raw_delim_too_long : Error<
   "raw string delimiter longer than 16 characters"

--- a/clang/test/Lexer/Inputs/__counter__-system-header.h
+++ b/clang/test/Lexer/Inputs/__counter__-system-header.h
@@ -1,0 +1,7 @@
+#define COUNTER_ALIAS __COUNTER__
+#define COUNTER_MACRO() __COUNTER__
+
+int header_counter_value = __COUNTER__;
+int header_counter_alias = COUNTER_ALIAS;
+int header_counter_macro = COUNTER_MACRO();
+

--- a/clang/test/Lexer/__counter__-system-include.c
+++ b/clang/test/Lexer/__counter__-system-include.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1                  -Wpedantic %s -fsyntax-only -isystem %S/Inputs -verify=ext
+// RUN: %clang_cc1 -std=c2y         -Wpedantic %s -fsyntax-only -isystem %S/Inputs -verify
+// RUN: %clang_cc1 -std=c2y -Wpre-c2y-compat   %s -fsyntax-only -isystem %S/Inputs -verify=pre
+// RUN: %clang_cc1                            -pedantic %s -fsyntax-only -isystem %S/Inputs -verify=ext
+// RUN: %clang_cc1 -std=c2y -Wpre-c2y-compat  -pedantic %s -fsyntax-only -isystem %S/Inputs -verify=pre
+// RUN: %clang_cc1                            -pedantic-errors %s -fsyntax-only -isystem %S/Inputs -verify=pedant
+// RUN: %clang_cc1 -std=c2y -Wpre-c2y-compat  -pedantic-errors %s -fsyntax-only -isystem %S/Inputs -verify=pre
+
+#include <__counter__-system-header.h>
+
+// expected-no-diagnostics
+
+int tu_direct_reference = __COUNTER__; // #errorline
+// ext-warning@#errorline {{'__COUNTER__' is a C2y extension}}
+// pre-warning@#errorline {{'__COUNTER__' is incompatible with standards before C2y}}
+// pedant-error@#errorline {{'__COUNTER__' is a C2y extension}}
+int tu_counter_alias = COUNTER_ALIAS;
+int tu_counter_macro = COUNTER_MACRO();


### PR DESCRIPTION
The introduction of extension and compatibility warnings means that `__COUNTER__` has started causing warnings (and -Werror= build failures) due to use of system APIs.

This PR simply ensures that these diagnostics don't get reported for system macro expansions as well.