### PR TITLE
[MLIR] Make MLIRRegisterAllPasses depend on mlir-headers

### DIFF
--- a/mlir/lib/CMakeLists.txt
+++ b/mlir/lib/CMakeLists.txt
@@ -41,6 +41,12 @@ add_mlir_library(MLIRRegisterAllPasses
 
   PARTIAL_SOURCES_INTENDED
 
+  # This TU includes dialect pass registration headers that depend on
+  # TableGen outputs (e.g. Passes.h.inc) wired into mlir-headers. Without this
+  # dependency it may compile before those headers are regenerated.
+  DEPENDS
+  mlir-headers
+
   LINK_LIBS PUBLIC
   ${dialect_libs} # Some passes are part of the dialect libs
   ${conversion_libs}


### PR DESCRIPTION
RegisterAllPasses.cpp pulls in dialect Passes.h / generated Passes.h.inc via TableGen targets that are tied to mlir-headers, but add_mlir_library only adds mlir-generic-headers by default, so this TU can compile before those generated headers are ready and registerAllPasses() can miss passes (e.g. sporadic mlir-opt --help gaps). Add DEPENDS mlir-headers to MLIRRegisterAllPasses in mlir/lib/CMakeLists.txt so it waits for those outputs. Verified with ninja mlir-opt and mlir-opt --help | grep -E 'nvvm-attach-target|rocdl-attach-target' (or similar stable upstream passes in your tree).