### PR TITLE
[libc] Fix for SYS_mmap2 offset computation

### DIFF
--- a/libc/src/__support/OSUtil/linux/syscall_wrappers/mmap.h
+++ b/libc/src/__support/OSUtil/linux/syscall_wrappers/mmap.h
@@ -14,7 +14,6 @@
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
 #include "src/__support/macros/config.h"
-#include <linux/param.h> // For EXEC_PAGESIZE
 #include <sys/syscall.h> // For syscall numbers
 
 namespace LIBC_NAMESPACE_DECL {
@@ -25,12 +24,12 @@ LIBC_INLINE ErrorOr<void *> mmap(void *addr, size_t size, int prot, int flags,
   // TODO: Perform POSIX-prescribed argument validation not done by the
   // linux syscall.
 
-  // EXEC_PAGESIZE is used for the page size. While this is OK for x86_64,
-  // it might not be correct in general.
-  // TODO: Use pagesize read from the ELF aux vector instead of
-  // EXEC_PAGESIZE.
 #ifdef SYS_mmap2
-  offset /= EXEC_PAGESIZE;
+  // The mmap2 syscall uses 4k units, regardless of the actual page, size on
+  // almost every architecture. If porting to a new architecture (Openrisc,
+  // hexagon?), please confirm this code is correct.
+  constexpr off_t MMAP2_FACTOR = 4096;
+  offset /= MMAP2_FACTOR;
   long syscall_number = SYS_mmap2;
 #elif defined(SYS_mmap)
   long syscall_number = SYS_mmap;


### PR DESCRIPTION
The comment implies that the offset argument is a multiple of page size, but
[this](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/csky/kernel/syscall.c#L25) [is](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/parisc/kernel/sys_parisc.c#L193) [not](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/microblaze/kernel/sys_microblaze.c#L50) [the](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/riscv/kernel/sys_riscv.c#L48) [case](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/arm64/kernel/sys32.c#L47) [for](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/sparc/kernel/sys_sparc_32.c#L113) [almost](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/m68k/kernel/sys_m68k.c#L44) [every](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/powerpc/kernel/syscalls.c#L56) [architecture](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/sh/kernel/sys_sh.c#L46) [supported](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/powerpc/kernel/syscalls.c#L56) [by](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/mips/kernel/syscall.c#L76) [linux](https://github.com/torvalds/linux/blob/1d5dcaa3bd65f2e8c9baa14a393d3a2dc5db7524/arch/arm/kernel/entry-common.S#L410). Most architectures just use fixed 4k units instead.

x86 code does not reference the pages sizes anywhere, but x86 always has a 4k (base) page size. The same is probably true for Nios II, though information is a bit scarce on that one. I believe openrisc uses fixed 8k units, but this should be confirmed when/if we're porting to that architecture.

Itanium had configurable page sizes and did not use fixed mmap2 scaling, but itanium support was removed from the kernel two years ago. Hexagon and ARC may be the only currently supported architectures that do the same, but this is also best confirmed during porting.

This patch is a no-op for any architecture we currently support, but it makes it clear that this behavior is deliberate, and not something to be fixed. This code was introduced way back in
[2019](https://reviews.llvm.org/D71634) and while the review contained a discussion on page sizes, it revolved around the right way to obtain it, rather than the question of whether it is actually necessary.