### PR TITLE
[LV] Recognize UF*vscale as a valid canonical-IV increment step

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -724,7 +724,9 @@ VPInstruction *vputils::findCanonicalIVIncrement(VPlan &Plan) {
 
     VPSymbolicValue &UF = Plan.getUF();
     if (!UF.isMaterialized())
-      return Step == &UF;
+      return Step == &UF ||
+             match(Step, m_c_Mul(m_Specific(&Plan.getUF()),
+                                 m_VPInstruction<VPInstruction::VScale>()));
 
     unsigned ConcreteUF = Plan.getConcreteUF();
     // Fixed VF: step is just the concrete UF.

--- a/llvm/test/Transforms/LoopVectorize/AArch64/transform-narrow-interleave-to-widen-memory-epilogue-vec.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/transform-narrow-interleave-to-widen-memory-epilogue-vec.ll
@@ -84,6 +84,9 @@ exit:
 ; materializes VFxUF and the canonical IV increment step is UF*vscale.
 %pair = type { i64, i64 }
 define void @test(ptr noalias %A, i64 %v, i64 %n) #0 {
+; CHECK-LABEL: define void @test(
+; CHECK:       vector.body:
+;
 entry:
   br label %for.body
 

--- a/llvm/test/Transforms/LoopVectorize/AArch64/transform-narrow-interleave-to-widen-memory-epilogue-vec.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/transform-narrow-interleave-to-widen-memory-epilogue-vec.ll
@@ -79,3 +79,26 @@ loop:
 exit:
   ret i32 0
 }
+
+; Test that vectorization does not crash when narrowInterleaveGroups
+; materializes VFxUF and the canonical IV increment step is UF*vscale.
+%pair = type { i64, i64 }
+define void @test(ptr noalias %A, i64 %v, i64 %n) #0 {
+entry:
+  br label %for.body
+
+for.body:
+  %iv = phi i64 [ 0, %entry ], [ %iv.next, %for.body ]
+  %idx.0 = getelementptr inbounds %pair, ptr %A, i64 %iv, i32 0
+  %idx.1 = getelementptr inbounds %pair, ptr %A, i64 %iv, i32 1
+  store i64 %v, ptr %idx.0
+  store i64 %v, ptr %idx.1
+  %iv.next = add nuw nsw i64 %iv, 1
+  %exitcond = icmp eq i64 %iv.next, %n
+  br i1 %exitcond, label %exit, label %for.body
+
+exit:
+  ret void
+}
+
+attributes #0 = { "target-features"="+sve" vscale_range(2,16) }

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1804,38 +1804,5 @@ TEST_F(VPInstructionTest, VPSymbolicValueAddUserAfterMaterialization) {
 }
 #endif
 
-TEST_F(VPRecipeTest, UFVScaleUserBeforeMaterialization) {
-  VPlan &Plan = getPlan();
-  VPBasicBlock *Header = Plan.createVPBasicBlock("vector.header");
-  VPBasicBlock *Latch = Plan.createVPBasicBlock("vector.latch");
-  VPRegionBlock *LoopRegion =
-      Plan.createLoopRegion(Type::getInt32Ty(C), DebugLoc::getUnknown(),
-                            "vector.loop", Header, Latch);
-  VPBlockUtils::connectBlocks(Header, Latch);
-  VPBlockUtils::connectBlocks(Plan.getEntry(), LoopRegion);
-  VPBlockUtils::connectBlocks(LoopRegion, Plan.getScalarHeader());
-
-  auto *VScale = new VPInstruction(VPInstruction::VScale, {});
-  Plan.getVectorPreheader()->appendRecipe(VScale);
-
-  VPValue *UF = &Plan.getUF();
-  auto *Step = new VPInstruction(Instruction::Mul, {VScale, UF},
-                                 VPIRFlags::getDefaultFlags(Instruction::Mul));
-  Plan.getVectorPreheader()->appendRecipe(Step);
-
-  auto *Increment = new VPInstruction(
-      Instruction::Add, {LoopRegion->getCanonicalIV(), Step},
-      VPIRFlags::WrapFlagsTy(LoopRegion->hasCanonicalIVNUW(), false), {},
-      DebugLoc::getUnknown(), "index.next");
-  Latch->appendRecipe(Increment);
-
-  auto *Br = new VPInstruction(VPInstruction::BranchOnCount,
-                               {Increment, &Plan.getVectorTripCount()});
-  Latch->appendRecipe(Br);
-
-  Plan.getVFxUF().markMaterialized();
-  EXPECT_EQ(Increment, LoopRegion->getOrCreateCanonicalIVIncrement());
-}
-
 } // namespace
 } // namespace llvm

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1804,5 +1804,38 @@ TEST_F(VPInstructionTest, VPSymbolicValueAddUserAfterMaterialization) {
 }
 #endif
 
