### PR TITLE
[clang] Add Tom Honermann as SYCL maintainer

### DIFF
--- a/clang/Maintainers.md
+++ b/clang/Maintainers.md
@@ -316,10 +316,10 @@ ekeane@nvidia.com (email), ErichKeane (Phabricator), [erichkeane](https://github
 ### SYCL conformance
 
 Alexey Bader \
-alexey.bader@intel.com (email), bader (Phabricator), [bader](https://github.com/bader) (GitHub)
+alexey.bader@intel.com (email), [bader](https://github.com/bader) (GitHub), bader7427 (Discord), bader (Discourse)
 
 Tom Honermann \
-tom@honermann.net (email), tahonermann (Phabricator), [tahonermann](https://github.com/tahonermann) (GitHub)
+tom@honermann.net (email), [tahonermann](https://github.com/tahonermann) (GitHub), tahonermann (Discord), tahonermann (Discourse)
 
 ### HLSL conformance
 

--- a/clang/Maintainers.md
+++ b/clang/Maintainers.md
@@ -318,6 +318,9 @@ ekeane@nvidia.com (email), ErichKeane (Phabricator), [erichkeane](https://github
 Alexey Bader \
 alexey.bader@intel.com (email), bader (Phabricator), [bader](https://github.com/bader) (GitHub)
 
+Tom Honermann \
+tom@honermann.net (email), tahonermann (Phabricator), [tahonermann](https://github.com/tahonermann) (GitHub)
+
 ### HLSL conformance
 
 Chris Bieneman \


### PR DESCRIPTION
Tom Honermann has become a key contributor to SYCL support in Clang,
delivering high-quality front-end improvements.

He is also an active reviewer, providing thorough feedback
and helping maintain code quality across the SYCL implementation.

Updated my account ids: added Discord and Discourse and removed Phabricator.