### PR TITLE
[clang-tidy][NFC] Use `std::array` instead of `SmallVector` in `UseTrailingReturnTypeCheck`

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -228,7 +228,7 @@ classifyToken(const FunctionDecl &F, Preprocessor &PP, Token Tok) {
   Token End;
   End.startToken();
   End.setKind(tok::eof);
-  const SmallVector<Token, 2> Stream{Tok, End};
+  const std::array<Token, 2> Stream{Tok, End};
 
   // FIXME: do not report these token to Preprocessor.TokenWatcher.
   PP.EnterTokenStream(Stream, false, /*IsReinject=*/false);


### PR DESCRIPTION
We know we have exactly 2 `Token` in the array. There is no need to use `SmallVector` here.