### PR TITLE
[BasicAA] Remove special malloc handling

### DIFF
--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -59,11 +59,6 @@ isAllocationFn(const Value *V,
                function_ref<const TargetLibraryInfo &(Function &)> GetTLI);
 
 /// Tests if a value is a call or invoke to a library function that
-/// allocates memory similar to malloc or calloc.
-LLVM_ABI bool isMallocOrCallocLikeFn(const Value *V,
-                                     const TargetLibraryInfo *TLI);
-
-/// Tests if a value is a call or invoke to a library function that
 /// allocates memory (either malloc, calloc, or strdup like).
 LLVM_ABI bool isAllocLikeFn(const Value *V, const TargetLibraryInfo *TLI);
 

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1033,20 +1033,6 @@ ModRefInfo BasicAAResult::getModRefInfo(const CallBase *Call,
   if (!isModAndRefSet(Result))
     return Result;
 
-  // If the call is malloc/calloc like, we can assume that it doesn't
-  // modify any IR visible value.  This is only valid because we assume these
-  // routines do not read values visible in the IR.  TODO: Consider special
-  // casing realloc and strdup routines which access only their arguments as
-  // well.  Or alternatively, replace all of this with inaccessiblememonly once
-  // that's implemented fully.
-  if (isMallocOrCallocLikeFn(Call, &TLI)) {
-    // Be conservative if the accessed pointer may alias the allocation -
-    // fallback to the generic handling below.
-    if (AAQI.AAR.alias(MemoryLocation::getBeforeOrAfter(Call), Loc, AAQI) ==
-        AliasResult::NoAlias)
-      return ModRefInfo::NoModRef;
-  }
-
   // Like assumes, invariant.start intrinsics were also marked as arbitrarily
   // writing so that proper control dependencies are maintained but they never
   // mod any particular memory location visible to the IR.

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -295,14 +295,6 @@ bool llvm::isAllocationFn(
 }
 
 /// Tests if a value is a call or invoke to a library function that
-/// allocates memory similar to malloc or calloc.
-bool llvm::isMallocOrCallocLikeFn(const Value *V,
-                                  const TargetLibraryInfo *TLI) {
-  // TODO: Function behavior does not match name.
-  return getAllocationData(V, MallocOrOpNewLike, TLI).has_value();
-}
-
-/// Tests if a value is a call or invoke to a library function that
 /// allocates memory (either malloc, calloc, or strdup like).
 bool llvm::isAllocLikeFn(const Value *V, const TargetLibraryInfo *TLI) {
   return getAllocationData(V, AllocLike, TLI).has_value() ||

--- a/llvm/test/Analysis/BasicAA/new.ll
+++ b/llvm/test/Analysis/BasicAA/new.ll
@@ -1,0 +1,14 @@
+; RUN: opt -passes=aa-eval -print-all-alias-modref-info -disable-output < %s 2>&1 | FileCheck %s
+
+; Don't assume that operator new without attributes does not access unrelated
+; memory.
+
+declare noalias ptr @_Znwm(i64)
+
+; CHECK-LABEL: Function: test:
+; CHECK: Both ModRef:  Ptr: i8* %p	<->  %1 = call ptr @_Znwm(i64 4)
+define void @test(ptr %p) {
+  call ptr @_Znwm(i64 4)
+  load i8, ptr %p
+  ret void
+}

--- a/llvm/test/Transforms/GVN/nonescaping.ll
+++ b/llvm/test/Transforms/GVN/nonescaping.ll
@@ -6,7 +6,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 
 declare noalias ptr @malloc(i64) nounwind allockind("alloc,uninitialized") allocsize(0) inaccessiblememonly
 declare noalias ptr @calloc(i64, i64) allockind("alloc,zeroed") allocsize(0,1) inaccessiblememonly
-declare noalias ptr @_Znwm(i64)
+declare noalias ptr @_Znwm(i64) memory(inaccessiblemem: readwrite)
 declare void @escape(ptr)
 
 define i8 @test_malloc(ptr %p) {


### PR DESCRIPTION
We currently assume that allocation functions don't ModRef other memory. However, this is something that should be controlled by the `memory` attribute on the allocator, which is typically inaccessiblememonly for things like malloc.

This code path specifically only affected hardcoded allocation functions from MemoryBuiltins (not those using allocator attributes). Nowadays, these are only the `operator new` family functions.

For those functions, we should not unconditionally assume that they don't access other memory: They are replaceable global allocators, which in principle can have arbitrary memory effects (they can just be pair-wise elided, but must be respected if not elided.)

https://github.com/llvm/llvm-project/pull/217652 changed clang to emit `memory(inaccessiblemem: readwrite, errnomem: write)` for `operator new` if `-fassume-sane-operator-new` is used (which is the default). We should not make any additional assumptions in BasicAA if the attribute is not present.