### PR TITLE
[lldb][Windows] Cache thread context in NativeRegisterContextWindows_arm64

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
@@ -101,52 +101,62 @@ CreateRegisterInfoInterface(const ArchSpec &target_arch) {
       target_arch, RegisterInfoPOSIX_arm64::eRegsetMaskDefault);
 }
 
-static Status
-GetThreadContextHelper(lldb::thread_t thread_handle, DWORD context_flags,
-                       PCONTEXT &context,
-                       std::shared_ptr<DataBufferHeap> &context_buffer) {
+static Status GetThreadContextLength(DWORD context_flags,
+                                     DWORD &context_length) {
   Log *log = GetLog(WindowsLog::Registers);
   Status error;
-  DWORD context_length = 0;
 
   if (InitializeContext(nullptr, context_flags, nullptr, &context_length)) {
     error = Status::FromErrorString("InitializeContext succeeded unexpectedly");
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    LLDB_LOG(log, "{0}", error);
     return error;
   }
 
   if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
     error = Status(GetLastError(), eErrorTypeWin32);
     LLDB_LOG(log,
-             "{0} InitializeContext failed with unexpected error {1}, expected "
+             "InitializeContext failed with unexpected error {0}, expected "
              "ERROR_INSUFFICIENT_BUFFER",
-             __FUNCTION__, error);
+             error);
     return error;
   }
 
-  if (context_buffer)
-    context_buffer->SetByteSize(context_length);
-  else
-    context_buffer = std::make_shared<DataBufferHeap>(context_length, 0);
+  return error;
+}
+
+static Status GetThreadContextHelper(lldb::thread_t thread_handle,
+                                     DWORD context_flags, PCONTEXT &context,
+                                     DataBufferHeap *context_buffer) {
+  Log *log = GetLog(WindowsLog::Registers);
+  Status error;
+  DWORD context_length = 0;
 
   if (!context_buffer) {
-    error = Status::FromErrorString("Failed to allocate context buffer");
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    error = Status::FromErrorString("context buffer not allocated");
+    LLDB_LOG(log, "{0}", error);
+    return error;
+  }
+
+  error = GetThreadContextLength(context_flags, context_length);
+  if (error.Fail())
+    return error;
+
+  if (context_buffer->SetByteSize(context_length) != context_length) {
+    error = Status::FromErrorString("failed to resize context buffer");
+    LLDB_LOG(log, "{0}", error);
     return error;
   }
 
   if (!InitializeContext(context_buffer->GetBytes(), context_flags, &context,
                          &context_length)) {
     error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log, "{0} InitializeContext failed with error {1}", __FUNCTION__,
-             error);
+    LLDB_LOG(log, "InitializeContext failed with error {0}", error);
     return error;
   }
 
   if (!::GetThreadContext(thread_handle, context)) {
     error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log, "{0} GetThreadContext failed with error {1}", __FUNCTION__,
-             error);
+    LLDB_LOG(log, "GetThreadContext failed with error {0}", error);
     return error;
   }
 
@@ -159,8 +169,7 @@ static Status SetThreadContextHelper(lldb::thread_t thread_handle,
   Status error;
   if (!::SetThreadContext(thread_handle, context)) {
     error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log, "{0} SetThreadContext failed with error {1}", __FUNCTION__,
-             error);
+    LLDB_LOG(log, "SetThreadContext failed with error {0}", error);
     return error;
   }
   return error;
@@ -302,12 +311,12 @@ NativeRegisterContextWindows_arm64::GPRWrite(const uint32_t reg,
   auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
 
   PCONTEXT context = nullptr;
-  std::shared_ptr<DataBufferHeap> context_buffer;
+  DataBufferHeap context_buffer;
   DWORD context_flags = CONTEXT_CONTROL | CONTEXT_INTEGER;
   auto thread_handle = GetThreadHandle();
 
   Status error = GetThreadContextHelper(thread_handle, context_flags, context,
-                                        context_buffer);
+                                        &context_buffer);
   if (error.Fail())
     return error;
 
