### PR TITLE
[X86] combineINSERT_SUBVECTOR - only fold vXi1 zero-widening if scalar mask source has one use

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -61204,8 +61204,8 @@ static SDValue combineINSERT_SUBVECTOR(SDNode *N, SelectionDAG &DAG,
 
     // See if were inserting into a zero vXi1 vector and the subvector was
     // bitcast from a gpr that could be zero-extended directly.
-    if (IsI1Vector && TLI.isTypeLegal(OpVT)) {
-      SDValue SubInt = peekThroughBitcasts(SubVec);
+    if (IsI1Vector && TLI.isTypeLegal(OpVT) && SubVec.hasOneUse()) {
+      SDValue SubInt = peekThroughOneUseBitcasts(SubVec);
       EVT IntVT = EVT::getIntegerVT(*DAG.getContext(), VecNumElts);
       if (TLI.isTypeLegal(IntVT) && SubInt.getValueType().isScalarInteger()) {
         SubInt = DAG.getNode(ISD::ZERO_EXTEND, dl, IntVT, SubInt);

--- a/llvm/test/CodeGen/X86/avx512-skx-insert-subvec.ll
+++ b/llvm/test/CodeGen/X86/avx512-skx-insert-subvec.ll
@@ -209,3 +209,24 @@ define i8 @test15(<2 x i64> %x) {
   %c = bitcast <8 x i1> %b to i8
   ret i8 %c
 }
+
+; Ensure multiple uses of mask source doesn't cause infinite loop
+define <16 x i8> @test_insert_subvector_v8i1_v16i1(i8 %a0) {
+; CHECK-LABEL: test_insert_subvector_v8i1_v16i1:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    xorb $1, %dil
+; CHECK-NEXT:    kmovd %edi, %k1
+; CHECK-NEXT:    kmovb %k1, %k2
+; CHECK-NEXT:    vmovdqu8 0, %xmm0 {%k2} {z}
+; CHECK-NEXT:    vpxor %xmm1, %xmm1, %xmm1
+; CHECK-NEXT:    vmovdqu64 %zmm1, 0 {%k1}
+; CHECK-NEXT:    vzeroupper
+; CHECK-NEXT:    retq
+  %xor = xor i8 %a0, 1
+  %zext = zext i8 %xor to i16
+  %mask16 = bitcast i16 %zext to <16 x i1>
+  %load = call <16 x i8> @llvm.masked.load.v16i8.p0(ptr null, <16 x i1> %mask16, <16 x i8> zeroinitializer)
+  %mask8 = bitcast i8 %xor to <8 x i1>
+  call void @llvm.masked.store.v8i64.p0(<8 x i64> zeroinitializer, ptr null, <8 x i1> %mask8)
+  ret <16 x i8> %load
+}


### PR DESCRIPTION
Fixes infinite loop reported on #192699