### PR TITLE
[MLIR][Affine] Copy-in sparse-write regions in affine-data-copy-generate

### DIFF
--- a/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
@@ -2439,6 +2439,50 @@ mlir::affine::affineDataCopyGenerate(Block::iterator begin, Block::iterator end,
     return failure();
   }
 
+  // Synthesise a copy-IN for any write-only region we cannot prove covers its
+  // bounding box. The post-loop copy-OUT writes the whole bounding box back,
+  // so gap cells must be initialised first (#54994).
+  llvm::SmallDenseMap<Value, int64_t> provenTouched;
+  block->walk(begin, end, [&](Operation *opInst) {
+    Value memref;
+    if (auto load = dyn_cast<AffineLoadOp>(opInst))
+      memref = load.getMemRef();
+    else if (auto store = dyn_cast<AffineStoreOp>(opInst))
+      memref = store.getMemRef();
+    if (!memref || !writeRegions.count(memref) || readRegions.count(memref))
+      return;
+    SmallVector<Value, 4> enclosingIVs;
+    getAffineIVs(*opInst, enclosingIVs);
+    int64_t iter = 1;
+    for (unsigned k = copyDepth, e = enclosingIVs.size(); k < e; ++k) {
+      auto forOp = getForInductionVarOwner(enclosingIVs[k]);
+      if (!forOp)
+        return;
+      std::optional<uint64_t> trip = getConstantTripCount(forOp);
+      if (!trip || *trip == 0 ||
+          static_cast<uint64_t>(iter) >
+              std::numeric_limits<int64_t>::max() / *trip)
+        return;
+      iter *= static_cast<int64_t>(*trip);
+    }
+    int64_t &m = provenTouched[memref];
+    if (iter > m)
+      m = iter;
+  });
+  for (auto &[memref, region] : writeRegions) {
+    if (readRegions.count(memref))
+      continue;
+    std::optional<int64_t> volume = region->getConstantBoundingSizeAndShape();
+    auto it = provenTouched.find(memref);
+    if (volume && it != provenTouched.end() && it->second >= *volume)
+      continue;
+    auto inRegion = std::make_unique<MemRefRegion>(region->loc);
+    inRegion->memref = region->memref;
+    inRegion->write = false;
+    inRegion->cst.clearAndCopyFrom(region->cst);
+    readRegions[memref] = std::move(inRegion);
+  }
+
   uint64_t totalCopyBuffersSizeInBytes = 0;
   bool ret = true;
   auto processRegions =

--- a/mlir/test/Dialect/Affine/data-copy-non-unit-stride.mlir
+++ b/mlir/test/Dialect/Affine/data-copy-non-unit-stride.mlir
@@ -1,0 +1,39 @@
+// RUN: mlir-opt %s -affine-data-copy-generate="fast-mem-capacity=64 fast-mem-space=0" | FileCheck %s
+
+// Issue #54994: a sparse write (16 iterations, 31-cell bounding box) must
+// emit a copy-IN so the post-loop copy-OUT doesn't clobber gap cells.
+
+// CHECK-LABEL: func @non_unit_stride_store
+// CHECK:         [[BUF:%[a-zA-Z0-9_]+]] = memref.alloc
+// CHECK:         affine.for %[[I:.*]] = 0 to 31 {
+// CHECK-NEXT:      affine.load %{{.*}}[%[[I]]] : memref<32xf32>
+// CHECK-NEXT:      affine.store %{{.*}}, [[BUF]][%[[I]]]
+// CHECK-NEXT:    }
+// CHECK:         affine.for %{{.*}} = 0 to 16 {
+// CHECK-NEXT:      affine.store %{{.*}}, [[BUF]][%{{.*}} * 2]
+// CHECK-NEXT:    }
+// CHECK:         affine.for %{{.*}} = 0 to 31 {
+func.func @non_unit_stride_store(%arg0: memref<32xf32>) {
+  %cst = arith.constant 0.000000e+00 : f32
+  affine.for %arg1 = 0 to 16 {
+    affine.store %cst, %arg0[%arg1 * 2] : memref<32xf32>
+  }
+  return
+}
+
+// -----
+
+// Dense tile (iteration count 512 = bounding-box volume): no extra copy-IN.
+
+// CHECK-LABEL: func @densely_tiled_access
+// CHECK:         memref.alloc
+func.func @densely_tiled_access(%arg0: memref<512xf32>) {
+  affine.for %kT = 0 to 32 {
+    affine.for %kk = 0 to 16 {
+      %k = affine.apply affine_map<(d0, d1) -> (16 * d0 + d1)>(%kT, %kk)
+      %v = affine.load %arg0[%k] : memref<512xf32>
+      affine.store %v, %arg0[%k] : memref<512xf32>
+    }
+  }
+  return
+}


