### PR TITLE
[X86] Hoist ReservedIdentifiers to MCAsmInfo and shrink setup cost. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfo.h
+++ b/llvm/include/llvm/MC/MCAsmInfo.h
@@ -15,7 +15,9 @@
 #ifndef LLVM_MC_MCASMINFO_H
 #define LLVM_MC_MCASMINFO_H
 
+#include "llvm/ADT/CachedHashString.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCDirectives.h"
@@ -433,6 +435,10 @@ protected:
   llvm::StringMap<uint32_t> NameToAtSpecifier;
   void initializeAtSpecifiers(ArrayRef<AtSpecifier>);
 
+  // Lowercase identifiers (e.g. register names, dialect keywords) that must be
+  // quoted when used as a symbol name.
+  llvm::DenseSet<llvm::CachedHashStringRef> ReservedIdentifiers;
+
   const MCTargetOptions &TargetOptions;
 
 public:
@@ -491,6 +497,14 @@ public:
   /// Return true if the identifier \p Name does not need quotes to be
   /// syntactically correct.
   virtual bool isValidUnquotedName(StringRef Name) const;
+
+  llvm::DenseSet<llvm::CachedHashStringRef> &getReservedIdentifiers() {
+    return ReservedIdentifiers;
+  }
+  const llvm::DenseSet<llvm::CachedHashStringRef> &
+  getReservedIdentifiers() const {
+    return ReservedIdentifiers;
+  }
 
   virtual void printSwitchToSection(const MCSection &, uint32_t Subsection,
                                     const Triple &, raw_ostream &) const {}

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -187,32 +187,32 @@ X86MCAsmInfoMicrosoftMASM::X86MCAsmInfoMicrosoftMASM(
   AllowAtAtStartOfIdentifier = true;
 }
 
-static bool isValidX86UnquotedName(const MCAsmInfo &MAI,
-                                   const StringSet<> &ReservedIdentifiers,
-                                   StringRef Name) {
+static bool isValidX86UnquotedName(const MCAsmInfo &MAI, StringRef Name) {
   if (!MAI.MCAsmInfo::isValidUnquotedName(Name))
     return false;
   // Only Intel-syntax output needs to avoid register/keyword collisions; AT&T
   // disambiguates registers with '%' and doesn't treat `byte`, `ptr`, etc. as
   // keywords.
-  return MAI.getOutputAssemblerDialect() == 0 ||
-         !ReservedIdentifiers.contains(Name.lower());
+  if (MAI.getOutputAssemblerDialect() == 0)
+    return true;
+  return !MAI.getReservedIdentifiers().contains(
+      CachedHashStringRef(Name.lower()));
 }
 
 bool X86MCAsmInfoDarwin::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, ReservedIdentifiers, Name);
+  return isValidX86UnquotedName(*this, Name);
 }
 
 bool X86ELFMCAsmInfo::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, ReservedIdentifiers, Name);
+  return isValidX86UnquotedName(*this, Name);
 }
 
 bool X86MCAsmInfoMicrosoft::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, ReservedIdentifiers, Name);
+  return isValidX86UnquotedName(*this, Name);
 }
 
 bool X86MCAsmInfoGNUCOFF::isValidUnquotedName(StringRef Name) const {
-  return isValidX86UnquotedName(*this, ReservedIdentifiers, Name);
+  return isValidX86UnquotedName(*this, Name);
 }
 
 void X86MCAsmInfoGNUCOFF::anchor() { }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.h
@@ -14,7 +14,6 @@
 #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCASMINFO_H
 
 #include "MCTargetDesc/X86MCExpr.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/MC/MCAsmInfoCOFF.h"
 #include "llvm/MC/MCAsmInfoDarwin.h"
 #include "llvm/MC/MCAsmInfoELF.h"
