### PR TITLE
[PseudoProbe] Preserve pseudoprobe for tailcall pseudo instrs

### DIFF
--- a/llvm/lib/CodeGen/PseudoProbeInserter.cpp
+++ b/llvm/lib/CodeGen/PseudoProbeInserter.cpp
@@ -28,6 +28,14 @@
 using namespace llvm;
 
 namespace {
+
+// A real instruction is a non-meta, non-pseudo instruction. Calls (including
+// call pseudos like tail-call returns) are also treated as real because they
+// expand to a branch and any preceding call probe must be preserved.
+static bool isCallOrRealInstruction(const MachineInstr &MI) {
+  return MI.isCall() || (!MI.isPseudo() && !MI.isMetaInstruction());
+}
+
 class PseudoProbeInserter : public MachineFunctionPass {
 public:
   static char ID;
@@ -56,7 +64,7 @@ public:
       for (MachineInstr &MI : MBB) {
         // Pseudo instructions like TCRETURNdi results in a branch instruction
         // and the call probe for that tail call should be preserved.
-        if ((!MI.isPseudo() && !MI.isMetaInstruction()) || MI.isCall())
+        if (isCallOrRealInstruction(MI))
           FirstInstr = &MI;
         if (MI.isCall()) {
           if (DILocation *DL = MI.getDebugLoc()) {
@@ -92,8 +100,10 @@ public:
         auto MII = MBB.rbegin();
         while (MII != MBB.rend()) {
           // Skip all pseudo probes followed by a real instruction since they
-          // are not dangling.
-          if (!MII->isPseudo())
+          // are not dangling. Treat call pseudos (e.g. tail-call returns)
+          // as real instructions to keep this consistent with the forward
+          // scan above.
+          if (isCallOrRealInstruction(*MII))
             break;
           auto Cur = MII++;
           if (Cur->getOpcode() != TargetOpcode::PSEUDO_PROBE)

--- a/llvm/lib/CodeGen/PseudoProbeInserter.cpp
+++ b/llvm/lib/CodeGen/PseudoProbeInserter.cpp
@@ -54,7 +54,7 @@ public:
     for (MachineBasicBlock &MBB : MF) {
       MachineInstr *FirstInstr = nullptr;
       for (MachineInstr &MI : MBB) {
-        // Pseudo instructions like TCRETURNbi results in a branch instruction
+        // Pseudo instructions like TCRETURNdi results in a branch instruction
         // and the call probe for that tail call should be preserved.
         if ((!MI.isPseudo() && !MI.isMetaInstruction()) || MI.isCall())
           FirstInstr = &MI;

--- a/llvm/lib/CodeGen/PseudoProbeInserter.cpp
+++ b/llvm/lib/CodeGen/PseudoProbeInserter.cpp
@@ -56,7 +56,7 @@ public:
       for (MachineInstr &MI : MBB) {
         // Pseudo instructions like TCRETURNbi results in a branch instruction
         // and the call probe for that tail call should be preserved.
-        if (!MI.isPseudo() || MI.isCall())
+        if ((!MI.isPseudo() && !MI.isMetaInstruction()) || MI.isCall())
           FirstInstr = &MI;
         if (MI.isCall()) {
           if (DILocation *DL = MI.getDebugLoc()) {

--- a/llvm/lib/CodeGen/PseudoProbeInserter.cpp
+++ b/llvm/lib/CodeGen/PseudoProbeInserter.cpp
@@ -54,7 +54,9 @@ public:
     for (MachineBasicBlock &MBB : MF) {
       MachineInstr *FirstInstr = nullptr;
       for (MachineInstr &MI : MBB) {
-        if (!MI.isPseudo())
+        // Pseudo instructions like TCRETURNbi results in a branch instruction
+        // and the call probe for that tail call should be preserved.
+        if (!MI.isPseudo() || MI.isCall())
           FirstInstr = &MI;
         if (MI.isCall()) {
           if (DILocation *DL = MI.getDebugLoc()) {

--- a/llvm/test/CodeGen/AArch64/aarch64-pseudo-probe-tail-call.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-pseudo-probe-tail-call.ll
@@ -10,9 +10,9 @@
 ; RUN: llc -mtriple=arm64-apple-macos -stop-after=pseudo-probe-inserter %s -o - | FileCheck %s
 
 ; CHECK-LABEL: name: foo_tail
-; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 1, 0, 0
-; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 2, 2, 0
-; CHECK: TCRETURNdi @bar
+; CHECK: PSEUDO_PROBE 3369713592223921200, 1, 0, 0
+; CHECK-NEXT: PSEUDO_PROBE 3369713592223921200, 2, 2, 0
+; CHECK-NEXT: TCRETURNdi @bar
 
 declare !dbg !26 i32 @bar(i32 noundef) local_unnamed_addr
 

--- a/llvm/test/CodeGen/AArch64/aarch64-pseudo-probe-tail-call.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-pseudo-probe-tail-call.ll
@@ -1,13 +1,12 @@
 ; Verify that pseudo-probe call probes on tail call is not considered dangling
 ; Source:
 ; int bar(int);
-; int foo(int x) {
+; int foo_tail(int x) {
 ;   # entry probe
 ;   # direct call probe
 ;   return bar(x); // tail call probe is dropped
 ; }
 
-; REQUIRES: aarch64-registered-target
 ; RUN: llc -mtriple=arm64-apple-macos -stop-after=pseudo-probe-inserter %s -o - | FileCheck %s
 
 ; CHECK-LABEL: name: foo_tail

--- a/llvm/test/CodeGen/X86/pseudo-probe-tail-call.ll
+++ b/llvm/test/CodeGen/X86/pseudo-probe-tail-call.ll
@@ -10,9 +10,9 @@
 ; RUN: llc -mtriple=x86_64-unknown-unknown -stop-after=pseudo-probe-inserter %s -o - | FileCheck %s
 
 ; CHECK-LABEL: name: foo_tail
-; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 1, 0, 0
-; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 2, 2, 0
-; CHECK: TAILJMPd64 {{.*}} @bar
+; CHECK: PSEUDO_PROBE 3369713592223921200, 1, 0, 0
+; CHECK-NEXT: PSEUDO_PROBE 3369713592223921200, 2, 2, 0
+; CHECK-NEXT: TAILJMPd64 {{.*}} @bar
 
 declare !dbg !26 i32 @bar(i32 noundef) local_unnamed_addr
 

--- a/llvm/test/CodeGen/X86/pseudo-probe-tail-call.ll
+++ b/llvm/test/CodeGen/X86/pseudo-probe-tail-call.ll
@@ -1,0 +1,47 @@
+; Verify that pseudo-probe call probes on tail call is not considered dangling
+; Source:
+; int bar(int);
+; int foo_tail(int x) {
+;   # entry probe
+;   # direct call probe
+;   return bar(x); // tail call probe is dropped
+; }
+
+; RUN: llc -mtriple=x86_64-unknown-unknown -stop-after=pseudo-probe-inserter %s -o - | FileCheck %s
+
+; CHECK-LABEL: name: foo_tail
+; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 1, 0, 0
+; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 2, 2, 0
+; CHECK: TAILJMPd64 {{.*}} @bar
+
+declare !dbg !26 i32 @bar(i32 noundef) local_unnamed_addr
+
+define dso_local i32 @foo_tail(i32 noundef %x) local_unnamed_addr !dbg !15 {
+entry:
+  call void @llvm.pseudoprobe(i64 3369713592223921200, i64 1, i32 0, i64 -1), !dbg !22
+  %call = tail call i32 @bar(i32 noundef %x), !dbg !23
+  ret i32 %call, !dbg !25
+}
+
+declare void @llvm.pseudoprobe(i64, i64, i32, i64)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+!llvm.pseudo_probe_desc = !{!14}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, isOptimized: true, emissionKind: FullDebug)
+!1 = !DIFile(filename: "tail.c", directory: "/tmp")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!14 = !{i64 3369713592223921200, i64 281479271677951, !"foo_tail"}
+!15 = distinct !DISubprogram(name: "foo_tail", scope: !1, file: !1, line: 3, type: !16, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !18}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!22 = !DILocation(line: 4, column: 16, scope: !15)
+!23 = !DILocation(line: 4, column: 12, scope: !24)
+!24 = !DILexicalBlockFile(scope: !15, file: !1, discriminator: 455082007)
+!25 = !DILocation(line: 4, column: 5, scope: !15)
+!26 = !DISubprogram(name: "bar", scope: !1, file: !1, line: 1, type: !16, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+
+

--- a/llvm/test/Transforms/SampleProfile/pseudo-probe-tailcall.ll
+++ b/llvm/test/Transforms/SampleProfile/pseudo-probe-tailcall.ll
@@ -1,0 +1,47 @@
+; Verify that pseudo-probe call probes on tail call is not considered dangling
+; Source:
+; int bar(int);
+; int foo(int x) {
+;   # entry probe
+;   # direct call probe
+;   return bar(x); // tail call probe is dropped
+; }
+
+; REQUIRES: aarch64-registered-target
+; RUN: llc -mtriple=arm64-apple-macos -stop-after=pseudo-probe-inserter %s -o - | FileCheck %s
+
+; CHECK-LABEL: name: foo_tail
+; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 1, 0, 0
+; CHECK-DAG: PSEUDO_PROBE 3369713592223921200, 2, 2, 0
+; CHECK: TCRETURNdi @bar
+
+declare !dbg !26 i32 @bar(i32 noundef) local_unnamed_addr
+
+define dso_local i32 @foo_tail(i32 noundef %x) local_unnamed_addr !dbg !15 {
+entry:
+  call void @llvm.pseudoprobe(i64 3369713592223921200, i64 1, i32 0, i64 -1), !dbg !22
+  %call = tail call i32 @bar(i32 noundef %x), !dbg !23
+  ret i32 %call, !dbg !25
+}
+
+declare void @llvm.pseudoprobe(i64, i64, i32, i64)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+!llvm.pseudo_probe_desc = !{!14}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, isOptimized: true, emissionKind: FullDebug)
+!1 = !DIFile(filename: "tail.c", directory: "/tmp")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!14 = !{i64 3369713592223921200, i64 281479271677951, !"foo_tail"}
+!15 = distinct !DISubprogram(name: "foo_tail", scope: !1, file: !1, line: 3, type: !16, scopeLine: 3, spFlags: DISPFlagDefinition, unit: !0)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!18, !18}
+!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!22 = !DILocation(line: 4, column: 16, scope: !15)
+!23 = !DILocation(line: 4, column: 12, scope: !24)
+!24 = !DILexicalBlockFile(scope: !15, file: !1, discriminator: 455082007)
+!25 = !DILocation(line: 4, column: 5, scope: !15)
+!26 = !DISubprogram(name: "bar", scope: !1, file: !1, line: 1, type: !16, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+


### PR DESCRIPTION
Preserve probes for tail call pseudo instructions. 

On AArch64, X86, and other platforms, the lowering of tail calls requires a pseudo instruction like `TCRETURNdi`. It is often the case that `TCRETURNdi` is within its own MBB, and the direct call probe associated with that tail call is considered dangling and removed. This patch tries to preserve that. 