### PR TITLE
[AA] Consider read-only provenance capture for synchronization effects

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -469,13 +469,19 @@ ModRefInfo llvm::getSyncEffects(AAResults *AA, const MemoryLocation &Loc,
   // an effect if the object is only captured *later*. As such, set I to null
   // and ReturnCaptures to true here.
   const Value *Obj = getUnderlyingObject(Loc.Ptr);
-  if (capturesNothing(AAQI.CA->getCapturesBefore(
-          Obj, /*I=*/nullptr, /*OrAt=*/true, /*ReturnCaptures=*/true)))
+  CaptureComponents CC = AAQI.CA->getCapturesBefore(
+      Obj, /*I=*/nullptr, /*OrAt=*/true, /*ReturnCaptures=*/true);
+  if (capturesNothing(CC))
     return ModRefInfo::NoModRef;
+
+  // If only read provenance was captured, other threads may only read the
+  // object.
+  ModRefInfo MR =
+      capturesReadProvenanceOnly(CC) ? ModRefInfo::Ref : ModRefInfo::ModRef;
 
   // If Loc is a constant memory location, the synchronization operation
   // definitely could not modify it.
-  return AA->getModRefInfoMask(Loc);
+  return MR & AA->getModRefInfoMask(Loc);
 }
 
 ModRefInfo AAResults::getModRefInfo(const LoadInst *L,

--- a/llvm/test/Analysis/BasicAA/atomics.ll
+++ b/llvm/test/Analysis/BasicAA/atomics.ll
@@ -84,15 +84,15 @@ define void @alloca_escape_after(ptr %x) {
 }
 
 ; CHECK-LABEL: Function: alloca_escape_after_readonly:
-; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence acq_rel
+; CHECK:  Just Ref:  Ptr: i32* %a	<->  fence acq_rel
 ; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence acq_rel
-; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Just Ref:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
 ; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
-; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Just Ref:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
 ; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
-; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Just Ref:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
 ; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
-; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Just Ref:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
 ; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
 define void @alloca_escape_after_readonly(ptr %x) {
   %a = alloca i32

--- a/llvm/test/Analysis/BasicAA/atomics.ll
+++ b/llvm/test/Analysis/BasicAA/atomics.ll
@@ -83,6 +83,32 @@ define void @alloca_escape_after(ptr %x) {
   ret void
 }
 
+; CHECK-LABEL: Function: alloca_escape_after_readonly:
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  fence acq_rel
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  fence acq_rel
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %1 = atomicrmw add ptr %x, i32 1 acq_rel, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %2 = cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  %3 = load atomic i32, ptr %x acquire, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %a	<->  store atomic i32 0, ptr %x release, align 4
+; CHECK:  Both ModRef:  Ptr: i32* %x	<->  store atomic i32 0, ptr %x release, align 4
+define void @alloca_escape_after_readonly(ptr %x) {
+  %a = alloca i32
+  store i32 0, ptr %a
+
+  fence acq_rel
+  atomicrmw add ptr %x, i32 1 acq_rel
+  cmpxchg ptr %x, i32 0, i32 1 acq_rel monotonic
+  load atomic i32, ptr %x acquire, align 4
+  store atomic i32 0, ptr %x release, align 4
+
+  call void @escape(ptr captures(address, read_provenance) %a)
+
+  ret void
+}
+
 ; CHECK-LABEL: Function: alloca_no_escape_aliasing:
 ; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %1 = atomicrmw add ptr %a, i32 1 monotonic, align 4
 ; CHECK:  Both ModRef:  Ptr: i32* %a	<->  %2 = cmpxchg ptr %a, i32 0, i32 1 monotonic monotonic, align 4


### PR DESCRIPTION
If only read-only provenance is captured, this means that another thread may only read the object, not write to it. As such, we can also model synchronizing operations as only reading the location (and thus allow reordering of reads, but not writes, across the synchronization).

