### PR TITLE
[clang][NFC] Mark CWG743 and CWG950 as implemented and add tests

### DIFF
--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -342,6 +342,9 @@ struct S {
 };
 
 decltype(S())::T i;
+
+template <typename T>
+using foo = typename decltype(T())::I;
 #endif
 } // namespace cwg743
 

--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -335,6 +335,16 @@ namespace cwg727 { // cwg727: partial
   Collision<int, int> c; // #cwg727-Collision-int-int
 } // namespace cwg727
 
+namespace cwg743 { // cwg743: 3.1
+#if __cplusplus >= 201103L
+struct S {
+  using T = int;
+};
+
+decltype(S())::T i;
+#endif
+} // namespace cwg743
+
 namespace cwg777 { // cwg777: 3.7
 #if __cplusplus >= 201103L
 template <typename... T>

--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -55,6 +55,9 @@ namespace cwg950 { // cwg950: 3.1
 #if __cplusplus >= 201103L
 struct A {};
 struct B : decltype(A()) {};
+
+template <typename T>
+struct C : decltype(T()) {};
 #endif
 } // namespace cwg950
 

--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -51,6 +51,13 @@ namespace cwg948 { // cwg948: 3.7
 #endif
 } // namespace cwg948
 
+namespace cwg950 { // cwg950: 3.1
+#if __cplusplus >= 201103L
+struct A {};
+struct B : decltype(A()) {};
+#endif
+} // namespace cwg950
+
 namespace cwg952 { // cwg952: 2.8
 namespace example1 {
 struct A {

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -6427,7 +6427,7 @@
     <td>[<a href="https://wg21.link/dcl.type.simple">dcl.type.simple</a>]</td>
     <td>CD2</td>
     <td>Use of <TT>decltype</TT> as a <I>class-name</I></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.1</td>
   </tr>
   <tr id="951">
     <td><a href="https://cplusplus.github.io/CWG/issues/951.html">951</a></td>

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -5230,7 +5230,7 @@
     <td>[<a href="https://wg21.link/expr.prim.general">expr.prim.general</a>]</td>
     <td>CD2</td>
     <td>Use of <TT>decltype</TT> in a <I>nested-name-specifier</I></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.1</td>
   </tr>
   <tr id="744">
     <td><a href="https://cplusplus.github.io/CWG/issues/744.html">744</a></td>


### PR DESCRIPTION
[CWG743](https://wg21.link/cwg743) allows using `decltype` in a *nested-name-specifier*, i.e.: `decltype(foo)::type`. [CWG950](https://wg21.link/cwg950) allows using it as a *base-specifier*, i.e.: `struct B : decltype(foo)`. Both these DRs were resolved by [N3049](https://wg21.link/n3049).


Clang supports both of these since 3.1: https://godbolt.org/z/aohPs5zaa