### PR TITLE
[NFC][DebugInfo] Add Annotations parameter to DIBuilder::createStructType

### DIFF
--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -574,12 +574,15 @@ namespace llvm {
     ///                     for more info.
     /// \param TemplateParms Template type parameters.
     /// \param UniqueIdentifier A unique identifier for the class.
+    /// \param Annotations  Attribute annotations, emitted as
+    /// DW_TAG_LLVM_annotation entries.
     LLVM_ABI DICompositeType *createClassType(
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
         DINode::DIFlags Flags, DIType *DerivedFrom, DINodeArray Elements,
         unsigned RunTimeLang = 0, DIType *VTableHolder = nullptr,
-        MDNode *TemplateParms = nullptr, StringRef UniqueIdentifier = "");
+        MDNode *TemplateParms = nullptr, StringRef UniqueIdentifier = "",
+        DINodeArray Annotations = nullptr);
 
     /// Create debugging information entry for a struct.
     /// \param Scope        Scope in which this struct is defined.
@@ -623,12 +626,15 @@ namespace llvm {
     /// \param NumExtraInhabitants The number of extra inhabitants of the type.
     /// An extra inhabitant is a bit pattern that does not represent a valid
     /// value for instances of a given type. This is used by the Swift language.
+    /// \param Annotations  Attribute annotations, emitted as
+    /// DW_TAG_LLVM_annotation entries.
     LLVM_ABI DICompositeType *createStructType(
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
         DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang = 0,
         DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "",
-        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0);
+        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0,
+        DINodeArray Annotations = nullptr);
 
     /// Create debugging information entry for an union.
     /// \param Scope        Scope in which this union is defined.
@@ -641,12 +647,13 @@ namespace llvm {
     /// \param Elements     Union elements.
     /// \param RunTimeLang  Optional parameter, Objective-C runtime version.
     /// \param UniqueIdentifier A unique identifier for the union.
-    LLVM_ABI DICompositeType *
-    createUnionType(DIScope *Scope, StringRef Name, DIFile *File,
-                    unsigned LineNumber, uint64_t SizeInBits,
-                    uint32_t AlignInBits, DINode::DIFlags Flags,
-                    DINodeArray Elements, unsigned RunTimeLang = 0,
-                    StringRef UniqueIdentifier = "");
+    /// \param Annotations  Attribute annotations, emitted as
+    /// DW_TAG_LLVM_annotation entries.
+    LLVM_ABI DICompositeType *createUnionType(
+        DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
+        uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
+        DINodeArray Elements, unsigned RunTimeLang = 0,
+        StringRef UniqueIdentifier = "", DINodeArray Annotations = nullptr);
 
     /// Create debugging information entry for a variant part.  A
     /// variant part normally has a discriminator (though this is not

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -597,12 +597,15 @@ namespace llvm {
     /// \param NumExtraInhabitants The number of extra inhabitants of the type.
     /// An extra inhabitant is a bit pattern that does not represent a valid
     /// value for instances of a given type. This is used by the Swift language.
+    /// \param Annotations  Attribute annotations, emitted as
+    /// DW_TAG_LLVM_annotation entries.
     LLVM_ABI DICompositeType *createStructType(
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         Metadata *SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
         DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang = 0,
         DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "",
-        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0);
+        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0,
+        DINodeArray Annotations = nullptr);
 
     /// Create debugging information entry for a struct.
     /// \param Scope        Scope in which this struct is defined.

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -619,7 +619,7 @@ DICompositeType *DIBuilder::createClassType(
     uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
     DINode::DIFlags Flags, DIType *DerivedFrom, DINodeArray Elements,
     unsigned RunTimeLang, DIType *VTableHolder, MDNode *TemplateParams,
-    StringRef UniqueIdentifier) {
+    StringRef UniqueIdentifier, DINodeArray Annotations) {
   assert((!Context || isa<DIScope>(Context)) &&
          "createClassType should be called with a valid Context");
 
@@ -627,7 +627,8 @@ DICompositeType *DIBuilder::createClassType(
       VMContext, dwarf::DW_TAG_class_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits,
       OffsetInBits, Flags, Elements, RunTimeLang, /*EnumKind=*/std::nullopt,
-      VTableHolder, cast_or_null<MDTuple>(TemplateParams), UniqueIdentifier);
+      VTableHolder, cast_or_null<MDTuple>(TemplateParams), UniqueIdentifier,
+      nullptr, nullptr, nullptr, nullptr, nullptr, Annotations);
   trackIfUnresolved(R);
   if (isa_and_nonnull<DILocalScope>(Context))
     getSubprogramNodesTrackingVector(Context).emplace_back(R);
@@ -657,13 +658,13 @@ DICompositeType *DIBuilder::createStructType(
     uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
     DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang,
     DIType *VTableHolder, StringRef UniqueIdentifier, DIType *Specification,
-    uint32_t NumExtraInhabitants) {
+    uint32_t NumExtraInhabitants, DINodeArray Annotations) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_structure_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits, 0,
       Flags, Elements, RunTimeLang, /*EnumKind=*/std::nullopt, VTableHolder,
       nullptr, UniqueIdentifier, nullptr, nullptr, nullptr, nullptr, nullptr,
-      nullptr, Specification, NumExtraInhabitants);
+      Annotations, Specification, NumExtraInhabitants);
   trackIfUnresolved(R);
   if (isa_and_nonnull<DILocalScope>(Context))
     getSubprogramNodesTrackingVector(Context).emplace_back(R);
