### PR TITLE
clang-format: ensure ternary operands are aligned

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1276,6 +1276,22 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
     CurrentState.BreakBeforeParameter = false;
     CurrentState.AlignedTo = &Current;
   }
+  if (Style.AlignOperands != FormatStyle::OAS_DontAlign &&
+      Current.is(TT_ConditionalExpr)) {
+    switch (Style.AlignOperands) {
+    case FormatStyle::OAS_Align:
+      CurrentState.AlignedTo = Current.is(tok::question)
+                                   ? Current.getPrevious(tok::equal)
+                                   : Current.getPrevious(tok::question);
+      break;
+    case FormatStyle::OAS_AlignAfterOperator:
+      if (Current.is(tok::colon))
+        CurrentState.AlignedTo = Current.getPrevious(tok::question);
+      break;
+    case FormatStyle::OAS_DontAlign:
+      break;
+    }
+  }
 
   if (!DryRun) {
     unsigned MaxEmptyLinesToKeep = Style.MaxEmptyLinesToKeep + 1;

--- a/clang/unittests/Format/AlignmentTest.cpp
+++ b/clang/unittests/Format/AlignmentTest.cpp
@@ -3599,6 +3599,16 @@ TEST_F(AlignmentTest, ContinuedAligned) {
                "\t},\n"
                "\tvariant);",
                Style);
+
+  Style.ColumnLimit = 40;
+  Style.IndentWidth = Style.TabWidth = Style.ContinuationIndentWidth = 8;
+
+  verifyFormat("void f() {\n"
+               "\tint aaaaaaaaaaaaaaaaaaaa =\n"
+               "\t\t000000000000000001 ? 2\n"
+               "\t\t                   : 3;\n"
+               "}",
+               Style);
 }
 
 } // namespace


### PR DESCRIPTION
Set ParentState::AlignedTo for ternary operands.