### PR TITLE
[clang][bytecode] Fix a crash in Descriptor::getElemDataSize()

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.cpp
+++ b/clang/lib/AST/ByteCode/Descriptor.cpp
@@ -493,6 +493,8 @@ bool Descriptor::isUnion() const { return isRecord() && ElemRecord->isUnion(); }
 unsigned Descriptor::getElemDataSize() const {
   if ((isPrimitive() || isPrimitiveArray()) &&
       isIntegerOrBoolType(getPrimType())) {
+    if (getPrimType() == PT_Bool)
+      return 1;
     FIXED_SIZE_INT_TYPE_SWITCH(getPrimType(), { return T::bitWidth() / 8; });
   }
   return ElemSize;

--- a/clang/test/AST/ByteCode/literals.cpp
+++ b/clang/test/AST/ByteCode/literals.cpp
@@ -1503,3 +1503,7 @@ namespace ExternRedecl {
   constexpr int a = 10;
   static_assert(*p == 10, "");
 }
+
+namespace GetElemDataSizeBool {
+  int foo[(intptr_t)(bool *)0]; // both-warning {{variable length array folded to constant array as an extension}}
+}


### PR DESCRIPTION
`FIXED_SIZE_INT_TYPE_SWITCH` does not handle `PT_Bool`, handle it explicitly before.