### PR TITLE
[lldb] Fix Broken Test For Embedded Source in Binary

### DIFF
--- a/lldb/test/Shell/Commands/command-source-embedded.test
+++ b/lldb/test/Shell/Commands/command-source-embedded.test
@@ -3,8 +3,10 @@
 # When a program with embedded source being debugged reaches a breakpoint, its
 # source code should be listed. This test prevents a regression identified in #191801.
 
+# UNSUPPORTED: system-windows
+
 # RUN: split-file %s %t
-# RUN: %clang_host -g -gdwarf -gembed-source %t/main.c -o %t.out
+# RUN: %clang_host -g -gdwarf-5 -gembed-source %t/main.c -o %t.out
 # RUN: %lldb -x -b -s %t/commands %t.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
 
@@ -22,7 +24,7 @@ run
 # CHECK-LABEL: run
 # CHECK-NEXT:  Process [[PID:.*]] launched
 # CHECK-NEXT:  Process [[PID]] stopped
-# CHECK-NEXT:  name = {{.*}}, stop reason = breakpoint 1.1
+# CHECK-NEXT:  stop reason = breakpoint 1.1
 # CHECK-NEXT:  frame #0: {{.*}}`main at main.c:2:3
 # CHECK-NEXT:  1   	int main() {
 # CHECK-NEXT:  -> 2   					return 0;


### PR DESCRIPTION
A previous change to fix a regression when displaying source of programs that embed their source code into their debugging information (using, e.g., DW_LNCT_LLVM_source) should display included a test that was not appropriately robust to all platforms.

Disable the regression on Windows systems and make the CHECKs robust against output generated on different platforms.