### PR TITLE
[clang][bytecode] Fix a crash with invalid ArraySubscriptExprs

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2018,7 +2018,7 @@ bool Compiler<Emitter>::VisitImplicitValueInitExpr(
 
 template <class Emitter>
 bool Compiler<Emitter>::VisitArraySubscriptExpr(const ArraySubscriptExpr *E) {
-  if (E->getType()->isVoidType())
+  if (E->getType()->isVoidType() || E->containsErrors())
     return false;
 
   const Expr *LHS = E->getLHS();

--- a/clang/test/AST/ByteCode/arrays.cpp
+++ b/clang/test/AST/ByteCode/arrays.cpp
@@ -847,3 +847,11 @@ namespace MultiDimArrayInitLoop {
   constexpr S s = {1};
   constexpr T t = {s};
 }
+
+namespace ErroneousArraySubscriptExpr {
+  constexpr int &foo(int *arr, size_t idx) { return arr[idx]; } // both-error {{unknown type name 'size_t'}}
+  void bar() {
+    int val[] = {1, 2, 3, 4};
+    foo(val, 2) = 42;
+  }
+}


### PR DESCRIPTION
In the attached test case, `arr` becomes the _index_, not the base, which causes us later to run into issues because the index is a pointer and not an integer.