### PR TITLE
[AMDGPU] Prevent prefetch and load reordering

### DIFF
--- a/llvm/lib/Target/AMDGPU/FLATInstructions.td
+++ b/llvm/lib/Target/AMDGPU/FLATInstructions.td
@@ -530,6 +530,7 @@ class FLAT_Prefetch_Pseudo<string opName, dag addr = (ins VGPROp_64:$vaddr), str
   let mayStore = 1;
   let VM_CNT = 0;
   let LGKM_CNT = 0;
+  let hasSideEffects = 1;
 }
 
 multiclass FLAT_Flat_Prefetch_Pseudo<string opName> {

--- a/llvm/lib/Target/AMDGPU/SMInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SMInstructions.td
@@ -251,6 +251,7 @@ class SM_Prefetch_Pseudo <string opName, RegisterClass baseClass, bit hasSBase>
   let ScalarStore = 0;
   let has_offset = 1;
   let has_soffset = 1;
+  let hasSideEffects = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.flat.prefetch.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.flat.prefetch.ll
@@ -107,3 +107,22 @@ entry:
   tail call void @llvm.amdgcn.flat.prefetch(ptr %ptr, i32 27)
   ret void
 }
+
+define amdgpu_ps float @flat_prefetch_and_load_b32_idxprom(ptr align 4 inreg %p, i32 %idx) {
+; GCN-LABEL: flat_prefetch_and_load_b32_idxprom:
+; GCN:       ; %bb.0: ; %entry
+; GCN-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GCN-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_lshl_add_u64 v[2:3], v[0:1], 2, s[0:1]
+; GCN-NEXT:    flat_prefetch_b8 v[2:3]
+; GCN-NEXT:    flat_load_b32 v0, v0, s[0:1] scale_offset
+; GCN-NEXT:    s_wait_loadcnt_dscnt 0x0
+; GCN-NEXT:    ; return to shader part epilog
+entry:
+  %idxprom = sext i32 %idx to i64
+  %ptr = getelementptr inbounds float, ptr %p, i64 %idxprom
+  tail call void @llvm.amdgcn.flat.prefetch(ptr %ptr, i32 0)
+  %ret = load float, ptr %ptr, align 4
+  ret float %ret
+}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.global.prefetch.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.global.prefetch.ll
@@ -107,3 +107,22 @@ entry:
   tail call void @llvm.amdgcn.global.prefetch(ptr addrspace(1) %ptr, i32 27)
   ret void
 }
+
+define amdgpu_ps float @global_prefetch_and_load_b32_idxprom(ptr addrspace(1) align 4 inreg %p, i32 %idx) {
+; GCN-LABEL: global_prefetch_and_load_b32_idxprom:
+; GCN:       ; %bb.0: ; %entry
+; GCN-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
+; GCN-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_lshl_add_u64 v[2:3], v[0:1], 2, s[0:1]
+; GCN-NEXT:    global_prefetch_b8 v[2:3], off
+; GCN-NEXT:    global_load_b32 v0, v0, s[0:1] scale_offset
+; GCN-NEXT:    s_wait_loadcnt 0x0
+; GCN-NEXT:    ; return to shader part epilog
+entry:
+  %idxprom = sext i32 %idx to i64
+  %ptr = getelementptr inbounds float, ptr addrspace(1) %p, i64 %idxprom
+  tail call void @llvm.amdgcn.global.prefetch(ptr addrspace(1) %ptr, i32 0)
+  %ret = load float, ptr addrspace(1) %ptr, align 4
+  ret float %ret
+}

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.prefetch.data.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.prefetch.data.ll
@@ -144,6 +144,20 @@ entry:
   ret void
 }
 
