### PR TITLE
[BOLT] Fix data race in multi-threaded DWP type unit processing and DWP type unit duplication

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -286,7 +286,7 @@ class BinaryContext {
   void deregisterSectionName(const BinarySection &Section);
 
   /// Mutex used for parallel processing of DWP type units.
-  mutable std::recursive_mutex DWPUnitsMutex;
+  mutable std::mutex DWPUnitsMutex;
 
 public:
   static Expected<std::unique_ptr<BinaryContext>> createBinaryContext(
@@ -295,7 +295,7 @@ public:
       std::unique_ptr<DWARFContext> DwCtx, JournalingStreams Logger);
 
   /// Returns the mutex guarding concurrent access to DWP units.
-  std::recursive_mutex &getUnitsMutex() { return DWPUnitsMutex; }
+  std::mutex &getUnitsMutex() { return DWPUnitsMutex; }
 
   /// Superset of compiler units that will contain overwritten code that needs
   /// new debug info. In a few cases, functions may end up not being

--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -286,7 +286,7 @@ class BinaryContext {
   void deregisterSectionName(const BinarySection &Section);
 
   /// Mutex used for parallel processing of DWP type units.
-  mutable std::mutex DWPUnitsMutex;
+  std::mutex DWPUnitsMutex;
 
 public:
   static Expected<std::unique_ptr<BinaryContext>> createBinaryContext(

--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -48,6 +48,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
@@ -284,11 +285,17 @@ class BinaryContext {
   /// Internal helper for removing section name from a lookup table.
   void deregisterSectionName(const BinarySection &Section);
 
+  /// Mutex used for parallel processing of DWP type units.
+  mutable std::recursive_mutex DWPUnitsMutex;
+
 public:
   static Expected<std::unique_ptr<BinaryContext>> createBinaryContext(
       Triple TheTriple, std::shared_ptr<orc::SymbolStringPool> SSP,
       StringRef InputFileName, SubtargetFeatures *Features, bool IsPIC,
       std::unique_ptr<DWARFContext> DwCtx, JournalingStreams Logger);
+
+  /// Returns the mutex guarding concurrent access to DWP units.
+  std::recursive_mutex &getUnitsMutex() { return DWPUnitsMutex; }
 
   /// Superset of compiler units that will contain overwritten code that needs
   /// new debug info. In a few cases, functions may end up not being

--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -217,6 +217,14 @@ private:
   /// Returns true if DWARFUnit is registered successfully.
   bool registerUnit(DWARFUnit &DU, bool NeedSort);
 
+  /// Builds type units without extra synchronization.
+  void buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
+                          const bool Init);
+
+  /// Serializes type-unit construction for DWP-backed split DWARF contexts.
+  void buildTypeUnitsThreadSafe(DebugStrOffsetsWriter *StrOffsetWriter,
+                                const bool Init);
+
   /// \return the unique ID of \p U if it exists.
   std::optional<uint32_t> getUnitId(const DWARFUnit &DU);
 

--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -217,13 +217,8 @@ private:
   /// Returns true if DWARFUnit is registered successfully.
   bool registerUnit(DWARFUnit &DU, bool NeedSort);
 
-  /// Builds type units without extra synchronization.
-  void buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
-                          const bool Init);
-
-  /// Serializes type-unit construction for DWP-backed split DWARF contexts.
-  void buildTypeUnitsThreadSafe(DebugStrOffsetsWriter *StrOffsetWriter,
-                                const bool Init);
+  /// Builds type units needed in the DWO.
+  void buildDWPTypeUnitsForUnit(DWARFUnit &U);
 
   /// \return the unique ID of \p U if it exists.
   std::optional<uint32_t> getUnitId(const DWARFUnit &DU);

--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -220,6 +220,14 @@ private:
   /// Returns true if DWARFUnit is registered successfully.
   bool registerUnit(DWARFUnit &DU, bool NeedSort);
 
+  /// Builds type units without extra synchronization.
+  void buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
+                          const bool Init);
+
+  /// Serializes type-unit construction for DWP-backed split DWARF contexts.
+  void buildTypeUnitsThreadSafe(DebugStrOffsetsWriter *StrOffsetWriter,
+                                const bool Init);
+
   /// \return the unique ID of \p U if it exists.
   std::optional<uint32_t> getUnitId(const DWARFUnit &DU);
 

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -238,22 +238,6 @@ static unsigned int getCUNum(DWARFContext *DwarfContext, bool IsDWO) {
 
 void DIEBuilder::buildTypeUnits(DebugStrOffsetsWriter *StrOffsetWriter,
                                 const bool Init) {
-  if (DwarfContext->isDWP()) {
-    buildTypeUnitsThreadSafe(StrOffsetWriter, Init);
-    return;
-  }
-
-  buildTypeUnitsImpl(StrOffsetWriter, Init);
-}
-
-void DIEBuilder::buildTypeUnitsThreadSafe(
-    DebugStrOffsetsWriter *StrOffsetWriter, const bool Init) {
-  std::unique_lock<std::recursive_mutex> LockGuard(BC.getUnitsMutex());
-  buildTypeUnitsImpl(StrOffsetWriter, Init);
-}
-
-void DIEBuilder::buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
-                                    const bool Init) {
   if (Init)
     BuilderState.reset(new State());
 
@@ -297,6 +281,73 @@ void DIEBuilder::buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
     if (StrOffsetWriter)
       StrOffsetWriter->finalizeSection(*DU, *this);
   }
+}
+
+static void collectReferencedTypeSignatures(DWARFDie Die,
+                                            DenseSet<uint64_t> &ProcessedTU,
+                                            SmallVectorImpl<uint64_t> &TUlist) {
+  SmallVector<DWARFDie, 8> DIElist;
+  DIElist.push_back(Die);
+
+  while (!DIElist.empty()) {
+    DWARFDie Current = DIElist.pop_back_val();
+    if (!Current)
+      continue;
+
+    for (const DWARFAttribute &Attr : Current.attributes()) {
+      if (Attr.Value.getForm() != dwarf::DW_FORM_ref_sig8)
+        continue;
+      if (const std::optional<uint64_t> Signature =
+              Attr.Value.getAsSignatureReference())
+        if (ProcessedTU.insert(*Signature).second)
+          TUlist.push_back(*Signature);
+    }
+
+    for (DWARFDie Child : Current.children())
+      DIElist.push_back(Child);
+  }
+}
+
+void DIEBuilder::buildDWPTypeUnitsForUnit(DWARFUnit &U) {
+  // Avoid processing the same type unit multiple times.
+  DenseSet<uint64_t> ProcessedTU;
+  SmallVector<uint64_t, 8> TUlist;
+  // Collecting signatures of type units referenced by this unit.
+  collectReferencedTypeSignatures(U.getUnitDIE(), ProcessedTU, TUlist);
+
+  // addressing type units referenced.
+  for (unsigned I = 0; I != TUlist.size(); ++I) {
+    const uint64_t Signature = TUlist[I];
+    DWARFTypeUnit *TU = DwarfContext->getTypeUnitForHash(Signature, true);
+    if (!TU)
+      continue;
+
+    getState().Type = TU->getVersion() < 5 ? ProcessingType::DWARF4TUs
+                                           : ProcessingType::DWARF5TUs;
+    if (!registerUnit(*TU, false))
+      continue;
+
+    const std::optional<uint32_t> UnitId = getUnitId(*TU);
+    if (!UnitId || getState().CloneUnitCtxMap[*UnitId].IsConstructed)
+      continue;
+
+    collectReferencedTypeSignatures(TU->getUnitDIE(), ProcessedTU, TUlist);
+  }
+
+  // Ensure deterministic order of processing type units
+  auto SortByOffset = [](const DWARFUnit *A, const DWARFUnit *B) {
+    return A->getOffset() < B->getOffset();
+  };
+  llvm::sort(getState().DWARF4TUVector, SortByOffset);
+  llvm::sort(getState().DWARF5TUVector, SortByOffset);
+
+  getState().Type = ProcessingType::DWARF4TUs;
+  for (DWARFUnit *TU : getState().DWARF4TUVector)
+    constructFromUnit(*TU);
+
+  getState().Type = ProcessingType::DWARF5TUs;
+  for (DWARFUnit *TU : getState().DWARF5TUVector)
+    constructFromUnit(*TU);
 }
 
 void DIEBuilder::buildCompileUnits(const bool Init) {
@@ -344,7 +395,12 @@ void DIEBuilder::buildCompileUnits(const std::vector<DWARFUnit *> &CUs) {
 void DIEBuilder::buildDWOUnit(DWARFUnit &U) {
   BuilderState.release();
   BuilderState = std::make_unique<State>();
-  buildTypeUnits(nullptr, false);
+  if (DwarfContext->isDWP()) {
+    std::unique_lock<std::recursive_mutex> LockGuard(BC.getUnitsMutex());
+    buildDWPTypeUnitsForUnit(U);
+  } else {
+    buildTypeUnits(nullptr, false);
+  }
   getState().Type = ProcessingType::CUs;
   registerUnit(U, false);
   constructFromUnit(U);

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -396,7 +396,7 @@ void DIEBuilder::buildDWOUnit(DWARFUnit &U) {
   BuilderState.release();
   BuilderState = std::make_unique<State>();
   if (DwarfContext->isDWP()) {
-    std::unique_lock<std::recursive_mutex> LockGuard(BC.getUnitsMutex());
+    std::unique_lock<std::mutex> LockGuard(BC.getUnitsMutex());
     buildDWPTypeUnitsForUnit(U);
   } else {
     buildTypeUnits(nullptr, false);

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -238,6 +238,22 @@ static unsigned int getCUNum(DWARFContext *DwarfContext, bool IsDWO) {
 
 void DIEBuilder::buildTypeUnits(DebugStrOffsetsWriter *StrOffsetWriter,
                                 const bool Init) {
+  if (isDWO() && DwarfContext && DwarfContext->isDWP()) {
+    buildTypeUnitsThreadSafe(StrOffsetWriter, Init);
+    return;
+  }
+
+  buildTypeUnitsImpl(StrOffsetWriter, Init);
+}
+
+void DIEBuilder::buildTypeUnitsThreadSafe(
+    DebugStrOffsetsWriter *StrOffsetWriter, const bool Init) {
+  std::unique_lock<std::recursive_mutex> LockGuard(BC.getUnitsMutex());
+  buildTypeUnitsImpl(StrOffsetWriter, Init);
+}
+
+void DIEBuilder::buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
+                                    const bool Init) {
   if (Init)
     BuilderState.reset(new State());
 

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -283,6 +283,11 @@ void DIEBuilder::buildTypeUnits(DebugStrOffsetsWriter *StrOffsetWriter,
   }
 }
 
+/// Recursively collects type unit signatures from the given DIE and all of its
+/// children.
+///
+/// Note: De-duplication of the collected signatures is handled at the outer
+/// level by registerUnit.
 static void collectReferencedTypeSignatures(DWARFDie Die,
                                             DenseSet<uint64_t> &ProcessedTU,
                                             SmallVectorImpl<uint64_t> &TUlist) {
@@ -309,6 +314,7 @@ static void collectReferencedTypeSignatures(DWARFDie Die,
 }
 
 void DIEBuilder::buildDWPTypeUnitsForUnit(DWARFUnit &U) {
+  std::unique_lock<std::mutex> LockGuard(BC.getUnitsMutex());
   // Avoid processing the same type unit multiple times.
   DenseSet<uint64_t> ProcessedTU;
   SmallVector<uint64_t, 8> TUlist;
@@ -334,19 +340,18 @@ void DIEBuilder::buildDWPTypeUnitsForUnit(DWARFUnit &U) {
     collectReferencedTypeSignatures(TU->getUnitDIE(), ProcessedTU, TUlist);
   }
 
-  // Ensure deterministic order of processing type units
+  // Ensure original order of processing type units
   auto SortByOffset = [](const DWARFUnit *A, const DWARFUnit *B) {
     return A->getOffset() < B->getOffset();
   };
-  llvm::sort(getState().DWARF4TUVector, SortByOffset);
-  llvm::sort(getState().DWARF5TUVector, SortByOffset);
 
-  getState().Type = ProcessingType::DWARF4TUs;
-  for (DWARFUnit *TU : getState().DWARF4TUVector)
-    constructFromUnit(*TU);
+  // For Split DWARF, we have either DWARF4 or DWARF5, they cannot be mixed.
+  std::vector<DWARFUnit *> &TUVec = !getState().DWARF4TUVector.empty()
+                                        ? getState().DWARF4TUVector
+                                        : getState().DWARF5TUVector;
+  llvm::sort(TUVec, SortByOffset);
 
-  getState().Type = ProcessingType::DWARF5TUs;
-  for (DWARFUnit *TU : getState().DWARF5TUVector)
+  for (DWARFUnit *TU : TUVec)
     constructFromUnit(*TU);
 }
 
@@ -396,7 +401,6 @@ void DIEBuilder::buildDWOUnit(DWARFUnit &U) {
   BuilderState.release();
   BuilderState = std::make_unique<State>();
   if (DwarfContext->isDWP()) {
-    std::unique_lock<std::mutex> LockGuard(BC.getUnitsMutex());
     buildDWPTypeUnitsForUnit(U);
   } else {
     buildTypeUnits(nullptr, false);

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -321,15 +321,14 @@ void DIEBuilder::buildDWPTypeUnitsForUnit(DWARFUnit &U) {
   // Collecting signatures of type units referenced by this unit.
   collectReferencedTypeSignatures(U.getUnitDIE(), ProcessedTU, TUlist);
 
+  getState().Type = U.getVersion() < 5 ? ProcessingType::DWARF4TUs
+                                       : ProcessingType::DWARF5TUs;
   // addressing type units referenced.
   for (unsigned I = 0; I != TUlist.size(); ++I) {
     const uint64_t Signature = TUlist[I];
     DWARFTypeUnit *TU = DwarfContext->getTypeUnitForHash(Signature, true);
     if (!TU)
       continue;
-
-    getState().Type = TU->getVersion() < 5 ? ProcessingType::DWARF4TUs
-                                           : ProcessingType::DWARF5TUs;
     if (!registerUnit(*TU, false))
       continue;
 
@@ -346,7 +345,7 @@ void DIEBuilder::buildDWPTypeUnitsForUnit(DWARFUnit &U) {
   };
 
   // For Split DWARF, we have either DWARF4 or DWARF5, they cannot be mixed.
-  std::vector<DWARFUnit *> &TUVec = !getState().DWARF4TUVector.empty()
+  std::vector<DWARFUnit *> &TUVec = getState().Type == ProcessingType::DWARF4TUs
                                         ? getState().DWARF4TUVector
                                         : getState().DWARF5TUVector;
   llvm::sort(TUVec, SortByOffset);

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -238,7 +238,7 @@ static unsigned int getCUNum(DWARFContext *DwarfContext, bool IsDWO) {
 
 void DIEBuilder::buildTypeUnits(DebugStrOffsetsWriter *StrOffsetWriter,
                                 const bool Init) {
-  if (isDWO() && DwarfContext && DwarfContext->isDWP()) {
+  if (DwarfContext->isDWP()) {
     buildTypeUnitsThreadSafe(StrOffsetWriter, Init);
     return;
   }

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -268,6 +268,22 @@ static unsigned int getCUNum(DWARFContext *DwarfContext, bool IsDWO) {
 
 void DIEBuilder::buildTypeUnits(DebugStrOffsetsWriter *StrOffsetWriter,
                                 const bool Init) {
+  if (isDWO() && DwarfContext && DwarfContext->isDWP()) {
+    buildTypeUnitsThreadSafe(StrOffsetWriter, Init);
+    return;
+  }
+
+  buildTypeUnitsImpl(StrOffsetWriter, Init);
+}
+
+void DIEBuilder::buildTypeUnitsThreadSafe(
+    DebugStrOffsetsWriter *StrOffsetWriter, const bool Init) {
+  std::unique_lock<std::recursive_mutex> LockGuard(BC.getUnitsMutex());
+  buildTypeUnitsImpl(StrOffsetWriter, Init);
+}
+
+void DIEBuilder::buildTypeUnitsImpl(DebugStrOffsetsWriter *StrOffsetWriter,
+                                    const bool Init) {
   if (Init)
     BuilderState.reset(new State());
 

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -496,12 +496,8 @@ static void emitDWOBuilder(const std::string &DWOName,
       createDIEStreamer(*TheTriple, *ObjOS, "DwoStreamerInitAug2",
                         DWODIEBuilder, GDBIndexSection);
   if (SplitCU.getContext().getMaxDWOVersion() >= 5) {
-    for (std::unique_ptr<llvm::DWARFUnit> &CU :
-         SplitCU.getContext().dwo_info_section_units()) {
-      if (!CU->isTypeUnit())
-        continue;
+    for (DWARFUnit *CU : DWODIEBuilder.getDWARF5TUVector())
       emitUnit(DWODIEBuilder, *Streamer, *CU);
-    }
     emitUnit(DWODIEBuilder, *Streamer, SplitCU);
   } else {
     emitUnit(DWODIEBuilder, *Streamer, SplitCU);

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -441,10 +441,10 @@ RewriteInstance::RewriteInstance(ELFObjectFileBase *File, const int Argc,
   auto BCOrErr = BinaryContext::createBinaryContext(
       TheTriple, std::make_shared<orc::SymbolStringPool>(), File->getFileName(),
       Features.get(), IsPIC,
-      DWARFContext::create(*File, DWARFContext::ProcessDebugRelocations::Ignore,
-                           nullptr, opts::DWPPathName,
-                           WithColor::defaultErrorHandler,
-                           WithColor::defaultWarningHandler),
+      DWARFContext::create(
+          *File, DWARFContext::ProcessDebugRelocations::Ignore, nullptr,
+          opts::DWPPathName, WithColor::defaultErrorHandler,
+          WithColor::defaultWarningHandler, !opts::DWPPathName.empty()),
       JournalingStreams{Stdout, Stderr});
   if (Error E = BCOrErr.takeError()) {
     Err = std::move(E);

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -444,7 +444,7 @@ RewriteInstance::RewriteInstance(ELFObjectFileBase *File, const int Argc,
       DWARFContext::create(
           *File, DWARFContext::ProcessDebugRelocations::Ignore, nullptr,
           opts::DWPPathName, WithColor::defaultErrorHandler,
-          WithColor::defaultWarningHandler, !opts::DWPPathName.empty()),
+          WithColor::defaultWarningHandler, true),
       JournalingStreams{Stdout, Stderr});
   if (Error E = BCOrErr.takeError()) {
     Err = std::move(E);

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -441,10 +441,10 @@ RewriteInstance::RewriteInstance(ELFObjectFileBase *File, const int Argc,
   auto BCOrErr = BinaryContext::createBinaryContext(
       TheTriple, std::make_shared<orc::SymbolStringPool>(), File->getFileName(),
       Features.get(), IsPIC,
-      DWARFContext::create(
-          *File, DWARFContext::ProcessDebugRelocations::Ignore, nullptr,
-          opts::DWPPathName, WithColor::defaultErrorHandler,
-          WithColor::defaultWarningHandler, true),
+      DWARFContext::create(*File, DWARFContext::ProcessDebugRelocations::Ignore,
+                           nullptr, opts::DWPPathName,
+                           WithColor::defaultErrorHandler,
+                           WithColor::defaultWarningHandler, true),
       JournalingStreams{Stdout, Stderr});
   if (Error E = BCOrErr.takeError()) {
     Err = std::move(E);

--- a/bolt/test/X86/dwarf5-df-types-dup-dwp-input.test
+++ b/bolt/test/X86/dwarf5-df-types-dup-dwp-input.test
@@ -7,7 +7,7 @@
 ; RUN: -split-dwarf-file=helper.dwo -o helper.o
 ; RUN: %clang %cflags -gdwarf-5 -gsplit-dwarf=split main.o helper.o -o main.exe
 ; RUN: llvm-dwp -e main.exe -o main.exe.dwp
-; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections
+; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections  --debug-thread-count=4 --cu-processing-batch-size=4
 ; RUN: llvm-dwarfdump --debug-info -r 0 main.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-MAIN %s
 ; RUN: llvm-dwarfdump --debug-info -r 0 helper.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-HELPER %s
 

--- a/bolt/test/X86/dwarf5-df-types-dup-dwp-input.test
+++ b/bolt/test/X86/dwarf5-df-types-dup-dwp-input.test
@@ -7,7 +7,7 @@
 ; RUN: -split-dwarf-file=helper.dwo -o helper.o
 ; RUN: %clang %cflags -gdwarf-5 -gsplit-dwarf=split main.o helper.o -o main.exe
 ; RUN: llvm-dwp -e main.exe -o main.exe.dwp
-; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections  --debug-thread-count=4 --cu-processing-batch-size=4
+; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections
 ; RUN: llvm-dwarfdump --debug-info -r 0 main.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-MAIN %s
 ; RUN: llvm-dwarfdump --debug-info -r 0 helper.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-HELPER %s
 

--- a/bolt/test/X86/dwarf5-df-types-dup-dwp-input.test
+++ b/bolt/test/X86/dwarf5-df-types-dup-dwp-input.test
@@ -11,17 +11,18 @@
 ; RUN: llvm-dwarfdump --debug-info -r 0 main.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-MAIN %s
 ; RUN: llvm-dwarfdump --debug-info -r 0 helper.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-HELPER %s
 
-;; Tests that BOLT correctly handles DWARF5 DWP file as input. Output has correct CU, and all the type units are written out.
+;; Tests that BOLT correctly handles DWARF5 DWP file as input. Output has the correct CU,
+;; and only type units referenced by that CU are written out.
 
 ; BOLT-DWO-DWO-MAIN: debug_info.dwo
 ; BOLT-DWO-DWO-MAIN-NEXT: type_signature = 0x49dc260088be7e56
 ; BOLT-DWO-DWO-MAIN: type_signature = 0x104ec427d2ebea6f
-; BOLT-DWO-DWO-MAIN: type_signature = 0xca1e65a66d92b970
+; BOLT-DWO-DWO-MAIN-NOT: type_signature = 0xca1e65a66d92b970
 ; BOLT-DWO-DWO-MAIN: Compile Unit
 ; BOLT-DWO-DWO-MAIN-SAME: DWO_id = 0x52bda211bf6d26b7
 ; BOLT-DWO-DWO-MAIN-NOT: Compile Unit
 ; BOLT-DWO-DWO-HELPER: debug_info.dwo
-; BOLT-DWO-DWO-HELPER-NEXT: type_signature = 0x49dc260088be7e56
+; BOLT-DWO-DWO-HELPER-NOT: type_signature = 0x49dc260088be7e56
 ; BOLT-DWO-DWO-HELPER: type_signature = 0x104ec427d2ebea6f
 ; BOLT-DWO-DWO-HELPER: type_signature = 0xca1e65a66d92b970
 ; BOLT-DWO-DWO-HELPER: Compile Unit

--- a/bolt/test/X86/dwarf5-dwp-tsan-data-race.test
+++ b/bolt/test/X86/dwarf5-dwp-tsan-data-race.test
@@ -1,0 +1,26 @@
+; RUN: rm -rf %t
+; RUN: mkdir %t
+; RUN: cd %t
+; RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf5-df-types-dup-main.s \
+; RUN:   -split-dwarf-file=main.dwo -o main.o
+; RUN: llvm-mc -dwarf-version=5 -filetype=obj -triple x86_64-unknown-linux %p/Inputs/dwarf5-df-types-dup-helper.s \
+; RUN:   -split-dwarf-file=helper.dwo -o helper.o
+; RUN: %clang %cflags -gdwarf-5 -gsplit-dwarf=split main.o helper.o -o main.exe
+; RUN: llvm-dwp -e main.exe -o main.exe.dwp
+; RUN: llvm-bolt main.exe -o main.exe.bolt --update-debug-sections \
+; RUN:   --thread-count=4 --cu-processing-batch-size=4 --dwp=main.exe.dwp 2>&1 | FileCheck %s
+; RUN: llvm-dwarfdump --debug-info -r 0 main.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-MAIN %s
+; RUN: llvm-dwarfdump --debug-info -r 0 helper.dwo.dwo | FileCheck -check-prefix=BOLT-DWO-DWO-HELPER %s
+
+;; Tests that BOLT correctly handles DWARF5 DWP file as input in a
+;; multi-threaded configuration without triggering ThreadSanitizer (TSan)
+;; data race reports. The binary must be built with TSan instrumentation
+;; (i.e. LLVM_USE_SANITIZER=Thread) for this test to be effective.
+;; REQUIRES: tsan
+
+; CHECK-NOT: ThreadSanitizer: data race
+; CHECK-NOT: ThreadSanitizer: reported
+; CHECK-NOT: WARNING: ThreadSanitizer
+
+; BOLT-DWO-DWO-MAIN: DW_TAG_compile_unit
+; BOLT-DWO-DWO-HELPER: DW_TAG_compile_unit


### PR DESCRIPTION
## Summary
This PR fixes a race condition in LLVM BOLT's DIEBuilder::buildTypeUnits() that is triggered when DWARF5 split-DWARF (.dwo/.dwp) inputs are processed with multi-threaded CU processing. Concurrent invocations from different worker threads share the same DWP type-unit state, which results in duplicated DIE extraction, assertion failures, and intermittent crashes. The fix serializes buildTypeUnits() for DWP inputs via a function-local static std::mutex, leaving the non-DWO fast path unchanged.
## Problem Description
When BOLT processes DWARF debug info with --debug-thread-count=4 --cu-processing-batch-size=4 on testcase dwarf5-df-types-dup-dwp-input.test, multiple threads concurrently call DIEBuilder::buildTypeUnits() on shared DWP type units. Since type units within a DWP file are shared across compilation units, multiple threads may attempt to extract DIEs from the same type unit simultaneously, violating the assertion.

**Note:** This is an intermittent failure — due to its dependence on thread scheduling and interleaving, it does not reproduce on every run, and may require multiple executions under the multi-threaded configuration to surface, which is why it escaped earlier single-threaded testing.