### PR TITLE
[clang][bytecode] Pass correct QualType to getFixedPointSemantics()

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4756,7 +4756,7 @@ bool Compiler<Emitter>::visitZeroInitializer(PrimType T, QualType QT,
     return this->emitFloat(F, E);
   }
   case PT_FixedPoint: {
-    auto Sem = Ctx.getASTContext().getFixedPointSemantics(E->getType());
+    auto Sem = Ctx.getASTContext().getFixedPointSemantics(QT);
     return this->emitConstFixedPoint(FixedPoint::zero(Sem), E);
   }
   }

--- a/clang/test/AST/ByteCode/fixed-point.cpp
+++ b/clang/test/AST/ByteCode/fixed-point.cpp
@@ -84,3 +84,8 @@ namespace Cmp {
   static_assert(A < B);
   static_assert(A <= B);
 }
+
+struct S {
+  _Accum s[2];
+};
+S s = S();


### PR DESCRIPTION
The expression type might be different, so pass the QualType we have at hand.