### PR TITLE
[CIR] Make collectUnreachable more robust

### DIFF
--- a/clang/include/clang/CIR/Dialect/Transforms/CIRTransformUtils.h
+++ b/clang/include/clang/CIR/Dialect/Transforms/CIRTransformUtils.h
@@ -6,12 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIR_DIALECT_TRANSFORMS_CIRTRANSFORMUTILS_H
-#define CIR_DIALECT_TRANSFORMS_CIRTRANSFORMUTILS_H
+#ifndef LLVM_CLANG_CIR_DIALECT_TRANSFORMS_CIRTRANSFORMUTILS_H
+#define LLVM_CLANG_CIR_DIALECT_TRANSFORMS_CIRTRANSFORMUTILS_H
 
 #include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+
+#include "llvm/ADT/SmallVector.h"
 
 namespace cir {
 
@@ -30,6 +32,13 @@ mlir::Block *replaceCallWithTryCall(cir::CallOp callOp, mlir::Block *unwindDest,
                                     mlir::Location loc,
                                     mlir::RewriterBase &rewriter);
 
+/// Collect ops in blocks that are unreachable from their region's entry,
+/// appending them to \p ops. Used by CIR passes that drive
+/// `applyPartialConversion` and need to feed it operations the conversion
+/// driver's dominance-order traversal would otherwise skip.
+void collectUnreachable(mlir::Operation *parent,
+                        llvm::SmallVectorImpl<mlir::Operation *> &ops);
+
 } // namespace cir
 
-#endif // CIR_DIALECT_TRANSFORMS_CIRTRANSFORMUTILS_H
+#endif // LLVM_CLANG_CIR_DIALECT_TRANSFORMS_CIRTRANSFORMUTILS_H

