### PR TITLE
[clang-tidy] Correct `std::has_one_bit` to `std::has_single_bit` in `modernize-use-std-bit`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdBitCheck.cpp
@@ -71,13 +71,13 @@ void UseStdBitCheck::registerMatchers(MatchFinder *Finder) {
   };
 
   // Determining if an integer is a power of 2 with following pattern:
-  // has_one_bit(v) = v && !(v & (v - 1));
+  // has_single_bit(v) = v && !(v & (v - 1));
   Finder->addMatcher(
       LogicalAnd(IsNonNull(BindDeclRef("v")),
                  LogicalNot(BitwiseAnd(
                      BoundDeclRef("v"),
                      Sub(BoundDeclRef("v"), integerLiteral(equals(1))))))
-          .bind("has_one_bit_expr"),
+          .bind("has_single_bit_expr"),
       this);
 
   // Computing popcount with following pattern:
@@ -120,16 +120,17 @@ void UseStdBitCheck::check(const MatchFinder::MatchResult &Result) {
   const SourceManager &Source = Context.getSourceManager();
 
   if (const auto *MatchedExpr =
-          Result.Nodes.getNodeAs<BinaryOperator>("has_one_bit_expr")) {
+          Result.Nodes.getNodeAs<BinaryOperator>("has_single_bit_expr")) {
     const auto *MatchedVarDecl = Result.Nodes.getNodeAs<VarDecl>("v");
 
     auto Diag =
-        diag(MatchedExpr->getBeginLoc(), "use 'std::has_one_bit' instead");
+        diag(MatchedExpr->getBeginLoc(), "use 'std::has_single_bit' instead");
     if (auto R = MatchedExpr->getSourceRange();
         !R.getBegin().isMacroID() && !R.getEnd().isMacroID()) {
       Diag << FixItHint::CreateReplacement(
                   MatchedExpr->getSourceRange(),
-                  ("std::has_one_bit(" + MatchedVarDecl->getName() + ")").str())
+                  ("std::has_single_bit(" + MatchedVarDecl->getName() + ")")
+                      .str())
            << IncludeInserter.createIncludeInsertion(
                   Source.getFileID(MatchedExpr->getBeginLoc()), "<bit>");
     }

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-std-bit.rst
@@ -8,16 +8,16 @@ Finds common idioms which can be replaced by standard functions from the
 
 Covered scenarios:
 
-============================== =======================
+============================== ==========================
 Expression                     Replacement
------------------------------- -----------------------
-``x && !(x & (x - 1))``        ``std::has_one_bit(x)``
-``(x != 0) && !(x & (x - 1))`` ``std::has_one_bit(x)``
-``(x > 0) && !(x & (x - 1))``  ``std::has_one_bit(x)``
+------------------------------ --------------------------
+``x && !(x & (x - 1))``        ``std::has_single_bit(x)``
+``(x != 0) && !(x & (x - 1))`` ``std::has_single_bit(x)``
+``(x > 0) && !(x & (x - 1))``  ``std::has_single_bit(x)``
 ``std::bitset<N>(x).count()``  ``std::popcount(x)``
 ``x << 3 | x >> 61``           ``std::rotl(x, 3)``
 ``x << 61 | x >> 3``           ``std::rotr(x, 3)``
-============================== =======================
+============================== ==========================
 
 Options
 -------

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-bit.cpp
@@ -6,80 +6,80 @@
  * has_one_bit pattern
  */
 unsigned has_one_bit_bithack(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return x && !(x & (x - 1));
 }
 
 unsigned long has_one_bit_bithack(unsigned long x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return x && !(x & (x - 1));
 }
 
 unsigned short has_one_bit_bithack(unsigned short x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return x && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithack_perm(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return x && !((x - 1) & (x));
 }
 
 unsigned has_one_bit_bithack_otherperm(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return !((x - 1) & (x)) && x;
 }
 
 unsigned has_one_bit_bithack_variant_neq(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (x != 0) && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithack_variant_neq_perm(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (x != 0) && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithack_variant_gt(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (x > 0) && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithacks_variant_gte(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (x >= 1) && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithacks_variant_lt(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (0 < x) && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithacks_variant_lte(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (1 <= x) && !(x & (x - 1));
 }
 
 unsigned has_one_bit_bithack_variant_gt_perm(unsigned x) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
-  // CHECK-FIXES: return std::has_one_bit(x);
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
+  // CHECK-FIXES: return std::has_single_bit(x);
   return (x > 0) && !(x & (x - 1));
 }
 
 #define HAS_ONE_BIT v && !(v & (v - 1))
 unsigned has_one_bit_bithack_macro(unsigned v) {
-  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_one_bit' instead [modernize-use-std-bit]
+  // CHECK-MESSAGES: :[[@LINE+2]]:10: warning: use 'std::has_single_bit' instead [modernize-use-std-bit]
   // No fixes, it comes from macro expansion.
   return HAS_ONE_BIT;
 }


### PR DESCRIPTION
There isn't `std::has_one_bit` in standard library, the function checks if a number is an integral power of 2 is `std::has_single_bit`.

https://en.cppreference.com/cpp/header/bit