### PR TITLE
[ASan][Darwin] Make multiple_sigaltstack.cpp test use MINSIGSTKSZ

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/multiple_sigaltstack.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/multiple_sigaltstack.cpp
@@ -5,7 +5,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#if (__APPLE__)
+char global_alt_stack[MINSIGSTKSZ];
+#else
 char global_alt_stack[4096 * 4];
+#endif
 
 int main() {
   stack_t altstack;


### PR DESCRIPTION
Currently this test is failing on Darwin due to the specified stack size being below the minimum (as defined by MINSIGSTKSZ).

This patch allocates a buffer with size MINSIGSTKSZ in order to overcome this.

rdar://176838125