### PR TITLE
[CIR] Fix problems with stale insert locations

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -365,7 +365,7 @@ public:
       cgf.cgm.errorNYI(e->getBeginLoc(), "aggregate three-way comparison");
 
     mlir::Location loc = cgf.getLoc(e->getSourceRange());
-    CIRGenBuilderTy builder = cgf.getBuilder();
+    CIRGenBuilderTy &builder = cgf.getBuilder();
 
     if (e->getType()->isAnyComplexType())
       cgf.cgm.errorNYI(e->getBeginLoc(), "VisitBinCmp: complex type");
@@ -540,7 +540,7 @@ public:
   /// real initializer list.
   void VisitCXXStdInitializerListExpr(CXXStdInitializerListExpr *e) {
     ASTContext &ctx = cgf.getContext();
-    CIRGenBuilderTy builder = cgf.getBuilder();
+    CIRGenBuilderTy &builder = cgf.getBuilder();
     mlir::Location loc = cgf.getLoc(e->getExprLoc());
 
     LValue array = cgf.emitLValue(e->getSubExpr());

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -366,7 +366,7 @@ static void emitNullBaseClassInitialization(CIRGenFunction &cgf,
     assert(stores.size() == 1 && "Expected only one store");
     assert(stores[0].first == CharUnits::Zero() &&
            "Expected store to begin at offset zero");
-    CIRGenBuilderTy builder = cgf.getBuilder();
+    CIRGenBuilderTy &builder = cgf.getBuilder();
     mlir::Location loc = cgf.getLoc(base->getBeginLoc());
     builder.createStore(loc, builder.getConstant(loc, nullConstantForBase),
                         destPtr);

--- a/clang/test/CIR/CodeGen/initializer-list-size-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/initializer-list-size-cleanup.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+namespace std {
+template <typename T> class initializer_list {
+  const T *data;
+  __SIZE_TYPE__ len;
+
+public:
+  initializer_list();
+};
+} // namespace std
+
+struct Elem {
+  Elem(int);
+  ~Elem();
+};
+
+struct Container {
+  Container(std::initializer_list<Elem>);
+  ~Container();
+};
+
+void build_container() {
+  Container c = {1, 2, 3};
+}
+
+// CIR-LABEL: cir.func {{.*}}@_Z15build_containerv
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[LEN_CONST:.*]] = cir.const #cir.int<3> : !u64i
+// CIR:           %[[LEN_PTR:.*]] = cir.get_member {{.*}}[1] {name = "len"}
+// CIR:           cir.store {{.*}} %[[LEN_CONST]], %[[LEN_PTR]]

--- a/clang/test/CIR/CodeGen/three-way-compare-cleanup.cpp
+++ b/clang/test/CIR/CodeGen/three-way-compare-cleanup.cpp
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+namespace std {
+struct strong_ordering {
+  int v;
+  constexpr strong_ordering(int v) : v(v) {}
+  static const strong_ordering equal;
+  static const strong_ordering less;
+  static const strong_ordering greater;
+};
+inline constexpr strong_ordering strong_ordering::equal{0};
+inline constexpr strong_ordering strong_ordering::less{-1};
+inline constexpr strong_ordering strong_ordering::greater{1};
+} // namespace std
+
+struct Holder {
+  int v;
+  Holder(int x);
+  ~Holder();
+  operator int() const;
+};
+
+auto three_way_cmp_with_temp(int a) {
+  return Holder(a).operator int() <=> 0;
+}
+
+// CIR-LABEL: cir.func {{.*}}three_way_cmp_with_temp
+// CIR:         cir.call @_ZN6HolderC1Ei
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[CONV:.*]] = cir.call @_ZNK6HoldercviEv
+// CIR:           %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:           %[[LT:.*]] = cir.const #cir.int<-1> : !s32i
+// CIR:           %[[EQ:.*]] = cir.const #cir.int<0> : !s32i
+// CIR:           %[[GT:.*]] = cir.const #cir.int<1> : !s32i
+// CIR:           %[[CMP_LT:.*]] = cir.cmp lt %[[CONV]], %[[ZERO]]
+// CIR:           %[[SEL1:.*]] = cir.select if %[[CMP_LT]] then %[[LT]] else %[[GT]]
+// CIR:           %[[CMP_EQ:.*]] = cir.cmp eq %[[CONV]], %[[ZERO]]
+// CIR:           %[[RESULT:.*]] = cir.select if %[[CMP_EQ]] then %[[EQ]] else %[[SEL1]]
+// CIR:           %[[FIELD:.*]] = cir.get_member {{.*}}[0] {name = "v"}
+// CIR:           cir.store {{.*}} %[[RESULT]], %[[FIELD]]
+// CIR:           cir.yield
+// CIR:         } cleanup normal {
+// CIR:           cir.call @_ZN6HolderD1Ev
+// CIR:           cir.yield
+// CIR:         }
+// CIR:         cir.return


### PR DESCRIPTION
This change fixes three places where we were copying the builder rather than getting a reference to it, leading to potential problems with incorrect state, including insert locations. Two of these cases were causing observable problems, and I'm adding regression tests for those. The third doesn't seem to have caused any actual problems, but I'm changing it to avoid potential problems in the future.

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh