### PR TITLE
[llvm] Add a tablegen !sort operator

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -2009,7 +2009,6 @@ and non-0 as true.
     The size of a DAG is the number of arguments; the operator does not count.
 
 ``!sort(``\ *var*\ ``,`` *list*\ ``,`` *key*\ ``)``
-
     This operator creates a new ``list`` containing the same elements as *list*
     but in sorted order. To determine the order, TableGen binds the variable
     *var* to each element and evaluates the *key* expression, which presumably

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -2008,6 +2008,20 @@ and non-0 as true.
     This operator produces the size of the string, list, or dag *a*.
     The size of a DAG is the number of arguments; the operator does not count.
 
+``!sort(``\ *var*\ ``,`` *list*\ ``,`` *key*\ ``)``
+
+    This operator creates a new ``list`` containing the same elements as *list*
+    but in sorted order. To determine the order, TableGen binds the variable
+    *var* to each element and evaluates the *key* expression, which presumably
+    refers to *var*. The key must produce a ``string`` or integer value
+    (``bit``, ``bits``, or ``int``); all keys must be of the same type. Elements
+    with equal keys preserve their original relative order, resulting in a
+    stable sort.
+
+    For example, to sort a list of records by their ``Name`` field::
+
+      list<Thing> sorted = !sort(t, Things, t.Name);
+
 ``!sra(``\ *a*\ ``,`` *count*\ ``)``
     This operator shifts *a* right arithmetically by *count* bits and produces the resulting
     value. The operation is performed on a 64-bit integer; the result

--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -2019,6 +2019,8 @@ and non-0 as true.
 
     For example, to sort a list of records by their ``Name`` field::
 
+    .. code-block:: text
+
       list<Thing> sorted = !sort(t, Things, t.Name);
 
 ``!sra(``\ *a*\ ``,`` *count*\ ``)``

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -968,6 +968,7 @@ public:
     FIND,
     SETDAGARG,
     SETDAGNAME,
