### PR TITLE
[Dexter] Add basic debugging support for structured scripts

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/DebuggerControllerBase.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/DebuggerControllerBase.py
@@ -28,7 +28,7 @@ class DebuggerControllerBase(object, metaclass=abc.ABCMeta):
         # Fetch command line options, if any.
         the_cmdline = []
         commands = self.step_collection.commands
-        if "DexCommandLine" in commands:
+        if commands and "DexCommandLine" in commands:
             cmd_line_objs = commands["DexCommandLine"]
             assert len(cmd_line_objs) == 1
             cmd_line_obj = cmd_line_objs[0]

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
@@ -25,20 +25,20 @@ from dex.utils.Timeout import Timeout
 from dex.dextIR import DextIR, FrameIR, StepIR
 
 
-def paths_differ(expected: str, actual: str) -> bool:
-    """Returns True if expected is not a trailing subpath of actual, i.e. if `actual` does not end with `expected` after
-    normalizing both paths."""
-    normalized_expected: str = os.path.normcase(os.path.normpath(expected))
-    normalized_actual: str = os.path.normcase(os.path.normpath(actual))
-    return not normalized_actual.endswith(normalized_expected)
+def is_subpath(subpath: str, superpath: str) -> bool:
+    """Returns True if subpath is not a trailing subpath of superpath, i.e. if `superpath` does not end with `subpath`
+    after normalizing both paths."""
+    normalized_subpath: str = os.path.normcase(os.path.normpath(subpath))
+    normalized_superpath: str = os.path.normcase(os.path.normpath(superpath))
+    return normalized_superpath.endswith(normalized_subpath)
 
 
-# A very simple matcher, returns True iff `where` matches `frame`.
 def match_where_to_frame(
     where: Where,
     frame: FrameIR,
 ) -> bool:
-    if where.file is not None and paths_differ(where.file, frame.loc.path):
+    """A very simple matcher, returns True iff `where` matches `frame`."""
+    if where.file is not None and not is_subpath(where.file, frame.loc.path):
         return False
     if where.function is not None:
         fn = frame.function
