### PR TITLE
MachOObjectFile: Don't limit `getSectionSize` to object's file size

### DIFF
--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -1950,32 +1950,9 @@ uint64_t MachOObjectFile::getSectionIndex(DataRefImpl Sec) const {
 }
 
 uint64_t MachOObjectFile::getSectionSize(DataRefImpl Sec) const {
-  // In the case if a malformed Mach-O file where the section offset is past
-  // the end of the file or some part of the section size is past the end of
-  // the file return a size of zero or a size that covers the rest of the file
-  // but does not extend past the end of the file.
-  uint32_t SectOffset, SectType;
-  uint64_t SectSize;
-
-  if (is64Bit()) {
-    MachO::section_64 Sect = getSection64(Sec);
-    SectOffset = Sect.offset;
-    SectSize = Sect.size;
-    SectType = Sect.flags & MachO::SECTION_TYPE;
-  } else {
-    MachO::section Sect = getSection(Sec);
-    SectOffset = Sect.offset;
-    SectSize = Sect.size;
-    SectType = Sect.flags & MachO::SECTION_TYPE;
-  }
-  if (SectType == MachO::S_ZEROFILL || SectType == MachO::S_GB_ZEROFILL)
-    return SectSize;
-  uint64_t FileSize = getData().size();
-  if (SectOffset > FileSize)
-    return 0;
-  if (FileSize - SectOffset < SectSize)
-    return FileSize - SectOffset;
-  return SectSize;
+  if (is64Bit())
+    return getSection64(Sec).size;
+  return getSection(Sec).size;
 }
 
 ArrayRef<uint8_t> MachOObjectFile::getSectionContents(uint64_t Offset,

--- a/llvm/test/Object/macho-dsym-section-size.test
+++ b/llvm/test/Object/macho-dsym-section-size.test
@@ -1,0 +1,47 @@
+## Show that for MH_DSYM files, MachOObjectFile::getSectionSize returns the
+## size from the section header even when the section's offset is past the
+## end of the file (as the DSYM may be smaller than the original object file).
+
+# RUN: yaml2obj %s -o %t.dsym
+# RUN: %python -c "import sys; f = open(sys.argv[1], 'r+b'); f.truncate(1024); f.close()" %t.dsym
+# RUN: llvm-objdump --section-headers %t.dsym | FileCheck %s
+
+# CHECK:      Sections:
+# CHECK-NEXT: Idx Name   Size     VMA              Type
+# CHECK-NEXT:   0 __text 00000100 0000000000000000 TEXT
+
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x01000007
+  cpusubtype:      0x00000003
+  filetype:        0x0000000A
+  ncmds:           1
+  sizeofcmds:      152
+  flags:           0x00000000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          0
+    vmsize:          0x100
+    fileoff:         0
+    filesize:        0
+    maxprot:         5
+    initprot:        5
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0
+        size:            0x100
+        offset:          0x2000
+        align:           0
+        reloff:          0x0
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x0
+        reserved2:       0x0
+        reserved3:       0x0


### PR DESCRIPTION
`MachOObjectFile::getSectionSize` currently bounds its return value based on the size of the file.  This breaks with separate-debuginfo `MH_DSYM` files, where the file size is not necessarily larger than the sections described within it.

This check was added in 2015 (https://github.com/llvm/llvm-project/commit/46e642f8c56022f4218699a7071996e7e0863ba2) to fix a crash in llvm-objdump with malformed files. Better parse-time checking was added later (https://github.com/llvm/llvm-project/commit/c614d283b7aecbc9bee0b7bdb7902d2796b04a8c), so the original failure should not reproduce.

This PR just removes the check, which makes it consistent with other
implementations of `getSectionSize`.  Note the unit test was written with AI.