### PR TITLE
[MLIR][Vector] Add canonicalization for interleave/deinterleave chain

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -584,6 +584,7 @@ def Vector_InterleaveOp :
       return ::llvm::cast<VectorType>(getResult().getType());
     }
   }];
+  let hasCanonicalizer = 1;
 }
 
 class ResultIsHalfSourceVectorType<string result> : TypesMatchWith<
@@ -2560,7 +2561,7 @@ def Vector_TypeCastOp :
 }
 
 def Vector_ConstantMaskOp :
-  Vector_Op<"constant_mask", [Pure, 
+  Vector_Op<"constant_mask", [Pure,
    DeclareOpInterfaceMethods<VectorUnrollOpInterface>
    ]>,
     Arguments<(ins DenseI64ArrayAttr:$mask_dim_sizes)>,
@@ -2620,7 +2621,7 @@ def Vector_ConstantMaskOp :
 }
 
 def Vector_CreateMaskOp :
-  Vector_Op<"create_mask", [Pure, 
+  Vector_Op<"create_mask", [Pure,
    DeclareOpInterfaceMethods<VectorUnrollOpInterface>
    ]>,
     Arguments<(ins Variadic<Index>:$mask_dim_sizes)>,

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -8360,7 +8360,7 @@ struct InterleaveDeinterleaveFolder : public OpRewritePattern<InterleaveOp> {
     if (!lhsDefOp || !rhsDefOp || lhsDefOp != rhsDefOp)
       return failure();
     for (auto [idx, operand] : llvm::enumerate(interleaveOp.getOperands())) {
-      if (auto opRes = cast<OpResult>(operand); opRes.getResultNumber() != idx)
+      if (cast<OpResult>(operand).getResultNumber() != idx)
         return failure();
     }
     rewriter.replaceOp(interleaveOp, lhsDefOp.getSource());

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -8355,12 +8355,9 @@ struct InterleaveDeinterleaveFolder : public OpRewritePattern<InterleaveOp> {
 
   LogicalResult matchAndRewrite(InterleaveOp interleaveOp,
                                 PatternRewriter &rewriter) const override {
-    auto lhsDefOp = interleaveOp.getLhs().getDefiningOp();
-    auto rhsDefOp = interleaveOp.getRhs().getDefiningOp();
+    auto lhsDefOp = interleaveOp.getLhs().getDefiningOp<DeinterleaveOp>();
+    auto rhsDefOp = interleaveOp.getRhs().getDefiningOp<DeinterleaveOp>();
     if (!lhsDefOp || !rhsDefOp)
-      return rewriter.notifyMatchFailure(
-          interleaveOp, "expected both operands to be defined by an op");
-    if (!isa<DeinterleaveOp>(lhsDefOp) || !isa<DeinterleaveOp>(rhsDefOp))
       return rewriter.notifyMatchFailure(
           interleaveOp,
           "expected both operands to be defined by a deinterleave op");
@@ -8378,8 +8375,7 @@ struct InterleaveDeinterleaveFolder : public OpRewritePattern<InterleaveOp> {
       return rewriter.notifyMatchFailure(
           interleaveOp, "expected the rhs operand to be the second result of "
                         "the deinterleave op");
-    rewriter.replaceOp(interleaveOp,
-                       cast<DeinterleaveOp>(lhsDefOp).getSource());
+    rewriter.replaceOp(interleaveOp, lhsDefOp.getSource());
     return success();
   }
 };

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -8346,6 +8346,50 @@ Value mlir::vector::selectPassthru(OpBuilder &builder, Value mask,
 // InterleaveOp
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+/// This canonicalization folds the following round-trip identity:
+///  interleave(deinterleave(x).even, deinterleave(x).odd) -> x
+struct InterleaveDeinterleaveFolder : public OpRewritePattern<InterleaveOp> {
+  using Base::Base;
+
+  LogicalResult matchAndRewrite(InterleaveOp interleaveOp,
+                                PatternRewriter &rewriter) const override {
+    auto lhsDefOp = interleaveOp.getLhs().getDefiningOp();
+    auto rhsDefOp = interleaveOp.getRhs().getDefiningOp();
+    if (!lhsDefOp || !rhsDefOp)
+      return rewriter.notifyMatchFailure(
+          interleaveOp, "expected both operands to be defined by an op");
+    if (!isa<DeinterleaveOp>(lhsDefOp) || !isa<DeinterleaveOp>(rhsDefOp))
+      return rewriter.notifyMatchFailure(
+          interleaveOp,
+          "expected both operands to be defined by a deinterleave op");
+    if (lhsDefOp != rhsDefOp)
+      return rewriter.notifyMatchFailure(
+          interleaveOp,
+          "expected both operands to be defined by the same deinterleave op");
+    if (auto deinterleaveRes = cast<OpResult>(interleaveOp.getLhs());
+        deinterleaveRes.getResultNumber())
+      return rewriter.notifyMatchFailure(interleaveOp,
+                                         "expected the lhs operand to be the "
+                                         "first result of the deinterleave op");
+    if (auto deinterleaveRes = cast<OpResult>(interleaveOp.getRhs());
+        deinterleaveRes.getResultNumber() != 1)
+      return rewriter.notifyMatchFailure(
+          interleaveOp, "expected the rhs operand to be the second result of "
+                        "the deinterleave op");
+    rewriter.replaceOp(interleaveOp,
+                       cast<DeinterleaveOp>(lhsDefOp).getSource());
+    return success();
+  }
+};
+} // namespace
+
+void InterleaveOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                               MLIRContext *context) {
+  results.add<InterleaveDeinterleaveFolder>(context);
+}
+
 std::optional<SmallVector<int64_t, 4>> InterleaveOp::getShapeForUnroll() {
   return llvm::to_vector<4>(getResultVectorType().getShape());
 }

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -8348,7 +8348,7 @@ Value mlir::vector::selectPassthru(OpBuilder &builder, Value mask,
 
 namespace {
 
-/// This canonicalization folds the following round-trip identity:
+/// This folder works on the following round-trip identity:
 ///  interleave(deinterleave(x).even, deinterleave(x).odd) -> x
 struct InterleaveDeinterleaveFolder : public OpRewritePattern<InterleaveOp> {
   using Base::Base;
@@ -8357,24 +8357,12 @@ struct InterleaveDeinterleaveFolder : public OpRewritePattern<InterleaveOp> {
                                 PatternRewriter &rewriter) const override {
     auto lhsDefOp = interleaveOp.getLhs().getDefiningOp<DeinterleaveOp>();
     auto rhsDefOp = interleaveOp.getRhs().getDefiningOp<DeinterleaveOp>();
-    if (!lhsDefOp || !rhsDefOp)
-      return rewriter.notifyMatchFailure(
-          interleaveOp,
-          "expected both operands to be defined by a deinterleave op");
-    if (lhsDefOp != rhsDefOp)
-      return rewriter.notifyMatchFailure(
-          interleaveOp,
-          "expected both operands to be defined by the same deinterleave op");
-    if (auto deinterleaveRes = cast<OpResult>(interleaveOp.getLhs());
-        deinterleaveRes.getResultNumber())
-      return rewriter.notifyMatchFailure(interleaveOp,
-                                         "expected the lhs operand to be the "
-                                         "first result of the deinterleave op");
-    if (auto deinterleaveRes = cast<OpResult>(interleaveOp.getRhs());
-        deinterleaveRes.getResultNumber() != 1)
-      return rewriter.notifyMatchFailure(
-          interleaveOp, "expected the rhs operand to be the second result of "
-                        "the deinterleave op");
+    if (!lhsDefOp || !rhsDefOp || lhsDefOp != rhsDefOp)
+      return failure();
+    for (auto [idx, operand] : llvm::enumerate(interleaveOp.getOperands())) {
+      if (auto opRes = cast<OpResult>(operand); opRes.getResultNumber() != idx)
+        return failure();
+    }
     rewriter.replaceOp(interleaveOp, lhsDefOp.getSource());
     return success();
   }

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -4407,3 +4407,13 @@ func.func @no_fold_alltrue_mask_empty_body_scalar_result(
   %result = vector.mask %all_true, %passthru { vector.yield %val : i32 } : vector<1xi1> -> i32
   return %result : i32
 }
+
+// Fold interleave(deinterleave(x).even, deinterleave(x).odd) -> x
+// CHECK-LABEL: func @interleave_deinterleave_fold
+//  CHECK-SAME: (%[[ARG0:.*]]: vector<4xf32>)
+//       CHECK: return %[[ARG0]]
+func.func @interleave_deinterleave_fold(%arg0: vector<4xf32>) -> vector<4xf32> {
+  %even, %odd = vector.deinterleave %arg0 : vector<4xf32> -> vector<2xf32>
+  %result = vector.interleave %even, %odd : vector<2xf32> -> vector<4xf32>
+  return %result : vector<4xf32>
+}

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -4408,7 +4408,12 @@ func.func @no_fold_alltrue_mask_empty_body_scalar_result(
   return %result : i32
 }
 
-// Fold interleave(deinterleave(x).even, deinterleave(x).odd) -> x
+// -----
+
+// The test checks the `InterleaveDeinterleaveFolder` pattern of `vector.interleave`
+// to correctly fold the following identity:
+//  interleave(deinterleave(x).even, deinterleave(x).odd) -> x
+
 // CHECK-LABEL: func @interleave_deinterleave_fold
 //  CHECK-SAME: (%[[ARG0:.*]]: vector<4xf32>)
 //       CHECK: return %[[ARG0]]


### PR DESCRIPTION
This PR adds a canonicalization that folds a chain of `vector.deinterleave` and `vector.interleave` trivially. 