### PR TITLE
[PowerPC] Update base crypto builtins and intrinsics

### DIFF
--- a/clang/include/clang/Basic/BuiltinsPPC.def
+++ b/clang/include/clang/Basic/BuiltinsPPC.def
@@ -1131,35 +1131,35 @@ UNALIASED_CUSTOM_BUILTIN(disassemble_dmr, "vv*W1024*", false,
 UNALIASED_CUSTOM_BUILTIN(build_dmr, "vW1024*VVVVVVVV", false,
                          "mma,isa-future-instructions")
 
-UNALIASED_CUSTOM_BUILTIN(mma_dmsha2hash, "vW1024*W1024*Ii", true,
+UNALIASED_CUSTOM_BUILTIN(dmsha2hash, "vW1024*W1024*i1", true,
                          "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_dmsha3hash, "vW2048*Ii", true,
+UNALIASED_CUSTOM_BUILTIN(dmsha3hash, "vW2048*i31", true,
                          "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_dmxxshapad, "vW1024*VIiIiIi", true,
+UNALIASED_CUSTOM_BUILTIN(dmxxshapad, "vW1024*Vi3i1i3", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmsha256hash, mma_dmsha2hash, "vW1024*W1024*", true,
+CUSTOM_BUILTIN(dmsha256hash, dmsha2hash, "vW1024*W1024*", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmsha512hash, mma_dmsha2hash, "vW1024*W1024*", true,
+CUSTOM_BUILTIN(dmsha512hash, dmsha2hash, "vW1024*W1024*", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmsha3dw, mma_dmsha3hash, "vW2048*", true,
+CUSTOM_BUILTIN(dmsha3dw, dmsha3hash, "vW2048*", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmcryshash, mma_dmsha3hash, "vW2048*", true,
+CUSTOM_BUILTIN(dmcryshash, dmsha3hash, "vW2048*", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxsha3512pad, mma_dmxxshapad, "vW1024*Vi1", true,
+CUSTOM_BUILTIN(dmxxsha3512pad, dmxxshapad, "vW1024*Vi1", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxsha3384pad, mma_dmxxshapad, "vW1024*Vi1", true,
+CUSTOM_BUILTIN(dmxxsha3384pad, dmxxshapad, "vW1024*Vi1", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxsha3256pad, mma_dmxxshapad, "vW1024*Vi1", true,
+CUSTOM_BUILTIN(dmxxsha3256pad, dmxxshapad, "vW1024*Vi1", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxsha3224pad, mma_dmxxshapad, "vW1024*Vi1", true,
+CUSTOM_BUILTIN(dmxxsha3224pad, dmxxshapad, "vW1024*Vi1", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxshake256pad, mma_dmxxshapad, "vW1024*Vi1", true,
+CUSTOM_BUILTIN(dmxxshake256pad, dmxxshapad, "vW1024*Vi1", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxshake128pad, mma_dmxxshapad, "vW1024*Vi1", true,
+CUSTOM_BUILTIN(dmxxshake128pad, dmxxshapad, "vW1024*Vi1", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxsha384512pad, mma_dmxxshapad, "vW1024*V", true,
+CUSTOM_BUILTIN(dmxxsha384512pad, dmxxshapad, "vW1024*V", true,
                          "mma,isa-future-instructions")
-CUSTOM_BUILTIN(dmxxsha224256pad, mma_dmxxshapad, "vW1024*V", true,
+CUSTOM_BUILTIN(dmxxsha224256pad, dmxxshapad, "vW1024*V", true,
                          "mma,isa-future-instructions")
 
 // MMA builtins with positive/negative multiply/accumulate.

--- a/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
@@ -1236,7 +1236,7 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
     switch (BuiltinID) {
     case PPC::BI__builtin_dmmr:
     case PPC::BI__builtin_dmxor:
-    case PPC::BI__builtin_mma_dmsha2hash: {
+    case PPC::BI__builtin_dmsha2hash: {
       Address Addr = EmitPointerWithAlignment(E->getArg(1));
       Ops[1] = Builder.CreateLoad(Addr);
       break;

--- a/clang/test/CodeGen/PowerPC/builtins-ppc-dmf.c
+++ b/clang/test/CodeGen/PowerPC/builtins-ppc-dmf.c
@@ -214,7 +214,7 @@ void test_dmf_basic2(char *p1, char *res1, char *res2,
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
 // CHECK-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -223,14 +223,14 @@ void test_dmf_basic2(char *p1, char *res1, char *res2,
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
+// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
 // AIX-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
 void test_dmsha2hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned char *resp) {
   __dmr1024 vdmr1 = *((__dmr1024 *)vdmrp1);
   __dmr1024 vdmr2 = *((__dmr1024 *)vdmrp2);
-  __builtin_mma_dmsha2hash(&vdmr1, &vdmr2, 1);
+  __builtin_dmsha2hash(&vdmr1, &vdmr2, 1);
   *((__dmr1024 *)resp) = vdmr1;
 }
 
@@ -238,7 +238,7 @@ void test_dmsha2hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned char
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA10:![0-9]+]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 4)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> [[TMP0]], i32 4)
 // CHECK-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA10]]
 // CHECK-NEXT:    ret void
 //
@@ -246,13 +246,13 @@ void test_dmsha2hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned char
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA10:![0-9]+]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 4)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> [[TMP0]], i32 4)
 // AIX-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA10]]
 // AIX-NEXT:    ret void
 //
 void test_dmsha3hash(unsigned char *vdmrpp,  unsigned char *resp) {
   __dmr2048 vdmrp = *((__dmr2048 *)vdmrpp);
-  __builtin_mma_dmsha3hash(&vdmrp, 4);
+  __builtin_dmsha3hash(&vdmrp, 4);
   *((__dmr2048 *)resp) = vdmrp;
 }
 
@@ -260,7 +260,7 @@ void test_dmsha3hash(unsigned char *vdmrpp,  unsigned char *resp) {
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 1, i32 5)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 1, i32 3)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -268,13 +268,13 @@ void test_dmsha3hash(unsigned char *vdmrpp,  unsigned char *resp) {
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 1, i32 5)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 1, i32 3)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
 void test_dmxxshapad(unsigned char *vdmrp, vector unsigned char vc, unsigned char *resp) {
   __dmr1024 vdmr = *((__dmr1024 *)vdmrp);
-  __builtin_mma_dmxxshapad(&vdmr, vc, 2, 1, 5);
+  __builtin_dmxxshapad(&vdmr, vc, 2, 1, 3);
   *((__dmr1024 *)resp) = vdmr;
 }
 
@@ -283,7 +283,7 @@ void test_dmxxshapad(unsigned char *vdmrp, vector unsigned char vc, unsigned cha
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 0)
 // CHECK-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -292,7 +292,7 @@ void test_dmxxshapad(unsigned char *vdmrp, vector unsigned char vc, unsigned cha
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 0)
+// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 0)
 // AIX-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -308,7 +308,7 @@ void test_dmsha256hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned ch
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
 // CHECK-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -317,7 +317,7 @@ void test_dmsha256hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned ch
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
+// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
 // AIX-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -332,7 +332,7 @@ void test_dmsha512hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned ch
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA10]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 0)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> [[TMP0]], i32 0)
 // CHECK-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA10]]
 // CHECK-NEXT:    ret void
 //
@@ -340,7 +340,7 @@ void test_dmsha512hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned ch
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA10]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 0)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> [[TMP0]], i32 0)
 // AIX-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA10]]
 // AIX-NEXT:    ret void
 //
@@ -354,7 +354,7 @@ void test_dmsha3dw(unsigned char *vdmrpp,  unsigned char *resp) {
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA10]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 12)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> [[TMP0]], i32 12)
 // CHECK-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA10]]
 // CHECK-NEXT:    ret void
 //
@@ -362,7 +362,7 @@ void test_dmsha3dw(unsigned char *vdmrpp,  unsigned char *resp) {
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA10]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 12)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> [[TMP0]], i32 12)
 // AIX-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA10]]
 // AIX-NEXT:    ret void
 //
