### PR TITLE
[AMDGPU][MIRFormatter] Human-readable mask for S_WAITCNT_soft

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUMIRFormatter.cpp
@@ -91,6 +91,7 @@ void AMDGPUMIRFormatter::printImm(raw_ostream &OS, const MachineInstr &MI,
 
   switch (MI.getOpcode()) {
   case AMDGPU::S_WAITCNT:
+  case AMDGPU::S_WAITCNT_soft:
     printSWaitcntImm(Imm, OS);
     break;
   case AMDGPU::S_WAITCNT_DEPCTR:
@@ -116,6 +117,7 @@ bool AMDGPUMIRFormatter::parseImmMnemonic(const unsigned OpCode,
 
   switch (OpCode) {
   case AMDGPU::S_WAITCNT:
+  case AMDGPU::S_WAITCNT_soft:
     return parseSWaitcntImmMnemonic(OpIdx, Imm, Src, ErrorCallback);
   case AMDGPU::S_WAITCNT_DEPCTR:
     return parseSWaitAluImmMnemonic(OpIdx, Imm, Src, ErrorCallback);

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/memory-legalizer-atomic-fence.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/memory-legalizer-atomic-fence.ll
@@ -13,19 +13,19 @@
 define amdgpu_kernel void @system_one_as_acquire() #0 {
   ; GFX6-LABEL: name: system_one_as_acquire
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_one_as_acquire
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_one_as_acquire
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -33,7 +33,7 @@ define amdgpu_kernel void @system_one_as_acquire() #0 {
   ;
   ; GFX10CU-LABEL: name: system_one_as_acquire
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -41,7 +41,7 @@ define amdgpu_kernel void @system_one_as_acquire() #0 {
   ;
   ; GFX11WGP-LABEL: name: system_one_as_acquire
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -49,7 +49,7 @@ define amdgpu_kernel void @system_one_as_acquire() #0 {
   ;
   ; GFX11CU-LABEL: name: system_one_as_acquire
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -62,35 +62,35 @@ entry:
 define amdgpu_kernel void @system_one_as_release() #0 {
   ; GFX6-LABEL: name: system_one_as_release
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_one_as_release
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_one_as_release
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: system_one_as_release
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: system_one_as_release
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: system_one_as_release
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -101,19 +101,19 @@ entry:
 define amdgpu_kernel void @system_one_as_acq_rel() #0 {
   ; GFX6-LABEL: name: system_one_as_acq_rel
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_one_as_acq_rel
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_one_as_acq_rel
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -121,7 +121,7 @@ define amdgpu_kernel void @system_one_as_acq_rel() #0 {
   ;
   ; GFX10CU-LABEL: name: system_one_as_acq_rel
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -129,7 +129,7 @@ define amdgpu_kernel void @system_one_as_acq_rel() #0 {
   ;
   ; GFX11WGP-LABEL: name: system_one_as_acq_rel
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -137,7 +137,7 @@ define amdgpu_kernel void @system_one_as_acq_rel() #0 {
   ;
   ; GFX11CU-LABEL: name: system_one_as_acq_rel
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -150,19 +150,19 @@ entry:
 define amdgpu_kernel void @system_one_as_seq_cst() #0 {
   ; GFX6-LABEL: name: system_one_as_seq_cst
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_one_as_seq_cst
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_one_as_seq_cst
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -170,7 +170,7 @@ define amdgpu_kernel void @system_one_as_seq_cst() #0 {
   ;
   ; GFX10CU-LABEL: name: system_one_as_seq_cst
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -178,7 +178,7 @@ define amdgpu_kernel void @system_one_as_seq_cst() #0 {
   ;
   ; GFX11WGP-LABEL: name: system_one_as_seq_cst
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -186,7 +186,7 @@ define amdgpu_kernel void @system_one_as_seq_cst() #0 {
   ;
   ; GFX11CU-LABEL: name: system_one_as_seq_cst
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -315,19 +315,19 @@ entry:
 define amdgpu_kernel void @agent_one_as_acquire() #0 {
   ; GFX6-LABEL: name: agent_one_as_acquire
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_one_as_acquire
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_one_as_acquire
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -335,7 +335,7 @@ define amdgpu_kernel void @agent_one_as_acquire() #0 {
   ;
   ; GFX10CU-LABEL: name: agent_one_as_acquire
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -343,7 +343,7 @@ define amdgpu_kernel void @agent_one_as_acquire() #0 {
   ;
   ; GFX11WGP-LABEL: name: agent_one_as_acquire
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -351,7 +351,7 @@ define amdgpu_kernel void @agent_one_as_acquire() #0 {
   ;
   ; GFX11CU-LABEL: name: agent_one_as_acquire
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -364,35 +364,35 @@ entry:
 define amdgpu_kernel void @agent_one_as_release() #0 {
   ; GFX6-LABEL: name: agent_one_as_release
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_one_as_release
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_one_as_release
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: agent_one_as_release
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: agent_one_as_release
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: agent_one_as_release
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -403,19 +403,19 @@ entry:
 define amdgpu_kernel void @agent_one_as_acq_rel() #0 {
   ; GFX6-LABEL: name: agent_one_as_acq_rel
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_one_as_acq_rel
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_one_as_acq_rel
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -423,7 +423,7 @@ define amdgpu_kernel void @agent_one_as_acq_rel() #0 {
   ;
   ; GFX10CU-LABEL: name: agent_one_as_acq_rel
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -431,7 +431,7 @@ define amdgpu_kernel void @agent_one_as_acq_rel() #0 {
   ;
   ; GFX11WGP-LABEL: name: agent_one_as_acq_rel
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -439,7 +439,7 @@ define amdgpu_kernel void @agent_one_as_acq_rel() #0 {
   ;
   ; GFX11CU-LABEL: name: agent_one_as_acq_rel
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -452,19 +452,19 @@ entry:
 define amdgpu_kernel void @agent_one_as_seq_cst() #0 {
   ; GFX6-LABEL: name: agent_one_as_seq_cst
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 3952
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_one_as_seq_cst
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 3952
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_one_as_seq_cst
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -472,7 +472,7 @@ define amdgpu_kernel void @agent_one_as_seq_cst() #0 {
   ;
   ; GFX10CU-LABEL: name: agent_one_as_seq_cst
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -480,7 +480,7 @@ define amdgpu_kernel void @agent_one_as_seq_cst() #0 {
   ;
   ; GFX11WGP-LABEL: name: agent_one_as_seq_cst
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -488,7 +488,7 @@ define amdgpu_kernel void @agent_one_as_seq_cst() #0 {
   ;
   ; GFX11CU-LABEL: name: agent_one_as_seq_cst
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -509,7 +509,7 @@ define amdgpu_kernel void @workgroup_one_as_acquire() #0 {
   ;
   ; GFX10WGP-LABEL: name: workgroup_one_as_acquire
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10WGP-NEXT:   S_ENDPGM 0
@@ -520,7 +520,7 @@ define amdgpu_kernel void @workgroup_one_as_acquire() #0 {
   ;
   ; GFX11WGP-LABEL: name: workgroup_one_as_acquire
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX11WGP-NEXT:   S_ENDPGM 0
@@ -544,27 +544,27 @@ define amdgpu_kernel void @workgroup_one_as_release() #0 {
   ;
   ; GFX10WGP-LABEL: name: workgroup_one_as_release
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_lds_direct
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: workgroup_one_as_release
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_lds_direct
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_one_as_release
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_one_as_release
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -583,7 +583,7 @@ define amdgpu_kernel void @workgroup_one_as_acq_rel() #0 {
   ;
   ; GFX10WGP-LABEL: name: workgroup_one_as_acq_rel
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_lds_direct
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -591,21 +591,21 @@ define amdgpu_kernel void @workgroup_one_as_acq_rel() #0 {
   ;
   ; GFX10CU-LABEL: name: workgroup_one_as_acq_rel
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_lds_direct
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_one_as_acq_rel
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_one_as_acq_rel
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -624,7 +624,7 @@ define amdgpu_kernel void @workgroup_one_as_seq_cst() #0 {
   ;
   ; GFX10WGP-LABEL: name: workgroup_one_as_seq_cst
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_lds_direct
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -632,21 +632,21 @@ define amdgpu_kernel void @workgroup_one_as_seq_cst() #0 {
   ;
   ; GFX10CU-LABEL: name: workgroup_one_as_seq_cst
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_lds_direct
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_one_as_seq_cst
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_one_as_seq_cst
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 1015
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -773,19 +773,19 @@ entry:
 define amdgpu_kernel void @system_acquire() #0 {
   ; GFX6-LABEL: name: system_acquire
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_acquire
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_acquire
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -793,7 +793,7 @@ define amdgpu_kernel void @system_acquire() #0 {
   ;
   ; GFX10CU-LABEL: name: system_acquire
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -801,7 +801,7 @@ define amdgpu_kernel void @system_acquire() #0 {
   ;
   ; GFX11WGP-LABEL: name: system_acquire
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -809,7 +809,7 @@ define amdgpu_kernel void @system_acquire() #0 {
   ;
   ; GFX11CU-LABEL: name: system_acquire
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -822,35 +822,35 @@ entry:
 define amdgpu_kernel void @system_release() #0 {
   ; GFX6-LABEL: name: system_release
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_release
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_release
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: system_release
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: system_release
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: system_release
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -861,19 +861,19 @@ entry:
 define amdgpu_kernel void @system_acq_rel() #0 {
   ; GFX6-LABEL: name: system_acq_rel
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_acq_rel
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_acq_rel
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -881,7 +881,7 @@ define amdgpu_kernel void @system_acq_rel() #0 {
   ;
   ; GFX10CU-LABEL: name: system_acq_rel
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -889,7 +889,7 @@ define amdgpu_kernel void @system_acq_rel() #0 {
   ;
   ; GFX11WGP-LABEL: name: system_acq_rel
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -897,7 +897,7 @@ define amdgpu_kernel void @system_acq_rel() #0 {
   ;
   ; GFX11CU-LABEL: name: system_acq_rel
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -910,19 +910,19 @@ entry:
 define amdgpu_kernel void @system_seq_cst() #0 {
   ; GFX6-LABEL: name: system_seq_cst
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: system_seq_cst
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: system_seq_cst
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -930,7 +930,7 @@ define amdgpu_kernel void @system_seq_cst() #0 {
   ;
   ; GFX10CU-LABEL: name: system_seq_cst
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -938,7 +938,7 @@ define amdgpu_kernel void @system_seq_cst() #0 {
   ;
   ; GFX11WGP-LABEL: name: system_seq_cst
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -946,7 +946,7 @@ define amdgpu_kernel void @system_seq_cst() #0 {
   ;
   ; GFX11CU-LABEL: name: system_seq_cst
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1075,19 +1075,19 @@ entry:
 define amdgpu_kernel void @agent_acquire() #0 {
   ; GFX6-LABEL: name: agent_acquire
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_acquire
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_acquire
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1095,7 +1095,7 @@ define amdgpu_kernel void @agent_acquire() #0 {
   ;
   ; GFX10CU-LABEL: name: agent_acquire
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1103,7 +1103,7 @@ define amdgpu_kernel void @agent_acquire() #0 {
   ;
   ; GFX11WGP-LABEL: name: agent_acquire
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1111,7 +1111,7 @@ define amdgpu_kernel void @agent_acquire() #0 {
   ;
   ; GFX11CU-LABEL: name: agent_acquire
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1124,35 +1124,35 @@ entry:
 define amdgpu_kernel void @agent_release() #0 {
   ; GFX6-LABEL: name: agent_release
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_release
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_release
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: agent_release
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: agent_release
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: agent_release
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -1163,19 +1163,19 @@ entry:
 define amdgpu_kernel void @agent_acq_rel() #0 {
   ; GFX6-LABEL: name: agent_acq_rel
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_acq_rel
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_acq_rel
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1183,7 +1183,7 @@ define amdgpu_kernel void @agent_acq_rel() #0 {
   ;
   ; GFX10CU-LABEL: name: agent_acq_rel
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1191,7 +1191,7 @@ define amdgpu_kernel void @agent_acq_rel() #0 {
   ;
   ; GFX11WGP-LABEL: name: agent_acq_rel
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1199,7 +1199,7 @@ define amdgpu_kernel void @agent_acq_rel() #0 {
   ;
   ; GFX11CU-LABEL: name: agent_acq_rel
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1212,19 +1212,19 @@ entry:
 define amdgpu_kernel void @agent_seq_cst() #0 {
   ; GFX6-LABEL: name: agent_seq_cst
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 112
+  ; GFX6-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX6-NEXT:   BUFFER_WBINVL1 implicit $exec
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: agent_seq_cst
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 112
+  ; GFX8-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX8-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: agent_seq_cst
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1232,7 +1232,7 @@ define amdgpu_kernel void @agent_seq_cst() #0 {
   ;
   ; GFX10CU-LABEL: name: agent_seq_cst
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX10CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1240,7 +1240,7 @@ define amdgpu_kernel void @agent_seq_cst() #0 {
   ;
   ; GFX11WGP-LABEL: name: agent_seq_cst
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1248,7 +1248,7 @@ define amdgpu_kernel void @agent_seq_cst() #0 {
   ;
   ; GFX11CU-LABEL: name: agent_seq_cst
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   BUFFER_GL1_INV implicit $exec
   ; GFX11CU-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1261,36 +1261,36 @@ entry:
 define amdgpu_kernel void @workgroup_acquire() #0 {
   ; GFX6-LABEL: name: workgroup_acquire
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 127
+  ; GFX6-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: workgroup_acquire
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 127
+  ; GFX8-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: workgroup_acquire
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: workgroup_acquire
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 49279
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_acquire
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_acquire
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 64519
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
   fence syncscope("workgroup") acquire
@@ -1300,37 +1300,37 @@ entry:
 define amdgpu_kernel void @workgroup_release() #0 {
   ; GFX6-LABEL: name: workgroup_release
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 127
+  ; GFX6-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: workgroup_release
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 127
+  ; GFX8-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: workgroup_release
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_lds_direct
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX10CU-LABEL: name: workgroup_release
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_lds_direct
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_release
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_release
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -1341,17 +1341,17 @@ entry:
 define amdgpu_kernel void @workgroup_acq_rel() #0 {
   ; GFX6-LABEL: name: workgroup_acq_rel
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 127
+  ; GFX6-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: workgroup_acq_rel
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 127
+  ; GFX8-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: workgroup_acq_rel
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_lds_direct
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1359,21 +1359,21 @@ define amdgpu_kernel void @workgroup_acq_rel() #0 {
   ;
   ; GFX10CU-LABEL: name: workgroup_acq_rel
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_lds_direct
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_acq_rel
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_acq_rel
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:
@@ -1384,17 +1384,17 @@ entry:
 define amdgpu_kernel void @workgroup_seq_cst() #0 {
   ; GFX6-LABEL: name: workgroup_seq_cst
   ; GFX6: bb.0.entry:
-  ; GFX6-NEXT:   S_WAITCNT_soft 127
+  ; GFX6-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX6-NEXT:   S_ENDPGM 0
   ;
   ; GFX8-LABEL: name: workgroup_seq_cst
   ; GFX8: bb.0.entry:
-  ; GFX8-NEXT:   S_WAITCNT_soft 127
+  ; GFX8-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX8-NEXT:   S_ENDPGM 0
   ;
   ; GFX10WGP-LABEL: name: workgroup_seq_cst
   ; GFX10WGP: bb.0.entry:
-  ; GFX10WGP-NEXT:   S_WAITCNT_soft 112
+  ; GFX10WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10WGP-NEXT:   S_WAITCNT_lds_direct
   ; GFX10WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10WGP-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -1402,21 +1402,21 @@ define amdgpu_kernel void @workgroup_seq_cst() #0 {
   ;
   ; GFX10CU-LABEL: name: workgroup_seq_cst
   ; GFX10CU: bb.0.entry:
-  ; GFX10CU-NEXT:   S_WAITCNT_soft 112
+  ; GFX10CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10CU-NEXT:   S_WAITCNT_lds_direct
   ; GFX10CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10CU-NEXT:   S_ENDPGM 0
   ;
   ; GFX11WGP-LABEL: name: workgroup_seq_cst
   ; GFX11WGP: bb.0.entry:
-  ; GFX11WGP-NEXT:   S_WAITCNT_soft 7
+  ; GFX11WGP-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11WGP-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11WGP-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX11WGP-NEXT:   S_ENDPGM 0
   ;
   ; GFX11CU-LABEL: name: workgroup_seq_cst
   ; GFX11CU: bb.0.entry:
-  ; GFX11CU-NEXT:   S_WAITCNT_soft 7
+  ; GFX11CU-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX11CU-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX11CU-NEXT:   S_ENDPGM 0
 entry:

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-atomic-insert-end.mir
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-atomic-insert-end.mir
@@ -79,7 +79,7 @@ body:             |
   ; CHECK-NEXT:   $sgpr6 = S_MOV_B32 0
   ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   $vgpr1_vgpr2 = BUFFER_LOAD_DWORDX2_ADDR64 killed $vgpr1_vgpr2, $sgpr4_sgpr5_sgpr6_sgpr7, 0, 0, 1, 0, implicit $exec :: (volatile load (s64) from %ir.tid.gep, addrspace 1)
-  ; CHECK-NEXT:   S_WAITCNT_soft 3952
+  ; CHECK-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; CHECK-NEXT:   $vgpr0 = V_XOR_B32_e32 1, killed $vgpr0, implicit $exec
   ; CHECK-NEXT:   V_CMP_NE_U32_e32 0, killed $vgpr0, implicit-def $vcc, implicit $exec
   ; CHECK-NEXT:   $sgpr2_sgpr3 = S_AND_SAVEEXEC_B64 killed $vcc, implicit-def $exec, implicit-def $scc, implicit $exec
@@ -97,9 +97,9 @@ body:             |
   ; CHECK-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; CHECK-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
   ; CHECK-NEXT:   S_WAITCNT .Vmcnt_0
-  ; CHECK-NEXT:   S_WAITCNT_soft 3952
+  ; CHECK-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; CHECK-NEXT:   BUFFER_ATOMIC_SMAX_ADDR64 killed $vgpr0, killed $vgpr1_vgpr2, killed $sgpr4_sgpr5_sgpr6_sgpr7, 0, 400, 0, implicit $exec :: (volatile load syncscope("one-as") seq_cst (s32) from %ir.gep, addrspace 1)
-  ; CHECK-NEXT:   S_WAITCNT_soft 3952
+  ; CHECK-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; CHECK-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.exit:

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-multiple-mem-operands-atomics.mir
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-multiple-mem-operands-atomics.mir
@@ -51,9 +51,9 @@ body:             |
   ; GCN-NEXT:   S_WAITCNT .Lgkmcnt_0
   ; GCN-NEXT:   $sgpr0 = S_LSHL_B32 killed $sgpr0, 2, implicit-def dead $scc
   ; GCN-NEXT:   $vgpr0 = V_ADD_CO_U32_e32 killed $sgpr0, killed $vgpr0, implicit-def dead $vcc, implicit $exec
-  ; GCN-NEXT:   S_WAITCNT_soft 3952
+  ; GCN-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GCN-NEXT:   $vgpr0 = BUFFER_LOAD_DWORD_OFFEN killed $vgpr0, killed $sgpr8_sgpr9_sgpr10_sgpr11, $sgpr3, 0, 1, 0, implicit $exec :: (load syncscope("agent-one-as") unordered (s32) from `ptr addrspace(1) poison`, addrspace 1), (load syncscope("workgroup-one-as") seq_cst (s32) from `ptr addrspace(5) poison`, addrspace 5)
-  ; GCN-NEXT:   S_WAITCNT_soft 3952
+  ; GCN-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GCN-NEXT:   BUFFER_WBINVL1_VOL implicit $exec
   ; GCN-NEXT:   $vgpr1 = V_MOV_B32_e32 $sgpr4, implicit $exec, implicit-def $vgpr1_vgpr2, implicit $sgpr4_sgpr5
   ; GCN-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr5, implicit $exec, implicit $sgpr4_sgpr5, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/memory-legalizer-single-wave-workgroup-memops.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory-legalizer-single-wave-workgroup-memops.ll
@@ -44,7 +44,7 @@ define amdgpu_kernel void @wg_fence_acq_rel_single64() #1 {
   ;
   ; GFX10-W32-LABEL: name: wg_fence_acq_rel_single64
   ; GFX10-W32: bb.0 (%ir-block.0):
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -82,19 +82,19 @@ define amdgpu_kernel void @wg_fence_acq_rel_single64() #1 {
 define amdgpu_kernel void @wg_fence_acq_rel_multi() #2 {
   ; GFX9-LABEL: name: wg_fence_acq_rel_multi
   ; GFX9: bb.0 (%ir-block.0):
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   S_ENDPGM 0
   ;
   ; GFX942-LABEL: name: wg_fence_acq_rel_multi
   ; GFX942: bb.0 (%ir-block.0):
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   S_ENDPGM 0
   ;
   ; GFX10-LABEL: name: wg_fence_acq_rel_multi
   ; GFX10: bb.0 (%ir-block.0):
-  ; GFX10-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -132,7 +132,7 @@ define amdgpu_kernel void @wg_fence_acquire_single64() #1 {
   ;
   ; GFX10-W32-LABEL: name: wg_fence_acquire_single64
   ; GFX10-W32: bb.0 (%ir-block.0):
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
@@ -175,7 +175,7 @@ define amdgpu_kernel void @wg_fence_release_single64() #1 {
   ;
   ; GFX10-W32-LABEL: name: wg_fence_release_single64
   ; GFX10-W32: bb.0 (%ir-block.0):
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   S_ENDPGM 0
@@ -219,7 +219,7 @@ define amdgpu_kernel void @wg_fence_seq_cst_single64() #1 {
   ;
   ; GFX10-W32-LABEL: name: wg_fence_seq_cst_single64
   ; GFX10-W32: bb.0 (%ir-block.0):
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
@@ -329,11 +329,11 @@ define amdgpu_kernel void @wg_ld_seq_cst_single64(ptr addrspace(1) %p) #1 {
   ; GFX10-W32-NEXT: {{  $}}
   ; GFX10-W32-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   dead renamable $vgpr0 = GLOBAL_LOAD_DWORD_SADDR killed renamable $sgpr0_sgpr1, killed renamable $vgpr0, 0, 1, implicit $exec :: ("amdgpu-noclobber" load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 1)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
   ;
@@ -395,7 +395,7 @@ define amdgpu_kernel void @wg_ld_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX9-NEXT: {{  $}}
   ; GFX9-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX9-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   dead renamable $vgpr0 = GLOBAL_LOAD_DWORD_SADDR killed renamable $sgpr0_sgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: ("amdgpu-noclobber" load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 1)
   ; GFX9-NEXT:   S_ENDPGM 0
@@ -406,7 +406,7 @@ define amdgpu_kernel void @wg_ld_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX942-NEXT: {{  $}}
   ; GFX942-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX942-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   dead renamable $vgpr0 = GLOBAL_LOAD_DWORD_SADDR killed renamable $sgpr0_sgpr1, killed renamable $vgpr0, 0, 1, implicit $exec :: ("amdgpu-noclobber" load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 1)
   ; GFX942-NEXT:   S_ENDPGM 0
@@ -417,11 +417,11 @@ define amdgpu_kernel void @wg_ld_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX10-NEXT: {{  $}}
   ; GFX10-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
-  ; GFX10-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-NEXT:   dead renamable $vgpr0 = GLOBAL_LOAD_DWORD_SADDR killed renamable $sgpr0_sgpr1, killed renamable $vgpr0, 0, 1, implicit $exec :: ("amdgpu-noclobber" load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 1)
-  ; GFX10-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-NEXT:   S_ENDPGM 0
   ;
@@ -484,7 +484,7 @@ define amdgpu_kernel void @wg_ld_acquire_single64(ptr addrspace(1) %p) #1 {
   ; GFX10-W32-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   dead renamable $vgpr0 = GLOBAL_LOAD_DWORD_SADDR killed renamable $sgpr0_sgpr1, killed renamable $vgpr0, 0, 1, implicit $exec :: ("amdgpu-noclobber" load syncscope("workgroup") acquire (s32) from %ir.p.load, addrspace 1)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 16240
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
   ;
@@ -679,7 +679,7 @@ define amdgpu_kernel void @wg_st_seq_cst_single64(ptr addrspace(1) %p, i32 %x) #
   ; GFX10-W32-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load, addrspace 1)
@@ -746,7 +746,7 @@ define amdgpu_kernel void @wg_st_seq_cst_multi(ptr addrspace(1) %p, i32 %x) #2 {
   ; GFX9-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX9-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX9-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load, addrspace 1)
   ; GFX9-NEXT:   S_ENDPGM 0
@@ -759,7 +759,7 @@ define amdgpu_kernel void @wg_st_seq_cst_multi(ptr addrspace(1) %p, i32 %x) #2 {
   ; GFX942-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX942-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX942-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr0_sgpr1, 0, 1, implicit $exec :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load, addrspace 1)
   ; GFX942-NEXT:   S_ENDPGM 0
@@ -772,7 +772,7 @@ define amdgpu_kernel void @wg_st_seq_cst_multi(ptr addrspace(1) %p, i32 %x) #2 {
   ; GFX10-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load, addrspace 1)
