### PR TITLE
[lldb] Add specific error message for "process plugin" with no plugin loaded

### DIFF
--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -952,6 +952,10 @@ public:
       return process->GetPluginCommandObject();
     return nullptr;
   }
+
+  llvm::StringRef GetUnsupportedError() override {
+    return "no process plugin commands are currently registered";
+  }
 };
 
 // CommandObjectProcessLoad

--- a/lldb/test/Shell/Commands/command-process-plugin-no-plugin.test
+++ b/lldb/test/Shell/Commands/command-process-plugin-no-plugin.test
@@ -1,0 +1,3 @@
+# RUN: not %lldb -b -o "process plugin" 2>&1 | FileCheck %s
+
+# CHECK: error: no process plugin commands are currently registered


### PR DESCRIPTION
Fixes #196535.

The error was:
> command is not implemented

Which is incorrect. It is now:
> no process plugin commands are currently registered

Which is not very helpful either but it's not wrong at least. We could expand it but I'm not sure what would help anyone here, given how rare it is that anyone encounters this anyway.