### PR TITLE
[ELF] Fix location counter used for output section address with MEMOR…

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -1193,7 +1193,9 @@ bool LinkerScript::assignOffsets(OutputSection *sec) {
     else
       dot = state->tbssAddr;
   } else {
-    if (state->memRegion)
+    // If there is an explicit address expression this takes precedence over
+    // the memory region address.
+    if (state->memRegion && !(hasSectionsCommand && sec->addrExpr))
       dot = state->memRegion->curPos;
     if (sec->addrExpr)
       setDot(sec->addrExpr, sec->location, false);

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -48,6 +48,12 @@ Breaking changes
   feature saw no adoption beyond a Chromium experiment that has since been
   retired.
 
+* An OutputSection that has an address expression, and is also assigned
+  to a MEMORY region, will now use the address expression in preference
+  to the next available location in the MEMORY region. This brings LLD
+  in line with GNU ld, but is a change in behavior from previous LLD
+  releases.
+  
 COFF Improvements
 -----------------
 

--- a/lld/test/ELF/linkerscript/end-overflow-check.test
+++ b/lld/test/ELF/linkerscript/end-overflow-check.test
@@ -35,7 +35,7 @@ MEMORY
 
 SECTIONS
 {
-    _abss ALIGN(REGION1__PRE_ALIGNMENT) :
+    _abss : ALIGN(REGION1__PRE_ALIGNMENT)
     {
         REGION1__BEGIN = .; REGION1__ALIGNED_BEGIN = .; REGION1_ALIGNED_BEGIN = .;
         *(.a.bss)
@@ -58,7 +58,7 @@ MEMORY
 
 SECTIONS
 {
-    _abss ALIGN(REGION1__PRE_ALIGNMENT) :
+    _abss : ALIGN(REGION1__PRE_ALIGNMENT) 
     {
         REGION1__BEGIN = .; REGION1__ALIGNED_BEGIN = .; REGION1_ALIGNED_BEGIN = .;
         *(.a.bss)

--- a/lld/test/ELF/linkerscript/memory-loc-counter-dot-addr.s
+++ b/lld/test/ELF/linkerscript/memory-loc-counter-dot-addr.s
@@ -1,0 +1,41 @@
+# REQUIRES: x86
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 asm.s -o t.o
+# RUN: ld.lld -T lds t.o -o t.out
+# RUN: llvm-readelf -S t.out | FileCheck %s
+
+## Test that when a section uses '.' as its address expression inside a MEMORY
+## region, the global location counter is used, not the memory region position.
+## GNU ld manual: explicit address takes precedence over memory region position.
+## s01 placed at FLASH origin 0x1000
+# CHECK: s01 PROGBITS 0000000000001000
+## s02 uses '.' as explicit address — global dot after ALIGN(4) = 0x1004
+# CHECK: s02 PROGBITS 0000000000001004
+## s03 has no explicit address — follows memRegion->curPos after s02
+## second ALIGN(4) does not affect s03 as it has no explicit address
+# CHECK: s03 PROGBITS 0000000000001006
+
+#--- asm.s
+.section s01, "a", @progbits
+.byte 1
+
+.section s02, "a", @progbits
+.short 1
+
+.section s03, "a", @progbits
+.short 1
+
+#--- lds
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x1000, LENGTH = 0x100
+}
+
+SECTIONS
+{
+  s01 : { *(s01) } > FLASH
+  . = ALIGN(4);
+  s02 . : { *(s02) } > FLASH
+  . = ALIGN(4);
+  s03 : { *(s03) } > FLASH
+}


### PR DESCRIPTION
When a section uses '.' as its address expression inside a MEMORY region (e.g. 's02 . : { ... } > FLASH'), lld was incorrectly evaluating '.' against the memory region's current position instead of the global location counter. Save the global dot before the memRegion override and restore it when an explicit addrExpr is present.

Fixes #112919

@maskray @smithp35 could you please review this patch?