### PR TITLE
[RISCV][XCV] Fix incorrect llvm.ctlz lowering to cv.fl1

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -454,6 +454,8 @@ RISCVTargetLowering::RISCVTargetLowering(const TargetMachine &TM,
         (Subtarget.hasStdExtZbb() || Subtarget.hasStdExtP()))
       setOperationAction({ISD::CTLZ, ISD::CTLZ_ZERO_POISON}, MVT::i32, Custom);
   } else {
+    if (Subtarget.hasVendorXCVbitmanip() && !Subtarget.is64Bit())
+      setOperationAction(ISD::CTLZ_ZERO_POISON, XLenVT, Legal);
     setOperationAction(ISD::CTLZ, XLenVT, Expand);
   }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -734,7 +734,10 @@ let Predicates = [HasVendorXCVbitmanip, IsRV32] in {
                                           (CV_LO5 cv_uimm10:$imm))>;
 
   def : PatGpr<cttz, CV_FF1, i32>;
-  def : PatGpr<ctlz, CV_FL1, i32>;
+
+  // ctlz(x) = 31 - fl1(x), for x != 0. Not intercepting the x == 0 case.
+  def : Pat<(i32 (ctlz_zero_poison GPR:$rs1)), (XORI (CV_FL1 GPR:$rs1), 31)>;
+
   def : PatGpr<int_riscv_cv_bitmanip_clb, CV_CLB>;
   def : PatGpr<ctpop, CV_CNT, i32>;
 

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -191,10 +191,7 @@ public:
     return HasStdExtZfhmin || HasStdExtZfbfmin;
   }
 
-  bool hasCLZLike() const {
-    return HasStdExtZbb || HasVendorXTHeadBb ||
-           (HasVendorXCVbitmanip && !IsRV64);
-  }
+  bool hasCLZLike() const { return HasStdExtZbb || HasVendorXTHeadBb; }
   bool hasCTZLike() const {
     return HasStdExtZbb || (HasVendorXCVbitmanip && !IsRV64);
   }

--- a/llvm/test/CodeGen/RISCV/xcvbitmanip.ll
+++ b/llvm/test/CodeGen/RISCV/xcvbitmanip.ll
@@ -116,7 +116,48 @@ define i32 @test.cv.fl1(i32 %a) {
 ; CHECK-LABEL: test.cv.fl1:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    cv.fl1 a0, a0
+; CHECK-NEXT:    xori a0, a0, 31
 ; CHECK-NEXT:    ret
+  %1 = call i32 @llvm.ctlz.i32(i32 %a, i1 1)
+  ret i32 %1
+}
+
+; Verifies that ctlz with defined-on-zero behavior is lowered
+; correctly: a zero-check guard branches around the cv.fl1 + xori 31
+; sequence and returns 32 directly when the input is zero. This
+; relies on ISD::CTLZ being Expand and ISD::CTLZ_ZERO_POISON being
+; Legal for XCVbitmanip; the LegalizeDAG framework synthesises the
+; branch-guarded form automatically.
+define i32 @test.ctlz.zero.defined(i32 %a) {
+; CHECK-O0-LABEL: test.ctlz.zero.defined:
+; CHECK-O0:       # %bb.0:
+; CHECK-O0-NEXT:    addi sp, sp, -16
+; CHECK-O0-NEXT:    .cfi_def_cfa_offset 16
+; CHECK-O0-NEXT:    cv.fl1 a1, a0
+; CHECK-O0-NEXT:    xori a1, a1, 31
+; CHECK-O0-NEXT:    li a2, 32
+; CHECK-O0-NEXT:    sw a2, 8(sp) # 4-byte Folded Spill
+; CHECK-O0-NEXT:    sw a1, 12(sp) # 4-byte Folded Spill
+; CHECK-O0-NEXT:    bnez a0, .LBB13_2
+; CHECK-O0-NEXT:  # %bb.1:
+; CHECK-O0-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; CHECK-O0-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; CHECK-O0-NEXT:  .LBB13_2:
+; CHECK-O0-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; CHECK-O0-NEXT:    addi sp, sp, 16
+; CHECK-O0-NEXT:    .cfi_def_cfa_offset 0
+; CHECK-O0-NEXT:    ret
+;
+; CHECK-O3-LABEL: test.ctlz.zero.defined:
+; CHECK-O3:       # %bb.0:
+; CHECK-O3-NEXT:    beqz a0, .LBB13_2
+; CHECK-O3-NEXT:  # %bb.1: # %cond.false
+; CHECK-O3-NEXT:    cv.fl1 a0, a0
+; CHECK-O3-NEXT:    xori a0, a0, 31
+; CHECK-O3-NEXT:    ret
+; CHECK-O3-NEXT:  .LBB13_2:
+; CHECK-O3-NEXT:    li a0, 32
+; CHECK-O3-NEXT:    ret
   %1 = call i32 @llvm.ctlz.i32(i32 %a, i1 0)
   ret i32 %1
 }


### PR DESCRIPTION
Fixes #197006.

The XCVbitmanip pattern `def : PatGpr<ctlz, CV_FL1, i32>;` is
semantically incorrect: `cv.fl1` returns a bit position while
`llvm.ctlz` returns a leading-zero count. They differ by up to 31 on
every non-zero input, miscompiling every use of `__builtin_clz`,
including compiler-rt's `__udivdi3`.

This PR:
- Replaces the pattern with one matching `llvm.ctlz` with
  `is_zero_poison=true`, lowered to `xori (cv.fl1 rs1), 31`.
- Adds explicit `setOperationAction` calls in `RISCVISelLowering.cpp`
  to route `ISD::CTLZ` to generic expansion and keep
  `ISD::CTLZ_ZERO_*` matched by the `.td` pattern.

The companion `def : PatGpr<cttz, CV_FF1, i32>;` is correct as-is
(both return 32 on zero, coincide on non-zero), and is left
untouched.

See the linked issue for the full analysis including a CV32E40P sim
trace showing miscompilation of `__udivdi3` in compiler-rt.