### PR TITLE
[libc] Fix -Wshadow warning in sqrtf128.h

### DIFF
--- a/libc/src/__support/math/sqrtf128.h
+++ b/libc/src/__support/math/sqrtf128.h
@@ -60,8 +60,6 @@ namespace math {
 
 namespace sqrtf128_internal {
 
-using FPBits = fputil::FPBits<float128>;
-
 template <typename T, typename U = T> LIBC_INLINE constexpr T prod_hi(T, U);
 
 // Get high part of integer multiplications.


### PR DESCRIPTION
sqrtf128() contained both `using namespace sqrtf128_internal;` and `using FPBits = fputil::FPBits<float128>;`, but sqrtf128_internal also had a `using FPBits = fputil::FPBits<float128>;`. The outer `using` wasn't actually used, so remove that one.