### PR TITLE
[clang-tidy] modernize-use-nullptr: Add new libstdc++ compare type

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
@@ -490,13 +490,16 @@ private:
   bool PruneSubtree = false;
 };
 
+static constexpr char DefaultIgnoredTypes[] = "_CmpUnspecifiedParam;"
+                                              "^std::__cmp_cat::__unspec;";
+
 } // namespace
 
 UseNullptrCheck::UseNullptrCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       NullMacrosStr(Options.get("NullMacros", "NULL")),
-      IgnoredTypes(utils::options::parseStringList(Options.get(
-          "IgnoredTypes", "_CmpUnspecifiedParam;^std::__cmp_cat::__unspec"))) {
+      IgnoredTypes(utils::options::parseStringList(
+          Options.get("IgnoredTypes", DefaultIgnoredTypes))) {
   NullMacrosStr.split(NullMacros, ",");
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
@@ -490,8 +490,10 @@ private:
   bool PruneSubtree = false;
 };
 
-static constexpr char DefaultIgnoredTypes[] = "_CmpUnspecifiedParam;"
-                                              "^std::__cmp_cat::__unspec;";
+static constexpr char DefaultIgnoredTypes[] =
+    "_CmpUnspecifiedParam;"
+    "^std::__cmp_cat::__unspec;"
+    "^std::__cmp_cat::__literal_zero;";
 
 } // namespace
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-nullptr.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-nullptr.rst
@@ -43,7 +43,7 @@ Options
 
   Semicolon-separated list of regular expressions to match pointer types for
   which implicit casts will be ignored. Default value:
-  `std::_CmpUnspecifiedParam::;^std::__cmp_cat::__unspec`.
+  `std::_CmpUnspecifiedParam::;^std::__cmp_cat::__unspec;^std::__cmp_cat::__literal_zero`.
 
 .. option:: NullMacros
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-cxx20.cpp
@@ -1,5 +1,6 @@
 // RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -D UNSPECIFIED_TYPE=_CmpUnspecifiedParam
 // RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -D UNSPECIFIED_TYPE=__cmp_cat::__unspec
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -D UNSPECIFIED_TYPE=__cmp_cat::__literal_zero
 
 namespace std {
 class strong_ordering;
@@ -13,6 +14,9 @@ struct _CmpUnspecifiedParam {
 namespace __cmp_cat {
   struct __unspec {
     constexpr __unspec(__unspec*) noexcept { }
+  };
+  struct __literal_zero {
+    constexpr __literal_zero(__literal_zero*) noexcept { }
   };
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-cxx20.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr-cxx20.cpp
@@ -1,28 +1,20 @@
-// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -DGCC
-// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -DCLANG
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -D UNSPECIFIED_TYPE=_CmpUnspecifiedParam
+// RUN: %check_clang_tidy -std=c++20-or-later %s modernize-use-nullptr %t -- -- -D UNSPECIFIED_TYPE=__cmp_cat::__unspec
 
 namespace std {
 class strong_ordering;
 
 // Mock how STD defined unspecified parameters for the operators below.
-#ifdef CLANG
 struct _CmpUnspecifiedParam {
   consteval
   _CmpUnspecifiedParam(int _CmpUnspecifiedParam::*) noexcept {}
 };
 
-#define UNSPECIFIED_TYPE _CmpUnspecifiedParam
-#endif
-
-#ifdef GCC
 namespace __cmp_cat {
   struct __unspec {
     constexpr __unspec(__unspec*) noexcept { }
   };
 }
-
-#define UNSPECIFIED_TYPE __cmp_cat::__unspec
-#endif
 
 struct strong_ordering {
   signed char value;


### PR DESCRIPTION
For gcc 16, the libstdc++ type `__unspec` has been renamed to `__literal_zero`, so update the default ignore list to take that into account.

Link: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=d9a4c7158a70896c5d4281f42310e88c987acb3e