### PR TITLE
[libc] Remove broken __builtin_aarch64_wsr fallback in set_thread_ptr

### DIFF
--- a/libc/startup/linux/aarch64/tls.cpp
+++ b/libc/startup/linux/aarch64/tls.cpp
@@ -86,8 +86,8 @@ bool set_thread_ptr(uintptr_t val) {
 // https://github.com/gcc-mirror/gcc/commit/fc42900d21abd5eacb7537c3c8ffc5278d510195
 #if __has_builtin(__builtin_arm_wsr64)
   __builtin_arm_wsr64("tpidr_el0", val);
-#elif __has_builtin(__builtin_aarch64_wsr)
-  __builtin_aarch64_wsr("tpidr_el0", val);
+#elif __has_builtin(__builtin_aarch64_wsr64)
+  __builtin_aarch64_wsr64("tpidr_el0", val);
 #elif defined(__GNUC__)
   asm volatile("msr tpidr_el0, %0" ::"r"(val));
 #else


### PR DESCRIPTION
The fallback used __builtin_aarch64_wsr (32-bit) instead of __builtin_aarch64_wsr64, truncating the 64-bit thread pointer value and causing non-deterministic runtime crashes.

Modern GCC correctly warns about it and -Werror=conversion catches it.


```
/var/tmp/portage/llvm-runtimes/libc-22.1.5/work/libc/startup/linux/aarch64/tls.cpp: In function ‘bool __llvm_libc_22_1_5_::set_thread_ptr(uintptr_t)’:
/var/tmp/portage/llvm-runtimes/libc-22.1.5/work/libc/startup/linux/aarch64/tls.cpp:90:38: error: conversion from ‘uintptr_t’ {aka ‘long unsigned int’} to ‘unsigned int’ may change value [-Werror=conversion]
   90 |   __builtin_aarch64_wsr("tpidr_el0", val);
      |                                      ^~~
cc1plus: all warnings being treated as errors
```