### PR TITLE
[lldb][Windows] Use WaitForDebugEventEx if available

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -25,6 +25,7 @@
 
 #include "Plugins/Process/Windows/Common/ProcessWindowsLog.h"
 
+#include "lldb/Utility/LLDBLog.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Threading.h"
@@ -40,9 +41,40 @@
 using namespace lldb;
 using namespace lldb_private;
 
+typedef BOOL WINAPI WaitForDebugEventFn(LPDEBUG_EVENT, DWORD);
+static WaitForDebugEventFn *g_wait_for_debug_event = nullptr;
+
+static WaitForDebugEventFn *GetWaitForDebugEventEx() {
+  HMODULE h_kernel32 = LoadLibraryW(L"kernel32.dll");
+  if (!h_kernel32) {
+    llvm::Error err = llvm::errorCodeToError(
+        std::error_code(GetLastError(), std::system_category()));
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), std::move(err),
+                   "Could not load kernel32: {0}");
+    return nullptr;
+  }
+
+  return reinterpret_cast<WaitForDebugEventFn *>(
+      GetProcAddress(h_kernel32, "WaitForDebugEventEx"));
+}
+
+/// WaitForDebugEventEx is only available on Windows 10+. This lazily checks if
+/// the function is available and falls back to WaitForDebugEvent if
+/// unavailable. The -Ex version ensures correct forwarding of
+/// OutputDebugStringW events.
+static void InitializeWaitForDebugEvent() {
+  if (g_wait_for_debug_event)
+    return;
+
+  g_wait_for_debug_event = GetWaitForDebugEventEx();
+  if (!g_wait_for_debug_event)
+    g_wait_for_debug_event = &WaitForDebugEvent;
+}
+
 DebuggerThread::DebuggerThread(DebugDelegateSP debug_delegate)
     : m_debug_delegate(debug_delegate), m_pid_to_detach(0),
       m_is_shutting_down(false) {
+  InitializeWaitForDebugEvent();
   m_debugging_ended_event = ::CreateEvent(nullptr, TRUE, FALSE, nullptr);
 }
 
@@ -236,7 +268,7 @@ void DebuggerThread::DebugLoop() {
   LLDB_LOG_VERBOSE(log, "Entering WaitForDebugEvent loop");
   while (should_debug) {
     LLDB_LOG_VERBOSE(log, "Calling WaitForDebugEvent");
-    BOOL wait_result = WaitForDebugEvent(&dbe, INFINITE);
+    BOOL wait_result = g_wait_for_debug_event(&dbe, INFINITE);
     if (wait_result) {
       DWORD continue_status = DBG_CONTINUE;
       bool shutting_down = m_is_shutting_down;
@@ -314,7 +346,7 @@ void DebuggerThread::DebugLoop() {
           // target threads are running at this time, there is possibility to
           // have some breakpoint exception between last WaitForDebugEvent and
           // DebugActiveProcessStop but ignore for now.
-          while (WaitForDebugEvent(&dbe, 0)) {
+          while (g_wait_for_debug_event(&dbe, 0)) {
             continue_status = DBG_CONTINUE;
             if (dbe.dwDebugEventCode == EXCEPTION_DEBUG_EVENT &&
                 !(dbe.u.Exception.ExceptionRecord.ExceptionCode ==

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -67,8 +67,13 @@ static void InitializeWaitForDebugEvent() {
     return;
 
   g_wait_for_debug_event = GetWaitForDebugEventEx();
-  if (!g_wait_for_debug_event)
+  if (!g_wait_for_debug_event) {
+    LLDB_LOG(
+        GetLog(LLDBLog::Host),
+        "WaitForDebugEventEx unavailable, using WaitForDebugEvent instead. "
+        "Unicode strings from OutputDebugStringW might show incorrectly.");
     g_wait_for_debug_event = &WaitForDebugEvent;
+  }
 }
 
 DebuggerThread::DebuggerThread(DebugDelegateSP debug_delegate)


### PR DESCRIPTION
This makes use of [`WaitForDebugEventEx`](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-waitfordebugeventex) over `WaitForDebugEvent` if available (Windows 10+).

The two functions are identical except for the handling of `OutputDebugStringW`. The `-Ex` version forwards the string as Unicode whereas the other version forwards ASCII strings. Since we don't handle these outputs yet, it shouldn't make any difference.

Split from #196395.