### PR TITLE
[Modules] Fix lazy-loading buffer inconsistency in createFileID under…

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -714,6 +714,10 @@ class SourceManager : public RefCountedBase<SourceManager> {
   /// as they do not refer to a file.
   std::vector<SrcMgr::ContentCache*> MemBufferInfos;
 
+  /// A cache to speed up FileID lookup by FileEntryRef, avoiding expensive
+  /// linear scans through LoadedSLocEntryTable and LocalSLocEntryTable.
+  mutable llvm::DenseMap<const FileEntry *, FileID> FileIDLookup;
+
   /// The table of SLocEntries that are local to this module.
   ///
   /// Positive FileIDs are indexes into this table. Entry 0 indicates an invalid

--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -339,6 +339,7 @@ void SourceManager::clearIDTables() {
   LastLookupStartOffset = LastLookupEndOffset = 0;
 
   IncludedLocMap.clear();
+  FileIDLookup.clear();
   if (LineTable)
     LineTable->clear();
 
@@ -540,6 +541,19 @@ FileID SourceManager::createFileID(FileEntryRef SourceFile,
                                    SrcMgr::CharacteristicKind FileCharacter,
                                    int LoadedID,
                                    SourceLocation::UIntTy LoadedOffset) {
+  if (LoadedID >= 0 && MainFileID.isValid()) {
+    // If this file was already registered as a virtual/overridden file (e.g.,
+    // eagerly loaded input files in ASTReader), force the deserialization of
+    // its SLocEntry now. This ensures the embedded MemoryBuffer is filled from
+    // the PCM before we create a new FileID, avoiding incorrect fallbacks to
+    // disk when Preprocessor attempts to read it.
+    FileID ExistingFID = translateFile(SourceFile);
+    if (ExistingFID.isValid()) {
+      bool Invalid = false;
+      (void)getSLocEntry(ExistingFID, &Invalid);
+    }
+  }
+
   SrcMgr::ContentCache &IR = getOrCreateContentCache(SourceFile,
                                                      isSystem(FileCharacter));
 
@@ -605,6 +619,10 @@ FileID SourceManager::createFileIDImpl(ContentCache &File, StringRef Filename,
     LoadedSLocEntryTable[Index] = SLocEntry::get(
         LoadedOffset, FileInfo::get(IncludePos, File, FileCharacter, Filename));
     SLocEntryLoaded[Index] = SLocEntryOffsetLoaded[Index] = true;
+    if (File.OrigEntry) {
+      FileIDLookup.try_emplace(&File.OrigEntry->getFileEntry(),
+                               FileID::get(LoadedID));
+    }
     return FileID::get(LoadedID);
   }
   unsigned FileSize = File.getSize();
@@ -643,6 +661,9 @@ FileID SourceManager::createFileIDImpl(ContentCache &File, StringRef Filename,
   // Set LastFileIDLookup to the newly created file.  The next getFileID call is
   // almost guaranteed to be from that file.
   FileID FID = FileID::get(LocalSLocEntryTable.size()-1);
+  if (File.OrigEntry) {
+    FileIDLookup.try_emplace(&File.OrigEntry->getFileEntry(), FID);
+  }
   return LastFileIDLookup = FID;
 }
 
@@ -1572,8 +1593,18 @@ SourceLocation SourceManager::translateFileLineCol(const FileEntry *SourceFile,
 FileID SourceManager::translateFile(const FileEntry *SourceFile) const {
   assert(SourceFile && "Null source file!");
 
-  // First, check the main file ID, since it is common to look for a
-  // location in the main file.
+  // First, consult the O(1) fast cache map.
+  // Historically, translateFile performs an expensive linear scan through both
+  // LocalSLocEntryTable and LoadedSLocEntryTable. Under lazy-loading (modules),
+  // accessing un-deserialized loaded SLocEntries triggers their full parsing
+  // (e.g., getLoadedSLocEntry -> loadSLocEntry), severely degrading compilation
+  // performance if called frequently (like during createFileID).
+  // Using this cache bypasses the linear scan and lazy-loading overhead.
+  auto It = FileIDLookup.find(SourceFile);
+  if (It != FileIDLookup.end())
+    return It->second;
+
+  FileID Result;
   if (MainFileID.isValid()) {
     bool Invalid = false;
     const SLocEntry &MainSLoc = getSLocEntry(MainFileID, &Invalid);
@@ -1582,28 +1613,41 @@ FileID SourceManager::translateFile(const FileEntry *SourceFile) const {
 
     if (MainSLoc.isFile()) {
       if (MainSLoc.getFile().getContentCache().OrigEntry == SourceFile)
-        return MainFileID;
+        Result = MainFileID;
     }
   }
 
-  // The location we're looking for isn't in the main file; look
-  // through all of the local source locations.
-  for (unsigned I = 0, N = local_sloc_entry_size(); I != N; ++I) {
-    const SLocEntry &SLoc = getLocalSLocEntry(I);
-    if (SLoc.isFile() &&
-        SLoc.getFile().getContentCache().OrigEntry == SourceFile)
-      return FileID::get(I);
+  if (Result.isInvalid()) {
+    // The location we're looking for isn't in the main file; look
+    // through all of the local source locations.
+    for (unsigned I = 0, N = local_sloc_entry_size(); I != N; ++I) {
+      const SLocEntry &SLoc = getLocalSLocEntry(I);
+      if (SLoc.isFile() &&
+          SLoc.getFile().getContentCache().OrigEntry == SourceFile) {
+        Result = FileID::get(I);
+        break;
+      }
+    }
   }
 
-  // If that still didn't help, try the modules.
-  for (unsigned I = 0, N = loaded_sloc_entry_size(); I != N; ++I) {
-    const SLocEntry &SLoc = getLoadedSLocEntry(I);
-    if (SLoc.isFile() &&
-        SLoc.getFile().getContentCache().OrigEntry == SourceFile)
-      return FileID::get(-int(I) - 2);
+  if (Result.isInvalid()) {
+    // If that still didn't help, try the modules.
+    for (unsigned I = 0, N = loaded_sloc_entry_size(); I != N; ++I) {
+      const SLocEntry &SLoc = getLoadedSLocEntry(I);
+      if (SLoc.isFile() &&
+          SLoc.getFile().getContentCache().OrigEntry == SourceFile) {
+        Result = FileID::get(-int(I) - 2);
+        break;
+      }
+    }
   }
 
-  return FileID();
+  if (Result.isValid()) {
+    FileIDLookup[SourceFile] =
+        Result; // Cache the result for subsequent lookups.
+  }
+
+  return Result;
 }
 
 /// Get the source location in \arg FID for the given line:col.

--- a/clang/test/Modules/home-is-cwd-search-paths.c
+++ b/clang/test/Modules/home-is-cwd-search-paths.c
@@ -21,7 +21,8 @@ module a { header "a.h" }
 //--- dir2/b.modulemap
 module b { header "b.h" }
 //--- dir2/b.h
-#include "search.h" // expected-error{{'search.h' file not found}}
+// expected-no-diagnostics
+#include "search.h"
 // The second compilation is configured such that -I search is an empty directory.
 // However, since b.pcm simply embeds the headers as "search/search.h", this compilation
 // ends up seeing it too. This relies solely on ASTReader::ReadPragmaDiagnosticMappings()


### PR DESCRIPTION
… home-is-cwd

This change is a preparatory prerequisite for fixing issue #169768 (missing header error with embedded files under lazy-loading). It resolves an internal compiler inconsistency that occurs when using precompiled modules (PCM) with embedded files under `-fmodule-map-file-home-is-cwd`.

### Root Causes:
Under some circumstances (e.g., home-is-cwd), virtual files are registered in FileManager beforehand due to Bitstream eagerness (e.g. deserializing pragma diagnostic mappings), but their corresponding SLocEntries (source location records containing the embedded buffer Blob) remain lazy-loaded. When Preprocessor creates a new FileID and attempts to read the buffer, it bypasses PCM's embedded buffer (since SLocEntry is not yet loaded) and falls back to reading from the physical disk. Because the physical header is missing, this triggers a fatal `cannot open file` error (assertion/I/O failure) and crashes compilation.

### Fixes:
1. **Force SLocEntry Deserialization (Buffer Fill)**:
   - Added `FileIDLookup` map in `SourceManager` to cache FileID by FileEntryRef in O(1).
   - Updated `SourceManager::createFileID` to check if the target file already has an existing Loaded FileID. If so, it forces SLocEntry deserialization (`getSLocEntry`) to fill the MemoryBuffer cache from PCM before creating the new FileID, avoiding incorrect fallbacks to disk.
   - **Assertion Crash Fix**: Checked `MainFileID.isValid()` before forcing deserialization to prevent assertion crashes inside `ASTReader::getImportLocation` during the early `Chained Includes` setup phase when no main file is active.
2. **Test Coverage**:
   - Updated `clang/test/Modules/home-is-cwd-search-paths.c` expectations as missing embedded headers are now successfully resolved from PCM instead of triggering a fatal inconsistency error.