### PR TITLE
[lldb] Remove .noindex suffix from test output directory for non-Darwin

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -235,7 +235,7 @@ def create_parser():
         dest="test_build_dir",
         metavar="Test build directory",
         default=(
-            "lldb-test-build" if sys.platform == "win32" else "lldb-test-build.noindex"
+            "lldb-test-build.noindex" if sys.platform == "darwin" else "lldb-test-build"
         ),
         help="The root build directory for the tests. It will be removed before running.",
     )

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -234,7 +234,9 @@ def create_parser():
         "--build-dir",
         dest="test_build_dir",
         metavar="Test build directory",
-        default="lldb-test-build.noindex",
+        default=(
+            "lldb-test-build" if sys.platform == "win32" else "lldb-test-build.noindex"
+        ),
         help="The root build directory for the tests. It will be removed before running.",
     )
     group.add_argument(

--- a/lldb/test/API/sanity/TestModuleCacheSanity.py
+++ b/lldb/test/API/sanity/TestModuleCacheSanity.py
@@ -16,9 +16,7 @@ class ModuleCacheSanityTestCase(TestBase):
 
     def test(self):
         build_dir_name = (
-            "lldb-test-build"
-            if sys.platform == "win32"
-            else "lldb-test-build.noindex"
+            "lldb-test-build" if sys.platform == "win32" else "lldb-test-build.noindex"
         )
         self.expect(
             "settings show symbols.clang-modules-cache-path",

--- a/lldb/test/API/sanity/TestModuleCacheSanity.py
+++ b/lldb/test/API/sanity/TestModuleCacheSanity.py
@@ -16,7 +16,7 @@ class ModuleCacheSanityTestCase(TestBase):
 
     def test(self):
         build_dir_name = (
-            "lldb-test-build" if sys.platform == "win32" else "lldb-test-build.noindex"
+            "lldb-test-build.noindex" if sys.platform == "darwin" else "lldb-test-build"
         )
         self.expect(
             "settings show symbols.clang-modules-cache-path",

--- a/lldb/test/API/sanity/TestModuleCacheSanity.py
+++ b/lldb/test/API/sanity/TestModuleCacheSanity.py
@@ -4,6 +4,8 @@ correctly and points inside the default test build directory.
 """
 
 
+import sys
+
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
@@ -13,7 +15,12 @@ class ModuleCacheSanityTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def test(self):
+        build_dir_name = (
+            "lldb-test-build"
+            if sys.platform == "win32"
+            else "lldb-test-build.noindex"
+        )
         self.expect(
             "settings show symbols.clang-modules-cache-path",
-            substrs=["lldb-test-build.noindex", "module-cache-lldb"],
+            substrs=[build_dir_name, "module-cache-lldb"],
         )

--- a/lldb/test/API/sanity/TestModuleCacheSanity.py
+++ b/lldb/test/API/sanity/TestModuleCacheSanity.py
@@ -4,8 +4,6 @@ correctly and points inside the default test build directory.
 """
 
 
-import sys
-
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
@@ -15,10 +13,7 @@ class ModuleCacheSanityTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     def test(self):
-        build_dir_name = (
-            "lldb-test-build.noindex" if sys.platform == "darwin" else "lldb-test-build"
-        )
         self.expect(
             "settings show symbols.clang-modules-cache-path",
-            substrs=[build_dir_name, "module-cache-lldb"],
+            substrs=["lldb-test-build", "module-cache-lldb"],
         )

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -42,16 +42,15 @@ if(LLDB_BUILT_STANDALONE)
 endif()
 
 # Configure the build directory.
-# The .noindex suffix is a marker for Spotlight to never index the
-# build directory.  LLDB queries Spotlight to locate .dSYM bundles
-# based on the UUID embedded in a binary, and because the UUID is a
-# hash of filename and .text section, there *will* be conflicts inside
-# the build directory.
-# Omit it for Windows since it's a no-op and exacerbates path-length issues.
-if(WIN32)
-  set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build" CACHE PATH "The build root for building tests.")
-else()
+if(APPLE)
+  # The .noindex suffix is a marker for Spotlight to never index the
+  # build directory.  LLDB queries Spotlight to locate .dSYM bundles
+  # based on the UUID embedded in a binary, and because the UUID is a
+  # hash of filename and .text section, there *will* be conflicts inside
+  # the build directory.
   set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build.noindex" CACHE PATH "The build root for building tests.")
+else()
+  set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build" CACHE PATH "The build root for building tests.")
 endif()
 
 # Configure and create module cache directories.

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -47,7 +47,12 @@ endif()
 # based on the UUID embedded in a binary, and because the UUID is a
 # hash of filename and .text section, there *will* be conflicts inside
 # the build directory.
-set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build.noindex" CACHE PATH "The build root for building tests.")
+# Omit it for Windows since it's a no-op and exacerbates path-length issues.
+if(WIN32)
+  set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build" CACHE PATH "The build root for building tests.")
+else()
+  set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build.noindex" CACHE PATH "The build root for building tests.")
+endif()
 
 # Configure and create module cache directories.
 set(LLDB_TEST_MODULE_CACHE_LLDB "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-lldb" CACHE PATH "The Clang module cache used by the Clang embedded in LLDB while running tests.")

--- a/lldb/test/Shell/Settings/TestModuleCacheSanity.test
+++ b/lldb/test/Shell/Settings/TestModuleCacheSanity.test
@@ -1,4 +1,4 @@
 # This is a sanity check that verifies that the module cache path is set
 # correctly and points inside the default test build directory.
 RUN: %lldb -o 'settings show symbols.clang-modules-cache-path' | FileCheck  %s
-CHECK: lldb-test-build.noindex{{.*}}module-cache-lldb
+CHECK: lldb-test-build{{(\.noindex)?}}{{.*}}module-cache-lldb

--- a/lldb/test/Shell/Settings/TestModuleCacheSanity.test
+++ b/lldb/test/Shell/Settings/TestModuleCacheSanity.test
@@ -1,4 +1,4 @@
 # This is a sanity check that verifies that the module cache path is set
 # correctly and points inside the default test build directory.
 RUN: %lldb -o 'settings show symbols.clang-modules-cache-path' | FileCheck  %s
-CHECK: lldb-test-build{{(\.noindex)?}}{{.*}}module-cache-lldb
+CHECK: lldb-test-build{{.*}}module-cache-lldb


### PR DESCRIPTION
.noindex is only needed for macOS Spotlight. Given that some platforms limit path length, there's a benefit to omitting it except for Darwin.