### PR TITLE
[clang] Preload Function ODRHash in ODRDiagsEmitter::diagnoseMismatch

### DIFF
--- a/clang/lib/AST/ODRDiagsEmitter.cpp
+++ b/clang/lib/AST/ODRDiagsEmitter.cpp
@@ -890,9 +890,13 @@ bool ODRDiagsEmitter::diagnoseMismatch(
 
   auto PopulateHashes = [](DeclHashes &Hashes, const RecordDecl *Record,
                            const DeclContext *DC) {
-    for (const Decl *D : Record->decls()) {
+    for (Decl *D : Record->decls()) {
       if (!ODRHash::isSubDeclToBeProcessed(D, DC))
         continue;
+      if (auto *Function = dyn_cast<FunctionDecl>(D)) {
+        // Compute/Preload ODRHash into FunctionDecl.
+        Function->getODRHash();
+      }
       Hashes.emplace_back(D, computeODRHash(D));
     }
   };


### PR DESCRIPTION
Motivation: LLDB is crashing when importing the std module and using forward_list.

FunctionDecl has 2 getODRHash implementations: one non-const (which computes and stores the hash) and the other const (which assumes it has already been computed).

ODRHash::AddCXXRecordDecl preloads the ODR Hashes for FunctionDecls before visiting the FunctionDecl, sidestepping the assertion that it is already computed in the const method.

However, when running an expression in LLDB, the ASTReader may diagnose ODR violations as it deserializes. A given FunctionDecl may have never had its ODR Hash computed prior to diagnosing a mistmatch.

To account for this, I modified the `PopulateHashes` lambda in ODRDiagsEmitter::diagnoseMismatch to match what
ODRHash::AddCXXRecordDecl already does.