### PR TITLE
[lldb][Python] Include limited API library directory

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -37,6 +37,12 @@ set(python_plugin_sources
   Interfaces/ScriptedThreadPythonInterface.cpp
 )
 
+if (WIN32)
+  # Add the library directories to allow Python to use #pragma comment(lib, "python3.lib").
+  # FIXME: We should use Python3_SABI_LIBRARY_DIRS here, but this requires CMake 3.26.
+  set(PYTHON_SABI_LIBRARY_DIRS ${Python3_LIBRARY_DIRS})
+endif()
+
 if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
   # Shared library loaded at runtime by PluginManager. Private lldb symbols are
   # resolved via liblldb's re-exports, so lldb_private libs aren't linked here.
@@ -70,12 +76,8 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
   target_include_directories(lldbStaticScriptInterpreterPython
     PUBLIC ${Python3_INCLUDE_DIRS})
 
-  if (WIN32)
-    # Add the library directories to allow Python to use #pragma comment(lib, "python3.lib").
-    # FIXME: We should use Python3_SABI_LIBRARY_DIRS here, but this requires CMake 3.26.
-    target_link_directories(lldbPluginScriptInterpreterPython PRIVATE ${Python3_LIBRARY_DIRS})
-    target_link_directories(lldbStaticScriptInterpreterPython PUBLIC ${Python3_LIBRARY_DIRS})
-  endif()
+  target_link_directories(lldbPluginScriptInterpreterPython PRIVATE ${PYTHON_SABI_LIBRARY_DIRS})
+  target_link_directories(lldbStaticScriptInterpreterPython PUBLIC ${PYTHON_SABI_LIBRARY_DIRS})
 else()
   add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
     ${python_plugin_sources}
@@ -92,11 +94,7 @@ else()
       ${Python3_LIBRARIES}
       ${LLDB_LIBEDIT_LIBS}
   )
-  if (WIN32)
-    # Add the library directories to allow Python to use #pragma comment(lib, "python3.lib").
-    # FIXME: We should use Python3_SABI_LIBRARY_DIRS here, but this requires CMake 3.26.
-    target_link_directories(lldbPluginScriptInterpreterPython PUBLIC ${Python3_LIBRARY_DIRS})
-  endif()
+  target_link_directories(lldbPluginScriptInterpreterPython PUBLIC ${PYTHON_SABI_LIBRARY_DIRS})
 endif()
 
 target_include_directories(lldbPluginScriptInterpreterPython

--- a/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/CMakeLists.txt
@@ -69,6 +69,13 @@ if (LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS)
   )
   target_include_directories(lldbStaticScriptInterpreterPython
     PUBLIC ${Python3_INCLUDE_DIRS})
+
+  if (WIN32)
+    # Add the library directories to allow Python to use #pragma comment(lib, "python3.lib").
+    # FIXME: We should use Python3_SABI_LIBRARY_DIRS here, but this requires CMake 3.26.
+    target_link_directories(lldbPluginScriptInterpreterPython PRIVATE ${Python3_LIBRARY_DIRS})
+    target_link_directories(lldbStaticScriptInterpreterPython PUBLIC ${Python3_LIBRARY_DIRS})
+  endif()
 else()
   add_lldb_library(lldbPluginScriptInterpreterPython PLUGIN
     ${python_plugin_sources}
@@ -85,6 +92,11 @@ else()
       ${Python3_LIBRARIES}
       ${LLDB_LIBEDIT_LIBS}
   )
+  if (WIN32)
+    # Add the library directories to allow Python to use #pragma comment(lib, "python3.lib").
+    # FIXME: We should use Python3_SABI_LIBRARY_DIRS here, but this requires CMake 3.26.
+    target_link_directories(lldbPluginScriptInterpreterPython PUBLIC ${Python3_LIBRARY_DIRS})
+  endif()
 endif()
 
 target_include_directories(lldbPluginScriptInterpreterPython


### PR DESCRIPTION
On Windows, when compiling with the limited API in non-debug mode, Python will instruct the linker to link `python3.lib` [here](https://github.com/python/cpython/blob/f5fb491341e566bbaf17d9bf3e4ec3af4a56bb3f/PC/pyconfig.h#L344-L345).

Currently, we don't directly specify the library in CMake. We specify `python3xx.lib`. When the linker encounters the `python3.lib` requirement, it errors out, because it doesn't know where that is. With this PR, we add the directory of `python3xx.lib`. This is the same one as `python3.lib`. So the linker can find the library.

This is more of a temporary fix. As commented in the code, we should use `Python3_SABI_LIBRARY_DIRS` once we require CMake 3.26. Furthermore, I'm not fully sure why we link to `python3xx.lib` when the limited API is requested (presumably because of #167001?).