### PR TITLE
[ELF] Fix --reproduce non-determinism with parallel input loading

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -188,6 +188,7 @@ struct LoadJob {
   uint32_t groupId;
   SmallVector<std::unique_ptr<InputFile>, 0> out;
   std::vector<std::unique_ptr<llvm::MemoryBuffer>> thinBufs;
+  SmallVector<std::pair<std::string, llvm::StringRef>, 0> tarEntries;
 };
 
 class LinkerDriver {

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -210,8 +210,8 @@ std::vector<std::pair<MemoryBufferRef, uint64_t>> static getArchiveMembers(
               mb.getBufferIdentifier() +
                   ": could not get the buffer for a child of the archive");
     if (addToTar)
-      ctx.tar->append(relativeToRoot(check(c.getFullName())),
-                      mbref.getBuffer());
+      job.tarEntries.emplace_back(relativeToRoot(check(c.getFullName())),
+                                  mbref.getBuffer());
     v.push_back(std::make_pair(mbref, c.getChildOffset()));
   }
   if (err)
@@ -246,6 +246,7 @@ void LinkerDriver::addFile(StringRef path, bool withLOption) {
                         /*asNeeded=*/false,
                         /*withLOption=*/false,
                         nextGroupId,
+                        {},
                         {},
                         {}});
   } else {
@@ -284,6 +285,7 @@ void LinkerDriver::addFile(StringRef path, bool withLOption) {
                         ctx.arg.asNeeded,
                         withLOption,
                         nextGroupId,
+                        {},
                         {},
                         {}});
   }
@@ -2202,6 +2204,9 @@ void LinkerDriver::loadFiles() {
   for (auto &job : loadJobs) {
     if (job.kind == LoadJob::Archive)
       archiveFiles.emplace_back(job.path, (unsigned)job.out.size());
+    if (ctx.tar)
+      for (const auto &[path, data] : job.tarEntries)
+        ctx.tar->append(path, data);
     files.append(std::make_move_iterator(job.out.begin()),
                  std::make_move_iterator(job.out.end()));
     ctx.memoryBuffers.append(std::make_move_iterator(job.thinBufs.begin()),

--- a/lld/test/ELF/reproduce-thin-archive.s
+++ b/lld/test/ELF/reproduce-thin-archive.s
@@ -12,11 +12,23 @@
 # CHECK: [[PATH]]/foo.a
 # CHECK: [[PATH]]/foo.o
 
-# RUN: ld.lld -m elf_x86_64 --whole-archive foo.a -o /dev/null --reproduce repro2.tar
+## With multiple thin archives + --threads>1, ensure deterministic member order.
+# RUN: llvm-mc -filetype=obj -triple=x86_64 /dev/null -o n.o
+# RUN: cp n.o b.o && cp n.o c.o && cp n.o d.o
+# RUN: llvm-ar --format=gnu rcT b.a b.o
+# RUN: llvm-ar --format=gnu rcT c.a c.o
+# RUN: llvm-ar --format=gnu rcT d.a d.o
+# RUN: ld.lld foo.a b.a --whole-archive c.a d.a --reproduce repro2.tar
 # RUN: tar tf repro2.tar | FileCheck -DPATH='repro2/%:t.dir' --check-prefix=CHECK2 %s
 
-# CHECK2: [[PATH]]/foo.a
-# CHECK2: [[PATH]]/foo.o
+# CHECK2:      [[PATH]]/foo.a
+# CHECK2-NEXT: [[PATH]]/b.a
+# CHECK2-NEXT: [[PATH]]/c.a
+# CHECK2-NEXT: [[PATH]]/d.a
+# CHECK2-NEXT: [[PATH]]/foo.o
+# CHECK2-NEXT: [[PATH]]/b.o
+# CHECK2-NEXT: [[PATH]]/c.o
+# CHECK2-NEXT: [[PATH]]/d.o
 
 .globl _start
 _start:


### PR DESCRIPTION
After #191690, LoadJob::Archive runs in parallel and getArchiveMembers()
calls ctx.tar->append() from the parallel body. TarWriter::append is
unsynchronized. Member order in the tar is also non-deterministic
because parallelFor scheduling determines append order.

Buffer per-job tar entries during the parallel pass and flush them in the
existing serial post-pass, mirroring the thinBufs / files pattern.