### PR TITLE
[mlir][dataflow] IntRange: Bump int-range-analysis widening budget.

### DIFF
--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -68,7 +68,7 @@ LogicalResult staticallyNonNegative(DataFlowSolver &solver, Operation *op) {
 /// ratchet pathology this widening exists to cut off (loop-carried ranges
 /// growing by one per worklist visit) terminates after at most this many
 /// extra solver iterations rather than ~2^31.
-static constexpr unsigned kIntegerRangeWideningBudget = 128;
+static constexpr unsigned kIntegerRangeWideningBudget = 1024;
 
 ChangeResult IntegerValueRangeLattice::join(const AbstractSparseLattice &rhs) {
   ChangeResult changed = Lattice::join(rhs);


### PR DESCRIPTION
Downstream testing (Triton) found budget is too low on realistic workloads. I'm going to switch to pass option probably, but for now, just bump the budget to unblock things.

See https://github.com/llvm/llvm-project/pull/196616#issuecomment-4430041952