### PR TITLE
[llvm-split] Generalize split-by-category to accept an arbitrary attribute name

### DIFF
--- a/llvm/test/tools/llvm-split/SplitByCategory/complex-indirect-call-chain1.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/complex-indirect-call-chain1.ll
@@ -1,7 +1,7 @@
 ; Check that Module splitting can trace through more complex call stacks
 ; involving several nested indirect calls.
 
-; RUN: llvm-split -split-by-category=module-id -S < %s -o %t
+; RUN: llvm-split -split-by-category=attribute --category-attribute=module-id -S < %s -o %t
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
 ; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz

--- a/llvm/test/tools/llvm-split/SplitByCategory/complex-indirect-call-chain2.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/complex-indirect-call-chain2.ll
@@ -1,6 +1,6 @@
 ; Check that Module splitting can trace indirect calls through signatures.
 
-; RUN: llvm-split -split-by-category=module-id -S < %s -o %t
+; RUN: llvm-split -split-by-category=attribute --category-attribute=module-id -S < %s -o %t
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @kernel_A --implicit-check-not @bbb
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \

--- a/llvm/test/tools/llvm-split/SplitByCategory/missing-attribute-value.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/missing-attribute-value.ll
@@ -3,4 +3,4 @@
 ; RUN: not llvm-split -split-by-category=attribute -S < %s -o %t 2>&1 \
 ; RUN:   | FileCheck %s
 
-; CHECK: -split-by-category=attribute requires --category-attribute=<name>
+; CHECK: error: -split-by-category=attribute requires --category-attribute=<name>

--- a/llvm/test/tools/llvm-split/SplitByCategory/missing-attribute-value.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/missing-attribute-value.ll
@@ -1,0 +1,6 @@
+; Test that -split-by-category=attribute without --category-attribute produces an error.
+
+; RUN: not llvm-split -split-by-category=attribute -S < %s -o %t 2>&1 \
+; RUN:   | FileCheck %s
+
+; CHECK: -split-by-category=attribute requires --category-attribute=<name>

--- a/llvm/test/tools/llvm-split/SplitByCategory/module-split-func-ptr.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/module-split-func-ptr.ll
@@ -1,7 +1,7 @@
 ; This test checks that Module splitting can properly perform device code split by tracking
 ; all uses of functions (not only direct calls).
 
-; RUN: llvm-split -split-by-category=module-id -S < %s -o %t
+; RUN: llvm-split -split-by-category=attribute --category-attribute=module-id -S < %s -o %t
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix=CHECK-IR0
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix=CHECK-IR1
 

--- a/llvm/test/tools/llvm-split/SplitByCategory/split-by-source.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/split-by-source.ll
@@ -1,7 +1,7 @@
 ; Test checks that kernels are being split by attached module-id metadata and
 ; used functions are being moved with kernels that use them.
 
-; RUN: llvm-split -split-by-category=module-id -S < %s -o %t
+; RUN: llvm-split -split-by-category=attribute --category-attribute=module-id -S < %s -o %t
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-TU0,CHECK
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-TU1,CHECK
 

--- a/llvm/test/tools/llvm-split/SplitByCategory/split-with-kernel-declarations.ll
+++ b/llvm/test/tools/llvm-split/SplitByCategory/split-with-kernel-declarations.ll
@@ -1,6 +1,6 @@
 ; The test checks that Module splitting does not treat declarations as entry points.
 
