### PR TITLE
[OpenMP][Flang][Clang][Offload] Prevent shadow pointer write-back to null host pointers

### DIFF
--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -1029,6 +1029,8 @@ postProcessingTargetDataEnd(DeviceTy *Device,
     const bool HasFrom = ArgType & OMP_TGT_MAPTYPE_FROM;
     if (HasFrom) {
       Entry->foreachShadowPointerInfo([&](const ShadowPtrInfoTy &ShadowPtr) {
+        if (*ShadowPtr.HstPtrAddr == nullptr)
+          return OFFLOAD_SUCCESS;
         constexpr int64_t VoidPtrSize = sizeof(void *);
         if (ShadowPtr.PtrSize > VoidPtrSize) {
           ODBG(ODT_Mapping)
@@ -1465,6 +1467,8 @@ static int targetDataContiguous(ident_t *Loc, DeviceTy &Device, void *ArgsBase,
       AsyncInfo.addPostProcessingFunction([=]() -> int {
         int Ret = Entry->foreachShadowPointerInfo(
             [&](const ShadowPtrInfoTy &ShadowPtr) {
+              if (*ShadowPtr.HstPtrAddr == nullptr)
+                return OFFLOAD_SUCCESS;
               constexpr int64_t VoidPtrSize = sizeof(void *);
               if (ShadowPtr.PtrSize > VoidPtrSize) {
                 ODBG(ODT_Mapping)

--- a/offload/test/offloading/fortran/no-null-write-back.f90
+++ b/offload/test/offloading/fortran/no-null-write-back.f90
@@ -1,0 +1,70 @@
+! OpenMP offloading regression test that checks we do not write-back data
+! in cases where the host descriptor and data have been deallocated during the
+! time the data was on device. This predominantly crops up as an issue in the
+! UMT benchmark.
+!
+! The key component of this test is that we map back elements of an array inside
+! of a derived type, and then want to deallocate them on the host, but subsequent
+! maps back from device of other elements re-allocate/re-map back the old data we
+! just went deallocated on host.
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+program prog
+   implicit none
+
+   type :: dtype_a
+      real(8),      pointer, contiguous :: array2d(:,:) => null()
+      integer :: scalar_int
+   end type dtype_a
+
+   type :: dtype_b
+      type(dtype_a),      pointer     :: array1d(:) => null()
+   end type dtype_b
+
+   integer :: i, j = 4
+   type(dtype_b), pointer :: alloca_dtype => null()
+
+   allocate(alloca_dtype)
+   allocate(alloca_dtype%array1d(j))
+   do i = 1, j
+      allocate(alloca_dtype%array1d(i)%array2d(10,10))
+   enddo
+
+    !$omp target enter data map(to:alloca_dtype)
+    !$omp target enter data map(always,to:alloca_dtype%array1d)
+   do i = 1, j
+    !$omp target enter data map(always,to:alloca_dtype%array1d(i)%array2d)
+   end do
+
+    ! Check everything is all still associated as we'd expect.
+    do i = 1, j
+        if (associated(alloca_dtype%array1d(i)%array2d)) then
+          write (*,*) "iteration", i, "is associated"
+       endif
+    enddo
+
+! In this loop, we map back scalar_int and array2d of the corresponding
+! array1d iteration, however, subsequent map backs of scalar_int, will
+! re-allocate and re-associate the previous iteration of array2d.
+    do i = 1, j
+!$omp target update from(alloca_dtype%array1d(i)%scalar_int)
+!$omp target update from(alloca_dtype%array1d(i)%array2d)
+        deallocate(alloca_dtype%array1d(i)%array2d)
+    enddo
+
+    do i = 1, j
+        if (associated(alloca_dtype%array1d(i)%array2d) .NEQV. .TRUE.) then
+            write (*,*) "iteration", i, "is unassociated"
+       endif
+    enddo
+end program prog
+
+! CHECK:  iteration  1  is associated
+! CHECK:  iteration  2  is associated
+! CHECK:  iteration  3  is associated
+! CHECK:  iteration  4  is associated
+! CHECK:  iteration  1  is unassociated
+! CHECK:  iteration  2  is unassociated
+! CHECK:  iteration  3  is unassociated
+! CHECK:  iteration  4  is unassociated


### PR DESCRIPTION
This patch attempts to solve an issue encountered in the UMT Fortran benchmark, where setting up a derived (record) type map and then updating it to host can cause some unideal map backs of other elements of the derived type due to shadow pointer registration.

In this particular reproducing example we end up re-allocating prior deallocated data in a subsequent iteration of a for loop that updates a different variable, which seems to be triggered by the shadow pointer system.