### PR TITLE
[IR] Preserve samesign when cloning ICmpInst

### DIFF
--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -4358,7 +4358,9 @@ FCmpInst *FCmpInst::cloneImpl() const {
 }
 
 ICmpInst *ICmpInst::cloneImpl() const {
-  return new ICmpInst(getPredicate(), Op<0>(), Op<1>());
+  auto *Result = new ICmpInst(getPredicate(), Op<0>(), Op<1>());
+  Result->setSameSign(hasSameSign());
+  return Result;
 }
 
 ExtractValueInst *ExtractValueInst::cloneImpl() const {


### PR DESCRIPTION
Clone should preserve IR flags faithfully.