### PR TITLE
[Profile] Remove unused argument of DataExtractor constructor (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/GCOV.h
+++ b/llvm/include/llvm/ProfileData/GCOV.h
@@ -81,9 +81,9 @@ public:
     StringRef buf = Buffer->getBuffer();
     StringRef magic = buf.substr(0, 4);
     if (magic == "gcno") {
-      de = DataExtractor(buf.substr(4), false, 0);
+      de = DataExtractor(buf.substr(4), false);
     } else if (magic == "oncg") {
-      de = DataExtractor(buf.substr(4), true, 0);
+      de = DataExtractor(buf.substr(4), true);
     } else {
       errs() << "unexpected magic: " << magic << "\n";
       return false;
@@ -96,9 +96,9 @@ public:
     StringRef buf = Buffer->getBuffer();
     StringRef magic = buf.substr(0, 4);
     if (magic == "gcda") {
-      de = DataExtractor(buf.substr(4), false, 0);
+      de = DataExtractor(buf.substr(4), false);
     } else if (magic == "adcg") {
-      de = DataExtractor(buf.substr(4), true, 0);
+      de = DataExtractor(buf.substr(4), true);
     } else {
       return false;
     }
@@ -179,7 +179,7 @@ public:
     return bool(cursor);
   }
 
-  DataExtractor de{ArrayRef<uint8_t>{}, false, 0};
+  DataExtractor de{ArrayRef<uint8_t>{}, false};
   DataExtractor::Cursor cursor{0};
 
 private:

--- a/llvm/lib/ProfileData/InstrProfCorrelator.cpp
+++ b/llvm/lib/ProfileData/InstrProfCorrelator.cpp
@@ -334,7 +334,7 @@ DwarfInstrProfCorrelator<IntPtrT>::getLocation(const DWARFDie &Die) const {
   auto &DU = *Die.getDwarfUnit();
   auto AddressSize = DU.getAddressByteSize();
   for (auto &Location : *Locations) {
-    DataExtractor Data(Location.Expr, DICtx->isLittleEndian(), AddressSize);
+    DataExtractor Data(Location.Expr, DICtx->isLittleEndian());
     DWARFExpression Expr(Data, AddressSize);
     for (auto &Op : Expr) {
       if (Op.getCode() == dwarf::DW_OP_addr)


### PR DESCRIPTION
`AddressSize` parameter is not used by `DataExtractor` and will be removed in the future. See #190519 for more context.