### PR TITLE
[analyzer] Fix bad logic in VisitArrayInitLoopExpr

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3431,7 +3431,7 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
     else
       Base = UnknownVal();
 
-    Bldr.generateNode(Ex, Pred, state->BindExpr(Ex, LCtx, Base));
+    Bldr.generateNode(Ex, Node, state->BindExpr(Ex, LCtx, Base));
   }
 
   getCheckerManager().runCheckersForPostStmt(Dst, EvalSet, Ex, *this);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3351,12 +3351,13 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
 
   const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
 
+  if (isa<CXXConstructExpr>(Ex->getSubExpr())) {
+    // The constructor visitior has already taken care of everything, let's
+    // skip the 'for' loop:
+    CheckerPreStmt.clear();
+  }
+
   for (auto *Node : CheckerPreStmt) {
-
-    // The constructor visitior has already taken care of everything.
-    if (isa<CXXConstructExpr>(Ex->getSubExpr()))
-      break;
-
     const LocationContext *LCtx = Node->getLocationContext();
     ProgramStateRef state = Node->getState();
 

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3347,7 +3347,7 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
   getCheckerManager().runCheckersForPreStmt(CheckerPreStmt, Pred, Ex, *this);
 
   ExplodedNodeSet EvalSet;
-  NodeBuilder Bldr(CheckerPreStmt, EvalSet, *currBldrCtx);
+  EvalSet.insert(CheckerPreStmt);
 
   const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
 
@@ -3431,7 +3431,8 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
     else
       Base = UnknownVal();
 
-    Bldr.generateNode(Ex, Node, state->BindExpr(Ex, LCtx, Base));
+    EvalSet.erase(Node);
+    EvalSet.insert(Engine.makeNodeWithBinding(Node, Ex, Base));
   }
 
   getCheckerManager().runCheckersForPostStmt(Dst, EvalSet, Ex, *this);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3346,17 +3346,17 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
   ExplodedNodeSet CheckerPreStmt;
   getCheckerManager().runCheckersForPreStmt(CheckerPreStmt, Pred, Ex, *this);
 
+  ExplodedNodeSet EvalSet;
+  NodeBuilder Bldr(CheckerPreStmt, EvalSet, *currBldrCtx);
+
   const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
 
-  ExplodedNodeSet EvalSet;
-  if (isa<CXXConstructExpr>(Ex->getSubExpr())) {
-    // The constructor visitior has already taken care of everything, so let's
-    // jump to the PostStmt step by skipping the 'for' loop:
-    EvalSet.insert(CheckerPreStmt);
-    CheckerPreStmt.clear();
-  }
-
   for (auto *Node : CheckerPreStmt) {
+
+    // The constructor visitior has already taken care of everything.
+    if (isa<CXXConstructExpr>(Ex->getSubExpr()))
+      break;
+
     const LocationContext *LCtx = Node->getLocationContext();
     ProgramStateRef state = Node->getState();
 
@@ -3431,7 +3431,7 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
     else
       Base = UnknownVal();
 
-    EvalSet.insert(Engine.makeNodeWithBinding(Node, Ex, Base));
+    Bldr.generateNode(Ex, Node, state->BindExpr(Ex, LCtx, Base));
   }
 
   getCheckerManager().runCheckersForPostStmt(Dst, EvalSet, Ex, *this);

--- a/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngine.cpp
@@ -3346,14 +3346,13 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
   ExplodedNodeSet CheckerPreStmt;
   getCheckerManager().runCheckersForPreStmt(CheckerPreStmt, Pred, Ex, *this);
 
-  ExplodedNodeSet EvalSet;
-  EvalSet.insert(CheckerPreStmt);
-
   const Expr *Arr = Ex->getCommonExpr()->getSourceExpr();
 
+  ExplodedNodeSet EvalSet;
   if (isa<CXXConstructExpr>(Ex->getSubExpr())) {
-    // The constructor visitior has already taken care of everything, let's
-    // skip the 'for' loop:
+    // The constructor visitior has already taken care of everything, so let's
+    // jump to the PostStmt step by skipping the 'for' loop:
+    EvalSet.insert(CheckerPreStmt);
     CheckerPreStmt.clear();
   }
 
@@ -3432,7 +3431,6 @@ void ExprEngine::VisitArrayInitLoopExpr(const ArrayInitLoopExpr *Ex,
     else
       Base = UnknownVal();
 
-    EvalSet.erase(Node);
     EvalSet.insert(Engine.makeNodeWithBinding(Node, Ex, Base));
   }
 


### PR DESCRIPTION
The method `VisitArrayInitLoopExpr` consists of three steps:
1. Run the `PreStmt<ArrayInitLoopExpr>` callbacks
2. Bind the right value to the expression
3. Run the `PostStmt<ArrayInitLoopExpr>` callbacks

However 8ef628088b54aebd4a8317ce3a0029e3283b3aa0 (which added this method in 2022) introduced bad logic: at step 2 it used `Pred` (the node received as an argument at the beginning) instead of `Node` (one of the nodes produced in step 1) as the parent of the freshly made nodes.

This logic error didn't cause practical problems because `ArrayInitLoopExpr` is a very esoteric AST node so there aren't any checkers that implement `PreStmt` callbacks for it.