### PR TITLE
[InstCombine] Reuse values when scalarizing phis with duplicated incoming edges

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -135,7 +135,7 @@ Instruction *InstCombinerImpl::scalarizePHI(ExtractElementInst &EI,
       PHINode::Create(EI.getType(), PN->getNumIncomingValues(), ""), PN->getIterator()));
   // Scalarize each PHI operand. A switch may produce multiple edges from the
   // same predecessor; reuse the scalar instruction for duplicate edges.
-  DenseMap<BasicBlock *, Value *> ScalarizedValues;
+  SmallDenseMap<BasicBlock *, Value *, 4> ScalarizedValues;
   for (unsigned i = 0; i < PN->getNumIncomingValues(); i++) {
     Value *PHIInVal = PN->getIncomingValue(i);
     BasicBlock *inBB = PN->getIncomingBlock(i);

--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -133,11 +133,21 @@ Instruction *InstCombinerImpl::scalarizePHI(ExtractElementInst &EI,
   // just before the current PHI node.
   PHINode *scalarPHI = cast<PHINode>(InsertNewInstWith(
       PHINode::Create(EI.getType(), PN->getNumIncomingValues(), ""), PN->getIterator()));
-  // Scalarize each PHI operand.
+  // Scalarize each PHI operand. A switch may produce multiple edges from the
+  // same predecessor; reuse the scalar instruction for duplicate edges.
+  DenseMap<BasicBlock *, Value *> ScalarizedValues;
   for (unsigned i = 0; i < PN->getNumIncomingValues(); i++) {
     Value *PHIInVal = PN->getIncomingValue(i);
     BasicBlock *inBB = PN->getIncomingBlock(i);
     Value *Elt = EI.getIndexOperand();
+
+    // Reuse scalar value for duplicate edges from the same predecessor.
+    if (Value *Existing = ScalarizedValues.lookup(inBB)) {
+      scalarPHI->addIncoming(Existing, inBB);
+      continue;
+    }
+
+    Value *ScalarVal;
     // If the operand is the PHI induction variable:
     if (PHIInVal == PHIUser) {
       // Scalarize the binary operation. One operand is the
@@ -153,11 +163,9 @@ Instruction *InstCombinerImpl::scalarizePHI(ExtractElementInst &EI,
       // non-commutative operations.
       Value *FirstOp = (B0->getOperand(0) == PN) ? scalarPHI : Op;
       Value *SecondOp = (B0->getOperand(0) == PN) ? Op : scalarPHI;
-      Value *newPHIUser =
-          InsertNewInstWith(BinaryOperator::CreateWithCopiedFlags(
-                                B0->getOpcode(), FirstOp, SecondOp, B0),
-                            B0->getIterator());
-      scalarPHI->addIncoming(newPHIUser, inBB);
+      ScalarVal = InsertNewInstWith(BinaryOperator::CreateWithCopiedFlags(
+                                        B0->getOpcode(), FirstOp, SecondOp, B0),
+                                    B0->getIterator());
     } else {
       // Scalarize PHI input:
       Instruction *newEI = ExtractElementInst::Create(PHIInVal, Elt, "");
@@ -170,10 +178,11 @@ Instruction *InstCombinerImpl::scalarizePHI(ExtractElementInst &EI,
         InsertPos = inBB->getFirstInsertionPt();
       }
 
-      InsertNewInstWith(newEI, InsertPos);
-
-      scalarPHI->addIncoming(newEI, inBB);
+      ScalarVal = InsertNewInstWith(newEI, InsertPos);
     }
+
+    ScalarizedValues[inBB] = ScalarVal;
+    scalarPHI->addIncoming(ScalarVal, inBB);
   }
 
   for (auto *E : Extracts) {

--- a/llvm/test/Transforms/InstCombine/vec_phi_extract.ll
+++ b/llvm/test/Transforms/InstCombine/vec_phi_extract.ll
@@ -164,3 +164,32 @@ for.end:
   ret i1 %tobool313
 }
 
+; Switch with multiple edges to the same block: scalarizePHI must reuse
+; the same scalar value for duplicate predecessor entries.
+define void @scalarize_phi_switch_multi_edge(ptr %0, <16 x i64> %a3) {
+; CHECK-LABEL: @scalarize_phi_switch_multi_edge(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <16 x i64> [[A3:%.*]], i64 0
+; CHECK-NEXT:    switch i33 0, label [[LBL_BR9:%.*]] [
+; CHECK-NEXT:      i33 -2547564735, label [[LBL_BR9]]
+; CHECK-NEXT:      i33 4, label [[LBL_BR9]]
+; CHECK-NEXT:    ]
+; CHECK:       lbl_br9:
+; CHECK-NEXT:    [[TMP2:%.*]] = phi i64 [ [[TMP1]], [[ENTRY:%.*]] ], [ [[TMP1]], [[ENTRY]] ], [ 0, [[LBL_BR9]] ], [ [[TMP1]], [[ENTRY]] ]
+; CHECK-NEXT:    store i64 [[TMP2]], ptr [[TMP0:%.*]], align 8
+; CHECK-NEXT:    br label [[LBL_BR9]]
+;
+entry:
+  switch i64 0, label %lbl_br9 [
+  i64 6042369857, label %lbl_br9
+  i64 4, label %lbl_br9
+  ]
+
+lbl_br9:
+  %a3.addr.1 = phi <16 x i64> [ %a3, %entry ], [ %a3, %entry ], [ %and, %lbl_br9 ], [ %a3, %entry ]
+  %vecext = extractelement <16 x i64> %a3.addr.1, i64 0
+  store i64 %vecext, ptr %0, align 8
+  %and = and <16 x i64> zeroinitializer, %a3.addr.1
+  br label %lbl_br9
+}
+


### PR DESCRIPTION
Fixes #196954.