### PR TITLE
[VPlan] Verify canonical IV has no users if there's a VPCurrentIterationPHI. NFC

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -4701,6 +4701,7 @@ public:
 
   /// Returns VF * UF of the vector loop region.
   VPSymbolicValue &getVFxUF() { return VFxUF; }
+  const VPSymbolicValue &getVFxUF() const { return VFxUF; }
 
   LLVMContext &getContext() const {
     return getScalarHeader()->getIRBasicBlock()->getContext();

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -96,10 +96,23 @@ bool VPlanVerifier::verifyPhiRecipes(const VPBasicBlock *VPBB) {
       return false;
     }
 
-    if (isa<VPCurrentIterationPHIRecipe>(RecipeI) &&
-        RecipeI->getIterator() != VPBB->begin()) {
-      errs() << "CurrentIteration PHI is not the first recipe\n";
-      return false;
+    if (isa<VPCurrentIterationPHIRecipe>(RecipeI)) {
+      if (RecipeI->getIterator() != VPBB->begin()) {
+        errs() << "CurrentIteration PHI is not the first recipe\n";
+        return false;
+      }
+      if (const VPValue *CanIV =
+              VPBB->getEnclosingLoopRegion()->getCanonicalIV()) {
+        if (!all_of(
+                CanIV->users(),
+                match_fn(m_Add(m_Specific(CanIV),
+                               m_Specific(&VPBB->getPlan()->getVFxUF()))))) {
+          errs()
+              << "There should be no users of the canonical IV other than the "
+                 "increment after a VPCurrentIterationPHI is added\n";
+          return false;
+        }
+      }
     }
 
     // Check if the recipe operands match the number of predecessors.


### PR DESCRIPTION
During the EVL transform we replace all uses of the canonical IV with a VPCurrentIterationPHI (the variably-stepping canonical IV).

Once it's added nothing else should use the canonical IV except for increment for the branch condition, otherwise the plan will be incorrect on the penultimate iteration.

This verifies this property in preparation for work to move the EVL transformation earlier in the pipeline
