### PR TITLE
[clangd][Parser][Sema] Fix TemplateIdAnnotation UAF with template-id …

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -581,6 +581,7 @@ Bug Fixes to C++ Support
 - Fixed a crash in Itanium C++ name mangling for a lambda in a local class field initializer inside a constructor/destructor. (#GH176395)
 - Fixed crashes in Itanium C++ name mangling for lambdas with trailing requires-clauses involving requires-expressions. (#GH100774) (#GH123854)
 - Fixed an invalid rejection and assertion failure while generating ``operator=`` for fields with the ``__restrict`` qualifier. (#GH37979)
+- Fixed a use-after-free bug when parsing default arguments containing lambdas in declarations with template-id declarators. (#GH196725)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7748,6 +7748,14 @@ void Parser::ParseParameterDeclarationClause(
           // Consume the '='.
           ConsumeToken();
 
+          // The default argument may contain a lambda whose body triggers
+          // MaybeDestroyTemplateIds at the end of the inner statements; avoid
+          // destroying parsed template-ids that may still be referenced by
+          // the enclosing declarator (e.g. a template-id in the function
+          // name or other parameters).
+          DelayTemplateIdDestructionRAII DontDestructTemplateIds(
+              *this, /*DelayTemplateIdDestruction=*/true);
+
           // The argument isn't actually potentially evaluated unless it is
           // used.
           EnterExpressionEvaluationContext Eval(

--- a/clang/test/Parser/cxx-default-args.cpp
+++ b/clang/test/Parser/cxx-default-args.cpp
@@ -40,3 +40,9 @@ struct U {
   void i(int x = ) {} // expected-error{{expected expression}}
   typedef int *fp(int x = ); // expected-error{{default arguments can only be specified for parameters in a function declaration}}
 };
+
+namespace {
+void f<>(int = []{;}) {} // expected-error{{no viable conversion from}} \
+                         // expected-error{{template specialization requires 'template<>'}} \
+                         // expected-note 2{{}}
+}

--- a/clang/test/Parser/cxx-default-args.cpp
+++ b/clang/test/Parser/cxx-default-args.cpp
@@ -41,8 +41,8 @@ struct U {
   typedef int *fp(int x = ); // expected-error{{default arguments can only be specified for parameters in a function declaration}}
 };
 
-namespace {
-void f<>(int = []{;}) {} // expected-error{{no viable conversion from}} \
-                         // expected-error{{template specialization requires 'template<>'}} \
-                         // expected-note 2{{}}
+namespace GH196725 {
+template <class T> void f();
+template <> void f<int>(int = []{ ; return 0; }()) {} // expected-error{{no function template matches function template specialization 'f'}} \
+                                                      // expected-note@-1{{candidate template ignored}}
 }


### PR DESCRIPTION
…declarator and lambda default argument.

I think this is another case of template annotations lifetime bug, similar to the one fixed by https://github.com/llvm/llvm-project/pull/89494.

Closes https://github.com/llvm/llvm-project/issues/196725.