### PR TITLE
[github] Fix invalid local action invocation in release-doxygen workflow

### DIFF
--- a/.github/workflows/release-doxygen.yml
+++ b/.github/workflows/release-doxygen.yml
@@ -60,7 +60,7 @@ jobs:
           LLVM_TOKEN_GENERATOR_PRIVATE_KEY: ${{ secrets.LLVM_TOKEN_GENERATOR_PRIVATE_KEY }}
 
       - name: Validate Input
-        ./.github/workflows/validate-release-version
+        uses: ./.github/workflows/validate-release-version
         with:
           release-version: ${{ inputs.release-version }}
 


### PR DESCRIPTION
Fix the `Validate Input` step in `.github/workflows/release-doxygen.yml` to use a valid local action invocation.

Before:
```yaml
- name: Validate Input
  ./.github/workflows/validate-release-version
  with:
    release-version: ${{ inputs.release-version }}
```

After:
```yaml
- name: Validate Input
  uses: ./.github/workflows/validate-release-version
  with:
    release-version: ${{ inputs.release-version }}
```

GitHub Actions steps must use `uses:` or `run:`. The current form is invalid.

This appears to have been introduced in #196769.

- Verified the workflow syntax change is minimal and correct.
- No functional behavior intended beyond fixing the invalid step declaration.