### PR TITLE
[lldb][test] Add missing include in TestFrameVarDILCast test program

### DIFF
--- a/lldb/test/API/commands/frame/var-dil/expr/Casts/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Casts/main.cpp
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <cstddef>
+#include <cstdint>
 
 namespace ns {
 


### PR DESCRIPTION
Fixes aaad6a201f0f13762c45727faacf5347be577a23 / #191908.