### PR TITLE
[NFC][AArch64] Extracted AArch64PassConfig::isGlobalISelOptNone

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -282,12 +282,12 @@ LLVMInitializeAArch64Target() {
   initializeAArch64Arm64ECCallLoweringPass(PR);
 }
 
-bool llvm::isGlobalISelOptNone(const TargetMachine *TM) {
+bool AArch64TargetMachine::isGlobalISelOptNone() const {
   const bool GlobalISelFlag =
       getCGPassBuilderOption().EnableGlobalISelOption.value_or(false);
 
-  return TM->getOptLevel() == CodeGenOptLevel::None ||
-         (static_cast<unsigned>(TM->getOptLevel()) >
+  return getOptLevel() == CodeGenOptLevel::None ||
+         (static_cast<unsigned>(getOptLevel()) >
               static_cast<unsigned>(EnableGlobalISelAtO) &&
           !GlobalISelFlag);
 }
@@ -755,7 +755,7 @@ bool AArch64PassConfig::addIRTranslator() {
 }
 
 void AArch64PassConfig::addPreLegalizeMachineIR() {
-  if (isGlobalISelOptNone(&getAArch64TargetMachine())) {
+  if (getAArch64TargetMachine().isGlobalISelOptNone()) {
     addPass(createAArch64O0PreLegalizerCombiner());
     addPass(new Localizer());
   } else {
@@ -773,7 +773,7 @@ bool AArch64PassConfig::addLegalizeMachineIR() {
 
 void AArch64PassConfig::addPreRegBankSelect() {
   const bool IsGlobalISelOptNone =
-      isGlobalISelOptNone(&getAArch64TargetMachine());
+      getAArch64TargetMachine().isGlobalISelOptNone();
   if (!IsGlobalISelOptNone) {
     addPass(createAArch64PostLegalizerCombiner(IsGlobalISelOptNone));
     if (EnableGISelLoadStoreOptPostLegal)
@@ -789,7 +789,7 @@ bool AArch64PassConfig::addRegBankSelect() {
 
 bool AArch64PassConfig::addGlobalInstructionSelect() {
   addPass(new InstructionSelect(getOptLevel()));
-  if (!isGlobalISelOptNone(&getAArch64TargetMachine()))
+  if (!getAArch64TargetMachine().isGlobalISelOptNone())
     addPass(createAArch64PostSelectOptimize());
   return false;
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -282,6 +282,16 @@ LLVMInitializeAArch64Target() {
   initializeAArch64Arm64ECCallLoweringPass(PR);
 }
 
+bool llvm::isGlobalISelOptNone(const TargetMachine *TM) {
+  const bool GlobalISelFlag =
+      getCGPassBuilderOption().EnableGlobalISelOption.value_or(false);
+
+  return TM->getOptLevel() == CodeGenOptLevel::None ||
+         (static_cast<unsigned>(TM->getOptLevel()) >
+              static_cast<unsigned>(EnableGlobalISelAtO) &&
+          !GlobalISelFlag);
+}
+
 void AArch64TargetMachine::reset() { SubtargetMap.clear(); }
 
 //===----------------------------------------------------------------------===//
@@ -584,9 +594,6 @@ public:
   bool addRegAssignAndRewriteOptimized() override;
 
   std::unique_ptr<CSEConfigBase> getCSEConfig() const override;
-
-private:
-  bool isGlobalISelOptNone() const;
 };
 
 } // end anonymous namespace
@@ -618,21 +625,6 @@ TargetPassConfig *AArch64TargetMachine::createPassConfig(PassManagerBase &PM) {
 
 std::unique_ptr<CSEConfigBase> AArch64PassConfig::getCSEConfig() const {
   return getStandardCSEConfigForOpt(TM->getOptLevel());
-}
-
-// This function checks whether the opt level is explicitly set to none,
-// or whether GlobalISel was enabled due to SDAG encountering an optnone
-// function. If the opt level is greater than the level we automatically enable
-// globalisel at, and it wasn't enabled via CLI, we know that it must be because
-// of an optnone function.
-bool AArch64PassConfig::isGlobalISelOptNone() const {
-  const bool GlobalISelFlag =
-      getCGPassBuilderOption().EnableGlobalISelOption.value_or(false);
-
-  return getOptLevel() == CodeGenOptLevel::None ||
-         (static_cast<unsigned>(getOptLevel()) >
-              getAArch64TargetMachine().getEnableGlobalISelAtO() &&
-          !GlobalISelFlag);
 }
 
 void AArch64PassConfig::addIRPasses() {
@@ -763,7 +755,7 @@ bool AArch64PassConfig::addIRTranslator() {
 }
 
 void AArch64PassConfig::addPreLegalizeMachineIR() {
-  if (isGlobalISelOptNone()) {
+  if (isGlobalISelOptNone(&getAArch64TargetMachine())) {
     addPass(createAArch64O0PreLegalizerCombiner());
     addPass(new Localizer());
   } else {
@@ -780,8 +772,10 @@ bool AArch64PassConfig::addLegalizeMachineIR() {
 }
 
 void AArch64PassConfig::addPreRegBankSelect() {
-  if (!isGlobalISelOptNone()) {
-    addPass(createAArch64PostLegalizerCombiner(isGlobalISelOptNone()));
+  const bool IsGlobalISelOptNone =
+      isGlobalISelOptNone(&getAArch64TargetMachine());
+  if (!IsGlobalISelOptNone) {
+    addPass(createAArch64PostLegalizerCombiner(IsGlobalISelOptNone));
     if (EnableGISelLoadStoreOptPostLegal)
       addPass(new LoadStoreOpt());
   }
@@ -795,7 +789,7 @@ bool AArch64PassConfig::addRegBankSelect() {
 
 bool AArch64PassConfig::addGlobalInstructionSelect() {
   addPass(new InstructionSelect(getOptLevel()));
-  if (!isGlobalISelOptNone())
+  if (!isGlobalISelOptNone(&getAArch64TargetMachine()))
     addPass(createAArch64PostSelectOptimize());
   return false;
 }

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.h
@@ -21,13 +21,6 @@
 
 namespace llvm {
 
-// This function checks whether the opt level is explicitly set to none,
-// or whether GlobalISel was enabled due to SDAG encountering an optnone
-// function. If the opt level is greater than the level we automatically enable
-// globalisel at, and it wasn't enabled via CLI, we know that it must be because
-// of an optnone function.
-bool isGlobalISelOptNone(const TargetMachine *TM);
-
 class AArch64TargetMachine : public CodeGenTargetMachineImpl {
 protected:
   std::unique_ptr<TargetLoweringObjectFile> TLOF;
@@ -88,6 +81,13 @@ public:
 
   /// Returns the optimisation level that enables GlobalISel.
   unsigned getEnableGlobalISelAtO() const;
+
+  /// This function checks whether the opt level is explicitly set to none,
+  /// or whether GlobalISel was enabled due to SDAG encountering an optnone
+  /// function. If the opt level is greater than the level we automatically
+  /// enable globalisel at, and it wasn't enabled via CLI, we know that it must
+  /// be because of an optnone function.
+  bool isGlobalISelOptNone() const;
 
 private:
   bool isLittle;

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.h
@@ -21,6 +21,13 @@
 
 namespace llvm {
 
+// This function checks whether the opt level is explicitly set to none,
+// or whether GlobalISel was enabled due to SDAG encountering an optnone
+// function. If the opt level is greater than the level we automatically enable
+// globalisel at, and it wasn't enabled via CLI, we know that it must be because
+// of an optnone function.
+bool isGlobalISelOptNone(const TargetMachine *TM);
+
 class AArch64TargetMachine : public CodeGenTargetMachineImpl {
 protected:
   std::unique_ptr<TargetLoweringObjectFile> TLOF;


### PR DESCRIPTION
Extracts AArch64PassConfig::isGlobalISelOptNone into a standalone function, as suggested in reviews for https://github.com/llvm/llvm-project/pull/194156

This will help with NewPM porting since this functionality is required in NewPM orchestration. 