### PR TITLE
[AMDGPU] Add VOP1 DPP8 pseudo infrastructure

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP1Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP1Instructions.td
@@ -105,6 +105,10 @@ class VOP1_DPP_Pseudo <string OpName, VOPProfile P, list<dag> pattern=[]> :
   VOP_DPP_Pseudo <OpName, P, pattern> {
 }
 
+class VOP1_DPP8_Pseudo <string OpName, VOPProfile P, list<dag> pattern=[]> :
+  VOP_DPP8_Pseudo <OpName, P, pattern> {
+}
+
 multiclass VOP1Inst <string opName, VOPProfile P,
                      SDPatternOperator node = null_frag, int VOPDOp = -1> {
   // We only want to set this on the basic, non-SDWA or DPP forms.
@@ -123,8 +127,11 @@ multiclass VOP1Inst <string opName, VOPProfile P,
   if P.HasExtSDWA then
     def _sdwa : VOP1_SDWA_Pseudo <opName, P>;
 
-  if P.HasExtDPP then
+  if P.HasExtDPP then {
     def _dpp : VOP1_DPP_Pseudo <opName, P>;
+    def _dpp8 : VOP1_DPP8_Pseudo <opName, P>;
+  }
+
 
   if P.HasExtVOP3DPP then
     def _e64_dpp  : VOP3_DPP_Pseudo <opName, P> {
@@ -972,8 +979,8 @@ class VOP1_DPP16_Gen<bits<8> op, VOP1_DPP_Pseudo ps, GFXGen Gen, VOPProfile p = 
   let True16Predicate = ps.True16Predicate;
 }
 
-class VOP1_DPP8<bits<8> op, VOP1_Pseudo ps, VOPProfile p = ps.Pfl> :
-    VOP_DPP8<ps.OpName, p> {
+class VOP1_DPP8<bits<8> op, VOP1_DPP8_Pseudo ps, int subtarget, VOPProfile p = ps.Pfl> :
+    VOP_DPP8<ps.OpName, p>, SIMCInstr<ps.PseudoInstr, subtarget> {
   let hasSideEffects = ps.hasSideEffects;
   let Defs = ps.Defs;
   let SchedRW = ps.SchedRW;
@@ -988,8 +995,8 @@ class VOP1_DPP8<bits<8> op, VOP1_Pseudo ps, VOPProfile p = ps.Pfl> :
   let Inst{31-25} = 0x3f;
 }
 
-class VOP1_DPP8_Gen<bits<8> op, VOP1_Pseudo ps, GFXGen Gen, VOPProfile p = ps.Pfl> :
-    VOP1_DPP8<op, ps, p> {
+class VOP1_DPP8_Gen<bits<8> op, VOP1_DPP8_Pseudo ps, GFXGen Gen, VOPProfile p = ps.Pfl> :
+    VOP1_DPP8<op, ps, Gen.Subtarget, p> {
   let AssemblerPredicate = Gen.AssemblerPredicate;
   let DecoderNamespace = Gen.DecoderNamespace;
   let True16Predicate = ps.True16Predicate;
@@ -1047,7 +1054,7 @@ multiclass VOP1_Real_dpp_with_name<GFXGen Gen, bits<9> op, string opName,
 multiclass VOP1_Real_dpp8<GFXGen Gen, bits<9> op, string opName = NAME> {
   defvar ps = !cast<VOP1_Pseudo>(opName#"_e32");
   if !not(ps.Pfl.HasExt64BitDPP) then
-    def _dpp8#Gen.Suffix : VOP1_DPP8_Gen<op{7-0}, ps, Gen>;
+    def _dpp8#Gen.Suffix : VOP1_DPP8_Gen<op{7-0}, !cast<VOP1_DPP8_Pseudo>(opName#"_dpp8"), Gen>;
 }
 
 multiclass VOP1_Real_dpp8_with_name<GFXGen Gen, bits<9> op, string opName,
@@ -1311,7 +1318,7 @@ let AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10" in {
   }
   multiclass VOP1_Real_dpp8_gfx10<bits<9> op> {
     if !cast<VOP1_Pseudo>(NAME#"_e32").Pfl.HasExt32BitDPP then
-    def _dpp8_gfx10 : VOP1_DPP8<op{7-0}, !cast<VOP1_Pseudo>(NAME#"_e32")>;
+    def _dpp8_gfx10 : VOP1_DPP8<op{7-0}, !cast<VOP1_DPP8_Pseudo>(NAME#"_dpp8"), SIEncodingFamily.GFX10>;
   }
 } // End AssemblerPredicate = isGFX10Only, DecoderNamespace = "GFX10"
 
@@ -1828,14 +1835,10 @@ defm V_PERMLANE16_SWAP_B32 : VOP1_OpSel_Real_e32e64_gfx9<0x059>;
 defm V_PERMLANE32_SWAP_B32 : VOP1_OpSel_Real_e32e64_gfx9<0x05a>;
 }
 
-class MovDPP8Pattern<Predicate Pred, Instruction Inst, ValueType vt> : GCNPat <
-  (vt (int_amdgcn_mov_dpp8 vt:$src, timm:$dpp8)),
-  (Inst VGPR_32:$src, VGPR_32:$src, (as_i32timm $dpp8), (i32 DPP8Mode.FI_0))> {
-  let OtherPredicates = [Pred];
-}
-
-foreach vt = Reg32Types.types in {
-  def : MovDPP8Pattern<isGFX10Only, V_MOV_B32_dpp8_gfx10, vt>;
-  def : MovDPP8Pattern<isGFX11Only, V_MOV_B32_dpp8_gfx11, vt>;
-  def : MovDPP8Pattern<isGFX12Only, V_MOV_B32_dpp8_gfx12, vt>;
+let OtherPredicates = [HasDPP8] in {
+  foreach vt = Reg32Types.types in {
+    def : GCNPat<
+      (vt (int_amdgcn_mov_dpp8 vt:$src, timm:$dpp8)),
+      (V_MOV_B32_dpp8 VGPR_32:$src, VGPR_32:$src, (as_i32timm $dpp8), (i32 DPP8Mode.FI_0))>;
+  }
 }

--- a/llvm/lib/Target/AMDGPU/VOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPInstructions.td
@@ -1229,6 +1229,31 @@ class VOP_DPP8_Base<string OpName, VOPProfile P, dag InsDPP8 = P.InsDPP8, string
 class VOP_DPP8<string OpName, VOPProfile P> :
   VOP_DPP8_Base<OpName, P>, VOP_DPP8e<P>;
 
+class VOP_DPP8_Pseudo<string OpName, VOPProfile P, list<dag> pattern=[]> :
+  VOP_Pseudo<OpName, "_dpp8", P, P.OutsDPP8, P.InsDPP8, P.AsmDPP8, pattern> {
+
+  let mayLoad = 0;
+  let mayStore = 0;
+  let hasSideEffects = 0;
+
+  let VALU = 1;
+  let DPP = 1;
+  let Size = 8;
+  let IsPacked = P.IsPacked;
+
+  let ReadsModeReg = !or(P.DstVT.isFP, P.Src0VT.isFP);
+  let mayRaiseFPException = ReadsModeReg;
+  let Uses = !if(ReadsModeReg, [MODE, EXEC], [EXEC]);
+  let isConvergent = 1;
+
+  string AsmOperands = P.AsmDPP8;
+
+  let AsmMatchConverter = "cvtDPP8";
+  let AssemblerPredicate = HasDPP8;
+  let AsmVariantName = AMDGPUAsmVariants.Disable;
+  let Constraints = !if(P.NumSrcArgs, P.TieRegDPP # " = $vdst", "");
+}
+
 class VOP3_DPP8_Base<string OpName, VOPProfile P> :
   VOP_DPP8_Base<OpName, P, P.InsVOP3DPP8, P.AsmVOP3DPP8> {
   let OutOperandList = P.OutsVOP3DPP8;


### PR DESCRIPTION
Add `VOP_DPP8_Pseudo`/`VOP1_DPP8_Pseudo` classes for DPP8 instructions, similar to the existing `VOP_DPP_Pseudo`/`VOP1_DPP_Pseudo` pattern.

We want to avoid using real instructions in pattern matching because that could potentially blow the matcher table's 16-bit opcode.