### PR TITLE
Use __cxa_thread_atexit_impl fallback on illumos.

### DIFF
--- a/libcxxabi/src/cxa_thread_atexit.cpp
+++ b/libcxxabi/src/cxa_thread_atexit.cpp
@@ -106,7 +106,7 @@ namespace {
 
 #endif // HAVE___CXA_THREAD_ATEXIT_IMPL
 
-#if defined(__linux__) || defined(__Fuchsia__)
+#if defined(__linux__) || defined(__Fuchsia__) || defined(__sun)
 extern "C" {
 
   _LIBCXXABI_FUNC_VIS int __cxa_thread_atexit(Dtor dtor, void* obj, void* dso_symbol) throw() {
@@ -142,5 +142,5 @@ extern "C" {
 #endif // HAVE___CXA_THREAD_ATEXIT_IMPL
   }
 } // extern "C"
-#endif // defined(__linux__) || defined(__Fuchsia__)
+#endif // defined(__linux__) || defined(__Fuchsia__) || defined(__sun)
 } // namespace __cxxabiv1


### PR DESCRIPTION
libcxxabi offers a fallback around __cxa_thread_atexit_impl for platforms that don't provide it. Since illumos doesn't provide this feature, include __sun in the guard so that the libcxxabi fallback is available.