@@ -376,7 +376,7 @@ void test_dmcryshash(unsigned char *vdmrpp,  unsigned char *resp) {
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 0)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 0)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -384,7 +384,7 @@ void test_dmcryshash(unsigned char *vdmrpp,  unsigned char *resp) {
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 0)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 0)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -398,7 +398,7 @@ void test_dmxxsha3512pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 1)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 1)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -406,7 +406,7 @@ void test_dmxxsha3512pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 1)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 1)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -420,7 +420,7 @@ void test_dmxxsha3384pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 2)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 2)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -428,7 +428,7 @@ void test_dmxxsha3384pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 2)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 0, i32 2)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -442,7 +442,7 @@ void test_dmxxsha3256pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 3)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 3)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -450,7 +450,7 @@ void test_dmxxsha3256pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 3)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 0, i32 1, i32 3)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -464,7 +464,7 @@ void test_dmxxsha3224pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 0, i32 0)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 0, i32 0)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -472,7 +472,7 @@ void test_dmxxsha3224pad(unsigned char *vdmrp, vector unsigned char vc, unsigned
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 0, i32 0)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 0, i32 0)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -486,7 +486,7 @@ void test_dmxxshake256pad(unsigned char *vdmrp, vector unsigned char vc, unsigne
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 1, i32 1)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 1, i32 1)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -494,7 +494,7 @@ void test_dmxxshake256pad(unsigned char *vdmrp, vector unsigned char vc, unsigne
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 1, i32 1)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 1, i32 1, i32 1)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -508,7 +508,7 @@ void test_dmxxshake128pad(unsigned char *vdmrp, vector unsigned char vc, unsigne
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 0, i32 0)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 0, i32 0)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -516,7 +516,7 @@ void test_dmxxshake128pad(unsigned char *vdmrp, vector unsigned char vc, unsigne
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 0, i32 0)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 0, i32 0)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //
@@ -530,7 +530,7 @@ void test_dmxxsha384512pad(unsigned char *vdmrp, vector unsigned char vc, unsign
 // CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 3, i32 0, i32 0)
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 3, i32 0, i32 0)
 // CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // CHECK-NEXT:    ret void
 //
