### PR TITLE
[gn] port 07b5dfe9473c6 + deps (LLVMABI dep in clang)

### DIFF
--- a/llvm/utils/gn/secondary/clang/lib/CodeGen/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/lib/CodeGen/BUILD.gn
@@ -14,6 +14,7 @@ static_library("CodeGen") {
     "//clang/lib/Basic",
     "//clang/lib/Frontend",
     "//clang/lib/Lex",
+    "//llvm/lib/ABI",
     "//llvm/lib/Analysis",
     "//llvm/lib/Bitcode/Reader",
     "//llvm/lib/CodeGen",

--- a/llvm/utils/gn/secondary/llvm/lib/ABI/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/ABI/BUILD.gn
@@ -1,0 +1,15 @@
+static_library("ABI") {
+  output_name = "LLVMABI"
+  deps = [
+    "//llvm/include/llvm/Config:config",
+    "//llvm/lib/IR",
+    "//llvm/lib/Support",
+  ]
+  sources = [
+    "Types.cpp",
+    "FunctionInfo.cpp",
+    "TargetInfo.cpp",
+    "IRTypeMapper.cpp",
+    "Targets/BPF.cpp",
+  ]
+}


### PR DESCRIPTION
Also adds build files for llvm/lib/ABI, which was dead code before 07b5dfe9473c6 (at least in the GN build).