### PR TITLE
 [Lit] Enable in-process built-ins to run as part of a command pipeline

### DIFF
--- a/llvm/utils/lit/lit/InprocBuiltins.py
+++ b/llvm/utils/lit/lit/InprocBuiltins.py
@@ -1,87 +1,304 @@
+from __future__ import annotations
+
+import abc
 import getopt
+import io
 import os
 import pathlib
-import platform
 import shutil
 import stat
 import subprocess
-from io import StringIO
+from dataclasses import dataclass
+from typing import Callable, Optional
 
 import lit.util
+from lit.ShCommands import Command
 from lit.ShellEnvironment import (
     InternalShellError,
-    ShellCommandResult,
-    expand_glob_expressions,
+    ShellEnvironment,
     kIsWindows,
-    processRedirects,
     updateEnv,
 )
 
 
-def executeBuiltinCd(cmd, shenv):
+class InprocBuiltinIOObject(abc.ABC):
+    """
+    Base class for IO streams used for in-process built-ins. This class has two
+    specializations: InprocBuiltinIOFile, wrapping a file open in text mode, and
+    InprocBuiltinIOMemory, wrapping a BytesIO object. These streams provide
+    a text IO interface, but support reading and writing binary data too.
+
+    The main reason that this exists is to solve the conflict that binary IO is
+    required for daemonized testing, as many tests involve tools reading and
+    writing binary files and piping binary data between themselves, but on z/OS
+    files must be opened in text mode so that the character encoding is correct.
+    So we need an IO object that can be both a file open in text mode and a
+    in-memory stream that can store binary data.
+    """
+
+    @abc.abstractmethod
+    def read(self) -> str:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def read_binary(self) -> bytes:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def write(self, data: str) -> int:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def write_binary(self, data: bytes) -> int:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def seek(self, pos: int):
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def flush(self):
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def get_filename(self) -> str | None:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def get_encoding(self) -> str | None:
+        raise NotImplemented
+
+
+@dataclass
+class InprocBuiltinIOFile(InprocBuiltinIOObject):
+    """
+    Specialization of InprocBuiltinIOObject wrapping a file which is open in
+    text mode. Files must be opened in text mode so that character encoding
+    tags are correctly handled on z/OS. Binary IO is still supported via the
+    OS APIs (needed for daemonized testing).
+    """
+
+    file: io.TextIOBase
+
+    def read(self) -> str:
+        return self.file.read()
+
+    def read_binary(self) -> bytes:
+        self.file.flush()
+        data = bytearray()
+        chunk_size = 1024
+
+        while True:
+            chunk = os.read(self.file.fileno(), chunk_size)
+            if not chunk:
+                break
+            data.extend(chunk)
+
+        return bytes(data)
+
+    def write(self, data: str) -> int:
+        return self.file.write(data)
+
+    def write_binary(self, data: bytes) -> int:
+        self.file.flush()
+        return os.write(self.file.fileno(), data)
+
+    def seek(self, pos: int):
+        self.file.seek(pos)
+
+    def flush(self):
+        self.file.flush()
+
+    def get_filename(self) -> str | None:
+        if hasattr(self.file, "name") and isinstance(self.file.name, str):
+            return self.file.name
+        return None
+
+    def get_encoding(self) -> str | None:
+        return str(self.file.encoding)
+
+
+@dataclass
+class InprocBuiltinIOMemory(InprocBuiltinIOObject):
+    """
+    Specialization of InprocBuiltinIOObject wrapping an in-memory binary stream.
+    """
+
+    obj: io.BytesIO
+    encoding: str = "utf-8"
+
+    def read(self) -> str:
+        return self.obj.read().decode(self.encoding, errors="replace")
+
+    def read_binary(self) -> bytes:
+        return self.obj.read()
+
+    def write(self, data: str) -> int:
+        return self.obj.write(data.encode(self.encoding, errors="replace"))
+
+    def write_binary(self, data: bytes) -> int:
+        return self.obj.write(data)
+
+    def seek(self, pos: int):
+        self.obj.seek(pos)
+
+    def flush(self):
+        pass
+
+    def get_filename(self) -> str | None:
+        return None
+
+    def get_encoding(self) -> str | None:
+        return self.encoding
+
+
+class InprocBuiltinIO:
+    """
+    Holds IO streams for an inproc builtin invocation.
+
+    NB: If stderr is redirected to be the same stream as stdout, then
+    `stder == stdout` is True.
+    """
+
+    stdin: InprocBuiltinIOObject
+    stdout: InprocBuiltinIOObject
+    stderr: InprocBuiltinIOObject
+
+    def __init__(self, stdin, stdout, stderr):
+        """
+        Configure the IO streams for an in-process builtin command in
+        the same way that IO streams are configured when calling
+        `subprocess.Popen`.
+
+        Each of stdin, stdout and stderr may be:
+        - A file object open in binary mode.
+        - `subprocess.PIPE`
+        - `subprocess.STDOUT` (for stderr)
+        - None
+        """
+
+        # If stderr is redirected to stdout, we make sure to use the same
+        # stream for both so that the order of output is preserved.
+        stderr_redirected_to_stdout = (
+            stdout == subprocess.PIPE and stderr == subprocess.STDOUT
+        )
+
+        # Replace sentinel values with in-memory streams.
+        def resolve_io_obj(stream) -> InprocBuiltinIOObject:
+            if stream == subprocess.PIPE or stream is None:
+                return InprocBuiltinIOMemory(io.BytesIO())
+            elif isinstance(stream, InprocBuiltinIOObject):
+                return stream
+            else:
+                return InprocBuiltinIOFile(stream)
+
+        self.stdin = resolve_io_obj(stdin)
+        self.stdout = resolve_io_obj(stdout)
+        if stderr_redirected_to_stdout:
+            # Make sure stderr and stdout are directed to the same stream.
+            self.stderr = self.stdout
+        else:
+            self.stderr = resolve_io_obj(stderr)
+
+
+InprocBuiltinExecuteFn = Callable[
+    [Command, "list[str]", ShellEnvironment, InprocBuiltinIO],
+    int,
+]
+"""
+Function called by an in-process builtin command.
+Parameters:
+    - `cmd`: The command itself.
+    - `args`: glob-expanded list of arguments (including argv[0] as the program name).
+    - `shenv`: The shell environment.
+    - `io`: Holds the input and output streams for the invocation. These are file-like objects (files, StringIO)
+
+The return value is the exit code.
+"""
+
+
+@dataclass
+class InprocBuiltin:
+    """
+    Represents a command that is run as an in-process builtins.
+    """
+
+    execute: InprocBuiltinExecuteFn
+
+
+def executeBuiltinCd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinCd - Change the current directory."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'cd' supports only one argument")
     # Update the cwd in the parent environment.
-    shenv.change_dir(cmd.args[1])
+    shenv.change_dir(args[1])
     # The cd builtin always succeeds. If the directory does not exist, the
     # following Popen calls will fail instead.
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinPushd(cmd, shenv):
+def executeBuiltinPushd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinPushd - Change the current dir and save the old."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'pushd' supports only one argument")
     shenv.dirStack.append(shenv.cwd)
