### PR TITLE
[lldb][windows] remove mandatory ordering of the lldb-python.h header

### DIFF
--- a/lldb/include/lldb/Host/windows/PosixApi.h
+++ b/lldb/include/lldb/Host/windows/PosixApi.h
@@ -21,6 +21,8 @@
 // time_t, timespec, etc.
 #include <ctime>
 
+#include <sys/types.h>
+
 #ifndef PATH_MAX
 #define PATH_MAX 32768
 #endif
@@ -56,13 +58,6 @@
 #define S_IRWXO 0
 #endif
 
-// pyconfig.h typedefs this.  We require python headers to be included before
-// any LLDB headers, but there's no way to prevent python's pid_t definition
-// from leaking, so this is the best option.
-#ifndef NO_PID_T
-#include <sys/types.h>
-#endif
-
 #ifdef _MSC_VER
 
 // PRIxxx format macros for printf()
@@ -73,12 +68,10 @@
 
 typedef unsigned short mode_t;
 
-// pyconfig.h typedefs this.  We require python headers to be included before
-// any LLDB headers, but there's no way to prevent python's pid_t definition
-// from leaking, so this is the best option.
-#ifndef NO_PID_T
-typedef uint32_t pid_t;
-#endif
+// Match the `typedef int pid_t;` in Python's pyconfig.h on Windows. Using an
+// identical underlying type lets this header coexist with Python headers in
+// any include order.
+typedef int pid_t;
 
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Breakpoint/Breakpoint.h"
 #include "lldb/Breakpoint/BreakpointResolverScripted.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/Thread.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Host/Config.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPlatformPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPlatformPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.cpp
@@ -6,12 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Target/Process.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-enumerations.h"
@@ -20,10 +18,6 @@
 #include "../ScriptInterpreterPythonImpl.h"
 #include "ScriptedThreadPythonInterface.h"
 #include "ScriptedProcessPythonInterface.h"
-
-// Included in this position to prevent redefinition of pid_t on Windows.
-#include "lldb/Target/Process.h"
-//clang-format off
 
 #include <optional>
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Host/Config.h"
 #include "lldb/Utility/Log.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedStopHookPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedStopHookPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Utility/Log.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "../lldb-python.h"
-//clang-format on
 
 #include "lldb/Host/Config.h"
 #include "lldb/Target/ExecutionContext.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
@@ -47,10 +47,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_PYTHON_PYTHONDATAOBJECTS_H
 #define LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_PYTHON_PYTHONDATAOBJECTS_H
 
-// clang-format off
-// LLDB Python header must be included first
 #include "lldb-python.h"
-//clang-format on
 
 #include "lldb/Host/File.h"
 #include "lldb/Utility/StructuredData.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h
@@ -12,10 +12,7 @@
 #include <optional>
 #include <string>
 
-// clang-format off
-// LLDB Python header must be included first
 #include "lldb-python.h"
-//clang-format on
 
 #include "Plugins/ScriptInterpreter/Python/PythonDataObjects.h"
 #include "lldb/lldb-forward.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -6,10 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-// LLDB Python header must be included first
 #include "lldb-python.h"
-//clang-format on
 
 #include "Interfaces/ScriptInterpreterPythonInterfaces.h"
 #include "PythonDataObjects.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -9,10 +9,7 @@
 #ifndef LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_PYTHON_SCRIPTINTERPRETERPYTHONIMPL_H
 #define LLDB_SOURCE_PLUGINS_SCRIPTINTERPRETER_PYTHON_SCRIPTINTERPRETERPYTHONIMPL_H
 
-// clang-format off
-// LLDB Python header must be included first
 #include "lldb-python.h"
-//clang-format on
 
 #include "PythonDataObjects.h"
 #include "ScriptInterpreterPython.h"

--- a/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/lldb-python.h
@@ -17,13 +17,6 @@ static llvm::Expected<bool> *g_fcxx_modules_workaround [[maybe_unused]];
 // END
 
 #include "llvm/Support/Compiler.h"
-#if defined(_WIN32)
-// If anyone #includes Host/PosixApi.h later, it will try to typedef pid_t.  We
-// need to ensure this doesn't happen.  At the same time, Python.h will also try
-// to redefine a bunch of stuff that PosixApi.h defines.  So define it all now
-// so that PosixApi.h doesn't redefine it.
-#define NO_PID_T
-#endif
 #if defined(__linux__)
 // features.h will define _POSIX_C_SOURCE if _GNU_SOURCE is defined.  This value
 // may be different from the value that Python defines it to be which results


### PR DESCRIPTION
`PosixApi.h` typedef'd `pid_t` as `uint32_t`, while Python's `pyconfig.h` on Windows  typedef's it as `int`. C++ forbids redeclaring a typedef with a different type, so the two headers cannot coexist. The `NO_PID_T` macro in `lldb-python.h` suppressed LLDB's typedef, but only if `lldb-python.h` got included before `PosixApi.h`.

`pid_t` on Windows was originally defined in d87fc157d2b7. At this time, there was no Python support for LLDB on Windows and `uint32_t` matches the `DWORD` type used by the Win32 API for process IDs.

This patch matches the Python type in `PosixApi.h`, removing the need for the include ordering.

This is a follow up to https://github.com/llvm/llvm-project/pull/197048.