### PR DESCRIPTION
## Summary

`affine-data-copy-generate` allocates a contiguous fast-memory buffer sized
for the bounding box of an access region. For write-only regions the
existing schedule skips the copy-IN, relying on the loop body to populate
every cell. When the access pattern is sparse (touched cells are a strict
subset of the bounding box, e.g. `%a[%i * 2]` writes 16 cells in a 31-cell
box), the gap cells in the fast buffer stay uninitialized and the
post-loop bounding-box copy-OUT clobbers the original memref's untouched
cells with those uninitialized values.

This patch classifies write-only regions as dense or sparse by comparing
the inner-loop iteration count to the bounding-box volume, and schedules a
copy-IN for the sparse ones so the gap cells survive the round-trip.

This is the bug tracked at LLVM issue #54994 (open since 2022, no fix
linked).

## Reproducer

```mlir
func.func @test(%arg0: memref<32xf32>) {
  %cst = arith.constant 0.000000e+00 : f32
  affine.for %arg1 = 0 to 16 {
    affine.store %cst, %arg0[%arg1 * 2] : memref<32xf32>
  }
  return
}
```

Apply:

```sh
mlir-opt repro.mlir -affine-data-copy-generate="fast-mem-capacity=64 fast-mem-space=0"
```

Before this patch, the pass emits:

```mlir
%alloc = memref.alloc() : memref<31xf32>
affine.for %arg1 = 0 to 16 {
  affine.store %cst, %alloc[%arg1 * 2] : memref<31xf32>   // even indices only
}
affine.for %arg1 = 0 to 31 {
  %0 = affine.load %alloc[%arg1] : memref<31xf32>          // loads UNDEF at odd indices
  affine.store %0, %arg0[%arg1] : memref<32xf32>           // clobbers original odd cells
}
```

The scalar loop wrote only the even cells of `%arg0`; the copy-out writes
all 31 cells of `%alloc`, including the never-initialized odd cells, into
`%arg0`.

## Why

`MemRefRegion::compute` produces a bounding-box constraint system that
overapproximates the set of touched cells; `getConstantBoundingSizeAndShape`
then reports the bounding-box volume as the buffer size. For dense accesses
(unit-stride, or strides composed of multiple inner IVs that tile the
bounding box exactly) the overapproximation is tight and the copy-out is
sound. For sparse accesses with a single inner IV at non-unit stride it is
not.

## Fix

After collecting per-memref read/write regions and before calling
`generateCopy`, classify each write-only memref as dense or sparse by
comparing the inner-loop iteration count to the bounding-box volume
returned by `getConstantBoundingSizeAndShape`. The iteration count for
each load/store op is the product of its enclosing inner loops' trip
counts (loops at depth `>= copyDepth`); per memref, the maximum over its
contributing ops is the largest cardinality the loop body could touch.

If `max_iteration_count >= bounding_box_volume` the loop covers the
bounding box and the existing copy-OUT-only schedule is sound. Otherwise
(including when the iteration count cannot be proved at all) we synthesise
a read region (a clone of the write region with `write = false`) so that
`processRegions(readRegions)` emits a copy-IN before the loop. The fast
buffer is then populated from the original memref before the loop runs,
the loop writes only its strided positions, and the unchanged
bounding-box copy-OUT carries the originally-read gap cells back
unmodified.

Trip counts come from `getConstantTripCount`, which handles relative
affine bounds (e.g. `(d0) -> (d0)` to `(d0) -> (d0 + 4)` is trip 4). When
even that cannot prove a constant trip, the conservative default is to
add the copy-IN — soundness over the (now-stale) "write-only skips
copy-IN" optimisation.

## Test

Added `mlir/test/Dialect/Affine/data-copy-non-unit-stride.mlir`:

- `@non_unit_stride_store` — `%arg0[%arg1 * 2]` (iteration 16, bounding box
  31) must get a copy-IN before the loop and a copy-OUT after.
- `@densely_tiled_access` — `16 * %kT + %kk` (iteration 32 * 16 = 512,
  bounding box 512) remains on the existing copy-OUT-only schedule.

Ran:

```sh
ninja -C build mlir-opt FileCheck
build/bin/llvm-lit -sv mlir/test/Dialect/Affine/
```

Result: 70/70 pass.

## How it was found

Surfaced by an in-progress SMT-solver-based analysis tool for MLIR affine
passes.

## Tool-use disclosure

This change was drafted with AI tool assistance per LLVM's AI Tool Use
Policy. All code was read, reviewed, and tested locally; the commit should
carry an `Assisted-by:` trailer.
