### PR TITLE
[AArch64][GlobalISel] Legalize pointer vector icmp through bitcast

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -4517,6 +4517,16 @@ LegalizerHelper::bitcast(MachineInstr &MI, unsigned TypeIdx, LLT CastTy) {
     Observer.changedInstr(MI);
     return Legalized;
   }
+  case TargetOpcode::G_ICMP: {
+    if (TypeIdx != 1)
+      return UnableToLegalize;
+
+    Observer.changingInstr(MI);
+    bitcastSrc(MI, CastTy, 2);
+    bitcastSrc(MI, CastTy, 3);
+    Observer.changedInstr(MI);
+    return Legalized;
+  }
   case TargetOpcode::G_SELECT: {
     if (TypeIdx != 0)
       return UnableToLegalize;

--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -767,7 +767,13 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
       .clampNumElements(1, v4s16, v8s16)
       .clampNumElements(1, v2s32, v4s32)
       .clampNumElements(1, v2s64, v2s64)
-      .clampNumElements(1, v2p0, v2p0)
+      .bitcastIf(isPointerVector(1),
+                 [=](const LegalityQuery &Query) {
+                   // Bitcast pointers vector to i64.
+                   const LLT DstTy = Query.Types[1];
+                   return std::pair(1,
+                                    DstTy.changeElementType(LLT::integer(64)));
+                 })
       .customIf(isVector(0));
 
   getActionDefinitionsBuilder(G_FCMP)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-cmp.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-cmp.mir
@@ -582,11 +582,15 @@ body:             |
     liveins:
     ; CHECK-LABEL: name: test_4xp0_ne
     ; CHECK: [[DEF:%[0-9]+]]:_(<2 x p0>) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:_(<2 x s64>) = G_ICMP intpred(eq), [[DEF]](<2 x p0>), [[DEF]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[DEF]](<2 x p0>)
+    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[DEF]](<2 x p0>)
+    ; CHECK-NEXT: [[BITCAST2:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[DEF]](<2 x p0>)
+    ; CHECK-NEXT: [[BITCAST3:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[DEF]](<2 x p0>)
+    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:_(<2 x s64>) = G_ICMP intpred(eq), [[BITCAST]](<2 x i64>), [[BITCAST2]]
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 -1
     ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[C]](s64), [[C]](s64)
     ; CHECK-NEXT: [[XOR:%[0-9]+]]:_(<2 x s64>) = G_XOR [[ICMP]], [[BUILD_VECTOR]]
-    ; CHECK-NEXT: [[ICMP1:%[0-9]+]]:_(<2 x s64>) = G_ICMP intpred(eq), [[DEF]](<2 x p0>), [[DEF]]
+    ; CHECK-NEXT: [[ICMP1:%[0-9]+]]:_(<2 x s64>) = G_ICMP intpred(eq), [[BITCAST1]](<2 x i64>), [[BITCAST3]]
     ; CHECK-NEXT: [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[C]](s64), [[C]](s64)
     ; CHECK-NEXT: [[XOR1:%[0-9]+]]:_(<2 x s64>) = G_XOR [[ICMP1]], [[BUILD_VECTOR1]]
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 1

--- a/llvm/test/CodeGen/AArch64/GlobalISel/legalize-vector-cmp.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/legalize-vector-cmp.mir
@@ -1936,7 +1936,9 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x p0>) = COPY $q0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<2 x p0>) = COPY $q1
-    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:_(<2 x s64>) = G_ICMP intpred(eq), [[COPY]](<2 x p0>), [[COPY1]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[COPY]](<2 x p0>)
+    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[COPY1]](<2 x p0>)
+    ; CHECK-NEXT: [[ICMP:%[0-9]+]]:_(<2 x s64>) = G_ICMP intpred(eq), [[BITCAST]](<2 x i64>), [[BITCAST1]]
     ; CHECK-NEXT: [[TRUNC:%[0-9]+]]:_(<2 x s32>) = G_TRUNC [[ICMP]](<2 x s64>)
     ; CHECK-NEXT: $d0 = COPY [[TRUNC]](<2 x s32>)
     ; CHECK-NEXT: RET_ReallyLR implicit $d0

