### PR TITLE
[include-cleaner][NFC] share main-file location classification

### DIFF
--- a/clang-tools-extra/include-cleaner/lib/Record.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Record.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang-include-cleaner/Record.h"
+#include "TypesInternal.h"
 #include "clang-include-cleaner/Types.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
@@ -159,13 +160,7 @@ public:
 
 private:
   bool shouldRecordMacroRef(SourceLocation Loc) const {
-    const SourceLocation ExpandedLoc = SM.getExpansionLoc(Loc);
-    const FileID FID = SM.getFileID(ExpandedLoc);
-    if (FID == SM.getMainFileID())
-      return true;
-    const SourceLocation IncludeLoc = SM.getIncludeLoc(FID);
-    return IncludeLoc.isValid() &&
-           SM.getFileID(IncludeLoc) == SM.getMainFileID();
+    return locateInMainFile(Loc, SM) != MainFileLocation::Other;
   }
 
   void recordMacroRef(const Token &Tok, const MacroInfo &MI,

--- a/clang-tools-extra/include-cleaner/lib/Types.cpp
+++ b/clang-tools-extra/include-cleaner/lib/Types.cpp
@@ -10,6 +10,7 @@
 #include "TypesInternal.h"
 #include "clang/AST/Decl.h"
 #include "clang/Basic/FileEntry.h"
+#include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -107,6 +108,20 @@ llvm::SmallString<128> normalizePath(llvm::StringRef Path) {
   path::remove_dots(P, /*remove_dot_dot=*/true);
   path::native(P, path::Style::posix);
   return P;
+}
+
+MainFileLocation locateInMainFile(SourceLocation Loc, const SourceManager &SM) {
+  const SourceLocation ExpandedLoc = SM.getExpansionLoc(Loc);
+  const FileID FID = SM.getFileID(ExpandedLoc);
+  if (FID == SM.getMainFileID())
+    return MainFileLocation::MainFile;
+  const SourceLocation IncludeLoc = SM.getIncludeLoc(FID);
+  if (!IncludeLoc.isValid())
+    return MainFileLocation::Other;
+  const FileID IncludeFID = SM.getFileID(SM.getExpansionLoc(IncludeLoc));
+  if (IncludeFID == SM.getMainFileID())
+    return MainFileLocation::DirectInclude;
+  return MainFileLocation::Other;
 }
 
 void Includes::addSearchDirectory(llvm::StringRef Path) {

--- a/clang-tools-extra/include-cleaner/lib/TypesInternal.h
+++ b/clang-tools-extra/include-cleaner/lib/TypesInternal.h
@@ -19,6 +19,9 @@
 namespace llvm {
 class raw_ostream;
 }
+namespace clang {
+class SourceManager;
+} // namespace clang
 namespace clang::include_cleaner {
 /// A place where a symbol can be provided.
 /// It is either a physical file of the TU (SourceLocation) or a logical
@@ -97,6 +100,13 @@ template <typename T> struct Hinted : public T {
 };
 
 llvm::SmallString<128> normalizePath(llvm::StringRef Path);
+
+enum class MainFileLocation {
+  MainFile,
+  DirectInclude,
+  Other,
+};
+MainFileLocation locateInMainFile(SourceLocation Loc, const SourceManager &SM);
 
 } // namespace clang::include_cleaner
 

--- a/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/TypesTest.cpp
@@ -10,6 +10,7 @@
 #include "TypesInternal.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/FileSystemOptions.h"
+#include "clang/Testing/TestAST.h"
 #include "clang/Tooling/Inclusions/StandardLibrary.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -112,6 +113,38 @@ TEST(NormalizePathTest, CanonicalizesSeparators) {
 
 TEST(NormalizePathTest, PreservesRootPath) {
   EXPECT_EQ(normalizePath("/").str(), "/");
+}
+
+TEST(MainFileLocationTest, ClassifiesSourceLocations) {
+  TestInputs Inputs;
+  Inputs.Code = R"cpp(
+    #include "direct.h"
+    int main_file;
+  )cpp";
+  Inputs.ExtraFiles["direct.h"] = R"cpp(
+    int direct_include;
+    #include "transitive.h"
+  )cpp";
+  Inputs.ExtraFiles["transitive.h"] = "int transitive_include;\n";
+  TestAST AST(Inputs);
+  const SourceManager &SM = AST.sourceManager();
+
+  EXPECT_EQ(locateInMainFile(SM.translateLineCol(SM.getMainFileID(), 3, 9), SM),
+            MainFileLocation::MainFile);
+  EXPECT_EQ(
+      locateInMainFile(
+          SM.translateFileLineCol(
+              &AST.fileManager().getOptionalFileRef("direct.h")->getFileEntry(),
+              2, 9),
+          SM),
+      MainFileLocation::DirectInclude);
+  EXPECT_EQ(locateInMainFile(
+                SM.translateFileLineCol(&AST.fileManager()
+                                             .getOptionalFileRef("transitive.h")
+                                             ->getFileEntry(),
+                                        1, 9),
+                SM),
+            MainFileLocation::Other);
 }
 
 } // namespace


### PR DESCRIPTION
Fragment support depends on a consistent distinction between the main file, direct includes, and other files. Sharing this classification avoids slightly different source-location rules across the codebase.