@@ -855,7 +855,7 @@ define amdgpu_kernel void @wg_st_release_single64(ptr addrspace(1) %p, i32 %x) #
   ; GFX10-W32-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   GLOBAL_STORE_DWORD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (store syncscope("workgroup") release (s32) into %ir.p.load, addrspace 1)
@@ -1169,7 +1169,7 @@ define amdgpu_kernel void @wg_rmw_add_seq_cst_single64(ptr addrspace(1) %p) #1 {
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   renamable $sgpr0 = S_MUL_I32 killed renamable $sgpr0, 7
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   GLOBAL_ATOMIC_ADD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr2_sgpr3, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst (s32) on %ir.p.load, addrspace 1)
@@ -1317,7 +1317,7 @@ define amdgpu_kernel void @wg_rmw_add_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX9-NEXT:   renamable $sgpr0 = S_MUL_I32 killed renamable $sgpr0, 7
   ; GFX9-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX9-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   GLOBAL_ATOMIC_ADD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr2_sgpr3, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst (s32) on %ir.p.load, addrspace 1)
   ; GFX9-NEXT: {{  $}}
@@ -1345,7 +1345,7 @@ define amdgpu_kernel void @wg_rmw_add_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX942-NEXT:   renamable $sgpr0 = S_MUL_I32 killed renamable $sgpr0, 7
   ; GFX942-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX942-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   GLOBAL_ATOMIC_ADD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr2_sgpr3, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst (s32) on %ir.p.load, addrspace 1)
   ; GFX942-NEXT: {{  $}}
