### PR TITLE
[clang][bytecode] Check value-dependency before calling evaluateValue()

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -7683,8 +7683,9 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
 
   // For C.
   if (!Ctx.getLangOpts().CPlusPlus) {
-    if (VD->getInit() && DeclType.isConstant(Ctx.getASTContext()) &&
-        !VD->isWeak() && VD->evaluateValue())
+    if (VD->getInit() && !VD->getInit()->isValueDependent() &&
+        DeclType.isConstant(Ctx.getASTContext()) && !VD->isWeak() &&
+        VD->evaluateValue())
       return revisit(VD, /*IsConstexprUnknown=*/false);
     return this->emitDummyPtr(D, E);
   }

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -457,3 +457,12 @@ void labelAndNull(void) { int bar = &*(void *)0 - &&baz; } // all-error {{use of
 
 void nonNumberRem(void) { *((int *)0) = (long)foo % 42; } // all-warning {{indirection of non-volatile null pointer will be deleted, not trap}} \
                                                           // all-note {{consider using __builtin_trap() or qualifying pointer with 'volatile'}}
+
+struct Oops {
+  int a; // all-note {{previous declaration is here}}
+  double a; // all-error {{duplicate member 'a'}}
+};
+void evaluatevalue(void) {
+  const struct Oops s = {0, 0.};
+  *(int *)(&s.a) = 42; // all-warning {{cast from 'const int *' to 'int *' drops const qualifier}}
+}


### PR DESCRIPTION
As always.