+TEST_F(VPRecipeTest, UFVScaleUserBeforeMaterialization) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *Header = Plan.createVPBasicBlock("vector.header");
+  VPBasicBlock *Latch = Plan.createVPBasicBlock("vector.latch");
+  VPRegionBlock *LoopRegion =
+      Plan.createLoopRegion(Type::getInt32Ty(C), DebugLoc::getUnknown(),
+                            "vector.loop", Header, Latch);
+  VPBlockUtils::connectBlocks(Header, Latch);
+  VPBlockUtils::connectBlocks(Plan.getEntry(), LoopRegion);
+  VPBlockUtils::connectBlocks(LoopRegion, Plan.getScalarHeader());
+
+  auto *VScale = new VPInstruction(VPInstruction::VScale, {});
+  Plan.getVectorPreheader()->appendRecipe(VScale);
+
+  VPValue *UF = &Plan.getUF();
+  auto *Step = new VPInstruction(Instruction::Mul, {VScale, UF},
+                                 VPIRFlags::getDefaultFlags(Instruction::Mul));
+  Plan.getVectorPreheader()->appendRecipe(Step);
+
+  auto *Increment = new VPInstruction(
+      Instruction::Add, {LoopRegion->getCanonicalIV(), Step},
+      VPIRFlags::WrapFlagsTy(LoopRegion->hasCanonicalIVNUW(), false), {},
+      DebugLoc::getUnknown(), "index.next");
+  Latch->appendRecipe(Increment);
+
+  auto *Br = new VPInstruction(VPInstruction::BranchOnCount,
+                               {Increment, &Plan.getVectorTripCount()});
+  Latch->appendRecipe(Br);
+
+  Plan.getVFxUF().markMaterialized();
+  EXPECT_EQ(Increment, LoopRegion->getOrCreateCanonicalIVIncrement());
+}
+
 } // namespace
 } // namespace llvm

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1804,5 +1804,39 @@ TEST_F(VPInstructionTest, VPSymbolicValueAddUserAfterMaterialization) {
 }
 #endif
 
+TEST_F(VPRecipeTest, UFAddUsersBeforeMaterialization) {
+  VPlan &Plan = getPlan();
+  VPBasicBlock *Header = Plan.createVPBasicBlock("vector.header");
+  VPBasicBlock *Latch = Plan.createVPBasicBlock("vector.latch");
+  VPRegionBlock *LoopRegion = Plan.createLoopRegion(
+      Type::getInt32Ty(C), DebugLoc(), "vector.loop", Header, Latch);
+  VPBlockUtils::connectBlocks(Header, Latch);
+  VPBlockUtils::connectBlocks(Plan.getEntry(), LoopRegion);
+  VPBlockUtils::connectBlocks(LoopRegion, Plan.getScalarHeader());
+
+  auto *VScale = new VPInstruction(VPInstruction::VScale, {});
+  Plan.getVectorPreheader()->appendRecipe(VScale);
+
+  VPValue *UF = &Plan.getUF();
+  auto *Step =
+      new VPInstruction(Instruction::Mul, {VScale, UF},
+                        VPIRFlags(VPIRFlags::WrapFlagsTy(false, false)));
+  Plan.getVectorPreheader()->appendRecipe(Step);
+
+  auto *Increment = new VPInstruction(
+      Instruction::Add, {LoopRegion->getCanonicalIV(), Step},
+      VPIRFlags(VPIRFlags::WrapFlagsTy(LoopRegion->hasCanonicalIVNUW(), false)),
+      {}, DebugLoc(), "index.next");
+  Latch->appendRecipe(Increment);
+
+  auto *Br = new VPInstruction(VPInstruction::BranchOnCount,
+                               {Increment, &Plan.getVectorTripCount()});
+  Latch->appendRecipe(Br);
+
+  Plan.getVFxUF().markMaterialized();
+  Plan.dump();
+  EXPECT_EQ(Increment, LoopRegion->getOrCreateCanonicalIVIncrement());
+}
+
 } // namespace
 } // namespace llvm

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1804,7 +1804,7 @@ TEST_F(VPInstructionTest, VPSymbolicValueAddUserAfterMaterialization) {
 }
 #endif
 
