### PR TITLE
Fix libc building errors for SPIRV target

### DIFF
--- a/libc/CMakeLists.txt
+++ b/libc/CMakeLists.txt
@@ -412,7 +412,7 @@ add_subdirectory(hdr)
 add_subdirectory(src)
 add_subdirectory(utils)
 
-if(LLVM_LIBC_FULL_BUILD)
+if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_ARCHITECTURE_IS_SPIRV)
   # The startup system can potentially depend on the library components so add
   # it after the library implementation directories.
   add_subdirectory(startup)

--- a/libc/config/gpu/spirv/entrypoints.txt
+++ b/libc/config/gpu/spirv/entrypoints.txt
@@ -31,6 +31,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.ctype.toupper
     libc.src.ctype.toupper_l
 
+    # errno.h entrypoints
+    libc.src.errno.errno
+
     # string.h entrypoints
     libc.src.string.memccpy
     libc.src.string.memchr


### PR DESCRIPTION
This is follow-up work of https://github.com/llvm/llvm-project/pull/181049 which aims to build LLVM libc for SPIRV target.
When building LLVM libc for 'spirv64-unknown-unknown' via:
cmake ../llvm -G Ninja -DCMAKE_BUILD_TYPE=Release  -DLLVM_ENABLE_PROJECTS="clang"  -DRUNTIMES_spirv64-unknown-unknown_LLVM_ENABLE_RUNTIMES="libc" -DLLVM_RUNTIME_TARGETS="default;spirv64-unknown-unknown"
Two errors came up:
1. cmake configuration fata error complaining"Target "libc.src.errno.errno" of type UTILITY may not be linked into another target."
2. cmake configuration fata error complaining "Target "libc.src.stdlib.exit" of type UTILITY may not be linked into another target."

For 1, the reason is we enabled some string functions which depends on libc errno but didn't add libc errno into entrypoints, so the dependency is not met in cmake configuration.
For 2, LLVM libc requires LLVM_LIBC_FULL_BUILD to be set and 'startup' will be built for GPU target. The 'startup' component requires stdlib.exit which is not in SPIRV entrypoints.

To fix 1, this patch adds errno to entrypoints. For 2, this patch just skips 'startup' for SPIRV, this is because 'startup'  component also requires RPC and SPIRV target doesn't support RPC.