### PR TITLE
[lldb] Update calls to VerifyBreakpointIDs to handle dummy targets

### DIFF
--- a/lldb/include/lldb/Breakpoint/BreakpointIDList.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointIDList.h
@@ -51,7 +51,7 @@ public:
   SplitIDRangeExpression(llvm::StringRef in_string);
 
   static llvm::Error FindAndReplaceIDRanges(
-      Args &old_args, ExecutionContext &exe_ctx, bool allow_locations,
+      Args &old_args, const ExecutionContext &exe_ctx, bool allow_locations,
       BreakpointName::Permissions ::PermissionKinds purpose, Args &new_args);
 
 private:

--- a/lldb/source/Breakpoint/BreakpointIDList.cpp
+++ b/lldb/source/Breakpoint/BreakpointIDList.cpp
@@ -83,7 +83,7 @@ static std::string LocationIDForStop(StopInfoSP stop_info_sp, uint32_t idx) {
 //  by the members of the range.
 
 llvm::Error BreakpointIDList::FindAndReplaceIDRanges(
-    Args &old_args, ExecutionContext &exe_ctx, bool allow_locations,
+    Args &old_args, const ExecutionContext &exe_ctx, bool allow_locations,
     BreakpointName::Permissions ::PermissionKinds purpose, Args &new_args) {
   Target *target = exe_ctx.GetTargetPtr();
   llvm::StringRef range_from;

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -2073,7 +2073,7 @@ protected:
     BreakpointIDList valid_bp_ids;
 
     CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-        command, m_exe_ctx, result, &valid_bp_ids,
+        command, &target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::disablePerm);
 
     if (result.Succeeded()) {
@@ -2406,7 +2406,7 @@ protected:
       // Particular breakpoints selected; show info about that breakpoint.
       BreakpointIDList valid_bp_ids;
       CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-          command, m_exe_ctx, result, &valid_bp_ids,
+          command, &target, result, &valid_bp_ids,
           BreakpointName::Permissions::PermissionKinds::listPerm);
 
       if (result.Succeeded()) {
@@ -2685,7 +2685,7 @@ protected:
 
       if (!command.empty()) {
         CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-            command, m_exe_ctx, result, &excluded_bp_ids,
+            command, &target, result, &excluded_bp_ids,
             BreakpointName::Permissions::PermissionKinds::deletePerm);
         if (!result.Succeeded())
           return;
@@ -3016,7 +3016,7 @@ protected:
     // Particular breakpoint selected; disable that breakpoint.
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointIDs(
-        command, m_exe_ctx, result, &valid_bp_ids,
+        command, &target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::listPerm);
 
     if (result.Succeeded()) {
@@ -3090,7 +3090,7 @@ protected:
     // Particular breakpoint selected; disable that breakpoint.
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointIDs(
-        command, m_exe_ctx, result, &valid_bp_ids,
+        command, &target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::deletePerm);
 
     if (result.Succeeded()) {
@@ -3888,7 +3888,7 @@ CommandObjectMultiwordBreakpoint::CommandObjectMultiwordBreakpoint(
 CommandObjectMultiwordBreakpoint::~CommandObjectMultiwordBreakpoint() = default;
 
 void CommandObjectMultiwordBreakpoint::VerifyIDs(
-    Args &args, ExecutionContext &exe_ctx, bool allow_locations,
+    Args &args, const ExecutionContext &exe_ctx, bool allow_locations,
     CommandReturnObject &result, BreakpointIDList *valid_ids,
     BreakpointName::Permissions ::PermissionKinds purpose) {
   // args can be strings representing 1). integers (for breakpoint ids)

--- a/lldb/source/Commands/CommandObjectBreakpoint.h
+++ b/lldb/source/Commands/CommandObjectBreakpoint.h
@@ -23,21 +23,21 @@ public:
   ~CommandObjectMultiwordBreakpoint() override;
 
   static void VerifyBreakpointOrLocationIDs(
-      Args &args, ExecutionContext &exe_ctx, CommandReturnObject &result,
+      Args &args, const ExecutionContext &exe_ctx, CommandReturnObject &result,
       BreakpointIDList *valid_ids,
       BreakpointName::Permissions ::PermissionKinds purpose) {
     VerifyIDs(args, exe_ctx, true, result, valid_ids, purpose);
   }
 
   static void
-  VerifyBreakpointIDs(Args &args, ExecutionContext &exe_ctx,
+  VerifyBreakpointIDs(Args &args, const ExecutionContext &exe_ctx,
                       CommandReturnObject &result, BreakpointIDList *valid_ids,
                       BreakpointName::Permissions::PermissionKinds purpose) {
     VerifyIDs(args, exe_ctx, false, result, valid_ids, purpose);
   }
 
 private:
-  static void VerifyIDs(Args &args, ExecutionContext &exe_ctx,
+  static void VerifyIDs(Args &args, const ExecutionContext &exe_ctx,
                         bool allow_locations, CommandReturnObject &result,
                         BreakpointIDList *valid_ids,
                         BreakpointName::Permissions::PermissionKinds purpose);

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -344,7 +344,7 @@ protected:
 
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-        command, m_exe_ctx, result, &valid_bp_ids,
+        command, &target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::listPerm);
 
     m_bp_options_vec.clear();
@@ -509,7 +509,7 @@ protected:
 
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-        command, m_exe_ctx, result, &valid_bp_ids,
+        command, &target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::listPerm);
 
     if (result.Succeeded()) {


### PR DESCRIPTION
Follow up to #194272. In that change, `VerifyBreakpointIDs` had its signature changed to take an `ExecutionContext` instead of a `Target`. In updating the call-sites, `m_exe_ctx` was used. However, in some of those places, the `target` argument reflected the use of a dummy target. The switch broke situations where a proper target does not exist.

This update changes those calls back to using the `target` variable, which may be the dummy target.

The `const` change to `ExecutionContext &` parameters is to support the passing of `&target`.