### PR TITLE
[lldb][windows] mark test_overrides_resolver_resolver_cmd as XFAIL

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/scripted_bkpt/overrides_resolver/TestOverridesResolver.py
+++ b/lldb/test/API/functionalities/breakpoint/scripted_bkpt/overrides_resolver/TestOverridesResolver.py
@@ -18,6 +18,7 @@ class TestOverridesResolver(TestBase):
         self.build()
         self.do_test(True)
 
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
     def test_overrides_resolver_resolver_cmd(self):
         """Use facade breakpoints to emulate hitting some locations"""
         self.build()


### PR DESCRIPTION
Follow up to https://github.com/llvm/llvm-project/pull/195392 to mark `test_overrides_resolver_resolver_cmd` as XFAIL on Windows, like `test_overrides_resolver_resolver_python`.