### PR TITLE
[InstCombine] Use KnownBits in `foldBoxMultiply`

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1509,7 +1509,7 @@ static Instruction *factorizeMathWithShlOps(BinaryOperator &I,
 
 /// Reduce a sequence of masked half-width multiplies to a single multiply.
 /// ((XLow * YHigh) + (YLow * XHigh)) << HalfBits) + (XLow * YLow) --> X * Y
-static Instruction *foldBoxMultiply(BinaryOperator &I) {
+Instruction *InstCombinerImpl::foldBoxMultiply(BinaryOperator &I) {
   unsigned BitWidth = I.getType()->getScalarSizeInBits();
   // Skip the odd bitwidth types.
   if ((BitWidth & 0x1))
@@ -1527,22 +1527,32 @@ static Instruction *foldBoxMultiply(BinaryOperator &I) {
                          m_OneUse(m_Mul(m_Value(YLo), m_Value(XLo))))))
     return nullptr;
 
-  // XLo = X & HalfMask
-  // YLo = Y & HalfMask
-  // TODO: Refactor with SimplifyDemandedBits or KnownBits known leading zeros
-  // to enhance robustness
+  // XLo = X & HalfMask or X if upper bits are known zero
+  // YLo = Y & HalfMask or Y if upper bits are known zero
   Value *X, *Y;
-  if (!match(XLo, m_And(m_Value(X), m_SpecificInt(HalfMask))) ||
-      !match(YLo, m_And(m_Value(Y), m_SpecificInt(HalfMask))))
-    return nullptr;
+  APInt HighMask = APInt::getHighBitsSet(BitWidth, HalfBits);
+  if (!match(XLo, m_And(m_Value(X), m_SpecificInt(HalfMask)))) {
+    if (!MaskedValueIsZero(XLo, HighMask, &I))
+      return nullptr;
+    X = XLo;
+  }
+
+  if (!match(YLo, m_And(m_Value(Y), m_SpecificInt(HalfMask)))) {
+    if (!MaskedValueIsZero(YLo, HighMask, &I))
+      return nullptr;
+    Y = YLo;
+  }
 
   // CrossSum = (X' * (Y >> Halfbits)) + (Y' * (X >> HalfBits))
   // X' can be either X or XLo in the pattern (and the same for Y')
-  if (match(CrossSum,
-            m_c_Add(m_c_Mul(m_LShr(m_Specific(Y), m_SpecificInt(HalfBits)),
-                            m_CombineOr(m_Specific(X), m_Specific(XLo))),
-                    m_c_Mul(m_LShr(m_Specific(X), m_SpecificInt(HalfBits)),
-                            m_CombineOr(m_Specific(Y), m_Specific(YLo))))))
+  auto XHiPat = m_LShr(m_Specific(X), m_SpecificInt(HalfBits));
+  auto YHiPat = m_LShr(m_Specific(Y), m_SpecificInt(HalfBits));
+  auto XPat = m_CombineOr(m_Specific(X), m_Specific(XLo));
+  auto YPat = m_CombineOr(m_Specific(Y), m_Specific(YLo));
+
+  if (match(CrossSum, m_c_Add(m_c_Mul(YHiPat, XPat), m_c_Mul(XHiPat, YPat))) ||
+      (X == XLo && match(CrossSum, m_c_Mul(YHiPat, XPat))) ||
+      (Y == YLo && match(CrossSum, m_c_Mul(XHiPat, YPat))))
     return BinaryOperator::CreateMul(X, Y);
 
   return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -565,6 +565,8 @@ public:
   ///     -> (zext (udiv (add nuw X, Y-1), Y))
   Instruction *foldDivCeil(BinaryOperator &I);
 
+  Instruction *foldBoxMultiply(BinaryOperator &I);
+
   /// This tries to simplify binary operations by factorizing out common terms
   /// (e. g. "(A*B)+(A*C)" -> "A*(B+C)").
   Value *tryFactorizationFolds(BinaryOperator &I);

--- a/llvm/test/Transforms/InstCombine/mul_fold.ll
+++ b/llvm/test/Transforms/InstCombine/mul_fold.ll
@@ -605,6 +605,52 @@ define i130 @mul130_low_one_extra_user(i130 %in0, i130 %in1) {
   ret i130 %retLo
 }
 
+; Both operands have known-zero upper bits
+define i32 @mul32_low_knownbits_both_zext(i16 %a, i16 %b) {
+; CHECK-LABEL: @mul32_low_knownbits_both_zext(
+; CHECK-NEXT:    [[IN0:%.*]] = zext i16 [[A:%.*]] to i32
+; CHECK-NEXT:    [[IN1:%.*]] = zext i16 [[B:%.*]] to i32
+; CHECK-NEXT:    [[RETLO:%.*]] = mul nuw i32 [[IN1]], [[IN0]]
+; CHECK-NEXT:    ret i32 [[RETLO]]
+;
+  %in0 = zext i16 %a to i32
+  %in1 = zext i16 %b to i32
+  %In0Hi = lshr i32 %in0, 16
+  %In1Hi = lshr i32 %in1, 16
+  %m10 = mul i32 %In1Hi, %in0
+  %m01 = mul i32 %in1, %In0Hi
+  %m00 = mul i32 %in1, %in0
+  %addc = add i32 %m10, %m01
+  %shl = shl i32 %addc, 16
+  %retLo = add i32 %shl, %m00
+  ret i32 %retLo
+}
+
+; One operand with known-zero upper bits, the other with `and`
+define i32 @mul32_low_knownbits_one_zext(i16 %a, i32 %in1) {
+; CHECK-LABEL: @mul32_low_knownbits_one_zext(
+; CHECK-NEXT:    [[IN0:%.*]] = zext i16 [[A:%.*]] to i32
+; CHECK-NEXT:    [[IN1LO:%.*]] = and i32 [[IN1:%.*]], 65535
+; CHECK-NEXT:    [[IN1HI:%.*]] = lshr i32 [[IN1]], 16
+; CHECK-NEXT:    [[M10:%.*]] = mul nuw i32 [[IN1HI]], [[IN0]]
+; CHECK-NEXT:    [[M00:%.*]] = mul nuw i32 [[IN1LO]], [[IN0]]
+; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[M10]], 16
+; CHECK-NEXT:    [[RETLO:%.*]] = add i32 [[SHL]], [[M00]]
+; CHECK-NEXT:    ret i32 [[RETLO]]
+;
+  %in0 = zext i16 %a to i32
+  %In0Hi = lshr i32 %in0, 16
+  %In1Lo = and i32 %in1, 65535
+  %In1Hi = lshr i32 %in1, 16
+  %m10 = mul i32 %In1Hi, %in0
+  %m01 = mul i32 %In1Lo, %In0Hi
+  %m00 = mul i32 %In1Lo, %in0
+  %addc = add i32 %m10, %m01
+  %shl = shl i32 %addc, 16
+  %retLo = add i32 %shl, %m00
+  ret i32 %retLo
+}
+
 ; Negative case: Skip odd bitwidth type
 define i9 @mul9_low(i9 %in0, i9 %in1) {
 ; CHECK-LABEL: @mul9_low(

--- a/llvm/test/Transforms/InstCombine/mul_fold.ll
+++ b/llvm/test/Transforms/InstCombine/mul_fold.ll
@@ -630,12 +630,7 @@ define i32 @mul32_low_knownbits_both_zext(i16 %a, i16 %b) {
 define i32 @mul32_low_knownbits_one_zext(i16 %a, i32 %in1) {
 ; CHECK-LABEL: @mul32_low_knownbits_one_zext(
 ; CHECK-NEXT:    [[IN0:%.*]] = zext i16 [[A:%.*]] to i32
-; CHECK-NEXT:    [[IN1LO:%.*]] = and i32 [[IN1:%.*]], 65535
-; CHECK-NEXT:    [[IN1HI:%.*]] = lshr i32 [[IN1]], 16
-; CHECK-NEXT:    [[M10:%.*]] = mul nuw i32 [[IN1HI]], [[IN0]]
-; CHECK-NEXT:    [[M00:%.*]] = mul nuw i32 [[IN1LO]], [[IN0]]
-; CHECK-NEXT:    [[SHL:%.*]] = shl i32 [[M10]], 16
-; CHECK-NEXT:    [[RETLO:%.*]] = add i32 [[SHL]], [[M00]]
+; CHECK-NEXT:    [[RETLO:%.*]] = mul i32 [[IN1:%.*]], [[IN0]]
 ; CHECK-NEXT:    ret i32 [[RETLO]]
 ;
   %in0 = zext i16 %a to i32


### PR DESCRIPTION
There is a TODO for this.

When the low-half operands (`XLo`/`YLo`) of the multiply pattern have upper bits known to be zero, this is effectively equivalent to applying an `and` mask.