### PR TITLE
Refactor ModuleNameHash storage using LLVM Module Flags and propagate…

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -47,6 +47,7 @@
 #include "clang/Basic/Version.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -67,6 +68,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/MD5.h"
 #include "llvm/Support/Hash.h"
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/TargetParser/AArch64TargetParser.h"
@@ -84,6 +86,28 @@ using namespace CodeGen;
 static llvm::cl::opt<bool> LimitedCoverage(
     "limited-coverage-experimental", llvm::cl::Hidden,
     llvm::cl::desc("Emit limited coverage mapping information (experimental)"));
+
+namespace {
+// Computes an MD5 hash for the given module path.
+// The hash is appended to the internal linakge symbol names after a ".__uniq."
+// suffix when -funique-internal-linkage-names is specified. This helps tools
+// like profilers to understand and distinguish profiles associated with
+// such symbols even when these symbols are defined multiple times in the
+// binary.
+static std::string computeModuleNameHash(
+    StringRef Path) {
+  llvm::MD5 Md5;
+  Md5.update(Path);
+  llvm::MD5::MD5Result R;
+  Md5.final(R);
+  llvm::SmallString<32> Str;
+  llvm::MD5::stringifyResult(R, Str);
+  // Convert MD5hash to Decimal. Demangler suffixes can either contain
+  // numbers or characters but not both.
+  llvm::APInt IntHash(128, Str.str(), 16);
+  return toString(IntHash, /* Radix = */ 10, /* Signed = */ false);
+}
+} // namespace
 
 static const char AnnotationSection[] = "llvm.metadata";
 static constexpr auto ErrnoTBAAMDName = "llvm.errno.tbaa";
@@ -530,7 +554,7 @@ CodeGenModule::CodeGenModule(ASTContext &C,
         Path = Entry.second + Path.substr(Entry.first.size());
         break;
       }
-    ModuleNameHash = llvm::getUniqueInternalLinkagePostfix(Path);
+    getModule().setModuleNameHash(computeModuleNameHash(Path));
   }
 
   // Record mregparm value now so it is visible through all of codegen.
