### PR TITLE
[clang][NFC] Mark CWG941 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -32,9 +32,14 @@ template<> void f<int>() {}
 template <typename>
 struct A {
   void f() = delete;
+
+  template <typename>
+  void g() = delete;
 };
 
 template<> void A<int>::f() {}
+
+template<> template<> void A<int>::g<int>() {}
 
 struct B {
   template <typename>

--- a/clang/test/CXX/drs/cwg9xx.cpp
+++ b/clang/test/CXX/drs/cwg9xx.cpp
@@ -22,6 +22,29 @@ static_assert(alignof(int[][2]) == alignof(int[2]), "");
 #endif
 } // namespace cwg930
 
+namespace cwg941 { // cwg941: 3.9
+#if __cplusplus >= 201103L
+template <typename>
+void f() = delete;
+
+template<> void f<int>() {}
+
+template <typename>
+struct A {
+  void f() = delete;
+};
+
+template<> void A<int>::f() {}
+
+struct B {
+  template <typename>
+  void f() = delete;
+};
+
+template<> void B::f<int>() {}
+#endif
+} // namespace cwg941
+
 namespace cwg948 { // cwg948: 3.7
 #if __cplusplus >= 201103L
   class A {

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -6364,7 +6364,7 @@
     <td>[<a href="https://wg21.link/temp.expl.spec">temp.expl.spec</a>]</td>
     <td>C++11</td>
     <td>Explicit specialization of deleted function template</td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.9</td>
   </tr>
   <tr id="942">
     <td><a href="https://cplusplus.github.io/CWG/issues/942.html">942</a></td>


### PR DESCRIPTION
[CWG941](https://wg21.link/cwg941) allowed specializing deleted function templates. Clang accepted this between 2.7 and 2.9, regressed and started emitting redefinition errors between 3.0 and 3.8, then went back to accepting in 3.9: https://godbolt.org/z/GKnf9je7j. I've marked it as implemented since 3.9.