### PR TITLE
[AsmParser] Use cantFail for FloatLiteral string conversion

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4162,8 +4162,6 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     if (!ExpectedTy->isFloatingPointTy())
       return error(ID.Loc, "floating-point constant invalid for type");
     ID.APFloatVal = APFloat(ExpectedTy->getFltSemantics());
-    // The lexer is responsible for rejecting malformed floating-point
-    // literals, so any conversion failure here is a programmer bug.
     APFloat::opStatus Except =
         cantFail(ID.APFloatVal.convertFromString(
                      Lex.getStrVal(), RoundingMode::NearestTiesToEven),

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4164,10 +4164,10 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     ID.APFloatVal = APFloat(ExpectedTy->getFltSemantics());
     // The lexer is responsible for rejecting malformed floating-point
     // literals, so any conversion failure here is a programmer bug.
-    APFloat::opStatus Except = cantFail(
-        ID.APFloatVal.convertFromString(Lex.getStrVal(),
-                                        RoundingMode::NearestTiesToEven),
-        "Invalid float strings should be caught by the lexer");
+    APFloat::opStatus Except =
+        cantFail(ID.APFloatVal.convertFromString(
+                     Lex.getStrVal(), RoundingMode::NearestTiesToEven),
+                 "Invalid float strings should be caught by the lexer");
     // Forbid overflowing and underflowing literals, but permit inexact
     // literals. Underflow is thrown when the result is denormal, so to allow
     // denormals, only reject underflowing literals that resulted in a zero.

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4162,15 +4162,18 @@ bool LLParser::parseValID(ValID &ID, PerFunctionState *PFS, Type *ExpectedTy) {
     if (!ExpectedTy->isFloatingPointTy())
       return error(ID.Loc, "floating-point constant invalid for type");
     ID.APFloatVal = APFloat(ExpectedTy->getFltSemantics());
-    auto Except = ID.APFloatVal.convertFromString(
-        Lex.getStrVal(), RoundingMode::NearestTiesToEven);
-    assert(Except && "Invalid float strings should be caught by the lexer");
+    // The lexer is responsible for rejecting malformed floating-point
+    // literals, so any conversion failure here is a programmer bug.
+    APFloat::opStatus Except = cantFail(
+        ID.APFloatVal.convertFromString(Lex.getStrVal(),
+                                        RoundingMode::NearestTiesToEven),
+        "Invalid float strings should be caught by the lexer");
     // Forbid overflowing and underflowing literals, but permit inexact
     // literals. Underflow is thrown when the result is denormal, so to allow
     // denormals, only reject underflowing literals that resulted in a zero.
-    if (*Except & APFloat::opOverflow)
+    if (Except & APFloat::opOverflow)
       return error(ID.Loc, "floating-point constant overflowed type");
-    if ((*Except & APFloat::opUnderflow) && ID.APFloatVal.isZero())
+    if ((Except & APFloat::opUnderflow) && ID.APFloatVal.isZero())
       return error(ID.Loc, "floating-point constant underflowed type");
     ID.Kind = ValID::t_APFloat;
     break;


### PR DESCRIPTION
With assertions disabled but `LLVM_ABI_BREAKING_CHECKS=FORCE_ON`, the `assert` was elided, the Expected stayed unchecked, and the subsequent `*Except` tripped `fatalUncheckedError`. Fix this by switching to `cantFail`.

Assisted-by: Claude Opus