### PR TITLE
[clangd] Fix parens suppression in mid-identifier code-completion

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -1536,46 +1536,6 @@ FuzzyFindRequest speculativeFuzzyFindRequestForCompletion(
   return CachedReq;
 }
 
-// This function is similar to Lexer::findNextToken(), but assumes
-// that the input SourceLocation is the completion point (which is
-// a case findNextToken() does not handle).
-std::optional<Token>
-findTokenAfterCompletionPoint(SourceLocation CompletionPoint,
-                              const SourceManager &SM,
-                              const LangOptions &LangOpts) {
-  SourceLocation Loc = CompletionPoint;
-  if (Loc.isMacroID()) {
-    if (!Lexer::isAtEndOfMacroExpansion(Loc, SM, LangOpts, &Loc))
-      return std::nullopt;
-  }
-
-  // Advance to the next SourceLocation after the completion point.
-  // Lexer::findNextToken() would call MeasureTokenLength() here,
-  // which does not handle the completion point (and can't, because
-  // the Lexer instance it constructs internally doesn't have a
-  // Preprocessor and so doesn't know about the completion point).
-  Loc = Loc.getLocWithOffset(1);
-
-  // Break down the source location.
-  std::pair<FileID, unsigned> LocInfo = SM.getDecomposedLoc(Loc);
-
-  // Try to load the file buffer.
-  bool InvalidTemp = false;
-  StringRef File = SM.getBufferData(LocInfo.first, &InvalidTemp);
-  if (InvalidTemp)
-    return std::nullopt;
-
-  const char *TokenBegin = File.data() + LocInfo.second;
-
-  // Lex from the start of the given location.
-  Lexer TheLexer(SM.getLocForStartOfFile(LocInfo.first), LangOpts, File.begin(),
-                 TokenBegin, File.end());
-  // Find the token.
-  Token Tok;
-  TheLexer.LexFromRawLexer(Tok);
-  return Tok;
-}
-
 // Runs Sema-based (AST) and Index-based completion, returns merged results.
 //
 // There are a few tricky considerations:
