### PR TITLE
[libc][mutex] add error checking support

### DIFF
--- a/libc/include/llvm-libc-macros/pthread-macros.h
+++ b/libc/include/llvm-libc-macros/pthread-macros.h
@@ -32,18 +32,18 @@
 #ifdef __linux__
 #define PTHREAD_MUTEX_INITIALIZER                                              \
   {                                                                            \
-      /* .__ftxw = */ {0},     /* .__priority_inherit = */ 0,                  \
-      /* .__recursive = */ 0,  /* .__robust = */ 0,                            \
-      /* .__pshared = */ 0,    /* .__owner = */ 0,                             \
-      /* .__lock_count = */ 0,                                                 \
+      /* .__ftxw = */ {0},    /* .__priority_inherit = */ 0,                   \
+      /* .__recursive = */ 0, /* .__robust = */ 0,                             \
+      /* .__pshared = */ 0,   /* .__error_checking = */ 0,                     \
+      /* .__owner = */ 0,     /* .__lock_count = */ 0,                         \
   }
 #else
 #define PTHREAD_MUTEX_INITIALIZER                                              \
   {                                                                            \
-      /* .__ftxw = */ {0},     /* .__priority_inherit = */ 0,                  \
-      /* .__recursive = */ 0,  /* .__robust = */ 0,                            \
-      /* .__pshared = */ 0,    /* .__owner = */ 0,                             \
-      /* .__lock_count = */ 0,                                                 \
+      /* .__ftxw = */ {0},    /* .__priority_inherit = */ 0,                   \
+      /* .__recursive = */ 0, /* .__robust = */ 0,                             \
+      /* .__pshared = */ 0,   /* .__error_checking = */ 0,                     \
+      /* .__owner = */ 0,     /* .__lock_count = */ 0,                         \
   }
 #endif
 

