### PR TITLE
[compiler-rt][Darwin] Force codesign for runtime dylibs

### DIFF
--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
@@ -429,7 +429,7 @@ function(add_compiler_rt_runtime name type)
 
         add_custom_command(TARGET ${libname}
           POST_BUILD
-          COMMAND ${CODESIGN} --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
+          COMMAND ${CODESIGN} --force --sign - ${EXTRA_CODESIGN_ARGUMENTS} $<TARGET_FILE:${libname}>
           WORKING_DIRECTORY ${COMPILER_RT_OUTPUT_LIBRARY_DIR}
           COMMAND_EXPAND_LISTS
         )


### PR DESCRIPTION
Force `codesign` in the Darwin runtime dylib post-build step.

Without `--force`, the `codesign --sign -` invocation may fail during
the `compiler-rt` runtimes build with:

```text
<dylib>: is already signed
```

This causes the runtimes build to fail even though the dylib was just
produced by the build.

Use codesign `--force --sign -` for Darwin runtime dylibs so the
post-build signing step is robust when a signature is already present.