### PR TITLE
[mlir][SPIR-V] Lower math.{exp2,log2} to GLSL.std.450 ops

### DIFF
--- a/mlir/lib/Conversion/MathToSPIRV/MathToSPIRV.cpp
+++ b/mlir/lib/Conversion/MathToSPIRV/MathToSPIRV.cpp
@@ -297,25 +297,18 @@ struct Log1pOpPattern final : public OpConversionPattern<math::Log1pOp> {
   }
 };
 
-/// Converts math.log2 and math.log10 to SPIR-V ops.
+/// Converts math.log10 to GLSL SPIR-V ops.
 ///
-/// SPIR-V does not have direct operations for log2 and log10. Explicitly
-/// lower to these operations using:
-///   log2(x) = log(x) * 1/log(2)
+/// GLSL.std.450 has no Log10 instruction. Lower it as:
 ///   log10(x) = log(x) * 1/log(10)
+struct Log10OpPattern final : public OpConversionPattern<math::Log10Op> {
+  using Base::Base;
 
-template <typename MathLogOp, typename SpirvLogOp>
-struct Log2Log10OpPattern final : public OpConversionPattern<MathLogOp> {
-  using OpConversionPattern<MathLogOp>::OpConversionPattern;
-  using typename OpConversionPattern<MathLogOp>::OpAdaptor;
-
-  static constexpr double log2Reciprocal =
-      1.442695040888963407359924681001892137426645954152985934135449407;
   static constexpr double log10Reciprocal =
       0.4342944819032518276511289189166050822943970058036665661144537832;
 
   LogicalResult
-  matchAndRewrite(MathLogOp operation, OpAdaptor adaptor,
+  matchAndRewrite(math::Log10Op operation, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     assert(adaptor.getOperands().size() == 1);
     if (LogicalResult res = checkSourceOpTypes(rewriter, operation);
@@ -342,14 +335,11 @@ struct Log2Log10OpPattern final : public OpConversionPattern<MathLogOp> {
                   vectorType, FloatAttr::get(elemType, value).getValue()));
         }
       }
-
-      llvm_unreachable("unimplemented types for log2/log10");
+      llvm_unreachable("unimplemented type for log10");
     };
 
-    Value constantValue = getConstantValue(
-        std::is_same<MathLogOp, math::Log2Op>() ? log2Reciprocal
-                                                : log10Reciprocal);
-    Value log = SpirvLogOp::create(rewriter, loc, adaptor.getOperand());
+    Value constantValue = getConstantValue(log10Reciprocal);
+    Value log = spirv::GLLogOp::create(rewriter, loc, adaptor.getOperand());
     rewriter.replaceOpWithNewOp<spirv::FMulOp>(operation, type, log,
                                                constantValue);
     return success();
@@ -530,34 +520,34 @@ void populateMathToSPIRVPatterns(const SPIRVTypeConverter &typeConverter,
           typeConverter, patterns.getContext());
 
   // GLSL patterns
-  patterns
-      .add<CountLeadingZerosPattern, Log1pOpPattern<spirv::GLLogOp>,
-           Log2Log10OpPattern<math::Log2Op, spirv::GLLogOp>,
-           Log2Log10OpPattern<math::Log10Op, spirv::GLLogOp>,
-           ExpM1OpPattern<spirv::GLExpOp>, PowFOpPattern, RoundOpPattern,
-           CheckedElementwiseOpPattern<math::AbsFOp, spirv::GLFAbsOp>,
-           CheckedElementwiseOpPattern<math::AbsIOp, spirv::GLSAbsOp>,
-           CheckedElementwiseOpPattern<math::AtanOp, spirv::GLAtanOp>,
-           CheckedElementwiseOpPattern<math::CeilOp, spirv::GLCeilOp>,
-           CheckedElementwiseOpPattern<math::CosOp, spirv::GLCosOp>,
-           CheckedElementwiseOpPattern<math::ExpOp, spirv::GLExpOp>,
-           CheckedElementwiseOpPattern<math::FloorOp, spirv::GLFloorOp>,
-           CheckedElementwiseOpPattern<math::FmaOp, spirv::GLFmaOp>,
-           CheckedElementwiseOpPattern<math::LogOp, spirv::GLLogOp>,
-           CheckedElementwiseOpPattern<math::RoundEvenOp, spirv::GLRoundEvenOp>,
-           CheckedElementwiseOpPattern<math::RsqrtOp, spirv::GLInverseSqrtOp>,
-           CheckedElementwiseOpPattern<math::SinOp, spirv::GLSinOp>,
-           CheckedElementwiseOpPattern<math::SqrtOp, spirv::GLSqrtOp>,
-           CheckedElementwiseOpPattern<math::TanhOp, spirv::GLTanhOp>,
-           CheckedElementwiseOpPattern<math::TanOp, spirv::GLTanOp>,
-           CheckedElementwiseOpPattern<math::AsinOp, spirv::GLAsinOp>,
-           CheckedElementwiseOpPattern<math::AcosOp, spirv::GLAcosOp>,
-           CheckedElementwiseOpPattern<math::SinhOp, spirv::GLSinhOp>,
-           CheckedElementwiseOpPattern<math::CoshOp, spirv::GLCoshOp>,
-           CheckedElementwiseOpPattern<math::AsinhOp, spirv::GLAsinhOp>,
-           CheckedElementwiseOpPattern<math::AcoshOp, spirv::GLAcoshOp>,
-           CheckedElementwiseOpPattern<math::AtanhOp, spirv::GLAtanhOp>>(
-          typeConverter, patterns.getContext());
+  patterns.add<
+      CountLeadingZerosPattern, Log1pOpPattern<spirv::GLLogOp>, Log10OpPattern,
+      ExpM1OpPattern<spirv::GLExpOp>, PowFOpPattern, RoundOpPattern,
+      CheckedElementwiseOpPattern<math::AbsFOp, spirv::GLFAbsOp>,
+      CheckedElementwiseOpPattern<math::AbsIOp, spirv::GLSAbsOp>,
+      CheckedElementwiseOpPattern<math::AtanOp, spirv::GLAtanOp>,
+      CheckedElementwiseOpPattern<math::CeilOp, spirv::GLCeilOp>,
+      CheckedElementwiseOpPattern<math::CosOp, spirv::GLCosOp>,
+      CheckedElementwiseOpPattern<math::ExpOp, spirv::GLExpOp>,
+      CheckedElementwiseOpPattern<math::Exp2Op, spirv::GLExp2Op>,
+      CheckedElementwiseOpPattern<math::FloorOp, spirv::GLFloorOp>,
+      CheckedElementwiseOpPattern<math::FmaOp, spirv::GLFmaOp>,
+      CheckedElementwiseOpPattern<math::LogOp, spirv::GLLogOp>,
+      CheckedElementwiseOpPattern<math::Log2Op, spirv::GLLog2Op>,
+      CheckedElementwiseOpPattern<math::RoundEvenOp, spirv::GLRoundEvenOp>,
+      CheckedElementwiseOpPattern<math::RsqrtOp, spirv::GLInverseSqrtOp>,
+      CheckedElementwiseOpPattern<math::SinOp, spirv::GLSinOp>,
+      CheckedElementwiseOpPattern<math::SqrtOp, spirv::GLSqrtOp>,
+      CheckedElementwiseOpPattern<math::TanhOp, spirv::GLTanhOp>,
+      CheckedElementwiseOpPattern<math::TanOp, spirv::GLTanOp>,
+      CheckedElementwiseOpPattern<math::AsinOp, spirv::GLAsinOp>,
+      CheckedElementwiseOpPattern<math::AcosOp, spirv::GLAcosOp>,
+      CheckedElementwiseOpPattern<math::SinhOp, spirv::GLSinhOp>,
+      CheckedElementwiseOpPattern<math::CoshOp, spirv::GLCoshOp>,
+      CheckedElementwiseOpPattern<math::AsinhOp, spirv::GLAsinhOp>,
+      CheckedElementwiseOpPattern<math::AcoshOp, spirv::GLAcoshOp>,
+      CheckedElementwiseOpPattern<math::AtanhOp, spirv::GLAtanhOp>>(
+      typeConverter, patterns.getContext());
 
   // OpenCL patterns
   patterns.add<

--- a/mlir/test/Conversion/MathToSPIRV/math-to-gl-spirv.mlir
+++ b/mlir/test/Conversion/MathToSPIRV/math-to-gl-spirv.mlir
@@ -12,6 +12,8 @@ func.func @float32_unary_scalar(%arg0: f32) {
   %1 = math.cos %arg0 : f32
   // CHECK: spirv.GL.Exp %{{.*}}: f32
   %2 = math.exp %arg0 : f32
+  // CHECK: spirv.GL.Exp2 %{{.*}}: f32
+  %exp2 = math.exp2 %arg0 : f32
   // CHECK: %[[EXP:.+]] = spirv.GL.Exp %arg0
   // CHECK: %[[ONE:.+]] = spirv.Constant 1.000000e+00 : f32
   // CHECK: spirv.FSub %[[EXP]], %[[ONE]]
@@ -22,9 +24,7 @@ func.func @float32_unary_scalar(%arg0: f32) {
   // CHECK: %[[ADDONE:.+]] = spirv.FAdd %[[ONE]], %{{.+}}
   // CHECK: spirv.GL.Log %[[ADDONE]]
   %5 = math.log1p %arg0 : f32
-  // CHECK: %[[LOG2_RECIPROCAL:.+]] = spirv.Constant 1.44269502 : f32
-  // CHECK: %[[LOG0:.+]] = spirv.GL.Log {{.+}}
-  // CHECK: spirv.FMul %[[LOG0]], %[[LOG2_RECIPROCAL]]
+  // CHECK: spirv.GL.Log2 %{{.*}}: f32
   %6 = math.log2 %arg0 : f32
   // CHECK: %[[LOG10_RECIPROCAL:.+]] = spirv.Constant 0.434294492 : f32
   // CHECK: %[[LOG1:.+]] = spirv.GL.Log {{.+}}
@@ -73,6 +73,8 @@ func.func @float32_unary_vector(%arg0: vector<3xf32>) {
   %1 = math.cos %arg0 : vector<3xf32>
   // CHECK: spirv.GL.Exp %{{.*}}: vector<3xf32>
   %2 = math.exp %arg0 : vector<3xf32>
+  // CHECK: spirv.GL.Exp2 %{{.*}}: vector<3xf32>
+  %exp2 = math.exp2 %arg0 : vector<3xf32>
   // CHECK: %[[EXP:.+]] = spirv.GL.Exp %arg0
   // CHECK: %[[ONE:.+]] = spirv.Constant dense<1.000000e+00> : vector<3xf32>
   // CHECK: spirv.FSub %[[EXP]], %[[ONE]]
@@ -83,9 +85,7 @@ func.func @float32_unary_vector(%arg0: vector<3xf32>) {
   // CHECK: %[[ADDONE:.+]] = spirv.FAdd %[[ONE]], %{{.+}}
   // CHECK: spirv.GL.Log %[[ADDONE]]
   %5 = math.log1p %arg0 : vector<3xf32>
-  // CHECK: %[[LOG2_RECIPROCAL:.+]] = spirv.Constant dense<1.44269502> : vector<3xf32>
-  // CHECK: %[[LOG0:.+]] = spirv.GL.Log {{.+}}
-  // CHECK: spirv.FMul %[[LOG0]], %[[LOG2_RECIPROCAL]]
+  // CHECK: spirv.GL.Log2 %{{.*}}: vector<3xf32>
   %6 = math.log2 %arg0 : vector<3xf32>
   // CHECK: %[[LOG10_RECIPROCAL:.+]] = spirv.Constant dense<0.434294492> : vector<3xf32>
   // CHECK: %[[LOG1:.+]] = spirv.GL.Log {{.+}}


### PR DESCRIPTION
Map:
 - math.exp2 -> spirv.GL.Exp2
 - math.log2 -> spirv.GL.Log2 (before it was lowered through decomposition)