### PR TITLE
[NFC][LLVM][IRTests] Namespace cleanup

### DIFF
--- a/llvm/unittests/IR/BasicBlockTest.cpp
+++ b/llvm/unittests/IR/BasicBlockTest.cpp
@@ -21,7 +21,8 @@
 #include "gtest/gtest.h"
 #include <memory>
 
-namespace llvm {
+using namespace llvm;
+
 namespace {
 
 TEST(BasicBlockTest, PhiRange) {
@@ -546,4 +547,3 @@ TEST(BasicBlockTest, DiscardValueNames2) {
 }
 
 } // End anonymous namespace.
-} // End llvm namespace.

--- a/llvm/unittests/IR/ConstantsTest.cpp
+++ b/llvm/unittests/IR/ConstantsTest.cpp
@@ -19,7 +19,8 @@
 #include "llvm/Support/SourceMgr.h"
 #include "gtest/gtest.h"
 
-namespace llvm {
+using namespace llvm;
+
 namespace {
 
 // Check that use count checks treat ConstantData like they have no uses.
@@ -920,4 +921,3 @@ TEST(ConstantsTest, ToConstantRangeConstantByteVector) {
 }
 
 } // end anonymous namespace
-} // end namespace llvm

--- a/llvm/unittests/IR/DroppedVariableStatsIRTest.cpp
+++ b/llvm/unittests/IR/DroppedVariableStatsIRTest.cpp
@@ -24,8 +24,6 @@
 #include <llvm/Support/raw_ostream.h>
 
 using namespace llvm;
-namespace llvm {
-void initializePassTest1Pass(PassRegistry &);
 
 static std::unique_ptr<Module> parseIR(LLVMContext &C, const char *IR) {
   SMDiagnostic Err;
@@ -34,7 +32,6 @@ static std::unique_ptr<Module> parseIR(LLVMContext &C, const char *IR) {
     Err.print("AbstractCallSiteTests", errs());
   return Mod;
 }
-} // namespace llvm
 
 namespace {
 

--- a/llvm/unittests/IR/InstructionsTest.cpp
+++ b/llvm/unittests/IR/InstructionsTest.cpp
@@ -33,8 +33,7 @@
 #include "gtest/gtest.h"
 #include <memory>
 
-namespace llvm {
-namespace {
+using namespace llvm;
 
 static std::unique_ptr<Module> parseIR(LLVMContext &C, const char *IR) {
   SMDiagnostic Err;
@@ -43,6 +42,8 @@ static std::unique_ptr<Module> parseIR(LLVMContext &C, const char *IR) {
     Err.print("InstructionsTests", errs());
   return Mod;
 }
+
+namespace {
 
 TEST(InstructionsTest, ReturnInst) {
   LLVMContext C;
@@ -2011,4 +2012,3 @@ TEST(InstructionsTest, StripAndAccumulateConstantOffset) {
 }
 
 } // end anonymous namespace
-} // end namespace llvm

--- a/llvm/unittests/IR/TimePassesTest.cpp
+++ b/llvm/unittests/IR/TimePassesTest.cpp
@@ -29,6 +29,8 @@ namespace llvm {
 void initializePass1Pass(PassRegistry &);
 void initializePass2Pass(PassRegistry &);
 
+} // namespace llvm
+
 namespace {
 struct Pass1 : public ModulePass {
   static char ID;
@@ -56,7 +58,6 @@ public:
 };
 char Pass2::ID;
 } // namespace
-} // namespace llvm
 
 INITIALIZE_PASS(Pass1, "Pass1", "Pass1", false, false)
 INITIALIZE_PASS(Pass2, "Pass2", "Pass2", false, false)
@@ -75,8 +76,8 @@ TEST(TimePassesTest, LegacyCustomOut) {
 
   // Setup pass manager
   legacy::PassManager PM1;
-  PM1.add(new llvm::Pass1());
-  PM1.add(new llvm::Pass2());
+  PM1.add(new Pass1());
+  PM1.add(new Pass2());
 
   // Enable time-passes and run passes.
   TimePassesIsEnabled = true;
@@ -100,7 +101,7 @@ TEST(TimePassesTest, LegacyCustomOut) {
 
   // Now run just a single pass to populate timers again.
   legacy::PassManager PM2;
-  PM2.add(new llvm::Pass2());
+  PM2.add(new Pass2());
   PM2.run(M);
 
   // Generate report again.

--- a/llvm/unittests/IR/VerifierTest.cpp
+++ b/llvm/unittests/IR/VerifierTest.cpp
@@ -21,7 +21,7 @@
 #include "llvm/IR/Module.h"
 #include "gtest/gtest.h"
 
-namespace llvm {
+using namespace llvm;
 namespace {
 
 TEST(VerifierTest, Branch_i1) {
@@ -538,4 +538,3 @@ TEST(VerifierTest, DeeplyNested) {
 }
 
 } // end anonymous namespace
-} // end namespace llvm


### PR DESCRIPTION
Remove llvm namespace surrounding entire .cpp files and instead use `using namespace` in these files.