### PR TITLE
[ADT] Hash pointers with densemap::detail::mix

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -84,8 +84,7 @@ struct DenseMapInfo<T*> {
   }
 
   static unsigned getHashValue(const T *PtrVal) {
-    return (unsigned((uintptr_t)PtrVal) >> 4) ^
-           (unsigned((uintptr_t)PtrVal) >> 9);
+    return densemap::detail::mix(reinterpret_cast<uintptr_t>(PtrVal));
   }
 
   static bool isEqual(const T *LHS, const T *RHS) { return LHS == RHS; }


### PR DESCRIPTION
The current DenseMapInfo<T*>::getHashValue is very weak.
Distinct bump-allocated pointers — the dominant key shape in clang and
the LLVM IR layer — share their high bits and differ only in low bits
that this hash collapses to a short range of buckets.

Quadratic probing has been masking the weakness because its probe
sequence spreads collisions out, but the latent quality issue still
hurts at high load factor and shows up directly as primary clustering
once probing becomes linear.

DeclContext::lookupImpl over a StoredDeclsMap keyed on DeclarationName
is the hottest example: the underlying IdentifierInfo* comes from
clang's bump allocator, so consecutive identifiers land on consecutive
low-bit hash values.

Switch to densemap::detail::mix, the splitmix64 mixer already defined
above and already used by the >32-bit unsigned integral specialization.

Root cause identified by Claude Opus 4.7

instructions:u is mixed across TUs but trends slightly down in aggregate.
https://llvm-compile-time-tracker.com/compare.php?from=c9560139d3053fe5eb49131c0354ed6a67177fbc&to=23d37b18147179d8c908716cd2a8427e5f491d6c&stat=instructions:u