@@ -1619,6 +1579,9 @@ class CodeCompleteFlow {
   // location is an opening parenthesis (tok::l_paren) because this would add
   // extra parenthesis.
   tok::TokenKind NextTokenKind = tok::eof;
+  // End of the identifier suffix after the completion cursor.
+  // Shared by NextTokenKind detection and replace-range calculation.
+  SourceLocation IdentifierSuffixEnd;
   // Counters for logging.
   int NSema = 0, NIndex = 0, NSemaAndIndex = 0, NIdent = 0;
   bool Incomplete = false; // Would more be available with a higher limit?
@@ -1675,11 +1638,20 @@ public:
       auto Style = getFormatStyleForFile(SemaCCInput.FileName,
                                          SemaCCInput.ParseInput.Contents,
                                          *SemaCCInput.ParseInput.TFS, false);
-      const auto NextToken = findTokenAfterCompletionPoint(
-          Recorder->CCSema->getPreprocessor().getCodeCompletionLoc(),
-          Recorder->CCSema->getSourceManager(), Recorder->CCSema->LangOpts);
-      if (NextToken)
-        NextTokenKind = NextToken->getKind();
+      const auto &SM = Recorder->CCSema->getSourceManager();
+      const LangOptions &LangOpts = Recorder->CCSema->getLangOpts();
+      // Skip past the NUL byte inserted at the cursor, then scan through any
+      // identifier continuation characters to find where the suffix ends.
+      IdentifierSuffixEnd = Lexer::findEndOfIdentifierContinuation(
+          Recorder->CCSema->getPreprocessor()
+              .getCodeCompletionLoc()
+              .getLocWithOffset(1),
+          SM, LangOpts);
+      // Lex the token after the identifier suffix to determine NextTokenKind.
+      if (Token NextToken;
+          !Lexer::getRawToken(IdentifierSuffixEnd, NextToken, SM, LangOpts,
+                              /*IgnoreWhiteSpace=*/true))
+        NextTokenKind = NextToken.getKind();
       // If preprocessor was run, inclusions from preprocessor callback should
       // already be added to Includes.
       Inserter.emplace(
@@ -1696,7 +1668,6 @@ public:
       // that happens here (though the per-URI-scheme initialization is lazy).
       // The per-result proximity scoring is (amortized) very cheap.
       FileDistanceOptions ProxOpts{}; // Use defaults.
-      const auto &SM = Recorder->CCSema->getSourceManager();
       llvm::StringMap<SourceParams> ProxSources;
       auto MainFileID =
           Includes.getID(SM.getFileEntryForID(SM.getMainFileID()));
@@ -1905,17 +1876,7 @@ private:
   // Returns the LSP position at the end of the identifier suffix after the
   // code completion cursor.
   Position getEndOfCodeCompletionReplace(const SourceManager &SM) {
-    const Preprocessor &PP = Recorder->CCSema->getPreprocessor();
-    const LangOptions &LangOpts = Recorder->CCSema->getLangOpts();
-
-    // Skip past the code completion NUL byte and scan forward through
-    // identifier continuation characters (letters, digits, _, $, UCN,
-    // unicode). This handles all cases uniformly: with prefix ("vac^1abc"),
-    // without prefix ("vec.^asdf"), and digit-starting ("vec.^1abc").
-    const SourceLocation SuffixBegin =
-        PP.getCodeCompletionLoc().getLocWithOffset(1);
-    Position End = sourceLocToPosition(
-        SM, Lexer::findEndOfIdentifierContinuation(SuffixBegin, SM, LangOpts));
+    Position End = sourceLocToPosition(SM, IdentifierSuffixEnd);
     // Adjust for the NUL byte inserted at the cursor by code completion,
     // which inflates the column by 1.
     End.character--;

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -4377,14 +4377,15 @@ TEST(CompletionTest, FunctionArgsExist) {
   EXPECT_THAT(
       completions(Context + "int y = fo^(42)", {}, Opts).Completions,
       UnorderedElementsAre(AllOf(labeled("foo(int A)"), snippetSuffix(""))));
-  // FIXME(kirillbobyrev): No snippet should be produced here.
-  EXPECT_THAT(completions(Context + "int y = fo^o(42)", {}, Opts).Completions,
-              UnorderedElementsAre(
-                  AllOf(labeled("foo(int A)"), snippetSuffix("(${1:int A})"))));
+  EXPECT_THAT(
+      completions(Context + "int y = fo^o(42)", {}, Opts).Completions,
+      UnorderedElementsAre(AllOf(labeled("foo(int A)"), snippetSuffix(""))));
   EXPECT_THAT(
       completions(Context + "int y = ba^", {}, Opts).Completions,
       UnorderedElementsAre(AllOf(labeled("bar()"), snippetSuffix("()"))));
   EXPECT_THAT(completions(Context + "int y = ba^()", {}, Opts).Completions,
+              UnorderedElementsAre(AllOf(labeled("bar()"), snippetSuffix(""))));
+  EXPECT_THAT(completions(Context + "int y = ba^r()", {}, Opts).Completions,
               UnorderedElementsAre(AllOf(labeled("bar()"), snippetSuffix(""))));
   EXPECT_THAT(
       completions(Context + "Object o = Obj^", {}, Opts).Completions,
@@ -4408,7 +4409,15 @@ TEST(CompletionTest, FunctionArgsExist) {
       Contains(AllOf(labeled("Container<typename T>(int Size)"),
                      snippetSuffix(""),
                      kind(CompletionItemKind::Constructor))));
+  EXPECT_THAT(
+      completions(Context + "Container c = Cont^ainer()", {}, Opts).Completions,
+      Contains(AllOf(labeled("Container<typename T>(int Size)"),
+                     snippetSuffix("<${1:typename T}>"),
+                     kind(CompletionItemKind::Constructor))));
   EXPECT_THAT(completions(Context + "MAC^(2)", {}, Opts).Completions,
+              Contains(AllOf(labeled("MACRO(x)"), snippetSuffix(""),
+                             kind(CompletionItemKind::Function))));
+  EXPECT_THAT(completions(Context + "MAC^RO(2)", {}, Opts).Completions,
               Contains(AllOf(labeled("MACRO(x)"), snippetSuffix(""),
                              kind(CompletionItemKind::Function))));
 }


### PR DESCRIPTION
When completing in the middle of an existing identifier (e.g. `fo^o<int>(42)`), the next-token check lexes the character immediately after the cursor, which prevents parens suppression to kick in.

After the fix, we go to the end of the current identifier first and only then we start lexing for the next token, which handles redundant parens even when the cursor is mid-identifier.

This also fixes the parens suppression in the replace mode which by design is used mid-identifier.