### PR TITLE
[OpenCL] Allow spirv-unknown-vulkan without shader stage environment

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -45,8 +45,8 @@ def note_fe_backend_plugin: Note<"%0">, BackendInfo;
 
 def err_target_spirv_requires_vulkan : Error<
     "SPIR-V target requires a Vulkan environment">;
-def err_target_spirv_requires_shader_stage : Error<
-    "SPIR-V target requires a valid shader stage environment">;
+def err_target_spirv_invalid_shader_stage : Error<
+    "SPIR-V target requires a valid shader stage or no environment">;
 
 def warn_fe_override_module : Warning<
     "overriding the module target triple with %0">,

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -360,9 +360,10 @@ public:
       Diags.Report(diag::err_target_spirv_requires_vulkan);
       return false;
     }
-    if (getTriple().getEnvironment() < llvm::Triple::Pixel ||
-        getTriple().getEnvironment() > llvm::Triple::Amplification) {
-      Diags.Report(diag::err_target_spirv_requires_shader_stage);
+    if (getTriple().getEnvironment() != llvm::Triple::UnknownEnvironment &&
+        (getTriple().getEnvironment() < llvm::Triple::Pixel ||
+         getTriple().getEnvironment() > llvm::Triple::Amplification)) {
+      Diags.Report(diag::err_target_spirv_invalid_shader_stage);
       return false;
     }
     return true;

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -261,6 +261,14 @@
 // RUN: FileCheck %s -check-prefix=AMDGPUSPIRV64
 // AMDGPUSPIRV64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n32:64-S32-G1-P4-A0"
 
+// RUN: %clang_cc1 -triple spirv-unknown-vulkan -o - -emit-llvm %s | \
+// RUN: FileCheck %s -check-prefix=SPIRVVULKAN
+// SPIRVVULKAN: target datalayout = "e-ve-i64:64-n8:16:32:64-G10"
+
+// RUN: %clang_cc1 -triple spirv32-unknown-vulkan -o - -emit-llvm %s | \
+// RUN: FileCheck %s -check-prefix=SPIRV32VULKAN
+// SPIRV32VULKAN: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+
 // RUN: %clang_cc1 -triple spirv64-unknown-vulkan -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIRV64VULKAN
 // SPIRV64VULKAN: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -4,11 +4,19 @@
 // RUN: %clang -### --target=spirv64 -x ir -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 // RUN: %clang -### --target=spirv64 -x clcpp -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 // RUN: %clang -### --target=spirv64 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
+// RUN: %clang -### --target=spirv-unknown-vulkan -x c -c %s 2>&1 | FileCheck --check-prefix=SPVVK %s
+// RUN: %clang -### --target=spirv32-unknown-vulkan -x c -c %s 2>&1 | FileCheck --check-prefix=SPV32VK %s
 // RUN: %clang -### --target=spirv64-unknown-vulkan -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64VK %s
 // RUN: %clang -### --target=spirv64-unknown-vulkan1.3 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64VK %s
 
 // SPV64: "-cc1" "-triple" "spirv64"
 // SPV64-SAME: "-o" {{".*o"}}
+
+// SPVVK: "-cc1" "-triple" "spirv-unknown-vulkan"
+// SPVVK-SAME: "-o" {{".*o"}}
+
+// SPV32VK: "-cc1" "-triple" "spirv32-unknown-vulkan"
+// SPV32VK-SAME: "-o" {{".*o"}}
 
 // SPV64VK: "-cc1" "-triple" "spirv64-unknown-vulkan{{(1\.3)?}}"
 // SPV64VK-SAME: "-o" {{".*o"}}

--- a/clang/test/Frontend/spirv-target-validation.c
+++ b/clang/test/Frontend/spirv-target-validation.c
@@ -2,6 +2,6 @@
 // RUN: not %clang_cc1 -triple spirv-vulkan-mlibc %s 2>&1 | FileCheck %s --check-prefix=CHECK-SHADER
 
 // CHECK-VULKAN: error: SPIR-V target requires a Vulkan environment
-// CHECK-SHADER: error: SPIR-V target requires a valid shader stage environment
+// CHECK-SHADER: error: SPIR-V target requires a valid shader stage or no environment
 
 int main() { return 0; }


### PR DESCRIPTION
Fix libclc spirv-unknown-vulkan target build error: `SPIR-V target requires a valid shader stage environment`.

libclc clspv triple was canonicalized to `spirv-unknown-vulkan` in 6ef9671. Relax the restriction for libclc which is an OpenCL library that a specific shader stage is not made yet.