### PR TITLE
[lldb] Support building test inferiors without debug info

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -259,6 +259,7 @@ class Builder:
             "debug_names": {"MAKE_DEBUG_NAMES": "YES"},
             "dwp": {"MAKE_DSYM": "NO", "MAKE_DWP": "YES"},
             "pdb": {"MAKE_PDB": "YES"},
+            "none": {"MAKE_DSYM": "NO", "MAKE_NO_DEBUG_INFO": "YES"},
         }
 
         # Collect all flags, with later options overriding earlier ones

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -240,6 +240,10 @@ ifeq "$(OS)" "Windows_NT"
 	DEBUG_INFO_FLAG ?= -gdwarf
 endif
 
+ifeq "$(MAKE_NO_DEBUG_INFO)" "YES"
+	DEBUG_INFO_FLAG := -g0
+endif
+
 DEBUG_INFO_FLAG ?= -g
 
 CFLAGS ?= $(DEBUG_INFO_FLAG) -O0

--- a/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/Makefile
+++ b/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/Makefile
@@ -1,4 +1,3 @@
 CXX_SOURCES := main.cpp
-CFLAGS_EXTRAS := -g0
 
 include Makefile.rules

--- a/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/TestFrameVarDILNoDebugInfo.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/TestFrameVarDILNoDebugInfo.py
@@ -10,9 +10,10 @@ from lldbsuite.test import lldbutil
 
 class TestFrameVarDILNoDebugInfo(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_no_debug_info(self):
-        self.build()
+        self.build(debug_info="none")
         lldbutil.run_to_name_breakpoint(self, "main")
 
         self.runCmd("settings set target.experimental.use-DIL true")

--- a/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/Makefile
+++ b/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/Makefile
@@ -1,4 +1,3 @@
 CXX_SOURCES := main.cpp
-CXXFLAGS_EXTRAS := -g0
 
 include Makefile.rules

--- a/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/TestObjCFromCppFramesWithoutDebugInfo.py
+++ b/lldb/test/API/lang/objcxx/objc-from-cpp-frames-without-debuginfo/TestObjCFromCppFramesWithoutDebugInfo.py
@@ -10,8 +10,11 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCFromCppFramesWithoutDebugInfo(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
     def test(self):
-        self.build()
+        self.build(debug_info="none")
         (_, process, _, _) = lldbutil.run_to_name_breakpoint(self, "main")
 
         self.assertState(process.GetState(), lldb.eStateStopped)


### PR DESCRIPTION
Add first class support for building test inferiors without debug info, instead of having to pass `-g0` in the Makefile or the build dictionary.

```
def test(self):
    self.build(debug_info="none")
```

rdar://164923931