@@ -1372,7 +1372,7 @@ define amdgpu_kernel void @wg_rmw_add_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   renamable $sgpr0 = S_MUL_I32 killed renamable $sgpr0, 7
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   GLOBAL_ATOMIC_ADD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr2_sgpr3, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst (s32) on %ir.p.load, addrspace 1)
@@ -1403,7 +1403,7 @@ define amdgpu_kernel void @wg_rmw_add_seq_cst_multi(ptr addrspace(1) %p) #2 {
   ; GFX10-W64-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W64-NEXT:   renamable $sgpr0 = S_MUL_I32 killed renamable $sgpr0, 7
   ; GFX10-W64-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX10-W64-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W64-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W64-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W64-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W64-NEXT:   GLOBAL_ATOMIC_ADD_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr2_sgpr3, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst (s32) on %ir.p.load, addrspace 1)
@@ -1541,7 +1541,7 @@ define amdgpu_kernel void @wg_rmw_xchg_acq_rel_single64(ptr addrspace(1) %p, i32
   ; GFX10-W32-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-W32-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   GLOBAL_ATOMIC_SWAP_SADDR killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (load store syncscope("workgroup") acq_rel (s32) on %ir.p.load, addrspace 1)
@@ -1635,7 +1635,7 @@ define amdgpu_kernel void @wg_cmpxchg_acq_rel_monotonic_single64(ptr addrspace(1
   ; GFX10-W32-NEXT:   renamable $vgpr2 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr3, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   GLOBAL_ATOMIC_CMPSWAP_SADDR killed renamable $vgpr2, killed renamable $vgpr0_vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (load store syncscope("workgroup") acq_rel monotonic (s32) on %ir.p.load, addrspace 1)
@@ -1710,7 +1710,7 @@ define amdgpu_kernel void @wg_cmpxchg_seq_cst_seq_cst_multi(ptr addrspace(1) %p,
   ; GFX9-NEXT:   renamable $vgpr2 = V_MOV_B32_e32 0, implicit $exec
   ; GFX9-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr3, implicit $exec, implicit $exec
   ; GFX9-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   GLOBAL_ATOMIC_CMPSWAP_SADDR killed renamable $vgpr2, killed renamable $vgpr0_vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst seq_cst (s32) on %ir.p.load, addrspace 1)
   ; GFX9-NEXT:   S_ENDPGM 0
@@ -1723,7 +1723,7 @@ define amdgpu_kernel void @wg_cmpxchg_seq_cst_seq_cst_multi(ptr addrspace(1) %p,
   ; GFX942-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
   ; GFX942-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr3, implicit $exec, implicit $exec
   ; GFX942-NEXT:   $vgpr3 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   GLOBAL_ATOMIC_CMPSWAP_SADDR killed renamable $vgpr0, killed renamable $vgpr2_vgpr3, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst seq_cst (s32) on %ir.p.load, addrspace 1)
   ; GFX942-NEXT:   S_ENDPGM 0
@@ -1736,7 +1736,7 @@ define amdgpu_kernel void @wg_cmpxchg_seq_cst_seq_cst_multi(ptr addrspace(1) %p,
   ; GFX10-NEXT:   renamable $vgpr2 = V_MOV_B32_e32 0, implicit $exec
   ; GFX10-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr3, implicit $exec, implicit $exec
   ; GFX10-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-NEXT:   GLOBAL_ATOMIC_CMPSWAP_SADDR killed renamable $vgpr2, killed renamable $vgpr0_vgpr1, killed renamable $sgpr0_sgpr1, 0, 0, implicit $exec :: (load store syncscope("workgroup") seq_cst seq_cst (s32) on %ir.p.load, addrspace 1)
@@ -1959,11 +1959,11 @@ define amdgpu_kernel void @lds_wg_ld_seq_cst_single64(ptr addrspace(3) %p) #1 {
   ; GFX10-W32-NEXT: {{  $}}
   ; GFX10-W32-NEXT:   renamable $sgpr0 = S_LOAD_DWORD_IMM killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s32) from %ir.p.kernarg.offset, addrspace 4)
   ; GFX10-W32-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   dead renamable $vgpr0 = DS_READ_B32_gfx9 killed renamable $vgpr0, 0, 0, implicit $exec :: (load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 3)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 49279
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
@@ -2026,10 +2026,10 @@ define amdgpu_kernel void @lds_wg_ld_seq_cst_multi(ptr addrspace(3) %p) #2 {
   ; GFX9-NEXT: {{  $}}
   ; GFX9-NEXT:   renamable $sgpr0 = S_LOAD_DWORD_IMM killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s32) from %ir.p.kernarg.offset, addrspace 4)
   ; GFX9-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   dead renamable $vgpr0 = DS_READ_B32_gfx9 killed renamable $vgpr0, 0, 0, implicit $exec :: (load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 3)
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   S_ENDPGM 0
   ;