-    shenv.change_dir(cmd.args[1])
-    return ShellCommandResult(cmd, "", "", 0, False)
+    shenv.change_dir(args[1])
+    return 0
 
 
-def executeBuiltinPopd(cmd, shenv):
+def executeBuiltinPopd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinPopd - Restore a previously saved working directory."""
-    if len(cmd.args) != 1:
+    if len(args) != 1:
         raise InternalShellError(cmd, "'popd' does not support arguments")
     if not shenv.dirStack:
         raise InternalShellError(cmd, "popd: directory stack empty")
     shenv.cwd = shenv.dirStack.pop()
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinExport(cmd, shenv):
+def executeBuiltinExport(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinExport - Set an environment variable."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'export' supports only one argument")
-    updateEnv(shenv, cmd.args)
-    return ShellCommandResult(cmd, "", "", 0, False)
+    updateEnv(shenv, args)
+    return 0
 
 
-def executeBuiltinEcho(cmd, shenv):
+def executeBuiltinEcho(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """Interpret a redirected echo or @echo command"""
     opened_files = []
-    stdin, stdout, stderr = processRedirects(cmd, subprocess.PIPE, shenv, opened_files)
-    if stdin != subprocess.PIPE or stderr != subprocess.PIPE:
-        raise InternalShellError(
-            cmd, f"stdin and stderr redirects not supported for {cmd.args[0]}"
-        )
 
-    # Some tests have un-redirected echo commands to help debug test failures.
-    # Buffer our output and return it to the caller.
-    is_redirected = True
-    if stdout == subprocess.PIPE:
-        is_redirected = False
-        stdout = StringIO()
-    elif kIsWindows:
+    stdout = io.stdout
+    if (
+        kIsWindows
+        and isinstance(io.stdout, InprocBuiltinIOFile)
+        and io.stdout.get_filename()
+    ):
         # Reopen stdout with `newline=""` to avoid CRLF translation.
         # The versions of echo we are replacing on Windows all emit plain LF,
         # and the LLVM tests now depend on this.
-        stdout = open(stdout.name, stdout.mode, encoding="utf-8", newline="")
+        stdout = open(
+            io.stdout.get_filename(),
+            io.stdout.file.mode,
+            encoding="utf-8",
+            newline="",
+        )
         opened_files.append((None, None, stdout, None))
 
     # Implement echo flags. We only support -e and -n, and not yet in
     # combination. We have to ignore unknown flags, because `echo "-D FOO"`
     # prints the dash.
-    args = cmd.args[1:]
+    args = args[1:]
     interpret_escapes = False
     write_newline = True
     while len(args) >= 1 and args[0] in ("-e", "-n"):
@@ -109,15 +326,15 @@ def executeBuiltinEcho(cmd, shenv):
     for name, mode, f, path in opened_files:
         f.close()
 
-    output = "" if is_redirected else stdout.getvalue()
-    return ShellCommandResult(cmd, output, "", 0, False)
+    return 0
 
 
-def executeBuiltinMkdir(cmd, cmd_shenv):
+def executeBuiltinMkdir(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinMkdir - Create new directories."""
-    args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
-        opts, args = getopt.gnu_getopt(args, "p")
+        opts, args = getopt.gnu_getopt(args[1:], "p")
     except getopt.GetoptError as err:
         raise InternalShellError(cmd, "Unsupported: 'mkdir':  %s" % str(err))
 
@@ -131,7 +348,6 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
     if len(args) == 0:
         raise InternalShellError(cmd, "Error: 'mkdir' is missing an operand")
 
-    stderr = StringIO()
     exitCode = 0
     for dir in args:
         dir = pathlib.Path(dir)
@@ -144,16 +360,17 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
             try:
                 dir.mkdir(exist_ok=True)
             except OSError as err:
-                stderr.write("Error: 'mkdir' command failed, %s\n" % str(err))
+                io.stderr.write(("Error: 'mkdir' command failed, %s\n" % str(err)))
                 exitCode = 1
