### PR TITLE
[CodeGen,IRNormalizer,BOLT] Duplicate stable hash_16_bytes locally. NFC

### DIFF
--- a/bolt/lib/Profile/StaleProfileMatching.cpp
+++ b/bolt/lib/Profile/StaleProfileMatching.cpp
@@ -42,6 +42,20 @@ using namespace llvm;
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "bolt-prof"
 
+// Frozen mixer; the block hashes computed below participate in BOLT's
+// stale profile matching, so this function's exact output is part of
+// the on-disk profile format. Do not change without versioning that
+// format.
+static constexpr uint64_t hash_16_bytes(uint64_t low, uint64_t high) {
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  uint64_t a = (low ^ high) * kMul;
+  a ^= (a >> 47);
+  uint64_t b = (high ^ a) * kMul;
+  b ^= (b >> 47);
+  b *= kMul;
+  return b;
+}
+
 namespace opts {
 
 extern cl::opt<bool> TimeRewrite;
@@ -414,7 +428,7 @@ void BinaryFunction::computeBlockHashes(HashFunction HashFunction) const {
     uint64_t Hash = 0;
     for (BinaryBasicBlock *SuccBB : BB->successors()) {
       uint64_t SuccHash = OpcodeHashes[SuccBB->getIndex()];
-      Hash = hashing::detail::hash_16_bytes(Hash, SuccHash);
+      Hash = hash_16_bytes(Hash, SuccHash);
     }
     if (HashFunction == HashFunction::StdHash) {
       // Compatibility with old behavior.
@@ -427,7 +441,7 @@ void BinaryFunction::computeBlockHashes(HashFunction HashFunction) const {
     Hash = 0;
     for (BinaryBasicBlock *PredBB : BB->predecessors()) {
       uint64_t PredHash = OpcodeHashes[PredBB->getIndex()];
-      Hash = hashing::detail::hash_16_bytes(Hash, PredHash);
+      Hash = hash_16_bytes(Hash, PredHash);
     }
     if (HashFunction == HashFunction::StdHash) {
       // Compatibility with old behavior.

--- a/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CodeGen/MachineBlockHashInfo.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineStableHash.h"
 #include "llvm/CodeGen/Passes.h"
@@ -21,16 +20,28 @@
 
 using namespace llvm;
 
+// Frozen mixer; the block hashes computed below are serialized into BB
+// section profile data, so this function's exact output is part of the
+// on-disk format. Do not change without versioning that format.
+static constexpr uint64_t hash_16_bytes(uint64_t low, uint64_t high) {
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  uint64_t a = (low ^ high) * kMul;
+  a ^= (a >> 47);
+  uint64_t b = (high ^ a) * kMul;
+  b ^= (b >> 47);
+  b *= kMul;
+  return b;
+}
+
 static uint64_t hashBlock(const MachineBasicBlock &MBB, bool HashOperands) {
   uint64_t Hash = 0;
   for (const MachineInstr &MI : MBB) {
     if (MI.isMetaInstruction() || MI.isTerminator())
       continue;
-    Hash = hashing::detail::hash_16_bytes(Hash, MI.getOpcode());
+    Hash = hash_16_bytes(Hash, MI.getOpcode());
     if (HashOperands) {
       for (unsigned i = 0; i < MI.getNumOperands(); i++) {
-        Hash = hashing::detail::hash_16_bytes(
-            Hash, stableHashValue(MI.getOperand(i)));
+        Hash = hash_16_bytes(Hash, stableHashValue(MI.getOperand(i)));
       }
     }
   }
@@ -46,10 +57,9 @@ static constexpr uint16_t fold_64_to_16(const uint64_t Value) {
   return Res;
 }
 
-// Keep stable to serialize data.
-static_assert(hashing::detail::hash_16_bytes(1, 2) == 9684580150926652833ull,
+static_assert(hash_16_bytes(1, 2) == 9684580150926652833ull,
               "Hash function must be stable");
-static_assert(hashing::detail::hash_16_bytes(-1, -2) == 7819786907124864172ull,
+static_assert(hash_16_bytes(-1, -2) == 7819786907124864172ull,
               "Hash function must be stable");
 static_assert(fold_64_to_16(1) == 1, "Fold function must be stable");
 static_assert(fold_64_to_16(12345678) == 25074, "Fold function must be stable");
@@ -97,12 +107,12 @@ MachineBlockHashInfoResult::MachineBlockHashInfoResult(
     // Append hashes of successors
     for (const MachineBasicBlock *SuccMBB : MBB.successors()) {
       uint64_t SuccHash = HashInfos[SuccMBB].OpcodeHash;
-      Hash = hashing::detail::hash_16_bytes(Hash, SuccHash);
+      Hash = hash_16_bytes(Hash, SuccHash);
     }
     // Append hashes of predecessors
     for (const MachineBasicBlock *PredMBB : MBB.predecessors()) {
       uint64_t PredHash = HashInfos[PredMBB].OpcodeHash;
-      Hash = hashing::detail::hash_16_bytes(Hash, PredHash);
+      Hash = hash_16_bytes(Hash, PredHash);
     }
     HashInfo.NeighborHash = Hash;
   }

--- a/llvm/lib/Transforms/Utils/IRNormalizer.cpp
+++ b/llvm/lib/Transforms/Utils/IRNormalizer.cpp
@@ -30,6 +30,19 @@
 
 using namespace llvm;
 
+// Frozen mixer; basic-block names derived from these hashes appear in
+// the normalized IR text and must be deterministic across processes
+// for the normalizer's "compare normalized IR" workflow to work.
+static constexpr uint64_t hash_16_bytes(uint64_t low, uint64_t high) {
+  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
+  uint64_t a = (low ^ high) * kMul;
+  a ^= (a >> 47);
+  uint64_t b = (high ^ a) * kMul;
+  b ^= (b >> 47);
+  b *= kMul;
+  return b;
+}
+
 namespace {
 /// IRNormalizer aims to transform LLVM IR into normal form.
 class IRNormalizer {
@@ -138,7 +151,7 @@ void IRNormalizer::nameBasicBlocks(Function &F) const {
     // Hash considering output instruction opcodes.
     for (auto &I : B)
       if (isOutput(&I))
-        Hash = hashing::detail::hash_16_bytes(Hash, I.getOpcode());
+        Hash = hash_16_bytes(Hash, I.getOpcode());
 
     if (Options.RenameAll || B.getName().empty()) {
       // Name basic block. Substring hash to make diffs more readable.
@@ -215,7 +228,7 @@ void IRNormalizer::nameAsInitialInstruction(Instruction *I) const {
   uint64_t Hash = MagicHashConstant;
 
   // Consider instruction's opcode in the hash.
-  Hash = hashing::detail::hash_16_bytes(Hash, I->getOpcode());
+  Hash = hash_16_bytes(Hash, I->getOpcode());
 
   SmallPtrSet<const Instruction *, 32> Visited;
   // Get output footprint for I.
@@ -223,7 +236,7 @@ void IRNormalizer::nameAsInitialInstruction(Instruction *I) const {
 
   // Consider output footprint in the hash.
   for (const int &Output : OutputFootprint)
-    Hash = hashing::detail::hash_16_bytes(Hash, Output);
+    Hash = hash_16_bytes(Hash, Output);
 
   // Base instruction name.
   SmallString<256> Name;
@@ -298,7 +311,7 @@ void IRNormalizer::nameAsRegularInstruction(Instruction *I) {
   uint64_t Hash = MagicHashConstant;
 
   // Consider instruction opcode in the hash.
-  Hash = hashing::detail::hash_16_bytes(Hash, I->getOpcode());
+  Hash = hash_16_bytes(Hash, I->getOpcode());
 
   // Operand opcodes for further sorting (commutative).
   SmallVector<int, 4> OperandsOpcodes;
@@ -312,7 +325,7 @@ void IRNormalizer::nameAsRegularInstruction(Instruction *I) {
 
   // Consider operand opcodes in the hash.
   for (const int Code : OperandsOpcodes)
-    Hash = hashing::detail::hash_16_bytes(Hash, Code);
+    Hash = hash_16_bytes(Hash, Code);
 
   // Base instruction name.
   SmallString<512> Name;


### PR DESCRIPTION
llvm/ADT/Hashing.h doesn't guarantee cross-process stability.
llvm/ADT/StableHashing.h provides stability for a specific compiler
version.

They reserve the right the right to adjust the implementation as the
compiler evolves.

Some callers of hashing::detail::hash_16_bytes rely on hash output
embedded in persisted artifacts:

* MachineBlockHashInfo serializes block hashes into BB section
  profile data and pins the mixer's exact output with a static_assert.
* BOLT's stale profile matching records block hashes in its on-disk
  profile format and replays them against potentially-rebuilt
  binaries (possibly built from a later LLVM revision).
* IRNormalizer derives basic-block names from the hash; the names
  land in the normalized IR text used to diff modules.

Move the implementation into each caller as a file-local static
constexpr helper with a comment documenting why it is frozen.
