### PR TITLE
[libc] Only back off GPU allocation under high contention

### DIFF
--- a/libc/src/__support/GPU/allocator.cpp
+++ b/libc/src/__support/GPU/allocator.cpp
@@ -327,15 +327,16 @@ struct Slab {
 
         uint32_t after = before | bitmask;
         uint64_t waiting = gpu::ballot(lane_mask, !result);
-        if (!result)
+        if (!result) {
           start =
               gpu::shuffle(waiting, cpp::countr_zero(waiting),
                            ~after ? __builtin_align_down(index, BITS_IN_WORD) +
                                         cpp::countr_zero(~after)
                                   : __builtin_align_down(
                                         impl::xorshift32(state), BITS_IN_WORD));
-        if (!result)
-          sleep_briefly();
+          if (!gpu::shuffle(waiting, cpp::countr_zero(waiting), ~after))
+            sleep_briefly();
+        }
       }
     }
     return result;


### PR DESCRIPTION
Summary:
Right now this sleeps if any threads failed, this is inefficient. We
want the sleep to stop livelock, though that is less common since the FW
progress bit was set by default. But we should only do this when the
bitfield is full to minimize sleeping when there's plenty of space
available.