@@ -673,12 +674,14 @@ DICompositeType *DIBuilder::createStructType(
 DICompositeType *DIBuilder::createUnionType(
     DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
     uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
-    DINodeArray Elements, unsigned RunTimeLang, StringRef UniqueIdentifier) {
+    DINodeArray Elements, unsigned RunTimeLang, StringRef UniqueIdentifier,
+    DINodeArray Annotations) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_union_type, Name, File, LineNumber,
       getNonCompileUnitScope(Scope), nullptr, SizeInBits, AlignInBits, 0, Flags,
       Elements, RunTimeLang, /*EnumKind=*/std::nullopt, nullptr, nullptr,
-      UniqueIdentifier);
+      UniqueIdentifier, nullptr, nullptr, nullptr, nullptr, nullptr,
+      Annotations);
   trackIfUnresolved(R);
   if (isa_and_nonnull<DILocalScope>(Scope))
     getSubprogramNodesTrackingVector(Scope).emplace_back(R);

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -639,13 +639,13 @@ DICompositeType *DIBuilder::createStructType(
     Metadata *SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
     DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang,
     DIType *VTableHolder, StringRef UniqueIdentifier, DIType *Specification,
-    uint32_t NumExtraInhabitants) {
+    uint32_t NumExtraInhabitants, DINodeArray Annotations) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_structure_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits, 0,
       Flags, Elements, RunTimeLang, /*EnumKind=*/std::nullopt, VTableHolder,
       nullptr, UniqueIdentifier, nullptr, nullptr, nullptr, nullptr, nullptr,
-      nullptr, Specification, NumExtraInhabitants);
+      Annotations, Specification, NumExtraInhabitants);
   trackIfUnresolved(R);
   if (isa_and_nonnull<DILocalScope>(Context))
     getSubprogramNodesTrackingVector(Context).emplace_back(R);

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -1420,6 +1420,67 @@ TEST(DIBuilder, CompositeTypes) {
   EXPECT_EQ(Enum->getTag(), dwarf::DW_TAG_enumeration_type);
 }
 
