### PR TITLE
[mlir][vector] Drop leading unit dims in memref op folding

### DIFF
--- a/mlir/lib/Dialect/MemRef/Transforms/FoldMemRefAliasOps.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/FoldMemRefAliasOps.cpp
@@ -223,10 +223,10 @@ AccessOpOfSubViewOpFolder::matchAndRewrite(memref::IndexedAccessOpInterface op,
     return rewriter.notifyMatchFailure(op, "not accessing a subview");
 
   SmallVector<int64_t> accessedShape = op.getAccessedShape();
-  // Note the subtle difference between accesedShape = {1} and accessedShape =
-  // {} here. The former prevents us from fdolding in a subview that doesn't
+  // Note the subtle difference between accessedShape = {1} and accessedShape =
+  // {} here. The former prevents us from folding in a subview that doesn't
   // have a unit stride on the final dimension, while the latter does not (since
-  // it indices scalar accesss).
+  // it indexes scalar accesses).
   int64_t accessedDims = accessedShape.size();
   if (!hasTrailingUnitStrides(subview, accessedDims))
     return rewriter.notifyMatchFailure(
@@ -237,7 +237,7 @@ AccessOpOfSubViewOpFolder::matchAndRewrite(memref::IndexedAccessOpInterface op,
 
   // Ignore outermost access dimension - we only care about dropped dimensions
   // between the accessed op's results, as those could break the accessing op's
-  // sematics.
+  // semantics.
   int64_t secondAccessedDim = sourceRank - (accessedDims - 1);
   if (secondAccessedDim < sourceRank) {
     for (int64_t d : llvm::seq(secondAccessedDim, sourceRank)) {
@@ -268,7 +268,12 @@ LogicalResult AccessOpOfExpandShapeOpFolder::matchAndRewrite(
 
   SmallVector<int64_t> rawAccessedShape = op.getAccessedShape();
   ArrayRef<int64_t> accessedShape = rawAccessedShape;
-  // Cut off the leading dimension, since we don't care about monifying its
+  if (expand.getSrcType().getRank() <
+      static_cast<int64_t>(accessedShape.size()))
+    return rewriter.notifyMatchFailure(
+        op, "expand_shape source rank is too small for the accessed shape");
+
+  // Cut off the leading dimension, since we don't care about modifying its
   // strides.
   if (!accessedShape.empty())
     accessedShape = accessedShape.drop_front();
@@ -278,7 +283,7 @@ LogicalResult AccessOpOfExpandShapeOpFolder::matchAndRewrite(
   if (!hasTrivialReassociationSuffix(reassocs, accessedShape.size()))
     return rewriter.notifyMatchFailure(
         op,
-        "expand_shape folding would merge semanvtically important dimensions");
+        "expand_shape folding would merge semantically important dimensions");
 
   SmallVector<Value> sourceIndices;
   memref::resolveSourceIndicesExpandShape(op.getLoc(), rewriter, expand,
@@ -301,6 +306,11 @@ LogicalResult AccessOpOfCollapseShapeOpFolder::matchAndRewrite(
 
   SmallVector<int64_t> rawAccessedShape = op.getAccessedShape();
   ArrayRef<int64_t> accessedShape = rawAccessedShape;
+  if (collapse.getSrcType().getRank() <
+      static_cast<int64_t>(accessedShape.size()))
+    return rewriter.notifyMatchFailure(
+        op, "collapse_shape source rank is too small for the accessed shape");
+
   // Cut off the leading dimension, since we don't care about its strides being
   // modified and we know that the dimensions within its reassociation group, if
   // it's non-trivial, must be contiguous.
@@ -310,9 +320,8 @@ LogicalResult AccessOpOfCollapseShapeOpFolder::matchAndRewrite(
   SmallVector<ReassociationIndices, 4> reassocs =
       collapse.getReassociationIndices();
   if (!hasTrivialReassociationSuffix(reassocs, accessedShape.size()))
-    return rewriter.notifyMatchFailure(op,
-                                       "collapse_shape folding would merge "
-                                       "semanvtically important dimensions");
+    return rewriter.notifyMatchFailure(op, "collapse_shape folding would merge "
+                                           "semantically important dimensions");
 
   SmallVector<Value> sourceIndices;
   memref::resolveSourceIndicesCollapseShape(op.getLoc(), rewriter, collapse,

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6581,8 +6581,8 @@ LogicalResult ExpandLoadOp::verify() {
     return failure();
   if (llvm::size(getIndices()) != memType.getRank())
     return emitOpError("requires ") << memType.getRank() << " indices";
-  if (resVType.getDimSize(0) != maskVType.getDimSize(0))
-    return emitOpError("expected result dim to match mask dim");
+  if (resVType.getShape() != maskVType.getShape())
+    return emitOpError("expected result shape to match mask shape");
   if (resVType != passVType)
     return emitOpError("expected pass_thru of same type as result type");
   return success();
@@ -6635,8 +6635,8 @@ LogicalResult CompressStoreOp::verify() {
     return failure();
   if (llvm::size(getIndices()) != memType.getRank())
     return emitOpError("requires ") << memType.getRank() << " indices";
-  if (valueVType.getDimSize(0) != maskVType.getDimSize(0))
-    return emitOpError("expected valueToStore dim to match mask dim");
+  if (valueVType.getShape() != maskVType.getShape())
+    return emitOpError("expected valueToStore shape to match mask shape");
   return success();
 }
 

--- a/mlir/lib/Dialect/Vector/Transforms/IndexedAccessOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/IndexedAccessOpInterfaceImpl.cpp
@@ -7,10 +7,12 @@
 //===----------------------------------------------------------------------===//
 // Implement IndexedAccessOpInterface on vector dialect operations with
 // %memref[%i, %j, ...] operands so generic memref-dialect passes can rewrite
-// their base/index pairs. Transfer ops keep their VectorTransferOpInterface
-// patterns; gather/scatter have tensor-or-memref bases and index-vector
-// operands that do not fit IndexedAccessOpInterface's rank-matched index
-// contract.
+// their base/index pairs. Redundant leading unit vector dimensions are omitted
+// from the accessed shape and restored with vector.shape_casts when an alias
+// rewrite drops those dimensions. Transfer ops keep their
+// VectorTransferOpInterface patterns; gather/scatter have tensor-or-memref
+// bases and index-vector operands that do not fit IndexedAccessOpInterface's
+// rank-matched index contract.
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Vector/Transforms/IndexedAccessOpInterfaceImpl.h"
@@ -18,29 +20,78 @@
 #include "mlir/Dialect/MemRef/IR/MemoryAccessOpInterfaces.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+
+#include <type_traits>
 
 using namespace mlir;
 using namespace mlir::memref;
 
-namespace {
 /// Return true if this op has the memref semantics expected by this model.
 template <typename LoadStoreOp>
-bool hasMemrefSemantics(Operation *op) {
+static bool hasMemrefSemantics(Operation *op) {
   return llvm::isa<MemRefType>(cast<LoadStoreOp>(op).getBase().getType());
 }
 
-/// Return the vector shape whose access strides must be preserved, marking
-/// scalable dimensions as dynamic.
-SmallVector<int64_t> getAccessedVectorShape(VectorType vecTy) {
+/// Return true if this op supports rank-0 vector operands/results.
+template <typename LoadStoreOp>
+static constexpr bool supportsRankZeroVectorAccess() {
+  return std::is_same_v<LoadStoreOp, vector::LoadOp> ||
+         std::is_same_v<LoadStoreOp, vector::StoreOp>;
+}
+
+/// Return the number of leading static unit dimensions in `vecTy`.
+static unsigned getNumLeadingUnitDims(VectorType vecTy) {
+  unsigned numLeadingUnitDims = 0;
+  for (auto [size, scalable] :
+       llvm::zip_equal(vecTy.getShape(), vecTy.getScalableDims())) {
+    if (size != 1 || scalable)
+      break;
+    ++numLeadingUnitDims;
+  }
+  return numLeadingUnitDims;
+}
+
+/// Return the vector shape whose access strides must be preserved, omitting
+/// redundant leading static unit dimensions and marking scalable dimensions as
+/// dynamic. If the op cannot access rank-0 vectors, preserve one trailing unit
+/// dimension instead of returning an empty shape.
+static SmallVector<int64_t> getAccessedVectorShape(VectorType vecTy,
+                                                   bool supportsRankZero) {
+  unsigned numLeadingUnitDims = getNumLeadingUnitDims(vecTy);
+  unsigned rank = static_cast<unsigned>(vecTy.getRank());
+  if (!supportsRankZero && numLeadingUnitDims == rank)
+    --numLeadingUnitDims;
   return llvm::map_to_vector(
-      llvm::zip_equal(vecTy.getShape(), vecTy.getScalableDims()), [](auto dim) {
+      llvm::zip_equal(vecTy.getShape().drop_front(numLeadingUnitDims),
+                      vecTy.getScalableDims().drop_front(numLeadingUnitDims)),
+      [](auto dim) {
         auto [size, scalable] = dim;
         return scalable ? ShapedType::kDynamic : size;
       });
 }
 
+/// Return `vecTy` with `numLeadingDims` dimensions dropped from the front.
+static VectorType dropLeadingDims(VectorType vecTy, unsigned numLeadingDims) {
+  return VectorType::get(vecTy.getShape().drop_front(numLeadingDims),
+                         vecTy.getElementType(),
+                         vecTy.getScalableDims().drop_front(numLeadingDims));
+}
+
+/// Return the shape-cast type for vector operands that match `vecTy`.
+static std::optional<VectorType>
+getShapeCastTypeForOperand(Value operand, VectorType vecTy,
+                           unsigned numLeadingDims) {
+  auto operandTy = dyn_cast<VectorType>(operand.getType());
+  if (!operandTy || operandTy.getShape() != vecTy.getShape() ||
+      operandTy.getScalableDims() != vecTy.getScalableDims())
+    return std::nullopt;
+  return dropLeadingDims(operandTy, numLeadingDims);
+}
+
+namespace {
 template <typename LoadStoreOp>
 struct VectorLoadStoreLikeOpImpl final
     : IndexedAccessOpInterface::ExternalModel<
@@ -56,7 +107,8 @@ struct VectorLoadStoreLikeOpImpl final
   SmallVector<int64_t> getAccessedShape(Operation *op) const {
     assert(hasMemrefSemantics<LoadStoreOp>(op) &&
            "expected vector op with memref semantics");
-    return getAccessedVectorShape(cast<LoadStoreOp>(op).getVectorType());
+    return getAccessedVectorShape(cast<LoadStoreOp>(op).getVectorType(),
+                                  supportsRankZeroVectorAccess<LoadStoreOp>());
   }
 
   std::optional<SmallVector<Value>>
@@ -66,10 +118,60 @@ struct VectorLoadStoreLikeOpImpl final
            "expected vector op with memref semantics");
     assert(llvm::isa<MemRefType>(newMemref.getType()) &&
            "expected replacement memref");
+
+    VectorType vecTy = cast<LoadStoreOp>(op).getVectorType();
+    if (static_cast<int64_t>(newIndices.size()) >= vecTy.getRank()) {
+      rewriter.modifyOpInPlace(op, [&]() {
+        auto concreteOp = cast<LoadStoreOp>(op);
+        concreteOp.getBaseMutable().assign(newMemref);
+        concreteOp.getIndicesMutable().assign(newIndices);
+      });
+      return std::nullopt;
+    }
+
+    unsigned numLeadingDimsToDrop = static_cast<unsigned>(
+        vecTy.getRank() - static_cast<int64_t>(newIndices.size()));
+    assert(numLeadingDimsToDrop <= getNumLeadingUnitDims(vecTy) &&
+           "expected only redundant leading unit dimensions to be dropped");
+
+    IRMapping dropDimsMap;
+    for (Value operand : op->getOperands()) {
+      std::optional<VectorType> castTy =
+          getShapeCastTypeForOperand(operand, vecTy, numLeadingDimsToDrop);
+      if (!castTy || dropDimsMap.lookupOrNull(operand))
+        continue;
+      Value castedOperand = vector::ShapeCastOp::create(
+          rewriter, operand.getLoc(), *castTy, operand);
+      dropDimsMap.map(operand, castedOperand);
+    }
+
+    if (op->getNumResults() == 1) {
+      // Result types cannot be changed in place on the original op because the
+      // caller replaces it using the returned value. Clone at the lower rank,
+      // then cast the result back to the original vector type.
+      VectorType droppedDimsTy = dropLeadingDims(vecTy, numLeadingDimsToDrop);
+      Operation *newOp = rewriter.clone(*op, dropDimsMap);
+      rewriter.modifyOpInPlace(newOp, [&]() {
+        auto concreteOp = cast<LoadStoreOp>(newOp);
+        concreteOp.getBaseMutable().assign(newMemref);
+        concreteOp.getIndicesMutable().assign(newIndices);
+        newOp->getResult(0).setType(droppedDimsTy);
+      });
+      Value castBack = vector::ShapeCastOp::create(rewriter, newOp->getLoc(),
+                                                   vecTy, newOp->getResult(0));
+      return {{castBack}};
+    }
+
+    // Store-like ops have no results to replace, so update their vector
+    // operands and base/index pair in place.
     rewriter.modifyOpInPlace(op, [&]() {
       auto concreteOp = cast<LoadStoreOp>(op);
       concreteOp.getBaseMutable().assign(newMemref);
       concreteOp.getIndicesMutable().assign(newIndices);
+      for (OpOperand &operand : op->getOpOperands()) {
+        if (Value replacement = dropDimsMap.lookupOrNull(operand.get()))
+          operand.set(replacement);
+      }
     });
     return std::nullopt;
   }
@@ -85,7 +187,7 @@ struct VectorLoadStoreLikeOpImpl final
 };
 
 template <typename... Ops>
-static void attachAll(MLIRContext *ctx) {
+static void attachLoadStoreLike(MLIRContext *ctx) {
   (Ops::template attachInterface<VectorLoadStoreLikeOpImpl<Ops>>(*ctx), ...);
 }
 
@@ -94,8 +196,8 @@ static void attachAll(MLIRContext *ctx) {
 void mlir::vector::registerIndexedAccessOpInterfaceExternalModels(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, vector::VectorDialect *dialect) {
-    attachAll<vector::LoadOp, vector::StoreOp, vector::MaskedLoadOp,
-              vector::MaskedStoreOp, vector::ExpandLoadOp,
-              vector::CompressStoreOp>(ctx);
+    attachLoadStoreLike<vector::LoadOp, vector::StoreOp, vector::MaskedLoadOp,
+                        vector::MaskedStoreOp, vector::ExpandLoadOp,
+                        vector::CompressStoreOp>(ctx);
   });
 }

--- a/mlir/test/Dialect/MemRef/fold-memref-alias-ops.mlir
+++ b/mlir/test/Dialect/MemRef/fold-memref-alias-ops.mlir
@@ -642,23 +642,21 @@ func.func @fold_vector_load_subview(%src : memref<24x64xf32>,
 
 // -----
 
-// TODO: This should fold, but implementing IndexedAccessOpInterface on vector.load
-// in a way that would allow the fold added complexity (emitting
-// `vector.shape_cast`s) that people wanted to keep out of the initial
-// implementation during previous discussions. (Note: this didn't work in the
-// pre-interface version of the pass either.)
-func.func @no_fold_scalar_equivalent_vector_load_subview(
+func.func @fold_scalar_equivalent_vector_load_subview(
   %arg0 : memref<16xf32>, %off : index, %idx : index) -> vector<1xf32> {
   %0 = memref.subview %arg0[%off][4][2] : memref<16xf32> to memref<4xf32, strided<[2], offset: ?>>
   %1 = vector.load %0[%idx] : memref<4xf32, strided<[2], offset: ?>>, vector<1xf32>
   return %1 : vector<1xf32>
 }
 
-// CHECK-LABEL: func @no_fold_scalar_equivalent_vector_load_subview
+// CHECK: #[[$STRIDED_INDEX:.+]] = affine_map<()[s0, s1] -> (s0 + s1 * 2)>
+// CHECK-LABEL: func @fold_scalar_equivalent_vector_load_subview
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<16xf32>
-//       CHECK:   %[[SUBVIEW:.*]] = memref.subview %[[ARG0]]
-//   CHECK-NOT:   vector.shape_cast
-//       CHECK:   vector.load %[[SUBVIEW]]
+//  CHECK-SAME:   %[[OFF:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:   %[[IDX:[a-zA-Z0-9_]+]]: index
+//       CHECK:   %[[RESOLVED:.*]] = affine.apply #[[$STRIDED_INDEX]](){{\[}}%[[OFF]], %[[IDX]]]
+//       CHECK:   %[[LOAD:.*]] = vector.load %[[ARG0]][%[[RESOLVED]]] : memref<16xf32>, vector<1xf32>
+//       CHECK:   return %[[LOAD]] : vector<1xf32>
 
 // -----
 
@@ -758,9 +756,7 @@ func.func @fold_vector_load_expand_shape(
 
 // -----
 
-// Folding this would require changing the vector op rank. That is handled by
-// vector drop-leading-unit-dim patterns, not by fold-memref-alias-ops.
-func.func @no_fold_vector_load_expand_shape_leading_unit(
+func.func @fold_vector_load_expand_shape_leading_unit(
   %arg0 : memref<32xf32>, %arg1 : index) -> vector<1x8xf32> {
   %c0 = arith.constant 0 : index
   %0 = memref.expand_shape %arg0 [[0, 1]] output_shape [4, 8] : memref<32xf32> into memref<4x8xf32>
@@ -768,11 +764,30 @@ func.func @no_fold_vector_load_expand_shape_leading_unit(
   return %1 : vector<1x8xf32>
 }
 
-// CHECK-LABEL: func @no_fold_vector_load_expand_shape_leading_unit
+// CHECK-LABEL: func @fold_vector_load_expand_shape_leading_unit
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<32xf32>
-//       CHECK:   memref.expand_shape %[[ARG0]]
-//   CHECK-NOT:   vector.shape_cast
-//       CHECK:   vector.load
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
+//       CHECK:   %[[C0:.*]] = arith.constant 0
+//       CHECK:   %[[IDX:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
+//       CHECK:   %[[LOAD:.*]] = vector.load %[[ARG0]][%[[IDX]]] : memref<32xf32>, vector<8xf32>
+//       CHECK:   %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<8xf32> to vector<1x8xf32>
+//       CHECK:   return %[[CAST]] : vector<1x8xf32>
+
+// -----
+
+func.func @fold_vector_load_expand_shape_all_unit(
+  %arg0 : memref<f32>) -> vector<1xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [] output_shape [1] : memref<f32> into memref<1xf32>
+  %1 = vector.load %0[%c0] : memref<1xf32>, vector<1xf32>
+  return %1 : vector<1xf32>
+}
+
+// CHECK-LABEL: func @fold_vector_load_expand_shape_all_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<f32>
+//       CHECK:   %[[LOAD:.*]] = vector.load %[[ARG0]][] : memref<f32>, vector<f32>
+//       CHECK:   %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<f32> to vector<1xf32>
+//       CHECK:   return %[[CAST]] : vector<1xf32>
 
 // -----
 
@@ -792,6 +807,46 @@ func.func @fold_vector_maskedload_expand_shape(
 //       CHECK:   %[[C0:.*]] = arith.constant 0
 //       CHECK:   %[[IDX:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
 //       CHECK:   vector.maskedload %[[ARG0]][%[[IDX]]], %[[ARG3]], %[[ARG4]]
+
+// -----
+
+func.func @fold_vector_maskedload_expand_shape_leading_unit(
+  %arg0 : memref<32xf32>, %arg1 : index, %mask: vector<1x8xi1>,
+  %pass: vector<1x8xf32>) -> vector<1x8xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [[0, 1]] output_shape [4, 8] : memref<32xf32> into memref<4x8xf32>
+  %1 = vector.maskedload %0[%arg1, %c0], %mask, %pass : memref<4x8xf32>, vector<1x8xi1>, vector<1x8xf32> into vector<1x8xf32>
+  return %1 : vector<1x8xf32>
+}
+
+// CHECK-LABEL: func @fold_vector_maskedload_expand_shape_leading_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<32xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:   %[[MASK:[a-zA-Z0-9_]+]]: vector<1x8xi1>
+//  CHECK-SAME:   %[[PASS:[a-zA-Z0-9_]+]]: vector<1x8xf32>
+//       CHECK:   %[[C0:.*]] = arith.constant 0
+//       CHECK:   %[[IDX:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
+//       CHECK:   %[[MASK_CAST:.*]] = vector.shape_cast %[[MASK]] : vector<1x8xi1> to vector<8xi1>
+//       CHECK:   %[[PASS_CAST:.*]] = vector.shape_cast %[[PASS]] : vector<1x8xf32> to vector<8xf32>
+//       CHECK:   %[[LOAD:.*]] = vector.maskedload %[[ARG0]][%[[IDX]]], %[[MASK_CAST]], %[[PASS_CAST]] : memref<32xf32>, vector<8xi1>, vector<8xf32> into vector<8xf32>
+//       CHECK:   %[[CAST:.*]] = vector.shape_cast %[[LOAD]] : vector<8xf32> to vector<1x8xf32>
+//       CHECK:   return %[[CAST]] : vector<1x8xf32>
+
+// -----
+
+func.func @negative_fold_vector_maskedload_expand_shape_all_unit(
+  %arg0 : memref<f32>, %mask: vector<1xi1>, %pass: vector<1xf32>)
+  -> vector<1xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [] output_shape [1] : memref<f32> into memref<1xf32>
+  %1 = vector.maskedload %0[%c0], %mask, %pass : memref<1xf32>, vector<1xi1>, vector<1xf32> into vector<1xf32>
+  return %1 : vector<1xf32>
+}
+
+// CHECK-LABEL: func @negative_fold_vector_maskedload_expand_shape_all_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<f32>
+//       CHECK:   %[[EXPAND:.*]] = memref.expand_shape %[[ARG0]]
+//       CHECK:   vector.maskedload %[[EXPAND]]
 
 // -----
 
@@ -828,9 +883,7 @@ func.func @fold_vector_store_expand_shape(
 
 // -----
 
-// Folding this would require changing the vector op rank. That is handled by
-// vector drop-leading-unit-dim patterns, not by fold-memref-alias-ops.
-func.func @no_fold_vector_store_expand_shape_leading_unit(
+func.func @fold_vector_store_expand_shape_leading_unit(
   %arg0 : memref<32xf32>, %arg1 : index, %val : vector<1x8xf32>) {
   %c0 = arith.constant 0 : index
   %0 = memref.expand_shape %arg0 [[0, 1]] output_shape [4, 8] : memref<32xf32> into memref<4x8xf32>
@@ -838,11 +891,30 @@ func.func @no_fold_vector_store_expand_shape_leading_unit(
   return
 }
 
-// CHECK-LABEL: func @no_fold_vector_store_expand_shape_leading_unit
+// CHECK-LABEL: func @fold_vector_store_expand_shape_leading_unit
 //  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<32xf32>
-//       CHECK:   memref.expand_shape %[[ARG0]]
-//   CHECK-NOT:   vector.shape_cast
-//       CHECK:   vector.store
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:   %[[VAL:[a-zA-Z0-9_]+]]: vector<1x8xf32>
+//       CHECK:   %[[C0:.*]] = arith.constant 0
+//       CHECK:   %[[IDX:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
+//       CHECK:   %[[CAST:.*]] = vector.shape_cast %[[VAL]] : vector<1x8xf32> to vector<8xf32>
+//       CHECK:   vector.store %[[CAST]], %[[ARG0]][%[[IDX]]] : memref<32xf32>, vector<8xf32>
+
+// -----
+
+func.func @fold_vector_store_expand_shape_all_unit(
+  %arg0 : memref<f32>, %val : vector<1xf32>) {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [] output_shape [1] : memref<f32> into memref<1xf32>
+  vector.store %val, %0[%c0] : memref<1xf32>, vector<1xf32>
+  return
+}
+
+// CHECK-LABEL: func @fold_vector_store_expand_shape_all_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<f32>
+//  CHECK-SAME:   %[[VAL:[a-zA-Z0-9_]+]]: vector<1xf32>
+//       CHECK:   %[[CAST:.*]] = vector.shape_cast %[[VAL]] : vector<1xf32> to vector<f32>
+//       CHECK:   vector.store %[[CAST]], %[[ARG0]][] : memref<f32>, vector<f32>
 
 // -----
 
@@ -865,6 +937,43 @@ func.func @fold_vector_maskedstore_expand_shape(
 
 // -----
 
+func.func @fold_vector_maskedstore_expand_shape_leading_unit(
+  %arg0 : memref<32xf32>, %arg1 : index, %mask: vector<1x8xi1>,
+  %val: vector<1x8xf32>) {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [[0, 1]] output_shape [4, 8] : memref<32xf32> into memref<4x8xf32>
+  vector.maskedstore %0[%arg1, %c0], %mask, %val : memref<4x8xf32>, vector<1x8xi1>, vector<1x8xf32>
+  return
+}
+
+// CHECK-LABEL: func @fold_vector_maskedstore_expand_shape_leading_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<32xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
+//  CHECK-SAME:   %[[MASK:[a-zA-Z0-9_]+]]: vector<1x8xi1>
+//  CHECK-SAME:   %[[VAL:[a-zA-Z0-9_]+]]: vector<1x8xf32>
+//       CHECK:   %[[C0:.*]] = arith.constant 0
+//       CHECK:   %[[IDX:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
+//       CHECK:   %[[MASK_CAST:.*]] = vector.shape_cast %[[MASK]] : vector<1x8xi1> to vector<8xi1>
+//       CHECK:   %[[VAL_CAST:.*]] = vector.shape_cast %[[VAL]] : vector<1x8xf32> to vector<8xf32>
+//       CHECK:   vector.maskedstore %[[ARG0]][%[[IDX]]], %[[MASK_CAST]], %[[VAL_CAST]] : memref<32xf32>, vector<8xi1>, vector<8xf32>
+
+// -----
+
+func.func @no_fold_vector_maskedstore_expand_shape_all_unit(
+  %arg0 : memref<f32>, %mask: vector<1xi1>, %val: vector<1xf32>) {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [] output_shape [1] : memref<f32> into memref<1xf32>
+  vector.maskedstore %0[%c0], %mask, %val : memref<1xf32>, vector<1xi1>, vector<1xf32>
+  return
+}
+
+// CHECK-LABEL: func @no_fold_vector_maskedstore_expand_shape_all_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<f32>
+//       CHECK:   %[[EXPAND:.*]] = memref.expand_shape %[[ARG0]]
+//       CHECK:   vector.maskedstore %[[EXPAND]]
+
+// -----
+
 func.func @fold_vector_expandload_expand_shape(
   %arg0 : memref<32xf32>, %arg1 : index, %arg3: vector<8xi1>, %arg4: vector<8xf32>) -> vector<8xf32> {
   %c0 = arith.constant 0 : index
@@ -884,6 +993,22 @@ func.func @fold_vector_expandload_expand_shape(
 
 // -----
 
+func.func @no_fold_vector_expandload_expand_shape_all_unit(
+  %arg0 : memref<f32>, %mask: vector<1xi1>, %pass: vector<1xf32>)
+  -> vector<1xf32> {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [] output_shape [1] : memref<f32> into memref<1xf32>
+  %1 = vector.expandload %0[%c0], %mask, %pass : memref<1xf32>, vector<1xi1>, vector<1xf32> into vector<1xf32>
+  return %1 : vector<1xf32>
+}
+
+// CHECK-LABEL: func @no_fold_vector_expandload_expand_shape_all_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<f32>
+//       CHECK:   %[[EXPAND:.*]] = memref.expand_shape %[[ARG0]]
+//       CHECK:   vector.expandload %[[EXPAND]]
+
+// -----
+
 func.func @fold_vector_compressstore_expand_shape(
   %arg0 : memref<32xf32>, %arg1 : index, %arg3: vector<8xi1>, %arg4: vector<8xf32>) {
   %c0 = arith.constant 0 : index
@@ -900,6 +1025,21 @@ func.func @fold_vector_compressstore_expand_shape(
 //       CHECK:   %[[C0:.*]] = arith.constant 0
 //       CHECK:   %[[IDX:.*]] = affine.linearize_index [%[[ARG1]], %[[C0]]] by (4, 8)
 //       CHECK:   vector.compressstore %[[ARG0]][%[[IDX]]], %[[ARG3]], %[[ARG4]]
+
+// -----
+
+func.func @negative_fold_vector_compressstore_expand_shape_all_unit(
+  %arg0 : memref<f32>, %mask: vector<1xi1>, %val: vector<1xf32>) {
+  %c0 = arith.constant 0 : index
+  %0 = memref.expand_shape %arg0 [] output_shape [1] : memref<f32> into memref<1xf32>
+  vector.compressstore %0[%c0], %mask, %val : memref<1xf32>, vector<1xi1>, vector<1xf32>
+  return
+}
+
+// CHECK-LABEL: func @negative_fold_vector_compressstore_expand_shape_all_unit
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9_]+]]: memref<f32>
+//       CHECK:   %[[EXPAND:.*]] = memref.expand_shape %[[ARG0]]
+//       CHECK:   vector.compressstore %[[EXPAND]]
 
 // -----
 

--- a/mlir/test/Dialect/Vector/invalid.mlir
+++ b/mlir/test/Dialect/Vector/invalid.mlir
@@ -1660,8 +1660,16 @@ func.func @expand_base_scalable(%base: memref<?xf32>, %mask: vector<[16]xi1>, %p
 
 func.func @expand_dim_mask_mismatch(%base: memref<?xf32>, %mask: vector<17xi1>, %pass_thru: vector<16xf32>) {
   %c0 = arith.constant 0 : index
-  // expected-error@+1 {{'vector.expandload' op expected result dim to match mask dim}}
+  // expected-error@+1 {{'vector.expandload' op expected result shape to match mask shape}}
   %0 = vector.expandload %base[%c0], %mask, %pass_thru : memref<?xf32>, vector<17xi1>, vector<16xf32> into vector<16xf32>
+}
+
+// -----
+
+func.func @expand_shape_mask_mismatch(%base: memref<?xf32>, %mask: vector<2x7xi1>, %pass_thru: vector<2x8xf32>) {
+  %c0 = arith.constant 0 : index
+  // expected-error@+1 {{'vector.expandload' op expected result shape to match mask shape}}
+  %0 = vector.expandload %base[%c0], %mask, %pass_thru : memref<?xf32>, vector<2x7xi1>, vector<2x8xf32> into vector<2x8xf32>
 }
 
 // -----
@@ -1714,8 +1722,16 @@ func.func @compress_scalable(%base: memref<?xf32>, %mask: vector<[16]xi1>, %valu
 
 func.func @compress_dim_mask_mismatch(%base: memref<?xf32>, %mask: vector<17xi1>, %value: vector<16xf32>) {
   %c0 = arith.constant 0 : index
-  // expected-error@+1 {{'vector.compressstore' op expected valueToStore dim to match mask dim}}
+  // expected-error@+1 {{'vector.compressstore' op expected valueToStore shape to match mask shape}}
   vector.compressstore %base[%c0], %mask, %value : memref<?xf32>, vector<17xi1>, vector<16xf32>
+}
+
+// -----
+
+func.func @compress_shape_mask_mismatch(%base: memref<?xf32>, %mask: vector<2x7xi1>, %value: vector<2x8xf32>) {
+  %c0 = arith.constant 0 : index
+  // expected-error@+1 {{'vector.compressstore' op expected valueToStore shape to match mask shape}}
+  vector.compressstore %base[%c0], %mask, %value : memref<?xf32>, vector<2x7xi1>, vector<2x8xf32>
 }
 
 // -----


### PR DESCRIPTION
Make the IndexedAccessOpInterface implementations for vector dialect operations a bit smarter by letting them drop redundant unit dimensions and shape_cast operations back. This allows folding in, for example, an expand_shape of a 1-D memref to a load of a `vector<1x1x8xf32>` by turning it into a load of a `vector<8xf32>` instead. This functionality is somewhat reduntant with dropleadunitdims, but is included for completeness and to better match the interface contract of IndexedAccessOpInterface.

While we're here, fix a bug in the verifier of
vector.expandshape/collapsestore - as near as I can tell, they were meant to check for the mask being the
same shape is the input vector, but they just checked the first dimension.

AI: Co-authored by Codex 5.5 (which also caught a bunch of my old typos)