--- a/clang/lib/CIR/Dialect/Transforms/CIRTransformUtils.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRTransformUtils.cpp
@@ -6,9 +6,33 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CIRTransformUtils.h"
+#include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
 
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+
+#include "llvm/ADT/DepthFirstIterator.h"
+
+void cir::collectUnreachable(mlir::Operation *parent,
+                             llvm::SmallVectorImpl<mlir::Operation *> &ops) {
+  // For every region under `parent`, find the blocks unreachable from the
+  // entry via a forward CFG traversal and collect their ops.
+  llvm::df_iterator_default_set<mlir::Block *, 16> reachable;
+  parent->walk([&](mlir::Region *region) {
+    // Empty regions have no blocks; single-block regions have only the
+    // entry, which is trivially reachable. Either way, nothing to collect.
+    if (region->empty() || region->hasOneBlock())
+      return;
+    reachable.clear();
+    for (mlir::Block *blk : llvm::depth_first_ext(&region->front(), reachable))
+      (void)blk;
+    for (mlir::Block &blk : *region) {
+      if (reachable.contains(&blk))
+        continue;
+      for (mlir::Operation &op : blk)
+        ops.push_back(&op);
+    }
+  });
+}
 
 mlir::Block *cir::replaceCallWithTryCall(cir::CallOp callOp,
                                          mlir::Block *unwindDest,

--- a/clang/lib/CIR/Dialect/Transforms/CIRTransformUtils.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRTransformUtils.cpp
@@ -22,9 +22,20 @@ void cir::collectUnreachable(mlir::Operation *parent,
     // entry, which is trivially reachable. Either way, nothing to collect.
     if (region->empty() || region->hasOneBlock())
       return;
+
+    // We clear this for each region as we walk the parent because each block
+    // is only in one region, so the reachable blocks from previously visited
+    // regions aren't needed.
     reachable.clear();
+
+    // The depth_first_ext range iterator internally adds each block to the
+    // reachable set as it visits it, so while this loop looks like it doesn't
+    // do anything, it's actually populating the set of reachable blocks in
+    // this region.
     for (mlir::Block *blk : llvm::depth_first_ext(&region->front(), reachable))
       (void)blk;
+
+    // Collect the unreachable blocks.
     for (mlir::Block &blk : *region) {
       if (reachable.contains(&blk))
         continue;

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -21,9 +21,9 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
 #include "clang/CIR/MissingFeatures.h"
 
-#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -1005,59 +1005,6 @@ populateCXXABIConversionTarget(mlir::ConversionTarget &target,
 // The Pass
 //===----------------------------------------------------------------------===//
 
-// The applyPartialConversion function traverses blocks in the dominance order,
-// so it does not lower and operations that are not reachachable from the
-// operations passed in as arguments. Since we do need to lower such code in
-// order to avoid verification errors occur, we cannot just pass the module op
-// to applyPartialConversion. We must build a set of unreachable ops and
-// explicitly add them, along with the module, to the vector we pass to
-// applyPartialConversion.
-//
-// For instance, this CIR code:
-//
-//    cir.func @foo(%arg0: !s32i) -> !s32i {
-//      %4 = cir.cast int_to_bool %arg0 : !s32i -> !cir.bool
-//      cir.if %4 {
-//        %5 = cir.const #cir.int<1> : !s32i
-//        cir.return %5 : !s32i
-//      } else {
-//        %5 = cir.const #cir.int<0> : !s32i
-//       cir.return %5 : !s32i
-//      }
-//      cir.return %arg0 : !s32i
-//    }
-//
-// contains an unreachable return operation (the last one). After the CXXABI
-// pass it will be placed into the unreachable block.  This will error because
-// it will have not converted the types in the block, making the legalizer fail.
-//
-// In the future we may want to get rid of this function and use a DCE pass or
-// something similar. But for now we need to guarantee the absence of the
-// dialect verification errors. Note: We do the same in LowerToLLVM as well,
-// this is a striaght copy/paste including most of the comment. We might wi sh
-// to combine these if we don't want to do a DCE pass/etc.
-static void collectUnreachable(mlir::Operation *parent,
-                               llvm::SmallVector<mlir::Operation *> &ops) {
-  // For every region under `parent`, find the blocks unreachable from the
-  // entry via a forward CFG traversal and collect their ops.
-  llvm::df_iterator_default_set<mlir::Block *, 16> reachable;
-  parent->walk([&](mlir::Region *region) {
-    // Empty regions have no blocks; single-block regions have only the
-    // entry, which is trivially reachable. Either way, nothing to collect.
-    if (region->empty() || region->hasOneBlock())
-      return;
-    reachable.clear();
-    for (mlir::Block *blk : llvm::depth_first_ext(&region->front(), reachable))
-      (void)blk;
-    for (mlir::Block &blk : *region) {
-      if (reachable.contains(&blk))
-        continue;
-      for (mlir::Operation &op : blk)
-        ops.push_back(&op);
-    }
-  });
-}
-
 void CXXABILoweringPass::runOnOperation() {
   auto mod = mlir::cast<mlir::ModuleOp>(getOperation());
   mlir::MLIRContext *ctx = mod.getContext();
@@ -1087,7 +1034,7 @@ void CXXABILoweringPass::runOnOperation() {
 
   llvm::SmallVector<mlir::Operation *> ops;
   ops.push_back(mod);
-  collectUnreachable(mod, ops);
+  cir::collectUnreachable(mod, ops);
 
   if (failed(mlir::applyPartialConversion(ops, target, std::move(patterns))))
     signalPassFailure();

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <deque>
-
 #include "PassDetail.h"
 #include "TargetLowering/LowerModule.h"
 
@@ -25,6 +23,7 @@
 #include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/MissingFeatures.h"
 
+#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -1039,34 +1038,24 @@ populateCXXABIConversionTarget(mlir::ConversionTarget &target,
 // to combine these if we don't want to do a DCE pass/etc.
 static void collectUnreachable(mlir::Operation *parent,
                                llvm::SmallVector<mlir::Operation *> &ops) {
-
-  llvm::SmallVector<mlir::Block *> unreachableBlocks;
-  parent->walk([&](mlir::Block *blk) { // check
-    if (blk->hasNoPredecessors() && !blk->isEntryBlock())
-      unreachableBlocks.push_back(blk);
-  });
-
-  std::set<mlir::Block *> visited;
-  for (mlir::Block *root : unreachableBlocks) {
-    // We create a work list for each unreachable block.
-    // Thus we traverse operations in some order.
-    std::deque<mlir::Block *> workList;
-    workList.push_back(root);
-
-    while (!workList.empty()) {
-      mlir::Block *blk = workList.back();
-      workList.pop_back();
-      if (visited.count(blk))
+  // For every region under `parent`, find the blocks unreachable from the
+  // entry via a forward CFG traversal and collect their ops.
+  llvm::df_iterator_default_set<mlir::Block *, 16> reachable;
+  parent->walk([&](mlir::Region *region) {
+    // Empty regions have no blocks; single-block regions have only the
+    // entry, which is trivially reachable. Either way, nothing to collect.
+    if (region->empty() || region->hasOneBlock())
+      return;
+    reachable.clear();
+    for (mlir::Block *blk : llvm::depth_first_ext(&region->front(), reachable))
+      (void)blk;
+    for (mlir::Block &blk : *region) {
+      if (reachable.contains(&blk))
         continue;
-      visited.emplace(blk);
-
-      for (mlir::Operation &op : *blk)
+      for (mlir::Operation &op : blk)
         ops.push_back(&op);
-
-      for (mlir::Block *succ : blk->getSuccessors())
-        workList.push_back(succ);
     }
-  }
+  });
 }
 
 void CXXABILoweringPass::runOnOperation() {

--- a/clang/lib/CIR/Dialect/Transforms/EHABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/EHABILowering.cpp
@@ -26,7 +26,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CIRTransformUtils.h"
 #include "PassDetail.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
@@ -35,6 +34,7 @@
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/TargetParser/Triple.h"

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CIRTransformUtils.h"
 #include "PassDetail.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Block.h"
@@ -24,6 +23,7 @@
 #include "clang/CIR/Dialect/IR/CIRDataLayout.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/CMakeLists.txt
@@ -20,6 +20,7 @@ add_clang_library(clangCIRLoweringDirectToLLVM
   ${dialect_libs}
   MLIRCIR
   MLIRCIRTargetLowering
+  MLIRCIRTransforms
   MLIRBuiltinToLLVMIRTranslation
   MLIRLLVMToLLVMIRTranslation
   MLIROpenMPToLLVM

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -40,10 +40,10 @@
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Dialect/Transforms/CIRTransformUtils.h"
 #include "clang/CIR/LoweringHelpers.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "clang/CIR/Passes.h"
-#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -3412,59 +3412,6 @@ static void buildCtorDtorList(
   mlir::LLVM::ReturnOp::create(builder, loc, result);
 }
 
-// The applyPartialConversion function traverses blocks in the dominance order,
-// so it does not lower and operations that are not reachachable from the
-// operations passed in as arguments. Since we do need to lower such code in
-// order to avoid verification errors occur, we cannot just pass the module op
-// to applyPartialConversion. We must build a set of unreachable ops and
-// explicitly add them, along with the module, to the vector we pass to
-// applyPartialConversion.
-//
-// For instance, this CIR code:
-//
-//    cir.func @foo(%arg0: !s32i) -> !s32i {
-//      %4 = cir.cast int_to_bool %arg0 : !s32i -> !cir.bool
-//      cir.if %4 {
-//        %5 = cir.const #cir.int<1> : !s32i
-//        cir.return %5 : !s32i
-//      } else {
-//        %5 = cir.const #cir.int<0> : !s32i
-//       cir.return %5 : !s32i
-//      }
-//      cir.return %arg0 : !s32i
-//    }
-//
-// contains an unreachable return operation (the last one). After the flattening
-// pass it will be placed into the unreachable block. The possible error
-// after the lowering pass is: error: 'cir.return' op expects parent op to be
-// one of 'cir.func, cir.scope, cir.if ... The reason that this operation was
-// not lowered and the new parent is llvm.func.
-//
-// In the future we may want to get rid of this function and use a DCE pass or
-// something similar. But for now we need to guarantee the absence of the
-// dialect verification errors.
-static void collectUnreachable(mlir::Operation *parent,
-                               llvm::SmallVector<mlir::Operation *> &ops) {
-  // For every region under `parent`, find the blocks unreachable from the
-  // entry via a forward CFG traversal and collect their ops.
-  llvm::df_iterator_default_set<mlir::Block *, 16> reachable;
-  parent->walk([&](mlir::Region *region) {
-    // Empty regions have no blocks; single-block regions have only the
-    // entry, which is trivially reachable. Either way, nothing to collect.
-    if (region->empty() || region->hasOneBlock())
-      return;
-    reachable.clear();
-    for (mlir::Block *blk : llvm::depth_first_ext(&region->front(), reachable))
-      (void)blk;
-    for (mlir::Block &blk : *region) {
-      if (reachable.contains(&blk))
-        continue;
-      for (mlir::Operation &op : blk)
-        ops.push_back(&op);
-    }
-  });
-}
-
 mlir::LogicalResult CIRToLLVMObjSizeOpLowering::matchAndRewrite(
     cir::ObjSizeOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -3802,7 +3749,7 @@ void ConvertCIRToLLVMPass::runOnOperation() {
 
   llvm::SmallVector<mlir::Operation *> ops;
   ops.push_back(module);
-  collectUnreachable(module, ops);
+  cir::collectUnreachable(module, ops);
 
   if (failed(applyPartialConversion(ops, target, std::move(patterns))))
     signalPassFailure();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -13,7 +13,6 @@
 #include "LowerToLLVM.h"
 
 #include <array>
-#include <deque>
 #include <optional>
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
@@ -44,6 +43,7 @@
 #include "clang/CIR/LoweringHelpers.h"
 #include "clang/CIR/MissingFeatures.h"
 #include "clang/CIR/Passes.h"
+#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -3445,34 +3445,24 @@ static void buildCtorDtorList(
 // dialect verification errors.
 static void collectUnreachable(mlir::Operation *parent,
                                llvm::SmallVector<mlir::Operation *> &ops) {
-
-  llvm::SmallVector<mlir::Block *> unreachableBlocks;
-  parent->walk([&](mlir::Block *blk) { // check
-    if (blk->hasNoPredecessors() && !blk->isEntryBlock())
-      unreachableBlocks.push_back(blk);
-  });
-
-  std::set<mlir::Block *> visited;
-  for (mlir::Block *root : unreachableBlocks) {
-    // We create a work list for each unreachable block.
-    // Thus we traverse operations in some order.
-    std::deque<mlir::Block *> workList;
-    workList.push_back(root);
-
-    while (!workList.empty()) {
-      mlir::Block *blk = workList.back();
-      workList.pop_back();
-      if (visited.count(blk))
+  // For every region under `parent`, find the blocks unreachable from the
+  // entry via a forward CFG traversal and collect their ops.
+  llvm::df_iterator_default_set<mlir::Block *, 16> reachable;
+  parent->walk([&](mlir::Region *region) {
+    // Empty regions have no blocks; single-block regions have only the
+    // entry, which is trivially reachable. Either way, nothing to collect.
+    if (region->empty() || region->hasOneBlock())
+      return;
+    reachable.clear();
+    for (mlir::Block *blk : llvm::depth_first_ext(&region->front(), reachable))
+      (void)blk;
+    for (mlir::Block &blk : *region) {
+      if (reachable.contains(&blk))
         continue;
-      visited.emplace(blk);
-
-      for (mlir::Operation &op : *blk)
+      for (mlir::Operation &op : blk)
         ops.push_back(&op);
-
-      for (mlir::Block *succ : blk->getSuccessors())
-        workList.push_back(succ);
     }
-  }
+  });
 }
 
 mlir::LogicalResult CIRToLLVMObjSizeOpLowering::matchAndRewrite(

--- a/clang/test/CIR/CodeGen/unreachable-cycle.c
+++ b/clang/test/CIR/CodeGen/unreachable-cycle.c
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+extern int x;
+void g(void);
+
+// The call to g() is unreachable, but we currently want to convert it during
+// the CIR-to-LLVM lowering pass to avoid verification errors.
+
+void f(void) {
+  goto end;
+lab:
+  if (0) goto lab;
+  if (x) g();
+end:;
+}
+
+// CIR-DAG: cir.global "private" external{{.*}} @x
+// CIR:     cir.func{{.*}} @f
+// CIR:       cir.goto "end"
+// CIR:       cir.label "lab"
+// CIR:       cir.get_global @x
+
+// LLVM:     @x = external {{(dso_local )?}}global i32
+// LLVM:     define dso_local void @f
+// LLVM:       load i32, ptr @x
+
+// OGCG:     @x = external {{.*}}global i32
+// OGCG:     define dso_local void @f
+// OGCG:       load i32, ptr @x


### PR DESCRIPTION
The CXXABILowering and LowerToLLVM passes both use a `collectUnreachable` function to find unreachable blocks and add them to a SmallVector that will be passed to `applyPartialConversion` to avoid leaving unconverted operations in the dead blocks. We can't simply call `eraseUnreachableBlocks` because we don't yet protect indirect branch and goto targets from being erased.

Application testing revealed that our `collectUnreachable` function was missing blocks in SCCs, because they were connected to each other. This change revises `collectUnreachable` to instead build a list of reachable blocks and then walk all blocks to find the ones that aren't in the reachable list (which is what `eraseUnreachableBlocks` does).

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh