### PR TITLE
[libc] Pass -c to compiler when detecting target

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -78,7 +78,7 @@ function(get_arch_and_system_from_triple triple arch_var sys_var)
   set(${sys_var} ${target_sys} PARENT_SCOPE)
 endfunction(get_arch_and_system_from_triple)
 
-execute_process(COMMAND ${CMAKE_CXX_COMPILER} -v
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} -c -v
                 RESULT_VARIABLE libc_compiler_info_result
                 OUTPUT_VARIABLE libc_compiler_info
                 ERROR_VARIABLE libc_compiler_info)


### PR DESCRIPTION
Follow-up to #176680 where I claimed having done this, but apparantly didn't actually add it to the commit.

Hopefully no observable behavior change; will tell the compiler to omit linker info in its output, which we don't need for this detection step.