### PR TITLE
[Object] Remove unused argument of DataExtractor constructor (NFC)

### DIFF
--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -220,7 +220,7 @@ static Error decodeCrel(
     function_ref<void(uint64_t /*relocation count*/, bool /*explicit addends*/)>
         HdrHandler,
     function_ref<void(Elf_Crel_Impl<Is64>)> EntryHandler) {
-  DataExtractor Data(Content, true, 8); // endian and address size are unused
+  DataExtractor Data(Content, true); // endian is unused
   DataExtractor::Cursor Cur(0);
   const uint64_t Hdr = Data.getULEB128(Cur);
   size_t Count = Hdr / 8;

--- a/llvm/lib/Object/Decompressor.cpp
+++ b/llvm/lib/Object/Decompressor.cpp
@@ -35,7 +35,7 @@ Error Decompressor::consumeCompressedHeader(bool Is64Bit, bool IsLittleEndian) {
   if (SectionData.size() < HdrSize)
     return createError("corrupted compressed section header");
 
-  DataExtractor Extractor(SectionData, IsLittleEndian, 0);
+  DataExtractor Extractor(SectionData, IsLittleEndian);
   uint64_t Offset = 0;
   auto ChType = Extractor.getUnsigned(&Offset, Is64Bit ? sizeof(Elf64_Word)
                                                        : sizeof(Elf32_Word));

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -414,7 +414,7 @@ ELFFile<ELFT>::decode_relrs(Elf_Relr_Range relrs) const {
 template <class ELFT>
 Expected<uint64_t>
 ELFFile<ELFT>::getCrelHeader(ArrayRef<uint8_t> Content) const {
-  DataExtractor Data(Content, isLE(), sizeof(typename ELFT::Addr));
+  DataExtractor Data(Content, isLE());
   Error Err = Error::success();
   uint64_t Hdr = 0;
   Hdr = Data.getULEB128(&Hdr, &Err);
@@ -475,7 +475,7 @@ ELFFile<ELFT>::android_relas(const Elf_Shdr &Sec) const {
   if (Content.size() < 4 || Content[0] != 'A' || Content[1] != 'P' ||
       Content[2] != 'S' || Content[3] != '2')
     return createError("invalid packed relocation header");
-  DataExtractor Data(Content, isLE(), ELFT::Is64Bits ? 8 : 4);
+  DataExtractor Data(Content, isLE());
   DataExtractor::Cursor Cur(/*Offset=*/4);
 
   uint64_t NumRelocs = Data.getSLEB128(Cur);

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -5360,7 +5360,7 @@ bool MachOObjectFile::is64Bit() const {
 
 void MachOObjectFile::ReadULEB128s(uint64_t Index,
                                    SmallVectorImpl<uint64_t> &Out) const {
-  DataExtractor extractor(ObjectFile::getData(), true, 0);
+  DataExtractor extractor(ObjectFile::getData(), true);
 
   uint64_t offset = Index;
   uint64_t data = 0;

--- a/llvm/lib/Object/XCOFFObjectFile.cpp
+++ b/llvm/lib/Object/XCOFFObjectFile.cpp
@@ -1463,8 +1463,7 @@ XCOFFTracebackTable::XCOFFTracebackTable(const uint8_t *Ptr, uint64_t &Size,
                                          Error &Err, bool Is64Bit)
     : TBPtr(Ptr), Is64BitObj(Is64Bit) {
   ErrorAsOutParameter EAO(Err);
-  DataExtractor DE(ArrayRef<uint8_t>(Ptr, Size), /*IsLittleEndian=*/false,
-                   /*AddressSize=*/0);
+  DataExtractor DE(ArrayRef<uint8_t>(Ptr, Size), /*IsLittleEndian=*/false);
   DataExtractor::Cursor Cur(/*Offset=*/0);
 
   // Skip 8 bytes of mandatory fields.


### PR DESCRIPTION
`AddressSize` parameter is not used by `DataExtractor` and will be removed in the future. See #190519 for more context.