### PR TITLE
[GlobalISel] Defer RegBankSelect operand mapper creation

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/RegBankSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/RegBankSelect.cpp
@@ -45,6 +45,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <utility>
 
 #define DEBUG_TYPE "regbankselect"
@@ -595,7 +596,7 @@ bool RegBankSelect::applyMapping(
     MachineInstr &MI, const RegisterBankInfo::InstructionMapping &InstrMapping,
     SmallVectorImpl<RegBankSelect::RepairingPlacement> &RepairPts) {
   // OpdMapper will hold all the information needed for the rewriting.
-  RegisterBankInfo::OperandsMapper OpdMapper(MI, InstrMapping, *MRI);
+  std::optional<RegisterBankInfo::OperandsMapper> OpdMapper;
 
   // First, place the repairing code.
   for (RepairingPlacement &RepairPt : RepairPts) {
@@ -620,8 +621,10 @@ bool RegBankSelect::applyMapping(
       // Don't insert additional instruction for debug instruction.
       if (MI.isDebugInstr())
         break;
-      OpdMapper.createVRegs(OpIdx);
-      if (!repairReg(MO, ValMapping, RepairPt, OpdMapper.getVRegs(OpIdx)))
+      if (!OpdMapper)
+        OpdMapper.emplace(MI, InstrMapping, *MRI);
+      OpdMapper->createVRegs(OpIdx);
+      if (!repairReg(MO, ValMapping, RepairPt, OpdMapper->getVRegs(OpIdx)))
         return false;
       break;
     default:
@@ -629,9 +632,16 @@ bool RegBankSelect::applyMapping(
     }
   }
 
+  // Default mappings only need rewriting when repairs create new operands.
+  if (!OpdMapper && InstrMapping.getID() == RegisterBankInfo::DefaultMappingID)
+    return true;
+
+  if (!OpdMapper)
+    OpdMapper.emplace(MI, InstrMapping, *MRI);
   // Second, rewrite the instruction.
-  LLVM_DEBUG(dbgs() << "Actual mapping of the operands: " << OpdMapper << '\n');
-  RBI->applyMapping(MIRBuilder, OpdMapper);
+  LLVM_DEBUG(dbgs() << "Actual mapping of the operands: " << *OpdMapper
+                    << '\n');
+  RBI->applyMapping(MIRBuilder, *OpdMapper);
 
   return true;
 }


### PR DESCRIPTION
RegBankSelect::applyMapping constructs an OperandsMapper before applying repairs. Default mappings that only need Reassign repairs only update the register bank and do not create replacement operands, so the generic applyDefaultMapping path has no rewriting work to do in that case.

Defer OperandsMapper creation until an Insert repair actually needs new virtual registers. If no mapper was needed for a default mapping, return after applying the repairs.

CTMark geomean -0.23% improvement on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=ed50ea52004259af958bb3e5636268342c49ee62&to=1a4730426e14969626cad43c6b06e93bde707bd1&stat=instructions%3Au

Assisted-by: Codex