### PR TITLE
[lldb][AArch64][Linux] Remove Is<type of register> forwarding methods

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.cpp
@@ -300,7 +300,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
   uint64_t sve_vg;
   std::vector<uint8_t> sve_reg_non_live;
 
-  if (IsGPR(reg)) {
+  if (GetRegisterInfo().IsGPR(reg)) {
     error = ReadGPR();
     if (error.Fail())
       return error;
@@ -309,7 +309,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     assert(offset < GetGPRSize());
     src = (uint8_t *)GetGPRBuffer() + offset;
 
-  } else if (IsFPR(reg)) {
+  } else if (GetRegisterInfo().IsFPR(reg)) {
     if (m_sve_state == SVEState::Disabled ||
         m_sve_state == SVEState::StreamingFPSIMD) {
       // FP registers come from the FP register set when:
@@ -359,7 +359,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
       assert(offset < GetSVEBufferSize());
       src = (uint8_t *)GetSVEBuffer() + offset;
     }
-  } else if (IsTLS(reg)) {
+  } else if (GetRegisterInfo().IsTLSReg(reg)) {
     error = ReadTLS();
     if (error.Fail())
       return error;
@@ -367,7 +367,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     offset = reg_info->byte_offset - GetRegisterInfo().GetTLSOffset();
     assert(offset < GetTLSBufferSize());
     src = (uint8_t *)GetTLSBuffer() + offset;
-  } else if (IsSVE(reg)) {
+  } else if (GetRegisterInfo().IsSVEReg(reg)) {
     if (m_sve_state == SVEState::Disabled || m_sve_state == SVEState::Unknown)
       return Status::FromErrorString("SVE disabled or not supported");
 
@@ -445,7 +445,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
         src = (uint8_t *)GetSVEBuffer() + offset;
       }
     }