-    return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
+    return exitCode
 
 
-def executeBuiltinRm(cmd, cmd_shenv):
+def executeBuiltinRm(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinRm - Removes (deletes) files or directories."""
-    args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
-        opts, args = getopt.gnu_getopt(args, "frR", ["--recursive"])
+        opts, args = getopt.gnu_getopt(args[1:], "frR", ["--recursive"])
     except getopt.GetoptError as err:
         raise InternalShellError(cmd, "Unsupported: 'rm':  %s" % str(err))
 
@@ -176,7 +393,6 @@ def executeBuiltinRm(cmd, cmd_shenv):
         os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
         os.remove(path)
 
-    stderr = StringIO()
     exitCode = 0
     for path in args:
         cwd = cmd_shenv.cwd
@@ -189,9 +405,9 @@ def executeBuiltinRm(cmd, cmd_shenv):
                 os.remove(path)
             elif os.path.isdir(path):
                 if not recursive:
-                    stderr.write("Error: %s is a directory\n" % path)
+                    io.stderr.write(("Error: %s is a directory\n" % path))
                     exitCode = 1
-                if platform.system() == "Windows":
+                if kIsWindows:
                     # NOTE: use ctypes to access `SHFileOperationsW` on Windows to
                     # use the NT style path to get access to long file paths which
                     # cannot be removed otherwise.
@@ -255,26 +471,28 @@ def executeBuiltinRm(cmd, cmd_shenv):
                     os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
                 os.remove(path)
         except OSError as err:
-            stderr.write("Error: 'rm' command failed, %s" % str(err))
+            io.stderr.write(("Error: 'rm' command failed, %s" % str(err)))
             exitCode = 1
-    return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
+    return exitCode
 
 
-def executeBuiltinUmask(cmd, shenv):
+def executeBuiltinUmask(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinUmask - Change the current umask."""
     if os.name != "posix":
         raise InternalShellError(cmd, "'umask' not supported on this system")
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'umask' supports only one argument")
     try:
         # Update the umask in the parent environment.
-        shenv.umask = int(cmd.args[1], 8)
+        shenv.umask = int(args[1], 8)
     except ValueError as err:
         raise InternalShellError(cmd, "Error: 'umask': %s" % str(err))
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinUlimit(cmd, shenv):
+def executeBuiltinUlimit(cmd: Command, args: list[str], shenv, io: InprocBuiltinIO):
     """executeBuiltinUlimit - Change the current limits."""
     try:
         # Try importing the resource module (available on POSIX systems) and
@@ -282,34 +500,59 @@ def executeBuiltinUlimit(cmd, shenv):
         import resource
     except ImportError:
         raise InternalShellError(cmd, "'ulimit' not supported on this system")
-    if len(cmd.args) != 3:
+    if len(args) != 3:
         raise InternalShellError(cmd, "'ulimit' requires two arguments")
     try:
-        if cmd.args[2] == "unlimited":
+        if args[2] == "unlimited":
             new_limit = resource.RLIM_INFINITY
         else:
-            new_limit = int(cmd.args[2])
+            new_limit = int(args[2])
     except ValueError as err:
         raise InternalShellError(cmd, "Error: 'ulimit': %s" % str(err))
-    if cmd.args[1] == "-v":
+    if args[1] == "-v":
         if new_limit != resource.RLIM_INFINITY:
             new_limit = new_limit * 1024
         shenv.ulimit["RLIMIT_AS"] = new_limit
-    elif cmd.args[1] == "-n":
+    elif args[1] == "-n":
         shenv.ulimit["RLIMIT_NOFILE"] = new_limit
-    elif cmd.args[1] == "-s":
+    elif args[1] == "-s":
         if new_limit != resource.RLIM_INFINITY:
             new_limit = new_limit * 1024
         shenv.ulimit["RLIMIT_STACK"] = new_limit
-    elif cmd.args[1] == "-f":
+    elif args[1] == "-f":
         shenv.ulimit["RLIMIT_FSIZE"] = new_limit
     else:
-        raise InternalShellError(
-            cmd, "'ulimit' does not support option: %s" % cmd.args[1]
-        )
-    return ShellCommandResult(cmd, "", "", 0, False)
+        raise InternalShellError(cmd, "'ulimit' does not support option: %s" % args[1])
+    return 0
 
 
-def executeBuiltinColon(cmd, cmd_shenv):
+def executeBuiltinColon(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinColon - Discard arguments and exit with status 0."""
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
+
+
+def get_default_inproc_builtins() -> dict[str, InprocBuiltin]:
+    """
+    get_default_inproc_builtins - Returns the map of command names to Lit's
+    in-process built-in implementations.
+    The entries are a pair of the callable for the builtin and a bool
+    that determines whether this inproc builtin may fall back to a
+    command of the same name in cases where in-proc builtins cannot be
+    used (e.g. as the argument to not --crash).
+    """
+
+    return {
+        "@echo": InprocBuiltin(executeBuiltinEcho),
+        "cd": InprocBuiltin(executeBuiltinCd),
+        "export": InprocBuiltin(executeBuiltinExport),
+        "echo": InprocBuiltin(executeBuiltinEcho),
+        "mkdir": InprocBuiltin(executeBuiltinMkdir),
+        "popd": InprocBuiltin(executeBuiltinPopd),
+        "pushd": InprocBuiltin(executeBuiltinPushd),
+        "rm": InprocBuiltin(executeBuiltinRm),
+        "ulimit": InprocBuiltin(executeBuiltinUlimit),
+        "umask": InprocBuiltin(executeBuiltinUmask),
+        ":": InprocBuiltin(executeBuiltinColon),
+    }

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, annotations
 
+import abc
 import os
 import pathlib
 import re
@@ -10,13 +11,20 @@ import sys
 import tempfile
 import threading
 import traceback
+import typing
+from dataclasses import dataclass
+from typing import Any
 
-import lit.InprocBuiltins as InprocBuiltins
 import lit.ShUtil as ShUtil
 import lit.Test as Test
 import lit.util
 from lit.BooleanExpression import BooleanExpression
-from lit.ShCommands import Command
+from lit.InprocBuiltins import (
+    InprocBuiltin,
+    InprocBuiltinIO,
+    get_default_inproc_builtins,
+)
+from lit.ShCommands import Command, Pipeline
 from lit.ShellEnvironment import (
     InternalShellError,
     ShellCommandResult,
@@ -159,7 +167,7 @@ class TimeoutHelper(object):
             self._doneKillPass = True
 
 
-def executeShCmd(cmd, shenv, results, timeout=0):
+def executeShCmd(cmd, shenv, results, timeout=0, extra_inproc_builtins={}):
     """
     Wrapper around _executeShCmd that handles
     timeout
@@ -170,7 +178,9 @@ def executeShCmd(cmd, shenv, results, timeout=0):
     if timeout > 0:
         timeoutHelper.startTimer()
     try:
-        finalExitCode = _executeShCmd(cmd, shenv, results, timeoutHelper)
+        finalExitCode = _executeShCmd(
+            cmd, shenv, results, timeoutHelper, extra_inproc_builtins
+        )
     except InternalShellError:
         e = sys.exc_info()[1]
         finalExitCode = 127
@@ -183,6 +193,108 @@ def executeShCmd(cmd, shenv, results, timeout=0):
         timeoutInfo = "Reached timeout of {} seconds".format(timeout)
 
     return (finalExitCode, timeoutInfo)
+
+
+@dataclass
+class InprocBuiltinResult:
+    """
+    Result of invoking an in-process builtin command. This stores its exit code
+    and stdout/stderr streams.
+    """
+
+    exit_code: int
+    stdout: typing.TextIO
+    stderr: typing.TextIO
+
+
+class CommandInvocation(abc.ABC):
+    """
+    Result of invoking a command: implementations hold either a Popen for an
+    out-of-proc command or an InprocCommandResult for an in-process command.
+    This is designed to mirror the functionality of Popen for in-process
+    commands too.
+    """
+
+    @abc.abstractmethod
+    def wait(self) -> int:
+        """
+        Wraps `Popen.wait`. For in-process builtin commands, there is nothing
+        to wait for, so just returns the exit code.
+        """
+
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def communicate(self) -> tuple[str, str]:
+        """
+        Wraps `Popen.communicate`. For in-process builtin commands, this is
+        the same as `read_output`.
+        """
+
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def stdout(self) -> typing.TextIO:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def stderr(self) -> typing.TextIO:
+        raise NotImplemented
+
+
+@dataclass
+class ProcessInvocation(CommandInvocation):
+    """
+    CommandInvocation wrapping a `subprocess.Popen`; the result of invoking an
+    out-of-process command.
+    """
+
+    popen: subprocess.Popen
+
+    def wait(self) -> int:
+        return self.popen.wait()
+
+    def communicate(self) -> tuple[str, str]:
+        return self.popen.communicate()
+
+    def stdout(self) -> typing.TextIO:
+        return self.popen.stdout
+
+    def stderr(self) -> typing.TextIO:
+        return self.popen.stderr
+
+
+@dataclass
+class InprocBuiltinInvocation(CommandInvocation):
+    """
+    CommandInvocation wrapping an `InprocBuiltinResult`; the result of invoking an
+    in-process builtin command.
+    """
+
+    result: InprocBuiltinResult
+
+    def wait(self) -> int:
+        # In-process builtins are not run asynchronously.
+        return self.result.exit_code
+
+    def communicate(self) -> tuple[str, str]:
+        if self.stdout():
+            stdout = self.stdout().read()
+        else:
+            stdout = ""
+
+        if self.stderr():
+            stderr = self.stderr().read()
+        else:
+            stderr = ""
+
+        return stdout, stderr
+
+    def stdout(self) -> typing.TextIO:
+        return self.result.stdout
+
+    def stderr(self) -> typing.TextIO:
+        return self.result.stderr
 
 
 def _expandLateSubstitutions(cmd, arguments, cwd, normalize_slashes=False):
@@ -211,7 +323,134 @@ def _expandLateSubstitutions(cmd, arguments, cwd, normalize_slashes=False):
     return arguments
 
 
-def _executeShCmd(cmd, shenv, results, timeoutHelper):
+def invoke_process(
+    pipeline: Pipeline,
+    command: Command,
+    command_index: int,
+    args: list[str],
+    stdin: Any,
+    stdout: Any,
+    stderr: Any,
+    piped_input: bytes | None,
+    shenv: ShellEnvironment,
+    cmd_shenv: ShellEnvironment,
+    stderrIsStdout: bool,
+    stderrTempFiles: list[Any],
+    builtin_commands_dir: str,
+    timeoutHelper: TimeoutHelper,
+) -> ProcessInvocation:
+    if not stderrIsStdout:
+        # Don't allow stderr on a PIPE except for the last
+        # process, this could deadlock.
+        #
+        # FIXME: This is slow, but so is deadlock.
+        if stderr == subprocess.PIPE and command != pipeline.commands[-1]:
+            stderr = tempfile.TemporaryFile(mode="w+b")
+            stderrTempFiles.append((command_index, stderr))
+
+    # Resolve the executable path ourselves.
+    executable = None
+    # For paths relative to cwd, use the cwd of the shell environment.
+    if args[0].startswith("."):
+        exe_in_cwd = os.path.join(cmd_shenv.cwd, args[0])
+        if os.path.isfile(exe_in_cwd):
+            executable = exe_in_cwd
+    if not executable:
+        # Use the path from cmd_shenv by default, but if the environment variable
+        # is unset (like if the user is using env -i), use the standard path.
+        path = cmd_shenv.env["PATH"] if "PATH" in cmd_shenv.env else shenv.env["PATH"]
+        executable = lit.util.which(args[0], path)
+    if not executable:
+        raise InternalShellError(command, "%r: command not found" % args[0])
+
+    # On Windows, do our own command line quoting for better compatibility
+    # with some core utility distributions.
+    if kIsWindows:
+        args = quote_windows_command(args)
+
+    # Handle any resource limits. We do this by launching the command with
+    # a wrapper that sets the necessary limits. We use a wrapper rather than
+    # setting the limits in process as we cannot reraise the limits back to
+    # their defaults without elevated permissions.
+    if cmd_shenv.ulimit:
+        executable = sys.executable
+        args.insert(0, sys.executable)
+        args.insert(1, os.path.join(builtin_commands_dir, "_launch_with_limit.py"))
+        for limit in cmd_shenv.ulimit:
+            cmd_shenv.env["LIT_INTERNAL_ULIMIT_" + limit] = str(cmd_shenv.ulimit[limit])
+
+    try:
+        # TODO(boomanaiden154): We currently wrap the subprocess.Popen with
+        # os.umask as the umask argument in subprocess.Popen is not
+        # available before Python 3.9. Once LLVM requires at least Python
+        # 3.9, this code should be updated to use umask argument.
+        old_umask = -1
+        if cmd_shenv.umask != -1:
+            old_umask = os.umask(cmd_shenv.umask)
+        proc = subprocess.Popen(
+            args,
+            cwd=cmd_shenv.cwd,
+            executable=executable,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            env=cmd_shenv.env,
+            close_fds=kUseCloseFDs,
+            universal_newlines=True,
+            errors="replace",
+        )
+        if old_umask != -1:
+            os.umask(old_umask)
+
+        # Let the helper know about this process
+        timeoutHelper.addProcess(proc)
+    except OSError as e:
+        raise InternalShellError(
+            command, "Could not create process ({}) due to {}".format(executable, e)
+        )
+
+    if piped_input:
+        os.write(proc.stdin.fileno(), piped_input)
+
+    # Immediately close stdin for any process taking stdin from us.
+    if stdin == subprocess.PIPE:
+        proc.stdin.close()
+        proc.stdin = None
+
+    return ProcessInvocation(proc)
+
+
+def invoke_inproc_builtin(
+    inproc_builtin: InprocBuiltin,
+    command: Command,
+    args: list[str],
+    stdin: Any,
+    stdout: Any,
+    stderr: Any,
+    cmd_shenv: ShellEnvironment,
+):
+    builtin_io = InprocBuiltinIO(stdin, stdout, stderr)
+
+    exit_code = inproc_builtin.execute(command, args, cmd_shenv, builtin_io)
+
+    # Make sure that the output is flushed, in case the next process
+    # tries to read it from a file (as temporary files are not closed
+    # until the end of the test, it may not yet be flushed).
+    builtin_io.stdout.seek(0)
+    builtin_io.stderr.seek(0)
+    builtin_io.stdout.flush()
+    builtin_io.stderr.flush()
+
+    return InprocBuiltinInvocation(
+        result=InprocBuiltinResult(
+            exit_code=exit_code,
+            stdout=builtin_io.stdout if stdout == subprocess.PIPE else None,
+            stderr=builtin_io.stderr if stderr == subprocess.PIPE else None,
+        ),
+    )
+
+
+def _executeShCmd(cmd, shenv, results, timeoutHelper, extra_inproc_builtins):
     if timeoutHelper.timeoutReached():
         # Prevent further recursion if the timeout has been hit
         # as we should try avoid launching more processes.
@@ -219,31 +458,43 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
     if isinstance(cmd, ShUtil.Seq):
         if cmd.op == ";":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
-            return _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
+            return _executeShCmd(
+                cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
 
         if cmd.op == "&":
             raise InternalShellError(cmd, "unsupported shell operator: '&'")
 
         if cmd.op == "||":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
             if res != 0:
-                res = _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+                res = _executeShCmd(
+                    cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+                )
             return res
 
         if cmd.op == "&&":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
             if res is None:
                 return res
 
             if res == 0:
-                res = _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+                res = _executeShCmd(
+                    cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+                )
             return res
 
         raise ValueError("Unknown shell command: %r" % cmd.op)
     assert isinstance(cmd, ShUtil.Pipeline)
 
-    procs = []
+    invocations = []
     proc_not_counts = []
     proc_not_fail_if_crash = []
     default_stdin = subprocess.PIPE
@@ -254,19 +505,8 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
     builtin_commands_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "builtin_commands"
     )
-    inproc_builtins = {
-        "cd": InprocBuiltins.executeBuiltinCd,
-        "export": InprocBuiltins.executeBuiltinExport,
-        "echo": InprocBuiltins.executeBuiltinEcho,
-        "@echo": InprocBuiltins.executeBuiltinEcho,
-        "mkdir": InprocBuiltins.executeBuiltinMkdir,
-        "popd": InprocBuiltins.executeBuiltinPopd,
-        "pushd": InprocBuiltins.executeBuiltinPushd,
-        "rm": InprocBuiltins.executeBuiltinRm,
-        "ulimit": InprocBuiltins.executeBuiltinUlimit,
-        "umask": InprocBuiltins.executeBuiltinUmask,
-        ":": InprocBuiltins.executeBuiltinColon,
-    }
+    inproc_builtins = get_default_inproc_builtins()
+    inproc_builtins.update(extra_inproc_builtins)
     # To avoid deadlock, we use a single stderr stream for piped
     # output. This is null until we have seen some output using
     # stderr.
@@ -354,9 +594,42 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                     j,
                     "Unsupported: '{}' cannot be part" " of a pipeline".format(args[0]),
                 )
-            result = inproc_builtin(Command(args, j.redirects), cmd_shenv)
+
+            stdin, stdout, stderr = processRedirects(
+                j, subprocess.PIPE, shenv, opened_files
+            )
+
+            args = expand_glob_expressions(args, cmd_shenv.cwd)
+
+            invocation = invoke_inproc_builtin(
+                inproc_builtin,
+                j,
+                args,
+                stdin,
+                stdout,
+                stderr,
+                cmd_shenv,
+            )
+
             if not_count % 2:
-                result.exitCode = int(not result.exitCode)
+                invocation.result.exit_code = int(not invocation.result.exit_code)
+
+            # Gather output from the streams.
+            out = ""
+            if stdout == subprocess.PIPE:
+                out = invocation.stdout().read()
+
+            err = ""
+            if stderr == subprocess.PIPE:
+                err = invocation.stderr().read()
+
+            result = ShellCommandResult(
+                j,
+                out,
+                err,
+                invocation.result.exit_code,
+                False,
+            )
             result.command.args = j.args
             results.append(result)
             return result.exitCode
@@ -402,107 +675,38 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         else:
             stderrIsStdout = False
 
-            # Don't allow stderr on a PIPE except for the last
-            # process, this could deadlock.
-            #
-            # FIXME: This is slow, but so is deadlock.
-            if stderr == subprocess.PIPE and j != cmd.commands[-1]:
-                stderr = tempfile.TemporaryFile(mode="w+b")
-                stderrTempFiles.append((i, stderr))
-
-        # Resolve the executable path ourselves.
-        executable = None
-        # For paths relative to cwd, use the cwd of the shell environment.
-        if args[0].startswith("."):
-            exe_in_cwd = os.path.join(cmd_shenv.cwd, args[0])
-            if os.path.isfile(exe_in_cwd):
-                executable = exe_in_cwd
-        if not executable:
-            # Use the path from cmd_shenv by default, but if the environment variable
-            # is unset (like if the user is using env -i), use the standard path.
-            path = (
-                cmd_shenv.env["PATH"] if "PATH" in cmd_shenv.env else shenv.env["PATH"]
-            )
-            executable = lit.util.which(args[0], path)
-        if not executable:
-            raise InternalShellError(j, "%r: command not found" % args[0])
-
-        # Replace uses of /dev/null with temporary files.
-        if kAvoidDevNull:
-            for i, arg in enumerate(args):
-                if isinstance(arg, str) and kDevNull in arg:
-                    f = tempfile.NamedTemporaryFile(delete=False)
-                    f.close()
-                    named_temp_files.append(f.name)
-                    args[i] = arg.replace(kDevNull, f.name)
-
-        # Expand all glob expressions
         args = expand_glob_expressions(args, cmd_shenv.cwd)
 
-        # On Windows, do our own command line quoting for better compatibility
-        # with some core utility distributions.
-        if kIsWindows:
-            args = quote_windows_command(args)
-
-        # Handle any resource limits. We do this by launching the command with
-        # a wrapper that sets the necessary limits. We use a wrapper rather than
-        # setting the limits in process as we cannot reraise the limits back to
-        # their defaults without elevated permissions.
-        if cmd_shenv.ulimit:
-            executable = sys.executable
-            args.insert(0, sys.executable)
-            args.insert(1, os.path.join(builtin_commands_dir, "_launch_with_limit.py"))
-            for limit in cmd_shenv.ulimit:
-                cmd_shenv.env["LIT_INTERNAL_ULIMIT_" + limit] = str(
-                    cmd_shenv.ulimit[limit]
-                )
-
-        try:
-            # TODO(boomanaiden154): We currently wrap the subprocess.Popen with
-            # os.umask as the umask argument in subprocess.Popen is not
-            # available before Python 3.9. Once LLVM requires at least Python
-            # 3.9, this code should be updated to use umask argument.
-            old_umask = -1
-            if cmd_shenv.umask != -1:
-                old_umask = os.umask(cmd_shenv.umask)
-            procs.append(
-                subprocess.Popen(
-                    args,
-                    cwd=cmd_shenv.cwd,
-                    executable=executable,
-                    stdin=stdin,
-                    stdout=stdout,
-                    stderr=stderr,
-                    env=cmd_shenv.env,
-                    close_fds=kUseCloseFDs,
-                    universal_newlines=True,
-                    errors="replace",
-                )
+        invocations.append(
+            invoke_process(
+                cmd,
+                j,
+                i,
+                args,
+                stdin,
+                stdout,
+                stderr,
+                None,
+                shenv,
+                cmd_shenv,
+                stderrIsStdout,
+                stderrTempFiles,
+                builtin_commands_dir,
+                timeoutHelper,
             )
-            if old_umask != -1:
-                os.umask(old_umask)
-            proc_not_counts.append(not_count)
-            if not not_crash and not_args == ["not"]:
-                proc_not_fail_if_crash.append(True)
-            else:
-                proc_not_fail_if_crash.append(False)
-            # Let the helper know about this process
-            timeoutHelper.addProcess(procs[-1])
-        except OSError as e:
-            raise InternalShellError(
-                j, "Could not create process ({}) due to {}".format(executable, e)
-            )
+        )
 
-        # Immediately close stdin for any process taking stdin from us.
-        if stdin == subprocess.PIPE:
-            procs[-1].stdin.close()
-            procs[-1].stdin = None
+        proc_not_counts.append(not_count)
+        if not not_crash and not_args == ["not"]:
+            proc_not_fail_if_crash.append(True)
+        else:
+            proc_not_fail_if_crash.append(False)
 
         # Update the current stdin source.
         if stdout == subprocess.PIPE:
-            default_stdin = procs[-1].stdout
+            default_stdin = invocations[-1].stdout()
         elif stderrIsStdout:
-            default_stdin = procs[-1].stderr
+            default_stdin = invocations[-1].stderr()
         else:
             default_stdin = subprocess.PIPE
 
@@ -514,18 +718,19 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         f.close()
 
     # FIXME: There is probably still deadlock potential here. Yawn.
-    procData = [None] * len(procs)
-    procData[-1] = procs[-1].communicate()
+    procData = [None] * len(invocations)
+    procData[-1] = invocations[-1].communicate()
 
-    for i in range(len(procs) - 1):
-        if procs[i].stdout is not None:
-            out = procs[i].stdout.read()
+    for i in range(len(invocations) - 1):
+        if invocations[i].stdout():
+            out = invocations[i].stdout().read()
         else:
             out = ""
-        if procs[i].stderr is not None:
-            err = procs[i].stderr.read()
+        if invocations[i].stderr():
+            err = invocations[i].stderr().read()
         else:
             err = ""
+
         procData[i] = (out, err)
 
     # Read stderr out of the temp files.
@@ -536,7 +741,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
     exitCode = None
     for i, (out, err) in enumerate(procData):
-        res = procs[i].wait()
+        res = invocations[i].wait()
         # Detect Ctrl-C in subprocess.
         if res == -signal.SIGINT:
             raise KeyboardInterrupt
@@ -658,7 +863,13 @@ def formatOutput(title, data, limit=None):
 # function), out contains only stdout from the script, err contains only stderr
 # from the script, and there is no execution trace.
 def executeScriptInternal(
-    test, litConfig, tmpBase, commands, cwd, debug=True
+    test,
+    litConfig,
+    tmpBase,
+    commands,
+    cwd,
+    debug=True,
+    extra_inproc_builtins={},
 ) -> tuple[str, str, int, str | None, str | None]:
     cmds = []
     update_output = None
@@ -703,7 +914,11 @@ def executeScriptInternal(
     shenv.env["LIT_CURRENT_TESTCASE"] = test.getFullName()
 
     exitCode, timeoutInfo = executeShCmd(
-        cmd, shenv, results, timeout=litConfig.maxIndividualTestTime
+        cmd,
+        shenv,
+        results,
+        timeout=litConfig.maxIndividualTestTime,
+        extra_inproc_builtins=extra_inproc_builtins,
     )
 
     out = err = ""
@@ -1809,7 +2024,14 @@ def parseIntegratedTestScript(test, additional_parsers=[], require_script=True):
     return script
 
 
-def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Result:
+def _runShTest(
+    test,
+    litConfig,
+    useExternalSh,
+    script,
+    tmpBase,
+    extra_inproc_builtins={},
+) -> lit.Test.Result:
     # Always returns the tuple (out, err, exitCode, timeoutInfo, status).
     def runOnce(
         execdir,
@@ -1845,7 +2067,12 @@ def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Resu
                 res = executeScript(test, litConfig, tmpBase, scriptCopy, execdir)
             else:
                 res = executeScriptInternal(
-                    test, litConfig, tmpBase, scriptCopy, execdir
+                    test,
+                    litConfig,
+                    tmpBase,
+                    scriptCopy,
+                    execdir,
+                    extra_inproc_builtins=extra_inproc_builtins,
                 )
         except ScriptFatal as e:
             out = f"# " + "\n# ".join(str(e).splitlines()) + "\n"
@@ -1922,7 +2149,12 @@ def _expandLateSubstitutionsExternal(commandLine):
     return commandLine
 
 def executeShTest(
-    test, litConfig, useExternalSh, extra_substitutions=[], preamble_commands=[]
+    test,
+    litConfig,
+    useExternalSh,
+    extra_substitutions=[],
+    preamble_commands=[],
+    extra_inproc_builtins={},
 ):
     if test.config.unsupported:
         return lit.Test.Result(Test.UNSUPPORTED, "Test is unsupported")
@@ -1959,4 +2191,11 @@ def executeShTest(
         for index, command in enumerate(script):
             script[index] = _expandLateSubstitutionsExternal(command)
 
-    return _runShTest(test, litConfig, useExternalSh, script, tmpBase)
+    return _runShTest(
+        test,
+        litConfig,
+        useExternalSh,
+        script,
+        tmpBase,
+        extra_inproc_builtins=extra_inproc_builtins,
+    )

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -411,7 +411,15 @@ def invoke_process(
         )
 
     if piped_input:
-        os.write(proc.stdin.fileno(), piped_input)
+        try:
+            os.write(proc.stdin.fileno(), piped_input)
+        except BrokenPipeError:
+            # There are some tests which pipe the output of echo into a
+            # subsequent command which isn't actually reading STDIN.
+            # This can result in a broken pipe error if the process
+            # has already closed by now, so we can just swallow
+            # the exception.
+            pass
 
     # Immediately close stdin for any process taking stdin from us.
     if stdin == subprocess.PIPE:

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -22,6 +22,7 @@ from lit.BooleanExpression import BooleanExpression
 from lit.InprocBuiltins import (
     InprocBuiltin,
     InprocBuiltinIO,
+    InprocBuiltinIOMemory,
     get_default_inproc_builtins,
 )
 from lit.ShCommands import Command, Pipeline
@@ -566,73 +567,26 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper, extra_inproc_builtins):
             else:
                 break
 
-        # Handle in-process builtins.
-        #
-        # Handle "echo" as a builtin if it is not part of a pipeline. This
-        # greatly speeds up tests that construct input files by repeatedly
-        # echo-appending to a file.
-        # FIXME: Standardize on the builtin echo implementation. We can use a
-        # temporary file to sidestep blocking pipe write issues.
-
         # Ensure args[0] is hashable.
         args[0] = expand_glob(args[0], cmd_shenv.cwd)[0]
 
+        # Decide if this command can be run as an in-process builtin.
+
+        # FIXME: Standardize on the builtin echo implementation. We can use a
+        # temporary file to sidestep blocking pipe write issues.
         inproc_builtin = inproc_builtins.get(args[0], None)
-        if inproc_builtin and (args[0] != "echo" or len(cmd.commands) == 1):
-            # env calling an in-process builtin is useless, so we take the safe
-            # approach of complaining.
-            if not cmd_shenv is shenv:
-                raise InternalShellError(
-                    j, "Error: 'env' cannot call '{}'".format(args[0])
-                )
+
+        error = None
+        if inproc_builtin:
+            # not --crash cannot call in-process builtins.
             if not_crash:
-                raise InternalShellError(
-                    j, "Error: 'not --crash' cannot call" " '{}'".format(args[0])
-                )
-            if len(cmd.commands) != 1:
-                raise InternalShellError(
-                    j,
-                    "Unsupported: '{}' cannot be part" " of a pipeline".format(args[0]),
-                )
+                error = "Error: 'not --crash' cannot call" " '{}'".format(args[0])
+            # env cannot call in-process builtins.
+            if not cmd_shenv is shenv:
+                error = "Error: 'env' cannot call '{}'".format(args[0])
 
-            stdin, stdout, stderr = processRedirects(
-                j, subprocess.PIPE, shenv, opened_files
-            )
-
-            args = expand_glob_expressions(args, cmd_shenv.cwd)
-
-            invocation = invoke_inproc_builtin(
-                inproc_builtin,
-                j,
-                args,
-                stdin,
-                stdout,
-                stderr,
-                cmd_shenv,
-            )
-
-            if not_count % 2:
-                invocation.result.exit_code = int(not invocation.result.exit_code)
-
-            # Gather output from the streams.
-            out = ""
-            if stdout == subprocess.PIPE:
-                out = invocation.stdout().read()
-
-            err = ""
-            if stderr == subprocess.PIPE:
-                err = invocation.stderr().read()
-
-            result = ShellCommandResult(
-                j,
-                out,
-                err,
-                invocation.result.exit_code,
-                False,
-            )
-            result.command.args = j.args
-            results.append(result)
-            return result.exitCode
+            if error:
+                raise InternalShellError(j, error)
 
         # Resolve any out-of-process builtin command before adding back 'not'
         # commands.
@@ -675,26 +629,56 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper, extra_inproc_builtins):
         else:
             stderrIsStdout = False
 
+        # Replace uses of /dev/null with temporary files.
+        if kAvoidDevNull:
+            for arg_index, arg in enumerate(args):
+                if isinstance(arg, str) and kDevNull in arg:
+                    f = tempfile.NamedTemporaryFile(delete=False)
+                    f.close()
+                    named_temp_files.append(f.name)
+                    args[arg_index] = arg.replace(kDevNull, f.name)
+
+        # Expand all glob expressions
         args = expand_glob_expressions(args, cmd_shenv.cwd)
 
-        invocations.append(
-            invoke_process(
-                cmd,
-                j,
-                i,
-                args,
-                stdin,
-                stdout,
-                stderr,
-                None,
-                shenv,
-                cmd_shenv,
-                stderrIsStdout,
-                stderrTempFiles,
-                builtin_commands_dir,
-                timeoutHelper,
+        if inproc_builtin:
+            invocations.append(
+                invoke_inproc_builtin(
+                    inproc_builtin,
+                    j,
+                    args,
+                    stdin,
+                    stdout,
+                    stderr,
+                    cmd_shenv,
+                )
             )
-        )
+        else:
+            # If the stdin source is the output stream of a in-process
+            # builtin, read it in order to provide it to the process.
+            piped_input = None
+            if isinstance(stdin, InprocBuiltinIOMemory):
+                piped_input = stdin.read_binary()
+                stdin = subprocess.PIPE
+
+            invocations.append(
+                invoke_process(
+                    cmd,
+                    j,
+                    i,
+                    args,
+                    stdin,
+                    stdout,
+                    stderr,
+                    piped_input,
+                    shenv,
+                    cmd_shenv,
+                    stderrIsStdout,
+                    stderrTempFiles,
+                    builtin_commands_dir,
+                    timeoutHelper,
+                )
+            )
 
         proc_not_counts.append(not_count)
         if not not_crash and not_args == ["not"]:

--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -19,11 +19,16 @@ class ShTest(FileBasedTest):
     """
 
     def __init__(
-        self, execute_external=False, extra_substitutions=[], preamble_commands=[]
+        self,
+        execute_external=False,
+        extra_substitutions=[],
+        preamble_commands=[],
+        extra_inproc_builtins={},
     ):
         self.execute_external = execute_external
         self.extra_substitutions = extra_substitutions
         self.preamble_commands = preamble_commands
+        self.extra_inproc_builtins = extra_inproc_builtins
 
     def execute(self, test, litConfig):
         return lit.TestRunner.executeShTest(
@@ -32,4 +37,5 @@ class ShTest(FileBasedTest):
             self.execute_external,
             self.extra_substitutions,
             self.preamble_commands,
+            self.extra_inproc_builtins,
         )

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/custom_inproc_builtins.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/custom_inproc_builtins.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from lit.InprocBuiltins import InprocBuiltinIO
+from lit.ShCommands import Command
+from lit.ShellEnvironment import ShellEnvironment
+
+
+def returns_0(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    return 0
+
+
+def returns_1(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    return 1
+
+
+def custom_echo(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    io.stdout.write(args[1])
+    return 0
+
+
+def echo_to_stderr(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    io.stderr.write(args[1])
+    return 0

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/lit.cfg
@@ -1,0 +1,23 @@
+import os
+import sys
+import lit.formats
+from lit.InprocBuiltins import InprocBuiltin
+
+# Import the module containing the custom in-process builtins.
+# NB: These cannot be defined in the lit.cfg module.
+sys.path.append(os.path.dirname(__file__))
+import custom_inproc_builtins
+
+config.name = "shtest-custom-inproc-builtins"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest(
+    extra_inproc_builtins={
+        "returns_0": InprocBuiltin(custom_inproc_builtins.returns_0),
+        "returns_1": InprocBuiltin(custom_inproc_builtins.returns_1),
+        "custom_echo": InprocBuiltin(custom_inproc_builtins.custom_echo),
+        "echo_to_stderr": InprocBuiltin(custom_inproc_builtins.echo_to_stderr),
+    }
+)
+config.test_source_root = None
+config.test_exec_root = None
+

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/use-custom-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/use-custom-inproc-builtins.txt
@@ -1,0 +1,13 @@
+RUN: returns_0
+RUN: not returns_1
+
+RUN: custom_echo "hello" > %t1
+RUN: grep -x "hello" < %t1
+
+RUN: custom_echo ", world" >> %t1
+RUN: grep -x "hello, world" < %t1
+
+RUN: echo_to_stderr "goodbye" 2> %t2
+RUN: grep -x "goodbye" < %t2
+RUN: echo_to_stderr ", for now" 2>> %t2
+RUN: grep -x "goodbye, for now" < %t2

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/custom_inproc_builtins.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/custom_inproc_builtins.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from lit.InprocBuiltins import InprocBuiltinIO
+from lit.ShCommands import Command
+from lit.ShellEnvironment import ShellEnvironment
+
+
+def execute_print_out_err(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
+    args = args[1:]
+
+    if len(args) != 2:
+        io.stderr.write("Expected two arguments.")
+        return 1
+
+    io.stdout.write(args[0])
+    io.stderr.write(args[1])
+
+    return 0
+
+
+def execute_uppercaser(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
+    io.stdout.write(io.stdin.read().upper())
+
+    return 0
+
+
+def execute_streq(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
+    args = args[1:]
+
+    if len(args) != 1:
+        io.stderr.write("Expected one argument.")
+        return 2
+
+    return int(io.stdin.read() != args[0])

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/extra-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/extra-inproc-builtins.txt
@@ -1,0 +1,23 @@
+This test verifies that the custom in-process builtins defined in lit.cfg
+are working as expected.
+
+Testing "streq"
+
+Testing "print_out_err"
+RUN: print_out_err "hello stdout" "hello stderr" > %t.out 2> %t.err
+RUN: grep -x "hello stdout" %t.out
+RUN: grep -x "hello stderr" %t.err
+
+Testing redirection in append mode.
+RUN: print_out_err "1" "2" >> %t.out 2>> %t.err
+RUN: grep -x "hello stdout1" %t.out
+RUN: grep -x "hello stderr2" %t.err
+
+RUN: not print_out_err > %t.out 2> %t.err
+RUN: streq < %t.out ""
+RUN: streq < %t.err "Expected two arguments."
+
+Testing "uppercaser"
+RUN: echo "testtest" > %t.lowercase
+RUN: uppercaser < %t.lowercase > %t.uppercase
+RUN: grep -x "TESTTEST" < %t.uppercase

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/lit.cfg
@@ -1,0 +1,20 @@
+import sys
+import os
+import lit.formats
+from lit.InprocBuiltins import InprocBuiltin
+
+sys.path.append(os.path.dirname(__file__))
+from custom_inproc_builtins import execute_print_out_err, execute_uppercaser, execute_streq
+
+
+config.name = "shtest-pipelined-inproc-builtins"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest(
+    extra_inproc_builtins={
+        "print_out_err": InprocBuiltin(execute_print_out_err),
+        "uppercaser": InprocBuiltin(execute_uppercaser),
+        "streq": InprocBuiltin(execute_streq),
+    },
+)
+config.test_source_root = None
+config.test_exec_root = None

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/pipelined-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/pipelined-inproc-builtins.txt
@@ -1,0 +1,27 @@
+Piping inproc builtin into inproc builtin into normal command.
+RUN: echo "hello" | uppercaser | grep -Fx "HELLO"
+
+Piping normal command into inproc builtin into normal command.
+RUN: echo "abcd" > %t
+RUN: cat %t | uppercaser | grep -Fx "ABCD"
+
+Redirecting stdin for inproc builtin from file.
+RUN: echo "lll" > %t
+RUN: uppercaser < %t | grep -Fx "LLL"
+
+Piping stderr, but not stdout, from normal command into inproc builtin.
+RUN: not cat does_not_exist.txt 2>&1 >/dev/null | uppercaser | streq "[ERRNO 2] NO SUCH FILE OR DIRECTORY: 'DOES_NOT_EXIST.TXT'"
+
+Piping stderr, and but stdout, from inproc builtin into normal command.
+RUN: print_out_err "ignoreme" "err" 2>&1 >/dev/null | grep -Fx "err"
+
+Piping stderr, but not stdout, from inproc builtin into inproc builtin.
+RUN: print_out_err "ignoreme" "err" 2>&1 >/dev/null | streq "err"
+
+Redirecting stderr to stdout for inproc builtin and piping it into another inproc builtin.
+RUN: print_out_err "aaa" "bbb" 2>&1 | streq "aaabbb"
+
+Redirecting stderr to stdout for inproc builtin and piping it into a regular process.
+RUN: print_out_err "aaa" "bbb" 2>&1 | grep "aaabbb"
+
+END.

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/colon-error.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/colon-error.txt
@@ -1,3 +1,0 @@
-# Check error on an unsupported ":". (cannot be part of a pipeline)
-#
-# RUN: : | echo "hello"

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/mkdir-error-0.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/mkdir-error-0.txt
@@ -1,3 +1,0 @@
-# Check error on a unsupported mkdir (cannot be part of a pipeline).
-#
-# RUN: mkdir -p temp | rm -rf temp

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/rm-error-0.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/rm-error-0.txt
@@ -1,3 +1,0 @@
-# Check error on a unsupported rm. (cannot be part of a pipeline)
-#
-# RUN: rm -rf temp | echo "hello"

--- a/llvm/utils/lit/tests/shtest-custom-inproc-builtins.py
+++ b/llvm/utils/lit/tests/shtest-custom-inproc-builtins.py
@@ -1,0 +1,10 @@
+## This test provides some custom in-process built-ins via the lit.cfg, and
+## verifies that their output can be redirected correctly.
+#
+# RUN: %{lit} -v %{inputs}/shtest-custom-inproc-builtins \
+# RUN: | FileCheck -match-full-lines %s
+# END.
+
+# CHECK: PASS: shtest-custom-inproc-builtins :: use-custom-inproc-builtins.txt ({{[^)]*}})
+
+# CHECK: Passed: 1 ({{[^)]*}})

--- a/llvm/utils/lit/tests/shtest-glob.py
+++ b/llvm/utils/lit/tests/shtest-glob.py
@@ -4,8 +4,7 @@
 # RUN: | FileCheck -dump-input=fail -match-full-lines --implicit-check-not=Error: %s
 # END.
 
-# CHECK: UNRESOLVED: shtest-glob :: glob-echo.txt ({{[^)]*}})
-# CHECK: TypeError: string argument expected, got 'GlobItem'
+# CHECK: PASS: shtest-glob :: glob-echo.txt ({{[^)]*}})
 
 # CHECK:      FAIL: shtest-glob :: glob-mkdir.txt ({{[^)]*}})
 # CHECK:      # | Error: 'mkdir' command failed, {{.*}}example_file1.input'

--- a/llvm/utils/lit/tests/shtest-pipelined-inproc-builtins.py
+++ b/llvm/utils/lit/tests/shtest-pipelined-inproc-builtins.py
@@ -1,0 +1,12 @@
+## This test suite tests pipelining in-process builtins.
+## This test suite has some extra in-process builtin registered in the config:
+## - uppercaser: Reads input on stdin, converts the string to uppercase and
+##   outputs the result on stderr.
+## - print_out_err: Writes the first argument to stdout, and the second to stderr.
+## - streq: Returns 0 if the first argument and the input from stdin are equal, 1 otherwise.
+
+# RUN: %{lit} -v %{inputs}/shtest-pipelined-inproc-builtins | FileCheck %s -match-full-lines
+# END.
+
+# CHECK: PASS: shtest-pipelined-inproc-builtins :: extra-inproc-builtins.txt ({{.*}})
+# CHECK: PASS: shtest-pipelined-inproc-builtins :: pipelined-inproc-builtins.txt ({{.*}})

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -497,37 +497,10 @@
 # CHECK-NEXT: # error: command failed with exit status: 1
 #      CHECK: ***
 
-# CHECK: FAIL: shtest-shell :: echo-at-redirect-stderr.txt
-# CHECK: *** TEST 'shtest-shell :: echo-at-redirect-stderr.txt' FAILED ***
-# CHECK: @echo 2> {{.*}}
-# CHECK: # executed command: @echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for @echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-at-redirect-stdin.txt
-# CHECK: *** TEST 'shtest-shell :: echo-at-redirect-stdin.txt' FAILED ***
-# CHECK: @echo < {{.*}}
-# CHECK: # executed command: @echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for @echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-redirect-stderr.txt
-# CHECK: *** TEST 'shtest-shell :: echo-redirect-stderr.txt' FAILED ***
-# CHECK: echo 2> {{.*}}
-# CHECK: # executed command: echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-redirect-stdin.txt
-# CHECK: *** TEST 'shtest-shell :: echo-redirect-stdin.txt' FAILED ***
-# CHECK: echo < {{.*}}
-# CHECK: # executed command: echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for echo
-# CHECK: error: command failed with exit status:
+# CHECK: PASS: shtest-shell :: echo-at-redirect-stderr.txt
+# CHECK: PASS: shtest-shell :: echo-at-redirect-stdin.txt
+# CHECK: PASS: shtest-shell :: echo-redirect-stderr.txt
+# CHECK: PASS: shtest-shell :: echo-redirect-stdin.txt
 
 # CHECK: FAIL: shtest-shell :: error-0.txt
 # CHECK: *** TEST 'shtest-shell :: error-0.txt' FAILED ***
@@ -634,4 +607,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (37)
+# CHECK: Failed Tests (33)

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -12,14 +12,6 @@
 
 # CHECK: -- Testing:
 
-# CHECK: FAIL: shtest-shell :: colon-error.txt
-# CHECK: *** TEST 'shtest-shell :: colon-error.txt' FAILED ***
-# CHECK: :
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | Unsupported: ':' cannot be part of a pipeline
-# CHECK: # error: command failed with exit status: 127
-# CHECK: ***
-
 # CHECK: PASS: shtest-shell :: continuations.txt
 
 # CHECK: PASS: shtest-shell :: dev-null.txt
@@ -529,14 +521,6 @@
 # CHECK: Unsupported redirect:
 # CHECK: ***
 
-# CHECK: FAIL: shtest-shell :: mkdir-error-0.txt
-# CHECK: *** TEST 'shtest-shell :: mkdir-error-0.txt' FAILED ***
-# CHECK: mkdir -p temp | rm -rf temp
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | Unsupported: 'mkdir' cannot be part of a pipeline
-# CHECK: # error: command failed with exit status: 127
-# CHECK: ***
-
 # CHECK: FAIL: shtest-shell :: mkdir-error-1.txt
 # CHECK: *** TEST 'shtest-shell :: mkdir-error-1.txt' FAILED ***
 # CHECK: mkdir -p -m 777 temp
@@ -559,14 +543,6 @@
 # CHECK: ***
 
 # CHECK: PASS: shtest-shell :: redirects.txt
-
-# CHECK: FAIL: shtest-shell :: rm-error-0.txt
-# CHECK: *** TEST 'shtest-shell :: rm-error-0.txt' FAILED ***
-# CHECK: rm -rf temp | echo "hello"
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | Unsupported: 'rm' cannot be part of a pipeline
-# CHECK: # error: command failed with exit status: 127
-# CHECK: ***
 
 # CHECK: FAIL: shtest-shell :: rm-error-1.txt
 # CHECK: *** TEST 'shtest-shell :: rm-error-1.txt' FAILED ***
@@ -607,4 +583,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (33)
+# CHECK: Failed Tests (30)


### PR DESCRIPTION
This PR is dependent on https://github.com/llvm/llvm-project/pull/196955 and https://github.com/llvm/llvm-project/pull/195114; the changes in the first commit in this PR are from those ones and their dependencies, so please review only the second commit on this PR and onward. As PRs are merged, I will rebase this branch to remove the other commits.

This PR finally enables in-process built-ins to run in command pipelines like regular process invocations. I've added a regression test is added for chaining in-process built-ins with each other and with regular process invocations.

This is part of the [Lit daemonized testing project](https://discourse.llvm.org/t/rfc-reducing-process-creation-overhead-in-llvm-regression-tests/88612/9).