### PR TITLE
Updating tests for usage of CLANG_RESOURCE_DIR (clang/test/Driver/driverkit-path.c) (1/4)

### DIFF
--- a/clang/test/Driver/driverkit-path.c
+++ b/clang/test/Driver/driverkit-path.c
@@ -1,10 +1,6 @@
 // UNSUPPORTED: system-windows
 //   Windows is unsupported because we use the Unix path separator `\`.
 
-// Determine the resource directory used by the compiler so we do not have to guess at it
-// RUN: rm -rf %t && mkdir %t
-// RUN: %clang -print-resource-dir | tr -d '\n' > %t/resource-dir
-
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -mlinker-version=0 \
 // RUN:   -isysroot %S/Inputs/DriverKit19.0.sdk -### 2>&1               \
 // RUN: | FileCheck %s --check-prefix=LD64-OLD
@@ -29,11 +25,11 @@ int main() { return 0; }
 
 
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -isysroot %S/Inputs/DriverKit19.0.sdk -x c++ -### 2>&1 \
-// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit19.0.sdk -DRESOURCE_DIR="%{readfile:%t/resource-dir}" --check-prefix=INC
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit19.0.sdk -DRESOURCE_DIR=%clang-resource-dir --check-prefix=INC
 // RUN: %clang %s -target x86_64-apple-driverkit21.0.1 -isysroot %S/Inputs/DriverKit21.0.1.sdk -x c++ -### 2>&1 \
-// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit21.0.1.sdk -DRESOURCE_DIR="%{readfile:%t/resource-dir}" --check-prefix=INC
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit21.0.1.sdk -DRESOURCE_DIR=%clang-resource-dir --check-prefix=INC
 // RUN: %clang %s -target x86_64-apple-driverkit23.0 -isysroot %S/Inputs/DriverKit23.0.sdk -x c++ -### 2>&1 \
-// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit23.0.sdk -DRESOURCE_DIR="%{readfile:%t/resource-dir}" --check-prefix=INC
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit23.0.sdk -DRESOURCE_DIR=%clang-resource-dir --check-prefix=INC
 //
 // INC: "-isysroot" "[[SDKROOT]]"
 // INC: "-internal-isystem" "[[SDKROOT]]/System/DriverKit/usr/local/include"

--- a/clang/test/Driver/driverkit-path.c
+++ b/clang/test/Driver/driverkit-path.c
@@ -33,7 +33,7 @@ int main() { return 0; }
 //
 // INC: "-isysroot" "[[SDKROOT]]"
 // INC: "-internal-isystem" "[[SDKROOT]]/System/DriverKit/usr/local/include"
-// INC: "-internal-isystem" "{{.+}}/lib{{(64)?}}/clang/{{[^/ ]+}}/include"
+// INC: "-internal-isystem" "{{.+}}/lib{{(64)?}}/clang{{/?[^"]*}}/include"
 // INC: "-internal-externc-isystem" "[[SDKROOT]]/System/DriverKit/usr/include"
 // INC: "-internal-iframework" "[[SDKROOT]]/System/DriverKit/System/Library/Frameworks"
 // INC: "-internal-iframework" "[[SDKROOT]]/System/DriverKit/System/Library/SubFrameworks"

--- a/clang/test/Driver/driverkit-path.c
+++ b/clang/test/Driver/driverkit-path.c
@@ -1,6 +1,10 @@
 // UNSUPPORTED: system-windows
 //   Windows is unsupported because we use the Unix path separator `\`.
 
+// Determine the resource directory used by the compiler so we do not have to guess at it
+// RUN: rm -rf %t && mkdir %t
+// RUN: %clang -print-resource-dir | tr -d '\n' > %t/resource-dir
+
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -mlinker-version=0 \
 // RUN:   -isysroot %S/Inputs/DriverKit19.0.sdk -### 2>&1               \
 // RUN: | FileCheck %s --check-prefix=LD64-OLD
