### PR TITLE
[InstCombine] Relax the requirements for (X ^ C2) + C -> (C2 + C) - X

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -951,13 +951,12 @@ Instruction *InstCombinerImpl::foldAddWithConstant(BinaryOperator &Add) {
     if (C2->isSignMask())
       return BinaryOperator::CreateAdd(X, ConstantInt::get(Ty, *C2 ^ *C));
 
-    // If X has no high-bits set above an xor mask:
-    // add (xor X, LowMaskC), C --> sub (LowMaskC + C), X
-    if (C2->isMask()) {
-      KnownBits LHSKnown = computeKnownBits(X, &Add);
-      if ((*C2 | LHSKnown.Zero).isAllOnes())
-        return BinaryOperator::CreateSub(ConstantInt::get(Ty, *C2 + *C), X);
-    }
+    // If X has no bits set other than an xor mask,
+    // xor is equivalent to sub with no borrow between bits:
+    // add (xor X, C2), C --> sub (C2 + C), X
+    KnownBits LHSKnown = computeKnownBits(X, &Add);
+    if ((*C2 | LHSKnown.Zero).isAllOnes())
+      return BinaryOperator::CreateSub(ConstantInt::get(Ty, *C2 + *C), X);
 
     // Look for a math+logic pattern that corresponds to sext-in-register of a
     // value with cleared high bits. Convert that into a pair of shifts:

--- a/llvm/test/Transforms/InstCombine/sub-xor.ll
+++ b/llvm/test/Transforms/InstCombine/sub-xor.ll
@@ -161,8 +161,7 @@ define <2 x i8> @xor_add_splat_undef(<2 x i8> %x) {
 define i32 @xor_notmask_add(i32 %x) {
 ; CHECK-LABEL: @xor_notmask_add(
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 28
-; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 61
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[XOR]], -10
+; CHECK-NEXT:    [[ADD:%.*]] = sub nuw nsw i32 51, [[AND]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %and = and i32 %x, 28
@@ -176,7 +175,7 @@ define i32 @xor_notmask_add_multiuse(i32 %x) {
 ; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 28
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 29
 ; CHECK-NEXT:    call void @use(i32 [[XOR]])
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[XOR]], 10
+; CHECK-NEXT:    [[ADD:%.*]] = sub nuw nsw i32 39, [[AND]]
 ; CHECK-NEXT:    ret i32 [[ADD]]
 ;
   %and = and i32 %x, 28
@@ -189,8 +188,7 @@ define i32 @xor_notmask_add_multiuse(i32 %x) {
 define <2 x i8> @xor_notmask_add_splat(<2 x i8> %x) {
 ; CHECK-LABEL: @xor_notmask_add_splat(
 ; CHECK-NEXT:    [[AND:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 24)
-; CHECK-NEXT:    [[XOR:%.*]] = xor <2 x i8> [[AND]], splat (i8 61)
-; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw <2 x i8> [[XOR]], splat (i8 42)
+; CHECK-NEXT:    [[ADD:%.*]] = sub nuw nsw <2 x i8> splat (i8 103), [[AND]]
 ; CHECK-NEXT:    ret <2 x i8> [[ADD]]
 ;
   %and = and <2 x i8> %x, <i8 24, i8 24>

--- a/llvm/test/Transforms/InstCombine/sub-xor.ll
+++ b/llvm/test/Transforms/InstCombine/sub-xor.ll
@@ -158,6 +158,86 @@ define <2 x i8> @xor_add_splat_undef(<2 x i8> %x) {
   ret <2 x i8> %add
 }
 
+define i32 @xor_notmask_add(i32 %x) {
+; CHECK-LABEL: @xor_notmask_add(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 28
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 61
+; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[XOR]], -10
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %and = and i32 %x, 28
+  %xor = xor i32 %and, 61
+  %add = add i32 %xor, -10
+  ret i32 %add
+}
+
+define i32 @xor_notmask_add_multiuse(i32 %x) {
+; CHECK-LABEL: @xor_notmask_add_multiuse(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 28
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 29
+; CHECK-NEXT:    call void @use(i32 [[XOR]])
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[XOR]], 10
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %and = and i32 %x, 28
+  %xor = xor i32 %and, 29
+  call void @use(i32 %xor)
+  %add = add i32 %xor, 10
+  ret i32 %add
+}
+
+define <2 x i8> @xor_notmask_add_splat(<2 x i8> %x) {
+; CHECK-LABEL: @xor_notmask_add_splat(
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 24)
+; CHECK-NEXT:    [[XOR:%.*]] = xor <2 x i8> [[AND]], splat (i8 61)
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw <2 x i8> [[XOR]], splat (i8 42)
+; CHECK-NEXT:    ret <2 x i8> [[ADD]]
+;
+  %and = and <2 x i8> %x, <i8 24, i8 24>
+  %xor = xor <2 x i8> %and, <i8 61, i8 61>
+  %add = add <2 x i8> %xor, <i8 42, i8 42>
+  ret <2 x i8> %add
+}
+
+define <2 x i8> @xor_notmask_add_splat_poison(<2 x i8> %x) {
+; CHECK-LABEL: @xor_notmask_add_splat_poison(
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 24)
+; CHECK-NEXT:    [[XOR:%.*]] = xor <2 x i8> [[AND]], <i8 62, i8 poison>
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw <2 x i8> [[XOR]], splat (i8 42)
+; CHECK-NEXT:    ret <2 x i8> [[ADD]]
+;
+  %and = and <2 x i8> %x, <i8 24, i8 24>
+  %xor = xor <2 x i8> %and, <i8 62, i8 poison>
+  %add = add <2 x i8> %xor, <i8 42, i8 42>
+  ret <2 x i8> %add
+}
+
+define <2 x i8> @xor_notmask_add_non_splat(<2 x i8> %x) {
+; CHECK-LABEL: @xor_notmask_add_non_splat(
+; CHECK-NEXT:    [[AND:%.*]] = and <2 x i8> [[X:%.*]], splat (i8 24)
+; CHECK-NEXT:    [[XOR:%.*]] = xor <2 x i8> [[AND]], <i8 62, i8 61>
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw <2 x i8> [[XOR]], splat (i8 42)
+; CHECK-NEXT:    ret <2 x i8> [[ADD]]
+;
+  %and = and <2 x i8> %x, <i8 24, i8 24>
+  %xor = xor <2 x i8> %and, <i8 62, i8 61>
+  %add = add <2 x i8> %xor, <i8 42, i8 42>
+  ret <2 x i8> %add
+}
+
+define i32 @xor_notmask_add_negative(i32 %x) {
+; CHECK-LABEL: @xor_notmask_add_negative(
+; CHECK-NEXT:    [[AND:%.*]] = and i32 [[X:%.*]], 28
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[AND]], 23
+; CHECK-NEXT:    [[ADD:%.*]] = add nuw nsw i32 [[XOR]], 10
+; CHECK-NEXT:    ret i32 [[ADD]]
+;
+  %and = and i32 %x, 28
+  %xor = xor i32 %and, 23
+  %add = add i32 %xor, 10
+  ret i32 %add
+}
+
 ; Make sure we don't convert sub to xor using dominating condition. That makes
 ; it hard for other passe to reverse.
 define i32 @xor_dominating_cond(i32 %x) {


### PR DESCRIPTION
If (C2 - X) has no borrow between bits, it is equivalent to (X ^ C2).
A borrow would occur when c2_bit=0 and x_bit=1.
It follows that c2_bit=1 or x_bit=0 means no borrow.

Remove an artificial condition that C2 must be a low bits mask.

Proof: https://alive2.llvm.org/ce/z/uNMsg_