### PR TITLE
[MachineBlockPlacement] Fix use-after-erase

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockPlacement.cpp
+++ b/llvm/lib/CodeGen/MachineBlockPlacement.cpp
@@ -1679,12 +1679,13 @@ MachineBlockPlacement::selectBestSuccessor(const MachineBasicBlock *BB,
   // applicable.
   auto FoundEdge = ComputedEdges.find(BB);
   if (FoundEdge != ComputedEdges.end()) {
-    MachineBasicBlock *Succ = FoundEdge->second.BB;
+    BlockAndTailDupResult Result = FoundEdge->second;
     ComputedEdges.erase(FoundEdge);
-    BlockChain *SuccChain = BlockToChain[Succ];
-    if (BB->isSuccessor(Succ) && (!BlockFilter || BlockFilter->count(Succ)) &&
-        SuccChain != &Chain && Succ == *SuccChain->begin())
-      return FoundEdge->second;
+    BlockChain *SuccChain = BlockToChain[Result.BB];
+    if (BB->isSuccessor(Result.BB) &&
+        (!BlockFilter || BlockFilter->count(Result.BB)) &&
+        SuccChain != &Chain && Result.BB == *SuccChain->begin())
+      return Result;
   }
 
   // if BB is part of a trellis, Use the trellis to determine the optimal


### PR DESCRIPTION
`ComputedEdges.erase(FoundEdge)` invalidates `FoundEdge`, but the
function then returns `FoundEdge->second`. Read the bucket value into
a local before erasing.