### PR TITLE
[Support] Remove unused argument of DataExtractor constructor (NFC)

### DIFF
--- a/llvm/include/llvm/Support/ELFAttrParserCompact.h
+++ b/llvm/include/llvm/Support/ELFAttrParserCompact.h
@@ -33,7 +33,7 @@ class LLVM_ABI ELFCompactAttrParser : public ELFAttributeParser {
 protected:
   ScopedPrinter *sw;
   TagNameMap tagToStringMap;
-  DataExtractor de{ArrayRef<uint8_t>{}, true, 0};
+  DataExtractor de{ArrayRef<uint8_t>{}, true};
   DataExtractor::Cursor cursor{0};
 
   void printAttribute(unsigned tag, unsigned value, StringRef valueDesc);

--- a/llvm/include/llvm/Support/ELFAttrParserExtended.h
+++ b/llvm/include/llvm/Support/ELFAttrParserExtended.h
@@ -25,7 +25,7 @@ class ScopedPrinter;
 class LLVM_ABI ELFExtendedAttrParser : public ELFAttributeParser {
 protected:
   ScopedPrinter *Sw;
-  DataExtractor De{ArrayRef<uint8_t>{}, true, 0};
+  DataExtractor De{ArrayRef<uint8_t>{}, true};
   DataExtractor::Cursor Cursor{0};
 
   // Data structure for holding Extended ELF Build Attribute subsection

--- a/llvm/lib/Support/ELFAttrParserCompact.cpp
+++ b/llvm/lib/Support/ELFAttrParserCompact.cpp
@@ -194,7 +194,7 @@ Error ELFCompactAttrParser::parseSubsection(uint32_t length) {
 Error ELFCompactAttrParser::parse(ArrayRef<uint8_t> section,
                                   llvm::endianness endian) {
   unsigned sectionNumber = 0;
-  de = DataExtractor(section, endian == llvm::endianness::little, 0);
+  de = DataExtractor(section, endian == llvm::endianness::little);
 
   // For early returns, we have more specific errors, consume the Error in
   // cursor.

--- a/llvm/lib/Support/ELFAttrParserExtended.cpp
+++ b/llvm/lib/Support/ELFAttrParserExtended.cpp
@@ -77,7 +77,7 @@ Error ELFExtendedAttrParser::parse(ArrayRef<uint8_t> Section,
                                    llvm::endianness Endian) {
 
   unsigned SectionNumber = 0;
-  De = DataExtractor(Section, Endian == llvm::endianness::little, 0);
+  De = DataExtractor(Section, Endian == llvm::endianness::little);
 
   // Early returns have specific errors. Consume the Error in Cursor.
   struct ClearCursorError {


### PR DESCRIPTION
`AddressSize` parameter is not used by `DataExtractor` and will be removed in the future. See #190519 for more context.