@@ -104,7 +104,7 @@ def get_active_where_expects(
 
 
 class DebuggerAction(Enum):
-    STEP = 0
+    STEP_OVER = 0
     STEP_OUT = 1
     CONTINUE = 2
     EXIT = 3
@@ -209,7 +209,7 @@ class ScriptDebuggerController(DebuggerControllerBase):
             if any(
                 frame_idx == 0 for frame_idx, expects in active_where_expects.values()
             ):
-                next_action = DebuggerAction.STEP
+                next_action = DebuggerAction.STEP_OVER
             elif active_where_expects:
                 next_action = DebuggerAction.STEP_OUT
             else:
@@ -229,7 +229,7 @@ class ScriptDebuggerController(DebuggerControllerBase):
 
             if next_action == DebuggerAction.EXIT:
                 break
-            elif next_action == DebuggerAction.STEP:
+            elif next_action == DebuggerAction.STEP_OVER:
                 self.debugger.step_next()
             elif next_action == DebuggerAction.STEP_OUT:
                 self.debugger.step_out()

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
@@ -11,7 +11,7 @@ recording debugger output."""
 from enum import Enum
 import os
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from dex.debugger.DebuggerControllers.DebuggerControllerBase import (
     DebuggerControllerBase,
@@ -26,8 +26,8 @@ from dex.dextIR import DextIR, FrameIR, StepIR
 
 
 def is_subpath(subpath: str, superpath: str) -> bool:
-    """Returns True if subpath is not a trailing subpath of superpath, i.e. if `superpath` does not end with `subpath`
-    after normalizing both paths."""
+    """Returns True if subpath is a trailing subpath of superpath, i.e. if `superpath` ends with `subpath` after
+    normalizing both paths."""
     normalized_subpath: str = os.path.normcase(os.path.normpath(subpath))
     normalized_superpath: str = os.path.normcase(os.path.normpath(superpath))
     return normalized_superpath.endswith(normalized_subpath)
@@ -123,10 +123,11 @@ class ScriptDebuggerController(DebuggerControllerBase):
         self.script: DexterScript = step_collection.script
 
         # We may need to pickle this debugger controller after running the
-        # debugger. Debuggers are not picklable objects, so set to None.
+        # debugger. Debuggers are not picklable objects, so this starts as None
+        # and will be set back to None after we finish running the debugger.
         self.debugger: DebuggerBase = None  # type: ignore
 
-    def add_where_entry_bp(self, where: Where, scope: Scope):
+    def add_where_entry_bp(self, where: Where, default_file: Optional[str] = None):
         """Adds a breakpoint to catch when we enter the given !where node."""
         added_ids = []
         if where.function:
@@ -138,7 +139,7 @@ class ScriptDebuggerController(DebuggerControllerBase):
         elif where.lines:
             # We prefer an explicit file, but we make a special allowance for root !where nodes, which are assumed to
             # refer to the script file if the file is omitted.
-            file = where.file or scope.file
+            file = where.file or default_file
             assert file, "Cannot set line breakpoints without a valid file!"
             # If this Where covers a range of lines, we breakpoint each of them to ensure that we don't miss any lines.
             for line in where.get_lines():
@@ -148,7 +149,7 @@ class ScriptDebuggerController(DebuggerControllerBase):
 
     def _init_bps(self):
         for where in self.script.root_wheres:
-            self.add_where_entry_bp(where, self.script.root_scope)
+            self.add_where_entry_bp(where, self.script.root_scope.file)
 
     def _run_debugger_custom(self, cmdline):
         if not isinstance(self.debugger, DAP):

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
@@ -64,7 +64,7 @@ def get_active_where_expects(
     script: DexterScript, step_info: StepIR
 ) -> Dict[Where, Tuple[int, List[Value]]]:
     """Match the script against the step_info, producing a dict that maps each !where that matches a stack frame to the
-    index of the (outermost) stack frame that it matches, and if the frame that it matches is the current stack frame
+    index of the (rootmost) stack frame that it matches, and if the frame that it matches is the current stack frame
     (i.e. the frame index is 0), also includes a list of every direct child !expect node for that !where.
     """
     active_where_expects: Dict[Where, Tuple[int, List[Value]]] = {}
@@ -74,7 +74,7 @@ def get_active_where_expects(
             raise NotImplementedError(
                 "Support for nested !where nodes currently unimplemented."
             )
-        # For this !where, search for the lowest stack frame (e.g. the outermost call) that matches it.
+        # For this !where, search for the rootmost stack frame that matches it.
         matching_frame_idx = next(
             (
                 frame_idx

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ScriptDebuggerController.py
@@ -1,0 +1,241 @@
+# DExTer : Debugging Experience Tester
+# ~~~~~~   ~         ~~         ~   ~~
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Debugger Controller Class for DExTer, responsible for driving a debugger session, invoking debugger actions and
+recording debugger output."""
+
+
+from enum import Enum
+import os
+import time
+from typing import Dict, List, Tuple
+
+from dex.debugger.DebuggerControllers.DebuggerControllerBase import (
+    DebuggerControllerBase,
+)
+from dex.debugger.DebuggerBase import DebuggerBase
+from dex.debugger.DAP import DAP
+from dex.test_script.Nodes import Expect, Value, Where
+from dex.test_script.Script import DexterScript, Scope
+from dex.tools import Context
+from dex.utils.Timeout import Timeout
+from dex.dextIR import DextIR, FrameIR, StepIR
+
+
+def paths_differ(expected: str, actual: str) -> bool:
+    """Returns True if expected is not a trailing subpath of actual, i.e. if `actual` does not end with `expected` after
+    normalizing both paths."""
+    normalized_expected: str = os.path.normcase(os.path.normpath(expected))
+    normalized_actual: str = os.path.normcase(os.path.normpath(actual))
+    return not normalized_actual.endswith(normalized_expected)
+
+
+# A very simple matcher, returns True iff `where` matches `frame`.
+def match_where_to_frame(
+    where: Where,
+    frame: FrameIR,
+) -> bool:
+    if where.file is not None and paths_differ(where.file, frame.loc.path):
+        return False
+    if where.function is not None:
+        fn = frame.function
+        if "(" in fn:
+            fn = fn.split("(")[0]
+        if where.function != fn:
+            return False
+    if where.lines is not None:
+        if frame.loc.lineno not in where.get_lines():
+            return False
+    if (
+        where.for_hit_count is not None
+        or where.after_hit_count is not None
+        or where.conditions is not None
+    ):
+        raise NotImplementedError(
+            "!where hit counts and conditions currently unsupported."
+        )
+    return True
+
+
+def get_active_where_expects(
+    script: DexterScript, step_info: StepIR
+) -> Dict[Where, Tuple[int, List[Value]]]:
+    """Match the script against the step_info, producing a dict that maps each !where that matches a stack frame to the
+    index of the (outermost) stack frame that it matches, and if the frame that it matches is the current stack frame
+    (i.e. the frame index is 0), also includes a list of every direct child !expect node for that !where.
+    """
+    active_where_expects: Dict[Where, Tuple[int, List[Value]]] = {}
+
+    def get_active_wheres(where: Where, scope: Scope):
+        if scope.where:
+            raise NotImplementedError(
+                "Support for nested !where nodes currently unimplemented."
+            )
+        # For this !where, search for the lowest stack frame (e.g. the outermost call) that matches it.
+        matching_frame_idx = next(
+            (
+                frame_idx
+                for frame_idx, frame in reversed(list(enumerate(step_info.frames)))
+                if match_where_to_frame(where, frame)
+            ),
+            None,
+        )
+        if matching_frame_idx is not None:
+            active_where_expects[where] = (matching_frame_idx, [])
+
+    # As we visit the script nodes in pre-order traversal, we can always assume that an expect's parent !where
+    # has already been visited, and thus should have an entry in active_where_expects if it is active.
+    def get_active_expects(expect: Expect, expected_value, scope: Scope):
+        assert isinstance(
+            expect, Value
+        ), "Values should be the only type of expect possible!"
+        if (
+            scope.where in active_where_expects
+            and active_where_expects[scope.where][0] == 0
+        ):
+            active_where_expects[scope.where][1].append(expect)
+
+    script.visit_script(visit_where=get_active_wheres, visit_expect=get_active_expects)
+
+    return active_where_expects
+
+
+class DebuggerAction(Enum):
+    STEP = 0
+    STEP_OUT = 1
+    CONTINUE = 2
+    EXIT = 3
+
+
+class ScriptDebuggerController(DebuggerControllerBase):
+    """Uses a Dexter Script to drive a debugger session, using "where" nodes to make breakpoint/stepping decisions, and
+    "expect" nodes to evaluate variables."""
+
+    def __init__(self, context: Context, step_collection: DextIR):
+        super().__init__(context, step_collection)
+        self._step_index = 0
+        self._pause_between_steps = context.options.pause_between_steps
+        self._max_steps = context.options.max_steps
+        assert step_collection.script is not None
+        self.script: DexterScript = step_collection.script
+
+        # We may need to pickle this debugger controller after running the
+        # debugger. Debuggers are not picklable objects, so set to None.
+        self.debugger: DebuggerBase = None  # type: ignore
+
+    def add_where_entry_bp(self, where: Where, scope: Scope):
+        """Adds a breakpoint to catch when we enter the given !where node."""
+        added_ids = []
+        if where.function:
+            if where.lines:
+                raise NotImplementedError(
+                    f"Implementation does not currently handle !where with function and lines: {where}"
+                )
+            added_ids.append(self.debugger.add_function_breakpoint(where.function))
+        elif where.lines:
+            # We prefer an explicit file, but we make a special allowance for root !where nodes, which are assumed to
+            # refer to the script file if the file is omitted.
+            file = where.file or scope.file
+            assert file, "Cannot set line breakpoints without a valid file!"
+            # If this Where covers a range of lines, we breakpoint each of them to ensure that we don't miss any lines.
+            for line in where.get_lines():
+                added_ids.append(self.debugger.add_breakpoint(file, line))
+        for id in added_ids:
+            self.context.logger.note(f"Added Entry BP {id} for {where}")
+
+    def _init_bps(self):
+        for where in self.script.root_wheres:
+            self.add_where_entry_bp(where, self.script.root_scope)
+
+    def _run_debugger_custom(self, cmdline):
+        if not isinstance(self.debugger, DAP):
+            raise NotImplementedError(
+                "Only DAP-based debuggers currently supported in structured scripts."
+            )
+
+        self.step_collection.clear_steps()
+
+        script: DexterScript = self.script
+        self._init_bps()
+
+        self.debugger.launch(cmdline)
+        time.sleep(self._pause_between_steps)
+
+        timed_out = False
+        total_timeout = Timeout(self.context.options.timeout_total)
+
+        while not self.debugger.is_finished:
+            ## Check for timeouts.
+            breakpoint_timeout = Timeout(self.context.options.timeout_breakpoint)
+            while self.debugger.is_running and not timed_out:
+                # Check to see whether we've timed out while we're waiting.
+                if total_timeout.timed_out():
+                    self.context.logger.error(
+                        "Debugger session has been "
+                        f"running for {total_timeout.elapsed}s, timeout reached!"
+                    )
+                    timed_out = True
+                if breakpoint_timeout.timed_out():
+                    self.context.logger.error(
+                        f"Debugger session has not "
+                        f"hit a breakpoint for {breakpoint_timeout.elapsed}s, timeout "
+                        "reached!"
+                    )
+                    timed_out = True
+
+            if timed_out or self.debugger.is_finished:
+                break
+
+            ## Fetch frame information and breakpoint information from the debugger.
+            step_info: StepIR = self.debugger.get_stack_frames(self._step_index)
+
+            active_where_expects = get_active_where_expects(script, step_info)
+
+            watches = [
+                watch
+                for frame_idx, expects in active_where_expects.values()
+                for expect in expects
+                if (watch := expect.get_watched_expr())
+            ]
+            self.debugger.collect_watches(step_info, watches)
+
+            # Our stepping behaviour is as follows:
+            # - If any !where matches the current stack frame, we step.
+            # - Otherwise, if any !where matches any non-current stack frame, we step out.
+            # - Otherwise, we continue.
+            if any(
+                frame_idx == 0 for frame_idx, expects in active_where_expects.values()
+            ):
+                next_action = DebuggerAction.STEP
+            elif active_where_expects:
+                next_action = DebuggerAction.STEP_OUT
+            else:
+                next_action = DebuggerAction.CONTINUE
+
+            if step_info.current_frame:
+                self._step_index += 1
+                # Record the step in step_collection.
+                self.step_collection.new_step(self.context, step_info)
+                if self._step_index > self._max_steps:
+                    next_action = DebuggerAction.EXIT
+
+            # If we have --trace enabled, report a short overview of this step.
+            self.context.logger.note(
+                f"Stopped at {step_info.current_function} {step_info.current_location.short_str()}, {len(active_where_expects)} !wheres on the stack, next_action={next_action}"
+            )
+
+            if next_action == DebuggerAction.EXIT:
+                break
+            elif next_action == DebuggerAction.STEP:
+                self.debugger.step_next()
+            elif next_action == DebuggerAction.STEP_OUT:
+                self.debugger.step_out()
+            else:
+                assert (
+                    next_action == DebuggerAction.CONTINUE
+                ), f"next_action has invalid value {next_action}"
+                self.debugger.go()
+            time.sleep(self._pause_between_steps)

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/DextIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/DextIR.py
@@ -13,6 +13,14 @@ from dex.dextIR.StepIR import StepIR, StepKind
 from dex.test_script.Script import DexterScript
 
 
+def file_matches(a, b):
+    if os.path.exists(a) and os.path.exists(b):
+        return os.path.samefile(a, b)
+    return os.path.normpath(os.path.normcase(a)) == os.path.normpath(
+        os.path.normcase(b)
+    )
+
+
 def _step_kind_func(context, step):
     if step.current_location.path is None or not os.path.exists(
         step.current_location.path
@@ -20,7 +28,7 @@ def _step_kind_func(context, step):
         return StepKind.FUNC_UNKNOWN
 
     if any(
-        os.path.samefile(step.current_location.path, f)
+        file_matches(step.current_location.path, f)
         for f in context.options.source_files
     ):
         return StepKind.FUNC

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/LocIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/LocIR.py
@@ -46,3 +46,8 @@ class LocIR:
             return self.column > rhs.column
 
         return self.lineno > rhs.lineno
+
+    def short_str(self):
+        """Returns a shortened version of the location string by using only the basename of the file."""
+        basename = os.path.basename(self.path) if self.path else None
+        return f"{basename}:{self.lineno}:{self.column}"

--- a/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/StepIR.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/dextIR/StepIR.py
@@ -108,3 +108,24 @@ class StepIR:
             return self.current_frame.loc
         except AttributeError:
             return LocIR(path=None, lineno=None, column=None)
+
+    def detailed_print(self) -> List[str]:
+        lines: List[str] = []
+        lines.append(f"Step {self.step_index}")
+        lines.append(f"Stopped for {self.stop_reason}")
+        lines.append(f"Step was {self.step_kind}")
+        lines.append(f"Frames:")
+        for idx, frame in enumerate(self.frames):
+            lines.append(f"  Frame {idx}:")
+            fn_text = (
+                "[Inline Function] " if frame.is_inlined else ""
+            ) + frame.function
+            lines.append(f"    {fn_text}")
+            lines.append(f"    {frame.loc}")
+            lines.append(f"    $pc = {frame.instruction_addr}")
+
+        if self.watches:
+            lines.append(f"Variables:")
+            for value in sorted(self.watches.values(), key=lambda v: v.expression):
+                lines.append(f"  {value}")
+        return lines

--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/test/Tool.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/test/Tool.py
@@ -17,6 +17,9 @@ from dex.command.ParseCommand import get_command_infos
 from dex.debugger.Debuggers import run_debugger_subprocess
 from dex.debugger.DebuggerControllers.DefaultController import DefaultController
 from dex.debugger.DebuggerControllers.ConditionalController import ConditionalController
+from dex.debugger.DebuggerControllers.ScriptDebuggerController import (
+    ScriptDebuggerController,
+)
 from dex.dextIR.DextIR import DextIR
 from dex.heuristic import Heuristic
 from dex.test_script.Script import get_dexter_script
@@ -112,6 +115,11 @@ class Tool(TestToolBase):
             action="store_true",
             help="if true, skip running the debugger and produce no output; used for testing purposes",
         )
+        parser.add_argument(
+            "--skip-evaluate",
+            action="store_true",
+            help="if true, skip evaluating the ouput from the debugger and just print the seen steps; used for testing purposes",
+        )
         super(Tool, self).add_tool_arguments(parser, defaults)
 
     def _init_debugger_controller(self):
@@ -127,9 +135,6 @@ class Tool(TestToolBase):
                 self.context.options.test_files[0],
                 self.context.options.source_root_dir,
             )
