### PR TITLE
[Github][CI] Don't build analysis targets when no relevant projects present

### DIFF
--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -74,9 +74,16 @@ jobs:
                 -DCLANG_INCLUDE_TESTS=OFF \
                 -DCMAKE_BUILD_TYPE=Release
 
-          ninja -C build \
-                clang-tablegen-targets \
-                genconfusable               # for "ConfusableIdentifierCheck.h"
+          ninja_targets=""
+          if [[ ";${projects_to_build};" == *";clang;"* ]]; then
+            ninja_targets="${ninja_targets} clang-tablegen-targets"
+          fi
+          if [[ ";${projects_to_build};" == *";clang-tools-extra;"* ]]; then
+            ninja_targets="${ninja_targets} genconfusable"
+          fi
+          if [[ -n "${ninja_targets}" ]]; then
+            ninja -C build ${ninja_targets}
+          fi
 
       - name: Run code linters
         env:


### PR DESCRIPTION
Fixes error described in [link](https://github.com/llvm/llvm-project/pull/194442#issuecomment-4330108752), When `clang-tools-extra` project was not computed to build but `genconfusable` (part of `clang-tools-extra`) was build anyway.