### PR TITLE
[mlir][SparseTensor] Terminology cleanup PIV -> PCV (NFC)

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/SparseTensor/File.h
+++ b/mlir/include/mlir/ExecutionEngine/SparseTensor/File.h
@@ -199,16 +199,16 @@ public:
 
   /// Allocates a new sparse-tensor storage object with the given encoding,
   /// initializes it by reading all the elements from the file, and then
-  /// closes the file. Templated on P, I, and V.
-  template <typename P, typename I, typename V>
-  SparseTensorStorage<P, I, V> *
+  /// closes the file. Templated on P, C, and V.
+  template <typename P, typename C, typename V>
+  SparseTensorStorage<P, C, V> *
   readSparseTensor(uint64_t lvlRank, const uint64_t *lvlSizes,
                    const LevelType *lvlTypes, const uint64_t *dim2lvl,
                    const uint64_t *lvl2dim) {
     const uint64_t dimRank = getRank();
     MapRef map(dimRank, lvlRank, dim2lvl, lvl2dim);
     auto *lvlCOO = readCOO<V>(map, lvlSizes);
-    auto *tensor = SparseTensorStorage<P, I, V>::newFromCOO(
+    auto *tensor = SparseTensorStorage<P, C, V>::newFromCOO(
         dimRank, getDimSizes(), lvlRank, lvlSizes, lvlTypes, dim2lvl, lvl2dim,
         lvlCOO);
     delete lvlCOO;

--- a/mlir/lib/ExecutionEngine/SparseTensor/Storage.cpp
+++ b/mlir/lib/ExecutionEngine/SparseTensor/Storage.cpp
@@ -50,20 +50,20 @@ SparseTensorStorageBase::SparseTensorStorageBase( // NOLINT
 }
 
 // Helper macro for wrong "partial method specialization" errors.
-#define FATAL_PIV(NAME)                                                        \
-  fprintf(stderr, "<P,I,V> type mismatch for: " #NAME);                        \
+#define FATAL_PCV(NAME)                                                        \
+  fprintf(stderr, "<P,C,V> type mismatch for: " #NAME);                        \
   exit(1);
 
 #define IMPL_GETPOSITIONS(PNAME, P)                                            \
   void SparseTensorStorageBase::getPositions(std::vector<P> **, uint64_t) {    \
-    FATAL_PIV("getPositions" #PNAME);                                          \
+    FATAL_PCV("getPositions" #PNAME);                                          \
   }
 MLIR_SPARSETENSOR_FOREVERY_FIXED_O(IMPL_GETPOSITIONS)
 #undef IMPL_GETPOSITIONS
 
 #define IMPL_GETCOORDINATES(CNAME, C)                                          \
   void SparseTensorStorageBase::getCoordinates(std::vector<C> **, uint64_t) {  \
-    FATAL_PIV("getCoordinates" #CNAME);                                        \
+    FATAL_PCV("getCoordinates" #CNAME);                                        \
   }
 MLIR_SPARSETENSOR_FOREVERY_FIXED_O(IMPL_GETCOORDINATES)
 #undef IMPL_GETCOORDINATES
@@ -71,21 +71,21 @@ MLIR_SPARSETENSOR_FOREVERY_FIXED_O(IMPL_GETCOORDINATES)
 #define IMPL_GETCOORDINATESBUFFER(CNAME, C)                                    \
   void SparseTensorStorageBase::getCoordinatesBuffer(std::vector<C> **,        \
                                                      uint64_t) {               \
-    FATAL_PIV("getCoordinatesBuffer" #CNAME);                                  \
+    FATAL_PCV("getCoordinatesBuffer" #CNAME);                                  \
   }
 MLIR_SPARSETENSOR_FOREVERY_FIXED_O(IMPL_GETCOORDINATESBUFFER)
 #undef IMPL_GETCOORDINATESBUFFER
 
 #define IMPL_GETVALUES(VNAME, V)                                               \
   void SparseTensorStorageBase::getValues(std::vector<V> **) {                 \
-    FATAL_PIV("getValues" #VNAME);                                             \
+    FATAL_PCV("getValues" #VNAME);                                             \
   }
 MLIR_SPARSETENSOR_FOREVERY_V(IMPL_GETVALUES)
 #undef IMPL_GETVALUES
 
 #define IMPL_LEXINSERT(VNAME, V)                                               \
   void SparseTensorStorageBase::lexInsert(const uint64_t *, V) {               \
-    FATAL_PIV("lexInsert" #VNAME);                                             \
+    FATAL_PCV("lexInsert" #VNAME);                                             \
   }
 MLIR_SPARSETENSOR_FOREVERY_V(IMPL_LEXINSERT)
 #undef IMPL_LEXINSERT
@@ -93,9 +93,9 @@ MLIR_SPARSETENSOR_FOREVERY_V(IMPL_LEXINSERT)
 #define IMPL_EXPINSERT(VNAME, V)                                               \
   void SparseTensorStorageBase::expInsert(uint64_t *, V *, bool *, uint64_t *, \
                                           uint64_t, uint64_t) {                \
-    FATAL_PIV("expInsert" #VNAME);                                             \
+    FATAL_PCV("expInsert" #VNAME);                                             \
   }
 MLIR_SPARSETENSOR_FOREVERY_V(IMPL_EXPINSERT)
 #undef IMPL_EXPINSERT
 
-#undef FATAL_PIV
+#undef FATAL_PCV


### PR DESCRIPTION
This PR standardizes terminology in the MLIR sparsifier by replacing the PIV (Pointer, Index, Value) terminology with the PCV (Position, Coordinate, Value) terminology established in https://reviews.llvm.org/D144773. The changes include renaming template parameters and error macros.