-TEST_F(VPRecipeTest, UFAddUsersBeforeMaterialization) {
+TEST_F(VPRecipeTest, UFVScaleUserBeforeMaterialization) {
   VPlan &Plan = getPlan();
   VPBasicBlock *Header = Plan.createVPBasicBlock("vector.header");
   VPBasicBlock *Latch = Plan.createVPBasicBlock("vector.latch");

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1834,7 +1834,6 @@ TEST_F(VPRecipeTest, UFAddUsersBeforeMaterialization) {
   Latch->appendRecipe(Br);
 
   Plan.getVFxUF().markMaterialized();
-  Plan.dump();
   EXPECT_EQ(Increment, LoopRegion->getOrCreateCanonicalIVIncrement());
 }
 

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -1808,8 +1808,9 @@ TEST_F(VPRecipeTest, UFAddUsersBeforeMaterialization) {
   VPlan &Plan = getPlan();
   VPBasicBlock *Header = Plan.createVPBasicBlock("vector.header");
   VPBasicBlock *Latch = Plan.createVPBasicBlock("vector.latch");
-  VPRegionBlock *LoopRegion = Plan.createLoopRegion(
-      Type::getInt32Ty(C), DebugLoc(), "vector.loop", Header, Latch);
+  VPRegionBlock *LoopRegion =
+      Plan.createLoopRegion(Type::getInt32Ty(C), DebugLoc::getUnknown(),
+                            "vector.loop", Header, Latch);
   VPBlockUtils::connectBlocks(Header, Latch);
   VPBlockUtils::connectBlocks(Plan.getEntry(), LoopRegion);
   VPBlockUtils::connectBlocks(LoopRegion, Plan.getScalarHeader());
@@ -1818,15 +1819,14 @@ TEST_F(VPRecipeTest, UFAddUsersBeforeMaterialization) {
   Plan.getVectorPreheader()->appendRecipe(VScale);
 
   VPValue *UF = &Plan.getUF();
-  auto *Step =
-      new VPInstruction(Instruction::Mul, {VScale, UF},
-                        VPIRFlags(VPIRFlags::WrapFlagsTy(false, false)));
+  auto *Step = new VPInstruction(Instruction::Mul, {VScale, UF},
+                                 VPIRFlags::getDefaultFlags(Instruction::Mul));
   Plan.getVectorPreheader()->appendRecipe(Step);
 
   auto *Increment = new VPInstruction(
       Instruction::Add, {LoopRegion->getCanonicalIV(), Step},
-      VPIRFlags(VPIRFlags::WrapFlagsTy(LoopRegion->hasCanonicalIVNUW(), false)),
-      {}, DebugLoc(), "index.next");
+      VPIRFlags::WrapFlagsTy(LoopRegion->hasCanonicalIVNUW(), false), {},
+      DebugLoc::getUnknown(), "index.next");
   Latch->appendRecipe(Increment);
 
   auto *Br = new VPInstruction(VPInstruction::BranchOnCount,


### PR DESCRIPTION
This patch teaches `findCanonicalIVIncrement` to recognize the
pre-materialization step pattern (`mul vscale, UF`) as a valid
canonical-IV step.