### PR TITLE
[AMDGPU] AMDGPULibCalls: Set new intrinsic calling convention to C

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -1624,6 +1624,7 @@ void AMDGPULibCalls::replaceLibCallWithSimpleIntrinsic(IRBuilder<> &B,
 
   CI->setCalledFunction(Intrinsic::getOrInsertDeclaration(
       CI->getModule(), IntrID, {CI->getType()}));
+  CI->setCallingConv(CallingConv::C);
 }
 
 bool AMDGPULibCalls::tryReplaceLibcallWithSimpleIntrinsic(

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-fabs.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-fabs.ll
@@ -32,6 +32,16 @@ define float @test_fabs_f32(float %arg) {
   ret float %fabs
 }
 
+define float @test_fabs_f32_fastcc(float %arg) {
+; CHECK-LABEL: define float @test_fabs_f32_fastcc
+; CHECK-SAME: (float [[ARG:%.*]]) {
+; CHECK-NEXT:    [[FABS:%.*]] = tail call float @llvm.fabs.f32(float [[ARG]])
+; CHECK-NEXT:    ret float [[FABS]]
+;
+  %fabs = tail call fastcc float @_Z4fabsf(float %arg)
+  ret float %fabs
+}
+
 define <2 x float> @test_fabs_v2f32(<2 x float> %arg) {
 ; CHECK-LABEL: define <2 x float> @test_fabs_v2f32
 ; CHECK-SAME: (<2 x float> [[ARG:%.*]]) {
@@ -266,7 +276,7 @@ define <2 x float> @test_fabs_v2f32_preserve_flags(<2 x float> %arg) {
 define float @test_fabs_f32_preserve_flags_md(float %arg) {
 ; CHECK-LABEL: define float @test_fabs_f32_preserve_flags_md
 ; CHECK-SAME: (float [[ARG:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = tail call nnan ninf float @llvm.fabs.f32(float [[ARG]]), !foo !0
+; CHECK-NEXT:    [[FABS:%.*]] = tail call nnan ninf float @llvm.fabs.f32(float [[ARG]]), !foo [[META0:![0-9]+]]
 ; CHECK-NEXT:    ret float [[FABS]]
 ;
   %fabs = tail call nnan ninf float @_Z4fabsf(float %arg), !foo !0
@@ -276,7 +286,7 @@ define float @test_fabs_f32_preserve_flags_md(float %arg) {
 define <2 x float> @test_fabs_v2f32_preserve_flags_md(<2 x float> %arg) {
 ; CHECK-LABEL: define <2 x float> @test_fabs_v2f32_preserve_flags_md
 ; CHECK-SAME: (<2 x float> [[ARG:%.*]]) {
-; CHECK-NEXT:    [[FABS:%.*]] = tail call nnan nsz contract <2 x float> @llvm.fabs.v2f32(<2 x float> [[ARG]]), !foo !0
+; CHECK-NEXT:    [[FABS:%.*]] = tail call nnan nsz contract <2 x float> @llvm.fabs.v2f32(<2 x float> [[ARG]]), !foo [[META0]]
 ; CHECK-NEXT:    ret <2 x float> [[FABS]]
 ;
   %fabs = tail call contract nsz nnan <2 x float> @_Z4fabsDv2_f(<2 x float> %arg), !foo !0


### PR DESCRIPTION
In #197151 libclc/test/math/fabs.cl, tryReplaceLibcallWithSimpleIntrinsic replaces `call fastcc float @_Z4fabsf` with `call fastcc float @llvm.fabs.f32`. But intrinsic call must use CallingConv::C.