@@ -527,12 +536,12 @@ NativeRegisterContextWindows_arm64::FPRWrite(const uint32_t reg,
   auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
 
   PCONTEXT context = nullptr;
-  std::shared_ptr<DataBufferHeap> context_buffer;
+  DataBufferHeap context_buffer;
   DWORD context_flags = CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
   auto thread_handle = GetThreadHandle();
 
   Status error = GetThreadContextHelper(thread_handle, context_flags, context,
-                                        context_buffer);
+                                        &context_buffer);
   if (error.Fail())
     return error;
 
@@ -722,20 +731,12 @@ Status NativeRegisterContextWindows_arm64::ReadAllRegisterValues(
 
   if (!m_context_buffer) {
     error = Status::FromErrorString("register context buffer is not available");
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    LLDB_LOG(log, "{0}", error);
     return error;
   }
 
-  const size_t data_size = m_context_buffer->GetByteSize();
-  data_sp = std::make_shared<DataBufferHeap>(data_size, 0);
-
-  if (!data_sp) {
-    error = Status::FromErrorString("failed to allocate register data buffer");
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
-    return error;
-  }
-
-  ::memcpy(data_sp->GetBytes(), m_context_buffer->GetBytes(), data_size);
+  data_sp = std::make_shared<DataBufferHeap>(m_context_buffer->GetBytes(),
+                                             m_context_buffer->GetByteSize());
 
   return error;
 }
@@ -749,44 +750,33 @@ Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
 
   if (!data_sp) {
     error = Status::FromErrorString("invalid data_sp");
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    LLDB_LOG(log, "{0}", error);
     return error;
   }
 
   DWORD context_flags = CONTEXT_ALL;
-
   DWORD context_length = 0;
-  if (InitializeContext(nullptr, context_flags, nullptr, &context_length)) {
-    error = Status::FromErrorString("InitializeContext succeeded unexpectedly");
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
-    return error;
-  }
 
-  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
-    error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log,
-             "{0} InitializeContext failed with unexpected error {1}, expected "
-             "ERROR_INSUFFICIENT_BUFFER",
-             __FUNCTION__, error);
+  error = GetThreadContextLength(context_flags, context_length);
+  if (error.Fail())
     return error;
-  }
 
   if (data_sp->GetByteSize() != context_length) {
     error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
         context_length, data_sp->GetByteSize());
-    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    LLDB_LOG(log, "{0}", error);
     return error;
   }
 
   PCONTEXT context = nullptr;
-  std::shared_ptr<DataBufferHeap> context_buffer;
+  DataBufferHeap context_buffer;
   error = GetThreadContextHelper(GetThreadHandle(), context_flags, context,
-                                 context_buffer);
+                                 &context_buffer);
   if (error.Fail())
     return error;
 
-  ::memcpy(context_buffer->GetBytes(), data_sp->GetBytes(), context_length);
+  ::memcpy(context_buffer.GetBytes(), data_sp->GetBytes(), context_length);
 
   return SetThreadContextHelper(GetThreadHandle(), context);
 }
@@ -809,12 +799,12 @@ NativeRegisterContextWindows_arm64::WriteHardwareDebugRegs(DREGType hwbType) {
   auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
 
   PCONTEXT context = nullptr;
-  std::shared_ptr<DataBufferHeap> context_buffer;
+  DataBufferHeap context_buffer;
   DWORD context_flags = CONTEXT_DEBUG_REGISTERS;
   auto thread_handle = GetThreadHandle();
 
   Status error = GetThreadContextHelper(thread_handle, context_flags, context,
-                                        context_buffer);
+                                        &context_buffer);
   if (error.Fail())
     return error.ToError();
 
@@ -842,13 +832,14 @@ Status NativeRegisterContextWindows_arm64::CacheAllRegisterValues() {
 
   m_context = nullptr;
 
-  auto cleanup = llvm::make_scope_exit([&]() {
-    if (error.Fail())
-      m_context = nullptr;
-  });
+  if (!m_context_buffer)
+    m_context_buffer = std::make_shared<DataBufferHeap>();
 
   error = GetThreadContextHelper(GetThreadHandle(), context_flags, m_context,
-                                 m_context_buffer);
+                                 m_context_buffer.get());
+
+  if (error.Fail())
+    m_context = nullptr;
 
   return error;
 }

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
@@ -14,11 +14,11 @@
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/HostThread.h"
 #include "lldb/Host/windows/HostThreadWindows.h"
