### PR TITLE
 [CloneModule] Clone undefined ifuncs

### DIFF
--- a/llvm/lib/Transforms/Utils/CloneModule.cpp
+++ b/llvm/lib/Transforms/Utils/CloneModule.cpp
@@ -119,7 +119,7 @@ std::unique_ptr<Module> llvm::CloneModule(
     // Defer setting the resolver function until after functions are cloned.
     if (!ShouldCloneDefinition(&I)) {
       // An ifunc also cannot act as an external reference, so we need to create
-      // a function depending on the value type.
+      // a function.
       GlobalValue *GV;
       assert(I.getValueType()->isFunctionTy() &&
              "ValueType of ifunc must be function type!");

--- a/llvm/lib/Transforms/Utils/CloneModule.cpp
+++ b/llvm/lib/Transforms/Utils/CloneModule.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<Module> llvm::CloneModule(
       // a function depending on the value type.
       GlobalValue *GV;
       assert(I.getValueType()->isFunctionTy() &&
-             "IFunc resolver must be function type!");
+             "ValueType of ifunc must be function type!");
       GV = Function::Create(cast<FunctionType>(I.getValueType()),
                             GlobalValue::ExternalLinkage, I.getAddressSpace(),
                             I.getName(), New.get());

--- a/llvm/lib/Transforms/Utils/CloneModule.cpp
+++ b/llvm/lib/Transforms/Utils/CloneModule.cpp
@@ -119,17 +119,13 @@ std::unique_ptr<Module> llvm::CloneModule(
     // Defer setting the resolver function until after functions are cloned.
     if (!ShouldCloneDefinition(&I)) {
       // An ifunc also cannot act as an external reference, so we need to create
-      // either a function or a global variable depending on the value type.
+      // a function depending on the value type.
       GlobalValue *GV;
-      if (I.getValueType()->isFunctionTy())
-        GV = Function::Create(cast<FunctionType>(I.getValueType()),
-                              GlobalValue::ExternalLinkage, I.getAddressSpace(),
-                              I.getName(), New.get());
-      else
-        GV = new GlobalVariable(*New, I.getValueType(), false,
-                                GlobalValue::ExternalLinkage, nullptr,
-                                I.getName(), nullptr, I.getThreadLocalMode(),
-                                I.getType()->getAddressSpace());
+      assert(I.getValueType()->isFunctionTy() &&
+             "IFunc resolver must be function type!");
+      GV = Function::Create(cast<FunctionType>(I.getValueType()),
+                            GlobalValue::ExternalLinkage, I.getAddressSpace(),
+                            I.getName(), New.get());
       VMap[&I] = GV;
       continue;
     }

--- a/llvm/lib/Transforms/Utils/CloneModule.cpp
+++ b/llvm/lib/Transforms/Utils/CloneModule.cpp
@@ -117,6 +117,22 @@ std::unique_ptr<Module> llvm::CloneModule(
 
   for (const GlobalIFunc &I : M.ifuncs()) {
     // Defer setting the resolver function until after functions are cloned.
+    if (!ShouldCloneDefinition(&I)) {
+      // An ifunc also cannot act as an external reference, so we need to create
+      // either a function or a global variable depending on the value type.
+      GlobalValue *GV;
+      if (I.getValueType()->isFunctionTy())
+        GV = Function::Create(cast<FunctionType>(I.getValueType()),
+                              GlobalValue::ExternalLinkage, I.getAddressSpace(),
+                              I.getName(), New.get());
+      else
+        GV = new GlobalVariable(*New, I.getValueType(), false,
+                                GlobalValue::ExternalLinkage, nullptr,
+                                I.getName(), nullptr, I.getThreadLocalMode(),
+                                I.getType()->getAddressSpace());
+      VMap[&I] = GV;
+      continue;
+    }
     auto *GI =
         GlobalIFunc::create(I.getValueType(), I.getAddressSpace(),
                             I.getLinkage(), I.getName(), nullptr, New.get());
@@ -174,6 +190,9 @@ std::unique_ptr<Module> llvm::CloneModule(
   }
 
   for (const GlobalIFunc &I : M.ifuncs()) {
+    // We already dealt with undefined ifuncs above.
+    if (!ShouldCloneDefinition(&I))
+      continue;
     GlobalIFunc *GI = cast<GlobalIFunc>(VMap[&I]);
     if (const Constant *Resolver = I.getResolver())
       GI->setResolver(MapValue(Resolver, VMap));

--- a/llvm/lib/Transforms/Utils/SplitModule.cpp
+++ b/llvm/lib/Transforms/Utils/SplitModule.cpp
@@ -162,6 +162,7 @@ static void findPartitions(Module &M, ClusterIDMapType &ClusterIDMap,
   llvm::for_each(M.functions(), recordGVSet);
   llvm::for_each(M.globals(), recordGVSet);
   llvm::for_each(M.aliases(), recordGVSet);
+  llvm::for_each(M.ifuncs(), recordGVSet);
 
   // Assigned all GVs to merged clusters while balancing number of objects in
   // each.

--- a/llvm/test/tools/llvm-split/alias-to-ifunc.ll
+++ b/llvm/test/tools/llvm-split/alias-to-ifunc.ll
@@ -2,32 +2,28 @@
 ; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
 ; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
 
+; CHECK0-DAG: @alias_foo = alias void (), ptr @foo_a.ifunc
 ; CHECK0-DAG: @foo_a.ifunc = ifunc void (), ptr @foo_a.resolver
+; CHECK0-DAG: define hidden ptr @foo_a.resolver()
+; CHECK1-DAG: declare void @alias_foo()
 ; CHECK1-DAG: declare void @foo_a.ifunc()
+; CHECK1-DAG: declare hidden ptr @foo_a.resolver()
 
+@alias_foo = alias void (), ptr @foo_a.ifunc
 @foo_a.ifunc = ifunc void (), ptr @foo_a.resolver
-
-; CHECK0-DAG: define hidden void @foo.impl()
-; CHECK1-DAG: declare hidden void @foo.impl()
 
 define internal void @foo.impl() {
 entry:
   ret void
 }
 
-; CHECK0-DAG: define hidden ptr @foo_a.resolver()
-; CHECK1-DAG: declare hidden ptr @foo_a.resolver()
-
 define internal ptr @foo_a.resolver() {
 entry:
   ret ptr @foo.impl
 }
 
-; CHECK0-DAG: declare void @bar_a()
-; CHECK1-DAG: define void @bar_a()
-
 define void @bar_a() {
 entry:
-  call void @foo_a.ifunc()
+  call void @alias_foo()
   ret void
 }

--- a/llvm/test/tools/llvm-split/ifunc.ll
+++ b/llvm/test/tools/llvm-split/ifunc.ll
@@ -2,7 +2,6 @@
 ; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
 ; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
 
-
 ; CHECK0-DAG: declare void @foo_a.ifunc()
 ; CHECK1-DAG: @foo_a.ifunc = ifunc void (), ptr @foo_a.resolver
 

--- a/llvm/test/tools/llvm-split/ifunc.ll
+++ b/llvm/test/tools/llvm-split/ifunc.ll
@@ -1,0 +1,34 @@
+; RUN: llvm-split -j2 -o %t %s
+; RUN: llvm-dis -o - %t0 | FileCheck --check-prefix=CHECK0 %s
+; RUN: llvm-dis -o - %t1 | FileCheck --check-prefix=CHECK1 %s
+
+
+; CHECK0-DAG: declare void @foo_a.ifunc()
+; CHECK1-DAG: @foo_a.ifunc = ifunc void (), ptr @foo_a.resolver
+
+@foo_a.ifunc = ifunc void (), ptr @foo_a.resolver
+
+; CHECK0-DAG: define hidden void @foo.impl()
+; CHECK1-DAG: declare hidden void @foo.impl()
+
+define internal void @foo.impl() {
+entry:
+  ret void
+}
+
+; CHECK0-DAG: declare hidden ptr @foo_a.resolver()
+; CHECK1-DAG: define hidden ptr @foo_a.resolver()
+
+define internal ptr @foo_a.resolver() {
+entry:
+  ret ptr @foo.impl
+}
+
+; CHECK0-DAG: declare void @bar_a()
+; CHECK1-DAG: define void @bar_a()
+
+define void @bar_a() {
+entry:
+  call void @foo_a.ifunc()
+  ret void
+}


### PR DESCRIPTION
To satisfy the verifier rule "IFunc resolver must be a definition". We fix iFunc handling when cloning modules.
When cloning a module, if an IFunc has no definition (ShouldCloneDefinition returns false), directly create an external GlobalValue (Function or GlobalVariable) instead of trying to clone the ifunc.
Add a test case for llvm-split to verify the ifunc cloning/splitting behavior works correctly.