### PR TITLE
[NFC] Fix C++23 build failures caused by incomplete types

### DIFF
--- a/clang/lib/Interpreter/IncrementalParser.h
+++ b/clang/lib/Interpreter/IncrementalParser.h
@@ -14,14 +14,11 @@
 #define LLVM_CLANG_LIB_INTERPRETER_INCREMENTALPARSER_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Support/Error.h"
 
 #include <list>
 #include <memory>
-
-namespace llvm {
-class Module;
-}
 
 namespace clang {
 class ASTConsumer;

--- a/clang/tools/libclang/CIndexDiagnostic.cpp
+++ b/clang/tools/libclang/CIndexDiagnostic.cpp
@@ -27,6 +27,9 @@ using namespace clang::cxloc;
 using namespace clang::cxdiag;
 using namespace llvm;
 
+CXDiagnosticSetImpl::CXDiagnosticSetImpl(bool isManaged)
+    : IsExternallyManaged(isManaged) {}
+
 CXDiagnosticSetImpl::~CXDiagnosticSetImpl() {}
 
 void

--- a/clang/tools/libclang/CIndexDiagnostic.h
+++ b/clang/tools/libclang/CIndexDiagnostic.h
@@ -28,8 +28,7 @@ class CXDiagnosticSetImpl {
   std::vector<std::unique_ptr<CXDiagnosticImpl>> Diagnostics;
   const bool IsExternallyManaged;
 public:
-  CXDiagnosticSetImpl(bool isManaged = false)
-    : IsExternallyManaged(isManaged) {}
+  CXDiagnosticSetImpl(bool isManaged = false);
 
   virtual ~CXDiagnosticSetImpl();
 

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -528,6 +528,10 @@ class SIInsertWaitcnts {
   struct BlockInfo {
     std::unique_ptr<WaitcntBrackets> Incoming;
     bool Dirty = true;
+    BlockInfo() = default;
+    BlockInfo(BlockInfo &&) = default;
+    BlockInfo &operator=(BlockInfo &&) = default;
+    ~BlockInfo();
   };
 
   MapVector<MachineBasicBlock *, BlockInfo> BlockInfos;
@@ -1050,6 +1054,8 @@ private:
   // mark yet. Initialized to all zeros.
   CounterValueArray AsyncScore{};
 };
+
+SIInsertWaitcnts::BlockInfo::~BlockInfo() = default;
 
 class SIInsertWaitcntsLegacy : public MachineFunctionPass {
 public:

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -42,6 +42,12 @@ using namespace llvm;
 
 #define DEBUG_TYPE "asm-printer"
 
+BPFAsmPrinter::BPFAsmPrinter(TargetMachine &TM,
+                             std::unique_ptr<MCStreamer> Streamer)
+    : AsmPrinter(TM, std::move(Streamer), ID), BTF(nullptr), TM(TM) {}
+
+BPFAsmPrinter::~BPFAsmPrinter() = default;
+
 bool BPFAsmPrinter::doInitialization(Module &M) {
   AsmPrinter::doInitialization(M);
 

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.h
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.h
@@ -18,8 +18,8 @@ namespace llvm {
 class BPFAsmPrinter : public AsmPrinter {
 public:
   explicit BPFAsmPrinter(TargetMachine &TM,
-                         std::unique_ptr<MCStreamer> Streamer)
-      : AsmPrinter(TM, std::move(Streamer), ID), BTF(nullptr), TM(TM) {}
+                         std::unique_ptr<MCStreamer> Streamer);
+  ~BPFAsmPrinter() override;
 
   StringRef getPassName() const override { return "BPF Assembly Printer"; }
   bool doInitialization(Module &M) override;

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -628,6 +628,9 @@ void GroupMatcher::optimize() {
 
 //===- SwitchMatcher ------------------------------------------------------===//
 
+SwitchMatcher::SwitchMatcher() : Matcher(MK_Switch) {}
+SwitchMatcher::~SwitchMatcher() = default;
+
 bool SwitchMatcher::recordsOperand() const {
   assert(!isa_and_present<RecordNamedOperandMatcher>(Condition.get()) &&
          "Switch conditions should not record named operands");

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.h
@@ -445,7 +445,8 @@ class SwitchMatcher : public Matcher {
   std::vector<std::unique_ptr<Matcher>> MatcherStorage;
 
 public:
-  SwitchMatcher() : Matcher(MK_Switch) {}
+  SwitchMatcher();
+  ~SwitchMatcher();
 
   static bool classof(const Matcher *M) { return M->getKind() == MK_Switch; }
 


### PR DESCRIPTION
GCC 15's libstdc++ in C++23 mode eagerly instantiates `unique_ptr<T>::~unique_ptr()` during type trait checks, trigging `static_assert(sizeof(T) > 0)` assertions on incomplete types. 

Fix by moving constructors and destructors out-of-line.