--- a/llvm/test/CodeGen/AArch64/GlobalISel/pr168872.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/pr168872.ll
@@ -16,8 +16,12 @@ define <4 x ptr> @pr168872(<4 x ptr> %ptrs) {
   ; CHECK-NEXT:   [[BITCAST1:%[0-9]+]]:_(<2 x p0>) = G_BITCAST [[COPY1]](<2 x i64>)
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(p0) = G_CONSTANT i64 0
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p0>) = G_BUILD_VECTOR [[C]](p0), [[C]](p0)
-  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(<2 x i64>) = G_ICMP intpred(ugt), [[BITCAST]](<2 x p0>), [[BUILD_VECTOR]]
-  ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(<2 x i64>) = G_ICMP intpred(ugt), [[BITCAST1]](<2 x p0>), [[BUILD_VECTOR]]
+  ; CHECK-NEXT:   [[BITCAST2:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[BITCAST]](<2 x p0>)
+  ; CHECK-NEXT:   [[BITCAST3:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[BITCAST1]](<2 x p0>)
+  ; CHECK-NEXT:   [[BITCAST4:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[BUILD_VECTOR]](<2 x p0>)
+  ; CHECK-NEXT:   [[BITCAST5:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[BUILD_VECTOR]](<2 x p0>)
+  ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(<2 x i64>) = G_ICMP intpred(ugt), [[BITCAST2]](<2 x i64>), [[BITCAST4]]
+  ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(<2 x i64>) = G_ICMP intpred(ugt), [[BITCAST3]](<2 x i64>), [[BITCAST5]]
   ; CHECK-NEXT:   [[PTRTOINT:%[0-9]+]]:_(<2 x i64>) = G_PTRTOINT [[BITCAST]](<2 x p0>)
   ; CHECK-NEXT:   [[PTRTOINT1:%[0-9]+]]:_(<2 x i64>) = G_PTRTOINT [[BITCAST1]](<2 x p0>)
   ; CHECK-NEXT:   [[PTRTOINT2:%[0-9]+]]:_(<2 x i64>) = G_PTRTOINT [[BUILD_VECTOR]](<2 x p0>)
@@ -34,10 +38,10 @@ define <4 x ptr> @pr168872(<4 x ptr> %ptrs) {
   ; CHECK-NEXT:   [[OR1:%[0-9]+]]:_(<2 x i64>) = G_OR [[AND1]], [[AND3]]
   ; CHECK-NEXT:   [[INTTOPTR:%[0-9]+]]:_(<2 x p0>) = G_INTTOPTR [[OR]](<2 x i64>)
   ; CHECK-NEXT:   [[INTTOPTR1:%[0-9]+]]:_(<2 x p0>) = G_INTTOPTR [[OR1]](<2 x i64>)
-  ; CHECK-NEXT:   [[BITCAST2:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[INTTOPTR]](<2 x p0>)
-  ; CHECK-NEXT:   [[BITCAST3:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[INTTOPTR1]](<2 x p0>)
-  ; CHECK-NEXT:   $q0 = COPY [[BITCAST2]](<2 x i64>)
-  ; CHECK-NEXT:   $q1 = COPY [[BITCAST3]](<2 x i64>)
+  ; CHECK-NEXT:   [[BITCAST6:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[INTTOPTR]](<2 x p0>)
+  ; CHECK-NEXT:   [[BITCAST7:%[0-9]+]]:_(<2 x i64>) = G_BITCAST [[INTTOPTR1]](<2 x p0>)
+  ; CHECK-NEXT:   $q0 = COPY [[BITCAST6]](<2 x i64>)
+  ; CHECK-NEXT:   $q1 = COPY [[BITCAST7]](<2 x i64>)
   ; CHECK-NEXT:   RET_ReallyLR implicit $q0, implicit $q1
 entry:
   %cmp = icmp ugt <4 x ptr> %ptrs, zeroinitializer

--- a/llvm/test/CodeGen/AArch64/icmp.ll
+++ b/llvm/test/CodeGen/AArch64/icmp.ll
@@ -2,11 +2,6 @@
 ; RUN: llc -mtriple=aarch64 -verify-machineinstrs %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc -mtriple=aarch64 -global-isel -global-isel-abort=2 -verify-machineinstrs %s -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:       warning: Instruction selection used fallback path for v2p0_p0
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for v3p0_p0
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for v4p0_p0
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for icmp_eq_v2p0_Zero_RHS
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for icmp_eq_v2p0_Zero_LHS
 
 define i64 @i64_i64(i64 %a, i64 %b, i64 %d, i64 %e) {
 ; CHECK-LABEL: i64_i64:
@@ -1428,11 +1423,18 @@ entry:
 }
 
 define <2 x ptr> @v2p0_p0(<2 x ptr> %a, <2 x ptr> %b, <2 x ptr> %d, <2 x ptr> %e) {
-; CHECK-LABEL: v2p0_p0:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    cmeq v0.2d, v0.2d, v1.2d
-; CHECK-NEXT:    bsl v0.16b, v3.16b, v2.16b
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: v2p0_p0:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    cmeq v0.2d, v0.2d, v1.2d
+; CHECK-SD-NEXT:    bsl v0.16b, v3.16b, v2.16b
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v2p0_p0:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    cmeq v0.2d, v0.2d, v1.2d
+; CHECK-GI-NEXT:    mvn v0.16b, v0.16b
+; CHECK-GI-NEXT:    bsl v0.16b, v2.16b, v3.16b
+; CHECK-GI-NEXT:    ret
 entry:
   %c = icmp ne <2 x ptr> %a, %b
   %s = select <2 x i1> %c, <2 x ptr> %d, <2 x ptr> %e
@@ -1440,32 +1442,62 @@ entry:
 }
 
 define <3 x ptr> @v3p0_p0(<3 x ptr> %a, <3 x ptr> %b, <3 x ptr> %d, <3 x ptr> %e) {
-; CHECK-LABEL: v3p0_p0:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    // kill: def $d4 killed $d4 def $q4
-; CHECK-NEXT:    // kill: def $d3 killed $d3 def $q3
-; CHECK-NEXT:    // kill: def $d1 killed $d1 def $q1
-; CHECK-NEXT:    // kill: def $d0 killed $d0 def $q0
-; CHECK-NEXT:    // kill: def $d6 killed $d6 def $q6
-; CHECK-NEXT:    // kill: def $d7 killed $d7 def $q7
-; CHECK-NEXT:    // kill: def $d5 killed $d5 def $q5
-; CHECK-NEXT:    // kill: def $d2 killed $d2 def $q2
-; CHECK-NEXT:    ldr d16, [sp, #24]
-; CHECK-NEXT:    ldr d17, [sp]
-; CHECK-NEXT:    mov v3.d[1], v4.d[0]
-; CHECK-NEXT:    mov v0.d[1], v1.d[0]
-; CHECK-NEXT:    mov v6.d[1], v7.d[0]
-; CHECK-NEXT:    ldp d1, d4, [sp, #8]
-; CHECK-NEXT:    mov v1.d[1], v4.d[0]
-; CHECK-NEXT:    cmgt v0.2d, v3.2d, v0.2d
-; CHECK-NEXT:    bsl v0.16b, v6.16b, v1.16b
-; CHECK-NEXT:    cmgt v1.2d, v5.2d, v2.2d
-; CHECK-NEXT:    mov v2.16b, v1.16b
-; CHECK-NEXT:    mov d1, v0.d[1]
-; CHECK-NEXT:    // kill: def $d0 killed $d0 killed $q0
-; CHECK-NEXT:    bsl v2.16b, v17.16b, v16.16b
-; CHECK-NEXT:    // kill: def $d2 killed $d2 killed $q2
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: v3p0_p0:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    // kill: def $d4 killed $d4 def $q4
+; CHECK-SD-NEXT:    // kill: def $d3 killed $d3 def $q3
+; CHECK-SD-NEXT:    // kill: def $d1 killed $d1 def $q1
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-SD-NEXT:    // kill: def $d6 killed $d6 def $q6
+; CHECK-SD-NEXT:    // kill: def $d7 killed $d7 def $q7
+; CHECK-SD-NEXT:    // kill: def $d5 killed $d5 def $q5
+; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 def $q2
+; CHECK-SD-NEXT:    ldr d16, [sp, #24]
+; CHECK-SD-NEXT:    ldr d17, [sp]
+; CHECK-SD-NEXT:    mov v3.d[1], v4.d[0]
+; CHECK-SD-NEXT:    mov v0.d[1], v1.d[0]
+; CHECK-SD-NEXT:    mov v6.d[1], v7.d[0]
+; CHECK-SD-NEXT:    ldp d1, d4, [sp, #8]
+; CHECK-SD-NEXT:    mov v1.d[1], v4.d[0]
+; CHECK-SD-NEXT:    cmgt v0.2d, v3.2d, v0.2d
+; CHECK-SD-NEXT:    bsl v0.16b, v6.16b, v1.16b
+; CHECK-SD-NEXT:    cmgt v1.2d, v5.2d, v2.2d
+; CHECK-SD-NEXT:    mov v2.16b, v1.16b
+; CHECK-SD-NEXT:    mov d1, v0.d[1]
+; CHECK-SD-NEXT:    // kill: def $d0 killed $d0 killed $q0
+; CHECK-SD-NEXT:    bsl v2.16b, v17.16b, v16.16b
+; CHECK-SD-NEXT:    // kill: def $d2 killed $d2 killed $q2
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v3p0_p0:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    fmov x8, d1
+; CHECK-GI-NEXT:    fmov x9, d4
+; CHECK-GI-NEXT:    // kill: def $d0 killed $d0 def $q0
+; CHECK-GI-NEXT:    // kill: def $d3 killed $d3 def $q3
+; CHECK-GI-NEXT:    // kill: def $d2 killed $d2 def $q2
+; CHECK-GI-NEXT:    // kill: def $d6 killed $d6 def $q6
+; CHECK-GI-NEXT:    // kill: def $d5 killed $d5 def $q5
+; CHECK-GI-NEXT:    ldr x10, [sp, #24]
+; CHECK-GI-NEXT:    ldp d4, d1, [sp, #8]
+; CHECK-GI-NEXT:    mov v0.d[1], x8
+; CHECK-GI-NEXT:    mov v3.d[1], x9
+; CHECK-GI-NEXT:    fmov x8, d7
+; CHECK-GI-NEXT:    fmov x9, d1
+; CHECK-GI-NEXT:    cmgt v1.2d, v5.2d, v2.2d
+; CHECK-GI-NEXT:    mov v6.d[1], x8
+; CHECK-GI-NEXT:    mov v4.d[1], x9
+; CHECK-GI-NEXT:    cmgt v0.2d, v3.2d, v0.2d
+; CHECK-GI-NEXT:    fmov x8, d1
+; CHECK-GI-NEXT:    ldr x9, [sp]
+; CHECK-GI-NEXT:    sbfx x8, x8, #0, #1
+; CHECK-GI-NEXT:    bsl v0.16b, v6.16b, v4.16b
+; CHECK-GI-NEXT:    and x9, x9, x8
+; CHECK-GI-NEXT:    bic x8, x10, x8
+; CHECK-GI-NEXT:    orr x8, x9, x8
+; CHECK-GI-NEXT:    fmov d2, x8
+; CHECK-GI-NEXT:    mov d1, v0.d[1]
+; CHECK-GI-NEXT:    ret
 entry:
   %c = icmp slt <3 x ptr> %a, %b
   %s = select <3 x i1> %c, <3 x ptr> %d, <3 x ptr> %e
@@ -1473,13 +1505,21 @@ entry:
 }
 
 define <4 x ptr> @v4p0_p0(<4 x ptr> %a, <4 x ptr> %b, <4 x ptr> %d, <4 x ptr> %e) {
-; CHECK-LABEL: v4p0_p0:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    cmgt v1.2d, v3.2d, v1.2d
-; CHECK-NEXT:    cmgt v0.2d, v2.2d, v0.2d
-; CHECK-NEXT:    bsl v1.16b, v5.16b, v7.16b
-; CHECK-NEXT:    bsl v0.16b, v4.16b, v6.16b
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: v4p0_p0:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    cmgt v1.2d, v3.2d, v1.2d
+; CHECK-SD-NEXT:    cmgt v0.2d, v2.2d, v0.2d
+; CHECK-SD-NEXT:    bsl v1.16b, v5.16b, v7.16b
+; CHECK-SD-NEXT:    bsl v0.16b, v4.16b, v6.16b
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v4p0_p0:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    cmgt v0.2d, v2.2d, v0.2d
+; CHECK-GI-NEXT:    cmgt v1.2d, v3.2d, v1.2d
+; CHECK-GI-NEXT:    bsl v0.16b, v4.16b, v6.16b
+; CHECK-GI-NEXT:    bsl v1.16b, v5.16b, v7.16b
+; CHECK-GI-NEXT:    ret
 entry:
   %c = icmp slt <4 x ptr> %a, %b
   %s = select <4 x i1> %c, <4 x ptr> %d, <4 x ptr> %e
@@ -1555,11 +1595,18 @@ define <2 x i1> @icmp_eq_v2i64_Zero_RHS(<2 x i64> %a) {
 }
 
 define <2 x i1> @icmp_eq_v2p0_Zero_RHS(<2 x ptr> %a) {
-; CHECK-LABEL: icmp_eq_v2p0_Zero_RHS:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    cmeq v0.2d, v0.2d, #0
-; CHECK-NEXT:    xtn v0.2s, v0.2d
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: icmp_eq_v2p0_Zero_RHS:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    cmeq v0.2d, v0.2d, #0
+; CHECK-SD-NEXT:    xtn v0.2s, v0.2d
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: icmp_eq_v2p0_Zero_RHS:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-GI-NEXT:    cmeq v0.2d, v0.2d, v1.2d
+; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
+; CHECK-GI-NEXT:    ret
     %c = icmp eq <2 x ptr> %a, splat (ptr null)
     ret <2 x i1> %c
 }
@@ -1897,11 +1944,18 @@ define <2 x i1> @icmp_eq_v2i64_Zero_LHS(<2 x i64> %a) {
 }
 
 define <2 x i1> @icmp_eq_v2p0_Zero_LHS(<2 x ptr> %a) {
-; CHECK-LABEL: icmp_eq_v2p0_Zero_LHS:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    cmeq v0.2d, v0.2d, #0
-; CHECK-NEXT:    xtn v0.2s, v0.2d
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: icmp_eq_v2p0_Zero_LHS:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    cmeq v0.2d, v0.2d, #0
+; CHECK-SD-NEXT:    xtn v0.2s, v0.2d
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: icmp_eq_v2p0_Zero_LHS:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    movi v1.2d, #0000000000000000
+; CHECK-GI-NEXT:    cmeq v0.2d, v0.2d, v1.2d
+; CHECK-GI-NEXT:    xtn v0.2s, v0.2d
+; CHECK-GI-NEXT:    ret
     %c = icmp eq <2 x ptr> splat (ptr null), %a
     ret <2 x i1> %c
 }


### PR DESCRIPTION
This fixes the lowering of pointer-vector icmp by bitcasting to an integer type, similar to what we do for other operations like vector shuffles (and in the future selects).