### PR TITLE
[clang] Prevent recursive copy initialization during variadic argument promotion

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -470,6 +470,9 @@ Improvements to Clang's diagnostics
 
 - Clang now emits an error when implicitly casting a complex type to a built-in vector type. (#GH186805)
 
+- Fixed a frontend crash caused by recursive variadic argument promotion
+  involving volatile class types (#GH196713).
+
 - Added ``-Wnonportable-include-path-separator`` (off by default) to catch
   #include directives that use backslashes as a path separator. The warning
   includes a FixIt to change all the backslashes to forward slashes, so that the

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -935,7 +935,8 @@ ExprResult Sema::DefaultArgumentPromotion(Expr *E) {
   //     is a prvalue for the temporary.
   // FIXME: add some way to gate this entire thing for correctness in
   // potentially potentially evaluated contexts.
-  if (getLangOpts().CPlusPlus && E->isGLValue() && !isUnevaluatedContext()) {
+  if (getLangOpts().CPlusPlus && E->isGLValue() && !isUnevaluatedContext() &&
+      !E->getType().isVolatileQualified()) {
     ExprResult Temp = PerformCopyInitialization(
                        InitializedEntity::InitializeTemporary(E->getType()),
                                                 E->getExprLoc(), E);

--- a/clang/test/CXX/drs/cwg6xx.cpp
+++ b/clang/test/CXX/drs/cwg6xx.cpp
@@ -757,9 +757,7 @@ namespace cwg656 { // cwg656: 2.8
     // expected-error@-1 {{call to deleted function 'accept'}}
     //   expected-note@#cwg656-accept-var {{candidate function [with T = const cwg656::A &] has been explicitly deleted}}
     //   expected-note@#cwg656-accept-T {{candidate function template not viable: no known conversion from 'volatile Y' to 'const A &' for 1st argument}}
-    // expected-error@#cwg656-vy {{no matching constructor for initialization of 'volatile Y'}}
-    //   expected-note@#cwg656-Y {{candidate constructor (the implicit copy constructor) not viable: 1st argument ('volatile Y') would lose volatile qualifier}}
-    //   expected-note@#cwg656-Y {{candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 1 was provided}}
+    // cxx98-error@#cwg656-vy {{cannot pass object of non-POD type 'volatile Y' through variadic function; call will abort at runtime}}
     accept<const D&>(c);
   }
 } // namespace cwg656

--- a/clang/test/SemaCXX/volatile-vararg-recursion.cpp
+++ b/clang/test/SemaCXX/volatile-vararg-recursion.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+namespace cwg535 {
+class X {
+  X(const X &);
+};
+
+struct B {
+  X y;
+  B(...);
+};
+
+extern volatile B b1;
+B b2(b1); // expected-error {{cannot pass object of non-trivial type 'volatile B' through variadic constructor; call will abort at runtime}}
+}


### PR DESCRIPTION
**Summary**
Avoid infinite recursion during variadic argument promotion of volatile
class types.

Clang could previously recurse indefinitely while attempting copy
initialization for variadic constructor arguments involving volatile
class objects, eventually crashing with stack exhaustion.

The recursion occurred when DefaultArgumentPromotion attempted to
materialize a temporary through PerformCopyInitialization, which
re-entered variadic argument promotion for the same type.

This patch prevents the recursive initialization path for volatile
qualified class types and adds a regression test covering the crash.

**Test Plan**
bin/llvm-lit ../clang/test/SemaCXX/volatile-vararg-recursion.cpp
bin/llvm-lit ../clang/test/SemaCXX

AI Assistance: AI tools were used to help with parts of the debugging process and
drafting the PR description. The final code changes and testing were
done manually.


Fixes #196713 
