### PR TITLE
[AArch64][GlobalISel] Fast-path common G_CONSTANT/G_BRCOND/G_FRAME_INDEX regbank mappings

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -969,6 +969,26 @@ AArch64RegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
         // We only care about the mapping of the destination for COPY.
         /*NumOperands*/ Opc == TargetOpcode::G_BITCAST ? 2 : 1);
   }
+  case TargetOpcode::G_CONSTANT: {
+    LLT DstTy = MRI.getType(MI.getOperand(0).getReg());
+    TypeSize Size = DstTy.getSizeInBits();
+    if (!(DstTy.isPointer() || (DstTy.isScalar() && Size >= 32 && Size <= 64)))
+      break;
+    // Scalar constants materialize in GPRs.
+    [[fallthrough]];
+  }
+  case TargetOpcode::G_BRCOND:
+  case TargetOpcode::G_FRAME_INDEX: {
+    // Operand 0 is the only banked operand and is mapped to GPR.
+    return getInstructionMapping(
+        DefaultMappingID, /*Cost=*/1,
+        getOperandsMapping(
+            {getValueMapping(
+                 PMI_FirstGPR,
+                 MRI.getType(MI.getOperand(0).getReg()).getSizeInBits()),
+             nullptr}),
+        /*NumOperands=*/2);
+  }
   default:
     break;
   }

--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -972,7 +972,7 @@ AArch64RegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
   case TargetOpcode::G_CONSTANT: {
     LLT DstTy = MRI.getType(MI.getOperand(0).getReg());
     TypeSize Size = DstTy.getSizeInBits();
-    if (!(DstTy.isPointer() || (DstTy.isScalar() && Size >= 32 && Size <= 64)))
+    if (!DstTy.isPointer() && (!DstTy.isScalar() || Size < 32 || Size > 64))
       break;
     // Scalar constants materialize in GPRs.
     [[fallthrough]];


### PR DESCRIPTION
Returning the default register-bank mapping directly for these opcodes is a -0.17% compile-time improvement on aarch64-O0-g.

https://llvm-compile-time-tracker.com/compare.php?from=b4aa4d4dcb6f1c8a00d1d1e53d2b353c97ec98b7&to=0779891fc6bf6a01e4f14d3f359e212c6ec52c0d&stat=instructions%3Au

Assisted-by: codex