### PR TITLE
[libclc] Create a static `.a` file in addition to the `.bc` file

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -52,7 +52,7 @@ function(libclc_set_source_options option)
   )
 endfunction()
 
-# Creates a static library target for libclc builtins and configures its
+# Creates an object library target for libclc builtins and configures its
 # compile options, include directories, and definitions. Subdirectories
 # populate sources via libclc_add_sources() after this call.
 function(libclc_add_builtin_library target_name)
@@ -63,53 +63,76 @@ function(libclc_add_builtin_library target_name)
     ${ARGN}
   )
 
-  add_library(${target_name} STATIC)
+  add_library(${target_name} OBJECT)
   target_compile_options(${target_name} PRIVATE ${ARG_COMPILE_OPTIONS})
   target_include_directories(${target_name} PRIVATE ${ARG_INCLUDE_DIRS})
   target_compile_definitions(${target_name} PRIVATE ${ARG_COMPILE_DEFINITIONS})
-  set_target_properties(${target_name} PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    FOLDER ${ARG_FOLDER}
-  )
+  set_target_properties(${target_name} PROPERTIES FOLDER ${ARG_FOLDER})
 endfunction()
 
-# Links one or more libclc builtin libraries together, optionally
-# internalizing dependencies, then produces a final .bc or .spv file.
-function(libclc_link_library target_name)
+# Links builtin libclc object libraries together into a merged bitcode or SPIR-V
+# file and a static archive.
+function(libclc_add_library target_name)
   cmake_parse_arguments(ARG
     ""
-    "ARCH;TRIPLE;TARGET_TRIPLE;FOLDER;OUTPUT_FILENAME"
+    "ARCH;TRIPLE;TARGET_TRIPLE;OUTPUT_FILENAME;PARENT_TARGET"
     "LIBRARIES;INTERNALIZE_LIBRARIES;OPT_FLAGS"
     ${ARGN}
   )
 
   if(NOT ARG_OUTPUT_FILENAME)
-    message(FATAL_ERROR "OUTPUT_FILENAME is required for libclc_link_library")
+    message(FATAL_ERROR "OUTPUT_FILENAME is required for libclc_add_library")
+  endif()
+  if(NOT ARG_PARENT_TARGET)
+    message(FATAL_ERROR "PARENT_TARGET is required for libclc_add_library")
   endif()
   if(NOT ARG_LIBRARIES)
-    message(FATAL_ERROR "LIBRARIES is required for libclc_link_library")
+    message(FATAL_ERROR "LIBRARIES is required for libclc_add_library")
   endif()
 
   set(library_dir ${LIBCLC_OUTPUT_LIBRARY_DIR}/${ARG_TARGET_TRIPLE})
   file(MAKE_DIRECTORY ${library_dir})
 
-  set(linked_bc ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.linked.bc)
+  # Create a combined static archive from all object libraries for installation.
+  set(archive_target ${target_name}.a)
+  add_library(${archive_target} STATIC)
+  target_link_libraries(${archive_target} PRIVATE
+    ${ARG_LIBRARIES} ${ARG_INTERNALIZE_LIBRARIES}
+  )
+  set_target_properties(${archive_target} PROPERTIES
+    OUTPUT_NAME ${ARG_OUTPUT_FILENAME}
+    PREFIX ""
+    ARCHIVE_OUTPUT_DIRECTORY ${library_dir}
+    FOLDER "libclc/Device IR/Library"
+  )
 
+  # Link the object files, using a temporary library as for internalization.
+  set(linked_bc ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.linked.bc)
   set(link_cmd ${llvm-link_exe})
+  set(link_deps ${llvm-link_target})
   foreach(lib ${ARG_LIBRARIES})
-    list(APPEND link_cmd $<TARGET_FILE:${lib}>)
+    add_library(${target_name}-${lib} STATIC)
+    target_link_libraries(${target_name}-${lib} PRIVATE ${lib})
+    set_target_properties(${target_name}-${lib} PROPERTIES
+      FOLDER "libclc/Device IR/Library"
+    )
+    list(APPEND link_cmd $<TARGET_FILE:${target_name}-${lib}>)
+    list(APPEND link_deps ${target_name}-${lib})
   endforeach()
   if(ARG_INTERNALIZE_LIBRARIES)
     list(APPEND link_cmd --internalize --only-needed)
     foreach(lib ${ARG_INTERNALIZE_LIBRARIES})
