### PR TITLE
[lldb][test] Don't overwrite existing decorators in _skipForVariant

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -222,7 +222,18 @@ def _skipForVariant(variant_name, expected_fn, bugnumber=None):
         if isinstance(func, type) and issubclass(func, unittest.TestCase):
             raise Exception("Decorator can only be used to decorate a test method")
         skip_dict = getattr(func, "__variant_skip__", {})
-        skip_dict[variant_name] = expected_fn
+        existing_fn = skip_dict.get(variant_name)
+        if existing_fn:
+            # Chain the decorator with the existing one.
+            def chained_fn(**kwargs):
+                reason = expected_fn(**kwargs)
+                if reason:
+                    return reason
+                return existing_fn(**kwargs)
+
+            skip_dict[variant_name] = chained_fn
+        else:
+            skip_dict[variant_name] = expected_fn
         func.__variant_skip__ = skip_dict
         return func
 


### PR DESCRIPTION
_skipForVariant uses a dictionary to save the decorator functions for specific variants. However, if the dictionary already contains a decorator function, then that decorator is overwritten in the current implementation.

This means that if we have two decorators that skip a variant in combination with another check, then the second decorator overwrites the first one and is effectively ignored.

Downstream we are hit by this because we have an embedded Swift variant. If we skip this variant for both Linux and Windows, then depending on the decorator order we still run the test on one of those two platforms (as one decorator is overwritten by the other).