### PR TITLE
[FileCheck] Fix -Wunused-variable in 48c864a

### DIFF
--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -1882,7 +1882,7 @@ bool FileCheck::readCheckFile(
            "Failed to move Buffer's start forward, or pointed prefix outside "
            "of the buffer!");
 
-    const char *BufferEnd = Buffer.data() + Buffer.size();
+    [[maybe_unused]] const char *BufferEnd = Buffer.data() + Buffer.size();
     assert(AfterSuffix.data() >= Buffer.data() &&
            AfterSuffix.data() <= BufferEnd &&
            "Parsing after suffix doesn't start inside of buffer!");


### PR DESCRIPTION
Variable is only used in an assertion. Mark it maybe_unused rather than
inlining as the variable name makes it a bit more readable, even if it
is a common idiom.