@@ -25,15 +29,15 @@ int main() { return 0; }
 
 
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -isysroot %S/Inputs/DriverKit19.0.sdk -x c++ -### 2>&1 \
-// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit19.0.sdk --check-prefix=INC
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit19.0.sdk -DRESOURCE_DIR="%{readfile:%t/resource-dir}" --check-prefix=INC
 // RUN: %clang %s -target x86_64-apple-driverkit21.0.1 -isysroot %S/Inputs/DriverKit21.0.1.sdk -x c++ -### 2>&1 \
-// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit21.0.1.sdk --check-prefix=INC
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit21.0.1.sdk -DRESOURCE_DIR="%{readfile:%t/resource-dir}" --check-prefix=INC
 // RUN: %clang %s -target x86_64-apple-driverkit23.0 -isysroot %S/Inputs/DriverKit23.0.sdk -x c++ -### 2>&1 \
-// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit23.0.sdk --check-prefix=INC
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit23.0.sdk -DRESOURCE_DIR="%{readfile:%t/resource-dir}" --check-prefix=INC
 //
 // INC: "-isysroot" "[[SDKROOT]]"
 // INC: "-internal-isystem" "[[SDKROOT]]/System/DriverKit/usr/local/include"
-// INC: "-internal-isystem" "{{.+}}/lib{{(64)?}}/clang{{/?[^"]*}}/include"
+// INC: "-internal-isystem" "[[RESOURCE_DIR]]/include"
 // INC: "-internal-externc-isystem" "[[SDKROOT]]/System/DriverKit/usr/include"
 // INC: "-internal-iframework" "[[SDKROOT]]/System/DriverKit/System/Library/Frameworks"
 // INC: "-internal-iframework" "[[SDKROOT]]/System/DriverKit/System/Library/SubFrameworks"

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -414,17 +414,8 @@ if config.enable_threads:
 
 # Add clang resource directory as a substitution
 if config.clang:
