### PR TITLE
[libcxx] Switch to check-runtimes for generic-llvm-libc

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -466,19 +466,7 @@ generic-llvm-libc)
     # Ensure we have the builtins archive built as we pass it in explicitly in
     # the test config.
     ninja -vC "${BUILD_DIR}" libclang_rt.builtins-x86_64.a
-
-    # Manually run only libcxx/libcxxabi tests as we currently cannot build
-    # libunwind due to a missing dl_iterate_phdr implementation.
-    # TODO(boomanaiden154): Remove this once we can build libunwind and pass
-    # the tests.
-    step "Building libc++ test dependencies"
-    ninja -vC "${BUILD_DIR}" cxx-test-depends
-
-    step "Running the libc++ tests"
-    ninja -vC "${BUILD_DIR}" check-cxx
-
-    step "Running the libc++abi tests"
-    ninja -vC "${BUILD_DIR}" check-cxxabi
+    check-runtimes
 ;;
 #
 # Module builds


### PR DESCRIPTION
After a1d21ccf78e7893134c8c8cccd78e7d7d545a9c3 we have a dl_iterate_phdr implementation sufficiently complete to run the libunwind tests, so now we can remove the hack to avoid testing libunwind and just use the generic check-runtimes function.