### PR TITLE
[clang-format] Harden annotation of operator keywords

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1684,6 +1684,8 @@ private:
       }
       while (CurrentToken &&
              CurrentToken->isNoneOf(tok::l_paren, tok::semi, tok::r_paren)) {
+        if (CurrentToken->isOneOf(tok::star, tok::amp))
+          CurrentToken->setType(TT_PointerOrReference);
         auto Next = CurrentToken->getNextNonComment();
         if (!Next)
           break;
@@ -1699,10 +1701,11 @@ private:
           break;
         if (Previous->isOneOf(TT_BinaryOperator, TT_UnaryOperator, tok::comma,
                               tok::arrow) ||
-            Previous->isPointerOrReference() ||
+            (!Previous->isTypeFinalized() &&
+             Previous->isPointerOrReference()) ||
             // User defined literal.
             Previous->TokenText.starts_with("\"\"")) {
-          Previous->overwriteFixedType(TT_OverloadedOperator);
+          Previous->setType(TT_OverloadedOperator);
           if (CurrentToken->isOneOf(tok::less, tok::greater))
             break;
         }

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1684,8 +1684,6 @@ private:
       }
       while (CurrentToken &&
              CurrentToken->isNoneOf(tok::l_paren, tok::semi, tok::r_paren)) {
-        if (CurrentToken->isOneOf(tok::star, tok::amp))
-          CurrentToken->setType(TT_PointerOrReference);
         auto Next = CurrentToken->getNextNonComment();
         if (!Next)
           break;
@@ -1704,7 +1702,7 @@ private:
             Previous->isPointerOrReference() ||
             // User defined literal.
             Previous->TokenText.starts_with("\"\"")) {
-          Previous->setType(TT_OverloadedOperator);
+          Previous->overwriteFixedType(TT_OverloadedOperator);
           if (CurrentToken->isOneOf(tok::less, tok::greater))
             break;
         }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -22318,6 +22318,7 @@ TEST_F(FormatTest, DoNotCrashOnInvalidInput) {
   verifyNoCrash("#define a\\\n /**/}");
   verifyNoCrash("        tst     %o5     ! are we doing the gray case?\n"
                 "LY52:                   ! [internal]");
+  verifyNoCrash("operator foo *;");
 }
 
 TEST_F(FormatTest, FormatsTableGenCode) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1208,9 +1208,6 @@ TEST_F(TokenAnnotatorTest, UnderstandsOverloadedOperators) {
   ASSERT_EQ(Tokens.size(), 9u) << Tokens;
   // Not TT_FunctionDeclarationName.
   EXPECT_TOKEN(Tokens[2], tok::kw_operator, TT_Unknown);
-
-  // Verify we don't crash.
-  annotate("operator foo*;");
 }
 
 TEST_F(TokenAnnotatorTest, OverloadedOperatorInTemplate) {

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -1208,6 +1208,9 @@ TEST_F(TokenAnnotatorTest, UnderstandsOverloadedOperators) {
   ASSERT_EQ(Tokens.size(), 9u) << Tokens;
   // Not TT_FunctionDeclarationName.
   EXPECT_TOKEN(Tokens[2], tok::kw_operator, TT_Unknown);
+
+  // Verify we don't crash.
+  annotate("operator foo*;");
 }
 
 TEST_F(TokenAnnotatorTest, OverloadedOperatorInTemplate) {


### PR DESCRIPTION
The star was already annotated as TT_PointerOrReference, just overwrite it for the sake of not crashing. Also remove the annotation above, since that would always be overwritten (or at least I don't see when not, and there's no failed test).

Fixes #196054.