-#include "lldb/Host/windows/windows.h"
 
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegisterValue.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -101,35 +101,67 @@ CreateRegisterInfoInterface(const ArchSpec &target_arch) {
       target_arch, RegisterInfoPOSIX_arm64::eRegsetMaskDefault);
 }
 
-static Status GetThreadContextHelper(lldb::thread_t thread_handle,
-                                     PCONTEXT context_ptr,
-                                     const DWORD control_flag) {
+static Status
+GetThreadContextHelper(lldb::thread_t thread_handle, DWORD context_flags,
+                       PCONTEXT &context,
+                       std::shared_ptr<DataBufferHeap> &context_buffer) {
   Log *log = GetLog(WindowsLog::Registers);
   Status error;
+  DWORD context_length = 0;
 
-  memset(context_ptr, 0, sizeof(::CONTEXT));
-  context_ptr->ContextFlags = control_flag;
-  if (!::GetThreadContext(thread_handle, context_ptr)) {
+  if (InitializeContext(nullptr, context_flags, nullptr, &context_length)) {
+    error = Status::FromErrorString("InitializeContext succeeded unexpectedly");
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    return error;
+  }
+
+  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    error = Status(GetLastError(), eErrorTypeWin32);
+    LLDB_LOG(log, "{0} InitializeContext failed with error {1}", __FUNCTION__,
+             error);
+    return error;
+  }
+
+  if (context_buffer)
+    context_buffer->SetByteSize(context_length);
+  else
+    context_buffer = std::make_shared<DataBufferHeap>(context_length, 0);
+
+  if (!context_buffer) {
+    error = Status::FromErrorString("Failed to allocate context buffer");
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    return error;
+  }
+
+  if (!InitializeContext(context_buffer->GetBytes(), context_flags, &context,
+                         &context_length)) {
+    error = Status(GetLastError(), eErrorTypeWin32);
+    LLDB_LOG(log, "{0} InitializeContext failed with error {1}", __FUNCTION__,
+             error);
+    return error;
+  }
+
+  if (!::GetThreadContext(thread_handle, context)) {
     error = Status(GetLastError(), eErrorTypeWin32);
     LLDB_LOG(log, "{0} GetThreadContext failed with error {1}", __FUNCTION__,
              error);
     return error;
   }
+
   return Status();
 }
 
 static Status SetThreadContextHelper(lldb::thread_t thread_handle,
-                                     PCONTEXT context_ptr) {
+                                     PCONTEXT context) {
   Log *log = GetLog(WindowsLog::Registers);
   Status error;
-  // It's assumed that the thread has stopped.
-  if (!::SetThreadContext(thread_handle, context_ptr)) {
+  if (!::SetThreadContext(thread_handle, context)) {
     error = Status(GetLastError(), eErrorTypeWin32);
     LLDB_LOG(log, "{0} SetThreadContext failed with error {1}", __FUNCTION__,
              error);
     return error;
   }
-  return Status();
+  return error;
 }
 
 std::unique_ptr<NativeRegisterContextWindows>
@@ -143,7 +175,8 @@ NativeRegisterContextWindows::CreateHostNativeRegisterContextWindows(
 NativeRegisterContextWindows_arm64::NativeRegisterContextWindows_arm64(
     const ArchSpec &target_arch, NativeThreadProtocol &native_thread)
     : NativeRegisterContextRegisterInfo(
-          native_thread, CreateRegisterInfoInterface(target_arch)) {
+          native_thread, CreateRegisterInfoInterface(target_arch)),
+      m_context(nullptr), m_context_buffer(nullptr) {
   // Currently, there is no API to query the maximum supported hardware
   // breakpoints and watchpoints on Windows. The values set below are based
   // on tests conducted on Windows 11 with Snapdragon Elite X hardware.
@@ -171,10 +204,7 @@ NativeRegisterContextWindows_arm64::GetRegisterSet(uint32_t set_index) const {
 
 Status NativeRegisterContextWindows_arm64::GPRRead(const uint32_t reg,
                                                    RegisterValue &reg_value) {
-  ::CONTEXT tls_context;
-  DWORD context_flag = CONTEXT_CONTROL | CONTEXT_INTEGER;
-  Status error =
-      GetThreadContextHelper(GetThreadHandle(), &tls_context, context_flag);
+  Status error = CacheAllRegisterValues();
   if (error.Fail())
     return error;
 
@@ -208,23 +238,23 @@ Status NativeRegisterContextWindows_arm64::GPRRead(const uint32_t reg,
   case gpr_x26_arm64:
   case gpr_x27_arm64:
   case gpr_x28_arm64:
-    reg_value.SetUInt64(tls_context.X[reg - gpr_x0_arm64]);
+    reg_value.SetUInt64(m_context->X[reg - gpr_x0_arm64]);
     break;
 
   case gpr_fp_arm64:
-    reg_value.SetUInt64(tls_context.Fp);
+    reg_value.SetUInt64(m_context->Fp);
     break;
   case gpr_sp_arm64:
-    reg_value.SetUInt64(tls_context.Sp);
+    reg_value.SetUInt64(m_context->Sp);
     break;
   case gpr_lr_arm64:
-    reg_value.SetUInt64(tls_context.Lr);
+    reg_value.SetUInt64(m_context->Lr);
     break;
   case gpr_pc_arm64:
-    reg_value.SetUInt64(tls_context.Pc);
+    reg_value.SetUInt64(m_context->Pc);
     break;
   case gpr_cpsr_arm64:
-    reg_value.SetUInt32(tls_context.Cpsr);
+    reg_value.SetUInt32(m_context->Cpsr);
     break;
 
   case gpr_w0_arm64:
@@ -257,7 +287,7 @@ Status NativeRegisterContextWindows_arm64::GPRRead(const uint32_t reg,
   case gpr_w27_arm64:
   case gpr_w28_arm64:
     reg_value.SetUInt32(
-        static_cast<uint32_t>(tls_context.X[reg - gpr_w0_arm64] & 0xffffffff));
+        static_cast<uint32_t>(m_context->X[reg - gpr_w0_arm64] & 0xffffffff));
     break;
   }
 
@@ -267,11 +297,15 @@ Status NativeRegisterContextWindows_arm64::GPRRead(const uint32_t reg,
 Status
 NativeRegisterContextWindows_arm64::GPRWrite(const uint32_t reg,
                                              const RegisterValue &reg_value) {
-  ::CONTEXT tls_context;
-  DWORD context_flag = CONTEXT_CONTROL | CONTEXT_INTEGER;
+  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+
+  PCONTEXT context = nullptr;
+  std::shared_ptr<DataBufferHeap> context_buffer;
+  DWORD context_flags = CONTEXT_CONTROL | CONTEXT_INTEGER;
   auto thread_handle = GetThreadHandle();
-  Status error =
-      GetThreadContextHelper(thread_handle, &tls_context, context_flag);
+
+  Status error = GetThreadContextHelper(thread_handle, context_flags, context,
+                                        context_buffer);
   if (error.Fail())
     return error;
 
@@ -305,23 +339,23 @@ NativeRegisterContextWindows_arm64::GPRWrite(const uint32_t reg,
   case gpr_x26_arm64:
   case gpr_x27_arm64:
   case gpr_x28_arm64:
-    tls_context.X[reg - gpr_x0_arm64] = reg_value.GetAsUInt64();
+    context->X[reg - gpr_x0_arm64] = reg_value.GetAsUInt64();
     break;
 
   case gpr_fp_arm64:
-    tls_context.Fp = reg_value.GetAsUInt64();
+    context->Fp = reg_value.GetAsUInt64();
     break;
   case gpr_sp_arm64:
-    tls_context.Sp = reg_value.GetAsUInt64();
+    context->Sp = reg_value.GetAsUInt64();
     break;
   case gpr_lr_arm64:
-    tls_context.Lr = reg_value.GetAsUInt64();
+    context->Lr = reg_value.GetAsUInt64();
     break;
   case gpr_pc_arm64:
-    tls_context.Pc = reg_value.GetAsUInt64();
+    context->Pc = reg_value.GetAsUInt64();
     break;
   case gpr_cpsr_arm64:
-    tls_context.Cpsr = reg_value.GetAsUInt32();
+    context->Cpsr = reg_value.GetAsUInt32();
     break;
 
   case gpr_w0_arm64:
@@ -353,19 +387,16 @@ NativeRegisterContextWindows_arm64::GPRWrite(const uint32_t reg,
   case gpr_w26_arm64:
   case gpr_w27_arm64:
   case gpr_w28_arm64:
-    tls_context.X[reg - gpr_w0_arm64] = reg_value.GetAsUInt32();
+    context->X[reg - gpr_w0_arm64] = reg_value.GetAsUInt32();
     break;
   }
 
-  return SetThreadContextHelper(thread_handle, &tls_context);
+  return SetThreadContextHelper(thread_handle, context);
 }
 
 Status NativeRegisterContextWindows_arm64::FPRRead(const uint32_t reg,
                                                    RegisterValue &reg_value) {
-  ::CONTEXT tls_context;
-  DWORD context_flag = CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
-  Status error =
-      GetThreadContextHelper(GetThreadHandle(), &tls_context, context_flag);
+  Status error = CacheAllRegisterValues();
   if (error.Fail())
     return error;
 
@@ -402,7 +433,7 @@ Status NativeRegisterContextWindows_arm64::FPRRead(const uint32_t reg,
   case fpu_v29_arm64:
   case fpu_v30_arm64:
   case fpu_v31_arm64:
-    reg_value.SetBytes(tls_context.V[reg - fpu_v0_arm64].B, 16,
+    reg_value.SetBytes(m_context->V[reg - fpu_v0_arm64].B, 16,
                        endian::InlHostByteOrder());
     break;
 
@@ -438,7 +469,7 @@ Status NativeRegisterContextWindows_arm64::FPRRead(const uint32_t reg,
   case fpu_s29_arm64:
   case fpu_s30_arm64:
   case fpu_s31_arm64:
-    reg_value.SetFloat(tls_context.V[reg - fpu_s0_arm64].S[0]);
+    reg_value.SetFloat(m_context->V[reg - fpu_s0_arm64].S[0]);
     break;
 
   case fpu_d0_arm64:
@@ -473,15 +504,15 @@ Status NativeRegisterContextWindows_arm64::FPRRead(const uint32_t reg,
   case fpu_d29_arm64:
   case fpu_d30_arm64:
   case fpu_d31_arm64:
-    reg_value.SetDouble(tls_context.V[reg - fpu_d0_arm64].D[0]);
+    reg_value.SetDouble(m_context->V[reg - fpu_d0_arm64].D[0]);
     break;
 
   case fpu_fpsr_arm64:
-    reg_value.SetUInt32(tls_context.Fpsr);
+    reg_value.SetUInt32(m_context->Fpsr);
     break;
 
   case fpu_fpcr_arm64:
-    reg_value.SetUInt32(tls_context.Fpcr);
+    reg_value.SetUInt32(m_context->Fpcr);
     break;
   }
 
@@ -491,11 +522,15 @@ Status NativeRegisterContextWindows_arm64::FPRRead(const uint32_t reg,
 Status
 NativeRegisterContextWindows_arm64::FPRWrite(const uint32_t reg,
                                              const RegisterValue &reg_value) {
-  ::CONTEXT tls_context;
-  DWORD context_flag = CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
+  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+
+  PCONTEXT context = nullptr;
+  std::shared_ptr<DataBufferHeap> context_buffer;
+  DWORD context_flags = CONTEXT_CONTROL | CONTEXT_FLOATING_POINT;
   auto thread_handle = GetThreadHandle();
-  Status error =
-      GetThreadContextHelper(thread_handle, &tls_context, context_flag);
+
+  Status error = GetThreadContextHelper(thread_handle, context_flags, context,
+                                        context_buffer);
   if (error.Fail())
     return error;
 
@@ -532,7 +567,7 @@ NativeRegisterContextWindows_arm64::FPRWrite(const uint32_t reg,
   case fpu_v29_arm64:
   case fpu_v30_arm64:
   case fpu_v31_arm64:
-    memcpy(tls_context.V[reg - fpu_v0_arm64].B, reg_value.GetBytes(), 16);
+    memcpy(context->V[reg - fpu_v0_arm64].B, reg_value.GetBytes(), 16);
     break;
 
   case fpu_s0_arm64:
@@ -567,7 +602,7 @@ NativeRegisterContextWindows_arm64::FPRWrite(const uint32_t reg,
   case fpu_s29_arm64:
   case fpu_s30_arm64:
   case fpu_s31_arm64:
-    tls_context.V[reg - fpu_s0_arm64].S[0] = reg_value.GetAsFloat();
+    context->V[reg - fpu_s0_arm64].S[0] = reg_value.GetAsFloat();
     break;
 
   case fpu_d0_arm64:
@@ -602,19 +637,19 @@ NativeRegisterContextWindows_arm64::FPRWrite(const uint32_t reg,
   case fpu_d29_arm64:
   case fpu_d30_arm64:
   case fpu_d31_arm64:
-    tls_context.V[reg - fpu_d0_arm64].D[0] = reg_value.GetAsDouble();
+    context->V[reg - fpu_d0_arm64].D[0] = reg_value.GetAsDouble();
     break;
 
   case fpu_fpsr_arm64:
-    tls_context.Fpsr = reg_value.GetAsUInt32();
+    context->Fpsr = reg_value.GetAsUInt32();
     break;
 
   case fpu_fpcr_arm64:
-    tls_context.Fpcr = reg_value.GetAsUInt32();
+    context->Fpcr = reg_value.GetAsUInt32();
     break;
   }
 
-  return SetThreadContextHelper(thread_handle, &tls_context);
+  return SetThreadContextHelper(thread_handle, context);
 }
 
 Status
@@ -677,52 +712,91 @@ Status NativeRegisterContextWindows_arm64::WriteRegister(
 
 Status NativeRegisterContextWindows_arm64::ReadAllRegisterValues(
     lldb::WritableDataBufferSP &data_sp) {
-  const size_t data_size = REG_CONTEXT_SIZE;
-  data_sp = std::make_shared<DataBufferHeap>(data_size, 0);
-  ::CONTEXT tls_context;
-  Status error =
-      GetThreadContextHelper(GetThreadHandle(), &tls_context, CONTEXT_ALL);
+  Log *log = GetLog(WindowsLog::Registers);
+
+  Status error = CacheAllRegisterValues();
   if (error.Fail())
     return error;
 
-  uint8_t *dst = data_sp->GetBytes();
-  ::memcpy(dst, &tls_context, data_size);
+  if (!m_context_buffer) {
+    error = Status::FromErrorString("register context buffer is not available");
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    return error;
+  }
+
+  const size_t data_size = m_context_buffer->GetByteSize();
+  data_sp = std::make_shared<DataBufferHeap>(data_size, 0);
+
+  if (!data_sp) {
+    error = Status::FromErrorString("failed to allocate register data buffer");
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    return error;
+  }
+
+  ::memcpy(data_sp->GetBytes(), m_context_buffer->GetBytes(), data_size);
+
   return error;
 }
 
 Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
     const lldb::DataBufferSP &data_sp) {
+  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+
+  Log *log = GetLog(WindowsLog::Registers);
   Status error;
-  const size_t data_size = REG_CONTEXT_SIZE;
+
   if (!data_sp) {
-    error = Status::FromErrorStringWithFormat(
-        "NativeRegisterContextWindows_arm64::%s invalid data_sp provided",
-        __FUNCTION__);
+    error = Status::FromErrorString("invalid data_sp");
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
     return error;
   }
 
-  if (data_sp->GetByteSize() != data_size) {
+  DWORD context_flags = CONTEXT_ALL;
+
+  DWORD context_length = 0;
+  if (InitializeContext(nullptr, context_flags, nullptr, &context_length)) {
+    error = Status::FromErrorString("InitializeContext succeeded unexpectedly");
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
+    return error;
+  }
+
+  if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    error = Status(GetLastError(), eErrorTypeWin32);
+    LLDB_LOG(log, "{0} InitializeContext failed with error {1}", __FUNCTION__,
+             error);
+    return error;
+  }
+
+  if (data_sp->GetByteSize() != context_length) {
     error = Status::FromErrorStringWithFormatv(
         "data_sp contained mismatched data size, expected {0}, actual {1}",
-        data_size, data_sp->GetByteSize());
+        context_length, data_sp->GetByteSize());
+    LLDB_LOG(log, "{0} {1}", __FUNCTION__, error);
     return error;
   }
 
-  ::CONTEXT tls_context;
-  memcpy(&tls_context, data_sp->GetBytes(), data_size);
-  return SetThreadContextHelper(GetThreadHandle(), &tls_context);
+  PCONTEXT context = nullptr;
+  std::shared_ptr<DataBufferHeap> context_buffer;
+  error = GetThreadContextHelper(GetThreadHandle(), context_flags, context,
+                                 context_buffer);
+  if (error.Fail())
+    return error;
+
+  ::memcpy(context_buffer->GetBytes(), data_sp->GetBytes(), context_length);
+
+  error = SetThreadContextHelper(GetThreadHandle(), context);
+
+  return error;
 }
 
 llvm::Error NativeRegisterContextWindows_arm64::ReadHardwareDebugInfo() {
-  ::CONTEXT tls_context;
-  Status error = GetThreadContextHelper(GetThreadHandle(), &tls_context,
-                                        CONTEXT_DEBUG_REGISTERS);
+  Status error = CacheAllRegisterValues();
   if (error.Fail())
     return error.ToError();
 
   for (uint32_t i = 0; i < m_max_hwp_supported; i++) {
-    m_hwp_regs[i].address = tls_context.Wvr[i];
-    m_hwp_regs[i].control = tls_context.Wcr[i];
+    m_hwp_regs[i].address = m_context->Wvr[i];
+    m_hwp_regs[i].control = m_context->Wcr[i];
   }
 
   return llvm::Error::success();
@@ -730,20 +804,51 @@ llvm::Error NativeRegisterContextWindows_arm64::ReadHardwareDebugInfo() {
 
 llvm::Error
 NativeRegisterContextWindows_arm64::WriteHardwareDebugRegs(DREGType hwbType) {
-  ::CONTEXT tls_context;
-  Status error = GetThreadContextHelper(GetThreadHandle(), &tls_context,
-                                        CONTEXT_DEBUG_REGISTERS);
+  auto cleanup = llvm::make_scope_exit([&]() { m_context = nullptr; });
+
+  PCONTEXT context = nullptr;
+  std::shared_ptr<DataBufferHeap> context_buffer;
+  DWORD context_flags = CONTEXT_DEBUG_REGISTERS;
+  auto thread_handle = GetThreadHandle();
+
+  Status error = GetThreadContextHelper(thread_handle, context_flags, context,
+                                        context_buffer);
   if (error.Fail())
     return error.ToError();
 
   if (hwbType == eDREGTypeWATCH) {
     for (uint32_t i = 0; i < m_max_hwp_supported; i++) {
-      tls_context.Wvr[i] = m_hwp_regs[i].address;
-      tls_context.Wcr[i] = m_hwp_regs[i].control;
+      context->Wvr[i] = m_hwp_regs[i].address;
+      context->Wcr[i] = m_hwp_regs[i].control;
     }
   }
 
-  return SetThreadContextHelper(GetThreadHandle(), &tls_context).ToError();
+  return SetThreadContextHelper(GetThreadHandle(), context).ToError();
+}
+
+void NativeRegisterContextWindows_arm64::InvalidateAllRegisters() {
+  m_context = nullptr;
+  m_context_buffer.reset();
+}
+
+Status NativeRegisterContextWindows_arm64::CacheAllRegisterValues() {
+  Status error;
+  DWORD context_flags = CONTEXT_ALL;
+
+  if (m_context && (m_context->ContextFlags & context_flags) == context_flags)
+    return error;
+
+  m_context = nullptr;
+
+  auto cleanup = llvm::make_scope_exit([&]() {
+    if (error.Fail())
+      m_context = nullptr;
+  });
+
+  error = GetThreadContextHelper(GetThreadHandle(), context_flags, m_context,
+                                 m_context_buffer);
+
+  return error;
 }
 
 #endif // defined(__aarch64__) || defined(_M_ARM64)

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.cpp
@@ -117,8 +117,10 @@ GetThreadContextHelper(lldb::thread_t thread_handle, DWORD context_flags,
 
   if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
     error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log, "{0} InitializeContext failed with error {1}", __FUNCTION__,
-             error);
+    LLDB_LOG(log,
+             "{0} InitializeContext failed with unexpected error {1}, expected "
+             "ERROR_INSUFFICIENT_BUFFER",
+             __FUNCTION__, error);
     return error;
   }
 
@@ -762,8 +764,10 @@ Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
 
   if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
     error = Status(GetLastError(), eErrorTypeWin32);
-    LLDB_LOG(log, "{0} InitializeContext failed with error {1}", __FUNCTION__,
-             error);
+    LLDB_LOG(log,
+             "{0} InitializeContext failed with unexpected error {1}, expected "
+             "ERROR_INSUFFICIENT_BUFFER",
+             __FUNCTION__, error);
     return error;
   }
 
@@ -784,9 +788,7 @@ Status NativeRegisterContextWindows_arm64::WriteAllRegisterValues(
 
   ::memcpy(context_buffer->GetBytes(), data_sp->GetBytes(), context_length);
 
-  error = SetThreadContextHelper(GetThreadHandle(), context);
-
-  return error;
+  return SetThreadContextHelper(GetThreadHandle(), context);
 }
 
 llvm::Error NativeRegisterContextWindows_arm64::ReadHardwareDebugInfo() {

--- a/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeRegisterContextWindows_arm64.h
@@ -10,11 +10,13 @@
 #ifndef liblldb_NativeRegisterContextWindows_arm64_h_
 #define liblldb_NativeRegisterContextWindows_arm64_h_
 
+#include "NativeRegisterContextWindows.h"
+
 #include "Plugins/Process/Utility/NativeRegisterContextDBReg_arm64.h"
 #include "Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h"
 #include "Plugins/Process/Utility/lldb-arm64-register-enums.h"
 
-#include "NativeRegisterContextWindows.h"
+#include "lldb/Host/windows/windows.h"
 
 namespace lldb_private {
 
@@ -41,6 +43,8 @@ public:
 
   Status WriteAllRegisterValues(const lldb::DataBufferSP &data_sp) override;
 
+  void InvalidateAllRegisters() override;
+
 protected:
   Status GPRRead(const uint32_t reg, RegisterValue &reg_value);
 
@@ -51,6 +55,9 @@ protected:
   Status FPRWrite(const uint32_t reg, const RegisterValue &reg_value);
 
 private:
+  PCONTEXT m_context;
+  std::shared_ptr<DataBufferHeap> m_context_buffer;
+
   bool IsGPR(uint32_t reg_index) const;
 
   bool IsFPR(uint32_t reg_index) const;
@@ -58,6 +65,8 @@ private:
   llvm::Error ReadHardwareDebugInfo() override;
 
   llvm::Error WriteHardwareDebugRegs(DREGType hwbType) override;
+
+  Status CacheAllRegisterValues();
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
Cache thread context in _NativeRegisterContextWindows_arm64_ to improve read performance. Previously, the thread context was retrieved for every read or write operation.

This change intends to lay the groundwork for provisioning debug support for SVE on WoA.

Assisted-by: Claude Sonnet 4.6