### PR TITLE
[TableGen] Add submulticlass typechecking to template arg values

### DIFF
--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -863,6 +863,11 @@ TGParser::ParseSubMultiClassReference(MultiClass *CurMC) {
     return Result;
   }
 
+  if (CheckTemplateArgValues(Result.TemplateArgs, ArgLocs, &Result.MC->Rec)) {
+    Result.MC = nullptr; // Error checking value list.
+    return Result;
+  }
+
   Result.RefRange.End = Lex.getLoc();
 
   return Result;

--- a/llvm/test/TableGen/submulticlass-leteq.td
+++ b/llvm/test/TableGen/submulticlass-leteq.td
@@ -1,0 +1,21 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+// XFAIL: vg_leak
+// CHECK:      def X0 { // C
+// CHECK-NEXT:   bit x = 1;
+// CHECK-NEXT: }
+// CHECK-NEXT: def X1 { // C
+// CHECK-NEXT:   bit x = 0;
+// CHECK-NEXT: }
+class C {
+  bit x;
+}
+multiclass M0<bits<8> Val> {
+  let x = !eq(Val, !cast<bits<8>>(-1)) in def NAME : C;
+}
+multiclass M1<bits<8> Val> {
+  let x = !eq(Val, -1) in def NAME : C;
+}
+multiclass M2_0 : M0<-1>;
+multiclass M2_1 : M1<-1>;
+defm X0 : M2_0;
+defm X1 : M2_1;

--- a/llvm/test/TableGen/submulticlass-typecheck.td
+++ b/llvm/test/TableGen/submulticlass-typecheck.td
@@ -1,0 +1,12 @@
+// RUN: not llvm-tblgen %s 2>&1 | FileCheck %s
+// XFAIL: vg_leak
+// CHECK: {{.*}}:11:30: error: Value specified for template argument 'B::op' is of type bits<4>; expected type bits<8>: C::op
+// CHECK-NEXT: multiclass C<bits<4> op> : B<op>;
+class A<bits<8> op> {
+  bits<8> f = op;
+}
+multiclass B<bits<8> op> {
+  def : A<op>;
+}
+multiclass C<bits<4> op> : B<op>;
+defm D : C<0>;


### PR DESCRIPTION
Some typechecking was missing when parsing a submulticlass reference. Add the
CheckTemplateArgValues call in ParseSubMultiClassReference.

Resolves https://github.com/llvm/llvm-project/issues/84910.