-  } else if (IsPAuth(reg)) {
+  } else if (GetRegisterInfo().IsPAuthReg(reg)) {
     error = ReadPAuthMask();
     if (error.Fail())
       return error;
@@ -453,7 +453,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     offset = reg_info->byte_offset - GetRegisterInfo().GetPAuthOffset();
     assert(offset < GetPACMaskSize());
     src = (uint8_t *)GetPACMask() + offset;
-  } else if (IsMTE(reg)) {
+  } else if (GetRegisterInfo().IsMTEReg(reg)) {
     error = ReadMTEControl();
     if (error.Fail())
       return error;
@@ -461,7 +461,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     offset = reg_info->byte_offset - GetRegisterInfo().GetMTEOffset();
     assert(offset < GetMTEControlSize());
     src = (uint8_t *)GetMTEControl() + offset;
-  } else if (IsSME(reg)) {
+  } else if (GetRegisterInfo().IsSMEReg(reg)) {
     if (GetRegisterInfo().IsSMERegZA(reg)) {
       error = ReadZAHeader();
       if (error.Fail())
@@ -508,7 +508,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
       assert(offset < GetSMEPseudoBufferSize());
       src = (uint8_t *)GetSMEPseudoBuffer() + offset;
     }
-  } else if (IsFPMR(reg)) {
+  } else if (GetRegisterInfo().IsFPMRReg(reg)) {
     error = ReadFPMR();
     if (error.Fail())
       return error;
@@ -516,7 +516,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     offset = reg_info->byte_offset - GetRegisterInfo().GetFPMROffset();
     assert(offset < GetFPMRBufferSize());
     src = (uint8_t *)GetFPMRBuffer() + offset;
-  } else if (IsGCS(reg)) {
+  } else if (GetRegisterInfo().IsGCSReg(reg)) {
     error = ReadGCS();
     if (error.Fail())
       return error;
@@ -524,7 +524,7 @@ NativeRegisterContextLinux_arm64::ReadRegister(const RegisterInfo *reg_info,
     offset = reg_info->byte_offset - GetRegisterInfo().GetGCSOffset();
     assert(offset < GetGCSBufferSize());
     src = (uint8_t *)GetGCSBuffer() + offset;
-  } else if (IsPOE(reg)) {
+  } else if (GetRegisterInfo().IsPOEReg(reg)) {
     error = ReadPOE();
     if (error.Fail())
       return error;
@@ -561,7 +561,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
   uint32_t offset = LLDB_INVALID_INDEX32;
   std::vector<uint8_t> sve_reg_non_live;
 
-  if (IsGPR(reg)) {
+  if (GetRegisterInfo().IsGPR(reg)) {
     error = ReadGPR();
     if (error.Fail())
       return error;
@@ -571,7 +571,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
     return WriteGPR();
-  } else if (IsFPR(reg)) {
+  } else if (GetRegisterInfo().IsFPR(reg)) {
     if (m_sve_state == SVEState::Disabled ||
         m_sve_state == SVEState::StreamingFPSIMD) {
       // SVE is not present, or we only have it in streaming mode and are
@@ -624,7 +624,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
       ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
       return WriteAllSVE();
     }
-  } else if (IsSVE(reg)) {
+  } else if (GetRegisterInfo().IsSVEReg(reg)) {
     if (m_sve_state == SVEState::Disabled || m_sve_state == SVEState::Unknown) {
       return Status::FromErrorString("SVE disabled or not supported");
     } else if (m_sve_state == SVEState::StreamingFPSIMD) {
@@ -741,7 +741,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
         return WriteAllSVE();
       }
     }
-  } else if (IsMTE(reg)) {
+  } else if (GetRegisterInfo().IsMTEReg(reg)) {
     error = ReadMTEControl();
     if (error.Fail())
       return error;
@@ -752,7 +752,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
     return WriteMTEControl();
-  } else if (IsTLS(reg)) {
+  } else if (GetRegisterInfo().IsTLSReg(reg)) {
     error = ReadTLS();
     if (error.Fail())
       return error;
@@ -763,7 +763,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
     return WriteTLS();
-  } else if (IsSME(reg)) {
+  } else if (GetRegisterInfo().IsSMEReg(reg)) {
     if (GetRegisterInfo().IsSMERegZA(reg)) {
       error = ReadZA();
       if (error.Fail())
@@ -790,7 +790,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     } else
       return Status::FromErrorString(
           "Writing to SVG or SVCR is not supported.");
-  } else if (IsFPMR(reg)) {
+  } else if (GetRegisterInfo().IsFPMRReg(reg)) {
     error = ReadFPMR();
     if (error.Fail())
       return error;
@@ -801,7 +801,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
     return WriteFPMR();
-  } else if (IsGCS(reg)) {
+  } else if (GetRegisterInfo().IsGCSReg(reg)) {
     error = ReadGCS();
     if (error.Fail())
       return error;
@@ -812,7 +812,7 @@ Status NativeRegisterContextLinux_arm64::WriteRegister(
     ::memcpy(dst, reg_value.GetBytes(), reg_info->byte_size);
 
     return WriteGCS();
-  } else if (IsPOE(reg)) {
+  } else if (GetRegisterInfo().IsPOEReg(reg)) {
     error = ReadPOE();
     if (error.Fail())
       return error;
@@ -1316,52 +1316,6 @@ Status NativeRegisterContextLinux_arm64::WriteAllRegisterValues(
   }
 
   return error;
-}
-
-bool NativeRegisterContextLinux_arm64::IsGPR(unsigned reg) const {
-  if (GetRegisterInfo().GetRegisterSetFromRegisterIndex(reg) ==
-      RegisterInfoPOSIX_arm64::GPRegSet)
-    return true;
-  return false;
-}
-
-bool NativeRegisterContextLinux_arm64::IsFPR(unsigned reg) const {
-  if (GetRegisterInfo().GetRegisterSetFromRegisterIndex(reg) ==
-      RegisterInfoPOSIX_arm64::FPRegSet)
-    return true;
-  return false;
-}
-
-bool NativeRegisterContextLinux_arm64::IsSVE(unsigned reg) const {
-  return GetRegisterInfo().IsSVEReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsSME(unsigned reg) const {
-  return GetRegisterInfo().IsSMEReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsPAuth(unsigned reg) const {
-  return GetRegisterInfo().IsPAuthReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsMTE(unsigned reg) const {
-  return GetRegisterInfo().IsMTEReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsTLS(unsigned reg) const {
-  return GetRegisterInfo().IsTLSReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsFPMR(unsigned reg) const {
-  return GetRegisterInfo().IsFPMRReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsGCS(unsigned reg) const {
-  return GetRegisterInfo().IsGCSReg(reg);
-}
-
-bool NativeRegisterContextLinux_arm64::IsPOE(unsigned reg) const {
-  return GetRegisterInfo().IsPOEReg(reg);
 }
 
 llvm::Error NativeRegisterContextLinux_arm64::ReadHardwareDebugInfo() {

--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm64.h
@@ -150,10 +150,6 @@ private:
     uint64_t gcspr_e0;
   } m_gcs_regs;
 
-  bool IsGPR(unsigned reg) const;
-
-  bool IsFPR(unsigned reg) const;
-
   Status ReadAllSVE();
 
   Status WriteAllSVE();
@@ -202,15 +198,6 @@ private:
   Status ReadPOE();
 
   Status WritePOE();
-
-  bool IsSVE(unsigned reg) const;
-  bool IsSME(unsigned reg) const;
-  bool IsPAuth(unsigned reg) const;
-  bool IsMTE(unsigned reg) const;
-  bool IsTLS(unsigned reg) const;
-  bool IsFPMR(unsigned reg) const;
-  bool IsGCS(unsigned reg) const;
-  bool IsPOE(unsigned reg) const;
 
   uint64_t GetSVERegVG() { return m_sve_header.vl / 8; }
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -598,6 +598,16 @@ bool RegisterInfoPOSIX_arm64::IsSMERegZT(unsigned reg) const {
          reg == m_sme_regnum_collection[3];
 }
 
+bool RegisterInfoPOSIX_arm64::IsGPR(unsigned reg) const {
+  return GetRegisterSetFromRegisterIndex(reg) ==
+         RegisterInfoPOSIX_arm64::GPRegSet;
+}
+
+bool RegisterInfoPOSIX_arm64::IsFPR(unsigned reg) const {
+  return GetRegisterSetFromRegisterIndex(reg) ==
+         RegisterInfoPOSIX_arm64::FPRegSet;
+}
+
 bool RegisterInfoPOSIX_arm64::IsPAuthReg(unsigned reg) const {
   return llvm::is_contained(pauth_regnum_collection, reg);
 }

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.h
@@ -156,6 +156,8 @@ public:
   bool IsGCSPresent() const { return m_opt_regsets.AnySet(eRegsetMaskGCS); }
   bool IsPOEPresent() const { return m_opt_regsets.AnySet(eRegsetMaskPOE); }
 
+  bool IsGPR(unsigned reg) const;
+  bool IsFPR(unsigned reg) const;
   bool IsSVEReg(unsigned reg) const;
   bool IsSVEZReg(unsigned reg) const;
   bool IsSVEPReg(unsigned reg) const;


### PR DESCRIPTION
These don't add any utility and just make you wonder if we're doing something more than the register info object can do. We are not.

Except for GPR and FPR, but nothing so complex that the register info cannot do it too, so I've moved those into there.