### PR TITLE
[SelectionDAG] Don't convert sextload to zextload through a multi-use freeze

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -16545,7 +16545,9 @@ SDValue DAGCombiner::reduceLoadWidth(SDNode *N) {
   // the freeze can depend on the full load value. But its still safe to change
   // the extension type from anyext to zext.
   if (FreezeNode && !FreezeNode.hasOneUse() &&
-      (LN0->getMemoryVT().bitsGT(ExtVT) || ExtType != ISD::ZEXTLOAD))
+      (LN0->getMemoryVT().bitsGT(ExtVT) || ExtType != ISD::ZEXTLOAD ||
+       (LN0->getExtensionType() != ISD::EXTLOAD &&
+        LN0->getExtensionType() != ISD::ZEXTLOAD)))
     return SDValue();
 
   auto AdjustBigEndianShift = [&](unsigned ShAmt) {

--- a/llvm/test/CodeGen/X86/reduce-load-width-freeze.ll
+++ b/llvm/test/CodeGen/X86/reduce-load-width-freeze.ll
@@ -358,14 +358,15 @@ define i16 @srl_freeze_load_i64_to_i16(ptr %p) {
 @g6 = global i8 0
 @g1 = global i16 0
 
-; incorrect sext -> zext
+; no incorrect sext -> zext
 define i1 @issue196590() {
 ; CHECK-LABEL: issue196590:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    movq g6@GOTPCREL(%rip), %rax
-; CHECK-NEXT:    movzbl (%rax), %eax
-; CHECK-NEXT:    movq g1@GOTPCREL(%rip), %rcx
-; CHECK-NEXT:    movw %ax, (%rcx)
+; CHECK-NEXT:    movsbl (%rax), %eax
+; CHECK-NEXT:    movzbl %al, %ecx
+; CHECK-NEXT:    movq g1@GOTPCREL(%rip), %rdx
+; CHECK-NEXT:    movw %cx, (%rdx)
 ; CHECK-NEXT:    leal (%rax,%rax), %ecx
 ; CHECK-NEXT:    cmpl %eax, %ecx
 ; CHECK-NEXT:    setg %al

--- a/llvm/test/CodeGen/X86/reduce-load-width-freeze.ll
+++ b/llvm/test/CodeGen/X86/reduce-load-width-freeze.ll
@@ -354,3 +354,31 @@ define i16 @srl_freeze_load_i64_to_i16(ptr %p) {
   %trunc = trunc i64 %srl to i16
   ret i16 %trunc
 }
+
+@g6 = global i8 0
+@g1 = global i16 0
+
+; incorrect sext -> zext
+define i1 @issue196590() {
+; CHECK-LABEL: issue196590:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movq g6@GOTPCREL(%rip), %rax
+; CHECK-NEXT:    movzbl (%rax), %eax
+; CHECK-NEXT:    movq g1@GOTPCREL(%rip), %rcx
+; CHECK-NEXT:    movw %ax, (%rcx)
+; CHECK-NEXT:    leal (%rax,%rax), %ecx
+; CHECK-NEXT:    cmpl %eax, %ecx
+; CHECK-NEXT:    setg %al
+; CHECK-NEXT:    retq
+  %a = load i8, ptr @g6
+  %zx = zext i8 %a to i16
+  store i16 %zx, ptr @g1
+  %sx = sext i8 %a to i32
+  %b = load i8, ptr @g6
+  %fr = freeze i8 %b
+  %fr16 = sext i8 %fr to i16
+  %add = add i16 %fr16, %fr16
+  %selsx = sext i16 %add to i32
+  %cmp = icmp sgt i32 %selsx, %sx
+  ret i1 %cmp
+}


### PR DESCRIPTION
Resolves #196590.

The patch https://github.com/llvm/llvm-project/pull/189317 to teach DAGCombiner to look through freeze incorrectly introduce a miscompile of sext -> zext. This resolves resolves the miscompile.