### PR TITLE
[mlir][dataflow] Generalize integer-range widening into `WidenableLattice`

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
@@ -25,38 +25,30 @@ namespace mlir {
 class RewriterBase;
 namespace dataflow {
 
-/// This lattice element represents the integer value range of an SSA value.
-///
-/// `join` overrides the base behaviour to apply per-state widening: once
-/// the lattice has absorbed enough strictly-increasing merges the range is
-/// forced to its max as a sound over-approximation. This is the sole
-/// convergence guarantee for `IntegerRangeAnalysis` on loop-carried
-/// values; without it, `scf.while` loops with dynamic bounds and nested
-/// region ops can keep the solver ratcheting a loop-carried range by +1
-/// per worklist visit for up to 2^31 iterations on i32. The budget is
-/// sized to be much larger than realistic merge counts on naturally
-/// bounded accumulators (e.g. `arith.minsi`/`arith.andi`-clamped iter
-/// args) so the analysis still converges to a tight range on those.
-///
-/// Note that only the `(const AbstractSparseLattice &)` overload is
-/// overridden, so the widening fires only at framework merge sites
-/// (block-arg / region-successor / callable-arg joins) —
-/// transfer-function updates that go through the non-virtual
-/// `join(const ValueT &)` overload are unaffected.
-class IntegerValueRangeLattice : public Lattice<IntegerValueRange> {
+/// Number of strict refinements `IntegerValueRangeLattice` is allowed to
+/// absorb at framework merge sites before `WidenableLattice::join` forces
+/// the range to its max as a sound over-approximation. Sized to be much
+/// larger than realistic merge counts on naturally bounded accumulators
+/// (e.g. `arith.minsi`/`arith.andi`-clamped iter args) but still a tight
+/// ceiling on the +1 ratchet pathology this widening exists to cut off
+/// (loop-carried ranges growing by one per worklist visit on `scf.while`
+/// loops with dynamic bounds and nested region ops, which can otherwise
+/// take up to ~2^31 iterations on i32 to converge).
+inline constexpr unsigned kIntegerRangeWideningBudget = 128;
+
+/// Lattice element for `IntegerRangeAnalysis`, with a per-state widening
+/// budget supplied by `WidenableLattice` to guarantee convergence on
+/// loop-carried values. See the comment on `WidenableLattice` for the
+/// merge-path / transfer-function distinction; integer ranges' top
+/// element here is `IntegerValueRange::getMaxRange(anchor)`.
+class IntegerValueRangeLattice
+    : public WidenableLattice<IntegerValueRange, kIntegerRangeWideningBudget> {
 public:
-  using Lattice::Lattice;
-  // The override below would otherwise hide the inherited
-  // `join(const ValueT &)` overload that callers (e.g. transfer functions)
-  // rely on for direct-value joins.
-  using Lattice::join;
+  using WidenableLattice::WidenableLattice;
 
-  ChangeResult join(const AbstractSparseLattice &rhs) override;
-
-private:
-  /// Per-state merge-site change counter. Drives the widening budget in
-  /// `join`.
-  unsigned mergeChangeCount = 0;
+  IntegerValueRange getWidenedValue() const override {
+    return IntegerValueRange::getMaxRange(cast<Value>(getAnchor()));
+  }
 };
 
 /// Integer range analysis determines the integer value range of SSA values

--- a/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/SparseAnalysis.h
@@ -168,6 +168,66 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
+// WidenableLattice
+//===----------------------------------------------------------------------===//
+
+/// A `Lattice<ValueT>` whose virtual `join` overload at framework merge
+/// sites is bounded by a per-state widening budget, guaranteeing
+/// termination on infinite-height value lattices that don't carry their
+/// own widening operator (integer ranges, constant intervals, ...).
+///
+/// Sparse data-flow analyses propagate lattices in two ways:
+///   * Through the analysis's transfer-function callback, which calls
+///     the *non-virtual* `join(const ValueT &)` overload directly. This
+///     path is unaffected by the widening, preserving precision on
+///     straight-line code.
+///   * At framework merge sites (block-arg / region-successor /
+///     callable-arg joins), where `SparseForwardDataFlowAnalysis::join`
+///     dispatches through the *virtual*
+///     `join(const AbstractSparseLattice &)` overload. After this state
+///     has absorbed `Budget` strict refinements on the merge path, the
+///     next merge forces the value to a derived-supplied
+///     `getWidenedValue()` (typically the lattice's top element).
+///
+/// Derived classes must override `getWidenedValue()`. `Budget` should be
+/// chosen large enough that naturally bounded loop-carried values
+/// converge to a tight fixpoint, but small enough to cut off unbounded
+/// `+1`-style ratchets in a small multiple of the lattice's logical
+/// height.
+///
+/// Note: only `join` is intercepted; `meet` is left unchanged. Backward
+/// analyses requiring a budget on `meet` should subclass `Lattice`
+/// directly with a dual (bottom-element) widening hook.
+template <typename ValueT, unsigned Budget>
+class WidenableLattice : public Lattice<ValueT> {
+public:
+  using Lattice<ValueT>::Lattice;
+  // Bring the inherited non-virtual `join(const ValueT &)` overload into
+  // scope; the virtual override below would otherwise hide it for
+  // direct-value joins from transfer functions.
+  using Lattice<ValueT>::join;
+
+  /// Returns the value this lattice is widened to once the merge budget
+  /// is exhausted. Typically the top element of the value lattice
+  /// (e.g. `IntegerValueRange::getMaxRange(getAnchor())`).
+  virtual ValueT getWidenedValue() const = 0;
+
+  ChangeResult join(const AbstractSparseLattice &rhs) override {
+    ChangeResult changed = Lattice<ValueT>::join(rhs);
+    if (mergeChangeCount >= Budget)
+      return changed | Lattice<ValueT>::join(getWidenedValue());
+    if (changed == ChangeResult::Change)
+      ++mergeChangeCount;
+    return changed;
+  }
+
+private:
+  /// Number of strict refinements absorbed via the virtual
+  /// `join(const AbstractSparseLattice &)` overload.
+  unsigned mergeChangeCount = 0;
+};
+
+//===----------------------------------------------------------------------===//
 // AbstractSparseForwardDataFlowAnalysis
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -58,29 +58,6 @@ LogicalResult staticallyNonNegative(DataFlowSolver &solver, Operation *op) {
 }
 } // namespace mlir::dataflow
 
-/// Number of merge-site joins a single integer-range lattice element is
-/// allowed to absorb before `IntegerValueRangeLattice::join` forces it to
-/// its max as a sound over-approximation.
-///
-/// Trade-off: high enough that realistic loops with dynamic bounds (which
-/// typically converge to a tight range in a small number of merge
-/// iterations) are not widened prematurely; low enough that the +1
-/// ratchet pathology this widening exists to cut off (loop-carried ranges
-/// growing by one per worklist visit) terminates after at most this many
-/// extra solver iterations rather than ~2^31.
-static constexpr unsigned kIntegerRangeWideningBudget = 128;
-
-ChangeResult IntegerValueRangeLattice::join(const AbstractSparseLattice &rhs) {
-  ChangeResult changed = Lattice::join(rhs);
-  if (mergeChangeCount >= kIntegerRangeWideningBudget) {
-    return changed | Lattice::join(IntegerValueRange::getMaxRange(
-                         cast<Value>(getAnchor())));
-  }
-  if (changed == ChangeResult::Change)
-    ++mergeChangeCount;
-  return changed;
-}
-
 LogicalResult IntegerRangeAnalysis::visitOperation(
     Operation *op, ArrayRef<const IntegerValueRangeLattice *> operands,
     ArrayRef<IntegerValueRangeLattice *> results) {


### PR DESCRIPTION
Kind of follow up to the https://github.com/llvm/llvm-project/pull/196616

Try to generalize widening to the core dataflow infra. Add `WidenableLattice` class which takes budget as template param.

I'm not entirely bought this is required to be in core as implementing widening directly is trivial so it's more of design question PR.