### PR TITLE
[lldb][NFC] Use DenseMap for ISAToDescriptorMap in ObjCLanguageRuntime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -340,7 +340,7 @@ protected:
 
   bool AddClass(ObjCISA isa, const ClassDescriptorSP &descriptor_sp) {
     if (isa != 0) {
-      m_isa_to_descriptor[isa] = descriptor_sp;
+      m_isa_to_descriptor.insert_or_assign(isa, descriptor_sp);
       return true;
     }
     return false;
@@ -352,7 +352,7 @@ protected:
   bool AddClass(ObjCISA isa, const ClassDescriptorSP &descriptor_sp,
                 uint32_t class_name_hash) {
     if (isa != 0) {
-      m_isa_to_descriptor[isa] = descriptor_sp;
+      m_isa_to_descriptor.insert_or_assign(isa, descriptor_sp);
       m_hash_to_isa_map.insert(std::make_pair(class_name_hash, isa));
       return true;
     }
@@ -419,7 +419,7 @@ private:
 
   typedef std::map<ClassAndSel, lldb::addr_t> MsgImplMap;
   typedef std::map<ClassAndSelStr, lldb::addr_t> MsgImplStrMap;
-  typedef std::map<ObjCISA, ClassDescriptorSP> ISAToDescriptorMap;
+  typedef llvm::DenseMap<ObjCISA, ClassDescriptorSP> ISAToDescriptorMap;
   typedef std::multimap<uint32_t, ObjCISA> HashToISAMap;
   typedef ISAToDescriptorMap::iterator ISAToDescriptorIterator;
   typedef HashToISAMap::iterator HashToISAIterator;


### PR DESCRIPTION
This datastruct maps addr_t's to shared_pointers, which is a good case for a DenseMap. The tree allocation functions were showing up in Instrument traces when evaluating frame variable commands.

In a benchmark evaluating `v self` in a SwiftUI object, this brought down the number of CPU cycles from 578M to 487M. (release, no assertions)