+    SORT,
   };
 
 private:

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1809,11 +1809,13 @@ static const Init *SortHelper(const Init *LHS, const Init *MHS, const Init *RHS,
     return ListInit::get({}, cast<ListRecTy>(Type)->getElementType());
 
   // Determine key type from the first element; all keys must agree.
-  bool UseInt = dyn_cast_or_null<IntInit>(
-                    KeyedList[0].first->convertInitializerTo(IntRecTy::get(RK))) != nullptr;
+  bool UseInt =
+      dyn_cast_or_null<IntInit>(KeyedList[0].first->convertInitializerTo(
+          IntRecTy::get(RK))) != nullptr;
   for (auto &[Key, Item] : KeyedList) {
     if (UseInt) {
-      if (!dyn_cast_or_null<IntInit>(Key->convertInitializerTo(IntRecTy::get(RK))))
+      if (!dyn_cast_or_null<IntInit>(
+              Key->convertInitializerTo(IntRecTy::get(RK))))
         return nullptr;
     } else {
       if (!isa<StringInit>(Key))
@@ -1823,9 +1825,12 @@ static const Init *SortHelper(const Init *LHS, const Init *MHS, const Init *RHS,
 
   llvm::stable_sort(KeyedList, [&RK, UseInt](const KV &A, const KV &B) {
     if (UseInt)
-      return cast<IntInit>(A.first->convertInitializerTo(IntRecTy::get(RK)))->getValue() <
-             cast<IntInit>(B.first->convertInitializerTo(IntRecTy::get(RK)))->getValue();
-    return cast<StringInit>(A.first)->getValue() < cast<StringInit>(B.first)->getValue();
+      return cast<IntInit>(A.first->convertInitializerTo(IntRecTy::get(RK)))
+                 ->getValue() <
+             cast<IntInit>(B.first->convertInitializerTo(IntRecTy::get(RK)))
+                 ->getValue();
+    return cast<StringInit>(A.first)->getValue() <
+           cast<StringInit>(B.first)->getValue();
   });
 
   SmallVector<const Init *, 8> Result;
@@ -2077,7 +2082,10 @@ std::string TernOpInit::getAsString() const {
   case DAG: Result = "!dag"; break;
   case FILTER: Result = "!filter"; UnquotedLHS = true; break;
   case FOREACH: Result = "!foreach"; UnquotedLHS = true; break;
-  case SORT: Result = "!sort"; UnquotedLHS = true; break;
+  case SORT:
+    Result = "!sort";
+    UnquotedLHS = true;
+    break;
   case IF: Result = "!if"; break;
   case RANGE:
     Result = "!range";

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1788,6 +1788,52 @@ static const Init *FilterHelper(const Init *LHS, const Init *MHS,
   return nullptr;
 }
 
+static const Init *SortHelper(const Init *LHS, const Init *MHS, const Init *RHS,
+                              const RecTy *Type, const Record *CurRec) {
+  const auto *MHSl = dyn_cast<ListInit>(MHS);
+  if (!MHSl)
+    return nullptr;
+
+  RecordKeeper &RK = LHS->getRecordKeeper();
+  using KV = std::pair<const Init *, const Init *>;
+  SmallVector<KV, 8> KeyedList;
+
+  for (const Init *Item : MHSl->getElements()) {
+    const Init *Key = ItemApply(LHS, Item, RHS, CurRec);
+    if (!Key)
+      return nullptr;
+    KeyedList.emplace_back(Key, Item);
+  }
+
+  if (KeyedList.empty())
+    return ListInit::get({}, cast<ListRecTy>(Type)->getElementType());
+
+  // Determine key type from the first element; all keys must agree.
+  bool UseInt = dyn_cast_or_null<IntInit>(
+                    KeyedList[0].first->convertInitializerTo(IntRecTy::get(RK))) != nullptr;
+  for (auto &[Key, Item] : KeyedList) {
+    if (UseInt) {
+      if (!dyn_cast_or_null<IntInit>(Key->convertInitializerTo(IntRecTy::get(RK))))
+        return nullptr;
+    } else {
+      if (!isa<StringInit>(Key))
+        return nullptr;
+    }
+  }
+
+  llvm::stable_sort(KeyedList, [&RK, UseInt](const KV &A, const KV &B) {
+    if (UseInt)
+      return cast<IntInit>(A.first->convertInitializerTo(IntRecTy::get(RK)))->getValue() <
+             cast<IntInit>(B.first->convertInitializerTo(IntRecTy::get(RK)))->getValue();
+    return cast<StringInit>(A.first)->getValue() < cast<StringInit>(B.first)->getValue();
+  });
+
+  SmallVector<const Init *, 8> Result;
+  for (auto &[Key, Item] : KeyedList)
+    Result.push_back(Item);
+  return ListInit::get(Result, cast<ListRecTy>(Type)->getElementType());
+}
+
 const Init *TernOpInit::Fold(const Record *CurRec) const {
   RecordKeeper &RK = getRecordKeeper();
   switch (getOpcode()) {
@@ -1841,6 +1887,12 @@ const Init *TernOpInit::Fold(const Record *CurRec) const {
 
   case FILTER: {
     if (const Init *Result = FilterHelper(LHS, MHS, RHS, getType(), CurRec))
+      return Result;
+    break;
+  }
+
+  case SORT: {
+    if (const Init *Result = SortHelper(LHS, MHS, RHS, getType(), CurRec))
       return Result;
     break;
   }
@@ -2004,7 +2056,7 @@ const Init *TernOpInit::resolveReferences(Resolver &R) const {
   const Init *mhs = MHS->resolveReferences(R);
   const Init *rhs;
 
-  if (getOpcode() == FOREACH || getOpcode() == FILTER) {
+  if (getOpcode() == FOREACH || getOpcode() == FILTER || getOpcode() == SORT) {
     ShadowResolver SR(R);
     SR.addShadow(lhs);
     rhs = RHS->resolveReferences(SR);
@@ -2025,6 +2077,7 @@ std::string TernOpInit::getAsString() const {
   case DAG: Result = "!dag"; break;
   case FILTER: Result = "!filter"; UnquotedLHS = true; break;
   case FOREACH: Result = "!foreach"; UnquotedLHS = true; break;
+  case SORT: Result = "!sort"; UnquotedLHS = true; break;
   case IF: Result = "!if"; break;
   case RANGE:
     Result = "!range";

--- a/llvm/lib/TableGen/TGLexer.cpp
+++ b/llvm/lib/TableGen/TGLexer.cpp
@@ -676,6 +676,7 @@ tgtok::TokKind TGLexer::LexExclaim() {
           .Case("listsplat", tgtok::XListSplat)
           .Case("listremove", tgtok::XListRemove)
           .Case("range", tgtok::XRange)
+          .Case("sort", tgtok::XSort)
           .Case("strconcat", tgtok::XStrConcat)
           .Case("initialized", tgtok::XInitialized)
           .Case("interleave", tgtok::XInterleave)

--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -156,6 +156,7 @@ enum TokKind {
   XToLower,
   XToUpper,
   XRange,
+  XSort,
   XGetDagArg,
   XGetDagName,
   XSetDagArg,

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2708,28 +2708,29 @@ const Init *TGParser::ParseOperationListComprehension(Record *CurRec,
     return nullptr;
   }
 
-  const RecTy *OutType = InEltType;
-  if (Operation == tgtok::XForEach && !IsDAG) {
-    const auto *RHSt = dyn_cast<TypedInit>(RHS);
-    if (!RHSt) {
-      TokError("could not get type of !foreach result expression");
-      return nullptr;
-    }
-    OutType = RHSt->getType()->getListTy();
-  } else if (Operation == tgtok::XFilter || Operation == tgtok::XSort) {
-    OutType = InEltType->getListTy();
-  }
-
+  const RecTy *OutType;
   TernOpInit::TernaryOp Opc;
   switch (Operation) {
   case tgtok::XForEach:
     Opc = TernOpInit::FOREACH;
+    if (IsDAG) {
+      OutType = InEltType;
+    } else {
+      const auto *RHSt = dyn_cast<TypedInit>(RHS);
+      if (!RHSt) {
+        TokError("could not get type of !foreach result expression");
+        return nullptr;
+      }
+      OutType = RHSt->getType()->getListTy();
+    }
     break;
   case tgtok::XFilter:
     Opc = TernOpInit::FILTER;
+    OutType = InEltType->getListTy();
     break;
   case tgtok::XSort:
     Opc = TernOpInit::SORT;
+    OutType = InEltType->getListTy();
     break;
   default:
     llvm_unreachable("unexpected token");

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -2630,10 +2630,11 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
     InEltType = InListTy->getElementType();
     if (ItemType) {
       if (const auto *OutListTy = dyn_cast<ListRecTy>(ItemType)) {
-        ExprEltType = (Operation == tgtok::XForEach)
-                          ? OutListTy->getElementType()
-                          : (Operation == tgtok::XFilter ? IntRecTy::get(Records)
-                                                         : nullptr);
+        ExprEltType =
+            (Operation == tgtok::XForEach)
+                ? OutListTy->getElementType()
+                : (Operation == tgtok::XFilter ? IntRecTy::get(Records)
+                                               : nullptr);
       } else {
         Error(OpLoc, "expected value of type '" +
                          Twine(ItemType->getAsString()) +

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -1943,7 +1943,7 @@ const Init *TGParser::ParseOperation(Record *CurRec, const RecTy *ItemType) {
   case tgtok::XForEach:
   case tgtok::XFilter:
   case tgtok::XSort: {
-    return ParseOperationForEachFilter(CurRec, ItemType);
+    return ParseOperationListComprehension(CurRec, ItemType);
   }
 
   case tgtok::XRange: {
@@ -2577,8 +2577,8 @@ const Init *TGParser::ParseOperationFind(Record *CurRec,
 /// ForEach ::= !foreach(ID, list-or-dag, expr) => list<expr type>
 /// Filter  ::= !filter(ID, list, predicate) ==> list<list type>
 /// Sort    ::= !sort(ID, list, key-expr) ==> list<list type>
-const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
-                                                  const RecTy *ItemType) {
+const Init *TGParser::ParseOperationListComprehension(Record *CurRec,
+                                                      const RecTy *ItemType) {
   SMLoc OpLoc = Lex.getLoc();
   tgtok::TokKind Operation = Lex.getCode();
   Lex.Lex(); // eat the operation
@@ -2630,11 +2630,19 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
     InEltType = InListTy->getElementType();
     if (ItemType) {
       if (const auto *OutListTy = dyn_cast<ListRecTy>(ItemType)) {
-        ExprEltType =
-            (Operation == tgtok::XForEach)
-                ? OutListTy->getElementType()
-                : (Operation == tgtok::XFilter ? IntRecTy::get(Records)
-                                               : nullptr);
+        switch (Operation) {
+        case tgtok::XForEach:
+          ExprEltType = OutListTy->getElementType();
+          break;
+        case tgtok::XFilter:
+          ExprEltType = IntRecTy::get(Records);
+          break;
+        case tgtok::XSort:
+          ExprEltType = nullptr;
+          break;
+        default:
+          llvm_unreachable("unexpected token");
+        }
       } else {
         Error(OpLoc, "expected value of type '" +
                          Twine(ItemType->getAsString()) +
@@ -2643,10 +2651,17 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
       }
     }
   } else if (const auto *InDagTy = dyn_cast<DagRecTy>(MHSt->getType())) {
-    if (Operation == tgtok::XFilter || Operation == tgtok::XSort) {
-      TokError(Twine("!") + (Operation == tgtok::XFilter ? "filter" : "sort") +
-               " must have a list argument");
+    switch (Operation) {
+    case tgtok::XFilter:
+      TokError("!filter must have a list argument");
       return nullptr;
+    case tgtok::XSort:
+      TokError("!sort must have a list argument");
+      return nullptr;
+    case tgtok::XForEach:
+      break;
+    default:
+      llvm_unreachable("unexpected token");
     }
     InEltType = InDagTy;
     if (ItemType && !isa<DagRecTy>(ItemType)) {
@@ -2656,13 +2671,19 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
     }
     IsDAG = true;
   } else {
-    if (Operation == tgtok::XForEach)
+    switch (Operation) {
+    case tgtok::XForEach:
       TokError("!foreach must have a list or dag argument");
-    else if (Operation == tgtok::XFilter)
+      return nullptr;
+    case tgtok::XFilter:
       TokError("!filter must have a list argument");
-    else
+      return nullptr;
+    case tgtok::XSort:
       TokError("!sort must have a list argument");
-    return nullptr;
+      return nullptr;
+    default:
+      llvm_unreachable("unexpected token");
+    }
   }
 
   // We need to create a temporary record to provide a scope for the
@@ -2699,11 +2720,20 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
     OutType = InEltType->getListTy();
   }
 
-  TernOpInit::TernaryOp Opc = TernOpInit::FOREACH;
-  if (Operation == tgtok::XFilter)
+  TernOpInit::TernaryOp Opc;
+  switch (Operation) {
+  case tgtok::XForEach:
+    Opc = TernOpInit::FOREACH;
+    break;
+  case tgtok::XFilter:
     Opc = TernOpInit::FILTER;
-  else if (Operation == tgtok::XSort)
+    break;
+  case tgtok::XSort:
     Opc = TernOpInit::SORT;
+    break;
+  default:
+    llvm_unreachable("unexpected token");
+  }
   return (TernOpInit::get(Opc, LHS, MHS, RHS, OutType))->Fold(CurRec);
 }
 

--- a/llvm/lib/TableGen/TGParser.cpp
+++ b/llvm/lib/TableGen/TGParser.cpp
@@ -1941,7 +1941,8 @@ const Init *TGParser::ParseOperation(Record *CurRec, const RecTy *ItemType) {
   }
 
   case tgtok::XForEach:
-  case tgtok::XFilter: {
+  case tgtok::XFilter:
+  case tgtok::XSort: {
     return ParseOperationForEachFilter(CurRec, ItemType);
   }
 
@@ -2571,10 +2572,11 @@ const Init *TGParser::ParseOperationFind(Record *CurRec,
   return (TernOpInit::get(Code, LHS, MHS, RHS, Type))->Fold(CurRec);
 }
 
-/// Parse the !foreach and !filter operations. Return null on error.
+/// Parse the !foreach, !filter, and !sort operations. Return null on error.
 ///
 /// ForEach ::= !foreach(ID, list-or-dag, expr) => list<expr type>
-/// Filter  ::= !foreach(ID, list, predicate) ==> list<list type>
+/// Filter  ::= !filter(ID, list, predicate) ==> list<list type>
+/// Sort    ::= !sort(ID, list, key-expr) ==> list<list type>
 const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
                                                   const RecTy *ItemType) {
   SMLoc OpLoc = Lex.getLoc();
@@ -2630,7 +2632,8 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
       if (const auto *OutListTy = dyn_cast<ListRecTy>(ItemType)) {
         ExprEltType = (Operation == tgtok::XForEach)
                           ? OutListTy->getElementType()
-                          : IntRecTy::get(Records);
+                          : (Operation == tgtok::XFilter ? IntRecTy::get(Records)
+                                                         : nullptr);
       } else {
         Error(OpLoc, "expected value of type '" +
                          Twine(ItemType->getAsString()) +
@@ -2639,8 +2642,9 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
       }
     }
   } else if (const auto *InDagTy = dyn_cast<DagRecTy>(MHSt->getType())) {
-    if (Operation == tgtok::XFilter) {
-      TokError("!filter must have a list argument");
+    if (Operation == tgtok::XFilter || Operation == tgtok::XSort) {
+      TokError(Twine("!") + (Operation == tgtok::XFilter ? "filter" : "sort") +
+               " must have a list argument");
       return nullptr;
     }
     InEltType = InDagTy;
@@ -2653,8 +2657,10 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
   } else {
     if (Operation == tgtok::XForEach)
       TokError("!foreach must have a list or dag argument");
-    else
+    else if (Operation == tgtok::XFilter)
       TokError("!filter must have a list argument");
+    else
+      TokError("!sort must have a list argument");
     return nullptr;
   }
 
@@ -2688,14 +2694,16 @@ const Init *TGParser::ParseOperationForEachFilter(Record *CurRec,
       return nullptr;
     }
     OutType = RHSt->getType()->getListTy();
-  } else if (Operation == tgtok::XFilter) {
+  } else if (Operation == tgtok::XFilter || Operation == tgtok::XSort) {
     OutType = InEltType->getListTy();
   }
 
-  return (TernOpInit::get((Operation == tgtok::XForEach) ? TernOpInit::FOREACH
-                                                         : TernOpInit::FILTER,
-                          LHS, MHS, RHS, OutType))
-      ->Fold(CurRec);
+  TernOpInit::TernaryOp Opc = TernOpInit::FOREACH;
+  if (Operation == tgtok::XFilter)
+    Opc = TernOpInit::FILTER;
+  else if (Operation == tgtok::XSort)
+    Opc = TernOpInit::SORT;
+  return (TernOpInit::get(Opc, LHS, MHS, RHS, OutType))->Fold(CurRec);
 }
 
 const Init *TGParser::ParseOperationCond(Record *CurRec,

--- a/llvm/lib/TableGen/TGParser.h
+++ b/llvm/lib/TableGen/TGParser.h
@@ -326,8 +326,8 @@ private: // Parser methods.
   const Init *ParseOperation(Record *CurRec, const RecTy *ItemType);
   const Init *ParseOperationSubstr(Record *CurRec, const RecTy *ItemType);
   const Init *ParseOperationFind(Record *CurRec, const RecTy *ItemType);
-  const Init *ParseOperationForEachFilter(Record *CurRec,
-                                          const RecTy *ItemType);
+  const Init *ParseOperationListComprehension(Record *CurRec,
+                                              const RecTy *ItemType);
   const Init *ParseOperationCond(Record *CurRec, const RecTy *ItemType);
   const RecTy *ParseOperatorType();
   const Init *ParseObjectName(MultiClass *CurMultiClass);

--- a/llvm/test/TableGen/sort.td
+++ b/llvm/test/TableGen/sort.td
@@ -9,10 +9,11 @@ def idempotent {
   list<string> already = !sort(item, ["a", "b", "c"], item);
 }
 
-// Sort records by a string field or an int field.
+// Sort records by a string field or an int field. The sort is stable, so order
+// is preserved on elements with equal key.
 // CHECK-LABEL: def key_expr
-// CHECK:   by_name  = [thing_a20, thing_a10, thing_b20, thing_c30];
-// CHECK:   by_value = [thing_a10, thing_a20, thing_b20, thing_c30];
+// CHECK:   by_name  = [thing_a20, thing_a10, thing_b20, thing_c30, thing_d10];
+// CHECK:   by_value = [thing_a10, thing_d10, thing_a20, thing_b20, thing_c30];
 class Thing<string N, int V> {
   string Name = N;
   int Value = V;
@@ -22,7 +23,7 @@ def thing_a20 : Thing<"alpha",   20>;
 def thing_b20 : Thing<"beta",    20>;
 def thing_c30 : Thing<"charlie", 30>;
 def thing_d10 : Thing<"delta",   10>;
-defvar Things = [thing_c30, thing_a20, thing_a10, thing_b20];
+defvar Things = [thing_c30, thing_a20, thing_a10, thing_b20, thing_d10];
 def key_expr {
   list<Thing> by_name  = !sort(t, Things, t.Name);
   list<Thing> by_value = !sort(t, Things, t.Value);

--- a/llvm/test/TableGen/sort.td
+++ b/llvm/test/TableGen/sort.td
@@ -2,11 +2,6 @@
 // RUN: not llvm-tblgen -DERROR_NONLIST %s 2>&1 | FileCheck --check-prefix=ERROR_NONLIST %s
 // RUN: not llvm-tblgen -DERROR_KEYTYPE %s 2>&1 | FileCheck --check-prefix=ERROR_KEYTYPE %s
 
-defvar EmptyStrings = []<string>;
-defvar EmptyInts = []<int>;
-defvar Creatures = ["cephalopod", "axolotl", "dragonfly", "barracuda"];
-defvar Nums = [5, 2, 8, 1, 3];
-
 // Sort an already-sorted list — should be a no-op.
 // CHECK-LABEL: def idempotent
 // CHECK:   already = ["a", "b", "c"];
@@ -45,6 +40,10 @@ def single {
 // CHECK:   sorted_ints = [1, 2, 3, 5, 8];
 // CHECK:   sorted_empty_strings = [];
 // CHECK:   sorted_empty_ints = [];
+defvar EmptyStrings = []<string>;
+defvar Creatures = ["cephalopod", "axolotl", "dragonfly", "barracuda"];
+defvar EmptyInts = []<int>;
+defvar Nums = [5, 2, 8, 1, 3];
 def sorted {
   list<string> sorted_strings = !sort(item, Creatures, item);
   list<int> sorted_ints = !sort(n, Nums, n);
@@ -54,17 +53,17 @@ def sorted {
 
 #ifdef ERROR_NONLIST
 // Dag is not a valid second argument.
-// ERROR_NONLIST: !sort must have a list argument
 def myop;
 defvar mydag = (myop);
 def err_nonlist {
+  // ERROR_NONLIST: sort.td:[[@LINE+1]]:38: error: !sort must have a list argument
   list<string> bad = !sort(x, mydag, !cast<string>(x));
 }
 #endif
 
 #ifdef ERROR_KEYTYPE
 // Key that cannot be resolved to int or string leaves the op unfolded.
-// ERROR_KEYTYPE: could not be fully resolved
+// ERROR_KEYTYPE: sort.td:[[@LINE+1]]:5: error: Initializer of 'bad' in 'err_keytype' could not be fully resolved
 def err_keytype {
   list<Thing> bad = !sort(t, Things, t);
 }

--- a/llvm/test/TableGen/sort.td
+++ b/llvm/test/TableGen/sort.td
@@ -7,38 +7,27 @@ defvar EmptyInts = []<int>;
 defvar Creatures = ["cephalopod", "axolotl", "dragonfly", "barracuda"];
 defvar Nums = [5, 2, 8, 1, 3];
 
-// Stable sort: equal keys preserve original relative order.
-// CHECK-LABEL: def duplicates
-// CHECK:   stable = ["a", "a", "b", "b", "c"];
-
-defvar DuplicateWords = ["b", "a", "b", "c", "a"];
-def duplicates {
-  list<string> stable = !sort(item, DuplicateWords, item);
-}
-
 // Sort an already-sorted list — should be a no-op.
 // CHECK-LABEL: def idempotent
 // CHECK:   already = ["a", "b", "c"];
-
 def idempotent {
   list<string> already = !sort(item, ["a", "b", "c"], item);
 }
 
 // Sort records by a string field or an int field.
+// CHECK-LABEL: def key_expr
+// CHECK:   by_name  = [thing_a20, thing_a10, thing_b20, thing_c30];
+// CHECK:   by_value = [thing_a10, thing_a20, thing_b20, thing_c30];
 class Thing<string N, int V> {
   string Name = N;
   int Value = V;
 }
-def thing_c : Thing<"charlie", 30>;
-def thing_a : Thing<"alpha",   10>;
-def thing_b : Thing<"beta",    20>;
-
-defvar Things = [thing_c, thing_a, thing_b];
-
-// CHECK-LABEL: def key_expr
-// CHECK:   by_name  = [thing_a, thing_b, thing_c];
-// CHECK:   by_value = [thing_a, thing_b, thing_c];
-
+def thing_a10 : Thing<"alpha",   10>;
+def thing_a20 : Thing<"alpha",   20>;
+def thing_b20 : Thing<"beta",    20>;
+def thing_c30 : Thing<"charlie", 30>;
+def thing_d10 : Thing<"delta",   10>;
+defvar Things = [thing_c30, thing_a20, thing_a10, thing_b20];
 def key_expr {
   list<Thing> by_name  = !sort(t, Things, t.Name);
   list<Thing> by_value = !sort(t, Things, t.Value);
@@ -47,7 +36,6 @@ def key_expr {
 // Sort a single-element list.
 // CHECK-LABEL: def single
 // CHECK:   one = ["only"];
-
 def single {
   list<string> one = !sort(item, ["only"], item);
 }
@@ -57,7 +45,6 @@ def single {
 // CHECK:   sorted_ints = [1, 2, 3, 5, 8];
 // CHECK:   sorted_empty_strings = [];
 // CHECK:   sorted_empty_ints = [];
-
 def sorted {
   list<string> sorted_strings = !sort(item, Creatures, item);
   list<int> sorted_ints = !sort(n, Nums, n);

--- a/llvm/test/TableGen/sort.td
+++ b/llvm/test/TableGen/sort.td
@@ -1,32 +1,27 @@
 // RUN: llvm-tblgen %s | FileCheck %s
-// RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
-// RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
+// RUN: not llvm-tblgen -DERROR_NONLIST %s 2>&1 | FileCheck --check-prefix=ERROR_NONLIST %s
+// RUN: not llvm-tblgen -DERROR_KEYTYPE %s 2>&1 | FileCheck --check-prefix=ERROR_KEYTYPE %s
 
 defvar EmptyStrings = []<string>;
 defvar EmptyInts = []<int>;
 defvar Creatures = ["cephalopod", "axolotl", "dragonfly", "barracuda"];
 defvar Nums = [5, 2, 8, 1, 3];
 
-// CHECK: def rec1
-// CHECK:   sorted_strings = ["axolotl", "barracuda", "cephalopod", "dragonfly"];
-// CHECK:   sorted_ints = [1, 2, 3, 5, 8];
-// CHECK:   sorted_empty_strings = [];
-// CHECK:   sorted_empty_ints = [];
-
-def rec1 {
-  list<string> sorted_strings = !sort(item, Creatures, item);
-  list<int> sorted_ints = !sort(n, Nums, n);
-  list<string> sorted_empty_strings = !sort(item, EmptyStrings, item);
-  list<int> sorted_empty_ints = !sort(n, EmptyInts, n);
-}
-
 // Stable sort: equal keys preserve original relative order.
-// CHECK: def rec2
+// CHECK-LABEL: def duplicates
 // CHECK:   stable = ["a", "a", "b", "b", "c"];
 
 defvar DuplicateWords = ["b", "a", "b", "c", "a"];
-def rec2 {
+def duplicates {
   list<string> stable = !sort(item, DuplicateWords, item);
+}
+
+// Sort an already-sorted list — should be a no-op.
+// CHECK-LABEL: def idempotent
+// CHECK:   already = ["a", "b", "c"];
+
+def idempotent {
+  list<string> already = !sort(item, ["a", "b", "c"], item);
 }
 
 // Sort records by a string field or an int field.
@@ -40,45 +35,50 @@ def thing_b : Thing<"beta",    20>;
 
 defvar Things = [thing_c, thing_a, thing_b];
 
-// CHECK: def rec3
+// CHECK-LABEL: def key_expr
 // CHECK:   by_name  = [thing_a, thing_b, thing_c];
 // CHECK:   by_value = [thing_a, thing_b, thing_c];
 
-def rec3 {
+def key_expr {
   list<Thing> by_name  = !sort(t, Things, t.Name);
   list<Thing> by_value = !sort(t, Things, t.Value);
 }
 
-// Sort an already-sorted list — should be a no-op.
-// CHECK: def rec4
-// CHECK:   already = ["a", "b", "c"];
-
-def rec4 {
-  list<string> already = !sort(item, ["a", "b", "c"], item);
-}
-
 // Sort a single-element list.
-// CHECK: def rec5
+// CHECK-LABEL: def single
 // CHECK:   one = ["only"];
 
-def rec5 {
+def single {
   list<string> one = !sort(item, ["only"], item);
 }
 
-#ifdef ERROR1
+// CHECK-LABEL: def sorted
+// CHECK:   sorted_strings = ["axolotl", "barracuda", "cephalopod", "dragonfly"];
+// CHECK:   sorted_ints = [1, 2, 3, 5, 8];
+// CHECK:   sorted_empty_strings = [];
+// CHECK:   sorted_empty_ints = [];
+
+def sorted {
+  list<string> sorted_strings = !sort(item, Creatures, item);
+  list<int> sorted_ints = !sort(n, Nums, n);
+  list<string> sorted_empty_strings = !sort(item, EmptyStrings, item);
+  list<int> sorted_empty_ints = !sort(n, EmptyInts, n);
+}
+
+#ifdef ERROR_NONLIST
 // Dag is not a valid second argument.
-// ERROR1: !sort must have a list argument
+// ERROR_NONLIST: !sort must have a list argument
 def myop;
 defvar mydag = (myop);
-def err1 {
+def err_nonlist {
   list<string> bad = !sort(x, mydag, !cast<string>(x));
 }
 #endif
 
-#ifdef ERROR2
+#ifdef ERROR_KEYTYPE
 // Key that cannot be resolved to int or string leaves the op unfolded.
-// ERROR2: could not be fully resolved
-def err2 {
+// ERROR_KEYTYPE: could not be fully resolved
+def err_keytype {
   list<Thing> bad = !sort(t, Things, t);
 }
 #endif

--- a/llvm/test/TableGen/sort.td
+++ b/llvm/test/TableGen/sort.td
@@ -1,0 +1,84 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+// RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
+// RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
+
+defvar EmptyStrings = []<string>;
+defvar EmptyInts = []<int>;
+defvar Creatures = ["cephalopod", "axolotl", "dragonfly", "barracuda"];
+defvar Nums = [5, 2, 8, 1, 3];
+
+// CHECK: def rec1
+// CHECK:   sorted_strings = ["axolotl", "barracuda", "cephalopod", "dragonfly"];
+// CHECK:   sorted_ints = [1, 2, 3, 5, 8];
+// CHECK:   sorted_empty_strings = [];
+// CHECK:   sorted_empty_ints = [];
+
+def rec1 {
+  list<string> sorted_strings = !sort(item, Creatures, item);
+  list<int> sorted_ints = !sort(n, Nums, n);
+  list<string> sorted_empty_strings = !sort(item, EmptyStrings, item);
+  list<int> sorted_empty_ints = !sort(n, EmptyInts, n);
+}
+
+// Stable sort: equal keys preserve original relative order.
+// CHECK: def rec2
+// CHECK:   stable = ["a", "a", "b", "b", "c"];
+
+defvar DuplicateWords = ["b", "a", "b", "c", "a"];
+def rec2 {
+  list<string> stable = !sort(item, DuplicateWords, item);
+}
+
+// Sort records by a string field or an int field.
+class Thing<string N, int V> {
+  string Name = N;
+  int Value = V;
+}
+def thing_c : Thing<"charlie", 30>;
+def thing_a : Thing<"alpha",   10>;
+def thing_b : Thing<"beta",    20>;
+
+defvar Things = [thing_c, thing_a, thing_b];
+
+// CHECK: def rec3
+// CHECK:   by_name  = [thing_a, thing_b, thing_c];
+// CHECK:   by_value = [thing_a, thing_b, thing_c];
+
+def rec3 {
+  list<Thing> by_name  = !sort(t, Things, t.Name);
+  list<Thing> by_value = !sort(t, Things, t.Value);
+}
+
+// Sort an already-sorted list — should be a no-op.
+// CHECK: def rec4
+// CHECK:   already = ["a", "b", "c"];
+
+def rec4 {
+  list<string> already = !sort(item, ["a", "b", "c"], item);
+}
+
+// Sort a single-element list.
+// CHECK: def rec5
+// CHECK:   one = ["only"];
+
+def rec5 {
+  list<string> one = !sort(item, ["only"], item);
+}
+
+#ifdef ERROR1
+// Dag is not a valid second argument.
+// ERROR1: !sort must have a list argument
+def myop;
+defvar mydag = (myop);
+def err1 {
+  list<string> bad = !sort(x, mydag, !cast<string>(x));
+}
+#endif
+
+#ifdef ERROR2
+// Key that cannot be resolved to int or string leaves the op unfolded.
+// ERROR2: could not be fully resolved
+def err2 {
+  list<Thing> bad = !sort(t, Things, t);
+}
+#endif


### PR DESCRIPTION
This operator creates a new ``list`` containing the same elements as *list*
but in sorted order. To determine the order, TableGen binds the variable
*var* to each element and evaluates the *key* expression, which presumably
refers to *var*. The key must produce a ``string`` or integer value
(``bit``, ``bits``, or ``int``); all keys must be of the same type. Elements
with equal keys preserve their original relative order, resulting in a stable
sort.

For example, to sort a list of records by their ``Name`` field::

`  list<Thing> sorted = !sort(t, Things, t.Name);`