@@ -27,7 +26,6 @@ class X86MCAsmInfoDarwin : public MCAsmInfoDarwin {
   virtual void anchor();
 
 public:
-  StringSet<> ReservedIdentifiers;
   explicit X86MCAsmInfoDarwin(const Triple &Triple,
                               const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
@@ -45,7 +43,6 @@ class X86ELFMCAsmInfo : public MCAsmInfoELF {
   void anchor() override;
 
 public:
-  StringSet<> ReservedIdentifiers;
   explicit X86ELFMCAsmInfo(const Triple &Triple,
                            const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
@@ -55,7 +52,6 @@ class X86MCAsmInfoMicrosoft : public MCAsmInfoMicrosoft {
   void anchor() override;
 
 public:
-  StringSet<> ReservedIdentifiers;
   explicit X86MCAsmInfoMicrosoft(const Triple &Triple,
                                  const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;
@@ -73,7 +69,6 @@ class X86MCAsmInfoGNUCOFF : public MCAsmInfoGNUCOFF {
   void anchor() override;
 
 public:
-  StringSet<> ReservedIdentifiers;
   explicit X86MCAsmInfoGNUCOFF(const Triple &Triple,
                                const MCTargetOptions &Options);
   bool isValidUnquotedName(StringRef Name) const override;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.cpp
@@ -420,24 +420,28 @@ static MCRegisterInfo *createX86MCRegisterInfo(const Triple &TT) {
   return X;
 }
 
-static void populateReservedIdentifiers(StringSet<> &Set,
+static void populateReservedIdentifiers(MCAsmInfo &MAI,
                                         const MCRegisterInfo &MRI) {
-  // Register names: `call rsi` is misassembled as an indirect call.
+  auto &Set = MAI.getReservedIdentifiers();
+  // Register names: `call rsi` is misassembled as an indirect call. Use the
+  // Intel printer's table directly — it's the lowercase asm name in stable
+  // storage. MRI::getName() returns the uppercase enum name and would need
+  // an extra .lower() heap allocation per entry.
   for (unsigned i = 1, e = MRI.getNumRegs(); i < e; ++i)
-    if (const char *Name = MRI.getName(i))
+    if (const char *Name = X86IntelInstPrinter::getRegisterName(i))
       if (Name[0])
-        Set.insert(StringRef(Name).lower());
+        Set.insert(CachedHashStringRef(Name));
   // Keywords that GAS Intel syntax misparses as constants, modifiers, or
   // pseudo-registers instead of symbol references (e.g., `call byte` calls
   // address 1, not symbol "byte"; `call flat` errors out).
   for (StringRef KW : {"byte", "word", "dword", "fword", "qword", "mmword",
                        "tbyte", "oword", "xmmword", "ymmword", "zmmword",
                        "offset", "flat", "near", "far", "short"})
-    Set.insert(KW);
+    Set.insert(CachedHashStringRef(KW));
   // Operator keywords parsed by GAS/X86AsmParser in Intel mode.
   for (StringRef KW : {"and", "eq", "ge", "gt", "le", "lt", "mod", "ne", "not",
                        "or", "shl", "shr", "xor"})
-    Set.insert(KW);
+    Set.insert(CachedHashStringRef(KW));
 }
 
 static MCAsmInfo *createX86MCAsmInfo(const MCRegisterInfo &MRI,
@@ -447,42 +451,27 @@ static MCAsmInfo *createX86MCAsmInfo(const MCRegisterInfo &MRI,
 
   MCAsmInfo *MAI;
   if (TheTriple.isOSBinFormatMachO()) {
-    if (is64Bit) {
-      auto *P = new X86_64MCAsmInfoDarwin(TheTriple, Options);
-      populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-      MAI = P;
-    } else {
-      auto *P = new X86MCAsmInfoDarwin(TheTriple, Options);
-      populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-      MAI = P;
-    }
+    if (is64Bit)
+      MAI = new X86_64MCAsmInfoDarwin(TheTriple, Options);
+    else
+      MAI = new X86MCAsmInfoDarwin(TheTriple, Options);
   } else if (TheTriple.isOSBinFormatELF()) {
     // Force the use of an ELF container.
-    auto *P = new X86ELFMCAsmInfo(TheTriple, Options);
-    populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-    MAI = P;
+    MAI = new X86ELFMCAsmInfo(TheTriple, Options);
   } else if (TheTriple.isWindowsMSVCEnvironment() ||
              TheTriple.isWindowsCoreCLREnvironment() || TheTriple.isUEFI()) {
-    if (Options.getAssemblyLanguage().equals_insensitive("masm")) {
-      auto *P = new X86MCAsmInfoMicrosoftMASM(TheTriple, Options);
-      populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-      MAI = P;
-    } else {
-      auto *P = new X86MCAsmInfoMicrosoft(TheTriple, Options);
-      populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-      MAI = P;
-    }
+    if (Options.getAssemblyLanguage().equals_insensitive("masm"))
+      MAI = new X86MCAsmInfoMicrosoftMASM(TheTriple, Options);
+    else
+      MAI = new X86MCAsmInfoMicrosoft(TheTriple, Options);
   } else if (TheTriple.isOSCygMing() ||
              TheTriple.isWindowsItaniumEnvironment()) {
-    auto *P = new X86MCAsmInfoGNUCOFF(TheTriple, Options);
-    populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-    MAI = P;
+    MAI = new X86MCAsmInfoGNUCOFF(TheTriple, Options);
   } else {
     // The default is ELF.
-    auto *P = new X86ELFMCAsmInfo(TheTriple, Options);
-    populateReservedIdentifiers(P->ReservedIdentifiers, MRI);
-    MAI = P;
+    MAI = new X86ELFMCAsmInfo(TheTriple, Options);
   }
+  populateReservedIdentifiers(*MAI, MRI);
 
   // Initialize initial frame state.
   // Calculate amount of bytes used for return address storing


### PR DESCRIPTION
PR #186570 added a per-MCAsmInfo `StringSet<>` populated with X86
register names plus Intel-syntax keywords, which caused a minor
instructions:u increase.

Avoid heap allocation and hoist `ReservedIdentifiers` to MCAsmInfo for
other targets.

For the register-name source, prefer
`X86IntelInstPrinter::getRegisterName` over `MCRegisterInfo::getName`.
The former is a TableGen-emitted accessor into a `static const char
AsmStrs[]` pool in `X86GenAsmWriter1.inc`, populated from the lowercase
asm-name argument of each `def XX : X86Reg<"xx", ...>;` in
`X86RegisterInfo.td`.
