### PR TITLE
[llvm][tools] Use temp dir for offload-binary unbundling test

### DIFF
--- a/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
+++ b/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
@@ -17,6 +17,8 @@
 ; RUN: diff %s %t4
 
 ; Test extracting all images without specifying --image filters.
+; RUN: rm -rf %.dir && mkdir %t.dir
+; RUN: cd %t.dir
 ; RUN: llvm-offload-binary %t | FileCheck --check-prefix=EXTRACT %s
 
 ; EXTRACT: Extracted: llvm-offload-binary.{{.*}}-x-y-z-abc.0.

--- a/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
+++ b/llvm/test/tools/llvm-offload-binary/llvm-offload-binary.ll
@@ -17,7 +17,7 @@
 ; RUN: diff %s %t4
 
 ; Test extracting all images without specifying --image filters.
-; RUN: rm -rf %.dir && mkdir %t.dir
+; RUN: rm -rf %t.dir && mkdir %t.dir
 ; RUN: cd %t.dir
 ; RUN: llvm-offload-binary %t | FileCheck --check-prefix=EXTRACT %s
 


### PR DESCRIPTION
Certain environments will leave some of the test dirs read-only for immutability purposes. Create a new temporary directory so that llvm-offload-binary has a writable directory to unbundle the image into. With this method we can also delete the temporary directory preventing breakage of the failure from still passing tests due to leftover files.