### PR TITLE
[mlir][AMDGPU] Canonicalize masks on global_load_async_to_lds

### DIFF
--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPUOps.td
@@ -1413,6 +1413,7 @@ def AMDGPU_GlobalLoadAsyncToLDSOp :
     attr-dict `:` $transferType `,` type($src) `,` type($dst)
   }];
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 }
 
 def AMDGPU_TransposeLoadOp :

--- a/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
+++ b/mlir/lib/Dialect/AMDGPU/IR/AMDGPUOps.cpp
@@ -1065,6 +1065,31 @@ LogicalResult GlobalLoadAsyncToLDSOp::verify() {
   return success();
 }
 
+static LogicalResult
+foldGlobalLoadAsyncToLDSConstantMask(GlobalLoadAsyncToLDSOp op,
+                                     PatternRewriter &rewriter) {
+  Value mask = op.getMask();
+  if (!mask)
+    return failure();
+
+  APInt maskValue;
+  if (!matchPattern(mask, m_ConstantInt(&maskValue)))
+    return failure();
+
+  if (maskValue.isZero()) {
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  rewriter.modifyOpInPlace(op, [&]() { op.getMaskMutable().clear(); });
+  return success();
+}
+
+void GlobalLoadAsyncToLDSOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.add(foldGlobalLoadAsyncToLDSConstantMask);
+}
+
 //===----------------------------------------------------------------------===//
 // TransposeLoadOp
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/AMDGPU/canonicalize.mlir
+++ b/mlir/test/Dialect/AMDGPU/canonicalize.mlir
@@ -162,6 +162,35 @@ func.func @fold_gather_to_lds_of_cast_dest(%global: memref<128x72xf32, 1>, %lds:
 
 // -----
 
+// CHECK-LABEL: func @global_load_async_to_lds_true_mask
+// CHECK-SAME: %[[SRC:.*]]: memref<16xf32, #gpu.address_space<global>>, %[[DST:.*]]: memref<16xf32, #gpu.address_space<workgroup>>
+func.func @global_load_async_to_lds_true_mask(%src: memref<16xf32, #gpu.address_space<global>>, %dst: memref<16xf32, #gpu.address_space<workgroup>>) {
+  // CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-NEXT: amdgpu.global_load_async_to_lds %[[SRC]][%[[C0]]], %[[DST]][%[[C0]]] : f32, memref<16xf32, #gpu.address_space<global>>, memref<16xf32, #gpu.address_space<workgroup>>
+  // CHECK-NEXT: return
+  %c0 = arith.constant 0 : index
+  %true = arith.constant true
+  amdgpu.global_load_async_to_lds %src[%c0], %dst[%c0], %true
+    : f32, memref<16xf32, #gpu.address_space<global>>,
+      memref<16xf32, #gpu.address_space<workgroup>>
+  func.return
+}
+
+// -----
+
+// CHECK-LABEL: func @global_load_async_to_lds_false_mask
+func.func @global_load_async_to_lds_false_mask(%src: memref<16xf32, #gpu.address_space<global>>, %dst: memref<16xf32, #gpu.address_space<workgroup>>) {
+  // CHECK-NEXT: return
+  %c0 = arith.constant 0 : index
+  %false = arith.constant false
+  amdgpu.global_load_async_to_lds %src[%c0], %dst[%c0], %false
+    : f32, memref<16xf32, #gpu.address_space<global>>,
+      memref<16xf32, #gpu.address_space<workgroup>>
+  func.return
+}
+
+// -----
+
 // CHECK-LABEL: func @scaled_mfma
 // CHECK: %[[SCALE_1:.*]] = vector.extract_strided_slice %0 {offsets = [0], sizes = [4], strides = [1]} : vector<16xf8E8M0FNU> to vector<4xf8E8M0FNU>
 // CHECK: %[[SCALE_2:.*]] = vector.extract_strided_slice %2 {offsets = [4], sizes = [4], strides = [1]} : vector<16xf8E8M0FNU> to vector<4xf8E8M0FNU>


### PR DESCRIPTION
If the mask is always true, remove the mask operand (there are patterns that key off the presence of the lack of a mask operand to know when they can be more aggressive). If the mask is always false, just go ahead and delete the op as it won't write anythig.

AI: I described the patterns, Codex 5.5 wrote them