### PR TITLE
[BOLT] Fix EH data encoding checks in relocateEHFrameSection

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2162,13 +2162,10 @@ void RewriteInstance::relocateEHFrameSection() {
       return;
 
     // Only fix references that are relative to other locations.
-    if (!(DwarfType & dwarf::DW_EH_PE_pcrel) &&
-        !(DwarfType & dwarf::DW_EH_PE_textrel) &&
-        !(DwarfType & dwarf::DW_EH_PE_funcrel) &&
-        !(DwarfType & dwarf::DW_EH_PE_datarel))
-      return;
-
-    if (!(DwarfType & dwarf::DW_EH_PE_sdata4))
+    if ((DwarfType & 0x70) != dwarf::DW_EH_PE_pcrel &&
+        (DwarfType & 0x70) != dwarf::DW_EH_PE_textrel &&
+        (DwarfType & 0x70) != dwarf::DW_EH_PE_funcrel &&
+        (DwarfType & 0x70) != dwarf::DW_EH_PE_datarel)
       return;
 
     uint32_t RelType;

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2162,10 +2162,11 @@ void RewriteInstance::relocateEHFrameSection() {
       return;
 
     // Only fix references that are relative to other locations.
-    if ((DwarfType & 0x70) != dwarf::DW_EH_PE_pcrel &&
-        (DwarfType & 0x70) != dwarf::DW_EH_PE_textrel &&
-        (DwarfType & 0x70) != dwarf::DW_EH_PE_funcrel &&
-        (DwarfType & 0x70) != dwarf::DW_EH_PE_datarel)
+    const uint64_t Mask = 0xf0 & ~dwarf::DW_EH_PE_indirect;
+    if ((DwarfType & Mask) != dwarf::DW_EH_PE_pcrel &&
+        (DwarfType & Mask) != dwarf::DW_EH_PE_textrel &&
+        (DwarfType & Mask) != dwarf::DW_EH_PE_funcrel &&
+        (DwarfType & Mask) != dwarf::DW_EH_PE_datarel)
       return;
 
     uint32_t RelType;


### PR DESCRIPTION
Previously committed in 7ab26d7c3a16 (#195691) and later reverted
in bc654b438ffe (#196672) due to failures extended bolt-tests.

The problem was that the mask should be `0x70` instead of `0xf0`,
so to allow `DW_EH_PE_indirect` to pass through.