### PR TITLE
[LLVM] Add FastMathFlags operand to simplifySelectInst.

### DIFF
--- a/llvm/include/llvm/Analysis/InstSimplifyFolder.h
+++ b/llvm/include/llvm/Analysis/InstSimplifyFolder.h
@@ -83,8 +83,9 @@ public:
     return simplifyGEPInst(Ty, Ptr, IdxList, NW, SQ);
   }
 
-  Value *FoldSelect(Value *C, Value *True, Value *False) const override {
-    return simplifySelectInst(C, True, False, SQ);
+  Value *FoldSelect(Value *C, Value *True, Value *False,
+                    FastMathFlags FMF = FastMathFlags()) const override {
+    return simplifySelectInst(C, True, False, FMF, SQ);
   }
 
   Value *FoldExtractValue(Value *Agg,

--- a/llvm/include/llvm/Analysis/InstructionSimplify.h
+++ b/llvm/include/llvm/Analysis/InstructionSimplify.h
@@ -166,7 +166,7 @@ LLVM_ABI Value *simplifyFCmpInst(CmpPredicate Predicate, Value *LHS, Value *RHS,
 
 /// Given operands for a SelectInst, fold the result or return null.
 LLVM_ABI Value *simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
-                                   const SimplifyQuery &Q);
+                                   FastMathFlags FMF, const SimplifyQuery &Q);
 
 /// Given operands for a GetElementPtrInst, fold the result or return null.
 LLVM_ABI Value *simplifyGEPInst(Type *SrcTy, Value *Ptr,

--- a/llvm/include/llvm/Analysis/TargetFolder.h
+++ b/llvm/include/llvm/Analysis/TargetFolder.h
@@ -130,7 +130,8 @@ public:
     return nullptr;
   }
 
-  Value *FoldSelect(Value *C, Value *True, Value *False) const override {
+  Value *FoldSelect(Value *C, Value *True, Value *False,
+                    FastMathFlags FMF) const override {
     auto *CC = dyn_cast<Constant>(C);
     auto *TC = dyn_cast<Constant>(True);
     auto *FC = dyn_cast<Constant>(False);

--- a/llvm/include/llvm/IR/ConstantFolder.h
+++ b/llvm/include/llvm/IR/ConstantFolder.h
@@ -119,7 +119,8 @@ public:
     return nullptr;
   }
 
-  Value *FoldSelect(Value *C, Value *True, Value *False) const override {
+  Value *FoldSelect(Value *C, Value *True, Value *False,
+                    FastMathFlags FMF) const override {
     auto *CC = dyn_cast<Constant>(C);
     auto *TC = dyn_cast<Constant>(True);
     auto *FC = dyn_cast<Constant>(False);

--- a/llvm/include/llvm/IR/IRBuilderFolder.h
+++ b/llvm/include/llvm/IR/IRBuilderFolder.h
@@ -56,7 +56,8 @@ public:
   virtual Value *FoldGEP(Type *Ty, Value *Ptr, ArrayRef<Value *> IdxList,
                          GEPNoWrapFlags NW) const = 0;
 
-  virtual Value *FoldSelect(Value *C, Value *True, Value *False) const = 0;
+  virtual Value *FoldSelect(Value *C, Value *True, Value *False,
+                            FastMathFlags FMF = FastMathFlags()) const = 0;
 
   virtual Value *FoldExtractValue(Value *Agg,
                                   ArrayRef<unsigned> IdxList) const = 0;

--- a/llvm/include/llvm/IR/NoFolder.h
+++ b/llvm/include/llvm/IR/NoFolder.h
@@ -80,7 +80,8 @@ public:
     return nullptr;
   }
 
-  Value *FoldSelect(Value *C, Value *True, Value *False) const override {
+  Value *FoldSelect(Value *C, Value *True, Value *False,
+                    FastMathFlags FMF) const override {
     return nullptr;
   }
 

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -79,7 +79,7 @@ static Value *simplifyCastInst(unsigned, Value *, Type *, const SimplifyQuery &,
                                unsigned);
 static Value *simplifyGEPInst(Type *, Value *, ArrayRef<Value *>,
                               GEPNoWrapFlags, const SimplifyQuery &, unsigned);
-static Value *simplifySelectInst(Value *, Value *, Value *,
+static Value *simplifySelectInst(Value *, Value *, Value *, FastMathFlags,
                                  const SimplifyQuery &, unsigned);
 static Value *simplifyInstructionWithOperands(Instruction *I,
                                               ArrayRef<Value *> NewOps,
@@ -4902,7 +4902,7 @@ static Value *simplifySelectWithICmpCond(Value *CondVal, Value *TrueVal,
 /// Try to simplify a select instruction when its condition operand is a
 /// floating-point comparison.
 static Value *simplifySelectWithFCmp(Value *Cond, Value *T, Value *F,
-                                     const SimplifyQuery &Q,
+                                     FastMathFlags FMF, const SimplifyQuery &Q,
                                      unsigned MaxRecurse) {
   CmpPredicate Pred;
   Value *CmpLHS, *CmpRHS;
@@ -4936,7 +4936,7 @@ static Value *simplifySelectWithFCmp(Value *Cond, Value *T, Value *F,
     return nullptr;
 
   // This transform is also safe if we do not have (do not care about) -0.0.
-  if (Q.CxtI && isa<FPMathOperator>(Q.CxtI) && Q.CxtI->hasNoSignedZeros()) {
+  if (FMF.noSignedZeros()) {
     // (T == F) ? T : F --> F
     if (Pred == FCmpInst::FCMP_OEQ)
       return F;
@@ -5035,7 +5035,8 @@ bool isSelectWithIdenticalPHI(PHINode &PN, PHINode &IdenticalPN) {
 /// Given operands for a SelectInst, see if we can fold the result.
 /// If not, this returns null.
 static Value *simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
-                                 const SimplifyQuery &Q, unsigned MaxRecurse) {
+                                 FastMathFlags FMF, const SimplifyQuery &Q,
+                                 unsigned MaxRecurse) {
   if (auto *CondC = dyn_cast<Constant>(Cond)) {
     if (auto *TrueC = dyn_cast<Constant>(TrueVal))
       if (auto *FalseC = dyn_cast<Constant>(FalseVal))
@@ -5201,7 +5202,8 @@ static Value *simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
   if (Value *V = simplifySelectWithBitTest(Cond, TrueVal, FalseVal))
     return V;
 
-  if (Value *V = simplifySelectWithFCmp(Cond, TrueVal, FalseVal, Q, MaxRecurse))
+  if (Value *V =
+          simplifySelectWithFCmp(Cond, TrueVal, FalseVal, FMF, Q, MaxRecurse))
     return V;
 
   std::optional<bool> Imp = isImpliedByDomCondition(Cond, Q.CxtI, Q.DL);
@@ -5219,8 +5221,8 @@ static Value *simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
 }
 
 Value *llvm::simplifySelectInst(Value *Cond, Value *TrueVal, Value *FalseVal,
-                                const SimplifyQuery &Q) {
-  return ::simplifySelectInst(Cond, TrueVal, FalseVal, Q, RecursionLimit);
+                                FastMathFlags FMF, const SimplifyQuery &Q) {
+  return ::simplifySelectInst(Cond, TrueVal, FalseVal, FMF, Q, RecursionLimit);
 }
 
 /// Given operands for an GetElementPtrInst, see if we can fold the result.
@@ -7652,8 +7654,13 @@ static Value *simplifyInstructionWithOperands(Instruction *I,
   case Instruction::FCmp:
     return simplifyFCmpInst(cast<FCmpInst>(I)->getPredicate(), NewOps[0],
                             NewOps[1], I->getFastMathFlags(), Q, MaxRecurse);
-  case Instruction::Select:
-    return simplifySelectInst(NewOps[0], NewOps[1], NewOps[2], Q, MaxRecurse);
+  case Instruction::Select: {
+    FastMathFlags FMF;
+    if (auto *FPMO = dyn_cast<FPMathOperator>(I))
+      FMF = FPMO->getFastMathFlags();
+    return simplifySelectInst(NewOps[0], NewOps[1], NewOps[2], FMF, Q,
+                              MaxRecurse);
+  }
   case Instruction::GetElementPtr: {
     auto *GEPI = cast<GetElementPtrInst>(I);
     return simplifyGEPInst(GEPI->getSourceElementType(), NewOps[0],

--- a/llvm/lib/IR/IRBuilder.cpp
+++ b/llvm/lib/IR/IRBuilder.cpp
@@ -1112,7 +1112,7 @@ Value *IRBuilderBase::CreateSelect(Value *C, Value *True, Value *False,
 Value *IRBuilderBase::CreateSelectFMF(Value *C, Value *True, Value *False,
                                       FMFSource FMFSource, const Twine &Name,
                                       Instruction *MDFrom) {
-  if (auto *V = Folder.FoldSelect(C, True, False))
+  if (auto *V = Folder.FoldSelect(C, True, False, FMFSource.get(FMF)))
     return V;
 
   SelectInst *Sel = SelectInst::Create(C, True, False);

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -4423,7 +4423,11 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
   Value *FalseVal = SI.getFalseValue();
   Type *SelType = SI.getType();
 
-  if (Value *V = simplifySelectInst(CondVal, TrueVal, FalseVal,
+  FastMathFlags FMF;
+  if (auto *FPMO = dyn_cast_if_present<FPMathOperator>(&SI))
+    FMF = FPMO->getFastMathFlags();
+
+  if (Value *V = simplifySelectInst(CondVal, TrueVal, FalseVal, FMF,
                                     SQ.getWithInstruction(&SI)))
     return replaceInstUsesWith(SI, V);
 
@@ -5083,7 +5087,7 @@ Instruction *InstCombinerImpl::visitSelectInst(SelectInst &SI) {
   // TODO: preserve FMF flags
   auto FoldSelectWithAndOrCond = [&](bool IsAnd, Value *A,
                                      Value *B) -> Instruction * {
-    if (Value *V = simplifySelectInst(B, TrueVal, FalseVal,
+    if (Value *V = simplifySelectInst(B, TrueVal, FalseVal, FMF,
                                       SQ.getWithInstruction(&SI))) {
       Value *NewTrueVal = IsAnd ? V : TrueVal;
       Value *NewFalseVal = IsAnd ? FalseVal : V;

--- a/llvm/lib/Transforms/Scalar/NewGVN.cpp
+++ b/llvm/lib/Transforms/Scalar/NewGVN.cpp
@@ -1213,7 +1213,7 @@ NewGVN::ExprResult NewGVN::createExpression(Instruction *I) const {
       assert(E->getOperand(1)->getType() == I->getOperand(1)->getType() &&
              E->getOperand(2)->getType() == I->getOperand(2)->getType());
       Value *V = simplifySelectInst(E->getOperand(0), E->getOperand(1),
-                                    E->getOperand(2), Q);
+                                    E->getOperand(2), FastMathFlags(), Q);
       if (auto Simplified = checkExprResults(E, I, V))
         return Simplified;
     }


### PR DESCRIPTION
This removes the potentially bogus use of SimplifyQuery.CxtI, whose FastMathFlags are not necessarily relevant to the simplification.

Most uses don't care about fast-math-flags so I followed FoldBinaryIntrinsic's lead and made FMF optional for the folder interface.