### PR TITLE
[clang-tidy] Move `ClassifiedToken` to cpp file

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -205,6 +205,16 @@ static bool isSpecifier(Token T) {
                    tok::kw_static, tok::kw_friend, tok::kw_virtual);
 }
 
+namespace {
+
+struct ClassifiedToken {
+  Token T;
+  bool IsQualifier;
+  bool IsSpecifier;
+};
+
+} // namespace
+
 static std::optional<ClassifiedToken>
 classifyToken(const FunctionDecl &F, Preprocessor &PP, Token Tok) {
   ClassifiedToken CT;

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.h
@@ -14,12 +14,6 @@
 
 namespace clang::tidy::modernize {
 
-struct ClassifiedToken {
-  Token T;
-  bool IsQualifier;
-  bool IsSpecifier;
-};
-
 /// Rewrites function signatures to use a trailing return type.
 ///
 /// For the user-facing documentation see:


### PR DESCRIPTION
`ClassifiedToken` is used in only the implementation of `UseTrailingReturnTypeCheck`. Move it into the unnamed namespace of the cpp file instead of it being in the header.