### PR TITLE
Adds GetOptions to CommandObjectBreakpointOverride{List, Delete}.

### DIFF
--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -3678,6 +3678,8 @@ public:
 
   ~CommandObjectBreakpointOverrideDelete() override = default;
 
+  Options *GetOptions() override { return &m_all_options; }
+
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     Target &target =
@@ -3729,6 +3731,8 @@ public:
   }
 
   ~CommandObjectBreakpointOverrideList() override = default;
+
+  Options *GetOptions() override { return &m_all_options; }
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -982,7 +982,7 @@ void Target::DescribeBreakpointOverrides(Stream &stream,
   bool empty = idxs.empty();
   bool print_first = true;
   for (auto const &elem : m_breakpoint_overrides) {
-    auto idx_pos = std::find(begin, end, elem.first);
+    auto idx_pos = empty ? end : std::find(begin, end, elem.first);
     if (empty || idx_pos != end) {
       if (print_first) {
         // FIXME: Is there some good way to flow the description?


### PR DESCRIPTION
This was causing flaky behavior in TestOverridesResolver.py.

I found this with ASAN, which also didn't like that I was running find with begin() & end() of an empty std::vector.  That surprised me a bit, but its easy to avoid, so I also changed that here.