### PR TITLE
[LifetimeSafety] Diagnose invalidated-global

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -94,6 +94,12 @@ public:
   virtual void reportInvalidatedField(const ParmVarDecl *PVD,
                                       const FieldDecl *Field,
                                       const Expr *InvalidationExpr) {}
+  virtual void reportInvalidatedGlobal(const Expr *IssueExpr,
+                                       const VarDecl *Global,
+                                       const Expr *InvalidationExpr) {}
+  virtual void reportInvalidatedGlobal(const ParmVarDecl *PVD,
+                                       const VarDecl *Global,
+                                       const Expr *InvalidationExpr) {}
 
   using EscapingTarget =
       llvm::PointerUnion<const Expr *, const FieldDecl *, const VarDecl *>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10989,6 +10989,10 @@ def warn_lifetime_safety_invalidated_field
     : Warning<"%select{object whose reference|parameter which}0 escapes to a field is later invalidated">,
       InGroup<LifetimeSafetyInvalidation>,
       DefaultIgnore;
+def warn_lifetime_safety_invalidated_global
+    : Warning<"%select{object whose reference|parameter which}0 escapes to global or static storage is later invalidated">,
+      InGroup<LifetimeSafetyInvalidation>,
+      DefaultIgnore;
 
 def warn_lifetime_safety_dangling_field
     : Warning<"address of stack memory escapes to a field">,

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -277,8 +277,19 @@ public:
               SemaHelper->reportInvalidatedField(InvalidatedPVD,
                                                  FieldEscape->getFieldDecl(),
                                                  Warning.InvalidatedByExpr);
-          } else if (isa<GlobalEscapeFact>(OEF)) {
-            // FIXME: Diagnose invalidated global escapes separately.
+          } else if (const auto *GlobalEscape =
+                         dyn_cast<GlobalEscapeFact>(OEF)) {
+            // Invalidated object escapes to global or static storage.
+            if (IssueExpr)
+              // Invalidated object escapes to global or static storage.
+              SemaHelper->reportInvalidatedGlobal(IssueExpr,
+                                                  GlobalEscape->getGlobal(),
+                                                  Warning.InvalidatedByExpr);
+            else if (InvalidatedPVD)
+              // Invalidated parameter escapes to global or static storage.
+              SemaHelper->reportInvalidatedGlobal(InvalidatedPVD,
+                                                  GlobalEscape->getGlobal(),
+                                                  Warning.InvalidatedByExpr);
           } else if (isa<ReturnEscapeFact>(OEF)) {
             // FIXME: Diagnose invalidated return escapes separately.
           } else

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -281,7 +281,8 @@ public:
                          dyn_cast<GlobalEscapeFact>(OEF)) {
             // Invalidated object escapes to global or static storage.
             if (IssueExpr)
-              // Invalidated object escapes to global or static storage.
+              // Invalidated object on stack escapes to global or static
+              // storage.
               SemaHelper->reportInvalidatedGlobal(IssueExpr,
                                                   GlobalEscape->getGlobal(),
                                                   Warning.InvalidatedByExpr);

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -180,6 +180,48 @@ public:
         << DanglingField->getEndLoc();
   }
 