-            assert (
-                self.context.options.skip_run
-            ), "Debugging not yet supported with --use-script"
         else:
             step_collection.commands, new_source_files = get_command_infos(
                 self.context.options.test_files, self.context.options.source_root_dir
@@ -141,11 +146,18 @@ class Tool(TestToolBase):
         if self.context.options.skip_run:
             return step_collection
 
-        cond_controller_cmds = ["DexLimitSteps", "DexStepFunction", "DexContinue"]
-        if any(c in step_collection.commands for c in cond_controller_cmds):
-            debugger_controller = ConditionalController(self.context, step_collection)
+        if self.context.options.use_script:
+            debugger_controller = ScriptDebuggerController(
+                self.context, step_collection
+            )
         else:
-            debugger_controller = DefaultController(self.context, step_collection)
+            cond_controller_cmds = ["DexLimitSteps", "DexStepFunction", "DexContinue"]
+            if any(c in step_collection.commands for c in cond_controller_cmds):
+                debugger_controller = ConditionalController(
+                    self.context, step_collection
+                )
+            else:
+                debugger_controller = DefaultController(self.context, step_collection)
 
         return debugger_controller
 
@@ -255,6 +267,14 @@ class Tool(TestToolBase):
                 if steps.script is not None:
                     print(steps.script.dump())
                 return
+            if self.context.options.skip_evaluate:
+                self.context.logger.warning("Skipping evaluation...")
+                for step in steps.steps:
+                    print("\n".join(step.detailed_print()))
+                return
+            assert (
+                not self.context.options.use_script
+            ), "Evaluation not yet supported with --use-script"
             self._record_steps(test_name, steps)
             heuristic_score = Heuristic(self.context, steps)
             self._record_score(test_name, heuristic_score)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/Inputs/header.h
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/Inputs/header.h
@@ -1,12 +1,12 @@
 
 int factorProduct(int a, int b) {
-    int result = 1;
-    int min = a > b ? b : a;
-    for (int i = 2; i < min; ++i) {
-        bool is_a = a % i == 0;
-        bool is_b = b % i == 0;
-        if (is_a && is_b)
-            result *= i;
-    }
-    return result;
+  int result = 1;
+  int min = a > b ? b : a;
+  for (int i = 2; i < min; ++i) {
+    bool is_a = a % i == 0;
+    bool is_b = b % i == 0;
+    if (is_a && is_b)
+      result *= i;
+  }
+  return result;
 }

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/Inputs/header.h
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/Inputs/header.h
@@ -1,0 +1,12 @@
+
+int factorProduct(int a, int b) {
+    int result = 1;
+    int min = a > b ? b : a;
+    for (int i = 2; i < min; ++i) {
+        bool is_a = a % i == 0;
+        bool is_b = b % i == 0;
+        if (is_a && is_b)
+            result *= i;
+    }
+    return result;
+}

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
@@ -29,7 +29,7 @@ int main() {
 
 /// Test that we can use functions in !where nodes, and that Dexter steps
 /// through the entirety of those functions. We expect both calls to `assign` to
-/// be stepped through, but only the outermost call of `replace` should be
+/// be stepped through, but only the non-recursive call of `replace` should be
 /// stepped through, as the !where matches to the rootmost applicable frame.
 
 // CHECK:      assign

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
@@ -29,7 +29,7 @@ int main() {
 
 /// Test that we can use functions in !where nodes, and that Dexter steps through the entirety of those functions.
 /// We expect both calls to `assign` to be stepped through, but only the outermost call of `replace` should be stepped
-/// through, as the !where matches to the first (outermost) applicable frame.
+/// through, as the !where matches to the rootmost applicable frame.
 
 // CHECK:      assign
 // CHECK-NEXT:   simple_where_function.cpp(6

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
@@ -1,35 +1,36 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
 
-
 void assign(int *Target, int Value) {
+    // A comment.
     *Target = Value;
 }
 
 void replace(int *Start, int Length, int Value, int NewValue) {
-    int *Middle = Start + Length / 2;
-    if (*Middle == Value) {
-        assign(Middle, NewValue);
-        return;
-    }
-    if (Length == 1)
-        return;
-    if (*Middle > Value)
-        replace(Start, Length / 2, Value, NewValue);
-    else
-        replace(Middle + 1, (Length - 1) / 2, Value, NewValue);
+  int *Middle = Start + Length / 2;
+  if (*Middle == Value) {
+    assign(Middle, NewValue);
+    return;
+  }
+  if (Length == 1)
+    return;
+  if (*Middle > Value)
+    replace(Start, Length / 2, Value, NewValue);
+  else
+    replace(Middle + 1, (Length - 1) / 2, Value, NewValue);
 }
 
 int main() {
-    int Array[] = { 2, 4, 6, 8, 10 };
-    assign(Array + 1, 5);
-    replace(Array, 5, 8, 9);
-    return Array[1] + Array[3];
+  int Array[] = {2, 4, 6, 8, 10};
+  assign(Array + 1, 5);
+  replace(Array, 5, 8, 9);
+  return Array[1] + Array[3];
 }
 
-/// Test that we can use functions in !where nodes, and that Dexter steps through the entirety of those functions.
-/// We expect both calls to `assign` to be stepped through, but only the outermost call of `replace` should be stepped
-/// through, as the !where matches to the rootmost applicable frame.
+/// Test that we can use functions in !where nodes, and that Dexter steps
+/// through the entirety of those functions. We expect both calls to `assign` to
+/// be stepped through, but only the outermost call of `replace` should be
+/// stepped through, as the !where matches to the rootmost applicable frame.
 
 // CHECK:      assign
 // CHECK-NEXT:   simple_where_function.cpp(6

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_function.cpp
@@ -1,0 +1,64 @@
+// RUN: %dexter_regression_test_cxx_build %s -o %t
+// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
+
+
+void assign(int *Target, int Value) {
+    *Target = Value;
+}
+
+void replace(int *Start, int Length, int Value, int NewValue) {
+    int *Middle = Start + Length / 2;
+    if (*Middle == Value) {
+        assign(Middle, NewValue);
+        return;
+    }
+    if (Length == 1)
+        return;
+    if (*Middle > Value)
+        replace(Start, Length / 2, Value, NewValue);
+    else
+        replace(Middle + 1, (Length - 1) / 2, Value, NewValue);
+}
+
+int main() {
+    int Array[] = { 2, 4, 6, 8, 10 };
+    assign(Array + 1, 5);
+    replace(Array, 5, 8, 9);
+    return Array[1] + Array[3];
+}
+
+/// Test that we can use functions in !where nodes, and that Dexter steps through the entirety of those functions.
+/// We expect both calls to `assign` to be stepped through, but only the outermost call of `replace` should be stepped
+/// through, as the !where matches to the first (outermost) applicable frame.
+
+// CHECK:      assign
+// CHECK-NEXT:   simple_where_function.cpp(6
+// CHECK:        "Value": (int) 5
+
+// CHECK:      replace
+// CHECK-NEXT:   simple_where_function.cpp(10
+// CHECK:        "Length": (int) 5
+// CHECK:      replace
+// CHECK-NEXT:   simple_where_function.cpp(11
+// CHECK:        "Length": (int) 5
+// CHECK:      replace
+// CHECK-NEXT:   simple_where_function.cpp(15
+// CHECK:        "Length": (int) 5
+// CHECK:      replace
+// CHECK-NEXT:   simple_where_function.cpp(17
+// CHECK:        "Length": (int) 5
+// CHECK:      replace
+// CHECK-NEXT:   simple_where_function.cpp(20
+// CHECK:        "Length": (int) 5
+
+/// The recursive call should not be stepped through by Dexter.
+// CHECK-NOT: "Length": (int) 2
+
+/*
+---
+!where {function: assign}:
+    !value Value: [5, 9]
+!where {function: replace}:
+    !value Length: 5
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_line.cpp
@@ -15,15 +15,15 @@
 // CHECK:   "c": (int) 42
 
 int multiply(int b, int a) {
-    int result = a * b;
-    return result;
+  int result = a * b;
+  return result;
 }
 
 int main() {
-    int a = 6;
-    int b = 7;
-    int c = multiply(a, b);
-    return c;
+  int a = 6;
+  int b = 7;
+  int c = multiply(a, b);
+  return c;
 }
 
 /*

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/simple_where_line.cpp
@@ -1,0 +1,40 @@
+// RUN: %dexter_regression_test_cxx_build %s -o %t
+// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s
+
+/// Test that we can perform a simple non-nested line-based !where.
+
+// CHECK-LABEL: Step 0
+// CHECK: multiply
+// CHECK:   "a": (int) 7
+// CHECK:   "b": (int) 6
+// CHECK:   "result": (int) 42
+// CHECK-LABEL: Step 2
+// CHECK: main
+// CHECK:   "a": (int) 6
+// CHECK:   "b": (int) 7
+// CHECK:   "c": (int) 42
+
+int multiply(int b, int a) {
+    int result = a * b;
+    return result;
+}
+
+int main() {
+    int a = 6;
+    int b = 7;
+    int c = multiply(a, b);
+    return c;
+}
+
+/*
+---
+!where {lines: 19}:
+    !value a: 7
+    !value b: 6
+    !value result: 42
+!where {lines: 26}:
+    !value a: 6
+    !value b: 7
+    !value c: 42
+...
+*/

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_file_paths.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_file_paths.cpp
@@ -1,31 +1,32 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s --implicit-check-not="header.h(9"
 
-/// Test that we can use file paths as part of a !where node, and that we can use a trailing subset of the file path,
-/// including just the base filename, to specify a file.
+/// Test that we can use file paths as part of a !where node, and that we can
+/// use a trailing subset of the file path, including just the base filename, to
+/// specify a file.
 
 // CHECK-LABEL: Step 0
 // CHECK: factorProduct
-// CHECK: Inputs/header.h(4:15)
+// CHECK: Inputs/header.h(4:13)
 // CHECK:   "a": (int) 21
 // CHECK-LABEL: Step 2
 // CHECK: factorProduct
-// CHECK: Inputs/header.h(11:12)
+// CHECK: Inputs/header.h(11:10)
 // CHECK:   "result": (int) 21
 // CHECK-LABEL: Step 4
 // CHECK: factorProduct
-// CHECK: Inputs/header.h(4:15)
+// CHECK: Inputs/header.h(4:13)
 // CHECK:   "a": (int) 10
 // CHECK-LABEL: Step 6
 // CHECK: factorProduct
-// CHECK: Inputs/header.h(11:12)
+// CHECK: Inputs/header.h(11:10)
 // CHECK:   "result": (int) 5
 
 #include "Inputs/header.h"
 
 int main() {
-    int Result = factorProduct(21, 42);
-    return Result + factorProduct(10, 35);
+  int Result = factorProduct(21, 42);
+  return Result + factorProduct(10, 35);
 }
 
 /*

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_file_paths.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/scripts/debugging/where_file_paths.cpp
@@ -1,0 +1,40 @@
+// RUN: %dexter_regression_test_cxx_build %s -o %t
+// RUN: %dexter_regression_test_run --use-script --skip-evaluate --binary %t -- %s | FileCheck %s --implicit-check-not="header.h(9"
+
+/// Test that we can use file paths as part of a !where node, and that we can use a trailing subset of the file path,
+/// including just the base filename, to specify a file.
+
+// CHECK-LABEL: Step 0
+// CHECK: factorProduct
+// CHECK: Inputs/header.h(4:15)
+// CHECK:   "a": (int) 21
+// CHECK-LABEL: Step 2
+// CHECK: factorProduct
+// CHECK: Inputs/header.h(11:12)
+// CHECK:   "result": (int) 21
+// CHECK-LABEL: Step 4
+// CHECK: factorProduct
+// CHECK: Inputs/header.h(4:15)
+// CHECK:   "a": (int) 10
+// CHECK-LABEL: Step 6
+// CHECK: factorProduct
+// CHECK: Inputs/header.h(11:12)
+// CHECK:   "result": (int) 5
+
+#include "Inputs/header.h"
+
+int main() {
+    int Result = factorProduct(21, 42);
+    return Result + factorProduct(10, 35);
+}
+
+/*
+---
+!where {file: "header.h", lines: 4}:
+    !value a: [21, 10]
+!where {file: "Inputs/header.h", lines: 11}:
+    !value result: [21, 5]
+!where {file: "FakePath/header.h", lines: 9}:
+    !value i: [3, 7, 5]
+...
+*/


### PR DESCRIPTION
This patch adds a debugger controller for structured scripts. This controller operates as follows:
- !where nodes at the root of the script (currently the only kind allowed) have function or line breakpoints set to cover them.
- Whenever the debugger stops, the controller will examine the stack to determine whether any !where nodes are in scope.
- While any !where is in scope, its associated !values will be evaluated in the debugger and the results stored, and the debugger will single-step.
- When no !where is in scope, the debugger will continue.

This is a simplified implementation compared to the final version, as it is missing support for nested !where nodes, Scope evaluation, and conditions/hit counts; these will be added in later commits.