### PR TITLE
[ADT] Remove xxHash64 ArrayRef/StringRef overloads. NFC

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -555,9 +555,6 @@ template <typename T> hash_code hash_value(ArrayRef<T> S) {
 /// Inline ArrayRef overloads of the xxhash entry points declared
 /// out-of-line in llvm/Support/xxhash.h. They live here so xxhash.h can stay
 /// free of ADT dependencies.
-inline uint64_t xxHash64(ArrayRef<uint8_t> data) {
-  return xxHash64(data.data(), data.size());
-}
 inline uint64_t xxh3_64bits(ArrayRef<uint8_t> data) {
   return xxh3_64bits(data.data(), data.size());
 }

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -944,9 +944,6 @@ inline std::string &operator+=(std::string &buffer, StringRef string) {
 /// Inline StringRef overloads of the xxhash entry points declared out-of-line
 /// in llvm/Support/xxhash.h. They live here so xxhash.h can stay free of ADT
 /// dependencies.
-inline uint64_t xxHash64(StringRef data) {
-  return xxHash64(reinterpret_cast<const uint8_t *>(data.data()), data.size());
-}
 inline uint64_t xxh3_64bits(StringRef data) {
   return xxh3_64bits(reinterpret_cast<const uint8_t *>(data.data()),
                      data.size());

--- a/llvm/lib/Support/Hash.cpp
+++ b/llvm/lib/Support/Hash.cpp
@@ -38,7 +38,9 @@ uint32_t llvm::getKCFITypeID(StringRef MangledTypeName,
   switch (Algorithm) {
   case KCFIHashAlgorithm::xxHash64:
     // Use lower 32 bits of xxHash64
-    return static_cast<uint32_t>(xxHash64(MangledTypeName));
+    return static_cast<uint32_t>(
+        xxHash64(reinterpret_cast<const uint8_t *>(MangledTypeName.data()),
+                 MangledTypeName.size()));
   case KCFIHashAlgorithm::FNV1a:
     // FNV-1a hash (32-bit)
     uint32_t Hash = 2166136261u; // FNV offset basis

--- a/llvm/unittests/Support/xxhashTest.cpp
+++ b/llvm/unittests/Support/xxhashTest.cpp
@@ -33,11 +33,15 @@ static void fillTestBuffer(uint8_t *buffer, size_t len) {
 }
 
 TEST(xxhashTest, Basic) {
-  EXPECT_EQ(0xef46db3751d8e999U, xxHash64(StringRef()));
-  EXPECT_EQ(0x33bf00a859c4ba3fU, xxHash64("foo"));
-  EXPECT_EQ(0x48a37c90ad27a659U, xxHash64("bar"));
+  EXPECT_EQ(0xef46db3751d8e999U, xxHash64(nullptr, 0));
+  EXPECT_EQ(0x33bf00a859c4ba3fU,
+            xxHash64(reinterpret_cast<const uint8_t *>("foo"), 3));
+  EXPECT_EQ(0x48a37c90ad27a659U,
+            xxHash64(reinterpret_cast<const uint8_t *>("bar"), 3));
   EXPECT_EQ(0x69196c1b3af0bff9U,
-            xxHash64("0123456789abcdefghijklmnopqrstuvwxyz"));
+            xxHash64(reinterpret_cast<const uint8_t *>(
+                         "0123456789abcdefghijklmnopqrstuvwxyz"),
+                     36));
 }
 
 TEST(xxhashTest, xxh3) {


### PR DESCRIPTION
xxHash64 is a legacy, pre-XXH3 hash whose only non-test caller in the
monorepo is llvm::getKCFITypeID. #196774 accidentally exposed the API.