### PR TITLE
[InstCombine] Fold or (ashr X, BW-1), zext (icmp ne|sgt X, 0) to scmp(X, 0)

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4670,6 +4670,23 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
   if (Value *Res = FoldOrOfSelectSmaxToAbs(I, Builder))
     return replaceInstUsesWith(I, Res);
 
+  // signum: or (ashr X, BW-1), zext (icmp ne|sgt X, 0) --> scmp(X, 0)
+  // The ashr already supplies -1 for negative X, so any predicate that
+  // produces 1 for positive X and 0 for X == 0 yields the same result here.
+  {
+    Value *X;
+    CmpPredicate SignPred;
+    unsigned BitWidth = Ty->getScalarSizeInBits();
+    if (match(&I,
+              m_c_Or(m_AShr(m_Value(X), m_SpecificIntAllowPoison(BitWidth - 1)),
+                     m_ZExt(m_ICmp(SignPred, m_Deferred(X), m_ZeroInt())))) &&
+        (SignPred == ICmpInst::ICMP_NE || SignPred == ICmpInst::ICMP_SGT) &&
+        (Op0->hasOneUse() || Op1->hasOneUse()))
+      return replaceInstUsesWith(
+          I, Builder.CreateIntrinsic(Ty, Intrinsic::scmp,
+                                     {X, Constant::getNullValue(Ty)}));
+  }
+
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -4667,6 +4667,22 @@ Instruction *InstCombinerImpl::visitOr(BinaryOperator &I) {
   if (Value *Res = FoldOrOfSelectSmaxToAbs(I, Builder))
     return replaceInstUsesWith(I, Res);
 
+  // signum: or (ashr X, BW-1), zext (icmp ne|sgt X, 0) --> scmp(X, 0)
+  // The ashr already supplies -1 for negative X, so any predicate that
+  // produces 1 for positive X and 0 for X == 0 yields the same result here.
+  {
+    Value *X;
+    CmpPredicate SignPred;
+    unsigned BitWidth = Ty->getScalarSizeInBits();
+    if (match(&I,
+              m_c_Or(m_AShr(m_Value(X), m_SpecificIntAllowPoison(BitWidth - 1)),
+                     m_ZExt(m_ICmp(SignPred, m_Deferred(X), m_ZeroInt())))) &&
+        (SignPred == ICmpInst::ICMP_NE || SignPred == ICmpInst::ICMP_SGT))
+      return replaceInstUsesWith(
+          I, Builder.CreateIntrinsic(Ty, Intrinsic::scmp,
+                                     {X, Constant::getNullValue(Ty)}));
+  }
+
   return nullptr;
 }
 