-; RUN: llvm-split -split-by-category=module-id -S < %s -o %t1
+; RUN: llvm-split -split-by-category=attribute --category-attribute=module-id -S < %s -o %t1
 ; RUN: FileCheck %s -input-file=%t1_0.ll --check-prefix CHECK-MODULE-ID0
 ; RUN: FileCheck %s -input-file=%t1_1.ll --check-prefix CHECK-MODULE-ID1
 

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -219,7 +219,6 @@ Error runSplitModuleByCategory(std::unique_ptr<Module> M) {
   if (SplitByCategory == SplitByCategoryType::SBCT_ByAttribute &&
       CategoryAttribute.empty())
     return createStringError(
-        inconvertibleErrorCode(),
         "-split-by-category=attribute requires --category-attribute=<name>");
 
   size_t OutputID = 0;
@@ -304,7 +303,7 @@ int main(int argc, char **argv) {
   if (SplitByCategory != SplitByCategoryType::SBCT_None) {
     auto E = runSplitModuleByCategory(std::move(M));
     if (E) {
-      errs() << toString(std::move(E)) << "\n";
+      errs() << "error: " << toString(std::move(E)) << "\n";
       return 1;
     }
 

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -78,7 +78,7 @@ static cl::opt<std::string>
          cl::value_desc("cpu"), cl::cat(SplitCategory));
 
 enum class SplitByCategoryType {
-  SBCT_ByModuleId,
+  SBCT_ByAttribute,
   SBCT_ByKernel,
   SBCT_None,
 };
@@ -88,12 +88,18 @@ static cl::opt<SplitByCategoryType> SplitByCategory(
     cl::desc("Split by category. If present, splitting by category is used "
              "with the specified categorization type."),
     cl::Optional, cl::init(SplitByCategoryType::SBCT_None),
-    cl::values(clEnumValN(SplitByCategoryType::SBCT_ByModuleId, "module-id",
-                          "one output module per translation unit marked with "
-                          "\"module-id\" attribute"),
+    cl::values(clEnumValN(SplitByCategoryType::SBCT_ByAttribute, "attribute",
+                          "one output module per unique value of the function "
+                          "attribute named by --category-attribute"),
                clEnumValN(SplitByCategoryType::SBCT_ByKernel, "kernel",
                           "one output module per kernel")),
     cl::cat(SplitCategory));
+
+static cl::opt<std::string>
+    CategoryAttribute("category-attribute",
+                      cl::desc("Function attribute name to use when splitting "
+                               "with -split-by-category=attribute"),
+                      cl::value_desc("name"), cl::cat(SplitCategory));
 
 static cl::opt<bool> OutputAssembly{
     "S", cl::desc("Write output as LLVM assembly"), cl::cat(SplitCategory)};
@@ -125,15 +131,16 @@ void writeModuleToFile(const Module &M, StringRef Path, bool OutputAssembly) {
     WriteBitcodeToFile(M, OS);
 }
 
-/// EntryPointCategorizer is used for splitting by category either by module-id
-/// or by kernels. It doesn't provide categories for functions other than
-/// kernels. Categorizer computes a string key for the given Function and
-/// records the association between the string key and an integer category. If a
-/// string key is already belongs to some category than the corresponding
-/// integer category is returned.
+/// EntryPointCategorizer is used for splitting by category either by a named
+/// function attribute or by kernels. It doesn't provide categories for
+/// functions other than kernels. Categorizer computes a string key for the
+/// given Function and records the association between the string key and an
+/// integer category. If a string key already belongs to some category then the
+/// corresponding integer category is returned.
 class EntryPointCategorizer {
 public:
-  EntryPointCategorizer(SplitByCategoryType Type) : Type(Type) {}
+  EntryPointCategorizer(SplitByCategoryType Type, StringRef AttributeName)
+      : Type(Type), AttributeName(AttributeName) {}
 
   EntryPointCategorizer() = delete;
   EntryPointCategorizer(EntryPointCategorizer &) = delete;
@@ -163,16 +170,15 @@ private:
     return F.hasKernelCallingConv();
   }
 
-  static SmallString<0> computeFunctionCategory(SplitByCategoryType Type,
-                                                const Function &F) {
-    static constexpr char ATTR_MODULE_ID[] = "module-id";
+  SmallString<0> computeFunctionCategory(SplitByCategoryType Type,
+                                         const Function &F) {
     SmallString<0> Key;
     switch (Type) {
     case SplitByCategoryType::SBCT_ByKernel:
       Key = F.getName().str();
       break;
-    case SplitByCategoryType::SBCT_ByModuleId:
-      Key = F.getFnAttribute(ATTR_MODULE_ID).getValueAsString().str();
+    case SplitByCategoryType::SBCT_ByAttribute:
+      Key = F.getFnAttribute(AttributeName).getValueAsString().str();
       break;
     default:
       llvm_unreachable("unexpected mode.");
@@ -197,6 +203,7 @@ private:
   };
 
   SplitByCategoryType Type;
+  std::string AttributeName;
   DenseMap<SmallString<0>, int, KeyInfo> StrKeyToID;
 };
 
@@ -209,6 +216,12 @@ void cleanupModule(Module &M) {
 }
 
 Error runSplitModuleByCategory(std::unique_ptr<Module> M) {
+  if (SplitByCategory == SplitByCategoryType::SBCT_ByAttribute &&
+      CategoryAttribute.empty())
+    return createStringError(
+        inconvertibleErrorCode(),
+        "-split-by-category=attribute requires --category-attribute=<name>");
+
   size_t OutputID = 0;
   auto PostSplitCallback = [&](std::unique_ptr<Module> MPart) -> Error {
     if (verifyModule(*MPart)) {
@@ -228,7 +241,7 @@ Error runSplitModuleByCategory(std::unique_ptr<Module> M) {
     return Error::success();
   };
 
-  auto Categorizer = EntryPointCategorizer(SplitByCategory);
+  auto Categorizer = EntryPointCategorizer(SplitByCategory, CategoryAttribute);
   return splitModuleTransitiveFromEntryPoints(std::move(M), Categorizer,
                                               PostSplitCallback);
 }
@@ -291,8 +304,7 @@ int main(int argc, char **argv) {
   if (SplitByCategory != SplitByCategoryType::SBCT_None) {
     auto E = runSplitModuleByCategory(std::move(M));
     if (E) {
-      errs() << E << "\n";
-      Err.print(argv[0], errs());
+      errs() << toString(std::move(E)) << "\n";
       return 1;
     }
 


### PR DESCRIPTION
Rename the `module-id` split-by-category mode to `attribute` and add a `--category-attribute=<name>` flag that specifies which function attribute to group by. This decouples `llvm-split` from the hardcoded "module-id" attribute name, making the tool reusable for any attribute-based splitting.

Also fix the error reporting path to properly consume the llvm::Error (use `toString(std::move(E))`) instead of streaming it and letting the unchecked Error destructor abort.

Co-Authored-By: Claude