--- a/libc/include/llvm-libc-types/__mutex_type.h
+++ b/libc/include/llvm-libc-types/__mutex_type.h
@@ -24,6 +24,7 @@ typedef struct {
   unsigned int __recursive : 1;
   unsigned int __robust : 1;
   unsigned int __pshared : 1;
+  unsigned int __error_checking : 1;
 
   pid_t __owner;
   size_t __lock_count;

--- a/libc/src/__support/threads/mutex.h
+++ b/libc/src/__support/threads/mutex.h
@@ -56,7 +56,7 @@ namespace LIBC_NAMESPACE_DECL {
 /// only a single thread executes code requiring a mutex lock.
 // TODO: declare abstract interface for timed_lock
 struct Mutex {
-  LIBC_INLINE constexpr Mutex(bool, bool, bool, bool) {}
+  LIBC_INLINE constexpr Mutex(bool, bool, bool, bool, bool = false) {}
 
   LIBC_INLINE MutexError lock() { return MutexError::NONE; }
   LIBC_INLINE MutexError unlock() { return MutexError::NONE; }

--- a/libc/src/__support/threads/mutex_common.h
+++ b/libc/src/__support/threads/mutex_common.h
@@ -16,6 +16,7 @@ namespace LIBC_NAMESPACE_DECL {
 enum class MutexError : int {
   NONE,
   BUSY,
+  DEADLOCK,
   TIMEOUT,
   UNLOCK_WITHOUT_LOCK,
   BAD_LOCK_STATE,

--- a/libc/src/__support/threads/unix_mutex.h
+++ b/libc/src/__support/threads/unix_mutex.h
@@ -48,8 +48,7 @@ class Mutex final : private RawMutex {
       lock_count++;
       return MutexError::NONE;
     }
-
-    if (is_error_checking() && owner == internal::gettid())
+    else if (is_error_checking() && owner == internal::gettid())
       return MutexError::DEADLOCK;
 
     MutexError res = do_lock();

--- a/libc/src/__support/threads/unix_mutex.h
+++ b/libc/src/__support/threads/unix_mutex.h
@@ -25,13 +25,13 @@ namespace LIBC_NAMESPACE_DECL {
 // TODO: support shared/recursive/robust mutexes.
 class Mutex final : private RawMutex {
   // Use bitfields to allow encoding more attributes.
-  // TODO: we may still need error checking or other flags and the robustness
-  //       and priority inheritance will need to be implemented.
+  // TODO: the robustness and priority inheritance will need to be implemented.
   //       See also https://github.com/llvm/llvm-project/issues/194396
   LIBC_PREFERED_TYPE(bool) unsigned int priority_inherit : 1;
   LIBC_PREFERED_TYPE(bool) unsigned int recursive : 1;
   LIBC_PREFERED_TYPE(bool) unsigned int robust : 1;
   LIBC_PREFERED_TYPE(bool) unsigned int pshared : 1;
+  LIBC_PREFERED_TYPE(bool) unsigned int error_checking : 1;
 
   // TLS address may not work across forked processes. Use thread id instead.
   cpp::Atomic<pid_t> owner;
@@ -49,20 +49,30 @@ class Mutex final : private RawMutex {
       return MutexError::NONE;
     }
 
+    if (is_error_checking() && owner == internal::gettid())
+      return MutexError::DEADLOCK;
+
     MutexError res = do_lock();
-    if (is_recursive() && res == MutexError::NONE) {
-      owner = internal::gettid();
-      lock_count = 1;
+
+    if (res == MutexError::NONE) {
+      if (is_recursive()) {
+        owner = internal::gettid();
+        lock_count = 1;
+      } else if (is_error_checking()) {
+        owner = internal::gettid();
+      }
     }
+
     return res;
   }
 
 public:
   LIBC_INLINE constexpr Mutex(bool is_priority_inherit, bool is_recursive,
-                              bool is_robust, bool is_pshared)
+                              bool is_robust, bool is_pshared,
+                              bool is_error_checking = false)
       : RawMutex(), priority_inherit(is_priority_inherit),
         recursive(is_recursive), robust(is_robust), pshared(is_pshared),
-        owner(0), lock_count(0) {}
+        error_checking(is_error_checking), owner(0), lock_count(0) {}
 
   LIBC_INLINE static MutexError destroy(Mutex *lock) {
     LIBC_ASSERT(lock->owner == 0 && lock->lock_count == 0 &&
@@ -97,6 +107,8 @@ public:
         owner = 0;
       else
         return MutexError::NONE;
+    } else if (is_error_checking() && owner == internal::gettid()) {
+      owner = 0;
     }
     if (this->RawMutex::unlock(this->pshared))
       return MutexError::NONE;
@@ -113,11 +125,12 @@ public:
 
   LIBC_INLINE bool can_be_requeued() const {
     return !this->pshared && !this->robust && !this->recursive &&
-           !this->priority_inherit;
+           !this->priority_inherit && !this->error_checking;
   }
 
   LIBC_INLINE bool is_robust() const { return this->robust; }
   LIBC_INLINE bool is_recursive() const { return this->recursive; }
+  LIBC_INLINE bool is_error_checking() const { return this->error_checking; }
 };
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/threads/unix_mutex.h
+++ b/libc/src/__support/threads/unix_mutex.h
@@ -101,13 +101,20 @@ public:
   }
 
   LIBC_INLINE MutexError unlock() {
-    if (is_recursive() && owner == internal::gettid()) {
+    if (is_recursive()) {
+      // lock_count == 0 can happen if previous unlock is
+      // suspended before signal frame
+      if (owner != internal::gettid() || lock_count == 0)
+        return MutexError::UNLOCK_WITHOUT_LOCK;
+
       lock_count--;
       if (lock_count == 0)
         owner = 0;
       else
         return MutexError::NONE;
-    } else if (is_error_checking() && owner == internal::gettid()) {
+    } else if (is_error_checking()) {
+      if (owner != internal::gettid())
+        return MutexError::UNLOCK_WITHOUT_LOCK;
       owner = 0;
     }
     if (this->RawMutex::unlock(this->pshared))

--- a/libc/src/__support/threads/unix_mutex.h
+++ b/libc/src/__support/threads/unix_mutex.h
@@ -47,8 +47,7 @@ class Mutex final : private RawMutex {
         return MutexError::OVERFLOW;
       lock_count++;
       return MutexError::NONE;
-    }
-    else if (is_error_checking() && owner == internal::gettid())
+    } else if (is_error_checking() && owner == internal::gettid())
       return MutexError::DEADLOCK;
 
     MutexError res = do_lock();

--- a/libc/src/pthread/CMakeLists.txt
+++ b/libc/src/pthread/CMakeLists.txt
@@ -464,6 +464,7 @@ add_entrypoint_object(
   HDRS
     pthread_mutex_lock.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.include.pthread
     libc.src.__support.threads.mutex
 )
@@ -475,6 +476,7 @@ add_entrypoint_object(
   HDRS
     pthread_mutex_trylock.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.include.pthread
     libc.src.__support.threads.mutex
 )

--- a/libc/src/pthread/CMakeLists.txt
+++ b/libc/src/pthread/CMakeLists.txt
@@ -488,7 +488,9 @@ add_entrypoint_object(
   HDRS
     pthread_mutex_unlock.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.include.pthread
+    libc.src.__support.libc_assert
     libc.src.__support.threads.mutex
 )
 

--- a/libc/src/pthread/pthread_mutex_init.cpp
+++ b/libc/src/pthread/pthread_mutex_init.cpp
@@ -28,9 +28,12 @@ LLVM_LIBC_FUNCTION(int, pthread_mutex_init,
                     const pthread_mutexattr_t *__restrict attr)) {
   auto mutexattr = attr == nullptr ? DEFAULT_MUTEXATTR : *attr;
   bool is_recursive = false;
+  bool is_error_checking = false;
   switch (get_mutexattr_type(mutexattr)) {
   case PTHREAD_MUTEX_NORMAL:
+    break;
   case PTHREAD_MUTEX_ERRORCHECK:
+    is_error_checking = true;
     break;
   case PTHREAD_MUTEX_RECURSIVE:
     is_recursive = true;
@@ -43,8 +46,8 @@ LLVM_LIBC_FUNCTION(int, pthread_mutex_init,
 
   bool is_pshared = get_mutexattr_pshared(mutexattr) == PTHREAD_PROCESS_SHARED;
 
-  new (m)
-      Mutex(/*is_priority_inherit=*/false, is_recursive, is_robust, is_pshared);
+  new (m) Mutex(/*is_priority_inherit=*/false, is_recursive, is_robust,
+                is_pshared, is_error_checking);
   return 0;
 }
 

--- a/libc/src/pthread/pthread_mutex_lock.cpp
+++ b/libc/src/pthread/pthread_mutex_lock.cpp
@@ -8,6 +8,7 @@
 
 #include "pthread_mutex_lock.h"
 
+#include "hdr/errno_macros.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/mutex.h"
@@ -16,9 +17,10 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-// The implementation currently handles only plain mutexes.
 LLVM_LIBC_FUNCTION(int, pthread_mutex_lock, (pthread_mutex_t * mutex)) {
-  reinterpret_cast<Mutex *>(mutex)->lock();
+  MutexError err = reinterpret_cast<Mutex *>(mutex)->lock();
+  if (err == MutexError::DEADLOCK)
+    return EDEADLK;
   // TODO: When the Mutex class supports all the possible error conditions
   // return the appropriate error value here.
   return 0;

--- a/libc/src/pthread/pthread_mutex_trylock.cpp
+++ b/libc/src/pthread/pthread_mutex_trylock.cpp
@@ -16,9 +16,11 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-// The implementation currently handles only plain mutexes.
 LLVM_LIBC_FUNCTION(int, pthread_mutex_trylock, (pthread_mutex_t * mutex)) {
-  if (reinterpret_cast<Mutex *>(mutex)->try_lock() == MutexError::BUSY)
+  MutexError err = reinterpret_cast<Mutex *>(mutex)->try_lock();
+  if (err == MutexError::DEADLOCK)
+    return EDEADLK;
+  if (err == MutexError::BUSY)
     return EBUSY;
   return 0;
 }

--- a/libc/src/pthread/pthread_mutex_unlock.cpp
+++ b/libc/src/pthread/pthread_mutex_unlock.cpp
@@ -8,7 +8,9 @@
 
 #include "pthread_mutex_unlock.h"
 
+#include "hdr/errno_macros.h"
 #include "src/__support/common.h"
+#include "src/__support/libc_assert.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/threads/mutex.h"
 
@@ -18,9 +20,12 @@ namespace LIBC_NAMESPACE_DECL {
 
 // The implementation currently handles only plain mutexes.
 LLVM_LIBC_FUNCTION(int, pthread_mutex_unlock, (pthread_mutex_t * mutex)) {
-  reinterpret_cast<Mutex *>(mutex)->unlock();
-  // TODO: When the Mutex class supports all the possible error conditions
-  // return the appropriate error value here.
+  MutexError err = reinterpret_cast<Mutex *>(mutex)->unlock();
+  // Per-POSIX specification and our implementation, EPERM is the only possible
+  // error.
+  if (err == MutexError::UNLOCK_WITHOUT_LOCK)
+    return EPERM;
+  LIBC_ASSERT(err == MutexError::NONE);
   return 0;
 }
 

--- a/libc/test/integration/src/pthread/CMakeLists.txt
+++ b/libc/test/integration/src/pthread/CMakeLists.txt
@@ -7,6 +7,7 @@ add_integration_test(
   SRCS
     pthread_mutex_test.cpp
   DEPENDS
+    libc.hdr.errno_macros
     libc.hdr.stdint_proxy
     libc.include.pthread
     libc.src.errno.errno

--- a/libc/test/integration/src/pthread/pthread_mutex_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_mutex_test.cpp
@@ -222,6 +222,8 @@ void initializer_acts_the_same_as_null_attr() {
   ASSERT_EQ(mutex_snapshot.__recursive, mutex_from_init_snapshot.__recursive);
   ASSERT_EQ(mutex_snapshot.__robust, mutex_from_init_snapshot.__robust);
   ASSERT_EQ(mutex_snapshot.__pshared, mutex_from_init_snapshot.__pshared);
+  ASSERT_EQ(mutex_snapshot.__error_checking,
+            mutex_from_init_snapshot.__error_checking);
   ASSERT_EQ(mutex_snapshot.__owner, mutex_from_init_snapshot.__owner);
   ASSERT_EQ(mutex_snapshot.__lock_count, mutex_from_init_snapshot.__lock_count);
 
@@ -234,6 +236,34 @@ void initializer_acts_the_same_as_null_attr() {
   ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_trylock(&mutex_from_init), EBUSY);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_unlock(&mutex_from_init), 0);
   ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_destroy(&mutex_from_init), 0);
+}
+
+void error_checking_mutex_test() {
+  pthread_mutexattr_t attr;
+  pthread_mutex_t error_checking_mutex;
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutexattr_init(&attr), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutexattr_settype(&attr,
+                                                      PTHREAD_MUTEX_ERRORCHECK),
+            0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_init(&error_checking_mutex, &attr),
+            0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutexattr_destroy(&attr), 0);
+
+  pthread_mutex_t snapshot = snapshot_mutex(&error_checking_mutex);
+  ASSERT_TRUE(snapshot.__error_checking);
+  ASSERT_EQ(snapshot.__owner, 0);
+  ASSERT_EQ(snapshot.__lock_count, size_t(0));
+
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_lock(&error_checking_mutex), 0);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_trylock(&error_checking_mutex),
+            EDEADLK);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_lock(&error_checking_mutex), EDEADLK);
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_unlock(&error_checking_mutex), 0);
+
+  snapshot = snapshot_mutex(&error_checking_mutex);
+  ASSERT_EQ(snapshot.__owner, 0);
+  ASSERT_EQ(snapshot.__lock_count, size_t(0));
+  ASSERT_EQ(LIBC_NAMESPACE::pthread_mutex_destroy(&error_checking_mutex), 0);
 }
 
 static constexpr int THREAD_COUNT = 10;
@@ -298,6 +328,7 @@ TEST_MAIN() {
   trylock_test();
   recursive_mutex_test();
   initializer_acts_the_same_as_null_attr();
+  error_checking_mutex_test();
   multiple_waiters();
   return 0;
 }


### PR DESCRIPTION
This PR adds the error checking bit and corresponding deadlock detection logic for
posix mutexes. If the mutex is already owned by the acquisition thread, when the error-checking
bit is set, lock and trylock returns EDEADLOCK instead of hanging on the mutex indefinitely.
If error-checking bit is not set, such check is not performed to reduce atomic operation on
fastpath.

Assisted-by: Codex with gpt-5.5 high fast