@@ -2163,7 +2187,7 @@ static void AppendCPUSpecificCPUDispatchMangling(const CodeGenModule &CGM,
 static bool isUniqueInternalLinkageDecl(GlobalDecl GD,
                                         CodeGenModule &CGM) {
   const Decl *D = GD.getDecl();
-  return !CGM.getModuleNameHash().empty() && isa<FunctionDecl>(D) &&
+  return !CGM.getModule().getModuleNameHash().empty() && isa<FunctionDecl>(D) &&
          (CGM.getFunctionLinkage(GD) == llvm::GlobalValue::InternalLinkage);
 }
 
@@ -2173,7 +2197,7 @@ static std::string getMangledNameImpl(CodeGenModule &CGM, GlobalDecl GD,
   SmallString<256> Buffer;
   llvm::raw_svector_ostream Out(Buffer);
   MangleContext &MC = CGM.getCXXABI().getMangleContext();
-  if (!CGM.getModuleNameHash().empty())
+  if (!CGM.getModule().getModuleNameHash().empty())
     MC.needsUniqueInternalLinkageNames();
   bool ShouldMangle = MC.shouldMangleDeclName(ND);
   if (ShouldMangle)
@@ -2213,7 +2237,7 @@ static std::string getMangledNameImpl(CodeGenModule &CGM, GlobalDecl GD,
   if (ShouldMangle && isUniqueInternalLinkageDecl(GD, CGM)) {
     assert(CGM.getCodeGenOpts().UniqueInternalLinkageNames &&
            "Hash computed when not explicitly requested");
-    Out << CGM.getModuleNameHash();
+    Out << ".__uniq." << CGM.getModule().getModuleNameHash();
   }
 
   if (const auto *FD = dyn_cast<FunctionDecl>(ND))

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -357,7 +357,6 @@ private:
   const TargetInfo &Target;
   std::unique_ptr<CGCXXABI> ABI;
   llvm::LLVMContext &VMContext;
-  std::string ModuleNameHash;
   bool CXX20ModuleInits = false;
   std::unique_ptr<CodeGenTBAA> TBAA;
 
@@ -754,8 +753,6 @@ public:
     return OMD && OMD->isDirectMethod() && OMD->isVariadic() &&
            isObjCDirectPreconditionThunkEnabled();
   }
-
-  const std::string &getModuleNameHash() const { return ModuleNameHash; }
 
   /// Return a reference to the configured OpenCL runtime.
   CGOpenCLRuntime &getOpenCLRuntime() {

--- a/llvm/include/llvm/IR/Module.h
+++ b/llvm/include/llvm/IR/Module.h
@@ -288,6 +288,12 @@ public:
   /// @returns a string containing the module-scope inline assembly blocks.
   const std::string &getModuleInlineAsm() const { return GlobalScopeAsm; }
 
+  /// Get module name hash.
+  std::string getModuleNameHash() const;
+
+  /// Set module name hash.
+  void setModuleNameHash(std::string Hash);
+
   /// Get a RandomNumberGenerator salted for use with this module. The
   /// RNG can be seeded via -rng-seed=<uint64> and is salted with the
   /// ModuleID and the provided pass salt. The returned RNG should not

--- a/llvm/lib/IR/Module.cpp
+++ b/llvm/lib/IR/Module.cpp
@@ -947,3 +947,15 @@ ControlFlowGuardMode Module::getControlFlowGuardMode() const {
     return static_cast<ControlFlowGuardMode>(CI->getZExtValue());
   return ControlFlowGuardMode::Disabled;
 }
+
+std::string Module::getModuleNameHash() const {
+  Metadata *MD = getModuleFlag("ModuleNameHash");
+  if (auto *MDS = dyn_cast_or_null<MDString>(MD))
+    return MDS->getString().str();
+  return {};
+}
+
+void Module::setModuleNameHash(std::string Hash) {
+  MDString *ID = MDString::get(getContext(), Hash);
+  setModuleFlag(ModFlagBehavior::Override, "ModuleNameHash", ID);
+}

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -451,9 +451,21 @@ static Function *createCloneDeclaration(Function &OrigF, coro::Shape &Shape,
                    ? Shape.getResumeFunctionType()
                    : getFunctionTypeFromAsyncSuspend(ActiveSuspend);
 
+  std::string Name = OrigF.getName().str();
+  std::string Hash = M->getModuleNameHash();
+  if (!Hash.empty()) {
+    std::string UniqSuffix = ".__uniq." + Hash;
+    size_t Pos = Name.rfind(UniqSuffix);
+    if (Pos != std::string::npos)
+      Name.erase(Pos);
+    Name = Name + Suffix.str() + UniqSuffix;
+  } else {
+    Name = Name + Suffix.str();
+  }
+
   Function *NewF =
       Function::Create(FnTy, GlobalValue::LinkageTypes::InternalLinkage,
-                       OrigF.getAddressSpace(), OrigF.getName() + Suffix);
+                       OrigF.getAddressSpace(), Name);
 
   M->getFunctionList().insert(InsertBefore, NewF);
 

--- a/llvm/test/Bitcode/module-name-hash.ll
+++ b/llvm/test/Bitcode/module-name-hash.ll
@@ -1,0 +1,12 @@
+; RUN: llvm-as < %s | llvm-dis | FileCheck %s
+; RUN: verify-uselistorder %s
+
+; Make sure that the ModuleNameHash flag is successfully serialized to bitcode
+; and deserialized back.
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 4, !"ModuleNameHash", !"323802289588745424661866488133278119720"}
+
+; CHECK: !llvm.module.flags = !{!0}
+; CHECK: !0 = !{i32 4, !"ModuleNameHash", !"323802289588745424661866488133278119720"}

--- a/llvm/test/Transforms/Coroutines/coro-split-unique-names.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-unique-names.ll
@@ -1,0 +1,98 @@
+; Tests that coro-split pass appends the .__uniq.<hash> suffix correctly at the end of split functions
+; RUN: opt < %s -passes='cgscc(coro-split)' -S | FileCheck %s
+
+; External linkage coroutine
+define ptr @f() presplitcoroutine {
+entry:
+  %id = call token @llvm.coro.id(i32 0, ptr null, ptr @f, ptr null)
+  %need.alloc = call i1 @llvm.coro.alloc(token %id)
+  br i1 %need.alloc, label %dyn.alloc, label %begin
+
+dyn.alloc:  
+  %size = call i32 @llvm.coro.size.i32()
+  %alloc = call ptr @malloc(i32 %size)
+  br label %begin
+
+begin:
+  %phi = phi ptr [ null, %entry ], [ %alloc, %dyn.alloc ]
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr %phi)
+  %0 = call i8 @llvm.coro.suspend(token none, i1 false)
+  switch i8 %0, label %suspend [i8 0, label %resume 
+                                i8 1, label %cleanup]
+resume:
+  br label %cleanup
+
+cleanup:
+  %mem = call ptr @llvm.coro.free(token %id, ptr %hdl)
+  call void @free(ptr %mem)
+  br label %suspend
+suspend:
+  call void @llvm.coro.end(ptr %hdl, i1 0, token none)  
+  ret ptr %hdl
+}
+
+; Internal linkage coroutine that already contains unique suffix
+define internal ptr @g.__uniq.123456789() presplitcoroutine {
+entry:
+  %id = call token @llvm.coro.id(i32 0, ptr null, ptr @g.__uniq.123456789, ptr null)
+  %need.alloc = call i1 @llvm.coro.alloc(token %id)
+  br i1 %need.alloc, label %dyn.alloc, label %begin
+
+dyn.alloc:  
+  %size = call i32 @llvm.coro.size.i32()
+  %alloc = call ptr @malloc(i32 %size)
+  br label %begin
+
+begin:
+  %phi = phi ptr [ null, %entry ], [ %alloc, %dyn.alloc ]
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr %phi)
+  %0 = call i8 @llvm.coro.suspend(token none, i1 false)
+  switch i8 %0, label %suspend [i8 0, label %resume 
+                                i8 1, label %cleanup]
+resume:
+  br label %cleanup
+
+cleanup:
+  %mem = call ptr @llvm.coro.free(token %id, ptr %hdl)
+  call void @free(ptr %mem)
+  br label %suspend
+suspend:
+  call void @llvm.coro.end(ptr %hdl, i1 0, token none)  
+  ret ptr %hdl
+}
+
+define void @caller() presplitcoroutine {
+entry:
+  %ptr1 = call ptr @f()
+  %ptr2 = call ptr @g.__uniq.123456789()
+  ret void
+}
+
+; CHECK-LABEL: define ptr @f()
+; CHECK: store ptr @f.resume.__uniq.123456789, ptr %hdl
+
+; CHECK-LABEL: define internal ptr @g.__uniq.123456789()
+; CHECK: store ptr @g.resume.__uniq.123456789, ptr %hdl
+
+; CHECK-LABEL: define internal fastcc void @f.resume.__uniq.123456789(
+; CHECK-LABEL: define internal fastcc void @f.destroy.__uniq.123456789(
+; CHECK-LABEL: define internal fastcc void @f.cleanup.__uniq.123456789(
+
+; CHECK-LABEL: define internal fastcc void @g.resume.__uniq.123456789(
+; CHECK-LABEL: define internal fastcc void @g.destroy.__uniq.123456789(
+; CHECK-LABEL: define internal fastcc void @g.cleanup.__uniq.123456789(
+
+declare ptr @llvm.coro.free(token, ptr)
+declare i32 @llvm.coro.size.i32()
+declare i8  @llvm.coro.suspend(token, i1)
+declare void @llvm.coro.resume(ptr)
+declare void @llvm.coro.destroy(ptr)
+declare token @llvm.coro.id(i32, ptr, ptr, ptr)
+declare i1 @llvm.coro.alloc(token)
+declare ptr @llvm.coro.begin(token, ptr)
+declare void @llvm.coro.end(ptr, i1, token) 
+declare noalias ptr @malloc(i32)
+declare void @free(ptr)
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 4, !"ModuleNameHash", !"123456789"}

--- a/llvm/unittests/IR/ModuleTest.cpp
+++ b/llvm/unittests/IR/ModuleTest.cpp
@@ -88,6 +88,16 @@ TEST(ModuleTest, setModuleFlag) {
   EXPECT_EQ(Val2, M.getModuleFlag(Key));
 }
 
+TEST(ModuleTest, ModuleNameHash) {
+  LLVMContext Context;
+  Module M("M", Context);
+  EXPECT_EQ("", M.getModuleNameHash());
+  M.setModuleNameHash("1234567890");
+  EXPECT_EQ("1234567890", M.getModuleNameHash());
+  M.setModuleNameHash("abcde");
+  EXPECT_EQ("abcde", M.getModuleNameHash());
+}
+
 TEST(ModuleTest, setModuleFlagInt) {
   LLVMContext Context;
   Module M("M", Context);


### PR DESCRIPTION
Today CodeGenModule bakes the module hash into the internal linkage symbols when -funique-internal-linkage-names is specified.

If later passes create local functions (like CoroSplit) then their names may conflict because the uniq suffix won't be applied there. 

This PR adds a ModuleNameHash field to the Module IR and computes and assigns the hash in CodeGenModule. If any pass creates an internal linkage function, the hash should be added to the name. 