### PR TITLE
[AMDGPU] Fine tune partial threshold for runtime unrolling.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.cpp
@@ -130,7 +130,7 @@ void AMDGPUTTIImpl::getUnrollingPreferences(
   // Enable runtime unrolling for loops whose trip count is not known at
   // compile time.  Use a reduced PartialThreshold to limit code-size growth.
   UP.Runtime = true;
-  UP.PartialThreshold = UP.Threshold / 4;
+  UP.PartialThreshold = UP.Threshold / 3;
 
   // Maximum alloca size than can fit registers. Reserve 16 registers.
   const unsigned MaxAlloca = (256 - 16) * 4;


### PR DESCRIPTION
Respond to reported issue:
https://github.com/llvm/llvm-project/issues/196372