### PR TITLE
[clang-format] Add `BILS_No` value to BreakInheritanceList option.

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -3895,6 +3895,15 @@ the configuration (without a prefix: ``Auto``).
 
   Possible values:
 
+  * ``BILS_No`` (in configuration: ``No``)
+    Do not break inheritance list. If the line is too long, the wrapped
+    lines are indented ContinuationIndentWidth spaces.
+
+    .. code-block:: c++
+
+       class Foo : Base1, Base2
+       {};
+
   * ``BILS_BeforeColon`` (in configuration: ``BeforeColon``)
     Break inheritance list before the colon and after the commas.
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -744,6 +744,8 @@ clang-format
   line if they exceed the specified count.
 - Add ``AfterComma`` value to ``BreakConstructorInitializers`` to allow breaking
   constructor initializers after commas, keeping the colon on the same line.
+- Add ``No`` value to ``BreakInheritanceList`` to disable breaking of the inheritance
+  list. If the list is too long, standard line breaking rules apply.
 - Extend ``BreakBinaryOperations`` to accept a structured configuration with
   per-operator break rules and minimum chain length gating via ``PerOperator``.
 - Add ``AllowShortRecordOnASingleLine`` option and set it to ``EmptyAndAttached`` for LLVM style.

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -2745,6 +2745,13 @@ struct FormatStyle {
 
   /// Different ways to break inheritance list.
   enum BreakInheritanceListStyle : int8_t {
+    /// Do not break inheritance list. If the line is too long, the wrapped
+    /// lines are indented ContinuationIndentWidth spaces.
+    /// \code
+    ///    class Foo : Base1, Base2
+    ///    {};
+    /// \endcode
+    BILS_No,
     /// Break inheritance list before the colon and after the commas.
     /// \code
     ///    class Foo

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1109,8 +1109,12 @@ void ContinuationIndenter::addTokenOnCurrentLine(LineState &State, bool DryRun,
     if (Style.BreakBeforeBinaryOperators == FormatStyle::BOS_None)
       CurrentState.LastSpace = State.Column;
   } else if (Previous.is(TT_InheritanceColon)) {
-    CurrentState.Indent = State.Column;
-    CurrentState.LastSpace = State.Column;
+    // Indent relative to the inheritance colon if the inheritance list
+    // is being broken into separate lines.
+    if (Style.BreakInheritanceList != FormatStyle::BILS_No) {
+      CurrentState.Indent = State.Column;
+      CurrentState.LastSpace = State.Column;
+    }
   } else if (Current.is(TT_CSharpGenericTypeConstraintColon)) {
     CurrentState.ColonPos = State.Column;
   } else if (Previous.opensScope()) {
@@ -1237,6 +1241,8 @@ unsigned ContinuationIndenter::addTokenOnNewLine(LineState &State,
   }
 
   switch (Style.BreakInheritanceList) {
+  case FormatStyle::BILS_No:
+    break;
   case FormatStyle::BILS_BeforeColon:
   case FormatStyle::BILS_AfterComma:
     if (Current.is(TT_InheritanceColon) || Previous.is(TT_InheritanceComma)) {
@@ -1859,7 +1865,8 @@ unsigned ContinuationIndenter::moveStateToNextToken(LineState &State,
     else
       CurrentState.BreakBeforeParameter = false;
   }
-  if (Current.is(TT_InheritanceColon)) {
+  if (Current.is(TT_InheritanceColon) &&
+      Style.BreakInheritanceList != FormatStyle::BILS_No) {
     CurrentState.Indent =
         State.FirstIndent + Style.ConstructorInitializerIndentWidth;
   }

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -364,6 +364,7 @@ template <>
 struct ScalarEnumerationTraits<FormatStyle::BreakInheritanceListStyle> {
   static void enumeration(IO &IO,
                           FormatStyle::BreakInheritanceListStyle &Value) {
+    IO.enumCase(Value, "No", FormatStyle::BILS_No);
     IO.enumCase(Value, "BeforeColon", FormatStyle::BILS_BeforeColon);
     IO.enumCase(Value, "BeforeComma", FormatStyle::BILS_BeforeComma);
     IO.enumCase(Value, "AfterColon", FormatStyle::BILS_AfterColon);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -524,6 +524,8 @@ TEST(ConfigParseTest, ParsesConfiguration) {
               BreakConstructorInitializers, FormatStyle::BCIS_BeforeComma);
 
   Style.BreakInheritanceList = FormatStyle::BILS_BeforeColon;
+  CHECK_PARSE("BreakInheritanceList: No", BreakInheritanceList,
+              FormatStyle::BILS_No);
   CHECK_PARSE("BreakInheritanceList: AfterComma", BreakInheritanceList,
               FormatStyle::BILS_AfterComma);
   CHECK_PARSE("BreakInheritanceList: BeforeComma", BreakInheritanceList,

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -3815,6 +3815,20 @@ TEST_F(FormatTest, FormatsClasses) {
 }
 
 TEST_F(FormatTest, BreakInheritanceStyle) {
+  FormatStyle StyleWithInheritanceBreakNo = getLLVMStyle();
+  StyleWithInheritanceBreakNo.BreakInheritanceList = FormatStyle::BILS_No;
+  verifyFormat("class MyClass : public X {};", StyleWithInheritanceBreakNo);
+  verifyFormat("class MyClass : public X, public Y {};",
+               StyleWithInheritanceBreakNo);
+  verifyFormat(
+      "class AAAAAAAAAAAAAAAAAAAAAA : public BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,\n"
+      "    public CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {};",
+      StyleWithInheritanceBreakNo);
+  verifyFormat("class MyOuterClass {\n"
+               "  class MyClass : public BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,\n"
+               "      public CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC {};",
+               StyleWithInheritanceBreakNo);
+
   FormatStyle StyleWithInheritanceBreakBeforeComma = getLLVMStyle();
   StyleWithInheritanceBreakBeforeComma.BreakInheritanceList =
       FormatStyle::BILS_BeforeComma;


### PR DESCRIPTION
When `BILS_No` is used, the inheritance list is handled like any other line. If the inheritance list needs to be broken down, the continuation indent width is used to indent the new lines.

The point of this value is to introduce a possibility of a "dumb" formatting, where the inheritance list has no special alignment.