-      list(APPEND link_cmd $<TARGET_FILE:${lib}>)
+      add_library(${target_name}-${lib} STATIC)
+      target_link_libraries(${target_name}-${lib} PRIVATE ${lib})
+      set_target_properties(${target_name}-${lib} PROPERTIES
+        FOLDER "libclc/Device IR/Library"
+      )
+      list(APPEND link_cmd $<TARGET_FILE:${target_name}-${lib}>)
+      list(APPEND link_deps ${target_name}-${lib})
     endforeach()
   endif()
   list(APPEND link_cmd -o ${linked_bc})
 
-  set(link_deps ${llvm-link_target}
-    ${ARG_LIBRARIES} ${ARG_INTERNALIZE_LIBRARIES}
-  )
   add_custom_command(OUTPUT ${linked_bc}
     COMMAND ${link_cmd}
     DEPENDS ${link_deps}
@@ -148,45 +171,12 @@ function(libclc_link_library target_name)
   add_custom_target(${target_name} ALL DEPENDS ${builtins_lib})
   set_target_properties(${target_name} PROPERTIES
     TARGET_FILE ${builtins_lib}
-    FOLDER ${ARG_FOLDER}
-  )
-endfunction()
-
-# Links builtin library targets, produces the final output file, and
-# registers it for installation.
-function(libclc_add_library target_name)
-  cmake_parse_arguments(ARG
-    ""
-    "ARCH;TRIPLE;TARGET_TRIPLE;OUTPUT_FILENAME;PARENT_TARGET"
-    "LIBRARIES;INTERNALIZE_LIBRARIES;OPT_FLAGS"
-    ${ARGN}
-  )
-
-  if(NOT ARG_OUTPUT_FILENAME)
-    message(FATAL_ERROR "OUTPUT_FILENAME is required for libclc_add_library")
-  endif()
-  if(NOT ARG_PARENT_TARGET)
-    message(FATAL_ERROR "PARENT_TARGET is required for libclc_add_library")
-  endif()
-  if(NOT ARG_LIBRARIES)
-    message(FATAL_ERROR "LIBRARIES is required for libclc_add_library")
-  endif()
-
-  libclc_link_library(${target_name}
-    ARCH ${ARG_ARCH}
-    TRIPLE ${ARG_TRIPLE}
-    TARGET_TRIPLE ${ARG_TARGET_TRIPLE}
-    LIBRARIES ${ARG_LIBRARIES}
-    INTERNALIZE_LIBRARIES ${ARG_INTERNALIZE_LIBRARIES}
-    OPT_FLAGS ${ARG_OPT_FLAGS}
-    OUTPUT_FILENAME "${ARG_OUTPUT_FILENAME}"
     FOLDER "libclc/Device IR/Library"
   )
 
-  add_dependencies(${ARG_PARENT_TARGET} ${target_name})
-  set(builtins_file $<TARGET_PROPERTY:${target_name},TARGET_FILE>)
+  add_dependencies(${ARG_PARENT_TARGET} ${target_name} ${archive_target})
 
-  install(FILES ${builtins_file}
+  install(FILES ${builtins_lib} $<TARGET_FILE:${archive_target}>
     DESTINATION ${LIBCLC_INSTALL_DIR}/${ARG_TARGET_TRIPLE}
     COMPONENT ${ARG_PARENT_TARGET}
   )


### PR DESCRIPTION
Summary:
This changes the libraries to be object libraries instead of static
libraries. We can then just link these into final static libraries that
contain everything we need.

The desire here is that we'd need static libraries if we wanted to move
away from `-mlink-builtin-bitcode` appraoches.

Effectively we'll have `libclc.a` next to `libclc.bc` and the idea is that we could alternatively link it and let the target linker handle it.