-    try:
-        clang_exe_cmd = subprocess.Popen(
-            [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE
-        )
-    except OSError:
-        print("could not exec clang")
-
-    clang_resource_dir = clang_exe_cmd.stdout.read().decode("ascii")
-    clang_exe_cmd.wait()
-
-    config.substitutions.append(("%clang-resource-dir", clang_resource_dir.strip()))
+    clang_resource_dir = subprocess.run([config.clang, "-print-resource-dir"], stdout=subprocess.PIPE, text=True).stdout.rstrip()
+    config.substitutions.append(("%clang-resource-dir", clang_resource_dir))
 
 # Check if we should allow outputs to console.
 run_console_tests = int(lit_config.params.get("enable_console", "0"))

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -200,6 +200,19 @@ def run_clang_repl(args):
 
     return clang_repl_out
 
+# Add clang resource directory as a substitution
+if config.clang:
+    try:
+        clang_exe_cmd = subprocess.Popen(
+            [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE
+        )
+    except OSError:
+        print("could not exec clang")
+
+    clang_resource_dir = clang_exe_cmd.stdout.read().decode("ascii")
+    clang_exe_cmd.wait()
+
+    config.substitutions.append(("%clang-resource-dir", clang_resource_dir.strip()))
 
 def have_host_jit_feature_support(feature_name):
     return "true" in run_clang_repl("--host-supports-" + feature_name)

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -414,7 +414,9 @@ if config.enable_threads:
 
 # Add clang resource directory as a substitution
 if config.clang:
-    clang_resource_dir = subprocess.run([config.clang, "-print-resource-dir"], stdout=subprocess.PIPE, text=True).stdout.rstrip()
+    clang_resource_dir = subprocess.run(
+        [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE, text=True
+    ).stdout.rstrip()
     config.substitutions.append(("%clang-resource-dir", clang_resource_dir))
 
 # Check if we should allow outputs to console.

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -200,19 +200,6 @@ def run_clang_repl(args):
 
     return clang_repl_out
 
-# Add clang resource directory as a substitution
-if config.clang:
-    try:
-        clang_exe_cmd = subprocess.Popen(
-            [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE
-        )
-    except OSError:
-        print("could not exec clang")
-
-    clang_resource_dir = clang_exe_cmd.stdout.read().decode("ascii")
-    clang_exe_cmd.wait()
-
-    config.substitutions.append(("%clang-resource-dir", clang_resource_dir.strip()))
 
 def have_host_jit_feature_support(feature_name):
     return "true" in run_clang_repl("--host-supports-" + feature_name)
@@ -424,6 +411,20 @@ if config.enable_backtrace:
 
 if config.enable_threads:
     config.available_features.add("thread_support")
+
+# Add clang resource directory as a substitution
+if config.clang:
+    try:
+        clang_exe_cmd = subprocess.Popen(
+            [config.clang, "-print-resource-dir"], stdout=subprocess.PIPE
+        )
+    except OSError:
+        print("could not exec clang")
+
+    clang_resource_dir = clang_exe_cmd.stdout.read().decode("ascii")
+    clang_exe_cmd.wait()
+
+    config.substitutions.append(("%clang-resource-dir", clang_resource_dir.strip()))
 
 # Check if we should allow outputs to console.
 run_console_tests = int(lit_config.params.get("enable_console", "0"))


### PR DESCRIPTION
We would like to enable the clang CMake option CLANG_RESOURCE_DIR on our build bots, but found that a few tests that need updating since they make assumptions about compiler paths that are modified when using CLANG_RESOURCE_DIR. This is change 1 of 4 to update these tests individually.

Test: clang/test/Driver/driverkit-path.c

The issue is with the regex on line 36, it assumes the path to the include directories does not change, which when using CLANG_RESOURCE_DIR, it can.

For example, the RUN line on line 27 is `%clang %s -target x86_64-apple-driverkit19.0 -isysroot %S/Inputs/DriverKit19.0.sdk -x c++ -###`, which when not using CLANG_RESOURCE_DIR, it generates the following output (edited for brevity and clarity):
```
"-isysroot" "/Users/dyung/src/git/llvm-project/clang/test/Driver/Inputs/DriverKit19.0.sdk"
"-internal-isystem" "/Users/dyung/src/git/llvm-project/clang/test/Driver/Inputs/DriverKit19.0.sdk/System/DriverKit/usr/local/include"
"-internal-isystem" "/Users/dyung/src/git/llvm-project/21776-baseline/lib/clang/23/include"
"-internal-externc-isystem" "/Users/dyung/src/git/llvm-project/clang/test/Driver/Inputs/DriverKit19.0.sdk/System/DriverKit/usr/include"
```
Note in the second instance of `-internal-isystem`, the path to the include directory includes `lib/clang/23`.

Now consider the case we would like to use where the compiler is built with `-DCLANG_RESOURCE_DIR=../lib/clang`. The output of the previous command is now the following output (edited for brevity and clarity):
```
"-isysroot" "/Users/dyung/src/git/llvm-project/clang/test/Driver/Inputs/DriverKit19.0.sdk"
"-internal-isystem" "/Users/dyung/src/git/llvm-project/clang/test/Driver/Inputs/DriverKit19.0.sdk/System/DriverKit/usr/local/include"
"-internal-isystem" "/Users/dyung/src/git/llvm-project/21776-relative/bin/../lib/clang/include"
"-internal-externc-isystem" "/Users/dyung/src/git/llvm-project/clang/test/Driver/Inputs/DriverKit19.0.sdk/System/DriverKit/usr/include"
```
Note here in the second instance of `-internal-isystem`, the path to the include directory is now `bin/../lib/clang`. In particular, the clang version number is no longer present in the path.

My proposed fix here is to update the regex so that it works both with and without the clang version number in the path to the include directory. While it won't necessarily work for any arbitrary value of CLANG_RESOURCE_DIR that someone might try to use, this is the value we would like to use and so we wish to update the test so that we can enable it on our build bots.