### PR TITLE
[flang] Correct MIN/MAX bug with DO CONCURRENT and REDUCE

### DIFF
--- a/flang/lib/Lower/Support/ReductionProcessor.cpp
+++ b/flang/lib/Lower/Support/ReductionProcessor.cpp
@@ -194,9 +194,23 @@ ReductionProcessor::getReductionName(ReductionIdentifier redId,
   case ReductionIdentifier::NEQV:
     reductionName = "neqv_reduction";
     break;
-  default:
-    reductionName = "other_reduction";
+  case ReductionIdentifier::MAX:
+    reductionName = "max_reduction";
     break;
+  case ReductionIdentifier::MIN:
+    reductionName = "min_reduction";
+    break;
+  case ReductionIdentifier::IAND:
+    reductionName = "iand_reduction";
+    break;
+  case ReductionIdentifier::IOR:
+    reductionName = "ior_reduction";
+    break;
+  case ReductionIdentifier::IEOR:
+    reductionName = "ieor_reduction";
+    break;
+  default:
+    llvm_unreachable("unsupported reduction identifier");
   }
 
   return getReductionName(reductionName, kindMap, ty, isByRef);

--- a/flang/test/Lower/loops3.f90
+++ b/flang/test/Lower/loops3.f90
@@ -44,3 +44,22 @@ subroutine loop_min_max_test
     hi = max(hi, real(i))
   enddo
 end subroutine loop_min_max_test
+
+! CHECK-LABEL: func.func @_QPloop_bitwise_test
+subroutine loop_bitwise_test
+  integer :: i
+  integer :: a, o, x
+  a = -1
+  o = 0
+  x = 0
+
+  ! CHECK: fir.do_concurrent.loop
+  ! CHECK-SAME: @iand_reduction_i32 #fir.reduce_attr<iand>
+  ! CHECK-SAME: @ior_reduction_i32 #fir.reduce_attr<ior>
+  ! CHECK-SAME: @ieor_reduction_i32 #fir.reduce_attr<ieor>
+  do concurrent (i=1:10) reduce(iand:a) reduce(ior:o) reduce(ieor:x)
+    a = iand(a, i)
+    o = ior(o, i)
+    x = ieor(x, i)
+  enddo
+end subroutine loop_bitwise_test

--- a/flang/test/Lower/loops3.f90
+++ b/flang/test/Lower/loops3.f90
@@ -28,3 +28,19 @@ subroutine loop_test
     m = max(m, sum)
   enddo
 end subroutine loop_test
+
+! CHECK-LABEL: func.func @_QPloop_min_max_test
+subroutine loop_min_max_test
+  integer :: i
+  real :: lo, hi
+  lo = huge(0.0)
+  hi = 0.0
+
+  ! CHECK: fir.do_concurrent.loop
+  ! CHECK-SAME: @min_reduction_f32 #fir.reduce_attr<min>
+  ! CHECK-SAME: @max_reduction_f32 #fir.reduce_attr<max>
+  do concurrent (i=1:10) reduce(min:lo) reduce(max:hi)
+    lo = min(lo, real(i))
+    hi = max(hi, real(i))
+  enddo
+end subroutine loop_min_max_test

--- a/flang/test/Lower/loops3.f90
+++ b/flang/test/Lower/loops3.f90
@@ -12,7 +12,7 @@ subroutine loop_test
 
   ! CHECK: %[[M:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_testEm"}
   ! CHECK: %[[SUM:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_testEsum"}
-  ! CHECK: fir.do_concurrent.loop ({{.*}}) = ({{.*}}) to ({{.*}}) step ({{.*}}) local(@_QFloop_testEtmp_private_i32 %{{.*}} -> %{{.*}} : !fir.ref<i32>) reduce(@add_reduction_i32 #fir.reduce_attr<add> %[[SUM]]#0 -> %{{.*}}, @other_reduction_f32 #fir.reduce_attr<max> %[[M]]#0 -> %{{.*}} : !fir.ref<i32>, !fir.ref<f32>) {
+  ! CHECK: fir.do_concurrent.loop ({{.*}}) = ({{.*}}) to ({{.*}}) step ({{.*}}) local(@_QFloop_testEtmp_private_i32 %{{.*}} -> %{{.*}} : !fir.ref<i32>) reduce(@add_reduction_i32 #fir.reduce_attr<add> %[[SUM]]#0 -> %{{.*}}, @max_reduction_f32 #fir.reduce_attr<max> %[[M]]#0 -> %{{.*}} : !fir.ref<i32>, !fir.ref<f32>) {
   ! CHECK: %[[TMP:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_testEtmp"}
   ! CHECK: %[[SUM_INNER:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_testEsum"}
   ! CHECK: %[[M_INNER:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFloop_testEm"}


### PR DESCRIPTION
Flang used a the same reduction name for MIN/MAX with meant that if both happened, the compiler would use the first reduction operation it saw for both MIN/MAX.  This is now corrected.