+  void reportInvalidatedGlobal(const Expr *IssueExpr,
+                               const VarDecl *DanglingGlobal,
+                               const Expr *InvalidationExpr) override {
+    auto InvalidationDiag = isa<CXXDeleteExpr>(InvalidationExpr)
+                                ? diag::note_lifetime_safety_freed_here
+                                : diag::note_lifetime_safety_invalidated_here;
+    S.Diag(IssueExpr->getExprLoc(),
+           diag::warn_lifetime_safety_invalidated_global)
+        << false << IssueExpr->getSourceRange();
+    S.Diag(InvalidationExpr->getExprLoc(), InvalidationDiag)
+        << InvalidationExpr->getSourceRange();
+    if (DanglingGlobal->isStaticLocal() || DanglingGlobal->isStaticDataMember())
+      S.Diag(DanglingGlobal->getLocation(),
+             diag::note_lifetime_safety_dangling_static_here)
+          << DanglingGlobal->getEndLoc();
+    else
+      S.Diag(DanglingGlobal->getLocation(),
+             diag::note_lifetime_safety_dangling_global_here)
+          << DanglingGlobal->getEndLoc();
+  }
+
+  void reportInvalidatedGlobal(const ParmVarDecl *PVD,
+                               const VarDecl *DanglingGlobal,
+                               const Expr *InvalidationExpr) override {
+    auto InvalidationDiag = isa<CXXDeleteExpr>(InvalidationExpr)
+                                ? diag::note_lifetime_safety_freed_here
+                                : diag::note_lifetime_safety_invalidated_here;
+    S.Diag(PVD->getSourceRange().getBegin(),
+           diag::warn_lifetime_safety_invalidated_global)
+        << true << PVD->getSourceRange();
+    S.Diag(InvalidationExpr->getExprLoc(), InvalidationDiag)
+        << InvalidationExpr->getSourceRange();
+    if (DanglingGlobal->isStaticLocal() || DanglingGlobal->isStaticDataMember())
+      S.Diag(DanglingGlobal->getLocation(),
+             diag::note_lifetime_safety_dangling_static_here)
+          << DanglingGlobal->getEndLoc();
+    else
+      S.Diag(DanglingGlobal->getLocation(),
+             diag::note_lifetime_safety_dangling_global_here)
+          << DanglingGlobal->getEndLoc();
+  }
+
   void suggestLifetimeboundToParmVar(SuggestionScope Scope,
                                      const ParmVarDecl *ParmToAnnotate,
                                      EscapingTarget Target) override {

--- a/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-invalidations.cpp
@@ -507,6 +507,67 @@ struct S {
 };
 } // namespace InvalidatedField
 
+namespace InvalidatedGlobal {
+std::string StableString;
+std::string_view GlobalFromLocalVector; // expected-note {{this global dangles}}
+std::string_view GlobalFromByValueParamString; // expected-note {{this global dangles}}
+std::string_view GlobalFromRefParamString; // expected-note {{this global dangles}}
+int *GlobalFromNew; // expected-note {{this global dangles}}
+int *GlobalFromPointerParam; // expected-note {{this global dangles}}
+std::string_view GlobalReassigned;
+
+struct S {
+  static std::string_view StaticMember; // expected-note {{this static storage dangles}}
+};
+
+void InvalidatedGlobalLocalVector() {
+  std::vector<std::string> strings;
+  GlobalFromLocalVector = *strings.begin(); // expected-warning {{object whose reference escapes to global or static storage is later invalidated}}
+  strings.push_back("1"); // expected-note {{invalidated here}}
+}
+
+void InvalidatedGlobalByValueParamString(std::string s) {
+  GlobalFromByValueParamString = s; // expected-warning {{object whose reference escapes to global or static storage is later invalidated}}
+  s.clear(); // expected-note {{invalidated here}}
+}
+
+void InvalidatedGlobalRefParamString(std::string &s) { // expected-warning {{parameter which escapes to global or static storage is later invalidated}}
+  GlobalFromRefParamString = s;
+  s.~basic_string(); // expected-note {{invalidated here}}
+}
+
+void InvalidatedGlobalDelete() {
+  int *p = new int; // expected-warning {{object whose reference escapes to global or static storage is later invalidated}}
+  GlobalFromNew = p;
+  delete p; // expected-note {{freed here}}
+}
+
+void InvalidatedGlobalDeleteParam(int *p) { // expected-warning {{parameter which escapes to global or static storage is later invalidated}}
+  GlobalFromPointerParam = p;
+  delete p; // expected-note {{freed here}}
+}
+
+void InvalidatedStaticLocalString() {
+  static std::string_view StaticFromLocalString; // expected-note {{this static storage dangles}}
+  std::string s;
+  StaticFromLocalString = s; // expected-warning {{object whose reference escapes to global or static storage is later invalidated}}
+  s.clear(); // expected-note {{invalidated here}}
+}
+
+void InvalidatedStaticMemberString() {
+  std::string s;
+  S::StaticMember = s; // expected-warning {{object whose reference escapes to global or static storage is later invalidated}}
+  s.clear(); // expected-note {{invalidated here}}
+}
+
+void GlobalReassignedBeforeInvalidation() {
+  std::vector<std::string> strings;
+  GlobalReassigned = *strings.begin();
+  GlobalReassigned = StableString;
+  strings.push_back("1");
+}
+} // namespace InvalidatedGlobal
+
 namespace AssociativeContainers {
 void SetInsertDoesNotInvalidate() {
   std::set<int> s;


### PR DESCRIPTION
Teach lifetime safety invalidation diagnostics to handle origins that escape through global or static storage before the referenced object is invalidated. Previously they were skipped.

Follow up of #196680
Closes https://github.com/llvm/llvm-project/issues/195706