### PR TITLE
[InstSimplify] Fold fshl/fshr of complementary shifts to identity

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -7285,18 +7285,17 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
     if (match(ShAmtArg, m_APInt(ShAmtC))) {
       // If there's effectively no shift, return the 1st arg or 2nd arg.
       APInt BitWidth = APInt(ShAmtC->getBitWidth(), ShAmtC->getBitWidth());
-      if (ShAmtC->urem(BitWidth).isZero())
+      const APInt ShAmt = ShAmtC->urem(BitWidth);
+      if (ShAmt.isZero())
         return Args[IID == Intrinsic::fshl ? 0 : 1];
 
       // fshl (lshr X, C1), (shl X, C2), C1 -> X when C1 + C2 == BW
       // fshr (lshr X, C1), (shl X, C2), C2 -> X when C1 + C2 == BW
       const APInt *C1, *C2;
       Value *X;
-      unsigned ShAmt = ShAmtC->urem(BitWidth).getZExtValue();
       if (match(Op0, m_LShr(m_Value(X), m_APInt(C1))) &&
           match(Op1, m_Shl(m_Specific(X), m_APInt(C2))) &&
-          *C1 + *C2 == BitWidth &&
-          ShAmt == (IID == Intrinsic::fshl ? C1 : C2)->getZExtValue())
+          *C1 + *C2 == BitWidth && ShAmt == *(IID == Intrinsic::fshl ? C1 : C2))
         return X;
     }
 

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -7287,6 +7287,17 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
       APInt BitWidth = APInt(ShAmtC->getBitWidth(), ShAmtC->getBitWidth());
       if (ShAmtC->urem(BitWidth).isZero())
         return Args[IID == Intrinsic::fshl ? 0 : 1];
+
+      // fshl (lshr X, C1), (shl X, C2), C1 -> X when C1 + C2 == BW
+      // fshr (lshr X, C1), (shl X, C2), C2 -> X when C1 + C2 == BW
+      const APInt *C1, *C2;
+      Value *X;
+      unsigned ShAmt = ShAmtC->urem(BitWidth).getZExtValue();
+      if (match(Op0, m_LShr(m_Value(X), m_APInt(C1))) &&
+          match(Op1, m_Shl(m_Specific(X), m_APInt(C2))) &&
+          *C1 + *C2 == BitWidth &&
+          ShAmt == (IID == Intrinsic::fshl ? C1 : C2)->getZExtValue())
+        return X;
     }
 
     // Rotating zero by anything is zero.

--- a/llvm/test/Transforms/InstSimplify/call.ll
+++ b/llvm/test/Transforms/InstSimplify/call.ll
@@ -590,6 +590,87 @@ define <2 x i8> @fshr_no_shift_modulo_bitwidth_splat(<2 x i8> %x, <2 x i8> %y) {
   ret <2 x i8> %z
 }
 
