### PR TITLE
[LLDB] Simplify the API of ClangUserExpression::ScanContext [NFC]

### DIFF
--- a/lldb/include/lldb/Expression/LLVMUserExpression.h
+++ b/lldb/include/lldb/Expression/LLVMUserExpression.h
@@ -78,9 +78,6 @@ protected:
             lldb::UserExpressionSP &shared_ptr_to_me,
             lldb::ExpressionVariableSP &result) override;
 
-  virtual void ScanContext(ExecutionContext &exe_ctx,
-                           lldb_private::Status &err) = 0;
-
   bool PrepareToExecuteJITExpression(DiagnosticManager &diagnostic_manager,
                                      ExecutionContext &exe_ctx,
                                      lldb::addr_t &struct_address);

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.cpp
@@ -91,7 +91,8 @@ ClangUserExpression::ClangUserExpression(
 
 ClangUserExpression::~ClangUserExpression() = default;
 
-void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
+void ClangUserExpression::ScanContext(DiagnosticManager &diagnostic_manager,
+                                      ExecutionContext &exe_ctx) {
   Log *log = GetLog(LLDBLog::Expressions);
 
   LLDB_LOGF(log, "ClangUserExpression::ScanContext()");
@@ -159,12 +160,12 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
         lldb::VariableListSP variable_list_sp(
             function_block->GetBlockVariableList(true));
 
-        const char *thisErrorString = "Stopped in a C++ method, but 'this' "
-                                      "isn't available; pretending we are in a "
-                                      "generic context";
+        const char *msg = "Stopped in a C++ method, but 'this' isn't "
+                          "available; pretending we are in a generic context";
 
         if (!variable_list_sp) {
-          err = Status::FromErrorString(thisErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
 
@@ -173,7 +174,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
         if (!this_var_sp || !this_var_sp->IsInScope(frame) ||
             !this_var_sp->LocationIsValidForFrame(frame)) {
-          err = Status::FromErrorString(thisErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
       }
@@ -189,12 +191,12 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
         lldb::VariableListSP variable_list_sp(
             function_block->GetBlockVariableList(true));
 
-        const char *selfErrorString = "Stopped in an Objective-C method, but "
-                                      "'self' isn't available; pretending we "
-                                      "are in a generic context";
+        const char *msg = "Stopped in an Objective-C method, but 'self' isn't "
+                          "available; pretending we are in a generic context";
 
         if (!variable_list_sp) {
-          err = Status::FromErrorString(selfErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
 
@@ -203,7 +205,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
         if (!self_variable_sp || !self_variable_sp->IsInScope(frame) ||
             !self_variable_sp->LocationIsValidForFrame(frame)) {
-          err = Status::FromErrorString(selfErrorString);
+          diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                           eDiagnosticOriginLLDB);
           return;
         }
       }
@@ -232,13 +235,13 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
           lldb::VariableListSP variable_list_sp(
               function_block->GetBlockVariableList(true));
 
-          const char *thisErrorString = "Stopped in a context claiming to "
-                                        "capture a C++ object pointer, but "
-                                        "'this' isn't available; pretending we "
-                                        "are in a generic context";
+          const char *msg = "Stopped in a context claiming to capture a C++ "
+                            "object pointer, but 'this' isn't available; "
+                            "pretending we are in a generic context";
 
           if (!variable_list_sp) {
-            err = Status::FromErrorString(thisErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
@@ -247,7 +250,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           if (!this_var_sp || !this_var_sp->IsInScope(frame) ||
               !this_var_sp->LocationIsValidForFrame(frame)) {
-            err = Status::FromErrorString(thisErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
         }
@@ -259,13 +263,13 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
           lldb::VariableListSP variable_list_sp(
               function_block->GetBlockVariableList(true));
 
-          const char *selfErrorString =
-              "Stopped in a context claiming to capture an Objective-C object "
-              "pointer, but 'self' isn't available; pretending we are in a "
-              "generic context";
+          const char *msg = "Stopped in a context claiming to capture an "
+                            "Objective-C object pointer, but 'self' isn't "
+                            "available; pretending we are in a generic context";
 
           if (!variable_list_sp) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
@@ -274,21 +278,24 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
           if (!self_variable_sp || !self_variable_sp->IsInScope(frame) ||
               !self_variable_sp->LocationIsValidForFrame(frame)) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
           Type *self_type = self_variable_sp->GetType();
 
           if (!self_type) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
           CompilerType self_clang_type = self_type->GetForwardCompilerType();
 
           if (!self_clang_type) {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
 
@@ -299,7 +306,8 @@ void ClangUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
             m_in_objectivec_method = true;
             m_needs_object_ptr = true;
           } else {
-            err = Status::FromErrorString(selfErrorString);
+            diagnostic_manager.AddDiagnostic(msg, lldb::eSeverityWarning,
+                                             eDiagnosticOriginLLDB);
             return;
           }
         } else {
@@ -525,7 +533,7 @@ bool ClangUserExpression::PrepareForParsing(
     return false;
 
   Status err;
-  ScanContext(exe_ctx, err);
+  ScanContext(diagnostic_manager, exe_ctx);
 
   if (!err.Success()) {
     diagnostic_manager.PutString(lldb::eSeverityWarning, err.AsCString());

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangUserExpression.h
@@ -197,8 +197,8 @@ private:
 
   void SetupCppModuleImports(ExecutionContext &exe_ctx);
 
-  void ScanContext(ExecutionContext &exe_ctx,
-                   lldb_private::Status &err) override;
+  void ScanContext(DiagnosticManager &diagnostic_manager,
+                   ExecutionContext &exe_ctx);
 
   bool AddArguments(ExecutionContext &exe_ctx, std::vector<lldb::addr_t> &args,
                     lldb::addr_t struct_address,


### PR DESCRIPTION
- this function is a virtual function, but it is called by the leaf class ClangUserExpression

- it also returns a Status only to then report any error as a warning

This patch devirtualizes the function, since there is use-case for overloading it in other expression evaluator plugins, and it cleans up the Status usage by passing in DiagnosticManager directly, like its sibling functions do.