### PR TITLE
[AArch64] Guard against vector invalidation in EmitAArch64CpuSupports.

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/ARM.cpp
@@ -7306,9 +7306,10 @@ Value *CodeGenFunction::EmitAArch64CpuInit() {
 Value *CodeGenFunction::EmitAArch64CpuSupports(const CallExpr *E) {
   const Expr *ArgExpr = E->getArg(0)->IgnoreParenCasts();
   StringRef ArgStr = cast<StringLiteral>(ArgExpr)->getString();
+  llvm::SmallVector<StringRef, 8> OrigFeatures;
+  ArgStr.split(OrigFeatures, "+");
   llvm::SmallVector<StringRef, 8> Features;
-  ArgStr.split(Features, "+");
-  for (auto &Feature : Features) {
+  for (StringRef Feature : OrigFeatures) {
     Feature = Feature.trim();
     if (!llvm::AArch64::parseFMVExtension(Feature))
       return Builder.getFalse();

--- a/clang/test/CodeGen/AArch64/cpu-supports-target.c
+++ b/clang/test/CodeGen/AArch64/cpu-supports-target.c
@@ -217,6 +217,21 @@ int test_versions() {
     return code();
 }
 
+// CHECK: Function Attrs: noinline nounwind optnone
+// CHECK-LABEL: define dso_local i32 @test_long(
+// CHECK-SAME: ) #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i64, ptr @__aarch64_cpu_features, align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = and i64 [[TMP0]], 577586773744664575
+// CHECK-NEXT:    [[TMP2:%.*]] = icmp eq i64 [[TMP1]], 577586773744664575
+// CHECK-NEXT:    [[TMP3:%.*]] = and i1 true, [[TMP2]]
+// CHECK-NEXT:    [[CONV:%.*]] = zext i1 [[TMP3]] to i32
+// CHECK-NEXT:    ret i32 [[CONV]]
+//
+int test_long(void) {
+  return __builtin_cpu_supports("rng+flagm+flagm2+fp16fml+dotprod+sm4+rdm+lse+fp+simd+aes+bf16+bti+crc+cssc+dit+dotprod+f32mm+f64mm+flagm+fp16fml+fp16+i8mm+mops+sha2+sha3+sm4+sve2");
+}
+
 //.
 // CHECK: attributes #[[ATTR0]] = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 // CHECK: attributes #[[ATTR1]] = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-features"="+fp-armv8,+neon" }


### PR DESCRIPTION
This prevents the Vector from being invalidated whilst iterator over it. As far as I can tell we were adding elements twice.

Fixes #196789