### PR TITLE
[clang][deps] Use single controller instance for by-name scans

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -110,7 +110,7 @@ public:
   llvm::Expected<dependencies::TranslationUnitDeps> getModuleDependencies(
       StringRef ModuleName, ArrayRef<std::string> CommandLine, StringRef CWD,
       const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
-      dependencies::LookupModuleOutputCallback LookupModuleOutput);
+      dependencies::DependencyActionController &Controller);
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 
@@ -201,10 +201,10 @@ public:
   /// @param CWD The current working directory used during the scan.
   /// @param CommandLine The commandline used for the scan.
   /// @return Error if the initializaiton fails.
-  static llvm::Expected<CompilerInstanceWithContext> initializeOrError(
-      DependencyScanningTool &Tool, StringRef CWD,
-      ArrayRef<std::string> CommandLine,
-      dependencies::LookupModuleOutputCallback LookupModuleOutput);
+  static llvm::Expected<CompilerInstanceWithContext>
+  initializeOrError(DependencyScanningTool &Tool, StringRef CWD,
+                    ArrayRef<std::string> CommandLine,
+                    dependencies::DependencyActionController &Controller);
 
   bool
   computeDependencies(StringRef ModuleName,
@@ -229,7 +229,7 @@ public:
   computeDependenciesByNameOrError(
       StringRef ModuleName,
       const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
-      dependencies::LookupModuleOutputCallback LookupModuleOutput);
+      dependencies::DependencyActionController &Controller);
 
   // MaxNumOfQueries is the upper limit of the number of names the by-name
   // scanning API (computeDependencies) can support after a

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -357,14 +357,14 @@ llvm::Expected<TranslationUnitDeps>
 DependencyScanningTool::getModuleDependencies(
     StringRef ModuleName, ArrayRef<std::string> CommandLine, StringRef CWD,
     const llvm::DenseSet<ModuleID> &AlreadySeen,
-    LookupModuleOutputCallback LookupModuleOutput) {
+    DependencyActionController &Controller) {
   auto MaybeCIWithContext = CompilerInstanceWithContext::initializeOrError(
-      *this, CWD, CommandLine, LookupModuleOutput);
+      *this, CWD, CommandLine, Controller);
   if (auto Error = MaybeCIWithContext.takeError())
     return Error;
 
   return MaybeCIWithContext->computeDependenciesByNameOrError(
-      ModuleName, AlreadySeen, LookupModuleOutput);
+      ModuleName, AlreadySeen, Controller);
 }
 
 static std::optional<SmallVector<std::string, 0>> getFirstCC1CommandLine(
@@ -431,12 +431,7 @@ CompilerInstanceWithContext::initializeFromCommandline(
 llvm::Expected<CompilerInstanceWithContext>
 CompilerInstanceWithContext::initializeOrError(
     DependencyScanningTool &Tool, StringRef CWD,
-    ArrayRef<std::string> CommandLine,
-    LookupModuleOutputCallback LookupModuleOutput) {
-  // It might seem wasteful to create fresh controller just for initializing the
-  // compiler instance, but repeated calls to computeDependenciesByNameOrError()
-  // do that as well, so this gets amortized.
-  CallbackActionController Controller(LookupModuleOutput);
+    ArrayRef<std::string> CommandLine, DependencyActionController &Controller) {
   auto DiagPrinterWithOS =
       std::make_unique<TextDiagnosticsPrinterWithOutput>(CommandLine);
 
@@ -452,9 +447,8 @@ CompilerInstanceWithContext::initializeOrError(
 llvm::Expected<TranslationUnitDeps>
 CompilerInstanceWithContext::computeDependenciesByNameOrError(
     StringRef ModuleName, const llvm::DenseSet<ModuleID> &AlreadySeen,
-    LookupModuleOutputCallback LookupModuleOutput) {
+    DependencyActionController &Controller) {
   FullDependencyConsumer Consumer(AlreadySeen);
-  CallbackActionController Controller(LookupModuleOutput);
   // We need to clear the DiagnosticOutput so that each by-name lookup
   // has a clean diagnostics buffer.
   DiagPrinterWithOS->DiagnosticOutput.clear();

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1102,16 +1102,18 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
         SmallVector<StringRef> Names;
         ModuleNameRef.split(Names, ',');
 
+        CallbackActionController Controller(LookupOutput);
+
         if (Names.size() == 1) {
           auto MaybeModuleDepsGraph = WorkerTool.getModuleDependencies(
               Names[0], Input->CommandLine, CWD, AlreadySeenModules,
-              LookupOutput);
+              Controller);
           if (handleModuleResult(Names[0], MaybeModuleDepsGraph, *FD,
                                  LocalIndex, DependencyOS, Errs))
             HadErrors = true;
         } else {
           auto CIWithCtx = CompilerInstanceWithContext::initializeOrError(
-              WorkerTool, CWD, Input->CommandLine, LookupOutput);
+              WorkerTool, CWD, Input->CommandLine, Controller);
           if (llvm::Error Err = CIWithCtx.takeError()) {
             handleErrorWithInfoString(
                 "Compiler instance with context setup error", std::move(Err),
@@ -1123,7 +1125,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
           for (auto N : Names) {
             auto MaybeModuleDepsGraph =
                 CIWithCtx->computeDependenciesByNameOrError(
-                    N, AlreadySeenModules, LookupOutput);
+                    N, AlreadySeenModules, Controller);
             if (handleModuleResult(N, MaybeModuleDepsGraph, *FD, LocalIndex,
                                    DependencyOS, Errs)) {
               HadErrors = true;


### PR DESCRIPTION
This avoids creating redundant instances of `DependencyActionController` in the by-name scanning APIs. NFCI