### PR TITLE
[CIR] Lower aligned operator new in CIRGen (and matching cleanup-during-new)

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -800,6 +800,14 @@ public:
     return alignment ? getI64IntegerAttr(alignment) : mlir::IntegerAttr();
   }
 
+  // Materialize an alignment value as a CIR integer constant of the given
+  // integer type.  Used to pass std::align_val_t (or its size_t fallback) to
+  // aligned-allocation operator new / operator delete calls.
+  cir::ConstantOp getAlignment(mlir::Location loc, mlir::Type t,
+                               clang::CharUnits alignment) {
+    return getConstantInt(loc, t, alignment.getQuantity());
+  }
+
   mlir::IntegerAttr getSizeFromCharUnits(clang::CharUnits size) {
     return getI64IntegerAttr(size.getQuantity());
   }

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -801,8 +801,7 @@ public:
   }
 
   // Materialize an alignment value as a CIR integer constant of the given
-  // integer type.  Used to pass std::align_val_t (or its size_t fallback) to
-  // aligned-allocation operator new / operator delete calls.
+  // integer type.
   cir::ConstantOp getAlignment(mlir::Location loc, mlir::Type t,
                                clang::CharUnits alignment) {
     return getConstantInt(loc, t, alignment.getQuantity());

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -897,8 +897,12 @@ public:
     // is an enum whose underlying type is std::size_t.
     // FIXME: Use the right type as the parameter type. Note that in a call
     // to operator delete(size_t, ...), we may not have it available.
-    if (isAlignedAllocation(params.Alignment))
-      cgf.cgm.errorNYI("CallDeleteDuringNew: aligned allocation");
+    if (isAlignedAllocation(params.Alignment)) {
+      QualType sizeType = cgf.getContext().getSizeType();
+      cir::ConstantOp align = cgf.getBuilder().getAlignment(
+          *cgf.currSrcLoc, cgf.convertType(sizeType), allocAlign);
+      deleteArgs.add(RValue::get(align), sizeType);
+    }
 
     // Pass the rest of the arguments, which must match exactly.
     for (unsigned i = 0; i != numPlacementArgs; ++i) {
@@ -1613,7 +1617,19 @@ mlir::Value CIRGenFunction::emitCXXNewExpr(const CXXNewExpr *e) {
 
     // The allocation alignment may be passed as the second argument.
     if (e->passAlignment()) {
-      cgm.errorNYI(e->getSourceRange(), "emitCXXNewExpr: pass alignment");
+      // The alignment is always the second positional argument to a
+      // C++17 aligned allocation function -- right after the size.
+      constexpr unsigned indexOfAlignArg = 1;
+      // The corresponding parameter type, if the allocator declares one;
+      // otherwise fall back to size_t (the underlying type of
+      // std::align_val_t).
+      QualType alignValType = sizeType;
+      if (allocatorType->getNumParams() > indexOfAlignArg)
+        alignValType = allocatorType->getParamType(indexOfAlignArg);
+      cir::ConstantOp align = builder.getAlignment(
+          *currSrcLoc, convertType(alignValType), allocAlign);
+      allocatorArgs.add(RValue::get(align), alignValType);
+      ++paramsToSkip;
     }
 
     // FIXME: Why do we not pass a CalleeDecl here?
@@ -1821,8 +1837,8 @@ void CIRGenFunction::emitDeleteCall(const FunctionDecl *deleteFD,
     CharUnits deleteTypeAlign =
         getContext().toCharUnitsFromBits(getContext().getTypeAlignIfKnown(
             deleteTy, /*NeedsPreferredAlignment=*/true));
-    cir::ConstantOp align = builder.getConstInt(
-        *currSrcLoc, convertType(alignValType), deleteTypeAlign.getQuantity());
+    cir::ConstantOp align = builder.getAlignment(
+        *currSrcLoc, convertType(alignValType), deleteTypeAlign);
     deleteArgs.add(RValue::get(align), alignValType);
   }
 

--- a/clang/test/CIR/CodeGen/aligned-allocation.cpp
+++ b/clang/test/CIR/CodeGen/aligned-allocation.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+struct alignas(32) Big {
+  char data[80];
+};
+
+void f() {
+  Big *p = new Big;
+  delete p;
+}
+
+// CIR-LABEL: cir.func{{.*}}@_Z1fv
+// CIR:         %[[SIZE_NEW:[0-9]+]] = cir.const #cir.int<96> : !u64i
+// CIR:         %[[ALIGN_NEW:[0-9]+]] = cir.const #cir.int<32> : !u64i
+// CIR:         cir.call @_ZnwmSt11align_val_t(%[[SIZE_NEW]], %[[ALIGN_NEW]])
+// CIR:         %[[SIZE_DEL:[0-9]+]] = cir.const #cir.int<96> : !u64i
+// CIR:         %[[ALIGN_DEL:[0-9]+]] = cir.const #cir.int<32> : !u64i
+// CIR:         cir.call @_ZdlPvmSt11align_val_t(%{{.+}}, %[[SIZE_DEL]], %[[ALIGN_DEL]])
+
+// LLVM-LABEL: define{{.*}}void @_Z1fv
+// LLVM:         call {{.*}}ptr @_ZnwmSt11align_val_t(i64 {{[^,]*}}96, i64 {{[^,]*}}32)
+// LLVM:         call void @_ZdlPvmSt11align_val_t(ptr {{[^,]*%[^,]+}}, i64 {{[^,]*}}96, i64 {{[^,]*}}32)


### PR DESCRIPTION
Two related `errorNYI`s in CIRGen for C++17 aligned `operator new` / `delete`:

- `emitCXXNewExpr` `errorNYI`'d on `"emitCXXNewExpr: pass alignment"` when the allocator is the `align_val_t`-overloaded form (called whenever you `new` an over-aligned type).
- The cleanup-during-new path (the `CallDeleteDuringNew` cleanup that fires if a ctor throws after `operator new` returns) `errorNYI`'d on the matching `"CallDeleteDuringNew: aligned allocation"`.

The non-cleanup delete path was already wired up; this just plumbs the matching new side.

Both fixes are direct ports of `clang/lib/CodeGen/CGExprCXX.cpp`.  In `emitCXXNewExpr` we look up the alignment parameter type from the allocator prototype (or fall back to `size_t` for the variadic corner case classic also handles), build a constant of that type, and append it after the size argument.  The cleanup uses `getSizeType()` for the alignment param type per the existing `// FIXME` comment that's also in classic.

Hit this trying to build `706.stockfish_r` from SPEC CPU 2026 with `-fclangir` — stockfish allocates over-aligned NNUE state via plain `new`.  The minimum repro:

```c++
struct alignas(64) Big { char data[64]; };
void f() { Big *p = new Big; delete p; }
```

The new test cross-checks against OGCG so any drift between the two backends shows up — both emit the same `_ZnwmSt11align_val_t(64, 64)` and `_ZdlPvmSt11align_val_t(p, 64, 64)` calls.

A few honest caveats worth flagging:

- The `CallDeleteDuringNew` fix isn't directly exercised by the test.  Triggering it needs `-fcxx-exceptions` plus a throwing ctor, and CIR's EH path has its own NYIs that would muddy the test.  The cleanup is a 1:1 mirror of the regular-delete-side fix that already landed and uses the same `getSizeType()` fallback as classic.
- The variadic `operator new(size_t, ...)` corner case is also untested.  The `if (allocatorType->getNumParams() > paramsToSkip)` branch covers the common case; the else branch falls back to `sizeType` (mirroring classic, which guards the equivalent with `assert(allocator->isVariadic())` and likewise has no test).
- The cleanup path uses `getSizeType()` for the alignment param type rather than the actual `align_val_t` enum, mirroring the existing `// FIXME` in classic.  ABI-equivalent — `align_val_t`'s underlying type is `size_t` — but the IR type label differs.

Both CIR test suites pass cleanly (`check-clang-cir-codegen` 325/326 + 1 unsupported, `check-clang-cir` 718/729 + 1 XFAIL + 10 unsupported).
