### PR TITLE
[flang][openacc] allow duplicate data sharing clauses

### DIFF
--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -33,7 +33,7 @@ local:
   or module, but it is allowed with a warning when same clause is used.
 * The OpenACC specification does not prohibit the same variable from appearing
   in multiple data clauses, but this is disallowed for variables appearing in
-  `private`, `firstprivate`, or `reduction` clauses.
+  `reduction` clauses.
 * The OpenACC specification does not prohibit the same variable from appearing
   multiple times in a `use_device` clause on a `host_data` construct, but this
   is disallowed.

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -5498,6 +5498,12 @@ struct OpenMPInvalidDirective {
 struct AccObject {
   UNION_CLASS_BOILERPLATE(AccObject);
   std::variant<Designator, /*common block*/ Name> u;
+  // Set by resolve-directives when this occurrence is a same-kind data-sharing
+  // duplicate (e.g. the second `x` in `private(x, x)`). Erased by
+  // rewrite-parse-tree so subsequent passes see a deduplicated clause list.
+  // Mutable so the attribute visitors, which walk the parse tree by const
+  // reference, can mark the offending occurrence in place.
+  mutable bool isDuplicate{false};
 };
 
 WRAPPER_CLASS(AccObjectList, std::list<AccObject>);

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -5498,12 +5498,6 @@ struct OpenMPInvalidDirective {
 struct AccObject {
   UNION_CLASS_BOILERPLATE(AccObject);
   std::variant<Designator, /*common block*/ Name> u;
-  // Set by resolve-directives when this occurrence is a same-kind data-sharing
-  // duplicate (e.g. the second `x` in `private(x, x)`). Erased by
-  // rewrite-parse-tree so subsequent passes see a deduplicated clause list.
-  // Mutable so the attribute visitors, which walk the parse tree by const
-  // reference, can mark the offending occurrence in place.
-  mutable bool isDuplicate{false};
 };
 
 WRAPPER_CLASS(AccObjectList, std::list<AccObject>);

--- a/flang/include/flang/Semantics/semantics.h
+++ b/flang/include/flang/Semantics/semantics.h
@@ -33,6 +33,7 @@ class IntrinsicTypeDefaultKinds;
 }
 
 namespace Fortran::parser {
+struct AccObject;
 struct Name;
 struct Program;
 class AllCookedSources;
@@ -336,6 +337,15 @@ public:
   void NoteUsedSymbols(const UnorderedSymbolSet &);
   bool IsSymbolUsed(const Symbol &) const;
 
+  // Track same-kind duplicate AccObjects between resolve-directives and
+  // rewrite-parse-tree (e.g. the second `x` in `private(x, x)`).
+  void MarkAccObjectDuplicate(const parser::AccObject *o) {
+    accObjectDuplicates_.insert(o);
+  }
+  bool IsAccObjectDuplicate(const parser::AccObject *o) const {
+    return accObjectDuplicates_.count(o) != 0;
+  }
+
   void DumpSymbols(llvm::raw_ostream &);
 
   // Top-level ProgramTrees are owned by the SemanticsContext for persistence.
@@ -395,6 +405,7 @@ private:
   std::map<const Symbol *, SourceName> moduleFileOutputRenamings_;
   UnorderedSymbolSet isDefined_;
   UnorderedSymbolSet isUsed_;
+  std::set<const parser::AccObject *> accObjectDuplicates_;
   std::list<ProgramTree> programTrees_;
 };
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1957,9 +1957,9 @@ void AccAttributeVisitor::CheckMultipleAppearances(const parser::Name &name,
     if (occurrence && firstFlag && *firstFlag == accFlag &&
         accFlag != Symbol::Flag::AccReduction) {
       context_.Warn(common::UsageWarning::OpenAccUsage, name.source,
-          "'%s' appears in more than one data-sharing clause on the same OpenACC directive"_warn_en_US,
+          "'%s' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored"_warn_en_US,
           name.ToString());
-      occurrence->isDuplicate = true;
+      context_.MarkAccObjectDuplicate(occurrence);
     } else {
       context_.Say(name.source,
           "'%s' appears in more than one data-sharing clause on the same OpenACC directive"_err_en_US,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -384,8 +384,8 @@ private:
   Symbol *ResolveAccCommonBlockName(const parser::Name *);
   Symbol *DeclareOrMarkOtherAccessEntity(const parser::Name &, Symbol::Flag);
   Symbol *DeclareOrMarkOtherAccessEntity(Symbol &, Symbol::Flag);
-  void CheckMultipleAppearances(
-      const parser::Name &, const Symbol &, Symbol::Flag);
+  void CheckMultipleAppearances(const parser::Name &, const Symbol &,
+      Symbol::Flag, const parser::AccObject *occurrence = nullptr);
   void AllowOnlyArrayAndSubArray(const parser::AccObjectList &objectList);
   void DoNotAllowAssumedSizedArray(const parser::AccObjectList &objectList);
   void AllowOnlyVariable(const parser::AccObject &object);
@@ -1875,7 +1875,7 @@ void AccAttributeVisitor::ResolveAccObject(
               if (auto *symbol{ResolveAcc(*name, accFlag, currScope())}) {
                 AddToContextObjectWithDSA(*symbol, accFlag);
                 if (dataSharingAttributeFlags.test(accFlag)) {
-                  CheckMultipleAppearances(*name, *symbol, accFlag);
+                  CheckMultipleAppearances(*name, *symbol, accFlag, &accObject);
                 }
               }
             } else {
@@ -1940,20 +1940,31 @@ Symbol *AccAttributeVisitor::DeclareOrMarkOtherAccessEntity(
   return &object;
 }
 
-static bool WithMultipleAppearancesAccException(
-    const Symbol &symbol, Symbol::Flag flag) {
-  return false; // Place holder
-}
-
-void AccAttributeVisitor::CheckMultipleAppearances(
-    const parser::Name &name, const Symbol &symbol, Symbol::Flag accFlag) {
+void AccAttributeVisitor::CheckMultipleAppearances(const parser::Name &name,
+    const Symbol &symbol, Symbol::Flag accFlag,
+    const parser::AccObject *occurrence) {
   const auto *target{&symbol};
-  if (HasDataSharingAttributeObject(*target) &&
-      !WithMultipleAppearancesAccException(symbol, accFlag)) {
-    context_.Say(name.source,
-        "'%s' appears in more than one data-sharing clause "
-        "on the same OpenACC directive"_err_en_US,
-        name.ToString());
+  if (HasDataSharingAttributeObject(*target)) {
+    // A same-kind duplicate (e.g. private(x, x) or private(x) private(x))
+    // is benign: warn and tag this AccObject occurrence so rewrite-parse-tree
+    // can drop it from the clause list. Cross-kind duplicates (e.g.
+    // private(x) firstprivate(x)) remain hard errors.
+    //
+    // Reduction is excluded from the benign case: two reduction clauses
+    // with the same Symbol::Flag may still differ in operator, which is a
+    // real conflict that dedup would silently hide.
+    auto firstFlag{GetContext().FindSymbolWithDSA(*target)};
+    if (occurrence && firstFlag && *firstFlag == accFlag &&
+        accFlag != Symbol::Flag::AccReduction) {
+      context_.Warn(common::UsageWarning::OpenAccUsage, name.source,
+          "'%s' appears in more than one data-sharing clause on the same OpenACC directive"_warn_en_US,
+          name.ToString());
+      occurrence->isDuplicate = true;
+    } else {
+      context_.Say(name.source,
+          "'%s' appears in more than one data-sharing clause on the same OpenACC directive"_err_en_US,
+          name.ToString());
+    }
   } else {
     AddDataSharingAttributeObject(*target);
   }

--- a/flang/lib/Semantics/rewrite-parse-tree.cpp
+++ b/flang/lib/Semantics/rewrite-parse-tree.cpp
@@ -497,11 +497,13 @@ void RewriteMutator::Post(parser::WriteStmt &x) {
   FixMisparsedUntaggedNamelistName(x);
 }
 
-// Erase AccObjects flagged by resolve-directives as same-kind data-sharing
-// duplicates. Cross-kind duplicates remain hard errors and never reach this
-// pass.
+// Erase AccObjects recorded in the context by resolve-directives as same-kind
+// data-sharing duplicates. Cross-kind duplicates remain hard errors and never
+// reach this pass.
 void RewriteMutator::Post(parser::AccObjectList &x) {
-  x.v.remove_if([](const parser::AccObject &o) { return o.isDuplicate; });
+  x.v.remove_if([this](const parser::AccObject &o) {
+    return context_.IsAccObjectDuplicate(&o);
+  });
 }
 
 bool RewriteParseTree(SemanticsContext &context, parser::Program &program) {

--- a/flang/lib/Semantics/rewrite-parse-tree.cpp
+++ b/flang/lib/Semantics/rewrite-parse-tree.cpp
@@ -62,6 +62,7 @@ public:
   void Post(parser::IfConstruct &);
   void Post(parser::ReadStmt &);
   void Post(parser::WriteStmt &);
+  void Post(parser::AccObjectList &);
 
   // Name resolution yet implemented:
   // TODO: Can some/all of these now be enabled?
@@ -494,6 +495,13 @@ void RewriteMutator::Post(parser::ReadStmt &x) {
 
 void RewriteMutator::Post(parser::WriteStmt &x) {
   FixMisparsedUntaggedNamelistName(x);
+}
+
+// Erase AccObjects flagged by resolve-directives as same-kind data-sharing
+// duplicates. Cross-kind duplicates remain hard errors and never reach this
+// pass.
+void RewriteMutator::Post(parser::AccObjectList &x) {
+  x.v.remove_if([](const parser::AccObject &o) { return o.isDuplicate; });
 }
 
 bool RewriteParseTree(SemanticsContext &context, parser::Program &program) {

--- a/flang/test/Lower/OpenACC/acc-dedup-private.f90
+++ b/flang/test/Lower/OpenACC/acc-dedup-private.f90
@@ -1,0 +1,63 @@
+! RUN: bbc -fopenacc -emit-hlfir %s -o - 2>/dev/null | FileCheck %s
+
+! Check that same-kind duplicate variables in OpenACC private/firstprivate
+! clauses lower without failure, and that each variable produces exactly one
+! acc.private / acc.firstprivate op (deduplication by rewrite-parse-tree).
+
+! -----------------------------------------------------------------------
+! private(x, x) -- duplicate within one clause
+
+subroutine test_private_pair(i)
+  integer :: x, i
+  !$acc parallel loop private(x, x)
+  do i = 1, 10
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_private_pair
+! x is privatized exactly once.
+! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+
+! -----------------------------------------------------------------------
+! private(x, x, x) -- two duplicates (from the triple-occurrence review note)
+
+subroutine test_private_triple(i)
+  integer :: x, i
+  !$acc parallel loop private(x, x, x)
+  do i = 1, 10
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_private_triple
+! x is privatized exactly once even with three source occurrences.
+! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+
+! -----------------------------------------------------------------------
+! private(x) private(x) -- duplicate across two separate clauses
+
+subroutine test_private_two_clauses(i)
+  integer :: x, i
+  !$acc parallel loop private(x) private(x)
+  do i = 1, 10
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_private_two_clauses
+! CHECK: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK-NOT: acc.private varPtr({{.*}}) recipe(@privatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+
+! -----------------------------------------------------------------------
+! firstprivate(x, x)
+
+subroutine test_firstprivate_pair(i)
+  integer :: x, i
+  !$acc parallel loop firstprivate(x, x)
+  do i = 1, 10
+  end do
+end subroutine
+
+! CHECK-LABEL: func.func @_QPtest_firstprivate_pair
+! CHECK: acc.firstprivate varPtr({{.*}}) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {name = "x"}
+! CHECK-NOT: acc.firstprivate varPtr({{.*}}) recipe(@firstprivatization_ref_i32) -> !fir.ref<i32> {name = "x"}

--- a/flang/test/Parser/acc-dedup-unparse.f90
+++ b/flang/test/Parser/acc-dedup-unparse.f90
@@ -1,0 +1,28 @@
+! RUN: %flang_fc1 -fopenacc -fdebug-unparse -w %s | FileCheck %s
+
+! Verify that same-kind duplicate variables in OpenACC data-sharing clauses are
+! removed by rewrite-parse-tree, so each variable appears at most once when
+! unparsed.
+
+subroutine dedup_pair(x, i)
+  integer, intent(inout) :: x, i
+  !$acc parallel loop private(x, x)
+  do i = 1, 10
+  end do
+end subroutine
+! CHECK-LABEL: SUBROUTINE dedup_pair
+! CHECK: PRIVATE(x)
+! CHECK-NOT: PRIVATE(x,x)
+! CHECK-NOT: PRIVATE(x, x)
+
+subroutine dedup_triple(x, i)
+  integer, intent(inout) :: x, i
+  !$acc parallel loop private(x, x, x)
+  do i = 1, 10
+  end do
+end subroutine
+! CHECK-LABEL: SUBROUTINE dedup_triple
+! Three occurrences reduce to one.
+! CHECK: PRIVATE(x)
+! CHECK-NOT: PRIVATE(x,x)
+! CHECK-NOT: PRIVATE(x, x)

--- a/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
+++ b/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
@@ -1,0 +1,115 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+
+! Same-kind data-sharing duplicates on an OpenACC directive (e.g.
+! private(x, x), private(x) private(x), copyin(x, x) ...) are not errors:
+! resolve-directives warns and rewrite-parse-tree drops the duplicate
+! occurrences from the clause object lists. Cross-kind duplicates
+! (e.g. private(x) firstprivate(x)) and reduction duplicates remain
+! hard errors.
+
+program test_dataclause_dedup
+  implicit none
+  integer :: x, y, z, i
+
+  ! passThis1.f90 pattern: duplicate within a single PRIVATE clause.
+  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !$acc parallel loop private(x, x)
+  do i = 1, 10
+  end do
+
+  ! passThis2.f90 pattern: duplicate within a single PRIVATE clause across
+  ! a continuation, with another variable in between.
+  !$acc parallel loop private(x, &
+  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !$acc&               y, x)
+  do i = 1, 10
+  end do
+
+  ! passThis3.f90 pattern: duplicate across two separate PRIVATE clauses
+  ! on the same directive.
+  !$acc parallel loop private(x) &
+  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !$acc&              private(y, x)
+  do i = 1, 10
+  end do
+
+  ! Same patterns generalize to FIRSTPRIVATE.
+  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !$acc parallel loop firstprivate(x, x)
+  do i = 1, 10
+  end do
+
+  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !$acc parallel loop firstprivate(x) firstprivate(y, x)
+  do i = 1, 10
+  end do
+
+  ! Multiple distinct duplicates on a single directive.
+  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'y' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !$acc parallel loop private(x, y, x, y)
+  do i = 1, 10
+  end do
+
+  ! Cross-kind duplicates on the same directive remain hard errors.
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel loop private(x) firstprivate(x)
+  do i = 1, 10
+  end do
+
+  ! Reduction is excluded from the benign case: same-flag duplicates may
+  ! differ in operator, which is a real conflict.
+  !ERROR: 'x' appears in more than one data-sharing clause on the same OpenACC directive
+  !$acc parallel loop reduction(+:x) reduction(*:x)
+  do i = 1, 10
+  end do
+
+  ! Regression coverage for non-bare designators: the dedup machinery only
+  ! examines simple-Name DataRefs, so distinct array elements and array
+  ! sections must pass through untouched, with no warning and no erasure.
+  block
+    integer :: arr(10)
+    integer, target :: t1, t2
+    integer, pointer :: p
+    type :: pt
+      integer :: a
+      integer :: b
+    end type
+    type(pt) :: s
+
+    ! Different array elements -- not duplicates.
+    !$acc parallel loop private(arr(1), arr(2))
+    do i = 1, 10
+    end do
+
+    ! Different array sections -- not duplicates.
+    !$acc parallel loop private(arr(1:5), arr(6:10))
+    do i = 1, 10
+    end do
+
+    ! Same array element listed twice -- not deduped, since GetDesignatorName-
+    ! IfDataRef returns null for ArrayElement and CheckMultipleAppearances
+    ! is never invoked. Compiles without diagnostics.
+    !$acc parallel loop private(arr(1), arr(1))
+    do i = 1, 10
+    end do
+
+    ! Same array section listed twice -- same reasoning, no diagnostic.
+    !$acc parallel loop private(arr(1:5), arr(1:5))
+    do i = 1, 10
+    end do
+
+    ! Distinct structure components -- not duplicates.
+    !$acc parallel loop private(s%a, s%b)
+    do i = 1, 10
+    end do
+
+    ! Mixing a bare-name designator and an array-element designator on the
+    ! same symbol must not trigger dedup -- the array element doesn't go
+    ! through the duplicate check at all.
+    !$acc parallel loop private(arr, arr(1))
+    do i = 1, 10
+    end do
+  end block
+
+end program

--- a/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
+++ b/flang/test/Semantics/OpenACC/acc-dataclause-dedup.f90
@@ -12,7 +12,7 @@ program test_dataclause_dedup
   integer :: x, y, z, i
 
   ! passThis1.f90 pattern: duplicate within a single PRIVATE clause.
-  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc parallel loop private(x, x)
   do i = 1, 10
   end do
@@ -20,7 +20,7 @@ program test_dataclause_dedup
   ! passThis2.f90 pattern: duplicate within a single PRIVATE clause across
   ! a continuation, with another variable in between.
   !$acc parallel loop private(x, &
-  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc&               y, x)
   do i = 1, 10
   end do
@@ -28,26 +28,33 @@ program test_dataclause_dedup
   ! passThis3.f90 pattern: duplicate across two separate PRIVATE clauses
   ! on the same directive.
   !$acc parallel loop private(x) &
-  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc&              private(y, x)
   do i = 1, 10
   end do
 
   ! Same patterns generalize to FIRSTPRIVATE.
-  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc parallel loop firstprivate(x, x)
   do i = 1, 10
   end do
 
-  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc parallel loop firstprivate(x) firstprivate(y, x)
   do i = 1, 10
   end do
 
   ! Multiple distinct duplicates on a single directive.
-  !WARNING: 'x' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
-  !WARNING: 'y' appears in more than one data-sharing clause on the same OpenACC directive [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
+  !WARNING: 'y' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
   !$acc parallel loop private(x, y, x, y)
+  do i = 1, 10
+  end do
+
+  ! Triple occurrence: two duplicates, both warned, only one survives dedup.
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
+  !WARNING: 'x' appears more than once in the same kind of data-sharing clause on an OpenACC directive; duplicate ignored [-Wopenacc-usage]
+  !$acc parallel loop private(x, x, x)
   do i = 1, 10
   end do
 


### PR DESCRIPTION
This PR allows duplicate OpenACC `private` and `firstprivate` clauses. While maintaining the restriction on `reduction` clauses.