### PR TITLE
[CIR] Lower __builtin_assume_dereferenceable

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6157,7 +6157,7 @@ def CIR_AssumeOp : CIR_Op<"assume"> {
   let summary = "Tell the optimizer that a boolean value is true";
   let description = [{
     The `cir.assume` operation takes a single boolean predicate as its first
-    argument and does not have any results.  The operation tells the optimizer
+    argument and does not have any results. The operation tells the optimizer
     that the predicate is always true.
 
     An optional operand bundle carries additional assumption metadata,

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6144,6 +6144,15 @@ def CIR_IsFPClassOp : CIR_Op<"is_fp_class", [Pure]> {
 // Assume Operations
 //===----------------------------------------------------------------------===//
 
+def CIR_AssumeBundleKind : CIR_I32EnumAttr<
+  "AssumeBundleKind", "kind of cir.assume operand bundle", [
+  I32EnumAttrCase<"None", 0>,
+  I32EnumAttrCase<"Align", 1, "align">,
+  I32EnumAttrCase<"SeparateStorage", 2, "separate_storage">,
+  I32EnumAttrCase<"Dereferenceable", 3, "dereferenceable">
+]> {
+}
+
 def CIR_AssumeOp : CIR_Op<"assume"> {
   let summary = "Tell the optimizer that a boolean value is true";
   let description = [{
@@ -6151,49 +6160,35 @@ def CIR_AssumeOp : CIR_Op<"assume"> {
     argument and does not have any results.  The operation tells the optimizer
     that the predicate is always true.
 
-    Optional operand bundles can be attached to carry additional assumption
-    metadata, mirroring MLIR LLVM dialect's `llvm.assume` operand bundles
-    (`mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td`).  Each bundle
-    has a string tag and a (possibly empty) list of operands.  For example,
+    An optional operand bundle carries additional assumption metadata,
+    mirroring MLIR LLVM dialect's `llvm.assume` operand bundles
+    (`mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td`).  The bundle
+    kind is a `AssumeBundleKind` enum; bundle operands follow the kind
+    keyword in the assembly form.  For example,
     `__builtin_assume_dereferenceable(p, n)` lowers to
-    `cir.assume %true ["dereferenceable"(%p, %n : !cir.ptr<!void>, !u64i)]`,
-    which in turn lowers to
+    `cir.assume %true dereferenceable(%p, %n : !cir.ptr<!void>, !u64i)
+    : !cir.bool`, which in turn lowers to
     `call void @llvm.assume(i1 true) [ "dereferenceable"(ptr, i64) ]`.
 
     This operation corresponds to the `__assume` / `__builtin_assume`
     builtins (no bundle), as well as `__builtin_assume_aligned`
-    (`"align"` bundle), `__builtin_assume_separate_storage`
-    (`"separate_storage"` bundle), and `__builtin_assume_dereferenceable`
-    (`"dereferenceable"` bundle).
+    (`align` bundle), `__builtin_assume_separate_storage`
+    (`separate_storage` bundle), and `__builtin_assume_dereferenceable`
+    (`dereferenceable` bundle).
   }];
 
   let arguments = (ins
     CIR_BoolType:$predicate,
-    VariadicOfVariadic<CIR_AnyType, "op_bundle_sizes">:$op_bundle_operands,
-    DenseI32ArrayAttr:$op_bundle_sizes,
-    OptionalAttr<ArrayAttr>:$op_bundle_tags
+    DefaultValuedAttr<CIR_AssumeBundleKind,
+                      "::cir::AssumeBundleKind::None">:$bundle_kind,
+    Variadic<CIR_AnyType>:$bundle_args
   );
 
   let assemblyFormat = [{
-    $predicate
-    custom<OpBundles>($op_bundle_operands, type($op_bundle_operands),
-                      $op_bundle_tags)
+    $predicate custom<AssumeBundle>($bundle_kind, $bundle_args,
+                                    type($bundle_args))
     `:` type($predicate) attr-dict
   }];
-
-  let builders = [
-    OpBuilder<(ins "mlir::Value":$predicate), [{
-      build($_builder, $_state, predicate,
-            /*op_bundle_operands=*/llvm::ArrayRef<mlir::ValueRange>{},
-            /*op_bundle_tags=*/mlir::ArrayAttr{});
-    }]>,
-    OpBuilder<(ins "mlir::Value":$predicate, "llvm::StringRef":$bundleTag,
-                   "mlir::ValueRange":$bundleArgs), [{
-      build($_builder, $_state, predicate,
-            llvm::ArrayRef<mlir::ValueRange>(bundleArgs),
-            $_builder.getStrArrayAttr(bundleTag));
-    }]>
-  ];
 
   let hasVerifier = 1;
 }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6147,19 +6147,47 @@ def CIR_IsFPClassOp : CIR_Op<"is_fp_class", [Pure]> {
 def CIR_AssumeOp : CIR_Op<"assume"> {
   let summary = "Tell the optimizer that a boolean value is true";
   let description = [{
-    The `cir.assume` operation takes a single boolean prediate as its only
+    The `cir.assume` operation takes a single boolean predicate as its first
     argument and does not have any results. The operation tells the optimizer
     that the predicate is always true.
 
+    An optional operand bundle (tag + variadic args) can be attached to carry
+    additional assumption metadata, mirroring LLVM dialect's `llvm.assume`
+    bundles.  For example, `__builtin_assume_dereferenceable(p, n)` lowers
+    to `cir.assume %true ["dereferenceable"(%p, %n : !cir.ptr<!void>, !u64i)]`,
+    which in turn lowers to
+    `call void @llvm.assume(i1 true) [ "dereferenceable"(ptr, i64) ]`.
+
     This operation corresponds to the `__assume` and the `__builtin_assume`
-    builtin functions.
+    builtin functions, and (with a bundle) to other `__builtin_assume_*`
+    variants such as `__builtin_assume_dereferenceable`.
   }];
 
-  let arguments = (ins CIR_BoolType:$predicate);
+  let arguments = (ins
+    CIR_BoolType:$predicate,
+    OptionalAttr<StrAttr>:$bundle_tag,
+    Variadic<CIR_AnyType>:$bundle_args
+  );
 
   let assemblyFormat = [{
-    $predicate `:` type($predicate) attr-dict
+    $predicate
+    ( ` ` `[` $bundle_tag^ `(` $bundle_args `:` type($bundle_args) `)` `]` )?
+    `:` type($predicate) attr-dict
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$predicate), [{
+      build($_builder, $_state, predicate, /*bundle_tag=*/mlir::StringAttr{},
+            /*bundle_args=*/mlir::ValueRange{});
+    }]>,
+    OpBuilder<(ins "mlir::Value":$predicate, "llvm::StringRef":$bundleTag,
+                   "mlir::ValueRange":$bundleArgs), [{
+      build($_builder, $_state, predicate,
+            $_builder.getStringAttr(bundleTag), bundleArgs);
+    }]>
+  ];
+
+  let hasVerifier = 1;
 }
 
 def CIR_AssumeAlignedOp : CIR_Op<"assume_aligned", [
@@ -6230,35 +6258,6 @@ def CIR_AssumeSepStorageOp : CIR_Op<"assume_separate_storage", [
 
   let assemblyFormat = [{
     $ptr1 `,` $ptr2 `:` qualified(type($ptr1)) attr-dict
-  }];
-}
-
-def CIR_AssumeDereferenceableOp : CIR_Op<"assume_dereferenceable"> {
-  let summary = "Tell the optimizer that a pointer is dereferenceable";
-  let description = [{
-    The `cir.assume_dereferenceable` operation takes a pointer and a size in
-    bytes.  It tells the optimizer that loading from `pointer` is well-defined
-    for any number of bytes up to `size`, i.e. the pointer is known to refer
-    to a region of at least `size` allocated bytes.
-
-    The size argument must be a pointer-sized integer (the lowering converts
-    smaller integer types to the target pointer width before emitting the
-    operand bundle).
-
-    This operation corresponds to the `__builtin_assume_dereferenceable`
-    builtin function.
-
-    Example:
-
-    ```
-    cir.assume_dereferenceable %p, %n : !cir.ptr<!void>, !u64i
-    ```
-  }];
-
-  let arguments = (ins CIR_PointerType:$pointer, CIR_IntType:$size);
-
-  let assemblyFormat = [{
-    $pointer `,` $size `:` qualified(type($pointer)) `,` type($size) attr-dict
   }];
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6233,6 +6233,35 @@ def CIR_AssumeSepStorageOp : CIR_Op<"assume_separate_storage", [
   }];
 }
 
+def CIR_AssumeDereferenceableOp : CIR_Op<"assume_dereferenceable"> {
+  let summary = "Tell the optimizer that a pointer is dereferenceable";
+  let description = [{
+    The `cir.assume_dereferenceable` operation takes a pointer and a size in
+    bytes.  It tells the optimizer that loading from `pointer` is well-defined
+    for any number of bytes up to `size`, i.e. the pointer is known to refer
+    to a region of at least `size` allocated bytes.
+
+    The size argument must be a pointer-sized integer (the lowering converts
+    smaller integer types to the target pointer width before emitting the
+    operand bundle).
+
+    This operation corresponds to the `__builtin_assume_dereferenceable`
+    builtin function.
+
+    Example:
+
+    ```
+    cir.assume_dereferenceable %p, %n : !cir.ptr<!void>, !u64i
+    ```
+  }];
+
+  let arguments = (ins CIR_PointerType:$pointer, CIR_IntType:$size);
+
+  let assemblyFormat = [{
+    $pointer `,` $size `:` qualified(type($pointer)) `,` type($size) attr-dict
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Branch Probability Operations
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -6148,117 +6148,54 @@ def CIR_AssumeOp : CIR_Op<"assume"> {
   let summary = "Tell the optimizer that a boolean value is true";
   let description = [{
     The `cir.assume` operation takes a single boolean predicate as its first
-    argument and does not have any results. The operation tells the optimizer
+    argument and does not have any results.  The operation tells the optimizer
     that the predicate is always true.
 
-    An optional operand bundle (tag + variadic args) can be attached to carry
-    additional assumption metadata, mirroring LLVM dialect's `llvm.assume`
-    bundles.  For example, `__builtin_assume_dereferenceable(p, n)` lowers
-    to `cir.assume %true ["dereferenceable"(%p, %n : !cir.ptr<!void>, !u64i)]`,
+    Optional operand bundles can be attached to carry additional assumption
+    metadata, mirroring MLIR LLVM dialect's `llvm.assume` operand bundles
+    (`mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td`).  Each bundle
+    has a string tag and a (possibly empty) list of operands.  For example,
+    `__builtin_assume_dereferenceable(p, n)` lowers to
+    `cir.assume %true ["dereferenceable"(%p, %n : !cir.ptr<!void>, !u64i)]`,
     which in turn lowers to
     `call void @llvm.assume(i1 true) [ "dereferenceable"(ptr, i64) ]`.
 
-    This operation corresponds to the `__assume` and the `__builtin_assume`
-    builtin functions, and (with a bundle) to other `__builtin_assume_*`
-    variants such as `__builtin_assume_dereferenceable`.
+    This operation corresponds to the `__assume` / `__builtin_assume`
+    builtins (no bundle), as well as `__builtin_assume_aligned`
+    (`"align"` bundle), `__builtin_assume_separate_storage`
+    (`"separate_storage"` bundle), and `__builtin_assume_dereferenceable`
+    (`"dereferenceable"` bundle).
   }];
 
   let arguments = (ins
     CIR_BoolType:$predicate,
-    OptionalAttr<StrAttr>:$bundle_tag,
-    Variadic<CIR_AnyType>:$bundle_args
+    VariadicOfVariadic<CIR_AnyType, "op_bundle_sizes">:$op_bundle_operands,
+    DenseI32ArrayAttr:$op_bundle_sizes,
+    OptionalAttr<ArrayAttr>:$op_bundle_tags
   );
 
   let assemblyFormat = [{
     $predicate
-    ( ` ` `[` $bundle_tag^ `(` $bundle_args `:` type($bundle_args) `)` `]` )?
+    custom<OpBundles>($op_bundle_operands, type($op_bundle_operands),
+                      $op_bundle_tags)
     `:` type($predicate) attr-dict
   }];
 
   let builders = [
     OpBuilder<(ins "mlir::Value":$predicate), [{
-      build($_builder, $_state, predicate, /*bundle_tag=*/mlir::StringAttr{},
-            /*bundle_args=*/mlir::ValueRange{});
+      build($_builder, $_state, predicate,
+            /*op_bundle_operands=*/llvm::ArrayRef<mlir::ValueRange>{},
+            /*op_bundle_tags=*/mlir::ArrayAttr{});
     }]>,
     OpBuilder<(ins "mlir::Value":$predicate, "llvm::StringRef":$bundleTag,
                    "mlir::ValueRange":$bundleArgs), [{
       build($_builder, $_state, predicate,
-            $_builder.getStringAttr(bundleTag), bundleArgs);
+            llvm::ArrayRef<mlir::ValueRange>(bundleArgs),
+            $_builder.getStrArrayAttr(bundleTag));
     }]>
   ];
 
   let hasVerifier = 1;
-}
-
-def CIR_AssumeAlignedOp : CIR_Op<"assume_aligned", [
-  Pure, AllTypesMatch<["pointer", "result"]>
-]> {
-  let summary = "Tell the optimizer that a pointer is aligned";
-  let description = [{
-    The `cir.assume_aligned` operation takes two or three arguments. The first
-    argument `pointer` gives the pointer value whose alignment is to be assumed,
-    and the second argument `align` is an integer attribute that gives the
-    assumed alignment.
-
-    The `offset` argument is optional. If given, it represents misalignment
-    offset. When it's present, this operation tells the optimizer that the
-    pointer is always misaligned to the alignment by `offset` bytes, a.k.a. the
-    pointer yielded by `(char *)pointer - offset` is aligned to the specified
-    alignment. Note that the `offset` argument is an SSA value rather than an
-    attribute, which means that you could pass a dynamically determined value
-    as the mialignment offset.
-
-    The result of this operation has the same value as the `pointer` argument,
-    but it additionally carries any alignment information indicated by this
-    operation.
-
-    This operation corresponds to the `__builtin_assume_aligned` builtin
-    function.
-
-    Example:
-
-    ```
-    // Assume that %0 is a CIR pointer value of type !cir.ptr<!s32i>
-    %1 = cir.assume_aligned %0 alignment 16 : !cir.ptr<!s32i>
-
-    // With a misalignment offset of 4 bytes:
-    %2 = cir.const #cir.int<4> : !u64i
-    %3 = cir.assume_aligned %0 alignment 16 [offset %2 : !u64i] : !cir.ptr<!s32i>
-    ```
-  }];
-
-  let arguments = (ins CIR_PointerType:$pointer,
-                       I64Attr:$alignment,
-                       Optional<CIR_IntType>:$offset);
-  let results = (outs CIR_PointerType:$result);
-
-  let assemblyFormat = [{
-    $pointer
-    `alignment` $alignment
-    (`[` `offset` $offset^ `:` type($offset) `]`)?
-    `:` qualified(type($pointer)) attr-dict
-  }];
-}
-
-def CIR_AssumeSepStorageOp : CIR_Op<"assume_separate_storage", [
-  SameTypeOperands
-]> {
-  let summary =
-      "Tell the optimizer that two pointers point to different allocations";
-  let description = [{
-    The `cir.assume_separate_storage` operation takes two pointers as arguments,
-    and the operation tells the optimizer that these two pointers point to
-    different allocations.
-
-    This operation corresponds to the `__builtin_assume_separate_storage`
-    builtin function.
-  }];
-
-  let arguments = (ins CIR_VoidPtrType:$ptr1, CIR_VoidPtrType:$ptr2);
-
-  let assemblyFormat = [{
-    $ptr1 `,` $ptr2 `:` qualified(type($ptr1)) attr-dict
-  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1087,7 +1087,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
       return RValue::get(nullptr);
 
     mlir::Value argValue = emitCheckedArgForAssume(e->getArg(0));
-    cir::AssumeOp::create(builder, loc, argValue);
+    cir::AssumeOp::create(builder, loc, argValue, cir::AssumeBundleKind::None,
+                          mlir::ValueRange{});
     return RValue::get(nullptr);
   }
 
@@ -1095,7 +1096,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     mlir::Value value0 = emitScalarExpr(e->getArg(0));
     mlir::Value value1 = emitScalarExpr(e->getArg(1));
     mlir::Value cond = builder.getBool(true, loc);
-    cir::AssumeOp::create(builder, loc, cond, "separate_storage",
+    cir::AssumeOp::create(builder, loc, cond,
+                          cir::AssumeBundleKind::SeparateStorage,
                           mlir::ValueRange{value0, value1});
     return RValue::get(nullptr);
   }
@@ -1109,7 +1111,8 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     if (sizeValue.getType() != uintPtrTy)
       sizeValue = builder.createIntCast(sizeValue, uintPtrTy);
     mlir::Value cond = builder.getBool(true, loc);
-    cir::AssumeOp::create(builder, loc, cond, "dereferenceable",
+    cir::AssumeOp::create(builder, loc, cond,
+                          cir::AssumeBundleKind::Dereferenceable,
                           mlir::ValueRange{ptrValue, sizeValue});
     return RValue::get(nullptr);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1098,6 +1098,18 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     return RValue::get(nullptr);
   }
 
+  case Builtin::BI__builtin_assume_dereferenceable: {
+    mlir::Value ptrValue = emitScalarExpr(e->getArg(0));
+    mlir::Value sizeValue = emitScalarExpr(e->getArg(1));
+    // The operand bundle expects a pointer-sized integer; widen/narrow to
+    // intptr_t to match classic CodeGen.
+    mlir::Type intPtrTy = convertType(getContext().getIntPtrType());
+    if (sizeValue.getType() != intPtrTy)
+      sizeValue = builder.createIntCast(sizeValue, intPtrTy);
+    cir::AssumeDereferenceableOp::create(builder, loc, ptrValue, sizeValue);
+    return RValue::get(nullptr);
+  }
+
   case Builtin::BI__builtin_assume_aligned: {
     const Expr *ptrExpr = e->getArg(0);
     mlir::Value ptrValue = emitScalarExpr(ptrExpr);

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1101,12 +1101,14 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_assume_dereferenceable: {
     mlir::Value ptrValue = emitScalarExpr(e->getArg(0));
     mlir::Value sizeValue = emitScalarExpr(e->getArg(1));
-    // The operand bundle expects a pointer-sized integer; widen/narrow to
-    // intptr_t to match classic CodeGen.
-    mlir::Type intPtrTy = convertType(getContext().getIntPtrType());
-    if (sizeValue.getType() != intPtrTy)
-      sizeValue = builder.createIntCast(sizeValue, intPtrTy);
-    cir::AssumeDereferenceableOp::create(builder, loc, ptrValue, sizeValue);
+    // The `dereferenceable` operand bundle expects a pointer-sized unsigned
+    // integer; widen/narrow as needed.
+    mlir::Type uintPtrTy = convertType(getContext().getUIntPtrType());
+    if (sizeValue.getType() != uintPtrTy)
+      sizeValue = builder.createIntCast(sizeValue, uintPtrTy);
+    mlir::Value cond = builder.getBool(true, loc);
+    cir::AssumeOp::create(builder, loc, cond, "dereferenceable",
+                          mlir::ValueRange{ptrValue, sizeValue});
     return RValue::get(nullptr);
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1094,7 +1094,9 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_assume_separate_storage: {
     mlir::Value value0 = emitScalarExpr(e->getArg(0));
     mlir::Value value1 = emitScalarExpr(e->getArg(1));
-    cir::AssumeSepStorageOp::create(builder, loc, value0, value1);
+    mlir::Value cond = builder.getBool(true, loc);
+    cir::AssumeOp::create(builder, loc, cond, "separate_storage",
+                          mlir::ValueRange{value0, value1});
     return RValue::get(nullptr);
   }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1474,7 +1474,8 @@ mlir::Value CIRGenFunction::emitAlignmentAssumption(
   llvm::SmallVector<mlir::Value> bundleArgs{ptrValue, alignValue};
   if (offsetValue)
     bundleArgs.push_back(offsetValue);
-  cir::AssumeOp::create(builder, assumeLoc, cond, "align", bundleArgs);
+  cir::AssumeOp::create(builder, assumeLoc, cond, cir::AssumeBundleKind::Align,
+                        bundleArgs);
   return ptrValue;
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -1468,8 +1468,14 @@ mlir::Value CIRGenFunction::emitAlignmentAssumption(
     mlir::Value ptrValue, QualType ty, SourceLocation loc,
     SourceLocation assumptionLoc, int64_t alignment, mlir::Value offsetValue) {
   assert(!cir::MissingFeatures::sanitizers());
-  return cir::AssumeAlignedOp::create(builder, getLoc(assumptionLoc), ptrValue,
-                                      alignment, offsetValue);
+  mlir::Location assumeLoc = getLoc(assumptionLoc);
+  mlir::Value alignValue = builder.getUInt64(alignment, assumeLoc);
+  mlir::Value cond = builder.getBool(true, assumeLoc);
+  llvm::SmallVector<mlir::Value> bundleArgs{ptrValue, alignValue};
+  if (offsetValue)
+    bundleArgs.push_back(offsetValue);
+  cir::AssumeOp::create(builder, assumeLoc, cond, "align", bundleArgs);
+  return ptrValue;
 }
 
 mlir::Value CIRGenFunction::emitAlignmentAssumption(

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -107,7 +107,8 @@ CIRGenFunction::emitAttributedStmt(const AttributedStmt &s) {
           !assumptionExpr->HasSideEffects(getContext())) {
         mlir::Value assumptionValue = emitCheckedArgForAssume(assumptionExpr);
         cir::AssumeOp::create(builder, getLoc(s.getSourceRange()),
-                              assumptionValue);
+                              assumptionValue, cir::AssumeBundleKind::None,
+                              mlir::ValueRange{});
       }
     } break;
     }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -376,110 +376,84 @@ LogicalResult cir::DeleteArrayOp::verify() {
 // AssumeOp
 //===----------------------------------------------------------------------===//
 
-// Print/parse helpers for the `custom<OpBundles>` directive on `cir.assume`.
-// These mirror the static helpers in mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
-// so the assembly form of CIR operand bundles matches the LLVM dialect 1:1.
+static void printAssumeBundle(OpAsmPrinter &p, cir::AssumeOp op,
+                              cir::AssumeBundleKindAttr kindAttr,
+                              OperandRange bundleArgs,
+                              TypeRange bundleArgTypes) {
+  cir::AssumeBundleKind kind = kindAttr.getValue();
+  if (kind == cir::AssumeBundleKind::None)
+    return;
 
-static void printOneOpBundle(OpAsmPrinter &p, OperandRange operands,
-                             TypeRange operandTypes, StringRef tag) {
-  p.printString(tag);
+  p << " " << cir::stringifyAssumeBundleKind(kind);
+  if (bundleArgs.empty())
+    return;
+
   p << "(";
-  if (!operands.empty()) {
-    p.printOperands(operands);
-    p << " : ";
-    llvm::interleaveComma(operandTypes, p);
-  }
+  p.printOperands(bundleArgs);
+  p << " : ";
+  llvm::interleaveComma(bundleArgTypes, p);
   p << ")";
 }
 
-static void printOpBundles(OpAsmPrinter &p, Operation *op,
-                           OperandRangeRange opBundleOperands,
-                           TypeRangeRange opBundleOperandTypes,
-                           std::optional<ArrayAttr> opBundleTags) {
-  if (opBundleOperands.empty())
-    return;
-  assert(opBundleTags && "expect operand bundle tags");
-
-  p << " [";
-  llvm::interleaveComma(
-      llvm::zip(opBundleOperands, opBundleOperandTypes, *opBundleTags), p,
-      [&p](auto bundle) {
-        auto bundleTag = cast<StringAttr>(std::get<2>(bundle)).getValue();
-        printOneOpBundle(p, std::get<0>(bundle), std::get<1>(bundle),
-                         bundleTag);
-      });
-  p << "]";
-}
-
-static ParseResult parseOneOpBundle(
-    OpAsmParser &p,
-    SmallVector<SmallVector<OpAsmParser::UnresolvedOperand>> &opBundleOperands,
-    SmallVector<SmallVector<Type>> &opBundleOperandTypes,
-    SmallVector<Attribute> &opBundleTags) {
-  SMLoc currentParserLoc = p.getCurrentLocation();
-  SmallVector<OpAsmParser::UnresolvedOperand> operands;
-  SmallVector<Type> types;
-  std::string tag;
-
-  if (p.parseString(&tag))
-    return p.emitError(currentParserLoc, "expect operand bundle tag");
-
-  if (p.parseLParen())
-    return failure();
-
-  if (p.parseOptionalRParen()) {
-    if (p.parseOperandList(operands) || p.parseColon() ||
-        p.parseTypeList(types) || p.parseRParen())
-      return failure();
+static ParseResult parseAssumeBundle(
+    OpAsmParser &p, cir::AssumeBundleKindAttr &bundleKindAttr,
+    llvm::SmallVector<mlir::OpAsmParser::UnresolvedOperand, 4> &bundleArgs,
+    llvm::SmallVector<mlir::Type, 1> &bundleArgTypes) {
+  StringRef keyword;
+  auto loc = p.getCurrentLocation();
+  if (failed(p.parseOptionalKeyword(&keyword))) {
+    bundleKindAttr = cir::AssumeBundleKindAttr::get(
+        p.getContext(), cir::AssumeBundleKind::None);
+    return success();
   }
 
-  opBundleOperands.push_back(std::move(operands));
-  opBundleOperandTypes.push_back(std::move(types));
-  opBundleTags.push_back(StringAttr::get(p.getContext(), tag));
+  std::optional<cir::AssumeBundleKind> parsedKind =
+      cir::symbolizeAssumeBundleKind(keyword);
+  if (!parsedKind)
+    return p.emitError(loc, "unknown assume bundle kind '") << keyword << "'";
 
-  return success();
-}
+  bundleKindAttr = cir::AssumeBundleKindAttr::get(p.getContext(), *parsedKind);
 
-static std::optional<ParseResult> parseOpBundles(
-    OpAsmParser &p,
-    SmallVector<SmallVector<OpAsmParser::UnresolvedOperand>> &opBundleOperands,
-    SmallVector<SmallVector<Type>> &opBundleOperandTypes,
-    ArrayAttr &opBundleTags) {
-  if (p.parseOptionalLSquare())
-    return std::nullopt;
-
-  if (succeeded(p.parseOptionalRSquare()))
+  if (p.parseOptionalLParen())
     return success();
 
-  SmallVector<Attribute> opBundleTagAttrs;
-  auto bundleParser = [&] {
-    return parseOneOpBundle(p, opBundleOperands, opBundleOperandTypes,
-                            opBundleTagAttrs);
-  };
-  if (p.parseCommaSeparatedList(bundleParser))
+  if (p.parseOperandList(bundleArgs) || p.parseColon() ||
+      p.parseTypeList(bundleArgTypes) || p.parseRParen())
     return failure();
-
-  if (p.parseRSquare())
-    return failure();
-
-  opBundleTags = ArrayAttr::get(p.getContext(), opBundleTagAttrs);
 
   return success();
 }
 
 LogicalResult cir::AssumeOp::verify() {
-  std::optional<ArrayAttr> tags = getOpBundleTags();
+  cir::AssumeBundleKind kind = getBundleKind();
+  size_t numArgs = getBundleArgs().size();
 
-  auto isStringAttr = [](Attribute attr) { return isa<StringAttr>(attr); };
-  if (tags && !llvm::all_of(*tags, isStringAttr))
-    return emitOpError("operand bundle tag must be a StringAttr");
+  if (kind == cir::AssumeBundleKind::None) {
+    if (numArgs != 0)
+      return emitOpError("unexpected bundle operands for kind 'none'");
+    return success();
+  }
 
-  size_t numBundles = getOpBundleOperands().size();
-  size_t numTags = tags ? tags->size() : 0;
-  if (numBundles != numTags)
-    return emitOpError("expected ")
-           << numBundles << " operand bundle tags, but actually got "
-           << numTags;
+  if (numArgs == 0)
+    return emitOpError("expected bundle operands for kind '")
+           << cir::stringifyAssumeBundleKind(kind) << "'";
+
+  switch (kind) {
+  case cir::AssumeBundleKind::Align:
+    if (numArgs != 2 && numArgs != 3)
+      return emitOpError("align bundle expects 2 or 3 operands");
+    break;
+  case cir::AssumeBundleKind::SeparateStorage:
+    if (numArgs != 2)
+      return emitOpError("separate_storage bundle expects 2 operands");
+    break;
+  case cir::AssumeBundleKind::Dereferenceable:
+    if (numArgs != 2)
+      return emitOpError("dereferenceable bundle expects 2 operands");
+    break;
+  default:
+    break;
+  }
   return success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -376,9 +376,110 @@ LogicalResult cir::DeleteArrayOp::verify() {
 // AssumeOp
 //===----------------------------------------------------------------------===//
 
+// Print/parse helpers for the `custom<OpBundles>` directive on `cir.assume`.
+// These mirror the static helpers in mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+// so the assembly form of CIR operand bundles matches the LLVM dialect 1:1.
+
+static void printOneOpBundle(OpAsmPrinter &p, OperandRange operands,
+                             TypeRange operandTypes, StringRef tag) {
+  p.printString(tag);
+  p << "(";
+  if (!operands.empty()) {
+    p.printOperands(operands);
+    p << " : ";
+    llvm::interleaveComma(operandTypes, p);
+  }
+  p << ")";
+}
+
+static void printOpBundles(OpAsmPrinter &p, Operation *op,
+                           OperandRangeRange opBundleOperands,
+                           TypeRangeRange opBundleOperandTypes,
+                           std::optional<ArrayAttr> opBundleTags) {
+  if (opBundleOperands.empty())
+    return;
+  assert(opBundleTags && "expect operand bundle tags");
+
+  p << " [";
+  llvm::interleaveComma(
+      llvm::zip(opBundleOperands, opBundleOperandTypes, *opBundleTags), p,
+      [&p](auto bundle) {
+        auto bundleTag = cast<StringAttr>(std::get<2>(bundle)).getValue();
+        printOneOpBundle(p, std::get<0>(bundle), std::get<1>(bundle),
+                         bundleTag);
+      });
+  p << "]";
+}
+
+static ParseResult parseOneOpBundle(
+    OpAsmParser &p,
+    SmallVector<SmallVector<OpAsmParser::UnresolvedOperand>> &opBundleOperands,
+    SmallVector<SmallVector<Type>> &opBundleOperandTypes,
+    SmallVector<Attribute> &opBundleTags) {
+  SMLoc currentParserLoc = p.getCurrentLocation();
+  SmallVector<OpAsmParser::UnresolvedOperand> operands;
+  SmallVector<Type> types;
+  std::string tag;
+
+  if (p.parseString(&tag))
+    return p.emitError(currentParserLoc, "expect operand bundle tag");
+
+  if (p.parseLParen())
+    return failure();
+
+  if (p.parseOptionalRParen()) {
+    if (p.parseOperandList(operands) || p.parseColon() ||
+        p.parseTypeList(types) || p.parseRParen())
+      return failure();
+  }
+
+  opBundleOperands.push_back(std::move(operands));
+  opBundleOperandTypes.push_back(std::move(types));
+  opBundleTags.push_back(StringAttr::get(p.getContext(), tag));
+
+  return success();
+}
+
+static std::optional<ParseResult> parseOpBundles(
+    OpAsmParser &p,
+    SmallVector<SmallVector<OpAsmParser::UnresolvedOperand>> &opBundleOperands,
+    SmallVector<SmallVector<Type>> &opBundleOperandTypes,
+    ArrayAttr &opBundleTags) {
+  if (p.parseOptionalLSquare())
+    return std::nullopt;
+
+  if (succeeded(p.parseOptionalRSquare()))
+    return success();
+
+  SmallVector<Attribute> opBundleTagAttrs;
+  auto bundleParser = [&] {
+    return parseOneOpBundle(p, opBundleOperands, opBundleOperandTypes,
+                            opBundleTagAttrs);
+  };
+  if (p.parseCommaSeparatedList(bundleParser))
+    return failure();
+
+  if (p.parseRSquare())
+    return failure();
+
+  opBundleTags = ArrayAttr::get(p.getContext(), opBundleTagAttrs);
+
+  return success();
+}
+
 LogicalResult cir::AssumeOp::verify() {
-  if (!getBundleTagAttr() && !getBundleArgs().empty())
-    return emitOpError("bundle args present without a bundle tag");
+  std::optional<ArrayAttr> tags = getOpBundleTags();
+
+  auto isStringAttr = [](Attribute attr) { return isa<StringAttr>(attr); };
+  if (tags && !llvm::all_of(*tags, isStringAttr))
+    return emitOpError("operand bundle tag must be a StringAttr");
+
+  size_t numBundles = getOpBundleOperands().size();
+  size_t numTags = tags ? tags->size() : 0;
+  if (numBundles != numTags)
+    return emitOpError("expected ")
+           << numBundles << " operand bundle tags, but actually got "
+           << numTags;
   return success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -373,6 +373,16 @@ LogicalResult cir::DeleteArrayOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// AssumeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult cir::AssumeOp::verify() {
+  if (!getBundleTagAttr() && !getBundleArgs().empty())
+    return emitOpError("bundle args present without a bundle tag");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LocalInitOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -820,11 +820,15 @@ mlir::LogicalResult CIRToLLVMSignBitOpLowering::matchAndRewrite(
 mlir::LogicalResult CIRToLLVMAssumeOpLowering::matchAndRewrite(
     cir::AssumeOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  llvm::SmallVector<mlir::ValueRange> bundleOperands;
-  for (mlir::ValueRange operands : adaptor.getOpBundleOperands())
-    bundleOperands.push_back(operands);
-  rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(
-      op, adaptor.getPredicate(), bundleOperands, op.getOpBundleTagsAttr());
+  mlir::Value cond = adaptor.getPredicate();
+  if (op.getBundleKind() == cir::AssumeBundleKind::None) {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond);
+    return mlir::success();
+  }
+
+  llvm::StringRef tag = cir::stringifyAssumeBundleKind(op.getBundleKind());
+  rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond, tag,
+                                                    adaptor.getBundleArgs());
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -820,8 +820,13 @@ mlir::LogicalResult CIRToLLVMSignBitOpLowering::matchAndRewrite(
 mlir::LogicalResult CIRToLLVMAssumeOpLowering::matchAndRewrite(
     cir::AssumeOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  auto cond = adaptor.getPredicate();
-  rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond);
+  mlir::Value cond = adaptor.getPredicate();
+  if (std::optional<llvm::StringRef> tag = op.getBundleTag()) {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond, *tag,
+                                                      adaptor.getBundleArgs());
+  } else {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond);
+  }
   return mlir::success();
 }
 
@@ -856,18 +861,6 @@ mlir::LogicalResult CIRToLLVMAssumeSepStorageOpLowering::matchAndRewrite(
   rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(
       op, cond, mlir::LLVM::AssumeSeparateStorageTag{}, adaptor.getPtr1(),
       adaptor.getPtr2());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMAssumeDereferenceableOpLowering::matchAndRewrite(
-    cir::AssumeDereferenceableOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  auto cond = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
-                                             rewriter.getI1Type(), 1);
-  mlir::LLVM::AssumeOp::create(
-      rewriter, op.getLoc(), cond, "dereferenceable",
-      mlir::ValueRange{adaptor.getPointer(), adaptor.getSize()});
-  rewriter.eraseOp(op);
   return mlir::success();
 }
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -859,6 +859,18 @@ mlir::LogicalResult CIRToLLVMAssumeSepStorageOpLowering::matchAndRewrite(
   return mlir::success();
 }
 
+mlir::LogicalResult CIRToLLVMAssumeDereferenceableOpLowering::matchAndRewrite(
+    cir::AssumeDereferenceableOp op, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  auto cond = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
+                                             rewriter.getI1Type(), 1);
+  mlir::LLVM::AssumeOp::create(
+      rewriter, op.getLoc(), cond, "dereferenceable",
+      mlir::ValueRange{adaptor.getPointer(), adaptor.getSize()});
+  rewriter.eraseOp(op);
+  return mlir::success();
+}
+
 static mlir::LLVM::AtomicOrdering
 getLLVMMemOrder(std::optional<cir::MemOrder> memorder) {
   if (!memorder)

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -820,47 +820,11 @@ mlir::LogicalResult CIRToLLVMSignBitOpLowering::matchAndRewrite(
 mlir::LogicalResult CIRToLLVMAssumeOpLowering::matchAndRewrite(
     cir::AssumeOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
-  mlir::Value cond = adaptor.getPredicate();
-  if (std::optional<llvm::StringRef> tag = op.getBundleTag()) {
-    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond, *tag,
-                                                      adaptor.getBundleArgs());
-  } else {
-    rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(op, cond);
-  }
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMAssumeAlignedOpLowering::matchAndRewrite(
-    cir::AssumeAlignedOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  SmallVector<mlir::Value, 3> opBundleArgs{adaptor.getPointer()};
-
-  auto alignment = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
-                                                  adaptor.getAlignmentAttr());
-  opBundleArgs.push_back(alignment);
-
-  if (mlir::Value offset = adaptor.getOffset())
-    opBundleArgs.push_back(offset);
-
-  auto cond = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
-                                             rewriter.getI1Type(), 1);
-  mlir::LLVM::AssumeOp::create(rewriter, op.getLoc(), cond, "align",
-                               opBundleArgs);
-
-  // The llvm.assume operation does not have a result, so we need to replace
-  // all uses of this cir.assume_aligned operation with the input ptr itself.
-  rewriter.replaceOp(op, adaptor.getPointer());
-  return mlir::success();
-}
-
-mlir::LogicalResult CIRToLLVMAssumeSepStorageOpLowering::matchAndRewrite(
-    cir::AssumeSepStorageOp op, OpAdaptor adaptor,
-    mlir::ConversionPatternRewriter &rewriter) const {
-  auto cond = mlir::LLVM::ConstantOp::create(rewriter, op.getLoc(),
-                                             rewriter.getI1Type(), 1);
+  llvm::SmallVector<mlir::ValueRange> bundleOperands;
+  for (mlir::ValueRange operands : adaptor.getOpBundleOperands())
+    bundleOperands.push_back(operands);
   rewriter.replaceOpWithNewOp<mlir::LLVM::AssumeOp>(
-      op, cond, mlir::LLVM::AssumeSeparateStorageTag{}, adaptor.getPtr1(),
-      adaptor.getPtr2());
+      op, adaptor.getPredicate(), bundleOperands, op.getOpBundleTagsAttr());
   return mlir::success();
 }
 

--- a/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
@@ -117,7 +117,7 @@ void *assume_aligned(void *ptr) {
 }
 
 // CIR: @_Z14assume_alignedPv
-// CIR:   cir.assume %{{.+}} ["align"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
+// CIR:   cir.assume %{{.+}} align(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i) : !cir.bool
 // CIR: }
 
 // LLVM: @_Z14assume_alignedPv
@@ -133,7 +133,7 @@ void *assume_aligned_misalignment(void *ptr, unsigned misalignment) {
 }
 
 // CIR: @_Z27assume_aligned_misalignmentPvj
-// CIR:   cir.assume %{{.+}} ["align"(%{{.+}}, %{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i, !u64i)] : !cir.bool
+// CIR:   cir.assume %{{.+}} align(%{{.+}}, %{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i, !u64i) : !cir.bool
 // CIR: }
 
 // LLVM: @_Z27assume_aligned_misalignmentPvj
@@ -149,7 +149,7 @@ void assume_separate_storage(void *p1, void *p2) {
 }
 
 // CIR: cir.func{{.*}} @_Z23assume_separate_storagePvS_
-// CIR:   cir.assume %{{.+}} ["separate_storage"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !cir.ptr<!void>)] : !cir.bool
+// CIR:   cir.assume %{{.+}} separate_storage(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !cir.ptr<!void>) : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z23assume_separate_storagePvS_
@@ -165,7 +165,7 @@ void assume_dereferenceable(void *p, unsigned long n) {
 }
 
 // CIR: cir.func{{.*}} @_Z22assume_dereferenceablePvm
-// CIR:   cir.assume %{{.+}} ["dereferenceable"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
+// CIR:   cir.assume %{{.+}} dereferenceable(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i) : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z22assume_dereferenceablePvm
@@ -181,7 +181,7 @@ void assume_dereferenceable_const(void *p) {
 }
 
 // CIR: cir.func{{.*}} @_Z28assume_dereferenceable_constPv
-// CIR:   cir.assume %{{.+}} ["dereferenceable"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
+// CIR:   cir.assume %{{.+}} dereferenceable(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i) : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z28assume_dereferenceable_constPv
@@ -197,7 +197,7 @@ void assume_dereferenceable_narrow_size(void *p, unsigned n) {
 }
 
 // CIR: cir.func{{.*}} @_Z34assume_dereferenceable_narrow_sizePvj
-// CIR:   cir.assume %{{.+}} ["dereferenceable"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
+// CIR:   cir.assume %{{.+}} dereferenceable(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i) : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z34assume_dereferenceable_narrow_sizePvj

--- a/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
@@ -160,6 +160,54 @@ void assume_separate_storage(void *p1, void *p2) {
 // OGCG:   call void @llvm.assume(i1 true) [ "separate_storage"(ptr %{{.+}}, ptr %{{.+}}) ]
 // OGCG: }
 
+void assume_dereferenceable(void *p, unsigned long n) {
+  __builtin_assume_dereferenceable(p, n);
+}
+
+// CIR: cir.func{{.*}} @_Z22assume_dereferenceablePvm
+// CIR:   cir.assume_dereferenceable %{{.+}}, %{{.+}} : !cir.ptr<!void>, !s64i
+// CIR: }
+
+// LLVM: define {{.*}}void @_Z22assume_dereferenceablePvm
+// LLVM:   call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %{{.+}}, i64 %{{.+}}) ]
+// LLVM: }
+
+// OGCG: define {{.*}}void @_Z22assume_dereferenceablePvm
+// OGCG:   call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %{{.+}}, i64 %{{.+}}) ]
+// OGCG: }
+
+void assume_dereferenceable_const(void *p) {
+  __builtin_assume_dereferenceable(p, 16);
+}
+
+// CIR: cir.func{{.*}} @_Z28assume_dereferenceable_constPv
+// CIR:   cir.assume_dereferenceable %{{.+}}, %{{.+}} : !cir.ptr<!void>, !s64i
+// CIR: }
+
+// LLVM: define {{.*}}void @_Z28assume_dereferenceable_constPv
+// LLVM:   call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %{{.+}}, i64 16) ]
+// LLVM: }
+
+// OGCG: define {{.*}}void @_Z28assume_dereferenceable_constPv
+// OGCG:   call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %{{.+}}, i64 16) ]
+// OGCG: }
+
+void assume_dereferenceable_narrow_size(void *p, unsigned n) {
+  __builtin_assume_dereferenceable(p, n);
+}
+
+// CIR: cir.func{{.*}} @_Z34assume_dereferenceable_narrow_sizePvj
+// CIR:   cir.assume_dereferenceable %{{.+}}, %{{.+}} : !cir.ptr<!void>, !s64i
+// CIR: }
+
+// LLVM: define {{.*}}void @_Z34assume_dereferenceable_narrow_sizePvj
+// LLVM:   call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %{{.+}}, i64 %{{.+}}) ]
+// LLVM: }
+
+// OGCG: define {{.*}}void @_Z34assume_dereferenceable_narrow_sizePvj
+// OGCG:   call void @llvm.assume(i1 true) [ "dereferenceable"(ptr %{{.+}}, i64 %{{.+}}) ]
+// OGCG: }
+
 void expect(int x, int y) {
   __builtin_expect(x, y);
 }

--- a/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
@@ -165,7 +165,7 @@ void assume_dereferenceable(void *p, unsigned long n) {
 }
 
 // CIR: cir.func{{.*}} @_Z22assume_dereferenceablePvm
-// CIR:   cir.assume_dereferenceable %{{.+}}, %{{.+}} : !cir.ptr<!void>, !s64i
+// CIR:   cir.assume %{{.+}} ["dereferenceable"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z22assume_dereferenceablePvm
@@ -181,7 +181,7 @@ void assume_dereferenceable_const(void *p) {
 }
 
 // CIR: cir.func{{.*}} @_Z28assume_dereferenceable_constPv
-// CIR:   cir.assume_dereferenceable %{{.+}}, %{{.+}} : !cir.ptr<!void>, !s64i
+// CIR:   cir.assume %{{.+}} ["dereferenceable"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z28assume_dereferenceable_constPv
@@ -197,7 +197,7 @@ void assume_dereferenceable_narrow_size(void *p, unsigned n) {
 }
 
 // CIR: cir.func{{.*}} @_Z34assume_dereferenceable_narrow_sizePvj
-// CIR:   cir.assume_dereferenceable %{{.+}}, %{{.+}} : !cir.ptr<!void>, !s64i
+// CIR:   cir.assume %{{.+}} ["dereferenceable"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z34assume_dereferenceable_narrow_sizePvj

--- a/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-call.cpp
@@ -117,7 +117,7 @@ void *assume_aligned(void *ptr) {
 }
 
 // CIR: @_Z14assume_alignedPv
-// CIR:   %{{.+}} = cir.assume_aligned %{{.+}} alignment 16 : !cir.ptr<!void>
+// CIR:   cir.assume %{{.+}} ["align"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)] : !cir.bool
 // CIR: }
 
 // LLVM: @_Z14assume_alignedPv
@@ -133,7 +133,7 @@ void *assume_aligned_misalignment(void *ptr, unsigned misalignment) {
 }
 
 // CIR: @_Z27assume_aligned_misalignmentPvj
-// CIR:   %{{.+}} = cir.assume_aligned %{{.+}} alignment 16[offset %{{.+}} : !u64i] : !cir.ptr<!void>
+// CIR:   cir.assume %{{.+}} ["align"(%{{.+}}, %{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i, !u64i)] : !cir.bool
 // CIR: }
 
 // LLVM: @_Z27assume_aligned_misalignmentPvj
@@ -149,7 +149,7 @@ void assume_separate_storage(void *p1, void *p2) {
 }
 
 // CIR: cir.func{{.*}} @_Z23assume_separate_storagePvS_
-// CIR:   cir.assume_separate_storage %{{.+}}, %{{.+}} : !cir.ptr<!void>
+// CIR:   cir.assume %{{.+}} ["separate_storage"(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !cir.ptr<!void>)] : !cir.bool
 // CIR: }
 
 // LLVM: define {{.*}}void @_Z23assume_separate_storagePvS_

--- a/clang/test/CIR/IR/assume.cir
+++ b/clang/test/CIR/IR/assume.cir
@@ -42,4 +42,16 @@ module {
 // CHECK:       !cir.ptr<!void>) : !cir.bool
 // CHECK:   cir.return
 // CHECK: }
+
+  cir.func @assume_align(%ptr : !cir.ptr<!void>, %align : !u64i) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    cir.assume %0 align(%ptr, %align : !cir.ptr<!void>, !u64i) : !cir.bool
+    cir.return
+  }
+// CHECK: cir.func{{.*}} @assume_align(
+// CHECK:   %0 = cir.const #true
+// CHECK:   cir.assume %0 align(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)
+// CHECK:       : !cir.bool
+// CHECK:   cir.return
+// CHECK: }
 }

--- a/clang/test/CIR/IR/assume.cir
+++ b/clang/test/CIR/IR/assume.cir
@@ -1,0 +1,45 @@
+// RUN: cir-opt %s --verify-roundtrip | FileCheck %s
+
+!void = !cir.void
+!u64i = !cir.int<u, 64>
+
+module {
+  cir.func @assume_plain() {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    cir.assume %0 : !cir.bool
+    cir.return
+  }
+// CHECK: #true = #cir.bool<true> : !cir.bool
+// CHECK: cir.func{{.*}} @assume_plain() {
+// CHECK:   %0 = cir.const #true
+// CHECK:   cir.assume %0 : !cir.bool
+// CHECK:   cir.return
+// CHECK: }
+
+  cir.func @assume_dereferenceable(%ptr : !cir.ptr<!void>, %size : !u64i) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    cir.assume %0 dereferenceable(%ptr, %size : !cir.ptr<!void>, !u64i)
+        : !cir.bool
+    cir.return
+  }
+// CHECK: cir.func{{.*}} @assume_dereferenceable(
+// CHECK:   %0 = cir.const #true
+// CHECK:   cir.assume %0 dereferenceable(%{{.+}}, %{{.+}} : !cir.ptr<!void>, !u64i)
+// CHECK:       : !cir.bool
+// CHECK:   cir.return
+// CHECK: }
+
+  cir.func @assume_separate_storage(%a : !cir.ptr<!void>,
+                                    %b : !cir.ptr<!void>) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    cir.assume %0 separate_storage(%a, %b : !cir.ptr<!void>, !cir.ptr<!void>)
+        : !cir.bool
+    cir.return
+  }
+// CHECK: cir.func{{.*}} @assume_separate_storage(
+// CHECK:   %0 = cir.const #true
+// CHECK:   cir.assume %0 separate_storage(%{{.+}}, %{{.+}} : !cir.ptr<!void>,
+// CHECK:       !cir.ptr<!void>) : !cir.bool
+// CHECK:   cir.return
+// CHECK: }
+}

--- a/clang/test/CIR/IR/invalid-assume.cir
+++ b/clang/test/CIR/IR/invalid-assume.cir
@@ -3,12 +3,10 @@
 !void = !cir.void
 
 module {
-  cir.func @assume_bundle_args_without_tag(%arg0 : !cir.ptr<!void>) {
+  cir.func @assume_bundle_args_without_kind(%arg0 : !cir.ptr<!void>) {
     %0 = cir.const #cir.bool<true> : !cir.bool
-    // expected-error@+1 {{expected 1 operand bundle tags, but actually got 0}}
-    "cir.assume"(%0, %arg0) {
-      op_bundle_sizes = array<i32: 1>
-    } : (!cir.bool, !cir.ptr<!void>) -> ()
+    // expected-error@+1 {{unexpected bundle operands for kind 'none'}}
+    "cir.assume"(%0, %arg0) : (!cir.bool, !cir.ptr<!void>) -> ()
     cir.return
   }
 }
@@ -18,13 +16,10 @@ module {
 !void = !cir.void
 
 module {
-  cir.func @assume_bundle_tag_not_string(%arg0 : !cir.ptr<!void>) {
+  cir.func @assume_deref_wrong_arity(%arg0 : !cir.ptr<!void>) {
     %0 = cir.const #cir.bool<true> : !cir.bool
-    // expected-error@+1 {{operand bundle tag must be a StringAttr}}
-    "cir.assume"(%0, %arg0) {
-      op_bundle_sizes = array<i32: 1>,
-      op_bundle_tags = [42 : i64]
-    } : (!cir.bool, !cir.ptr<!void>) -> ()
+    // expected-error@+1 {{dereferenceable bundle expects 2 operands}}
+    cir.assume %0 dereferenceable(%arg0 : !cir.ptr<!void>) : !cir.bool
     cir.return
   }
 }

--- a/clang/test/CIR/IR/invalid-assume.cir
+++ b/clang/test/CIR/IR/invalid-assume.cir
@@ -23,3 +23,55 @@ module {
     cir.return
   }
 }
+
+// -----
+
+!void = !cir.void
+
+module {
+  cir.func @assume_unknown_bundle(%arg0 : !cir.ptr<!void>) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    // expected-error@+1 {{unknown assume bundle kind 'bogus'}}
+    cir.assume %0 bogus(%arg0 : !cir.ptr<!void>) : !cir.bool
+    cir.return
+  }
+}
+
+// -----
+
+!void = !cir.void
+
+module {
+  cir.func @assume_align_no_operands() {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    // expected-error@+1 {{expected bundle operands for kind 'align'}}
+    cir.assume %0 align : !cir.bool
+    cir.return
+  }
+}
+
+// -----
+
+!void = !cir.void
+
+module {
+  cir.func @assume_align_wrong_arity(%ptr : !cir.ptr<!void>) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    // expected-error@+1 {{align bundle expects 2 or 3 operands}}
+    cir.assume %0 align(%ptr : !cir.ptr<!void>) : !cir.bool
+    cir.return
+  }
+}
+
+// -----
+
+!void = !cir.void
+
+module {
+  cir.func @assume_separate_storage_wrong_arity(%a : !cir.ptr<!void>) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    // expected-error@+1 {{separate_storage bundle expects 2 operands}}
+    cir.assume %0 separate_storage(%a : !cir.ptr<!void>) : !cir.bool
+    cir.return
+  }
+}

--- a/clang/test/CIR/IR/invalid-assume.cir
+++ b/clang/test/CIR/IR/invalid-assume.cir
@@ -5,8 +5,26 @@
 module {
   cir.func @assume_bundle_args_without_tag(%arg0 : !cir.ptr<!void>) {
     %0 = cir.const #cir.bool<true> : !cir.bool
-    // expected-error@+1 {{bundle args present without a bundle tag}}
-    "cir.assume"(%0, %arg0) {operandSegmentSizes = array<i32: 1, 1>} : (!cir.bool, !cir.ptr<!void>) -> ()
+    // expected-error@+1 {{expected 1 operand bundle tags, but actually got 0}}
+    "cir.assume"(%0, %arg0) {
+      op_bundle_sizes = array<i32: 1>
+    } : (!cir.bool, !cir.ptr<!void>) -> ()
+    cir.return
+  }
+}
+
+// -----
+
+!void = !cir.void
+
+module {
+  cir.func @assume_bundle_tag_not_string(%arg0 : !cir.ptr<!void>) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    // expected-error@+1 {{operand bundle tag must be a StringAttr}}
+    "cir.assume"(%0, %arg0) {
+      op_bundle_sizes = array<i32: 1>,
+      op_bundle_tags = [42 : i64]
+    } : (!cir.bool, !cir.ptr<!void>) -> ()
     cir.return
   }
 }

--- a/clang/test/CIR/IR/invalid-assume.cir
+++ b/clang/test/CIR/IR/invalid-assume.cir
@@ -1,0 +1,12 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+!void = !cir.void
+
+module {
+  cir.func @assume_bundle_args_without_tag(%arg0 : !cir.ptr<!void>) {
+    %0 = cir.const #cir.bool<true> : !cir.bool
+    // expected-error@+1 {{bundle args present without a bundle tag}}
+    "cir.assume"(%0, %arg0) {operandSegmentSizes = array<i32: 1, 1>} : (!cir.bool, !cir.ptr<!void>) -> ()
+    cir.return
+  }
+}


### PR DESCRIPTION
`__builtin_assume_dereferenceable` was reported NYI by ClangIR.  It's heavily exercised by libcxx via `__memory/valid_range.h`, so most of `<algorithm>` currently fails to compile under `-fclangir`.

Adds a `cir.assume_dereferenceable` op (pointer + pointer-sized integer), emits it from CIRGenBuiltin, and lowers it to

```
call void @llvm.assume(i1 true) [ "dereferenceable"(ptr, i64) ]
```

which is what classic Clang's `Builder.CreateDereferenceableAssumption` produces.

The size operand is widened/narrowed to `intptr_t` at the CIRGen layer to match classic CodeGen's `IntPtrTy` conversion.

Tests cover the dynamic-size, constant-size, and narrow-integer-size cases against CIR, CIR->LLVM, and OGCG.
