### PR TITLE
[ORC] Fix infinite wait upon disconnection initiated by SimpleRemoteEPC

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.h
@@ -96,7 +96,7 @@ public:
   /// Trigger disconnection from the transport. The implementation should
   /// respond by calling handleDisconnect on the client once disconnection
   /// is complete. May be called more than once and from different threads.
-  virtual void disconnect() = 0;
+  virtual void disconnect(Error Err = Error::success()) = 0;
 };
 
 /// Uses read/write on FileDescriptors for transport.
@@ -121,7 +121,7 @@ public:
   Error sendMessage(SimpleRemoteEPCOpcode OpC, uint64_t SeqNo,
                     ExecutorAddr TagAddr, ArrayRef<char> ArgBytes) override;
 
-  void disconnect() override;
+  void disconnect(Error Err) override;
 
 private:
   FDSimpleRemoteEPCTransport(SimpleRemoteEPCTransportClient &C, int InFD,

--- a/llvm/lib/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Shared/SimpleRemoteEPCUtils.cpp
@@ -108,26 +108,28 @@ Error FDSimpleRemoteEPCTransport::sendMessage(SimpleRemoteEPCOpcode OpC,
   return Error::success();
 }
 
-void FDSimpleRemoteEPCTransport::disconnect() {
-  if (Disconnected)
-    return; // Return if already disconnected.
+void FDSimpleRemoteEPCTransport::disconnect(Error Err) {
+  if (!Disconnected) {
+    Disconnected = true;
+    bool CloseOutFD = InFD != OutFD;
 
-  Disconnected = true;
-  bool CloseOutFD = InFD != OutFD;
-
-  // Close InFD.
-  while (close(InFD) == -1) {
-    if (errno == EBADF)
-      break;
-  }
-
-  // Close OutFD.
-  if (CloseOutFD) {
-    while (close(OutFD) == -1) {
+    // Close InFD.
+    while (close(InFD) == -1) {
       if (errno == EBADF)
         break;
     }
+
+    // Close OutFD.
+    if (CloseOutFD) {
+      while (close(OutFD) == -1) {
+        if (errno == EBADF)
+          break;
+      }
+    }
   }
+
+  // Call up to the client to handle the disconnection.
+  C.handleDisconnect(std::move(Err));
 }
 
 static Error makeUnexpectedEOFError() {
@@ -241,10 +243,7 @@ void FDSimpleRemoteEPCTransport::listenLoop() {
 
   // Attempt to close FDs, set Disconnected to true so that subsequent
   // sendMessage calls fail.
-  disconnect();
-
-  // Call up to the client to handle the disconnection.
-  C.handleDisconnect(std::move(Err));
+  disconnect(std::move(Err));
 }
 
 } // end namespace orc

--- a/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SimpleRemoteEPC.cpp
@@ -196,6 +196,13 @@ void SimpleRemoteEPC::handleDisconnect(Error Err) {
 
   {
     std::lock_guard<std::mutex> Lock(SimpleRemoteEPCMutex);
+    if (Disconnected) {
+      // The client is disconnected, there is no other ways to
+      // handle this error.
+      consumeError(std::move(Err));
+      return;
+    }
+
     std::swap(TmpPending, PendingCallWrapperResults);
   }
 


### PR DESCRIPTION
This was found when I tried to run a simple program with `llvm-jitlink --oop-executor-connect` on Linux: both the worker and the target processes run flawlessly...except the worker process never exits unless I interrupt it.

As it turns out, the executor process control's disconnection process (i.e. `SimplerRemoteEPC::disconnect`) will not conclude unless a flag, `Diconnected`, is set. This flag is supposed to be set by `SimpleRemoteEPC::handleDisconnect`, a callback meant for the transport layer. The problem is, that callback is never called if we disconnect in this way, hence the never ending wait in `SimplerRemoteEPC::disconnect` (`SimpleRemoteEPC::handleDisconnect` is only called when we received a hangup message)

This patch fixes this issue by asking `SimpleRemoteEPCTransport::disconnect` to call `SimpleRemoteEPC::handleDisconnect` (or more precisely speaking, `SimpleRemoteEPCTransportClient::handleDisconnect`).

-------
I have two concerns though:
  1. I have no idea how to write a test for this
  2. Because `handleDisconnect` takes an Error, I added an Error argument to `disconnect` to pass down the error that is meant for `handleDisconnect`. The problem is, since `SimpleRemoteEPCTransport::disconnect`  can be called multiple time, it's totally possible that `SimpleRemoteEPCTransportClient` might already disconnect when another `SimpleRemoteEPCTransport::disconnect` comes in. This forces me to silent the Error object when this happens, and I'm not sure whether this is the best way.

Other than the issue I fixed in this PR, there is actually another bug, regarding closing a file descriptor while it is being read by another thread. I tried to fix it in #196835 