+TEST(DIBuilder, CompositeTypeAnnotations) {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M = std::make_unique<Module>("MyModule", Ctx);
+  DIBuilder DIB(*M);
+
+  DIFile *F = DIB.createFile("main.c", "/");
+  DICompileUnit *CU = DIB.createCompileUnit(
+      DISourceLanguageName(dwarf::DW_LANG_C), F, "Test", false, "", 0);
+
+  auto MakeAnnotations = [&](StringRef Tag, StringRef Value) {
+    Metadata *Ops[2] = {MDString::get(Ctx, Tag), MDString::get(Ctx, Value)};
+    SmallVector<Metadata *, 1> Nodes;
+    Nodes.push_back(MDNode::get(Ctx, Ops));
+    return DIB.getOrCreateArray(Nodes);
+  };
+
+  DINodeArray ClassAnnotations = MakeAnnotations("class_tag", "class_value");
+  DICompositeType *Class = DIB.createClassType(
+      CU, "MyClass", F, 0, 8, 8, 0, {}, nullptr, {}, 0, nullptr, nullptr,
+      "ClassUniqueIdentifier", ClassAnnotations);
+  EXPECT_EQ(Class->getAnnotations().get(), ClassAnnotations.get());
+
+  DINodeArray StructAnnotations = MakeAnnotations("struct_tag", "struct_value");
+  DICompositeType *Struct = DIB.createStructType(
+      CU, "MyStruct", F, 0, 8, 8, {}, {}, {}, 0, {}, "StructUniqueIdentifier",
+      nullptr, 0, StructAnnotations);
+  EXPECT_EQ(Struct->getAnnotations().get(), StructAnnotations.get());
+
+  DINodeArray DynStructAnnotations =
+      MakeAnnotations("dyn_struct_tag", "dyn_struct_value");
+  DIScope *SPScope = DISubprogram::getDistinct(
+      Ctx, nullptr, "", "", nullptr, 0, nullptr, 0, nullptr, 0, 0,
+      DINode::FlagZero, DISubprogram::SPFlagZero, nullptr);
+  DIVariable *Len = DIB.createAutoVariable(SPScope, "length", F, 0, nullptr,
+                                           false, DINode::FlagZero, 0);
+  DICompositeType *DynStruct = DIB.createStructType(
+      CU, "MyDynStruct", F, 0, Len, 8, DINode::FlagZero, nullptr, {}, 0,
+      nullptr, "DynStructUniqueIdentifier", nullptr, 0, DynStructAnnotations);
+  EXPECT_EQ(DynStruct->getAnnotations().get(), DynStructAnnotations.get());
+
+  DINodeArray UnionAnnotations = MakeAnnotations("union_tag", "union_value");
+  DICompositeType *Union = DIB.createUnionType(
+      CU, "MyUnion", F, 0, 8, 8, {}, {}, 0, "UnionUniqueIdentifier",
+      UnionAnnotations);
+  EXPECT_EQ(Union->getAnnotations().get(), UnionAnnotations.get());
+
+  DICompositeType *NoAnnotClass =
+      DIB.createClassType(CU, "NoAnnotClass", F, 0, 8, 8, 0, {}, nullptr, {}, 0,
+                          nullptr, nullptr, "NoAnnotClassUniqueIdentifier");
+  EXPECT_EQ(NoAnnotClass->getAnnotations().get(), nullptr);
+
+  DICompositeType *NoAnnotStruct = DIB.createStructType(
+      CU, "NoAnnotStruct", F, 0, 8, 8, {}, {}, {}, 0, {},
+      "NoAnnotStructUniqueIdentifier");
+  EXPECT_EQ(NoAnnotStruct->getAnnotations().get(), nullptr);
+
+  DICompositeType *NoAnnotUnion = DIB.createUnionType(
+      CU, "NoAnnotUnion", F, 0, 8, 8, {}, {}, 0, "NoAnnotUnionUniqueIdentifier");
+  EXPECT_EQ(NoAnnotUnion->getAnnotations().get(), nullptr);
+}
+
 TEST(DIBuilder, DynamicOffsetAndSize) {
   LLVMContext Ctx;
   auto M = std::make_unique<Module>("MyModule", Ctx);

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -1461,9 +1461,9 @@ TEST(DIBuilder, CompositeTypeAnnotations) {
   EXPECT_EQ(DynStruct->getAnnotations().get(), DynStructAnnotations.get());
 
   DINodeArray UnionAnnotations = MakeAnnotations("union_tag", "union_value");
-  DICompositeType *Union = DIB.createUnionType(
-      CU, "MyUnion", F, 0, 8, 8, {}, {}, 0, "UnionUniqueIdentifier",
-      UnionAnnotations);
+  DICompositeType *Union =
+      DIB.createUnionType(CU, "MyUnion", F, 0, 8, 8, {}, {}, 0,
+                          "UnionUniqueIdentifier", UnionAnnotations);
   EXPECT_EQ(Union->getAnnotations().get(), UnionAnnotations.get());
 
   DICompositeType *NoAnnotClass =
@@ -1471,13 +1471,14 @@ TEST(DIBuilder, CompositeTypeAnnotations) {
                           nullptr, nullptr, "NoAnnotClassUniqueIdentifier");
   EXPECT_EQ(NoAnnotClass->getAnnotations().get(), nullptr);
 
-  DICompositeType *NoAnnotStruct = DIB.createStructType(
-      CU, "NoAnnotStruct", F, 0, 8, 8, {}, {}, {}, 0, {},
-      "NoAnnotStructUniqueIdentifier");
+  DICompositeType *NoAnnotStruct =
+      DIB.createStructType(CU, "NoAnnotStruct", F, 0, 8, 8, {}, {}, {}, 0, {},
+                           "NoAnnotStructUniqueIdentifier");
   EXPECT_EQ(NoAnnotStruct->getAnnotations().get(), nullptr);
 
-  DICompositeType *NoAnnotUnion = DIB.createUnionType(
-      CU, "NoAnnotUnion", F, 0, 8, 8, {}, {}, 0, "NoAnnotUnionUniqueIdentifier");
+  DICompositeType *NoAnnotUnion =
+      DIB.createUnionType(CU, "NoAnnotUnion", F, 0, 8, 8, {}, {}, 0,
+                          "NoAnnotUnionUniqueIdentifier");
   EXPECT_EQ(NoAnnotUnion->getAnnotations().get(), nullptr);
 }
 


### PR DESCRIPTION
DICompositeType already has an "Annotations" ivar. This simply adds a way to set it from the "createStructType" function.