### PR TITLE
[LLVM] Precise error message for intrinsic signature verification (1/n)

### DIFF
--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -866,7 +866,8 @@ struct MatchPosition {
   uint16_t IsRet : 1;
   uint16_t Num : 15; // Argument number (when IsRet = false).
   struct Index {
-    uint16_t IsStruct : 1; // Is this a struct element or vector element?
+    uint16_t IsStruct : 1; // If true, this is a struct element with element
+                           // index `Num`, else its a vector element.
     uint16_t Num : 15;     // Struct element index.
   };
   // We expect this to be just 2 levels deep, since nested structs are not
@@ -1002,8 +1003,7 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     bool IsValid = PT && PT->getAddressSpace() == AS;
     if (AS == 0)
       return PrintMsg(IsValid, "ptr");
-    else
-      return PrintMsg(IsValid, "ptr addrspace(" + Twine(AS) + ")");
+    return PrintMsg(IsValid, "ptr addrspace(" + Twine(AS) + ")");
   }
 
   case IITDescriptor::Struct: {

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -34,6 +34,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/NVVMIntrinsicUtils.h"
 #include "llvm/IR/Type.h"
+#include "llvm/Support/MathExtras.h"
 
 using namespace llvm;
 
@@ -844,81 +845,183 @@ bool Intrinsic::hasConstrainedFPRoundingModeOperand(Intrinsic::ID QID) {
   }
 }
 
-using DeferredIntrinsicMatchPair =
-    std::pair<Type *, ArrayRef<Intrinsic::IITDescriptor>>;
+// This class represents a position in the intrinsic's type signature and is
+// used to generate error messages in `matchIntrinsicType`. The printed position
+// can be of the following forms:
+//
+//   return
+//   return struct element 3
+//   return vector element
+//   return struct element 3 vector element
+//   argument 3
+//   argument 3 vector element
+//
+// To support deferred checks also being able to generate these error messages
+// we need to encode the position compactly so that it can be stashed into
+// DeferredIntrinsicMatchInfo below (without materializing it into a string).
+// The class below serves that purpose.
+//
+namespace {
+struct MatchPosition {
+  uint16_t IsRet : 1;
+  uint16_t Num : 15; // Argument number (when IsRet = false).
+  struct Index {
+    uint16_t IsStruct : 1; // Is this a struct element or vector element?
+    uint16_t Num : 15;     // Struct element index.
+  };
+  // We expect this to be just 2 levels deep, since nested structs are not
+  // supported.
+  static constexpr unsigned INDEX_TABLE_SIZE = 2;
+  Index Indices[INDEX_TABLE_SIZE];
+  uint16_t NumIndices = 0;
+
+  void pop_index() {
+    assert(NumIndices > 0 && "cannot pop from empty indices");
+    --NumIndices;
+  }
+
+  void push_struct_element(unsigned ElementNum) {
+    assert(NumIndices < INDEX_TABLE_SIZE && "index table overflow");
+    assert(isInt<15>(ElementNum) && "Element index overflow");
+    Indices[NumIndices].IsStruct = true;
+    Indices[NumIndices++].Num = ElementNum;
+  }
+
+  void push_vector_element() {
+    assert(NumIndices < INDEX_TABLE_SIZE && "index table overflow");
+    Indices[NumIndices].IsStruct = false;
+    Indices[NumIndices++].Num = 0;
+  }
+};
+} // namespace
+
+static raw_ostream &operator<<(raw_ostream &OS, const MatchPosition &Pos) {
+  OS << "intrinsic ";
+
+  if (Pos.IsRet)
+    OS << "return";
+  else
+    OS << "argument " << Pos.Num;
+
+  for (const MatchPosition::Index &Idx :
+       ArrayRef(Pos.Indices).take_front(Pos.NumIndices)) {
+    if (Idx.IsStruct)
+      OS << " struct element " << Idx.Num;
+    else
+      OS << " vector element";
+  }
+  return OS;
+}
+
+using DeferredIntrinsicMatchInfo =
+    std::tuple<Type *, ArrayRef<Intrinsic::IITDescriptor>, MatchPosition>;
 
 static bool
 matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
