### PR TITLE
[DirectX] Fix layering violation in b239b5c

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -818,6 +818,8 @@ struct DebugNameHeader {
 
 static_assert(sizeof(DebugNameHeader) == 4, "DebugNameHeader size incorrect.");
 
+using ILDNData = std::pair<DebugNameHeader, StringRef>;
+
 } // namespace dxbc
 } // namespace llvm
 

--- a/llvm/include/llvm/MC/DXContainerInfo.h
+++ b/llvm/include/llvm/MC/DXContainerInfo.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_MC_DXCONTAINERINFO_H
 #define LLVM_MC_DXCONTAINERINFO_H
 
-#include "llvm/Object/DXContainer.h"
+#include "llvm/BinaryFormat/DXContainer.h"
 
 namespace llvm {
 
@@ -18,7 +18,7 @@ class raw_ostream;
 namespace mcdxbc {
 
 struct DebugName {
-  object::DXContainer::ILDNData BaseData;
+  dxbc::ILDNData BaseData;
 
   DebugName() { BaseData.first.Flags = 0; }
 

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -460,7 +460,6 @@ public:
 class DXContainer {
 public:
   using DXILData = std::pair<dxbc::ProgramHeader, const char *>;
-  using ILDNData = std::pair<dxbc::DebugNameHeader, StringRef>;
 
 private:
   DXContainer(MemoryBufferRef O);
@@ -476,7 +475,7 @@ private:
   DirectX::Signature InputSignature;
   DirectX::Signature OutputSignature;
   DirectX::Signature PatchConstantSignature;
-  std::optional<ILDNData> DebugName;
+  std::optional<dxbc::ILDNData> DebugName;
 
   Error parseHeader();
   Error parsePartOffsets();
@@ -566,7 +565,7 @@ public:
 
   const std::optional<DXILData> &getDXIL() const { return DXIL; }
 
-  const std::optional<ILDNData> getDebugName() const { return DebugName; }
+  const std::optional<dxbc::ILDNData> getDebugName() const { return DebugName; }
 
   std::optional<uint64_t> getShaderFeatureFlags() const {
     return ShaderFeatureFlags;

--- a/llvm/lib/MC/DXContainerInfo.cpp
+++ b/llvm/lib/MC/DXContainerInfo.cpp
@@ -8,7 +8,6 @@
 
 #include "llvm/MC/DXContainerInfo.h"
 #include "llvm/BinaryFormat/DXContainer.h"
-#include "llvm/Object/DXContainer.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include <type_traits>
 

--- a/llvm/tools/obj2yaml/dxcontainer2yaml.cpp
+++ b/llvm/tools/obj2yaml/dxcontainer2yaml.cpp
@@ -71,7 +71,7 @@ dumpDXContainer(MemoryBufferRef Source) {
       break;
     }
     case dxbc::PartType::ILDN: {
-      std::optional<DXContainer::ILDNData> DebugName = Container.getDebugName();
+      std::optional<dxbc::ILDNData> DebugName = Container.getDebugName();
       assert(DebugName && "Since we are iterating and found a ILDN part, this "
                           "should never not have a value");
       NewPart.DebugName = DXContainerYAML::DebugName{

--- a/llvm/unittests/Object/DXContainerTest.cpp
+++ b/llvm/unittests/Object/DXContainerTest.cpp
@@ -249,7 +249,7 @@ TEST(DXCFile, ParseILDNPart) {
   DXContainer C =
       llvm::cantFail(DXContainer::create(getMemoryBuffer<116>(Buffer)));
   EXPECT_EQ(C.getHeader().PartCount, 1u);
-  const std::optional<object::DXContainer::ILDNData> &ILDN = C.getDebugName();
+  const std::optional<dxbc::ILDNData> &ILDN = C.getDebugName();
   EXPECT_TRUE(ILDN.has_value());
   dxbc::DebugNameHeader Header = ILDN->first;
   EXPECT_EQ(Header.Flags, 0u);


### PR DESCRIPTION
b239b5c07145df1fc3503bcde58481e21ba265a1 introduced a layering violation. It included a header from llvm/Object from a header in llvm/MC, which is a layering violation as llvm/Object depends on llvm/MC. Given the only thing needed here is a single type, just hoist it to a header in BinaryFormat which both MC and Object are allowed to depend on.