### PR TITLE
[clang][deps] Move logic out of the PP callback

### DIFF
--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -241,20 +241,9 @@ public:
   void moduleImport(SourceLocation ImportLoc, ModuleIdPath Path,
                     const Module *Imported) override;
 
-  void EndOfMainFile() override;
-
 private:
   /// The parent dependency collector.
   ModuleDepCollector &MDC;
-
-  void handleImport(const Module *Imported);
-
-  /// Returns the ID or nothing if the dependency is spurious and is ignored.
-  std::optional<ModuleID> handleTopLevelModule(serialization::ModuleFile *MF);
-
-  /// Adds direct module dependencies to the ModuleDeps instance. This includes
-  /// prebuilt module and implicitly-built modules.
-  void addAllModuleDeps(serialization::ModuleFile &MF, ModuleDeps &MD);
 };
 
 /// Collects modular and non-modular dependencies of the main file by attaching
@@ -268,6 +257,10 @@ public:
                      CompilerInvocation OriginalCI,
                      const PrebuiltModulesAttrsMap PrebuiltModulesASTMap,
                      const ArrayRef<StringRef> StableDirs);
+
+  /// Processes the accumulated dependency information and reports it to the
+  /// \c DependencyConsumer.
+  void run();
 
   void attachToPreprocessor(Preprocessor &PP) override;
   void attachToASTReader(ASTReader &R) override;
@@ -331,6 +324,15 @@ private:
   /// if needed. The callback is created and added to a Preprocessor instance by
   /// attachToPreprocessor and the Preprocessor instance owns it.
   ModuleDepCollectorPP *CollectorPPPtr = nullptr;
+
+  void handleImport(const Module *Imported);
+
+  /// Returns the ID or nothing if the dependency is spurious and is ignored.
+  std::optional<ModuleID> handleTopLevelModule(serialization::ModuleFile *MF);
+
+  /// Adds direct module dependencies to the ModuleDeps instance. This includes
+  /// prebuilt module and implicitly-built modules.
+  void addAllModuleDeps(serialization::ModuleFile &MF, ModuleDeps &MD);
 
   /// Checks whether the module is known as being prebuilt.
   bool isPrebuiltModule(const serialization::ModuleFile *MF);

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -780,8 +780,10 @@ bool DependencyScanningAction::runInvocation(
   const bool Result = ScanInstance.ExecuteAction(Action);
 
   if (Result) {
-    if (MDC)
+    if (MDC) {
+      MDC->run();
       MDC->applyDiscoveredDependencies(*OriginalInvocation);
+    }
 
     if (!Controller.finalize(ScanInstance, *OriginalInvocation))
       return false;

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -568,7 +568,7 @@ void ModuleDepCollectorPP::InclusionDirective(
     // here as `FileChanged` will never see it.
     MDC.addFileDep(FileName);
   }
-  handleImport(SuggestedModule);
+  MDC.handleImport(SuggestedModule);
 }
 
 void ModuleDepCollectorPP::moduleImport(SourceLocation ImportLoc,
@@ -583,10 +583,12 @@ void ModuleDepCollectorPP::moduleImport(SourceLocation ImportLoc,
     return;
   }
 
-  handleImport(Imported);
+  MDC.handleImport(Imported);
 }
 
-void ModuleDepCollectorPP::handleImport(const Module *Imported) {
+void ModuleDepCollector::handleImport(const Module *Imported) {
+  auto &MDC = *this;
+
   if (!Imported)
     return;
 
@@ -605,7 +607,9 @@ void ModuleDepCollectorPP::handleImport(const Module *Imported) {
   }
 }
 
-void ModuleDepCollectorPP::EndOfMainFile() {
+void ModuleDepCollector::run() {
+  auto &MDC = *this;
+
   FileID MainFileID = MDC.ScanInstance.getSourceManager().getMainFileID();
   MDC.MainFile = std::string(MDC.ScanInstance.getSourceManager()
                                  .getFileEntryRefForID(MainFileID)
@@ -693,7 +697,9 @@ static StringRef makeAbsoluteAndCanonicalize(CompilerInstance &CI,
 }
 
 std::optional<ModuleID>
-ModuleDepCollectorPP::handleTopLevelModule(serialization::ModuleFile *MF) {
+ModuleDepCollector::handleTopLevelModule(serialization::ModuleFile *MF) {
+  auto &MDC = *this;
+
   // If this module has been handled already, just return its ID.
   if (auto ModI = MDC.ModularDeps.find(MF); ModI != MDC.ModularDeps.end())
     return ModI->second->ID;
@@ -822,8 +828,10 @@ ModuleDepCollectorPP::handleTopLevelModule(serialization::ModuleFile *MF) {
   return MD.ID;
 }
 
-void ModuleDepCollectorPP::addAllModuleDeps(serialization::ModuleFile &MF,
-                                            ModuleDeps &MD) {
+void ModuleDepCollector::addAllModuleDeps(serialization::ModuleFile &MF,
+                                          ModuleDeps &MD) {
+  auto &MDC = *this;
+
   llvm::DenseSet<const Module *> Seen;
   for (serialization::ModuleFile *Import : MF.Imports) {
     if (MDC.isPrebuiltModule(Import)) {

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -603,10 +603,6 @@ bool CompilerInstanceWithContext::computeDependencies(
 
   assert(CB && "Must have PPCallbacks after module loading");
   CB->moduleImport(SourceLocation(), Path, ModResult);
-  // Note that we are calling the CB's EndOfMainFile function, which
-  // forwards the results to the dependency consumer.
-  // It does not indicate the end of processing the fake file.
-  CB->EndOfMainFile();
 
   if (!ModResult)
     return false;
@@ -614,6 +610,7 @@ bool CompilerInstanceWithContext::computeDependencies(
   if (CI.getDiagnostics().hasErrorOccurred())
     return false;
 
+  MDC->run();
   MDC->applyDiscoveredDependencies(ModuleInvocation);
 
   if (!Controller.finalize(CI, ModuleInvocation))


### PR DESCRIPTION
This PR moves the main scanner logic from `ModuleDepCollectorPP::EndOfMainFile()` to the new `ModuleDepCollector::run()`. In a follow-up PR, this will allow invoking the main logic with different `DependencyConsumer` objects and reusing the `ModuleDepCollector` state, skipping some work on subsequent calls.