### PR TITLE
[VPlan] Pass ArrayRef<VPValue *> instead ArrayRef<const VPValue *> (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1867,7 +1867,7 @@ VPCostContext::getOperandInfo(VPValue *V) const {
 }
 
 InstructionCost VPCostContext::getScalarizationOverhead(
-    Type *ResultTy, ArrayRef<const VPValue *> Operands, ElementCount VF,
+    Type *ResultTy, ArrayRef<VPValue *> Operands, ElementCount VF,
     TTI::VectorInstrContext VIC, bool AlwaysIncludeReplicatingR) {
   if (VF.isScalar())
     return 0;

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -366,7 +366,7 @@ struct VPCostContext {
   /// AlwaysIncludeReplicatingR is true, always compute the cost of scalarizing
   /// replicating operands.
   InstructionCost getScalarizationOverhead(
-      Type *ResultTy, ArrayRef<const VPValue *> Operands, ElementCount VF,
+      Type *ResultTy, ArrayRef<VPValue *> Operands, ElementCount VF,
       TTI::VectorInstrContext VIC = TTI::VectorInstrContext::None,
       bool AlwaysIncludeReplicatingR = false);
 

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1965,7 +1965,7 @@ void VPWidenIntrinsicRecipe::execute(VPTransformState &State) {
 
 /// Compute the cost for the intrinsic \p ID with \p Operands, produced by \p R.
 static InstructionCost getCostForIntrinsics(Intrinsic::ID ID,
-                                            ArrayRef<const VPValue *> Operands,
+                                            ArrayRef<VPValue *> Operands,
                                             const VPRecipeWithIRFlags &R,
                                             ElementCount VF,
                                             VPCostContext &Ctx) {
@@ -2011,7 +2011,7 @@ static InstructionCost getCostForIntrinsics(Intrinsic::ID ID,
 
 InstructionCost VPWidenIntrinsicRecipe::computeCost(ElementCount VF,
                                                     VPCostContext &Ctx) const {
-  SmallVector<const VPValue *> ArgOps(operands());
+  ArrayRef<VPValue *> ArgOps(operands().begin(), getNumOperands());
   return getCostForIntrinsics(VectorIntrinsicID, ArgOps, *this, VF, Ctx);
 }
 
@@ -3387,7 +3387,7 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
     auto *CalledFn =
         cast<Function>(getOperand(getNumOperands() - 1)->getLiveInIRValue());
 
-    SmallVector<const VPValue *> ArgOps(drop_end(operands()));
+    ArrayRef<VPValue *> ArgOps(operands().begin(), getNumOperands() - 1);
     SmallVector<Type *, 4> Tys;
     for (const VPValue *ArgOp : ArgOps)
       Tys.push_back(Ctx.Types.inferScalarType(ArgOp));
@@ -3457,9 +3457,11 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
         }))
       break;
 
-    ScalarCost = ScalarCost * VF.getFixedValue() +
-                 Ctx.getScalarizationOverhead(Ctx.Types.inferScalarType(this),
-                                              to_vector(operands()), VF);
+    ScalarCost =
+        ScalarCost * VF.getFixedValue() +
+        Ctx.getScalarizationOverhead(
+            Ctx.Types.inferScalarType(this),
+            ArrayRef<VPValue *>(operands().begin(), getNumOperands()), VF);
     // If the recipe is not predicated (i.e. not in a replicate region), return
     // the scalar cost. Otherwise handle predicated cost.
     if (!getRegion()->isReplicator())
@@ -3524,7 +3526,7 @@ InstructionCost VPReplicateRecipe::computeCost(ElementCount VF,
     if (isSingleScalar())
       return ScalarCost;
 
-    SmallVector<const VPValue *> OpsToScalarize;
+    SmallVector<VPValue *> OpsToScalarize;
     Type *ResultTy = Type::getVoidTy(PtrTy->getContext());
     // Set ResultTy and OpsToScalarize, if scalarization is needed. Currently we
     // don't assign scalarization overhead in general, if the target prefers


### PR DESCRIPTION
Operands are stored in SmallVector<VPValue *>. This means we cannot automatically convert this to ArrayRef<const VPValue *>. Update to pass ArrayRef<VPValue *> to some helpers, to avoid creating temporary SmallVectors.

I'm not 100% sure this is actually worthwhile.