-                   SmallVectorImpl<Type *> &OverloadTys,
-                   SmallVectorImpl<DeferredIntrinsicMatchPair> &DeferredChecks,
-                   bool IsDeferredCheck) {
+                   MatchPosition Position, SmallVectorImpl<Type *> &OverloadTys,
+                   SmallVectorImpl<DeferredIntrinsicMatchInfo> &DeferredChecks,
+                   bool IsDeferredCheck, raw_ostream &OS) {
   using namespace Intrinsic;
 
-  // If we ran out of descriptors, there are too many arguments.
-  if (Infos.empty())
+  // If we ran out of descriptors, there are too many arguments or returns.
+  if (Infos.empty()) {
+    OS << Position << " too many "
+       << (Position.IsRet ? "returns" : "arguments");
     return true;
+  }
 
   // Do this before slicing off the 'front' part
   auto InfosRef = Infos;
-  auto DeferCheck = [&DeferredChecks, &InfosRef](Type *T) {
-    DeferredChecks.emplace_back(T, InfosRef);
+  auto DeferCheck = [&DeferredChecks, &InfosRef, &Position](Type *T) {
+    DeferredChecks.emplace_back(T, InfosRef, Position);
     return false;
   };
 
   IITDescriptor D = Infos.consume_front();
 
+  auto PrintMsg = [&OS, &Position, Ty](bool IsValid,
+                                       const Twine &Expected) -> bool {
+    if (IsValid)
+      return false;
+    OS << Position << " type expected " << Expected << ", but got " << *Ty;
+    return true;
+  };
+
   switch (D.Kind) {
   case IITDescriptor::Void:
-    return !Ty->isVoidTy();
+    assert(Position.IsRet && Position.NumIndices == 0 &&
+           "void descriptor expected only for return type");
+    return PrintMsg(Ty->isVoidTy(), "void");
   case IITDescriptor::MMX: {
     FixedVectorType *VT = dyn_cast<FixedVectorType>(Ty);
-    return !VT || VT->getNumElements() != 1 ||
-           !VT->getElementType()->isIntegerTy(64);
+    return PrintMsg(VT && VT->getNumElements() == 1 &&
+                        VT->getElementType()->isIntegerTy(64),
+                    "x86_mmx (<1 x i64>)");
   }
   case IITDescriptor::AMX:
-    return !Ty->isX86_AMXTy();
+    return PrintMsg(Ty->isX86_AMXTy(), "x86_amx");
   case IITDescriptor::Token:
-    return !Ty->isTokenTy();
+    return PrintMsg(Ty->isTokenTy(), "token");
   case IITDescriptor::Metadata:
-    return !Ty->isMetadataTy();
+    return PrintMsg(Ty->isMetadataTy(), "metadata");
   case IITDescriptor::Half:
-    return !Ty->isHalfTy();
+    return PrintMsg(Ty->isHalfTy(), "half");
   case IITDescriptor::BFloat:
-    return !Ty->isBFloatTy();
+    return PrintMsg(Ty->isBFloatTy(), "bfloat");
   case IITDescriptor::Float:
-    return !Ty->isFloatTy();
+    return PrintMsg(Ty->isFloatTy(), "float");
   case IITDescriptor::Double:
-    return !Ty->isDoubleTy();
+    return PrintMsg(Ty->isDoubleTy(), "double");
   case IITDescriptor::Quad:
-    return !Ty->isFP128Ty();
+    return PrintMsg(Ty->isFP128Ty(), "fp128");
   case IITDescriptor::PPCQuad:
-    return !Ty->isPPC_FP128Ty();
+    return PrintMsg(Ty->isPPC_FP128Ty(), "ppc_fp128");
   case IITDescriptor::Integer:
-    return !Ty->isIntegerTy(D.IntegerWidth);
+    return PrintMsg(Ty->isIntegerTy(D.IntegerWidth),
+                    "i" + Twine(D.IntegerWidth));
   case IITDescriptor::AArch64Svcount:
-    return !isa<TargetExtType>(Ty) ||
-           cast<TargetExtType>(Ty)->getName() != "aarch64.svcount";
+    return PrintMsg(isa<TargetExtType>(Ty) &&
+                        cast<TargetExtType>(Ty)->getName() == "aarch64.svcount",
+                    "aarch64.svcount");
   case IITDescriptor::Vector: {
     VectorType *VT = dyn_cast<VectorType>(Ty);
-    return !VT || VT->getElementCount() != D.VectorWidth ||
-           matchIntrinsicType(VT->getElementType(), Infos, OverloadTys,
-                              DeferredChecks, IsDeferredCheck);
+    StringRef Scalable = D.VectorWidth.isScalable() ? "vscale " : "";
+    bool HasError =
+        PrintMsg(VT && VT->getElementCount() == D.VectorWidth,
+                 Twine(Scalable) + "vector with " +
+                     Twine(D.VectorWidth.getKnownMinValue()) + " elements");
+    if (HasError)
+      return true;
+    Position.push_vector_element();
+    return matchIntrinsicType(VT->getElementType(), Infos, Position,
+                              OverloadTys, DeferredChecks, IsDeferredCheck, OS);
   }
   case IITDescriptor::Pointer: {
     PointerType *PT = dyn_cast<PointerType>(Ty);
-    return !PT || PT->getAddressSpace() != D.PointerAddressSpace;
+    unsigned AS = D.PointerAddressSpace;
+    bool IsValid = PT && PT->getAddressSpace() == AS;
+    if (AS == 0)
+      return PrintMsg(IsValid, "ptr");
+    else
+      return PrintMsg(IsValid, "ptr addrspace(" + Twine(AS) + ")");
   }
 
   case IITDescriptor::Struct: {
     StructType *ST = dyn_cast<StructType>(Ty);
-    if (!ST || !ST->isLiteral() || ST->isPacked() ||
-        ST->getNumElements() != D.StructNumElements)
+    unsigned EC = D.StructNumElements;
+    bool HasError = PrintMsg(
+        ST && ST->isLiteral() && !ST->isPacked() && ST->getNumElements() == EC,
+        "literal non-packed struct with " + Twine(EC) + " elements");
+    if (HasError)
       return true;
 
-    for (unsigned i = 0, e = D.StructNumElements; i != e; ++i)
-      if (matchIntrinsicType(ST->getElementType(i), Infos, OverloadTys,
-                             DeferredChecks, IsDeferredCheck))
+    for (const auto &[Idx, ETy] : llvm::enumerate(ST->elements())) {
+      Position.push_struct_element(Idx);
+      if (matchIntrinsicType(ETy, Infos, Position, OverloadTys, DeferredChecks,
+                             IsDeferredCheck, OS))
         return true;
+      Position.pop_index();
+    }
     return false;
   }
 
@@ -997,9 +1100,10 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
       if (ReferenceType->getElementCount() != ThisArgType->getElementCount())
         return true;
       EltTy = ThisArgType->getElementType();
+      Position.push_vector_element();
     }
-    return matchIntrinsicType(EltTy, Infos, OverloadTys, DeferredChecks,
-                              IsDeferredCheck);
+    return matchIntrinsicType(EltTy, Infos, Position, OverloadTys,
+                              DeferredChecks, IsDeferredCheck, OS);
   }
   case IITDescriptor::VecOfAnyPtrsToElt: {
     unsigned RefOverloadIndex = D.getRefOverloadIndex();
@@ -1079,10 +1183,27 @@ static bool isSignatureValid(FunctionType *FTy,
                              unsigned NumArgs, bool IsVarArg,
                              SmallVectorImpl<Type *> &OverloadTys,
                              raw_ostream &OS) {
-  SmallVector<DeferredIntrinsicMatchPair, 2> DeferredChecks;
-  if (matchIntrinsicType(FTy->getReturnType(), Infos, OverloadTys,
-                         DeferredChecks, false)) {
-    OS << "intrinsic has incorrect return type!";
+  SmallVector<DeferredIntrinsicMatchInfo, 2> DeferredChecks;
+
+  assert(!Infos.empty() && "Table consistency error");
+
+  MatchPosition Pos;
+  Pos.IsRet = true;
+  Pos.Num = 0;
+
+  // Temporary fix to print an error message if `matchIntrinsicType` fails but
+  // does not print an error message. This will be removed once all failing
+  // cases in `matchIntrinsicType` start generating error messages.
+  uint64_t OSPos = OS.tell();
+  auto PrintMsg = [OSPos, &OS](StringRef Msg) {
+    if (OS.tell() != OSPos)
+      return;
+    OS << Msg;
+  };
+
+  if (matchIntrinsicType(FTy->getReturnType(), Infos, Pos, OverloadTys,
+                         DeferredChecks, false, OS)) {
+    PrintMsg("intrinsic has incorrect return type!");
     return false;
   }
   unsigned NumDeferredReturnChecks = DeferredChecks.size();
@@ -1093,22 +1214,25 @@ static bool isSignatureValid(FunctionType *FTy,
     return false;
   }
 
-  for (Type *Ty : FTy->params()) {
-    if (matchIntrinsicType(Ty, Infos, OverloadTys, DeferredChecks, false)) {
-      OS << "intrinsic has incorrect argument type!";
+  Pos.IsRet = false;
+  for (const auto &[Idx, Ty] : llvm::enumerate(FTy->params())) {
+    Pos.Num = Idx;
+    if (matchIntrinsicType(Ty, Infos, Pos, OverloadTys, DeferredChecks, false,
+                           OS)) {
+      PrintMsg("intrinsic has incorrect argument type!");
       return false;
     }
   }
 
   for (unsigned I = 0, E = DeferredChecks.size(); I != E; ++I) {
-    DeferredIntrinsicMatchPair &Check = DeferredChecks[I];
-    if (!matchIntrinsicType(Check.first, Check.second, OverloadTys,
-                            DeferredChecks, true))
+    auto &[DefTy, DefInfos, DefPosition] = DeferredChecks[I];
+    if (!matchIntrinsicType(DefTy, DefInfos, DefPosition, OverloadTys,
+                            DeferredChecks, true, OS))
       continue;
     if (I < NumDeferredReturnChecks)
-      OS << "intrinsic has incorrect return type!";
+      PrintMsg("intrinsic has incorrect return type!");
     else
-      OS << "intrinsic has incorrect argument type!";
+      PrintMsg("intrinsic has incorrect argument type!");
     return false;
   }
 

--- a/llvm/test/CodeGen/AArch64/sve-bad-intrinsics.ll
+++ b/llvm/test/CodeGen/AArch64/sve-bad-intrinsics.ll
@@ -4,13 +4,13 @@
 declare <4 x float> @llvm.arm.neon.vcvthf2fp(<vscale x 4 x i16>)
 declare <vscale x 4 x i16> @llvm.arm.neon.vcvtfp2hf(<vscale x 4 x float>)
 
-; CHECK-ERROR: intrinsic has incorrect return type!
+; CHECK-ERROR: intrinsic return type expected vector with 4 elements, but got <vscale x 4 x i16>
 define <vscale x 4 x i16> @bad1() {
   %r = call <vscale x 4 x i16> @llvm.arm.neon.vcvtfp2hf(<vscale x 4 x float> zeroinitializer)
   ret <vscale x 4 x i16> %r
 }
 
-; CHECK-ERROR: intrinsic has incorrect argument type!
+; CHECK-ERROR: intrinsic argument 0 type expected vector with 4 elements, but got <vscale x 4 x i16>
 define <4 x float> @bad2() {
   %r = call <4 x float> @llvm.arm.neon.vcvthf2fp(<vscale x 4 x i16> zeroinitializer)
   ret <4 x float> %r

--- a/llvm/test/CodeGen/WinEH/wineh-intrinsics-invalid.ll
+++ b/llvm/test/CodeGen/WinEH/wineh-intrinsics-invalid.ll
@@ -11,7 +11,7 @@ declare void @f()
 ;T1:   call ptr @llvm.eh.exceptionpointer.p0(i32 0)
 ;T1:   ret void
 ;T1: }
-;CHECK1: intrinsic has incorrect argument type!
+;CHECK1: intrinsic argument 0 type expected token, but got i32
 ;CHECK1-NEXT: ptr @llvm.eh.exceptionpointer.p0
 
 ;T2: declare ptr @llvm.eh.exceptionpointer.p0(token)

--- a/llvm/test/Verifier/intrinsic-bad-arg-type1.ll
+++ b/llvm/test/Verifier/intrinsic-bad-arg-type1.ll
@@ -275,3 +275,17 @@ entry:
   call { i32, i2 } @llvm.nvvm.elect.sync(i32 0)
   ret void
 }
+
+;--- test21.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test21.ll | FileCheck %t/test21.ll
+; CHECK: intrinsic return type expected literal non-packed struct with 2 elements, but got { i32, i1, i1 }
+; CHECK-NEXT: ptr @llvm.nvvm.elect.sync
+
+; Expected return type is { i32, i1 }.
+declare { i32, i1, i1 } @llvm.nvvm.elect.sync(i32)
+
+define void @test1() {
+entry:
+  call { i32, i1, i1 } @llvm.nvvm.elect.sync(i32 0)
+  ret void
+}

--- a/llvm/test/Verifier/intrinsic-bad-arg-type1.ll
+++ b/llvm/test/Verifier/intrinsic-bad-arg-type1.ll
@@ -1,0 +1,277 @@
+; RUN: split-file %s %t
+
+;--- test0.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test0.ll | FileCheck %t/test0.ll
+; CHECK: intrinsic return type expected void, but got float
+; CHECK-NEXT: ptr @llvm.set.rounding
+
+declare float @llvm.set.rounding(i32)
+
+define void @test0() {
+entry:
+  %t = call float @llvm.set.rounding(i32 0)
+  ret void
+}
+
+;--- test1.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test1.ll | FileCheck %t/test1.ll
+; CHECK: intrinsic return type expected x86_mmx (<1 x i64>), but got x86_amx
+; CHECK-NEXT: ptr @llvm.x86.sse.cvtps2pi
+
+declare x86_amx @llvm.x86.sse.cvtps2pi(<4 x float>)
+
+define void @test1(<4 x float> %a) {
+entry:
+  %t = call x86_amx @llvm.x86.sse.cvtps2pi(<4 x float> %a)
+  ret void
+}
+
+;--- test2.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test2.ll | FileCheck %t/test2.ll
+; CHECK: intrinsic argument 1 type expected x86_mmx (<1 x i64>), but got i32
+; CHECK-NEXT: ptr @llvm.x86.sse.cvtpi2ps
+
+declare <4 x float> @llvm.x86.sse.cvtpi2ps(<4 x float>, i32)
+
+define void @test1(<4 x float> %a) {
+entry:
+  %t = call <4 x float> @llvm.x86.sse.cvtpi2ps(<4 x float> %a, i32 0)
+  ret void
+}
+
+;--- test3.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test3.ll | FileCheck %t/test3.ll
+; CHECK: intrinsic return type expected x86_amx, but got float
+; CHECK-NEXT: ptr @llvm.x86.tileloadd64.internal
+
+declare float @llvm.x86.tileloadd64.internal(i16, i16, ptr, i64)
+
+define void @test1(ptr %a) {
+entry:
+  %t = call float @llvm.x86.tileloadd64.internal(i16 0, i16 0, ptr %a, i64 0)
+  ret void
+}
+
+;--- test4.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test4.ll | FileCheck %t/test4.ll
+; CHECK: intrinsic return type expected token, but got i32
+; CHECK-NEXT: ptr @llvm.call.preallocated.setup
+
+declare i32 @llvm.call.preallocated.setup(i32)
+
+define void @test1() {
+entry:
+  %t = call i32 @llvm.call.preallocated.setup(i32 0)
+  ret void
+}
+
+;--- test5.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test5.ll | FileCheck %t/test5.ll
+; CHECK: intrinsic argument 1 type expected metadata, but got i16
+; CHECK-NEXT: ptr @llvm.fptrunc.round.f64.f64
+
+declare double @llvm.fptrunc.round.f64.f64(double, i16)
+
+define void @test1() {
+entry:
+  %t = call double @llvm.fptrunc.round.f64.f64(double 1.0, i16 0)
+  ret void
+}
+
+;--- test6.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test6.ll | FileCheck %t/test6.ll
+; CHECK: intrinsic argument 0 type expected half, but got i16
+; CHECK-NEXT: ptr @llvm.nvvm.mul.rn.sat.f16
+
+declare half @llvm.nvvm.mul.rn.sat.f16(i16, half)
+
+define void @test1() {
+entry:
+  %t = call half @llvm.nvvm.mul.rn.sat.f16(i16 0, half 1.0)
+  ret void
+}
+
+;--- test7.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test7.ll | FileCheck %t/test7.ll
+; CHECK: intrinsic return type expected bfloat, but got half
+; CHECK-NEXT: ptr @llvm.arm.neon.vcvtbfp2bf
+
+declare half @llvm.arm.neon.vcvtbfp2bf(float)
+
+define void @test1() {
+entry:
+  %t = call half @llvm.arm.neon.vcvtbfp2bf(float 0.0)
+  ret void
+}
+
+;--- test8.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test8.ll | FileCheck %t/test8.ll
+; CHECK: intrinsic argument 2 type expected float, but got half
+; CHECK-NEXT: ptr @llvm.x86.avx512.vfmadd.f32
+
+declare float @llvm.x86.avx512.vfmadd.f32(float, float, half, i32)
+
+define void @test1() {
+entry:
+  %t = call float @llvm.x86.avx512.vfmadd.f32(float 0.0, float 0.0, half 0.0, i32 0)
+  ret void
+}
+
+;--- test9.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test9.ll | FileCheck %t/test9.ll
+; CHECK: intrinsic argument 2 type expected double, but got half
+; CHECK-NEXT: ptr @llvm.expect.with.probability.i32
+
+declare i32 @llvm.expect.with.probability.i32(i32, i32, half)
+
+define void @test1() {
+entry:
+  %t = call i32 @llvm.expect.with.probability.i32(i32 0, i32 0, half 0.0)
+  ret void
+}
+
+;--- test10.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test10.ll | FileCheck %t/test10.ll
+; CHECK: intrinsic argument 0 type expected fp128, but got double
+; CHECK-NEXT: ptr @llvm.ppc.truncf128.round.to.odd
+
+declare double @llvm.ppc.truncf128.round.to.odd(double)
+
+define void @test1() {
+entry:
+  %t = call double @llvm.ppc.truncf128.round.to.odd(double 0.0)
+  ret void
+}
+
+;--- test11.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test11.ll | FileCheck %t/test11.ll
+; CHECK: intrinsic argument 0 type expected ppc_fp128, but got double
+; CHECK-NEXT: ptr  @llvm.ppc.unpack.longdouble
+
+declare double @llvm.ppc.unpack.longdouble(double, i32)
+
+define void @test1() {
+entry:
+  %t = call double @llvm.ppc.unpack.longdouble(double 0.0, i32 0)
+  ret void
+}
+
+;--- test12.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test12.ll | FileCheck %t/test12.ll
+; CHECK: intrinsic return type expected i64, but got double
+; CHECK-NEXT: ptr @llvm.readcyclecounter
+
+declare double @llvm.readcyclecounter()
+
+define void @test1() {
+entry:
+  %t = call double @llvm.readcyclecounter()
+  ret void
+}
+
+;--- test13.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test13.ll | FileCheck %t/test13.ll
+; CHECK: intrinsic argument 0 type expected aarch64.svcount, but got i32
+; CHECK-NEXT: ptr @llvm.aarch64.sve.pext
+
+declare <4 x i32> @llvm.aarch64.sve.pext(i32, i32)
+
+define void @test1() {
+entry:
+  %t = call <4 x i32> @llvm.aarch64.sve.pext(i32 0, i32 0)
+  ret void
+}
+
+;--- test14.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test14.ll | FileCheck %t/test14.ll
+; CHECK: intrinsic return type expected vector with 16 elements, but got i32
+; CHECK-NEXT: ptr @llvm.aarch64.neon.pmull64
+
+; Correct return type is <16 x i8>
+declare i32 @llvm.aarch64.neon.pmull64(i64, i64)
+
+define void @test1() {
+entry:
+  %t = call i32 @llvm.aarch64.neon.pmull64(i64 0, i64 0)
+  ret void
+}
+
+;--- test15.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test15.ll | FileCheck %t/test15.ll
+; CHECK: intrinsic return vector element type expected i8, but got i32
+; CHECK-NEXT: ptr @llvm.aarch64.neon.pmull64
+
+declare <16 x i32> @llvm.aarch64.neon.pmull64(i64, i64)
+
+define void @test1() {
+entry:
+  %t = call <16 x i32> @llvm.aarch64.neon.pmull64(i64 0, i64 0)
+  ret void
+}
+
+;--- test16.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test16.ll | FileCheck %t/test16.ll
+; CHECK: intrinsic return type expected vector with 16 elements, but got <vscale x 16 x i32>
+; CHECK-NEXT: ptr @llvm.aarch64.neon.pmull64
+
+declare <vscale x 16 x i32> @llvm.aarch64.neon.pmull64(i64, i64)
+
+define void @test1() {
+entry:
+  %t = call <vscale x 16 x i32> @llvm.aarch64.neon.pmull64(i64 0, i64 0)
+  ret void
+}
+
+;--- test17.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test17.ll | FileCheck %t/test17.ll
+; CHECK: intrinsic argument 1 type expected ptr, but got i32
+; CHECK-NEXT: ptr @llvm.gcroot
+
+declare void @llvm.gcroot(ptr, i32)
+
+define void @test1() {
+entry:
+  call void @llvm.gcroot(ptr null, i32 0)
+  ret void
+}
+
+;--- test18.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test18.ll | FileCheck %t/test18.ll
+; CHECK: intrinsic argument 0 type expected ptr addrspace(1), but got ptr
+; CHECK-NEXT: ptr @llvm.nvvm.applypriority.global.L2.evict.normal
+
+declare void @llvm.nvvm.applypriority.global.L2.evict.normal(ptr, i64)
+
+define void @test1() {
+entry:
+  call void @llvm.nvvm.applypriority.global.L2.evict.normal(ptr null, i64 0)
+  ret void
+}
+
+;--- test19.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test19.ll | FileCheck %t/test19.ll
+; CHECK: intrinsic return type expected literal non-packed struct with 2 elements, but got void
+; CHECK-NEXT: ptr @llvm.nvvm.elect.sync
+
+; Expected return type is { i32, i1 }.
+declare void @llvm.nvvm.elect.sync(i32)
+
+define void @test1() {
+entry:
+  call void @llvm.nvvm.elect.sync(i32 0)
+  ret void
+}
+
+;--- test20.ll
+; RUN: not opt -S -passes=verify 2>&1 < %t/test20.ll | FileCheck %t/test20.ll
+; CHECK: intrinsic return struct element 1 type expected i1, but got i2
+; CHECK-NEXT: ptr @llvm.nvvm.elect.sync
+
+; Expected return type is { i32, i1 }.
+declare { i32, i2 } @llvm.nvvm.elect.sync(i32)
+
+define void @test1() {
+entry:
+  call { i32, i2 } @llvm.nvvm.elect.sync(i32 0)
+  ret void
+}

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -537,4 +537,40 @@ TEST(VerifierTest, DeeplyNested) {
   EXPECT_FALSE(verifyModule(M, &ErrorOS));
 }
 
+TEST(VerifierTest, IntrinsicRetInvalidStruct) {
+  LLVMContext Ctx;
+
+  // Create 2 invalid struct types for @llvm.nvvm.elect.sync intrinsic.
+  Type *I32Ty = Type::getInt32Ty(Ctx);
+  Type *I1Ty = Type::getInt1Ty(Ctx);
+
+  StructType *NonLiteral = StructType::create(Ctx, {I32Ty, I1Ty}, "st");
+  StructType *LiteralPacked =
+      StructType::get(Ctx, {I32Ty, I1Ty}, /*isPacked=*/true);
+  for (StructType *STy : {NonLiteral, LiteralPacked}) {
+    Module M("M", Ctx);
+    FunctionType *IntrFTy = FunctionType::get(STy, I32Ty, /*isVarArg=*/false);
+    Function *Intr = Function::Create(IntrFTy, Function::InternalLinkage,
+                                      "llvm.nvvm.elect.sync", M);
+
+    FunctionType *FTy =
+        FunctionType::get(Type::getVoidTy(Ctx), /*isVarArg=*/false);
+    Function *F = Function::Create(FTy, Function::ExternalLinkage, "foo", M);
+    BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", F);
+
+    Constant *Zero = ConstantInt::get(I32Ty, 0);
+    CallInst::Create(Intr, Zero, /*Bundles=*/{}, "ci", Entry);
+    ReturnInst::Create(Ctx, Entry);
+
+    std::string Error;
+    raw_string_ostream ErrorOS(Error);
+    EXPECT_TRUE(verifyFunction(*F, &ErrorOS));
+
+    EXPECT_TRUE(StringRef(Error).starts_with(
+        "intrinsic return type expected literal non-packed struct with 2 "
+        "elements, but got"))
+        << Error;
+  }
+}
+
 } // end anonymous namespace


### PR DESCRIPTION
Generate more precise error message when intrinsic signature verification fails. Keep track of the current position/component of the intrinsic signature being checked and print a more descriptive error message which includes the position/element of the signature that failed and the reason it failed.

Note that not all cases in `matchIntrinsicType` generate errors, so have a temporary fallback to keep generating a generic error message in those cases. This fallback will be eventually removed.

Added a C++ unit test for testing intrinsic struct return type that is either an identified struct or a packed struct, as these cases cannot be created from a .ll file directly (since autoupgrade in the parser fixes them up).