### PR TITLE
[MLIR][Affine] Account for view aliases in checkMemrefAccessDependence

### DIFF
--- a/mlir/lib/Dialect/Affine/Analysis/AffineAnalysis.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/AffineAnalysis.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Affine/Analysis/Utils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/IR/AffineValueMap.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -132,6 +133,79 @@ static bool isLocallyDefined(Value v, Operation *enclosingOp) {
   // Aliasing ops.
   auto viewOp = dyn_cast<ViewLikeOpInterface>(defOp);
   return viewOp && isLocallyDefined(viewOp.getViewSource(), enclosingOp);
+}
+
+// Walk the view chain rooted at `memref` to its ultimate base. When every link
+// is a rank-preserving `memref.cast`, `memref.subview`, or
+// `memref.reinterpret_cast` with fully static offsets and strides, returns
+// `success()` and composes the per-dimension affine transform
+// `base[d] = offsets[d] + strides[d] * memref[d]`. On any non-static or
+// non-rank-preserving link the walk still finishes to find `base` so callers
+// can compare bases, but returns `failure()` and leaves the transform vectors
+// unspecified.
+static LogicalResult
+resolveViewBaseAndStaticTransform(Value memref, Value &base,
+                                  SmallVectorImpl<int64_t> &offsets,
+                                  SmallVectorImpl<int64_t> &strides) {
+  auto memrefType = dyn_cast<MemRefType>(memref.getType());
+  if (!memrefType) {
+    base = memref;
+    return failure();
+  }
+  unsigned rank = memrefType.getRank();
+  offsets.assign(rank, 0);
+  strides.assign(rank, 1);
+  base = memref;
+  bool isStatic = true;
+  while (auto viewOp = base.getDefiningOp<ViewLikeOpInterface>()) {
+    Value src = viewOp.getViewSource();
+    auto srcType = dyn_cast<MemRefType>(src.getType());
+    if (!srcType || srcType.getRank() != static_cast<int64_t>(rank)) {
+      isStatic = false;
+    } else if (isa<memref::CastOp>(viewOp.getOperation())) {
+      // Identity index transform.
+    } else if (auto offSizeStr = dyn_cast<OffsetSizeAndStrideOpInterface>(
+                   viewOp.getOperation())) {
+      ArrayRef<int64_t> sOff = offSizeStr.getStaticOffsets();
+      ArrayRef<int64_t> sStr = offSizeStr.getStaticStrides();
+      if (sOff.size() != rank || sStr.size() != rank) {
+        isStatic = false;
+      } else {
+        for (unsigned d = 0; d < rank && isStatic; ++d) {
+          if (ShapedType::isDynamic(sOff[d]) ||
+              ShapedType::isDynamic(sStr[d])) {
+            isStatic = false;
+            break;
+          }
+          offsets[d] = sOff[d] + sStr[d] * offsets[d];
+          strides[d] = sStr[d] * strides[d];
+        }
+      }
+    } else {
+      isStatic = false;
+    }
+    base = src;
+  }
+  return success(isStatic);
+}
+
+// Build a B->C relation that applies `range[d] = offsets[d] + strides[d] *
+// domain[d]` so it can be composed into the range of an access relation via
+// `IntegerRelation::applyRange`.
+static IntegerRelation buildViewToBaseRelation(unsigned rank,
+                                               ArrayRef<int64_t> offsets,
+                                               ArrayRef<int64_t> strides) {
+  IntegerRelation rel(PresburgerSpace::getRelationSpace(
+      /*numDomain=*/rank, /*numRange=*/rank,
+      /*numSymbols=*/0, /*numLocals=*/0));
+  for (unsigned d = 0; d < rank; ++d) {
+    SmallVector<int64_t> eq(2 * rank + 1, 0);
+    eq[d] = -strides[d];
+    eq[rank + d] = 1;
+    eq.back() = -offsets[d];
+    rel.addEquality(eq);
+  }
+  return rel;
 }
 
 bool mlir::affine::isLoopMemoryParallel(AffineForOp forOp) {
@@ -615,9 +689,26 @@ DependenceResult mlir::affine::checkMemrefAccessDependence(
   LLVM_DEBUG(srcAccess.opInst->dump());
   LLVM_DEBUG(dstAccess.opInst->dump());
 
-  // Return 'NoDependence' if these accesses do not access the same memref.
-  if (srcAccess.memref != dstAccess.memref)
-    return DependenceResult::NoDependence;
+  // For accesses through distinct SSA memref values, resolve the view chain to
+  // its ultimate base. If the bases differ, the accesses cannot alias. If they
+  // match, try to compose each access's view chain into a static base-coord
+  // transform so the existing Presburger analysis can reason about overlap
+  // (e.g. disjoint subviews of the same base). Fall back to a conservative
+  // `Failure` when the view chain is not fully static or not rank-preserving.
+  SmallVector<int64_t, 4> srcOff, srcStr, dstOff, dstStr;
+  bool composeInBaseCoords = false;
+  if (srcAccess.memref != dstAccess.memref) {
+    Value srcBase, dstBase;
+    LogicalResult srcStatic = resolveViewBaseAndStaticTransform(
+        srcAccess.memref, srcBase, srcOff, srcStr);
+    LogicalResult dstStatic = resolveViewBaseAndStaticTransform(
+        dstAccess.memref, dstBase, dstOff, dstStr);
+    if (srcBase != dstBase)
+      return DependenceResult::NoDependence;
+    if (failed(srcStatic) || failed(dstStatic))
+      return DependenceResult::Failure;
+    composeInBaseCoords = true;
+  }
 
   // Return 'NoDependence' if one of these accesses is not an
   // AffineWriteOpInterface.
@@ -640,6 +731,13 @@ DependenceResult mlir::affine::checkMemrefAccessDependence(
     return DependenceResult::Failure;
   if (failed(dstAccess.getAccessRelation(dstRel)))
     return DependenceResult::Failure;
+
+  // Lift each view-coord access relation into shared base coordinates so the
+  // existing range-composition machinery can compare them directly.
+  if (composeInBaseCoords) {
+    srcRel.applyRange(buildViewToBaseRelation(srcOff.size(), srcOff, srcStr));
+    dstRel.applyRange(buildViewToBaseRelation(dstOff.size(), dstOff, dstStr));
+  }
 
   FlatAffineValueConstraints srcDomain(srcRel.getDomainSet());
   FlatAffineValueConstraints dstDomain(dstRel.getDomainSet());

--- a/mlir/test/Dialect/Affine/SuperVectorize/vectorize_view_alias.mlir
+++ b/mlir/test/Dialect/Affine/SuperVectorize/vectorize_view_alias.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-opt %s -affine-super-vectorize="virtual-vector-size=4" | FileCheck %s
+
+// This loop has a carried dependence through a view alias: iteration i stores
+// to %arg0[i + 1] via %reinterpret_cast, and iteration i + 1 reads that cell
+// through %arg0. It must not be vectorized as independent lanes.
+
+// CHECK-LABEL: func.func @view_alias_carried_dependence_unsupported
+// CHECK:         memref.reinterpret_cast
+// CHECK:         affine.for
+// CHECK:           affine.load
+// CHECK:           affine.store
+// CHECK-NOT:     vector.transfer_read
+// CHECK-NOT:     vector.transfer_write
+func.func @view_alias_carried_dependence_unsupported(%arg0: memref<8xi32>) {
+  %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [4], strides: [1] : memref<8xi32> to memref<4xi32, strided<[1], offset: 0>>
+  affine.for %i = 0 to 3 {
+    %0 = affine.load %arg0[%i] : memref<8xi32>
+    %1 = arith.addi %0, %0 : i32
+    affine.store %1, %reinterpret_cast[%i + 1] : memref<4xi32, strided<[1], offset: 0>>
+  }
+  return
+}

--- a/mlir/test/Dialect/Affine/memref-dependence-check.mlir
+++ b/mlir/test/Dialect/Affine/memref-dependence-check.mlir
@@ -1166,3 +1166,51 @@ func.func @affine_parallel_min_max_bounds(%arg0: memref<4090x2040xf32>, %arg1: f
   }
   return
 }
+
+// -----
+
+// Two disjoint memref.subview windows over the same base must not be flagged
+// as aliasing: the dependence analysis composes each view's static
+// offset/stride transform into base coordinates before testing overlap.
+// CHECK-LABEL: func @disjoint_subview_no_dependence
+func.func @disjoint_subview_no_dependence(%arg0: memref<8xi32>) {
+  %v1 = memref.subview %arg0[0] [4] [1] : memref<8xi32> to memref<4xi32, strided<[1], offset: 0>>
+  %v2 = memref.subview %arg0[4] [4] [1] : memref<8xi32> to memref<4xi32, strided<[1], offset: 4>>
+  affine.for %i = 0 to 4 {
+    %0 = affine.load %v1[%i] : memref<4xi32, strided<[1], offset: 0>>
+    // expected-remark@above {{dependence from 0 to 0 at depth 1 = false}}
+    // expected-remark@above {{dependence from 0 to 0 at depth 2 = false}}
+    // expected-remark@above {{dependence from 0 to 1 at depth 1 = false}}
+    // expected-remark@above {{dependence from 0 to 1 at depth 2 = false}}
+    affine.store %0, %v2[%i] : memref<4xi32, strided<[1], offset: 4>>
+    // expected-remark@above {{dependence from 1 to 0 at depth 1 = false}}
+    // expected-remark@above {{dependence from 1 to 0 at depth 2 = false}}
+    // expected-remark@above {{dependence from 1 to 1 at depth 1 = false}}
+    // expected-remark@above {{dependence from 1 to 1 at depth 2 = false}}
+  }
+  return
+}
+
+// -----
+
+// Overlapping subviews of the same base do alias: %v1 = [0, 4), %v2 = [2, 6),
+// and iteration i stores into a cell that iteration i + 2 reads back. The
+// carried dependence must be reported as [2, 2] at depth 1.
+// CHECK-LABEL: func @overlapping_subview_carries_dependence
+func.func @overlapping_subview_carries_dependence(%arg0: memref<8xi32>) {
+  %v1 = memref.subview %arg0[0] [4] [1] : memref<8xi32> to memref<4xi32, strided<[1], offset: 0>>
+  %v2 = memref.subview %arg0[2] [4] [1] : memref<8xi32> to memref<4xi32, strided<[1], offset: 2>>
+  affine.for %i = 0 to 4 {
+    %0 = affine.load %v1[%i] : memref<4xi32, strided<[1], offset: 0>>
+    // expected-remark@above {{dependence from 0 to 0 at depth 1 = false}}
+    // expected-remark@above {{dependence from 0 to 0 at depth 2 = false}}
+    // expected-remark@above {{dependence from 0 to 1 at depth 1 = false}}
+    // expected-remark@above {{dependence from 0 to 1 at depth 2 = false}}
+    affine.store %0, %v2[%i] : memref<4xi32, strided<[1], offset: 2>>
+    // expected-remark@above {{dependence from 1 to 0 at depth 1 = [2, 2]}}
+    // expected-remark@above {{dependence from 1 to 0 at depth 2 = false}}
+    // expected-remark@above {{dependence from 1 to 1 at depth 1 = false}}
+    // expected-remark@above {{dependence from 1 to 1 at depth 2 = false}}
+  }
+  return
+}


### PR DESCRIPTION
## Summary

`affine-super-vectorize` can currently miss a loop-carried dependence when one
access uses a base memref and another access uses a view-like alias of the same
storage. Dependence analysis compares the raw memref SSA values, treats them as
disjoint, and the loop can be widened as if its iterations were independent.

This patch makes `checkMemrefAccessDependence` view-aware: it composes each
side's static rank-preserving view chain (`memref.cast`, `memref.subview`,
`memref.reinterpret_cast`) into a per-dimension `base = offset + stride * idx`
transform, applies that to each access relation's range with
`IntegerRelation::applyRange`, and lets the existing Presburger machinery
reason about overlap in the shared base coordinate space.

## Reproducer

```mlir
func.func @view_alias_carried_dependence_unsupported(%arg0: memref<8xi32>) {
  %reinterpret_cast = memref.reinterpret_cast %arg0
    to offset: [0], sizes: [4], strides: [1]
    : memref<8xi32> to memref<4xi32, strided<[1], offset: 0>>
  affine.for %i = 0 to 3 {
    %0 = affine.load %arg0[%i] : memref<8xi32>
    %1 = arith.addi %0, %0 : i32
    affine.store %1, %reinterpret_cast[%i + 1]
      : memref<4xi32, strided<[1], offset: 0>>
  }
  return
}
```

Apply:

```sh
mlir-opt repro.mlir -affine-super-vectorize="virtual-vector-size=4"
```

Before this patch, the pass can vectorize the loop even though iteration `i`
writes through the view to the same underlying cell that iteration `i + 1`
reads through the base memref.

## Why

The loop has a loop-carried dependence through a view alias: iteration `i`
writes through `%reinterpret_cast[%i + 1]`, and iteration `i + 1` reads the
same underlying cell through `%arg0[%i + 1]`.

The dependence analysis compared raw memref SSA values, so `%arg0` and
`%reinterpret_cast` were treated as disjoint even though they refer to the
same storage. Super-vectorize then widened the loop as if the iterations were
independent.

## Fix

Resolve each side's view chain to a single base value and a per-dimension
static `offset + stride * idx` transform. The chain is accepted only when
every link is rank-preserving and exposes fully static offsets and strides
(via `OffsetSizeAndStrideOpInterface` for `subview` /
`reinterpret_cast`, identity for `cast`). If both sides resolve to the same
base, the transforms are encoded as small `IntegerRelation`s and composed
into the range of each access relation with `applyRange`, lifting both
accesses into shared base coordinates. The existing dependence pipeline then
checks overlap directly.

If the resolved bases differ, the accesses cannot alias and we return
`NoDependence`. If either chain cannot be resolved statically (dynamic
offset/stride, rank change, unknown view op), we keep the conservative
`Failure` fallback so soundness is preserved.

This gives both the soundness fix (the original bug — aliasing views were
declared independent) and precision over the previous patch iteration's
shared-base => `Failure` fallback: disjoint subviews of the same base now
correctly return `NoDependence`.

## Test

Added two regressions in `mlir/test/Dialect/Affine/memref-dependence-check.mlir`:

- `@disjoint_subview_no_dependence` — `subview[0..4)` vs `subview[4..8)` of
  the same base: every direction reports `false`.
- `@overlapping_subview_carries_dependence` — `subview[0..4)` vs
  `subview[2..6)` of the same base: `dependence from 1 to 0 at depth 1 =
  [2, 2]`.

Kept `mlir/test/Dialect/Affine/SuperVectorize/vectorize_view_alias.mlir`,
which asserts that the original `reinterpret_cast` aliasing reproducer stays
scalar and no vector transfer is emitted.

Ran:

```sh
ninja -C build mlir-opt FileCheck count not
build/bin/llvm-lit -sv mlir/test/Dialect/Affine/
build/bin/llvm-lit -sv mlir/test/Dialect/MemRef/ mlir/test/Transforms/
```

Result: 70/70 affine pass; 120/121 MemRef+Transforms pass (1 unrelated
`REQUIRES: asserts` skip on a Release build).

## How it was found

Surfaced by an in-progress SMT-solver-based analysis tool for MLIR affine
passes.

## Tool-use disclosure

This change was drafted with AI tool assistance per LLVM's AI Tool Use
Policy. All code was read, reviewed, and tested locally; the commit should
carry an `Assisted-by:` trailer.
