### PR TITLE
[CIR] Allow implicit truncation in CharacterLiteral codegen

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -247,8 +247,7 @@ public:
   mlir::Value VisitCharacterLiteral(const CharacterLiteral *e) {
     mlir::Type ty = cgf.convertType(e->getType());
     // Character literals are always stored in an unsigned (even for signed
-    // char), so allow implicit truncation here.  Mirrors classic CodeGen
-    // in CGExprScalar.cpp's VisitCharacterLiteral.
+    // char), so allow implicit truncation here.
     auto intTy = mlir::cast<cir::IntTypeInterface>(ty);
     llvm::APInt apValue(intTy.getWidth(), e->getValue(),
                         /*isSigned=*/false, /*implicitTrunc=*/true);

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -246,8 +246,14 @@ public:
 
   mlir::Value VisitCharacterLiteral(const CharacterLiteral *e) {
     mlir::Type ty = cgf.convertType(e->getType());
-    auto init = cir::IntAttr::get(ty, e->getValue());
-    return cir::ConstantOp::create(builder, cgf.getLoc(e->getExprLoc()), init);
+    // Character literals are always stored in an unsigned (even for signed
+    // char), so allow implicit truncation here.  Mirrors classic CodeGen
+    // in CGExprScalar.cpp's VisitCharacterLiteral.
+    auto intTy = mlir::cast<cir::IntTypeInterface>(ty);
+    llvm::APInt apValue(intTy.getWidth(), e->getValue(),
+                        /*isSigned=*/false, /*implicitTrunc=*/true);
+    return cir::ConstantOp::create(builder, cgf.getLoc(e->getExprLoc()),
+                                   cir::IntAttr::get(ty, apValue));
   }
 
   mlir::Value VisitCXXBoolLiteralExpr(const CXXBoolLiteralExpr *e) {

--- a/clang/test/CIR/CodeGen/character-literal.c
+++ b/clang/test/CIR/CodeGen/character-literal.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 void high_byte_to_signed_char(void) {
   signed char c = '\xFF';
@@ -17,9 +17,6 @@ void high_byte_to_signed_char(void) {
 // LLVM-LABEL: define{{.*}} void @high_byte_to_signed_char
 // LLVM:         store i8 -1, ptr %{{.*}}
 
-// OGCG-LABEL: define{{.*}} void @high_byte_to_signed_char
-// OGCG:         store i8 -1, ptr %{{.*}}
-
 void boundary_byte(void) {
   signed char c = '\x80';
   (void)c;
@@ -31,9 +28,6 @@ void boundary_byte(void) {
 
 // LLVM-LABEL: define{{.*}} void @boundary_byte
 // LLVM:         store i8 -128, ptr %{{.*}}
-
-// OGCG-LABEL: define{{.*}} void @boundary_byte
-// OGCG:         store i8 -128, ptr %{{.*}}
 
 void low_byte(void) {
   signed char c = 'A';
@@ -47,9 +41,6 @@ void low_byte(void) {
 // LLVM-LABEL: define{{.*}} void @low_byte
 // LLVM:         store i8 65, ptr %{{.*}}
 
-// OGCG-LABEL: define{{.*}} void @low_byte
-// OGCG:         store i8 65, ptr %{{.*}}
-
 void high_byte_to_unsigned_char(void) {
   unsigned char c = '\xFF';
   (void)c;
@@ -61,6 +52,3 @@ void high_byte_to_unsigned_char(void) {
 
 // LLVM-LABEL: define{{.*}} void @high_byte_to_unsigned_char
 // LLVM:         store i8 -1, ptr %{{.*}}
-
-// OGCG-LABEL: define{{.*}} void @high_byte_to_unsigned_char
-// OGCG:         store i8 -1, ptr %{{.*}}

--- a/clang/test/CIR/CodeGen/character-literal.c
+++ b/clang/test/CIR/CodeGen/character-literal.c
@@ -1,17 +1,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
-// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
-// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
-
-// A CharacterLiteral '\xFF' has AST type `int` and value 4294967295
-// (0xFFFFFFFF; the byte 0xFF reinterpreted as an unsigned 32-bit value).
-// Lowering it to an APInt must allow implicit truncation, mirroring
-// classic CodeGen's VisitCharacterLiteral.  Without that, constructing
-// `APInt(32, 4294967295, /*isSigned=*/true)` would trip the
-// `isIntN(...) && "Value is not an N-bit signed value"` assertion in
-// LLVM's APInt.h.  Regression test for that path.
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 void high_byte_to_signed_char(void) {
   signed char c = '\xFF';

--- a/clang/test/CIR/CodeGen/character-literal.c
+++ b/clang/test/CIR/CodeGen/character-literal.c
@@ -1,0 +1,74 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+// A CharacterLiteral '\xFF' has AST type `int` and value 4294967295
+// (0xFFFFFFFF; the byte 0xFF reinterpreted as an unsigned 32-bit value).
+// Lowering it to an APInt must allow implicit truncation, mirroring
+// classic CodeGen's VisitCharacterLiteral.  Without that, constructing
+// `APInt(32, 4294967295, /*isSigned=*/true)` would trip the
+// `isIntN(...) && "Value is not an N-bit signed value"` assertion in
+// LLVM's APInt.h.  Regression test for that path.
+
+void high_byte_to_signed_char(void) {
+  signed char c = '\xFF';
+  (void)c;
+}
+
+// CIR-LABEL: cir.func{{.*}} @high_byte_to_signed_char
+// CIR:         %[[VAL:.*]] = cir.const #cir.int<-1> : !s8i
+// CIR:         cir.store{{.*}} %[[VAL]], %{{.*}} : !s8i, !cir.ptr<!s8i>
+
+// LLVM-LABEL: define{{.*}} void @high_byte_to_signed_char
+// LLVM:         store i8 -1, ptr %{{.*}}
+
+// OGCG-LABEL: define{{.*}} void @high_byte_to_signed_char
+// OGCG:         store i8 -1, ptr %{{.*}}
+
+void boundary_byte(void) {
+  signed char c = '\x80';
+  (void)c;
+}
+
+// CIR-LABEL: cir.func{{.*}} @boundary_byte
+// CIR:         %[[VAL:.*]] = cir.const #cir.int<-128> : !s8i
+// CIR:         cir.store{{.*}} %[[VAL]], %{{.*}} : !s8i, !cir.ptr<!s8i>
+
+// LLVM-LABEL: define{{.*}} void @boundary_byte
+// LLVM:         store i8 -128, ptr %{{.*}}
+
+// OGCG-LABEL: define{{.*}} void @boundary_byte
+// OGCG:         store i8 -128, ptr %{{.*}}
+
+void low_byte(void) {
+  signed char c = 'A';
+  (void)c;
+}
+
+// CIR-LABEL: cir.func{{.*}} @low_byte
+// CIR:         %[[VAL:.*]] = cir.const #cir.int<65> : !s8i
+// CIR:         cir.store{{.*}} %[[VAL]], %{{.*}} : !s8i, !cir.ptr<!s8i>
+
+// LLVM-LABEL: define{{.*}} void @low_byte
+// LLVM:         store i8 65, ptr %{{.*}}
+
+// OGCG-LABEL: define{{.*}} void @low_byte
+// OGCG:         store i8 65, ptr %{{.*}}
+
+void high_byte_to_unsigned_char(void) {
+  unsigned char c = '\xFF';
+  (void)c;
+}
+
+// CIR-LABEL: cir.func{{.*}} @high_byte_to_unsigned_char
+// CIR:         %[[VAL:.*]] = cir.const #cir.int<255> : !u8i
+// CIR:         cir.store{{.*}} %[[VAL]], %{{.*}} : !u8i, !cir.ptr<!u8i>
+
+// LLVM-LABEL: define{{.*}} void @high_byte_to_unsigned_char
+// LLVM:         store i8 -1, ptr %{{.*}}
+
+// OGCG-LABEL: define{{.*}} void @high_byte_to_unsigned_char
+// OGCG:         store i8 -1, ptr %{{.*}}


### PR DESCRIPTION
`VisitCharacterLiteral` is calling the `IntAttr::get(Type, int64_t)`
builder, which builds the underlying `APInt` with
`isSigned=type.isSigned()` and no implicit truncation. That asserts the
moment a high-bit character literal like `'\xFF'` (which the AST stores
as `CharacterLiteral 'int' 4294967295`) comes through with `int` as the
destination type:

```
APInt.h:121: Assertion `llvm::isIntN(BitWidth, val) &&
                       "Value is not an N-bit signed value"' failed.
```

Classic CodeGen passes `IsSigned=false, ImplicitTrunc=true` here, with a
comment that says character literals are stored unsigned even for signed
char. Just mirror that: build the `APInt` explicitly with those flags
and hand it to `IntAttr::get`. After this the CIR const folder produces
`#cir.int<-1> : !s8i` for `signed char c = '\xFF';` and the lowered
LLVM is identical to OGCG.

Found while sweeping SPEC CPU 2026 with `-fclangir` -- hits cpython
(`Modules/_decimal/_decimal.c`) and omnetpp (yxml + 8 other TUs).
One-liner repro: `void f(void) { signed char c = '\xFF'; }`.

Test covers `\xFF`, `\x80`, `'A'`, and the unsigned-char destination,
all with the CIR + LLVM + OGCG triple.