@@ -538,7 +538,7 @@ void test_dmxxsha384512pad(unsigned char *vdmrp, vector unsigned char vc, unsign
 // AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // AIX-NEXT:  [[ENTRY:.*:]]
 // AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA7]]
-// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 3, i32 0, i32 0)
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 3, i32 0, i32 0)
 // AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA7]]
 // AIX-NEXT:    ret void
 //

--- a/clang/test/CodeGen/PowerPC/ppc-dmf-mma-builtin-err.c
+++ b/clang/test/CodeGen/PowerPC/ppc-dmf-mma-builtin-err.c
@@ -25,9 +25,9 @@ void test_mma(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp, v
   __builtin_dmxor(&vdmr, (__dmr1024*)vpp);
   __builtin_build_dmr(&vdmr, vc, vc, vc, vc, vc, vc, vc, vc);
   __builtin_disassemble_dmr(vdmrp, &vdmr);
-  __builtin_mma_dmsha2hash(&vdmr, &vdmr, 0);
-  __builtin_mma_dmsha3hash(&vdmrpair, 0);
-  __builtin_mma_dmxxshapad(&vdmr, vc, 0, 0, 0);
+  __builtin_dmsha2hash(&vdmr, &vdmr, 0);
+  __builtin_dmsha3hash(&vdmrpair, 0);
+  __builtin_dmxxshapad(&vdmr, vc, 0, 0, 0);
   __builtin_dmsha256hash(&vdmr, &vdmr);
   __builtin_dmsha512hash(&vdmr, &vdmr);
   __builtin_dmsha3dw(&vdmrpair);
@@ -52,9 +52,9 @@ void test_mma(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp, v
 // ISA_FUTURE: error: '__builtin_dmxor' needs target feature mma,isa-future-instructions
 // ISA_FUTURE: error: '__builtin_build_dmr' needs target feature mma,isa-future-instructions
 // ISA_FUTURE: error: '__builtin_disassemble_dmr' needs target feature mma,isa-future-instructions
-// CHECK: error: '__builtin_mma_dmsha2hash' needs target feature mma,isa-future-instructions
-// CHECK: error: '__builtin_mma_dmsha3hash' needs target feature mma,isa-future-instructions
-// CHECK: error: '__builtin_mma_dmxxshapad' needs target feature mma,isa-future-instructions
+// CHECK: error: '__builtin_dmsha2hash' needs target feature mma,isa-future-instructions
+// CHECK: error: '__builtin_dmsha3hash' needs target feature mma,isa-future-instructions
+// CHECK: error: '__builtin_dmxxshapad' needs target feature mma,isa-future-instructions
 // CHECK: error: '__builtin_dmsha256hash' needs target feature mma,isa-future-instructions
 // CHECK: error: '__builtin_dmsha512hash' needs target feature mma,isa-future-instructions
 // CHECK: error: '__builtin_dmsha3dw' needs target feature mma,isa-future-instructions

--- a/clang/test/Sema/PowerPC/ppc-dmf-mma-builtin-err.c
+++ b/clang/test/Sema/PowerPC/ppc-dmf-mma-builtin-err.c
@@ -18,9 +18,9 @@ void test_mma(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp, v
   __builtin_dmxor(&vdmr, (__dmr1024*)vpp); // expected-error {{'__builtin_dmxor' needs target feature mma,isa-future-instructions}}
   __builtin_build_dmr(&vdmr, vc, vc, vc, vc, vc, vc, vc, vc); // expected-error {{'__builtin_build_dmr' needs target feature mma,isa-future-instructions}}
   __builtin_disassemble_dmr(vdmrp, &vdmr); // expected-error {{'__builtin_disassemble_dmr' needs target feature mma,isa-future-instructions}}
-  __builtin_mma_dmsha2hash(&vdmr, &vdmr, 0); // expected-error {{'__builtin_mma_dmsha2hash' needs target feature mma,isa-future-instructions}}
-  __builtin_mma_dmsha3hash(&vdmrpair, 0); // expected-error {{'__builtin_mma_dmsha3hash' needs target feature mma,isa-future-instructions}}
-  __builtin_mma_dmxxshapad(&vdmr, vc, 0, 0, 0); // expected-error {{'__builtin_mma_dmxxshapad' needs target feature mma,isa-future-instructions}}
+  __builtin_dmsha2hash(&vdmr, &vdmr, 0); // expected-error {{'__builtin_dmsha2hash' needs target feature mma,isa-future-instructions}}
+  __builtin_dmsha3hash(&vdmrpair, 0); // expected-error {{'__builtin_dmsha3hash' needs target feature mma,isa-future-instructions}}
+  __builtin_dmxxshapad(&vdmr, vc, 0, 0, 0); // expected-error {{'__builtin_dmxxshapad' needs target feature mma,isa-future-instructions}}
 
   // DMF VSX Vector bfloat16 GER 2x builtins.
 

--- a/clang/test/Sema/builtins-ppc-crypto.c
+++ b/clang/test/Sema/builtins-ppc-crypto.c
@@ -10,6 +10,21 @@ void test_crypto(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp
   __vector_pair vp = *((__vector_pair *)vpp);
   int ia;
 
+  __builtin_dmsha2hash(&vdmr, &vdmr, 2);  // expected-error {{argument value 2 is outside the valid range [0, 1]}}
+  __builtin_dmsha2hash(&vdmr, &vdmr, -1);  // expected-error {{argument value -1 is outside the valid range [0, 1]}}
+  __builtin_dmsha2hash(&vdmr, &vdmr, ia);  // expected-error {{argument to '__builtin_dmsha2hash' must be a constant integer}}
+
+  __builtin_dmsha3hash(&vdmrpair, 32);  // expected-error {{argument value 32 is outside the valid range [0, 31]}}
+  __builtin_dmsha3hash(&vdmrpair, -2);  // expected-error {{argument value -2 is outside the valid range [0, 31]}}
+  __builtin_dmsha3hash(&vdmrpair, ia);  // expected-error {{argument to '__builtin_dmsha3hash' must be a constant integer}}
+
+  __builtin_dmxxshapad(&vdmr, vc, 4, 0, 3);  // expected-error {{argument value 4 is outside the valid range [0, 3]}}
+  __builtin_dmxxshapad(&vdmr, vc, 3, 2, 3);  // expected-error {{argument value 2 is outside the valid range [0, 1]}}
+  __builtin_dmxxshapad(&vdmr, vc, 3, 1, -1);  // expected-error {{argument value -1 is outside the valid range [0, 3]}}
+  __builtin_dmxxshapad(&vdmr, vc, ia, 1, 1);  // expected-error {{argument to '__builtin_dmxxshapad' must be a constant integer}}
+  __builtin_dmxxshapad(&vdmr, vc, 0, ia, 1);  // expected-error {{argument to '__builtin_dmxxshapad' must be a constant integer}}
+  __builtin_dmxxshapad(&vdmr, vc, 0, 1, ia);  // expected-error {{argument to '__builtin_dmxxshapad' must be a constant integer}}
+
   __builtin_dmxxsha3512pad(&vdmr, vc, 2);  // expected-error {{argument value 2 is outside the valid range [0, 1]}}
   __builtin_dmxxsha3512pad(&vdmr, vc, ia);  // expected-error {{argument to '__builtin_dmxxsha3512pad' must be a constant integer}}
 

--- a/llvm/include/llvm/IR/IntrinsicsPowerPC.td
+++ b/llvm/include/llvm/IR/IntrinsicsPowerPC.td
@@ -1915,16 +1915,16 @@ let TargetPrefix = "ppc" in {
   defm int_ppc_mma_pmdmxvf16gerx2 :
        PowerPC_MMA_DMR_Intrinsic<[llvm_v256i1_ty, llvm_v16i8_ty, llvm_i32_ty,
                                      llvm_i32_ty, llvm_i32_ty]>;
-  def int_ppc_mma_dmsha2hash :
+  def int_ppc_dmsha2hash :
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [llvm_v1024i1_ty,
                              llvm_v1024i1_ty, llvm_i32_ty],
                             [IntrNoMem, ImmArg<ArgIndex<2>>]>;
 
-  def int_ppc_mma_dmsha3hash :
+  def int_ppc_dmsha3hash :
       DefaultAttrsIntrinsic<[llvm_v2048i1_ty], [llvm_v2048i1_ty,
                              llvm_i32_ty], [IntrNoMem, ImmArg<ArgIndex<1>>]>;
 
-  def int_ppc_mma_dmxxshapad :
+  def int_ppc_dmxxshapad :
       DefaultAttrsIntrinsic<[llvm_v1024i1_ty], [llvm_v1024i1_ty,
                              llvm_v16i8_ty, llvm_i32_ty, llvm_i32_ty,
                              llvm_i32_ty], [IntrNoMem, ImmArg<ArgIndex<2>>,

--- a/llvm/lib/Target/PowerPC/PPCInstrFutureMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFutureMMA.td
@@ -511,14 +511,14 @@ let Predicates = [MMA, IsISAFuture] in {
       : XForm_AT3_T1_AB3<
             31, 14, 177, (outs dmr:$AT), (ins dmr:$ATi, dmr:$AB, u1imm:$T),
             "dmsha2hash $AT, $AB, $T",
-            [(set v1024i1:$AT, (int_ppc_mma_dmsha2hash v1024i1:$ATi,
+            [(set v1024i1:$AT, (int_ppc_dmsha2hash v1024i1:$ATi,
                                    v1024i1:$AB, u1imm_timm:$T))]>,
         RegConstraint<"$ATi = $AT">;
   def DMSHA3HASH
       : XForm_ATp2_SR5<31, 15, 177, (outs dmrp:$ATp),
                        (ins dmrp:$ATpi, u5imm:$SR), "dmsha3hash $ATp, $SR",
                        [(set v2048i1:$ATp,
-                           (int_ppc_mma_dmsha3hash v2048i1:$ATpi,
+                           (int_ppc_dmsha3hash v2048i1:$ATpi,
                                                    u5imm_timm:$SR))]>,
         RegConstraint<"$ATpi = $ATp">;
   def DMXXSHAPAD
@@ -593,7 +593,7 @@ let Predicates = [MMA, IsISAFuture] in {
             (DMXVF16GERX2NN $ATi, $XAp, RCCp.BToVSRC)>;
 
   // Cryptography Intrinsic
-  def : Pat<(v1024i1 (int_ppc_mma_dmxxshapad v1024i1:$ATi, v16i8:$XB,
+  def : Pat<(v1024i1 (int_ppc_dmxxshapad v1024i1:$ATi, v16i8:$XB,
                 u2imm_timm:$ID, u1imm_timm:$E, u2imm_timm:$BL)),
             (DMXXSHAPAD $ATi, RCCp.BToVSRC, $ID, $E, $BL)>;
 }

--- a/llvm/test/CodeGen/PowerPC/dmrp-spill.ll
+++ b/llvm/test/CodeGen/PowerPC/dmrp-spill.ll
@@ -10,7 +10,7 @@
 ; RUN:   -ppc-vsr-nums-as-vr -mcpu=future < %s | FileCheck %s --check-prefix=AIX32
 
 declare void @dummy_func()
-declare <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1>, i32)
+declare <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1>, i32)
 
 define dso_local void @test_dmsha3hash(ptr %vopp, ptr %resp) nounwind {
 ; CHECK-LABEL: test_dmsha3hash:
@@ -205,9 +205,9 @@ define dso_local void @test_dmsha3hash(ptr %vopp, ptr %resp) nounwind {
 ; AIX32-NEXT:    blr
   entry:
     %0 = load <2048 x i1>, ptr %vopp, align 64
-    %2 = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> %0, i32 5)
+    %2 = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> %0, i32 5)
     tail call void @dummy_func()
-    %3 = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> %0, i32 5)
+    %3 = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> %0, i32 5)
     store <2048 x i1> %2, ptr %resp, align 64
     ret void
 }

--- a/llvm/test/CodeGen/PowerPC/mmaplus-crypto.ll
+++ b/llvm/test/CodeGen/PowerPC/mmaplus-crypto.ll
@@ -6,7 +6,7 @@
 ; RUN:   -mcpu=future -ppc-asm-full-reg-names \
 ; RUN:   -ppc-vsr-nums-as-vr < %s | FileCheck %s --check-prefix=CHECK-BE
 
-declare <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1>, <1024 x i1>, i32)
+declare <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1>, <1024 x i1>, i32)
 
 define dso_local void @test_dmsha2hash(ptr %vop, ptr %vinp, ptr %resp) {
 ; CHECK-LABEL: test_dmsha2hash:
@@ -57,12 +57,12 @@ define dso_local void @test_dmsha2hash(ptr %vop, ptr %vinp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vop, align 64
   %1 = load <1024 x i1>, ptr %vinp, align 64
-  %3 = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> %0, <1024 x i1> %1, i32 0)
+  %3 = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> %0, <1024 x i1> %1, i32 0)
   store <1024 x i1> %3, ptr %resp, align 64
   ret void
 }
 
-declare <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1>, i32)
+declare <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1>, i32)
 
 define dso_local void @test_dmsha3hash(ptr %vopp, ptr %resp) {
 ; CHECK-LABEL: test_dmsha3hash:
@@ -124,12 +124,12 @@ define dso_local void @test_dmsha3hash(ptr %vopp, ptr %resp) {
 ; CHECK-BE-NEXT:    blr
 entry:
   %0 = load <2048 x i1>, ptr %vopp, align 64
-  %2 = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> %0, i32 5)
+  %2 = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> %0, i32 5)
   store <2048 x i1> %2, ptr %resp, align 64
   ret void
 }
 
-declare <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1>, <16 x i8>, i32, i32, i32)
+declare <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1>, <16 x i8>, i32, i32, i32)
 
 define dso_local void @test_dmxxshapad(ptr %vopp, ptr %vcp, ptr %resp) {
 ; CHECK-LABEL: test_dmxxshapad:
@@ -170,7 +170,7 @@ define dso_local void @test_dmxxshapad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 2, i32 1, i32 3)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 2, i32 1, i32 3)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -224,7 +224,7 @@ define dso_local void @test_dmsha512hash(ptr %vop, ptr %vinp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vop, align 64
   %1 = load <1024 x i1>, ptr %vinp, align 64
-  %3 = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> %0, <1024 x i1> %1, i32 1)
+  %3 = tail call <1024 x i1> @llvm.ppc.dmsha2hash(<1024 x i1> %0, <1024 x i1> %1, i32 1)
   store <1024 x i1> %3, ptr %resp, align 64
   ret void
 }
