### PR TITLE
libclc: use clang triples when configuring in README

### DIFF
--- a/libclc/README.md
+++ b/libclc/README.md
@@ -60,9 +60,9 @@ cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release
 #### Configure for SPIR-V targets
 ```
 cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release \
-  -DRUNTIMES_spirv-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
-  -DRUNTIMES_spirv64-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
-  -DLLVM_RUNTIME_TARGETS="spirv-mesa-mesa3d;spirv64-mesa-mesa3d"
+  -DRUNTIMES_spirv32--_LLVM_ENABLE_RUNTIMES=libclc \
+  -DRUNTIMES_spirv64--_LLVM_ENABLE_RUNTIMES=libclc \
+  -DLLVM_RUNTIME_TARGETS="spirv32--;spirv64--"
 ```
 
 To build multiple targets, pass them as a semicolon-separated list in

--- a/libclc/README.md
+++ b/libclc/README.md
@@ -60,9 +60,9 @@ cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release
 #### Configure for SPIR-V targets
 ```
 cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release \
-  -DRUNTIMES_spirv32--_LLVM_ENABLE_RUNTIMES=libclc \
-  -DRUNTIMES_spirv64--_LLVM_ENABLE_RUNTIMES=libclc \
-  -DLLVM_RUNTIME_TARGETS="spirv32--;spirv64--"
+  -DRUNTIMES_spirv32-unknown-unknown_LLVM_ENABLE_RUNTIMES=libclc \
+  -DRUNTIMES_spirv64-unknown-unknown_LLVM_ENABLE_RUNTIMES=libclc \
+  -DLLVM_RUNTIME_TARGETS="spirv32-unknown-unknown;spirv64-unknown-unknown"
 ```
 
 To build multiple targets, pass them as a semicolon-separated list in


### PR DESCRIPTION
In #196483 I've changed the triples in the README for the first time. Back then the triple `spirv32-mesa-mesa3d` was recognized and the correct triple was passed to clang:

```cmake
set(clang_triple ${LIBCLC_TARGET})
if(ARCH STREQUAL spirv AND LIBCLC_USE_SPIRV_BACKEND)
  set(clang_triple spirv32--)
```

But when #196351 landed, the triple `spirv32-mesa-mesa3d` was passed to clang as is:

```cmake
set(clang_triple ${LIBCLC_TARGET})
if(ARCH STREQUAL spirv OR ARCH STREQUAL spirv32 OR ARCH STREQUAL spirv64)
  if(NOT OS STREQUAL vulkan AND NOT LIBCLC_USE_SPIRV_BACKEND)
    if(ARCH STREQUAL spirv)
      set(clang_triple spir--)
    else()
      set(clang_triple spir64--)
    endif()
  endif()
endif()
```

Notice, that the OS `mesa3d` is not vulkan in `spirv32-mesa-mesa3d`.

We don't want to fight with libclc's `CMakeLists.txt` file so we think it is better to simply use the `spirv32--` and `spirv64--` triples as they are passed to clang anyway. The files will be installed in `spirv32-unknown-unknown` and `spirv64-unknown-unknown`.