### PR TITLE
[flang][OpenMP] Skip declare simd lowering for interface bodies

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -4362,6 +4362,29 @@ genOMP(lower::AbstractConverter &converter, lower::SymMap &symTable,
        const parser::OmpDeclareSimdDirective &declareSimdConstruct) {
   mlir::Location loc = converter.getCurrentLocation();
   const parser::OmpDirectiveSpecification &beginSpec = declareSimdConstruct.v;
+
+  // A `declare simd` directive may appear in the specification part of an
+  // interface body. In that case the PFT records the directive as an
+  // evaluation of the enclosing program unit rather than of the interface
+  // body's subprogram, and the clause operands (linear/aligned/uniform)
+  // reference dummy arguments that are local to the interface body and
+  // therefore have no address in the enclosing scope. Detect this by
+  // comparing the program unit lexically containing the directive with the
+  // procedure currently being lowered; if they differ, this evaluation is
+  // for a different procedure (the interface-body subprogram) and emitting
+  // an `omp.declare_simd` op here would create it with null operands. Skip
+  // emission: lowering for `declare simd` on an external procedure declared
+  // only via an interface body is not handled by this op-based form.
+  const semantics::Scope &progUnitScope =
+      semantics::GetProgramUnitContaining(semaCtx.FindScope(beginSpec.source));
+  lower::pft::FunctionLikeUnit *owningProc = eval.getOwningProcedure();
+  const semantics::Symbol *owningSym =
+      (owningProc && !owningProc->isMainProgram())
+          ? &owningProc->getSubprogramSymbol()
+          : (owningProc ? owningProc->getMainProgramSymbol() : nullptr);
+  if (progUnitScope.symbol() != owningSym)
+    return;
+
   List<Clause> clauses = makeClauses(beginSpec.Clauses(), semaCtx);
 
   mlir::omp::DeclareSimdOperands clauseOps;

--- a/flang/test/Lower/OpenMP/declare-simd-interface-body.f90
+++ b/flang/test/Lower/OpenMP/declare-simd-interface-body.f90
@@ -6,7 +6,7 @@
 ! dummy arguments, which are not in scope here, and creating it would yield
 ! null operands).
 
-! RUN: %flang_fc1 -emit-fir -fopenmp %s -o - | FileCheck %s
+! RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
 
 interface
   subroutine add2(i)

--- a/flang/test/Lower/OpenMP/declare-simd-interface-body.f90
+++ b/flang/test/Lower/OpenMP/declare-simd-interface-body.f90
@@ -1,0 +1,32 @@
+! Regression test for #192581:
+! DECLARE SIMD applies to the external procedure declared via the interface
+! body, not to the enclosing program unit.
+! Lowering must not emit an omp.declare_simd op in the enclosing
+! scope (the op-based form requires operands referring to the procedure's
+! dummy arguments, which are not in scope here, and creating it would yield
+! null operands).
+
+! RUN: %flang_fc1 -emit-fir -fopenmp %s -o - | FileCheck %s
+
+interface
+  subroutine add2(i)
+  !$omp declare simd(add2) linear(i:1)
+    integer :: i
+  end subroutine
+end interface
+
+! Implicit (no procedure name), same scope situation.
+interface
+  subroutine add3(i)
+  !$omp declare simd
+    integer :: i
+  end subroutine
+end interface
+
+print *, 'pass'
+end
+
+! CHECK-LABEL: func.func @_QQmain()
+! CHECK-NOT:   omp.declare_simd
+! CHECK:       return
+


### PR DESCRIPTION
When DECLARE SIMD appears in the specification part of an interface body, the PFT records the directive as an evaluation of the enclosing program unit rather than of the interface body's subprogram. Its clause operands (linear/aligned/uniform) reference dummy arguments local to the interface body, which have no address in the enclosing scope, causing a crash.

Detect the mismatch by comparing the program unit containing the directive with the procedure currently being lowered, and skip op emission when they differ.

This handles both explicit declare simd(proc-name) and implicit forms in any enclosing context.

Fixes #192581