@@ -2039,10 +2039,10 @@ define amdgpu_kernel void @lds_wg_ld_seq_cst_multi(ptr addrspace(3) %p) #2 {
   ; GFX942-NEXT: {{  $}}
   ; GFX942-NEXT:   renamable $sgpr0 = S_LOAD_DWORD_IMM killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s32) from %ir.p.kernarg.offset, addrspace 4)
   ; GFX942-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   dead renamable $vgpr0 = DS_READ_B32_gfx9 killed renamable $vgpr0, 0, 0, implicit $exec :: (load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 3)
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   S_ENDPGM 0
   ;
@@ -2052,11 +2052,11 @@ define amdgpu_kernel void @lds_wg_ld_seq_cst_multi(ptr addrspace(3) %p) #2 {
   ; GFX10-NEXT: {{  $}}
   ; GFX10-NEXT:   renamable $sgpr0 = S_LOAD_DWORD_IMM killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s32) from %ir.p.kernarg.offset, addrspace 4)
   ; GFX10-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
-  ; GFX10-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-NEXT:   dead renamable $vgpr0 = DS_READ_B32_gfx9 killed renamable $vgpr0, 0, 0, implicit $exec :: (load syncscope("workgroup") seq_cst (s32) from %ir.p.load, addrspace 3)
-  ; GFX10-NEXT:   S_WAITCNT_soft 49279
+  ; GFX10-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-NEXT:   S_ENDPGM 0
@@ -2122,7 +2122,7 @@ define amdgpu_kernel void @lds_wg_st_release_single64(ptr addrspace(3) %p, i32 %
   ; GFX10-W32-NEXT:   early-clobber renamable $sgpr0_sgpr1 = S_LOAD_DWORDX2_IMM_ec killed renamable $sgpr4_sgpr5, 36, 0 :: (dereferenceable invariant load (s64) from %ir.p.kernarg.offset, align 4, addrspace 4)
   ; GFX10-W32-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   DS_WRITE_B32_gfx9 killed renamable $vgpr0, killed renamable $vgpr1, 0, 0, implicit $exec :: (store syncscope("workgroup") release (s32) into %ir.2, addrspace 3)
@@ -2251,11 +2251,11 @@ define amdgpu_kernel void @lds_wg_rmw_add_acq_rel_single64(ptr addrspace(3) %p) 
   ; GFX10-W32-NEXT:   renamable $sgpr0 = S_MUL_I32 killed renamable $sgpr0, 3
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   DS_ADD_U32_gfx9 killed renamable $vgpr0, killed renamable $vgpr1, 0, 0, implicit $exec :: (load store syncscope("workgroup") acq_rel (s32) on %ir.p.load, addrspace 3)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 49279
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT: {{  $}}
@@ -2408,11 +2408,11 @@ define amdgpu_kernel void @lds_wg_cmpxchg_acq_rel_monotonic_single64(ptr addrspa
   ; GFX10-W32-NEXT:   $vgpr0 = V_MOV_B32_e32 killed $sgpr0, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-W32-NEXT:   DS_CMPST_B32_gfx9 killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $vgpr2, 0, 0, implicit $exec :: (load store syncscope("workgroup") acq_rel monotonic (s32) on %ir.2, addrspace 3)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 49279
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX10-W32-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
@@ -2531,7 +2531,7 @@ define amdgpu_kernel void @lds_wg_cmpxchg_monotonic_acquire_single64(ptr addrspa
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
   ; GFX10-W32-NEXT:   DS_CMPST_B32_gfx9 killed renamable $vgpr0, killed renamable $vgpr1, killed renamable $vgpr2, 0, 0, implicit $exec :: (load store syncscope("workgroup") monotonic acquire (s32) on %ir.2, addrspace 3)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 49279
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
   ;
@@ -2612,7 +2612,7 @@ define amdgpu_kernel void @flat_wg_ld_acquire_single64(ptr addrspace(0) %p) #1 {
   ; GFX10-W32-NEXT:   $vgpr0 = V_MOV_B32_e32 $sgpr0, implicit $exec, implicit-def $vgpr0_vgpr1, implicit $sgpr0_sgpr1
   ; GFX10-W32-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $sgpr0_sgpr1, implicit $exec
   ; GFX10-W32-NEXT:   dead renamable $vgpr0 = FLAT_LOAD_DWORD killed renamable $vgpr0_vgpr1, 0, 1, implicit $exec, implicit $flat_scr :: (load syncscope("workgroup") acquire (s32) from %ir.p.load)
-  ; GFX10-W32-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-W32-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-W32-NEXT:   BUFFER_GL0_INV implicit $exec
   ; GFX10-W32-NEXT:   S_ENDPGM 0
   ;
@@ -2673,7 +2673,7 @@ define amdgpu_kernel void @flat_wg_st_seq_cst_multi(ptr addrspace(0) %p, i32 %x)
   ; GFX9-NEXT:   $vgpr0 = V_MOV_B32_e32 $sgpr0, implicit $exec, implicit-def $vgpr0_vgpr1, implicit $sgpr0_sgpr1
   ; GFX9-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $sgpr0_sgpr1, implicit $exec
   ; GFX9-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX9-NEXT:   S_WAITCNT_soft 49279
+  ; GFX9-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX9-NEXT:   S_WAITCNT_lds_direct
   ; GFX9-NEXT:   FLAT_STORE_DWORD killed renamable $vgpr0_vgpr1, killed renamable $vgpr2, 0, 0, implicit $exec, implicit $flat_scr :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load)
   ; GFX9-NEXT:   S_ENDPGM 0
@@ -2686,7 +2686,7 @@ define amdgpu_kernel void @flat_wg_st_seq_cst_multi(ptr addrspace(0) %p, i32 %x)
   ; GFX942-NEXT:   renamable $sgpr2 = S_LOAD_DWORD_IMM killed renamable $sgpr4_sgpr5, 44, 0 :: (dereferenceable invariant load (s32) from %ir.x.kernarg.offset, addrspace 4)
   ; GFX942-NEXT:   $vgpr0_vgpr1 = V_MOV_B64_e32 killed $sgpr0_sgpr1, implicit $exec, implicit $exec
   ; GFX942-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX942-NEXT:   S_WAITCNT_soft 49279
+  ; GFX942-NEXT:   S_WAITCNT_soft .Lgkmcnt_0
   ; GFX942-NEXT:   S_WAITCNT_lds_direct
   ; GFX942-NEXT:   FLAT_STORE_DWORD killed renamable $vgpr0_vgpr1, killed renamable $vgpr2, 0, 1, implicit $exec, implicit $flat_scr :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load)
   ; GFX942-NEXT:   S_ENDPGM 0
@@ -2700,7 +2700,7 @@ define amdgpu_kernel void @flat_wg_st_seq_cst_multi(ptr addrspace(0) %p, i32 %x)
   ; GFX10-NEXT:   $vgpr0 = V_MOV_B32_e32 $sgpr0, implicit $exec, implicit-def $vgpr0_vgpr1, implicit $sgpr0_sgpr1
   ; GFX10-NEXT:   $vgpr1 = V_MOV_B32_e32 killed $sgpr1, implicit $exec, implicit $sgpr0_sgpr1, implicit $exec
   ; GFX10-NEXT:   $vgpr2 = V_MOV_B32_e32 killed $sgpr2, implicit $exec, implicit $exec
-  ; GFX10-NEXT:   S_WAITCNT_soft 112
+  ; GFX10-NEXT:   S_WAITCNT_soft .Vmcnt_0_Lgkmcnt_0
   ; GFX10-NEXT:   S_WAITCNT_lds_direct
   ; GFX10-NEXT:   S_WAITCNT_VSCNT_soft undef $sgpr_null, 0
   ; GFX10-NEXT:   FLAT_STORE_DWORD killed renamable $vgpr0_vgpr1, killed renamable $vgpr2, 0, 0, implicit $exec, implicit $flat_scr :: (store syncscope("workgroup") seq_cst (s32) into %ir.p.load)

--- a/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt_soft.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/s_waitcnt_soft.mir
@@ -1,0 +1,229 @@
+# RUN: split-file %s %t
+
+# Common tests that work on all targets
+;--- common.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx803 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -run-pass=none %t/common.mir -o - | FileCheck %t/common.mir --check-prefix=CHECK
+---
+name: vmcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_0
+    ; CHECK: S_WAITCNT_soft .Vmcnt_0
+    S_WAITCNT_soft .Vmcnt_0
+...
+---
+name: vmcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_1
+    ; CHECK: S_WAITCNT_soft .Vmcnt_1
+    S_WAITCNT_soft .Vmcnt_1
+...
+---
+name: expcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_0
+    ; CHECK: S_WAITCNT_soft .Expcnt_0
+    S_WAITCNT_soft .Expcnt_0
+...
+---
+name: expcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_1
+    ; CHECK: S_WAITCNT_soft .Expcnt_1
+    S_WAITCNT_soft .Expcnt_1
+...
+---
+name: expcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Expcnt_6
+    S_WAITCNT_soft .Expcnt_6
+...
+---
+name: lgkmcnt_0
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_0
+    ; CHECK: S_WAITCNT_soft .Lgkmcnt_0
+    S_WAITCNT_soft .Lgkmcnt_0
+...
+---
+name: lgkmcnt_1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_1
+    ; CHECK: S_WAITCNT_soft .Lgkmcnt_1
+    S_WAITCNT_soft .Lgkmcnt_1
+...
+---
+name: vmcnt_expcnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_expcnt
+    ; CHECK: S_WAITCNT_soft .Vmcnt_1_Expcnt_2
+    S_WAITCNT_soft .Vmcnt_1_Expcnt_2
+...
+---
+name: vmcnt_lgkmcnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_lgkmcnt
+    ; CHECK: S_WAITCNT_soft .Vmcnt_3_Lgkmcnt_5
+    S_WAITCNT_soft .Vmcnt_3_Lgkmcnt_5
+...
+---
+name: expcnt_lgkmcnt
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: expcnt_lgkmcnt
+    ; CHECK: S_WAITCNT_soft .Expcnt_4_Lgkmcnt_6
+    S_WAITCNT_soft .Expcnt_4_Lgkmcnt_6
+...
+---
+name: all-zero
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: all-zero
+    ; CHECK: S_WAITCNT_soft .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    S_WAITCNT_soft .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+...
+---
+name: all-off
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: all-off
+    ; CHECK: S_WAITCNT_soft .AllOff
+    S_WAITCNT_soft .AllOff
+...
+---
+name: zero-number
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: zero-number
+    ; CHECK: S_WAITCNT_soft .Vmcnt_0_Expcnt_0_Lgkmcnt_0
+    S_WAITCNT_soft 0
+...
+
+# GFX8-specific: vmcnt max=15, lgkmcnt max=15
+;--- gfx8.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx803 -run-pass=none %t/gfx8.mir -o - | FileCheck %t/gfx8.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Vmcnt_14
+    S_WAITCNT_soft .Vmcnt_14
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Lgkmcnt_14
+    S_WAITCNT_soft .Lgkmcnt_14
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; vmcnt=15, expcnt=7, lgkmcnt=15 -> 0xF7F = 3967
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT_soft .AllOff
+    S_WAITCNT_soft 3967
+...
+
+# GFX9-specific: vmcnt max=63, lgkmcnt max=15
+;--- gfx9.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=none %t/gfx9.mir -o - | FileCheck %t/gfx9.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Vmcnt_62
+    S_WAITCNT_soft .Vmcnt_62
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Lgkmcnt_14
+    S_WAITCNT_soft .Lgkmcnt_14
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; vmcnt=63, expcnt=7, lgkmcnt=15 -> 0xCF7F = 53119
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT_soft .AllOff
+    S_WAITCNT_soft 53119
+...
+
+# GFX10-specific: vmcnt max=63, lgkmcnt max=63
+;--- gfx10.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -run-pass=none %t/gfx10.mir -o - | FileCheck %t/gfx10.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Vmcnt_62
+    S_WAITCNT_soft .Vmcnt_62
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Lgkmcnt_62
+    S_WAITCNT_soft .Lgkmcnt_62
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; vmcnt=63, expcnt=7, lgkmcnt=63 -> 0xFF7F = 65407
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT_soft .AllOff
+    S_WAITCNT_soft 65407
+...
+
+# GFX11-specific: vmcnt max=63, lgkmcnt max=63 (different encoding than GFX10)
+;--- gfx11.mir
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -run-pass=none %t/gfx11.mir -o - | FileCheck %t/gfx11.mir
+---
+name: vmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Vmcnt_62
+    S_WAITCNT_soft .Vmcnt_62
+...
+---
+name: lgkmcnt_max-1
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: lgkmcnt_max-1
+    ; CHECK: S_WAITCNT_soft .Lgkmcnt_62
+    S_WAITCNT_soft .Lgkmcnt_62
+...
+---
+name: all-off-number
+body: |
+  bb.0:
+    ; GFX11 encoding: expcnt[2:0]=bits[2:0], lgkmcnt[5:0]=bits[9:4], vmcnt[5:0]=bits[15:10]
+    ; vmcnt=63, expcnt=7, lgkmcnt=63 -> 0xFFF7 = 65527
+    ; CHECK-LABEL: name: all-off-number
+    ; CHECK: S_WAITCNT_soft .AllOff
+    S_WAITCNT_soft 65527
+...


### PR DESCRIPTION
This patch reuses the S_WAITCNT mask printer and parser for S_WAITCNT_soft. It prints the mask in a human-readable format, showing the counter values like `Vmcnt_<NUM>_Expcnt_<NUM>_Lgkmcnt_<NUM>`.