### PR TITLE
[clang][test] Add AArch64 requirement to arm64_neon.h test

### DIFF
--- a/clang/test/CodeGen/arm64-neon-header.c
+++ b/clang/test/CodeGen/arm64-neon-header.c
@@ -2,6 +2,8 @@
 // RUN:     -fms-compatibility -fms-compatibility-version=19.00 \
 // RUN:     -emit-llvm -o - %s | FileCheck %s
 
+// REQUIRES: aarch64-registered-target
+
 #include <arm64_neon.h>
 
 // CHECK-LABEL: define{{.*}} @test_vld1q_s32_x4(


### PR DESCRIPTION
Only run test when the AArch64 target is built