### PR TITLE
[libc] Temporarily disable iscanonical, isnan, issignaling in shared/math.h

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -281,16 +281,19 @@
 #include "math/ilogbf128.h"
 #include "math/ilogbf16.h"
 #include "math/ilogbl.h"
-#include "math/iscanonical.h"
+// TODO: iscanonical is a macro in <math.h>
+// #include "math/iscanonical.h"
 #include "math/iscanonicalbf16.h"
 #include "math/iscanonicalf.h"
 #include "math/iscanonicalf128.h"
 #include "math/iscanonicalf16.h"
 #include "math/iscanonicall.h"
-#include "math/isnan.h"
+// TODO: isnan is a macro in <math.h>
+// #include "math/isnan.h"
 #include "math/isnanf.h"
 #include "math/isnanl.h"
-#include "math/issignaling.h"
+// TODO: issignaling is a macro in <math.h>
+// #include "math/issignaling.h"
 #include "math/issignalingbf16.h"
 #include "math/issignalingf.h"
 #include "math/issignalingf128.h"

--- a/libc/test/shared/shared_math_constexpr_test.cpp
+++ b/libc/test/shared/shared_math_constexpr_test.cpp
@@ -82,8 +82,10 @@ static_assert(0L == LIBC_NAMESPACE::shared::lround(0.0));
 static_assert(0.0 == LIBC_NAMESPACE::shared::nearbyint(0.0));
 static_assert(0.0 == LIBC_NAMESPACE::shared::nextafter(0.0, 0.0));
 static_assert(0.0 == LIBC_NAMESPACE::shared::rint(0.0));
-static_assert(1 == LIBC_NAMESPACE::shared::iscanonical(0.0));
-static_assert(0.0 == LIBC_NAMESPACE::shared::issignaling(0.0));
+// TODO: iscanonical clashes with a macro defined in <math.h>
+// static_assert(1 == LIBC_NAMESPACE::shared::iscanonical(0.0));
+// TODO: issignaling clashes with a macro defined in <math.h>
+// static_assert(0.0 == LIBC_NAMESPACE::shared::issignaling(0.0));
 static_assert(1 == [] {
   const char arg{};
   return LIBC_NAMESPACE::fputil::FPBits<double>(
@@ -93,7 +95,8 @@ static_assert(1 == [] {
 static_assert(0.0 == LIBC_NAMESPACE::shared::round(0.0));
 static_assert(0.0 == LIBC_NAMESPACE::shared::roundeven(0.0));
 static_assert(0.0 == LIBC_NAMESPACE::shared::trunc(0.0));
-static_assert(0 == LIBC_NAMESPACE::shared::isnan(0.0));
+// TODO: isnan clashes with a macro defined in <math.h>
+// static_assert(0 == LIBC_NAMESPACE::shared::isnan(0.0));
 
 //===----------------------------------------------------------------------===//
 //                       Float Tests

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -442,13 +442,16 @@ TEST(LlvmLibcSharedMathTest, AllDouble) {
   EXPECT_EQ(0LL, LIBC_NAMESPACE::shared::llround(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::nearbyint(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::rint(0.0));
-  EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonical(0.0L));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignaling(0.0));
+  // TODO: iscanonical clashes with a macro defined in <math.h>
+  // EXPECT_EQ(1, LIBC_NAMESPACE::shared::iscanonical(0.0));
+  // TODO: issignaling clashes with a macro defined in <math.h>
+  // EXPECT_EQ(0, LIBC_NAMESPACE::shared::issignaling(0.0));
   EXPECT_TRUE(FPBits(LIBC_NAMESPACE::shared::nan("")).is_nan());
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::round(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::roundeven(0.0));
   EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::shared::trunc(0.0));
-  EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnan(0.0));
+  // TODO: isnan clashes with a macro defined in <math.h>
+  // EXPECT_EQ(0, LIBC_NAMESPACE::shared::isnan(0.0));
 }
 
 // TODO: Enable the tests when double-double type is supported.


### PR DESCRIPTION
These clashes with same-name macros defined in <math.h>.