### PR TITLE
[GlobalISel] Use KnownBits to determine zeros and ones in CombineHelper.cpp

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -7440,7 +7440,6 @@ bool CombinerHelper::isConstantOrConstantVectorI(Register Src) const {
   return true;
 }
 
-// TODO: use knownbits to determine zeros
 bool CombinerHelper::tryFoldSelectOfConstants(GSelect *Select,
                                               BuildFnTy &MatchInfo) const {
   uint32_t Flags = Select->getFlags();
@@ -7464,51 +7463,100 @@ bool CombinerHelper::tryFoldSelectOfConstants(GSelect *Select,
   std::optional<ValueAndVReg> FalseOpt =
       getIConstantVRegValWithLookThrough(False, MRI);
 
+  // Use KnownBits to determine zeros when not a constant.
+  bool TrueIsZero = TrueOpt
+                        ? TrueOpt->Value.isZero()
+                        : (VT && VT->getKnownBits(True).isZero());
+  bool FalseIsZero = FalseOpt
+                         ? FalseOpt->Value.isZero()
+                         : (VT && VT->getKnownBits(False).isZero());
+
+  // Patterns with a constant true value and a zero false value.
+  if (TrueOpt && FalseIsZero) {
+    APInt TrueValue = TrueOpt->Value;
+
+    // select Cond, 1, 0 --> zext (Cond)
+    if (TrueValue.isOne()) {
+      MatchInfo = [=](MachineIRBuilder &B) {
+        B.setInstrAndDebugLoc(*Select);
+        B.buildZExtOrTrunc(Dest, Cond);
+      };
+      return true;
+    }
+
+    // select Cond, -1, 0 --> sext (Cond)
+    if (TrueValue.isAllOnes()) {
+      MatchInfo = [=](MachineIRBuilder &B) {
+        B.setInstrAndDebugLoc(*Select);
+        B.buildSExtOrTrunc(Dest, Cond);
+      };
+      return true;
+    }
+
+    // select Cond, Pow2, 0 --> (zext Cond) << log2(Pow2)
+    if (TrueValue.isPowerOf2()) {
+      MatchInfo = [=](MachineIRBuilder &B) {
+        B.setInstrAndDebugLoc(*Select);
+        Register Inner = MRI.createGenericVirtualRegister(TrueTy);
+        B.buildZExtOrTrunc(Inner, Cond);
+        // The shift amount must be scalar.
+        LLT ShiftTy = TrueTy.isVector() ? TrueTy.getElementType() : TrueTy;
+        auto ShAmtC = B.buildConstant(ShiftTy, TrueValue.exactLogBase2());
+        B.buildShl(Dest, Inner, ShAmtC, Flags);
+      };
+      return true;
+    }
+  }
+
+  // Patterns with a zero true value and a constant false value.
+  if (TrueIsZero && FalseOpt) {
+    APInt FalseValue = FalseOpt->Value;
+
+    // select Cond, 0, 1 --> zext (!Cond)
+    if (FalseValue.isOne()) {
+      MatchInfo = [=](MachineIRBuilder &B) {
+        B.setInstrAndDebugLoc(*Select);
+        Register Inner = MRI.createGenericVirtualRegister(CondTy);
+        B.buildNot(Inner, Cond);
+        B.buildZExtOrTrunc(Dest, Inner);
+      };
+      return true;
+    }
+
+    // select Cond, 0, -1 --> sext (!Cond)
+    if (FalseValue.isAllOnes()) {
+      MatchInfo = [=](MachineIRBuilder &B) {
+        B.setInstrAndDebugLoc(*Select);
+        Register Inner = MRI.createGenericVirtualRegister(CondTy);
+        B.buildNot(Inner, Cond);
+        B.buildSExtOrTrunc(Dest, Inner);
+      };
+      return true;
+    }
+
+    // select Cond, 0, Pow2 --> (zext (!Cond)) << log2(Pow2)
+    if (FalseValue.isPowerOf2()) {
+      MatchInfo = [=](MachineIRBuilder &B) {
+        B.setInstrAndDebugLoc(*Select);
+        Register Not = MRI.createGenericVirtualRegister(CondTy);
+        B.buildNot(Not, Cond);
+        Register Inner = MRI.createGenericVirtualRegister(TrueTy);
+        B.buildZExtOrTrunc(Inner, Not);
+        // The shift amount must be scalar.
+        LLT ShiftTy = TrueTy.isVector() ? TrueTy.getElementType() : TrueTy;
+        auto ShAmtC = B.buildConstant(ShiftTy, FalseValue.exactLogBase2());
+        B.buildShl(Dest, Inner, ShAmtC, Flags);
+      };
+      return true;
+    }
+  }
+
+  // The remaining patterns require both operands to be constants.
   if (!TrueOpt || !FalseOpt)
     return false;
 
   APInt TrueValue = TrueOpt->Value;
   APInt FalseValue = FalseOpt->Value;
-
-  // select Cond, 1, 0 --> zext (Cond)
-  if (TrueValue.isOne() && FalseValue.isZero()) {
-    MatchInfo = [=](MachineIRBuilder &B) {
-      B.setInstrAndDebugLoc(*Select);
-      B.buildZExtOrTrunc(Dest, Cond);
-    };
-    return true;
-  }
-
-  // select Cond, -1, 0 --> sext (Cond)
-  if (TrueValue.isAllOnes() && FalseValue.isZero()) {
-    MatchInfo = [=](MachineIRBuilder &B) {
-      B.setInstrAndDebugLoc(*Select);
-      B.buildSExtOrTrunc(Dest, Cond);
-    };
-    return true;
-  }
-
-  // select Cond, 0, 1 --> zext (!Cond)
-  if (TrueValue.isZero() && FalseValue.isOne()) {
-    MatchInfo = [=](MachineIRBuilder &B) {
-      B.setInstrAndDebugLoc(*Select);
-      Register Inner = MRI.createGenericVirtualRegister(CondTy);
-      B.buildNot(Inner, Cond);
-      B.buildZExtOrTrunc(Dest, Inner);
-    };
-    return true;
-  }
-
-  // select Cond, 0, -1 --> sext (!Cond)
-  if (TrueValue.isZero() && FalseValue.isAllOnes()) {
-    MatchInfo = [=](MachineIRBuilder &B) {
-      B.setInstrAndDebugLoc(*Select);
-      Register Inner = MRI.createGenericVirtualRegister(CondTy);
-      B.buildNot(Inner, Cond);
-      B.buildSExtOrTrunc(Dest, Inner);
-    };
-    return true;
-  }
 
   // select Cond, C1, C1-1 --> add (zext Cond), C1-1
   if (TrueValue - 1 == FalseValue) {
@@ -7528,36 +7576,6 @@ bool CombinerHelper::tryFoldSelectOfConstants(GSelect *Select,
       Register Inner = MRI.createGenericVirtualRegister(TrueTy);
       B.buildSExtOrTrunc(Inner, Cond);
       B.buildAdd(Dest, Inner, False);
-    };
-    return true;
-  }
-
-  // select Cond, Pow2, 0 --> (zext Cond) << log2(Pow2)
-  if (TrueValue.isPowerOf2() && FalseValue.isZero()) {
-    MatchInfo = [=](MachineIRBuilder &B) {
-      B.setInstrAndDebugLoc(*Select);
-      Register Inner = MRI.createGenericVirtualRegister(TrueTy);
-      B.buildZExtOrTrunc(Inner, Cond);
-      // The shift amount must be scalar.
-      LLT ShiftTy = TrueTy.isVector() ? TrueTy.getElementType() : TrueTy;
-      auto ShAmtC = B.buildConstant(ShiftTy, TrueValue.exactLogBase2());
-      B.buildShl(Dest, Inner, ShAmtC, Flags);
-    };
-    return true;
-  }
-
-  // select Cond, 0, Pow2 --> (zext (!Cond)) << log2(Pow2)
-  if (FalseValue.isPowerOf2() && TrueValue.isZero()) {
-    MatchInfo = [=](MachineIRBuilder &B) {
-      B.setInstrAndDebugLoc(*Select);
-      Register Not = MRI.createGenericVirtualRegister(CondTy);
-      B.buildNot(Not, Cond);
-      Register Inner = MRI.createGenericVirtualRegister(TrueTy);
-      B.buildZExtOrTrunc(Inner, Not);
-      // The shift amount must be scalar.
-      LLT ShiftTy = TrueTy.isVector() ? TrueTy.getElementType() : TrueTy;
-      auto ShAmtC = B.buildConstant(ShiftTy, FalseValue.exactLogBase2());
-      B.buildShl(Dest, Inner, ShAmtC, Flags);
     };
     return true;
   }
@@ -7589,7 +7607,6 @@ bool CombinerHelper::tryFoldSelectOfConstants(GSelect *Select,
   return false;
 }
 
-// TODO: use knownbits to determine zeros
 bool CombinerHelper::tryFoldBoolSelectToLogic(GSelect *Select,
                                               BuildFnTy &MatchInfo) const {
   uint32_t Flags = Select->getFlags();
@@ -7610,9 +7627,27 @@ bool CombinerHelper::tryFoldBoolSelectToLogic(GSelect *Select,
   if (CondTy != TrueTy)
     return false;
 
+  // Use KnownBits to determine zeros/ones when not a constant splat.
+  bool TrueIsZero = isZeroOrZeroSplat(True, /* AllowUndefs */ true);
+  bool TrueIsOne = isOneOrOneSplat(True, /* AllowUndefs */ true);
+  bool FalseIsZero = isZeroOrZeroSplat(False, /* AllowUndefs */ true);
+  bool FalseIsOne = isOneOrOneSplat(False, /* AllowUndefs */ true);
+  if (VT) {
+    if (!TrueIsZero && !TrueIsOne) {
+      KnownBits KnownTrue = VT->getKnownBits(True);
+      TrueIsZero = KnownTrue.isZero();
+      TrueIsOne = KnownTrue.isAllOnes();
+    }
+    if (!FalseIsZero && !FalseIsOne) {
+      KnownBits KnownFalse = VT->getKnownBits(False);
+      FalseIsZero = KnownFalse.isZero();
+      FalseIsOne = KnownFalse.isAllOnes();
+    }
+  }
+
   // select Cond, Cond, F --> or Cond, F
   // select Cond, 1, F    --> or Cond, F
-  if ((Cond == True) || isOneOrOneSplat(True, /* AllowUndefs */ true)) {
+  if ((Cond == True) || TrueIsOne) {
     MatchInfo = [=](MachineIRBuilder &B) {
       B.setInstrAndDebugLoc(*Select);
       Register Ext = MRI.createGenericVirtualRegister(TrueTy);
@@ -7625,7 +7660,7 @@ bool CombinerHelper::tryFoldBoolSelectToLogic(GSelect *Select,
 
   // select Cond, T, Cond --> and Cond, T
   // select Cond, T, 0    --> and Cond, T
-  if ((Cond == False) || isZeroOrZeroSplat(False, /* AllowUndefs */ true)) {
+  if ((Cond == False) || FalseIsZero) {
     MatchInfo = [=](MachineIRBuilder &B) {
       B.setInstrAndDebugLoc(*Select);
       Register Ext = MRI.createGenericVirtualRegister(TrueTy);
@@ -7637,7 +7672,7 @@ bool CombinerHelper::tryFoldBoolSelectToLogic(GSelect *Select,
   }
 
   // select Cond, T, 1 --> or (not Cond), T
-  if (isOneOrOneSplat(False, /* AllowUndefs */ true)) {
+  if (FalseIsOne) {
     MatchInfo = [=](MachineIRBuilder &B) {
       B.setInstrAndDebugLoc(*Select);
       // First the not.
@@ -7653,7 +7688,7 @@ bool CombinerHelper::tryFoldBoolSelectToLogic(GSelect *Select,
   }
 
   // select Cond, 0, F --> and (not Cond), F
-  if (isZeroOrZeroSplat(True, /* AllowUndefs */ true)) {
+  if (TrueIsZero) {
     MatchInfo = [=](MachineIRBuilder &B) {
       B.setInstrAndDebugLoc(*Select);
       // First the not.

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -7464,12 +7464,10 @@ bool CombinerHelper::tryFoldSelectOfConstants(GSelect *Select,
       getIConstantVRegValWithLookThrough(False, MRI);
 
   // Use KnownBits to determine zeros when not a constant.
-  bool TrueIsZero = TrueOpt
-                        ? TrueOpt->Value.isZero()
-                        : (VT && VT->getKnownBits(True).isZero());
-  bool FalseIsZero = FalseOpt
-                         ? FalseOpt->Value.isZero()
-                         : (VT && VT->getKnownBits(False).isZero());
+  bool TrueIsZero = TrueOpt ? TrueOpt->Value.isZero()
+                            : (VT && VT->getKnownBits(True).isZero());
+  bool FalseIsZero = FalseOpt ? FalseOpt->Value.isZero()
+                              : (VT && VT->getKnownBits(False).isZero());
 
   // Patterns with a constant true value and a zero false value.
   if (TrueOpt && FalseIsZero) {

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-select.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-select.mir
@@ -957,15 +957,8 @@ body:             |
     ; CHECK: liveins: $x0, $w1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
     ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
-    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
-    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
-    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
-    ; CHECK-NEXT: %one:_(s32) = G_CONSTANT i32 1
-    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %one, %known_zero
+    ; CHECK-NEXT: %sel:_(s32) = G_ZEXT %c(s1)
     ; CHECK-NEXT: $w0 = COPY %sel(s32)
     %0:_(s64) = COPY $x0
     %1:_(s32) = COPY $w1
@@ -989,15 +982,8 @@ body:             |
     ; CHECK: liveins: $x0, $w1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
     ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
-    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
-    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
-    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
-    ; CHECK-NEXT: %minus1:_(s32) = G_CONSTANT i32 -1
-    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %minus1, %known_zero
+    ; CHECK-NEXT: %sel:_(s32) = G_SEXT %c(s1)
     ; CHECK-NEXT: $w0 = COPY %sel(s32)
     %0:_(s64) = COPY $x0
     %1:_(s32) = COPY $w1
@@ -1021,15 +1007,10 @@ body:             |
     ; CHECK: liveins: $x0, $w1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
     ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
-    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
-    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
-    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
-    ; CHECK-NEXT: %pow2:_(s32) = G_CONSTANT i32 16
-    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %pow2, %known_zero
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT %c(s1)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 4
+    ; CHECK-NEXT: %sel:_(s32) = G_SHL [[ZEXT]], [[C]](s32)
     ; CHECK-NEXT: $w0 = COPY %sel(s32)
     %0:_(s64) = COPY $x0
     %1:_(s32) = COPY $w1
@@ -1053,15 +1034,10 @@ body:             |
     ; CHECK: liveins: $x0, $w1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
     ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
-    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
-    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
-    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
-    ; CHECK-NEXT: %one:_(s32) = G_CONSTANT i32 1
-    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %known_zero, %one
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(s1) = G_XOR %c, [[C]]
+    ; CHECK-NEXT: %sel:_(s32) = G_ZEXT [[XOR]](s1)
     ; CHECK-NEXT: $w0 = COPY %sel(s32)
     %0:_(s64) = COPY $x0
     %1:_(s32) = COPY $w1
@@ -1085,15 +1061,12 @@ body:             |
     ; CHECK: liveins: $x0, $w1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
     ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
-    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
-    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
-    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
-    ; CHECK-NEXT: %pow2:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %known_zero, %pow2
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(s1) = G_XOR %c, [[C]]
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[XOR]](s1)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 3
+    ; CHECK-NEXT: %sel:_(s32) = G_SHL [[ZEXT]], [[C1]](s32)
     ; CHECK-NEXT: $w0 = COPY %sel(s32)
     %0:_(s64) = COPY $x0
     %1:_(s32) = COPY $w1
@@ -1117,15 +1090,10 @@ body:             |
     ; CHECK: liveins: $x0, $w1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
     ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
-    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
-    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
-    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
-    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
-    ; CHECK-NEXT: %minus1:_(s32) = G_CONSTANT i32 -1
-    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %known_zero, %minus1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s1) = G_CONSTANT i1 true
+    ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(s1) = G_XOR %c, [[C]]
+    ; CHECK-NEXT: %sel:_(s32) = G_SEXT [[XOR]](s1)
     ; CHECK-NEXT: $w0 = COPY %sel(s32)
     %0:_(s64) = COPY $x0
     %1:_(s32) = COPY $w1

--- a/llvm/test/CodeGen/AArch64/GlobalISel/combine-select.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/combine-select.mir
@@ -947,3 +947,227 @@ body:             |
     %sel:_(<4 x s32>) = exact G_SELECT %c, %t, %f
     $q0 = COPY %sel(<4 x s32>)
 ...
+---
+# select Cond, 1, (known zero) --> zext(Cond)
+name:            select_cond_1_knownzero_to_zext
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_1_knownzero_to_zext
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %one:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %one, %known_zero
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 24
+    %width:_(s32) = G_CONSTANT i32 8
+    %known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %one:_(s32) = G_CONSTANT i32 1
+    %sel:_(s32) = G_SELECT %c, %one, %known_zero
+    $w0 = COPY %sel(s32)
+...
+---
+# select Cond, -1, (known zero) --> sext(Cond)
+name:            select_cond_minus1_knownzero_to_sext
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_minus1_knownzero_to_sext
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %minus1:_(s32) = G_CONSTANT i32 -1
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %minus1, %known_zero
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 24
+    %width:_(s32) = G_CONSTANT i32 8
+    %known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %minus1:_(s32) = G_CONSTANT i32 -1
+    %sel:_(s32) = G_SELECT %c, %minus1, %known_zero
+    $w0 = COPY %sel(s32)
+...
+---
+# select Cond, Pow2, (known zero) --> shl(zext(Cond), log2(Pow2))
+name:            select_cond_pow2_knownzero_to_shift
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_pow2_knownzero_to_shift
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %pow2:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %pow2, %known_zero
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 24
+    %width:_(s32) = G_CONSTANT i32 8
+    %known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %pow2:_(s32) = G_CONSTANT i32 16
+    %sel:_(s32) = G_SELECT %c, %pow2, %known_zero
+    $w0 = COPY %sel(s32)
+...
+---
+# select Cond, (known zero), 1 --> zext(!Cond)
+name:            select_cond_knownzero_1_to_zext_not
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_knownzero_1_to_zext_not
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %one:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %known_zero, %one
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 24
+    %width:_(s32) = G_CONSTANT i32 8
+    %known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %one:_(s32) = G_CONSTANT i32 1
+    %sel:_(s32) = G_SELECT %c, %known_zero, %one
+    $w0 = COPY %sel(s32)
+...
+---
+# select Cond, (known zero), Pow2 --> shl(zext(!Cond), log2(Pow2))
+name:            select_cond_knownzero_pow2_to_shift
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_knownzero_pow2_to_shift
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %pow2:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %known_zero, %pow2
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 24
+    %width:_(s32) = G_CONSTANT i32 8
+    %known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %pow2:_(s32) = G_CONSTANT i32 8
+    %sel:_(s32) = G_SELECT %c, %known_zero, %pow2
+    $w0 = COPY %sel(s32)
+...
+---
+# select Cond, (known zero), -1 --> sext(!Cond)
+name:            select_cond_knownzero_minus1_to_sext_not
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_knownzero_minus1_to_sext_not
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %minus1:_(s32) = G_CONSTANT i32 -1
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %known_zero, %minus1
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 24
+    %width:_(s32) = G_CONSTANT i32 8
+    %known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %minus1:_(s32) = G_CONSTANT i32 -1
+    %sel:_(s32) = G_SELECT %c, %known_zero, %minus1
+    $w0 = COPY %sel(s32)
+...
+---
+# Negative: UBFX extracts bits that are NOT known zero.
+name:            select_cond_pow2_not_knownzero
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: select_cond_pow2_not_knownzero
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s64) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $w1
+    ; CHECK-NEXT: %c:_(s1) = G_TRUNC [[COPY]](s64)
+    ; CHECK-NEXT: %mask:_(s32) = G_CONSTANT i32 65535
+    ; CHECK-NEXT: %masked:_(s32) = G_AND [[COPY1]], %mask
+    ; CHECK-NEXT: %lsb:_(s32) = G_CONSTANT i32 4
+    ; CHECK-NEXT: %width:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: %not_known_zero:_(s32) = G_UBFX %masked, %lsb(s32), %width
+    ; CHECK-NEXT: %pow2:_(s32) = G_CONSTANT i32 4
+    ; CHECK-NEXT: %sel:_(s32) = G_SELECT %c(s1), %pow2, %not_known_zero
+    ; CHECK-NEXT: $w0 = COPY %sel(s32)
+    %0:_(s64) = COPY $x0
+    %1:_(s32) = COPY $w1
+    %c:_(s1) = G_TRUNC %0
+    %mask:_(s32) = G_CONSTANT i32 65535
+    %masked:_(s32) = G_AND %1, %mask
+    %lsb:_(s32) = G_CONSTANT i32 4
+    %width:_(s32) = G_CONSTANT i32 8
+    %not_known_zero:_(s32) = G_UBFX %masked, %lsb, %width
+    %pow2:_(s32) = G_CONSTANT i32 4
+    %sel:_(s32) = G_SELECT %c, %pow2, %not_known_zero
+    $w0 = COPY %sel(s32)
+...


### PR DESCRIPTION
There are two TODOs for this.

Use `GISelValueTracking::getKnownBits()` in `tryFoldSelectOfConstants` and `tryFoldBoolSelectToLogic` to detect zeroes and all-ones operands that aren't constants.