### PR TITLE
[Support] Add a function to print the debug log

### DIFF
--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -104,6 +104,11 @@ LLVM_ABI extern bool EnableDebugBuffering;
 /// like: dbgs() << "foo" << "bar";
 LLVM_ABI raw_ostream &dbgs();
 
+/// If EnableDebugBuffering is true, this flushes the debug stream with
+/// the banner displayed, the same way it is printed automatically on
+/// program termination.
+LLVM_ABI void printDebugLog();
+
 // DEBUG macro - This macro should be used by passes to emit debug information.
 // If the '-debug' option is specified on the commandline, and if this is a
 // debug build, then the code specified as the option to the macro will be

--- a/llvm/lib/Support/Debug.cpp
+++ b/llvm/lib/Support/Debug.cpp
@@ -192,8 +192,7 @@ void llvm::initDebugOptions() {
   *DebugOnly;
 }
 
-// Signal handlers - dump debug output on termination.
-static void debug_user_sig_handler(void *Cookie) {
+static void printDebugLogImpl() {
   // This is a bit sneaky.  Since this is under #ifndef NDEBUG, we
   // know that debug mode is enabled and dbgs() really is a
   // circular_raw_ostream.  If NDEBUG is defined, then dbgs() ==
@@ -202,6 +201,9 @@ static void debug_user_sig_handler(void *Cookie) {
       static_cast<circular_raw_ostream &>(llvm::dbgs());
   dbgout.flushBufferWithBanner();
 }
+
+// Signal handlers - dump debug output on termination.
+static void debug_user_sig_handler(void *Cookie) { printDebugLogImpl(); }
 
 /// dbgs - Return a circular-buffered debug stream.
 raw_ostream &llvm::dbgs() {
@@ -224,6 +226,11 @@ raw_ostream &llvm::dbgs() {
   return thestrm.strm;
 }
 
+void llvm::printDebugLog() {
+  if (EnableDebugBuffering && DebugFlag && *DebugBufferSize != 0)
+    printDebugLogImpl();
+}
+
 #else
 // Avoid "has no symbols" warning.
 namespace llvm {
@@ -233,6 +240,8 @@ namespace llvm {
   }
 }
 void llvm::initDebugOptions() {}
+
+void llvm::printDebugLog() {}
 #endif
 
 /// EnableDebugBuffering - Turn on signal handler installation.


### PR DESCRIPTION
With `EnableDebugBuffering`, the debug log is stored in a circular buffer and printed, with a nice banner, on program termination - this is achieved via a signal handler. For in-process tool execution, such as for running the regression tests using daemon versions of the tools, we need to be able to trigger the printing/flushing of the debug log from the process itself. This PR just adds a small function `printDebugLog` which checks if debug output and debug log buffering are enabled and, if so, prints the debug log.

The code for printing the debug log in the signal handler is moved to a new function `printDebugLogImpl` which is called by the signal handler and `printDebugLog` - the reason this is separate from `printDebugLog` is to avoid running the option check in the signal handler implementation, in case options were reset before the signal handler is called, as this would be an unintentional behavioral change.