### PR TITLE
Handle typeidCompatibleVTable in skipModuleSummaryEntry

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1067,11 +1067,12 @@ bool LLParser::skipModuleSummaryEntry() {
   // support is in place we will look for the tokens corresponding to the
   // expected tags.
   if (Lex.getKind() != lltok::kw_gv && Lex.getKind() != lltok::kw_module &&
-      Lex.getKind() != lltok::kw_typeid && Lex.getKind() != lltok::kw_flags &&
-      Lex.getKind() != lltok::kw_blockcount)
-    return tokError(
-        "Expected 'gv', 'module', 'typeid', 'flags' or 'blockcount' at the "
-        "start of summary entry");
+      Lex.getKind() != lltok::kw_typeid &&
+      Lex.getKind() != lltok::kw_typeidCompatibleVTable &&
+      Lex.getKind() != lltok::kw_flags && Lex.getKind() != lltok::kw_blockcount)
+    return tokError("Expected 'gv', 'module', 'typeid', "
+                    "'typeidCompatibleVTable', 'flags' or 'blockcount' at the "
+                    "start of summary entry");
   if (Lex.getKind() == lltok::kw_flags)
     return parseSummaryIndexFlags();
   if (Lex.getKind() == lltok::kw_blockcount)

--- a/llvm/test/Assembler/thinlto-bad-summary1.ll
+++ b/llvm/test/Assembler/thinlto-bad-summary1.ll
@@ -2,7 +2,7 @@
 ; summary type label.
 ; RUN: not opt %s 2>&1 | FileCheck %s
 
-; CHECK: error: Expected 'gv', 'module', 'typeid', 'flags' or 'blockcount' at the start of summary entry
+; CHECK: error: Expected 'gv', 'module', 'typeid', 'typeidCompatibleVTable', 'flags' or 'blockcount' at the start of summary entry
 
 ; ModuleID = 'thinlto-function-summary-callgraph.ll'
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/llvm/test/Assembler/thinlto-vtable-skip.ll
+++ b/llvm/test/Assembler/thinlto-vtable-skip.ll
@@ -1,3 +1,7 @@
+; Disabling output means we'll just skip the summary entries, which is the code
+; path we're trying to test. There's no output to check against, so we have no
+; CHECKs.
+;
 ; RUN: opt %s -disable-output
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/llvm/test/Assembler/thinlto-vtable-skip.ll
+++ b/llvm/test/Assembler/thinlto-vtable-skip.ll
@@ -3,5 +3,5 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-^0 = module: (path: "test.ll", hash: (0, 0, 0, 0, 0))
+^0 = module: (path: "thinlto-vtable-skip.ll", hash: (0, 0, 0, 0, 0))
 ^1 = typeidCompatibleVTable: (name: "_ZTS1A", summary: ((offset: 16, ^0)))

--- a/llvm/test/Assembler/thinlto-vtable-skip.ll
+++ b/llvm/test/Assembler/thinlto-vtable-skip.ll
@@ -1,0 +1,7 @@
+; RUN: opt %s -disable-output
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+^0 = module: (path: "test.ll", hash: (0, 0, 0, 0, 0))
+^1 = typeidCompatibleVTable: (name: "_ZTS1A", summary: ((offset: 16, ^0)))


### PR DESCRIPTION
This method needs to match the set of cases handled in parseSummaryEntry.