### PR TITLE
[LoongArch] Use fallback path when relocation `SymA == nullptr`

### DIFF
--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
@@ -403,6 +403,11 @@ bool LoongArchAsmBackend::addReloc(const MCFragment &F, const MCFixup &Fixup,
   };
   uint64_t FixedValueA, FixedValueB;
   if (Target.getSubSym()) {
+    // It's possible for Target to have (SymB != nullptr && SymA == nullptr).
+    // Go to the fallback path when we encounter this. See also #196927.
+    if (!Target.getAddSym())
+      return Fallback();
+
     assert(Target.getSpecifier() == 0 &&
            "relocatable SymA-SymB cannot have relocation specifier");
     std::pair<MCFixupKind, MCFixupKind> FK;

--- a/llvm/test/MC/LoongArch/Relocations/sub-expr.s
+++ b/llvm/test/MC/LoongArch/Relocations/sub-expr.s
@@ -38,6 +38,8 @@
 # CHECK-NEXT:       0x30 R_LARCH_SUB64 x 0x0
 # CHECK-NEXT:       0x38 R_LARCH_ADD32 {{.*}} 0x0
 # CHECK-NEXT:       0x38 R_LARCH_SUB32 y 0x0
+# CHECK-NEXT:       0x3C R_LARCH_32_PCREL - 0xBEEF
+# CHECK-NEXT:       0x40 R_LARCH_64_PCREL - 0xBEEF
 # CHECK-NEXT:     }
 # NORELAX-NEXT:   Section ({{.*}}) .rela.sy {
 # NORELAX-NEXT:     0x0 R_LARCH_CALL36 foo 0x0
@@ -69,6 +71,10 @@ la.pcrel $a0, z
 .4byte y-x
 .8byte .-x
 .4byte .-y
+1:
+.4byte 0xbeef-1b
+1:
+.8byte 0xbeef-1b
 
 .section .sy,"ax"
 call36 foo


### PR DESCRIPTION
This PR adds a fallback path for `SymA == nullptr && SymB != nullptr` relocations. This prevents a null pointer dereference when trying to assemble such an instruction.

Related unit tests are also updated to reflect this change.

Fixes #196927.

---
**v2** (9aabcf3b49e620d1ee49e3a29d7a85adadf13580):
* Add some inline comments as suggested by @wangleiat.