### PR TITLE
[libc] Fix -Wshadow warning in atanf.h

### DIFF
--- a/libc/src/__support/math/atanf.h
+++ b/libc/src/__support/math/atanf.h
@@ -67,7 +67,6 @@ LIBC_INLINE constexpr float atanf(float x) {
 #if defined(LIBC_TARGET_CPU_HAS_FMA_FLOAT)
       return fputil::multiply_add(x, -0x1.0p-25f, x);
 #else
-      double x_d = static_cast<double>(x);
       return static_cast<float>(fputil::multiply_add(x_d, -0x1.0p-25, x_d));
 #endif // LIBC_TARGET_CPU_HAS_FMA_FLOAT
     }


### PR DESCRIPTION
x_d already exists in an outer scope and isn't modified if `x_abs < 0x3980'0000`, so no need to have a shadowing variable.

No behavior change.