### PR TITLE
[AArch64] Clean-up constrain register check in selectCopy (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -1056,11 +1056,8 @@ static bool selectCopy(MachineInstr &I, const TargetInstrInfo &TII,
     unsigned SrcSubReg = I.getOperand(1).getSubReg();
     unsigned SubReg;
 
-    if (SrcSubReg) {
-      if (!RBI.constrainGenericRegister(DstReg, *DstRC, MRI))
-        return false;
-      return true;
-    }
+    if (SrcSubReg)
+      return RBI.constrainGenericRegister(DstReg, *DstRC, MRI);
 
     // If the source bank doesn't support a subregister copy small enough,
     // then we first need to copy to the destination bank.


### PR DESCRIPTION
This addresses post-commit review from #188781.