### PR TITLE
[scudo] Add unit tests for common functions

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/common_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/common_test.cpp
@@ -116,4 +116,36 @@ TEST(ScudoCommonTest, Zeros) {
   MemMap.unmap();
 }
 
+TEST(ScudoCommonTest, IsPowerOfTwo) {
+  EXPECT_FALSE(isPowerOfTwo(0));
+  EXPECT_TRUE(isPowerOfTwo(1));
+  EXPECT_TRUE(isPowerOfTwo(2));
+  EXPECT_TRUE(isPowerOfTwo(4));
+  EXPECT_FALSE(isPowerOfTwo(3));
+}
+
+TEST(ScudoCommonTest, ComputePercentage) {
+  uptr Integral, Fractional;
+  computePercentage(50, 100, &Integral, &Fractional);
+  EXPECT_EQ(Integral, 50U);
+  EXPECT_EQ(Fractional, 0U);
+
+  computePercentage(1, 3, &Integral, &Fractional);
+  EXPECT_EQ(Integral, 33U);
+  EXPECT_EQ(Fractional, 33U);
+
+  computePercentage(2, 3, &Integral, &Fractional);
+  EXPECT_EQ(Integral, 66U);
+  EXPECT_EQ(Fractional, 67U);
+
+  computePercentage(0, 0, &Integral, &Fractional);
+  EXPECT_EQ(Integral, 100U);
+  EXPECT_EQ(Fractional, 0U);
+}
+
+TEST(ScudoCommonTest, IsAlignedSlow) {
+  EXPECT_TRUE(isAlignedSlow(64, 16));
+  EXPECT_FALSE(isAlignedSlow(65, 16));
+}
+
 } // namespace scudo


### PR DESCRIPTION
This patch adds unit tests for isPowerOfTwo, computePercentage, and isAlignedSlow in common_test.cpp. These additions increase the test coverage for common.h to 100%.