### PR TITLE
[compiler-rt][ORC] Mark Windows x86-64 ORC tests unsupported

### DIFF
--- a/compiler-rt/test/orc/TestCases/Windows/x86-64/lit.local.cfg.py
+++ b/compiler-rt/test/orc/TestCases/Windows/x86-64/lit.local.cfg.py
@@ -3,3 +3,15 @@ if config.root.host_arch not in ["AMD64", "x86_64"]:
 
 if config.target_arch not in ["AMD64", "x86_64"]:
     config.unsupported = True
+
+# These tests have never passed on Windows. The %llvm_jitlink substitution
+# defined in compiler-rt/test/orc/lit.cfg.py passes -no-process-syms=true on
+# Windows, which llvm-jitlink rejects when combined with -orc-runtime ("-orc-
+# runtime requires process symbols"). Simply dropping -no-process-syms exposes
+# further unresolved issues in the COFF orc-runtime support (missing __imp_*
+# CRT imports, JITSymbolTable index errors when materializing the orc-runtime
+# archive, etc.). Mark these tests unsupported on Windows until the underlying
+# orc-runtime issues are fixed. See
+# https://github.com/llvm/llvm-project/issues/77996.
+if config.target_os == "Windows":
+    config.unsupported = True


### PR DESCRIPTION
These nine ORC runtime tests have never passed on Windows:

  - TestCases/Windows/x86-64/hello-world.c
  - TestCases/Windows/x86-64/hello-world.cpp
  - TestCases/Windows/x86-64/priority-static-initializer.c
  - TestCases/Windows/x86-64/priority-static-initializer-three.c
  - TestCases/Windows/x86-64/sehframe-handling.cpp
  - TestCases/Windows/x86-64/static-initializer.S
  - TestCases/Windows/x86-64/static-initializer.cpp
  - TestCases/Windows/x86-64/trivial-atexit.c
  - TestCases/Windows/x86-64/trivial-jit-dlopen.c

The %llvm_jitlink substitution defined in compiler-rt/test/orc/lit.cfg.py passes -no-process-syms=true on Windows, which llvm-jitlink rejects when combined with -orc-runtime ("-orc-runtime requires process symbols").

Simply dropping -no-process-syms=true exposes further unresolved issues in the COFF orc-runtime support: unresolved __imp_* CRT imports (__imp___acrt_iob_func, __imp_fflush, __imp___stdio_common_vfprintf, etc.), missing __security_cookie / __security_check_cookie, and JITSymbolTable index errors when materializing the orc-runtime archive itself.

Mark these tests unsupported on Windows until the underlying orc-runtime issues are fixed, as suggested in #77996