### PR TITLE
[clang][NFC] Mark CWG988 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -169,6 +169,17 @@ enum struct E4 : int { e = static_cast<int>(E4()) };
 #endif
 } // namespace cwg977
 
+namespace cwg988 { // cwg988: 2.7
+#if __cplusplus >= 201103L
+void f(int& lvalue_ref, int&& rvalue_ref) {
+  static_assert(__is_same(decltype(lvalue_ref)&,  int&),  "");
+  static_assert(__is_same(decltype(lvalue_ref)&&, int&),  "");
+  static_assert(__is_same(decltype(rvalue_ref)&,  int&),  "");
+  static_assert(__is_same(decltype(rvalue_ref)&&, int&&), "");
+}
+#endif
+} // namespace cwg988
+
 namespace cwg990 { // cwg990: 3.5
 #if __cplusplus >= 201103L
   struct A { // #cwg990-A

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -6693,7 +6693,7 @@
     <td>[<a href="https://wg21.link/dcl.type.simple">dcl.type.simple</a>]</td>
     <td>CD2</td>
     <td>Reference-to-reference collapsing with <TT>decltype</TT></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 2.7</td>
   </tr>
   <tr id="989">
     <td><a href="https://cplusplus.github.io/CWG/issues/989.html">989</a></td>


### PR DESCRIPTION
[CWG988](https://wg21.link/cwg988) specifies that reference collapsing is performed when trying to form a reference to a `decltype`. Clang implements this since 2.7: https://godbolt.org/z/vYzKbv8x7 (and I checked a few versions after that to make sure there were no regressions).