+define amdgpu_ps float @prefetch_and_load_b32(ptr addrspace(4) align 4 inreg %p) {
+; GCN-LABEL: prefetch_and_load_b32:
+; GCN:       ; %bb.0: ; %entry
+; GCN-NEXT:    s_prefetch_data s[0:1], 0x0, null, 0
+; GCN-NEXT:    s_load_b32 s0, s[0:1], 0x0
+; GCN-NEXT:    s_wait_kmcnt 0x0
+; GCN-NEXT:    v_mov_b32_e32 v0, s0
+; GCN-NEXT:    ; return to shader part epilog
+entry:
+  tail call void @llvm.amdgcn.s.prefetch.data.p4(ptr addrspace(4) %p, i32 0)
+  %ret = load float, ptr addrspace(4) %p, align 4
+  ret float %ret
+}
+
 declare void @llvm.amdgcn.s.prefetch.data.p4(ptr addrspace(4) %ptr, i32 %len)
 declare void @llvm.amdgcn.s.prefetch.data.p1(ptr addrspace(1) %ptr, i32 %len)
 declare void @llvm.amdgcn.s.prefetch.data.p0(ptr %ptr, i32 %len)

--- a/llvm/test/CodeGen/AMDGPU/loop-prefetch-data.ll
+++ b/llvm/test/CodeGen/AMDGPU/loop-prefetch-data.ll
@@ -113,8 +113,8 @@ define amdgpu_kernel void @copy_flat(ptr nocapture %d, ptr nocapture readonly %s
 ; GFX1250-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 0xb0
 ; GFX1250-NEXT:  .LBB0_2: ; %for.body
 ; GFX1250-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX1250-NEXT:    flat_load_b128 v[2:5], v0, s[2:3] offset:-176
 ; GFX1250-NEXT:    flat_prefetch_b8 v0, s[2:3] scope:SCOPE_SE
+; GFX1250-NEXT:    flat_load_b128 v[2:5], v0, s[2:3] offset:-176
 ; GFX1250-NEXT:    s_add_co_i32 s6, s6, -1
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 16
@@ -183,8 +183,8 @@ define amdgpu_kernel void @copy_global(ptr addrspace(1) nocapture %d, ptr addrsp
 ; GFX12-SPREFETCH-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 0xb0
 ; GFX12-SPREFETCH-NEXT:  .LBB1_2: ; %for.body
 ; GFX12-SPREFETCH-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX12-SPREFETCH-NEXT:    global_load_b128 v[1:4], v0, s[2:3] offset:-176
 ; GFX12-SPREFETCH-NEXT:    s_prefetch_data s[2:3], 0x0, null, 0
+; GFX12-SPREFETCH-NEXT:    global_load_b128 v[1:4], v0, s[2:3] offset:-176
 ; GFX12-SPREFETCH-NEXT:    s_add_co_i32 s6, s6, -1
 ; GFX12-SPREFETCH-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 16
 ; GFX12-SPREFETCH-NEXT:    s_cmp_lg_u32 s6, 0
@@ -209,9 +209,9 @@ define amdgpu_kernel void @copy_global(ptr addrspace(1) nocapture %d, ptr addrsp
 ; GFX12ES2-SPREFETCH-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 0xb0
 ; GFX12ES2-SPREFETCH-NEXT:  .LBB1_2: ; %for.body
 ; GFX12ES2-SPREFETCH-NEXT:    ; =>This Inner Loop Header: Depth=1
+; GFX12ES2-SPREFETCH-NEXT:    s_prefetch_data s[2:3], 0x0, null, 0
 ; GFX12ES2-SPREFETCH-NEXT:    s_wait_alu depctr_va_vdst(0) depctr_vm_vsrc(0)
 ; GFX12ES2-SPREFETCH-NEXT:    global_load_b128 v[1:4], v0, s[2:3] offset:-176
-; GFX12ES2-SPREFETCH-NEXT:    s_prefetch_data s[2:3], 0x0, null, 0
 ; GFX12ES2-SPREFETCH-NEXT:    s_add_co_i32 s6, s6, -1
 ; GFX12ES2-SPREFETCH-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 16
 ; GFX12ES2-SPREFETCH-NEXT:    s_cmp_lg_u32 s6, 0
@@ -236,8 +236,8 @@ define amdgpu_kernel void @copy_global(ptr addrspace(1) nocapture %d, ptr addrsp
 ; GFX1250-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 0xb0
 ; GFX1250-NEXT:  .LBB1_2: ; %for.body
 ; GFX1250-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX1250-NEXT:    global_load_b128 v[2:5], v0, s[2:3] offset:-176
 ; GFX1250-NEXT:    global_prefetch_b8 v0, s[2:3] scope:SCOPE_SE
+; GFX1250-NEXT:    global_load_b128 v[2:5], v0, s[2:3] offset:-176
 ; GFX1250-NEXT:    s_add_co_i32 s6, s6, -1
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 16
@@ -306,8 +306,8 @@ define amdgpu_kernel void @copy_constant(ptr addrspace(1) nocapture %d, ptr addr
 ; GFX12-SPREFETCH-NEXT:  .LBB2_2: ; %for.body
 ; GFX12-SPREFETCH-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX12-SPREFETCH-NEXT:    s_wait_kmcnt 0x0
-; GFX12-SPREFETCH-NEXT:    s_load_b128 s[8:11], s[2:3], 0x0
 ; GFX12-SPREFETCH-NEXT:    s_prefetch_data s[2:3], 0xb0, null, 0
+; GFX12-SPREFETCH-NEXT:    s_load_b128 s[8:11], s[2:3], 0x0
 ; GFX12-SPREFETCH-NEXT:    s_add_co_i32 s6, s6, -1
 ; GFX12-SPREFETCH-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 16
 ; GFX12-SPREFETCH-NEXT:    s_cmp_lg_u32 s6, 0
@@ -333,8 +333,8 @@ define amdgpu_kernel void @copy_constant(ptr addrspace(1) nocapture %d, ptr addr
 ; GFX12ES2-SPREFETCH-NEXT:  .LBB2_2: ; %for.body
 ; GFX12ES2-SPREFETCH-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX12ES2-SPREFETCH-NEXT:    s_wait_kmcnt 0x0
-; GFX12ES2-SPREFETCH-NEXT:    s_load_b128 s[8:11], s[2:3], 0x0
 ; GFX12ES2-SPREFETCH-NEXT:    s_prefetch_data s[2:3], 0xb0, null, 0
+; GFX12ES2-SPREFETCH-NEXT:    s_load_b128 s[8:11], s[2:3], 0x0
 ; GFX12ES2-SPREFETCH-NEXT:    s_add_co_i32 s6, s6, -1
 ; GFX12ES2-SPREFETCH-NEXT:    s_add_nc_u64 s[2:3], s[2:3], 16
 ; GFX12ES2-SPREFETCH-NEXT:    s_cmp_lg_u32 s6, 0
@@ -843,8 +843,8 @@ define amdgpu_kernel void @copy_global_divergent(ptr addrspace(1) nocapture %d, 
 ; GFX1250-NEXT:    v_add_nc_u64_e32 v[2:3], 0xb0, v[2:3]
 ; GFX1250-NEXT:  .LBB5_2: ; %for.body
 ; GFX1250-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX1250-NEXT:    global_load_b128 v[4:7], v[2:3], off offset:-176
 ; GFX1250-NEXT:    global_prefetch_b8 v[2:3], off scope:SCOPE_SE
+; GFX1250-NEXT:    global_load_b128 v[4:7], v[2:3], off offset:-176
 ; GFX1250-NEXT:    s_wait_xcnt 0x0
 ; GFX1250-NEXT:    v_add_nc_u64_e32 v[2:3], 16, v[2:3]
 ; GFX1250-NEXT:    s_add_co_i32 s0, s0, -1


### PR DESCRIPTION
Mark prefetches as having side effects, otherwise scheduler
reorders these with loads.