@@ -289,7 +289,7 @@ define dso_local void @test_dmsha3dw(ptr %vopp, ptr %resp) {
 ; CHECK-BE-NEXT:    blr
 entry:
   %0 = load <2048 x i1>, ptr %vopp, align 64
-  %2 = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> %0, i32 0)
+  %2 = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> %0, i32 0)
   store <2048 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -354,7 +354,7 @@ define dso_local void @test_dmcryshash(ptr %vopp, ptr %resp) {
 ; CHECK-BE-NEXT:    blr
 entry:
   %0 = load <2048 x i1>, ptr %vopp, align 64
-  %2 = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> %0, i32 12)
+  %2 = tail call <2048 x i1> @llvm.ppc.dmsha3hash(<2048 x i1> %0, i32 12)
   store <2048 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -398,7 +398,7 @@ define dso_local void @test_dmxxsha3512pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 0)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 0)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -442,7 +442,7 @@ define dso_local void @test_dmxxsha3384pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 1)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 1)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -486,7 +486,7 @@ define dso_local void @test_dmxxsha3256pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 2)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 2)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -530,7 +530,7 @@ define dso_local void @test_dmxxsha3224pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 3)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 0, i32 1, i32 3)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -574,7 +574,7 @@ define dso_local void @test_dmxxshake256pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 1, i32 1, i32 0)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 1, i32 1, i32 0)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -618,7 +618,7 @@ define dso_local void @test_dmxxshake128pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 1, i32 1, i32 1)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 1, i32 1, i32 1)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -662,7 +662,7 @@ define dso_local void @test_dmxxsha384512pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 2, i32 0, i32 0)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 2, i32 0, i32 0)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }
@@ -706,7 +706,7 @@ define dso_local void @test_dmxxsha224256pad(ptr %vopp, ptr %vcp, ptr %resp) {
 entry:
   %0 = load <1024 x i1>, ptr %vopp, align 64
   %1 = load <16 x i8>, ptr %vcp, align 64
-  %2 = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 3, i32 0, i32 0)
+  %2 = tail call <1024 x i1> @llvm.ppc.dmxxshapad(<1024 x i1> %0, <16 x i8> %1, i32 3, i32 0, i32 0)
   store <1024 x i1> %2, ptr %resp, align 64
   ret void
 }


### PR DESCRIPTION
Update the base crypto builtins and LLVM intrinsics to drop the mma_ prefix.
Also fix the builtin definitions for dmsha2hash, dmsha3hash, and
dmxxshapad to use the correct immediate constraints.
