### PR TITLE
[lldb] Fix wrong buffer size when fetching Objective-C classes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2245,7 +2245,7 @@ AppleObjCRuntimeV2::DynamicClassInfoExtractor::UpdateISAToDescriptorMap(
 
   if (class_buffer_addr != LLDB_INVALID_ADDRESS) {
     arguments.GetValueAtIndex(index++)->GetScalar() = class_buffer_addr;
-    arguments.GetValueAtIndex(index++)->GetScalar() = class_buffer_byte_size;
+    arguments.GetValueAtIndex(index++)->GetScalar() = class_buffer_len;
   }
 
   // Only dump the runtime classes from the expression evaluation if the log is


### PR DESCRIPTION
LLDB calls objc_getRealizedClassList_trylock to fetch the list of realized Objective-C classes.

Jim spotted that we currently pass the buffer length in *bytes*, when actually this API takes the buffer length in number of elements. This causes that the Objective-C runtime write more memory that we allocated for it. This can cause that the function calling expression crashes and leaves the Objective-C runtime mutex locked.