### PR TITLE
Fix assertion failure of `APInt::sqrt` on U64 MAX input

### DIFF
--- a/llvm/lib/Support/APInt.cpp
+++ b/llvm/lib/Support/APInt.cpp
@@ -1301,12 +1301,12 @@ APInt APInt::sqrt() const {
   // floating point representation after 192 bits. There are no discrepancies
   // between this algorithm and pari/gp for bit widths < 192 bits.
   APInt square(x_old * x_old);
-  APInt nextSquare((x_old + 1) * (x_old +1));
   if (this->ult(square))
     return x_old;
-  assert(this->ule(nextSquare) && "Error in APInt::sqrt computation");
-  APInt midpoint((nextSquare - square).udiv(two));
+  APInt delta(2 * x_old + 1);
   APInt offset(*this - square);
+  assert(offset.ule(delta) && "Error in APInt::sqrt computation");
+  APInt midpoint(delta.udiv(two));
   if (offset.ult(midpoint))
     return x_old;
   return x_old + 1;

--- a/llvm/unittests/ADT/APIntTest.cpp
+++ b/llvm/unittests/ADT/APIntTest.cpp
@@ -4009,4 +4009,12 @@ TEST(APIntTest, clmulh) {
                 .getSExtValue(),
             21845);
 }
+
+TEST(APIntTest, sqrt) {
+  EXPECT_EQ(APInt::getMaxValue(64).sqrt(), 4294967296U);
+  EXPECT_EQ(APInt::getMaxValue(128).sqrt(),
+            APInt(128, "18446744073709551616", 10));
+  EXPECT_EQ(APInt::getMaxValue(256).sqrt(),
+            APInt(256, "340282366920938463463374607431768211456", 10));
+}
 } // end anonymous namespace


### PR DESCRIPTION
Closes #197145

In

https://github.com/llvm/llvm-project/blob/65a206f2ec552cccf7c96c5306147f0437832ec7/llvm/lib/Support/APInt.cpp#L1305-L1312

Instead of computing `nextSquare` completely (which overflows), we only need to compute the difference between `x_old^2` and `(x_old + 1)^2` which is simply `2 * x_old + 1` since `(x_old + 1)^2 = x_old^2 + 2 * x_old + 1`. We can use this difference for the following computation of the midpoint.