--- a/llvm/test/Transforms/InstCombine/add.ll
+++ b/llvm/test/Transforms/InstCombine/add.ll
@@ -3414,10 +3414,7 @@ define i32 @floor_sdiv_using_srem_by_2(i32 %x) {
 
 define i8 @signum_i8_i8(i8 %x) {
 ; CHECK-LABEL: @signum_i8_i8(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i8 [[X:%.*]], 7
-; CHECK-NEXT:    [[ISNOTNULL:%.*]] = icmp ne i8 [[X]], 0
-; CHECK-NEXT:    [[ISNOTNULL_ZEXT:%.*]] = zext i1 [[ISNOTNULL]] to i8
-; CHECK-NEXT:    [[R:%.*]] = or i8 [[SIGNBIT]], [[ISNOTNULL_ZEXT]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i8(i8 [[X:%.*]], i8 0)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %sgt0 = icmp sgt i8 %x, 0
@@ -3433,9 +3430,7 @@ define i8 @signum_i8_i8_use1(i8 %x) {
 ; CHECK-LABEL: @signum_i8_i8_use1(
 ; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i8 [[X:%.*]], 7
 ; CHECK-NEXT:    call void @use(i8 [[SIGNBIT]])
-; CHECK-NEXT:    [[ISNOTNULL:%.*]] = icmp ne i8 [[X]], 0
-; CHECK-NEXT:    [[ISNOTNULL_ZEXT:%.*]] = zext i1 [[ISNOTNULL]] to i8
-; CHECK-NEXT:    [[R:%.*]] = or i8 [[SIGNBIT]], [[ISNOTNULL_ZEXT]]
+; CHECK-NEXT:    [[R:%.*]] = call i8 @llvm.scmp.i8.i8(i8 [[X]], i8 0)
 ; CHECK-NEXT:    ret i8 [[R]]
 ;
   %sgt0 = icmp sgt i8 %x, 0
@@ -3489,10 +3484,7 @@ define i8 @signum_i8_i8_use3(i8 %x) {
 
 define <2 x i5> @signum_v2i5_v2i5(<2 x i5> %x) {
 ; CHECK-LABEL: @signum_v2i5_v2i5(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr <2 x i5> [[X:%.*]], <i5 4, i5 poison>
-; CHECK-NEXT:    [[ISNOTNULL:%.*]] = icmp ne <2 x i5> [[X]], zeroinitializer
-; CHECK-NEXT:    [[ISNOTNULL_ZEXT:%.*]] = zext <2 x i1> [[ISNOTNULL]] to <2 x i5>
-; CHECK-NEXT:    [[R:%.*]] = or <2 x i5> [[SIGNBIT]], [[ISNOTNULL_ZEXT]]
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i5> @llvm.scmp.v2i5.v2i5(<2 x i5> [[X:%.*]], <2 x i5> zeroinitializer)
 ; CHECK-NEXT:    ret <2 x i5> [[R]]
 ;
   %sgt0 = icmp sgt <2 x i5> %x, zeroinitializer

--- a/llvm/test/Transforms/InstCombine/and-or-icmps.ll
+++ b/llvm/test/Transforms/InstCombine/and-or-icmps.ll
@@ -2661,12 +2661,12 @@ define i64 @icmp_slt_0_or_icmp_sgt_0_i64_fail0(i64 %x) {
   ret i64 %E
 }
 
-define i64 @icmp_slt_0_or_icmp_sgt_0_i64_fail1(i64 %x) {
-; CHECK-LABEL: @icmp_slt_0_or_icmp_sgt_0_i64_fail1(
-; CHECK-NEXT:    [[B:%.*]] = icmp sgt i64 [[X:%.*]], 0
-; CHECK-NEXT:    [[C:%.*]] = ashr i64 [[X]], 63
-; CHECK-NEXT:    [[D:%.*]] = zext i1 [[B]] to i64
-; CHECK-NEXT:    [[E:%.*]] = or i64 [[C]], [[D]]
+; ashr (instead of icmp slt 0) on the LHS: not the icmp-or-icmp shape, but
+; this is the signum idiom and folds to scmp.
+
+define i64 @icmp_slt_0_or_icmp_sgt_0_i64_signum(i64 %x) {
+; CHECK-LABEL: @icmp_slt_0_or_icmp_sgt_0_i64_signum(
+; CHECK-NEXT:    [[E:%.*]] = call i64 @llvm.scmp.i64.i64(i64 [[X:%.*]], i64 0)
 ; CHECK-NEXT:    ret i64 [[E]]
 ;
   %B = icmp sgt i64 %x, 0

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2216,10 +2216,7 @@ declare void @use_i1(i1)
 
 define i32 @signum_i32_or_sgt(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_sgt(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2231,10 +2228,7 @@ define i32 @signum_i32_or_sgt(i32 %x) {
 
 define i32 @signum_i32_or_ne(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_ne(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[NZ:%.*]] = icmp ne i32 [[X]], 0
-; CHECK-NEXT:    [[ZNZ:%.*]] = zext i1 [[NZ]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZNZ]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2248,10 +2242,7 @@ define i32 @signum_i32_or_ne(i32 %x) {
 
 define i32 @signum_i32_or_sgt_commuted(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_sgt_commuted(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2265,10 +2256,7 @@ define i32 @signum_i32_or_sgt_commuted(i32 %x) {
 
 define <2 x i5> @signum_v2i5_or_sgt(<2 x i5> %x) {
 ; CHECK-LABEL: @signum_v2i5_or_sgt(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr <2 x i5> [[X:%.*]], <i5 4, i5 poison>
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt <2 x i5> [[X]], zeroinitializer
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext <2 x i1> [[SGT0]] to <2 x i5>
-; CHECK-NEXT:    [[R:%.*]] = or <2 x i5> [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i5> @llvm.scmp.v2i5.v2i5(<2 x i5> [[X:%.*]], <2 x i5> zeroinitializer)
 ; CHECK-NEXT:    ret <2 x i5> [[R]]
 ;
   %signbit = ashr <2 x i5> %x, <i5 4, i5 poison>
@@ -2284,9 +2272,7 @@ define i32 @signum_i32_or_sgt_use_ashr(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_sgt_use_ashr(
 ; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
 ; CHECK-NEXT:    call void @use(i32 [[SIGNBIT]])
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2297,15 +2283,14 @@ define i32 @signum_i32_or_sgt_use_ashr(i32 %x) {
   ret i32 %r
 }
 
-; negative test - extra use of zext blocks the fold (avoids increasing instruction count).
+; extra use of the zext is ok: the zext stays alive but the or still folds.
 
-define i32 @signum_i32_or_sgt_use_zext(i32 %x) {
-; CHECK-LABEL: @signum_i32_or_sgt_use_zext(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+define i32 @signum_i32_or_sgt_extra_use_zext(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_extra_use_zext(
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X:%.*]], 0
 ; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
 ; CHECK-NEXT:    call void @use(i32 [[ZGT0]])
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2316,15 +2301,13 @@ define i32 @signum_i32_or_sgt_use_zext(i32 %x) {
   ret i32 %r
 }
 
-; negative test - extra use of icmp blocks the fold.
+; extra use of the icmp is ok: the icmp/zext stay alive but the or still folds.
 
-define i32 @signum_i32_or_sgt_use_icmp(i32 %x) {
-; CHECK-LABEL: @signum_i32_or_sgt_use_icmp(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+define i32 @signum_i32_or_sgt_extra_use_icmp(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_extra_use_icmp(
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X:%.*]], 0
 ; CHECK-NEXT:    call void @use_i1(i1 [[SGT0]])
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2207,3 +2207,179 @@ define <2 x i8> @or_select_smax_multi_uses(<2 x i8> %a){
   %add = add <2 x i8> %or, %max
   ret <2 x i8> %add
 }
+
+declare void @use_i1(i1)
+
+; signum encoded with or:
+; (X s>> (BW - 1)) | (zext (X s> 0)) --> scmp(X, 0)
+; (X s>> (BW - 1)) | (zext (X != 0)) --> scmp(X, 0)
+
+define i32 @signum_i32_or_sgt(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+define i32 @signum_i32_or_ne(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_ne(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[NZ:%.*]] = icmp ne i32 [[X]], 0
+; CHECK-NEXT:    [[ZNZ:%.*]] = zext i1 [[NZ]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZNZ]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %nz = icmp ne i32 %x, 0
+  %znz = zext i1 %nz to i32
+  %r = or i32 %signbit, %znz
+  ret i32 %r
+}
+
+; commuted operands of or
+
+define i32 @signum_i32_or_sgt_commuted(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_commuted(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %zgt0, %signbit
+  ret i32 %r
+}
+
+; vector
+
+define <2 x i5> @signum_v2i5_or_sgt(<2 x i5> %x) {
+; CHECK-LABEL: @signum_v2i5_or_sgt(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr <2 x i5> [[X:%.*]], <i5 4, i5 poison>
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt <2 x i5> [[X]], zeroinitializer
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext <2 x i1> [[SGT0]] to <2 x i5>
+; CHECK-NEXT:    [[R:%.*]] = or <2 x i5> [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret <2 x i5> [[R]]
+;
+  %signbit = ashr <2 x i5> %x, <i5 4, i5 poison>
+  %sgt0 = icmp sgt <2 x i5> %x, zeroinitializer
+  %zgt0 = zext <2 x i1> %sgt0 to <2 x i5>
+  %r = or <2 x i5> %signbit, %zgt0
+  ret <2 x i5> %r
+}
+
+; extra use of the ashr is ok: the ashr stays alive but the or still folds.
+
+define i32 @signum_i32_or_sgt_use_ashr(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_use_ashr(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    call void @use(i32 [[SIGNBIT]])
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  call void @use(i32 %signbit)
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - extra use of zext blocks the fold (avoids increasing instruction count).
+
+define i32 @signum_i32_or_sgt_use_zext(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_use_zext(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    call void @use(i32 [[ZGT0]])
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  call void @use(i32 %zgt0)
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - extra use of icmp blocks the fold.
+
+define i32 @signum_i32_or_sgt_use_icmp(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_use_icmp(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    call void @use_i1(i1 [[SGT0]])
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  call void @use_i1(i1 %sgt0)
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - wrong shift amount.
+
+define i32 @signum_i32_or_wrong_sh_amt(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_wrong_sh_amt(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 30
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 30
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - wrong predicate (slt does not yield signum here).
+
+define i32 @signum_i32_or_wrong_pred(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_wrong_pred(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[X_LOBIT:%.*]] = lshr i32 [[X]], 31
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[X_LOBIT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %slt0 = icmp slt i32 %x, 0
+  %zlt0 = zext i1 %slt0 to i32
+  %r = or i32 %signbit, %zlt0
+  ret i32 %r
+}
+
+; negative test - sext instead of zext.
+
+define i32 @signum_i32_or_wrong_ext(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_wrong_ext(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[SGT0]], i32 -1, i32 [[SIGNBIT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %sgt0ext = sext i1 %sgt0 to i32
+  %r = or i32 %signbit, %sgt0ext
+  ret i32 %r
+}

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -1283,8 +1283,8 @@ define <16 x i1> @test51(<16 x i1> %arg, <16 x i1> %arg1) {
 ;
   %tmp = and <16 x i1> %arg, <i1 true, i1 true, i1 true, i1 true, i1 false, i1 true, i1 true, i1 false, i1 false, i1 true, i1 true, i1 false, i1 false, i1 false, i1 false, i1 false>
   %tmp2 = and <16 x i1> %arg1, <i1 false, i1 false, i1 false, i1 false, i1 true, i1 false, i1 false, i1 true, i1 true, i1 false, i1 false, i1 true, i1 true, i1 true, i1 true, i1 true>
-  %tmp3 = or <16 x i1> %tmp, %tmp2
-  ret <16 x i1> %tmp3
+  %res = or <16 x i1> %tmp, %tmp2
+  ret <16 x i1> %res
 }
 
 ; This would infinite loop because it reaches a transform
@@ -2215,10 +2215,7 @@ declare void @use_i1(i1)
 
 define i32 @signum_i32_or_sgt(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_sgt(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2230,10 +2227,7 @@ define i32 @signum_i32_or_sgt(i32 %x) {
 
 define i32 @signum_i32_or_ne(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_ne(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[NZ:%.*]] = icmp ne i32 [[X]], 0
-; CHECK-NEXT:    [[ZNZ:%.*]] = zext i1 [[NZ]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZNZ]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2247,10 +2241,7 @@ define i32 @signum_i32_or_ne(i32 %x) {
 
 define i32 @signum_i32_or_sgt_commuted(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_sgt_commuted(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X:%.*]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2264,10 +2255,7 @@ define i32 @signum_i32_or_sgt_commuted(i32 %x) {
 
 define <2 x i5> @signum_v2i5_or_sgt(<2 x i5> %x) {
 ; CHECK-LABEL: @signum_v2i5_or_sgt(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr <2 x i5> [[X:%.*]], <i5 4, i5 poison>
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt <2 x i5> [[X]], zeroinitializer
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext <2 x i1> [[SGT0]] to <2 x i5>
-; CHECK-NEXT:    [[R:%.*]] = or <2 x i5> [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call <2 x i5> @llvm.scmp.v2i5.v2i5(<2 x i5> [[X:%.*]], <2 x i5> zeroinitializer)
 ; CHECK-NEXT:    ret <2 x i5> [[R]]
 ;
   %signbit = ashr <2 x i5> %x, <i5 4, i5 poison>
@@ -2283,9 +2271,7 @@ define i32 @signum_i32_or_sgt_use_ashr(i32 %x) {
 ; CHECK-LABEL: @signum_i32_or_sgt_use_ashr(
 ; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
 ; CHECK-NEXT:    call void @use(i32 [[SIGNBIT]])
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2296,15 +2282,14 @@ define i32 @signum_i32_or_sgt_use_ashr(i32 %x) {
   ret i32 %r
 }
 
-; negative test - extra use of zext blocks the fold (avoids increasing instruction count).
+; extra use of the zext is ok: the zext stays alive but the or still folds.
 
-define i32 @signum_i32_or_sgt_use_zext(i32 %x) {
-; CHECK-LABEL: @signum_i32_or_sgt_use_zext(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+define i32 @signum_i32_or_sgt_extra_use_zext(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_extra_use_zext(
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X:%.*]], 0
 ; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
 ; CHECK-NEXT:    call void @use(i32 [[ZGT0]])
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
@@ -2315,21 +2300,40 @@ define i32 @signum_i32_or_sgt_use_zext(i32 %x) {
   ret i32 %r
 }
 
-; negative test - extra use of icmp blocks the fold.
+; extra use of the icmp is ok: the icmp/zext stay alive but the or still folds.
 
-define i32 @signum_i32_or_sgt_use_icmp(i32 %x) {
-; CHECK-LABEL: @signum_i32_or_sgt_use_icmp(
-; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
-; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+define i32 @signum_i32_or_sgt_extra_use_icmp(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_extra_use_icmp(
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X:%.*]], 0
 ; CHECK-NEXT:    call void @use_i1(i1 [[SGT0]])
-; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
-; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.scmp.i32.i32(i32 [[X]], i32 0)
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
   %signbit = ashr i32 %x, 31
   %sgt0 = icmp sgt i32 %x, 0
   call void @use_i1(i1 %sgt0)
   %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - not profitable if both operands have extra uses.
+
+define i32 @signum_i32_or_sgt_extra_use_both(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_extra_use_both(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    call void @use(i32 [[SIGNBIT]])
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    call void @use(i32 [[ZGT0]])
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  call void @use(i32 %signbit)
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  call void @use(i32 %zgt0)
   %r = or i32 %signbit, %zgt0
   ret i32 %r
 }

--- a/llvm/test/Transforms/InstCombine/or.ll
+++ b/llvm/test/Transforms/InstCombine/or.ll
@@ -2206,3 +2206,179 @@ define <2 x i8> @or_select_smax_multi_uses(<2 x i8> %a){
   %add = add <2 x i8> %or, %max
   ret <2 x i8> %add
 }
+
+declare void @use_i1(i1)
+
+; signum encoded with or:
+; (X s>> (BW - 1)) | (zext (X s> 0)) --> scmp(X, 0)
+; (X s>> (BW - 1)) | (zext (X != 0)) --> scmp(X, 0)
+
+define i32 @signum_i32_or_sgt(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+define i32 @signum_i32_or_ne(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_ne(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[NZ:%.*]] = icmp ne i32 [[X]], 0
+; CHECK-NEXT:    [[ZNZ:%.*]] = zext i1 [[NZ]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZNZ]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %nz = icmp ne i32 %x, 0
+  %znz = zext i1 %nz to i32
+  %r = or i32 %signbit, %znz
+  ret i32 %r
+}
+
+; commuted operands of or
+
+define i32 @signum_i32_or_sgt_commuted(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_commuted(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %zgt0, %signbit
+  ret i32 %r
+}
+
+; vector
+
+define <2 x i5> @signum_v2i5_or_sgt(<2 x i5> %x) {
+; CHECK-LABEL: @signum_v2i5_or_sgt(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr <2 x i5> [[X:%.*]], <i5 4, i5 poison>
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt <2 x i5> [[X]], zeroinitializer
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext <2 x i1> [[SGT0]] to <2 x i5>
+; CHECK-NEXT:    [[R:%.*]] = or <2 x i5> [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret <2 x i5> [[R]]
+;
+  %signbit = ashr <2 x i5> %x, <i5 4, i5 poison>
+  %sgt0 = icmp sgt <2 x i5> %x, zeroinitializer
+  %zgt0 = zext <2 x i1> %sgt0 to <2 x i5>
+  %r = or <2 x i5> %signbit, %zgt0
+  ret <2 x i5> %r
+}
+
+; extra use of the ashr is ok: the ashr stays alive but the or still folds.
+
+define i32 @signum_i32_or_sgt_use_ashr(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_use_ashr(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    call void @use(i32 [[SIGNBIT]])
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  call void @use(i32 %signbit)
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - extra use of zext blocks the fold (avoids increasing instruction count).
+
+define i32 @signum_i32_or_sgt_use_zext(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_use_zext(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    call void @use(i32 [[ZGT0]])
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  call void @use(i32 %zgt0)
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - extra use of icmp blocks the fold.
+
+define i32 @signum_i32_or_sgt_use_icmp(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_sgt_use_icmp(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    call void @use_i1(i1 [[SGT0]])
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  call void @use_i1(i1 %sgt0)
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - wrong shift amount.
+
+define i32 @signum_i32_or_wrong_sh_amt(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_wrong_sh_amt(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 30
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[ZGT0:%.*]] = zext i1 [[SGT0]] to i32
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[ZGT0]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 30
+  %sgt0 = icmp sgt i32 %x, 0
+  %zgt0 = zext i1 %sgt0 to i32
+  %r = or i32 %signbit, %zgt0
+  ret i32 %r
+}
+
+; negative test - wrong predicate (slt does not yield signum here).
+
+define i32 @signum_i32_or_wrong_pred(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_wrong_pred(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[X_LOBIT:%.*]] = lshr i32 [[X]], 31
+; CHECK-NEXT:    [[R:%.*]] = or i32 [[SIGNBIT]], [[X_LOBIT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %slt0 = icmp slt i32 %x, 0
+  %zlt0 = zext i1 %slt0 to i32
+  %r = or i32 %signbit, %zlt0
+  ret i32 %r
+}
+
+; negative test - sext instead of zext.
+
+define i32 @signum_i32_or_wrong_ext(i32 %x) {
+; CHECK-LABEL: @signum_i32_or_wrong_ext(
+; CHECK-NEXT:    [[SIGNBIT:%.*]] = ashr i32 [[X:%.*]], 31
+; CHECK-NEXT:    [[SGT0:%.*]] = icmp sgt i32 [[X]], 0
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[SGT0]], i32 -1, i32 [[SIGNBIT]]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %signbit = ashr i32 %x, 31
+  %sgt0 = icmp sgt i32 %x, 0
+  %sgt0ext = sext i1 %sgt0 to i32
+  %r = or i32 %signbit, %sgt0ext
+  ret i32 %r
+}


### PR DESCRIPTION
Recognize the bitwise signum encoding
  or (ashr X, BW-1), zext (icmp ne  X, 0) --> llvm.scmp(X, 0)
  or (ashr X, BW-1), zext (icmp sgt X, 0) --> llvm.scmp(X, 0)

Alive2: https://alive2.llvm.org/ce/z/UZ7a7Q