### PR TITLE
[gsymutil] Fix build error in 196448 and remove warning message

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFTypePrinter.h
@@ -184,13 +184,8 @@ template <typename DieType> DieType unwrapReferencedTypedefType(DieType D) {
     if (!Unwrapped || Unwrapped.getTag() != dwarf::DW_TAG_typedef)
       return Unwrapped;
 
-    if (!Visited.insert(Unwrapped.getOffset()).second) {
-      WithColor::warning()
-          << "typedef cycle detected: DW_TAG_typedef at offset 0x"
-          << utohexstr(Unwrapped.getOffset())
-          << " references itself through DW_TAG_typedef chain\n";
+    if (!Visited.insert(Unwrapped.getOffset()).second)
       return Unwrapped;
-    }
 
     D = Unwrapped;
   }

--- a/llvm/unittests/DebugInfo/GSYM/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/GSYM/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(LLVM_LINK_COMPONENTS
+  BinaryFormat
   DebugInfoDWARF
   DebugInfoGSYM
   MC


### PR DESCRIPTION
**Problem:**
#196448 broke the linux build of a test `DebugInfoGSYMTests`. See this [buildbot](https://lab.llvm.org/buildbot/#/builders/10/builds/28337).

**Root cause:**
The `BinaryFormat` is a dependency that is required when the build is done with `-DBUILD_SHARED_LIBS=ON`. This explains why some of the linux builds passes, while the above buildbot fails.

**Fix:**
This patch fixes this by adding that dependency.

This patch also removes the warning message that was added by the same patch, which should be added in a different way, as pointed out by this [comment](https://github.com/llvm/llvm-project/pull/196448#discussion_r3221162626).


**Tests:**
```
cmake -G Ninja -DLLVM_ENABLE_PROJECTS="clang;lldb" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" -DBUILD_SHARED_LIBS=ON ~/public_llvm/llvm-project/llvm

ninja -C ~/public_llvm/build DebugInfoGSYMTests DebugInfoDWARFTests

LD_LIBRARY_PATH=~/public_llvm/build/lib ~/public_llvm/build/unittests/DebugInfo/GSYM/DebugInfoGSYMTests
LD_LIBRARY_PATH=~/public_llvm/build/lib ~/public_llvm/build/unittests/DebugInfo/DWARF/DebugInfoDWARFTests
```