+declare i32 @llvm.fshl.i32(i32, i32, i32)
+declare i32 @llvm.fshr.i32(i32, i32, i32)
+
+define i32 @fshl_identity(i32 %x) {
+; CHECK-LABEL: @fshl_identity(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X1:%.*]], 24
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X1]], 8
+; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 24)
+; CHECK-NEXT:    ret i32 [[X]]
+;
+  %shr = lshr i32 %x, 24
+  %shl = shl i32 %x, 8
+  %r = call i32 @llvm.fshl.i32(i32 %shr, i32 %shl, i32 24)
+  ret i32 %r
+}
+
+define i32 @fshr_identity(i32 %x) {
+; CHECK-LABEL: @fshr_identity(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X1:%.*]], 24
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X1]], 8
+; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.fshr.i32(i32 [[SHR]], i32 [[SHL]], i32 8)
+; CHECK-NEXT:    ret i32 [[X]]
+;
+  %shr = lshr i32 %x, 24
+  %shl = shl i32 %x, 8
+  %r = call i32 @llvm.fshr.i32(i32 %shr, i32 %shl, i32 8)
+  ret i32 %r
+}
+
+define i32 @fshl_identity_modulo(i32 %x) {
+; CHECK-LABEL: @fshl_identity_modulo(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X1:%.*]], 8
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X1]], 24
+; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 40)
+; CHECK-NEXT:    ret i32 [[X]]
+;
+  %shr = lshr i32 %x, 8
+  %shl = shl i32 %x, 24
+  %r = call i32 @llvm.fshl.i32(i32 %shr, i32 %shl, i32 40)
+  ret i32 %r
+}
+
+define i32 @fshl_not_identity_wrong_shift(i32 %x) {
+; CHECK-LABEL: @fshl_not_identity_wrong_shift(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X:%.*]], 24
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X]], 8
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 8)
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %shr = lshr i32 %x, 24
+  %shl = shl i32 %x, 8
+  %r = call i32 @llvm.fshl.i32(i32 %shr, i32 %shl, i32 8)
+  ret i32 %r
+}
+
+define i32 @fshl_not_identity_different_operands(i32 %x, i32 %y) {
+; CHECK-LABEL: @fshl_not_identity_different_operands(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X:%.*]], 24
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[Y:%.*]], 8
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 24)
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %shr = lshr i32 %x, 24
+  %shl = shl i32 %y, 8
+  %r = call i32 @llvm.fshl.i32(i32 %shr, i32 %shl, i32 24)
+  ret i32 %r
+}
+
+define i32 @fshl_not_identity_wrong_sum(i32 %x) {
+; CHECK-LABEL: @fshl_not_identity_wrong_sum(
+; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X:%.*]], 24
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X]], 4
+; CHECK-NEXT:    [[R:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 24)
+; CHECK-NEXT:    ret i32 [[R]]
+;
+  %shr = lshr i32 %x, 24
+  %shl = shl i32 %x, 4
+  %r = call i32 @llvm.fshl.i32(i32 %shr, i32 %shl, i32 24)
+  ret i32 %r
+}
+
 ; If y is poison, eliminating the guard is not safe.
 
 define i8 @fshl_zero_shift_guard(i8 %x, i8 %y, i8 %sh) {

--- a/llvm/test/Transforms/InstSimplify/call.ll
+++ b/llvm/test/Transforms/InstSimplify/call.ll
@@ -590,9 +590,6 @@ define <2 x i8> @fshr_no_shift_modulo_bitwidth_splat(<2 x i8> %x, <2 x i8> %y) {
   ret <2 x i8> %z
 }
 
-declare i32 @llvm.fshl.i32(i32, i32, i32)
-declare i32 @llvm.fshr.i32(i32, i32, i32)
-
 define i32 @fshl_identity(i32 %x) {
 ; CHECK-LABEL: @fshl_identity(
 ; CHECK-NEXT:    ret i32 [[X:%.*]]

--- a/llvm/test/Transforms/InstSimplify/call.ll
+++ b/llvm/test/Transforms/InstSimplify/call.ll
@@ -595,10 +595,7 @@ declare i32 @llvm.fshr.i32(i32, i32, i32)
 
 define i32 @fshl_identity(i32 %x) {
 ; CHECK-LABEL: @fshl_identity(
-; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X1:%.*]], 24
-; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X1]], 8
-; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 24)
-; CHECK-NEXT:    ret i32 [[X]]
+; CHECK-NEXT:    ret i32 [[X:%.*]]
 ;
   %shr = lshr i32 %x, 24
   %shl = shl i32 %x, 8
@@ -608,10 +605,7 @@ define i32 @fshl_identity(i32 %x) {
 
 define i32 @fshr_identity(i32 %x) {
 ; CHECK-LABEL: @fshr_identity(
-; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X1:%.*]], 24
-; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X1]], 8
-; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.fshr.i32(i32 [[SHR]], i32 [[SHL]], i32 8)
-; CHECK-NEXT:    ret i32 [[X]]
+; CHECK-NEXT:    ret i32 [[X:%.*]]
 ;
   %shr = lshr i32 %x, 24
   %shl = shl i32 %x, 8
@@ -621,10 +615,7 @@ define i32 @fshr_identity(i32 %x) {
 
 define i32 @fshl_identity_modulo(i32 %x) {
 ; CHECK-LABEL: @fshl_identity_modulo(
-; CHECK-NEXT:    [[SHR:%.*]] = lshr i32 [[X1:%.*]], 8
-; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[X1]], 24
-; CHECK-NEXT:    [[X:%.*]] = call i32 @llvm.fshl.i32(i32 [[SHR]], i32 [[SHL]], i32 40)
-; CHECK-NEXT:    ret i32 [[X]]
+; CHECK-NEXT:    ret i32 [[X:%.*]]
 ;
   %shr = lshr i32 %x, 8
   %shl = shl i32 %x, 24


### PR DESCRIPTION
```
fshl(lshr x, C1, shl x, C2, C1)
fshr(lshr x, C1, shl x, C2, C2)
  when C1 + C2 == BitWidth
    --> x
```

Downstream: rust-lang/rust#156423
Alive2: https://alive2.llvm.org/ce/z/YQi-hY