### PR TITLE
[lldb][AArch64][Linux] Use member initialisers

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -214,26 +214,12 @@ NativeRegisterContextLinux_arm64::NativeRegisterContextLinux_arm64(
       GetRegisterInfoInterface().GetRegisterInfo(),
       GetRegisterInfoInterface().GetRegisterCount());
 
-  ::memset(&m_fpr, 0, sizeof(m_fpr));
-  ::memset(&m_gpr_arm64, 0, sizeof(m_gpr_arm64));
   ::memset(&m_hwp_regs, 0, sizeof(m_hwp_regs));
   ::memset(&m_hbp_regs, 0, sizeof(m_hbp_regs));
-  ::memset(&m_sve_header, 0, sizeof(m_sve_header));
-  ::memset(&m_pac_mask, 0, sizeof(m_pac_mask));
-  ::memset(&m_tls_regs, 0, sizeof(m_tls_regs));
-  ::memset(&m_sme_pseudo_regs, 0, sizeof(m_sme_pseudo_regs));
-  ::memset(&m_gcs_regs, 0, sizeof(m_gcs_regs));
-  ::memset(&m_poe_regs, 0, sizeof(m_poe_regs));
-  std::fill(m_zt_reg.begin(), m_zt_reg.end(), 0);
-
-  m_mte_ctrl_reg = 0;
-  m_fpmr_reg = 0;
 
   // 16 is just a maximum value, query hardware for actual watchpoint count
   m_max_hwp_supported = 16;
   m_max_hbp_supported = 16;
-
-  m_refresh_hwdebug_info = true;
 
   m_gpr_is_valid = false;
   m_fpu_is_valid = false;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
@@ -91,63 +91,56 @@ private:
   bool m_za_header_is_valid;
   bool m_pac_mask_is_valid;
   bool m_tls_is_valid;
-  size_t m_tls_size;
+  size_t m_tls_size = 0;
   bool m_gcs_is_valid;
   bool m_poe_is_valid;
 
-  struct user_pt_regs m_gpr_arm64; // 64-bit general purpose registers.
+  // 64-bit general purpose registers.
+  struct user_pt_regs m_gpr_arm64{};
 
-  RegisterInfoPOSIX_arm64::FPU
-      m_fpr; // floating-point registers including extended register sets.
+  // Floating-point registers including extended register sets.
+  RegisterInfoPOSIX_arm64::FPU m_fpr{};
 
   SVEState m_sve_state = SVEState::Unknown;
-  struct sve::user_sve_header m_sve_header;
+  struct sve::user_sve_header m_sve_header{};
   std::vector<uint8_t> m_sve_ptrace_payload;
 
   sve::user_za_header m_za_header;
   std::vector<uint8_t> m_za_ptrace_payload;
 
-  bool m_refresh_hwdebug_info;
+  bool m_refresh_hwdebug_info = true;
 
   struct user_pac_mask {
-    uint64_t data_mask;
-    uint64_t insn_mask;
-  };
+    uint64_t data_mask = 0;
+    uint64_t insn_mask = 0;
+  } m_pac_mask;
 
-  struct user_pac_mask m_pac_mask;
-
-  uint64_t m_mte_ctrl_reg;
+  uint64_t m_mte_ctrl_reg = 0;
 
   struct sme_pseudo_regs {
-    uint64_t ctrl_reg;
-    uint64_t svg_reg;
-  };
-
-  struct sme_pseudo_regs m_sme_pseudo_regs;
+    uint64_t ctrl_reg = 0;
+    uint64_t svg_reg = 0;
+  } m_sme_pseudo_regs;
 
   struct tls_regs {
-    uint64_t tpidr_reg;
+    uint64_t tpidr_reg = 0;
     // Only valid when SME is present.
-    uint64_t tpidr2_reg;
-  };
-
-  struct tls_regs m_tls_regs;
+    uint64_t tpidr2_reg = 0;
+  } m_tls_regs;
 
   // SME2's ZT is a 512 bit register.
-  std::array<uint8_t, 64> m_zt_reg;
+  std::array<uint8_t, 64> m_zt_reg{};
 
-  uint64_t m_fpmr_reg;
+  uint64_t m_fpmr_reg = 0;
 
   struct poe_regs {
-    uint64_t por_el0_reg;
-  };
-
-  struct poe_regs m_poe_regs;
+    uint64_t por_el0_reg = 0;
+  } m_poe_regs;
 
   struct gcs_regs {
-    uint64_t features_enabled;
-    uint64_t features_locked;
-    uint64_t gcspr_e0;
+    uint64_t features_enabled = 0;
+    uint64_t features_locked = 0;
+    uint64_t gcspr_e0 = 0;
   } m_gcs_regs;
 
   bool IsGPR(unsigned reg) const;

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
@@ -95,10 +95,10 @@ private:
   bool m_gcs_is_valid;
   bool m_poe_is_valid;
 
-  // 64-bit general purpose registers.
+  /// 64-bit general purpose registers.
   struct user_pt_regs m_gpr_arm64{};
 
-  // Floating-point registers including extended register sets.
+  /// Floating-point registers including extended register sets.
   RegisterInfoPOSIX_arm64::FPU m_fpr{};
 
   SVEState m_sve_state = SVEState::Unknown;


### PR DESCRIPTION
Member initialise a bunch of things in the register context instead of setting them all in the constructor with memsets.

The only things I've left are related to hardware breakpoints, and need changes to non-AArch64 classes so I'll try that separately.

I have not changed the validity bools because those will be removed by #197113.