### PR TITLE
[DAG] isIdentityElement - use KnownBits instead of constant splat to match identity constants

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -13594,32 +13594,34 @@ bool SelectionDAG::isIdentityElement(unsigned Opcode, SDNodeFlags Flags,
                                      unsigned OperandNo, unsigned Depth) const {
   // NOTE: The cases should match with IR's ConstantExpr::getBinOpIdentity().
   // TODO: Target-specific opcodes could be added.
-  if (auto *ConstV = isConstOrConstSplat(V, DemandedElts, /*AllowUndefs*/ false,
-                                         /*AllowTruncation*/ true)) {
-    APInt Const = ConstV->getAPIntValue().trunc(V.getScalarValueSizeInBits());
-    switch (Opcode) {
-    case ISD::ADD:
-    case ISD::OR:
-    case ISD::XOR:
-    case ISD::UMAX:
-      return Const.isZero();
-    case ISD::MUL:
-      return Const.isOne();
-    case ISD::AND:
-    case ISD::UMIN:
-      return Const.isAllOnes();
-    case ISD::SMAX:
-      return Const.isMinSignedValue();
-    case ISD::SMIN:
-      return Const.isMaxSignedValue();
-    case ISD::SUB:
-    case ISD::SHL:
-    case ISD::SRA:
-    case ISD::SRL:
-      return OperandNo == 1 && Const.isZero();
-    case ISD::UDIV:
-    case ISD::SDIV:
-      return OperandNo == 1 && Const.isOne();
+  if (V.getValueType().isInteger()) {
+    KnownBits Known = computeKnownBits(V, DemandedElts, Depth);
+    if (Known.isConstant()) {
+      const APInt &Const = Known.getConstant();
+      switch (Opcode) {
+      case ISD::ADD:
+      case ISD::OR:
+      case ISD::XOR:
+      case ISD::UMAX:
+        return Const.isZero();
+      case ISD::MUL:
+        return Const.isOne();
+      case ISD::AND:
+      case ISD::UMIN:
+        return Const.isAllOnes();
+      case ISD::SMAX:
+        return Const.isMinSignedValue();
+      case ISD::SMIN:
+        return Const.isMaxSignedValue();
+      case ISD::SUB:
+      case ISD::SHL:
+      case ISD::SRA:
+      case ISD::SRL:
+        return OperandNo == 1 && Const.isZero();
+      case ISD::UDIV:
+      case ISD::SDIV:
+        return OperandNo == 1 && Const.isOne();
+      }
     }
   } else if (auto *ConstFP = isConstOrConstSplatFP(V, DemandedElts)) {
     switch (Opcode) {

--- a/llvm/test/CodeGen/RISCV/rvv/vwadd-sdnode.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vwadd-sdnode.ll
@@ -1371,23 +1371,13 @@ define <vscale x 8 x i64> @vwaddu_wx_nxv8i64_nxv8i8(<vscale x 8 x i64> %va, i8 %
 ; Make sure that we don't introduce any V{S,Z}EXT_VL nodes with i1 types from
 ; combineBinOp_VLToVWBinOp_VL, since they can't be selected.
 define <vscale x 1 x i64> @i1_zext(<vscale x 1 x i1> %va, <vscale x 1 x i64> %vb, ptr %p) {
-; RV32-LABEL: i1_zext:
-; RV32:       # %bb.0:
-; RV32-NEXT:    vsetvli a1, zero, e64, m1, ta, ma
-; RV32-NEXT:    vmv.v.i v9, 0
-; RV32-NEXT:    vmerge.vim v9, v9, 1, v0
-; RV32-NEXT:    vadd.vv v8, v9, v8
-; RV32-NEXT:    li a1, 42
-; RV32-NEXT:    sh a1, 0(a0)
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: i1_zext:
-; RV64:       # %bb.0:
-; RV64-NEXT:    li a1, 42
-; RV64-NEXT:    vsetvli a2, zero, e64, m1, ta, mu
-; RV64-NEXT:    vadd.vi v8, v8, 1, v0.t
-; RV64-NEXT:    sh a1, 0(a0)
-; RV64-NEXT:    ret
+; CHECK-LABEL: i1_zext:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    li a1, 42
+; CHECK-NEXT:    vsetvli a2, zero, e64, m1, ta, mu
+; CHECK-NEXT:    vadd.vi v8, v8, 1, v0.t
+; CHECK-NEXT:    sh a1, 0(a0)
+; CHECK-NEXT:    ret
   %vc = zext <vscale x 1 x i1> %va to <vscale x 1 x i64>
   %vd = add <vscale x 1 x i64> %vc, %vb
 

--- a/llvm/test/CodeGen/Thumb2/mve-clmul.ll
+++ b/llvm/test/CodeGen/Thumb2/mve-clmul.ll
@@ -2153,10 +2153,6 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, r7, lr}
 ; CHECK-NEXT:    push {r4, r5, r6, r7, lr}
-; CHECK-NEXT:    .pad #4
-; CHECK-NEXT:    sub sp, #4
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    adr.w r0, .LCPI13_0
 ; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    vldrw.u32 q2, [r0]
@@ -2174,37 +2170,23 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmov r0, r3, d0
 ; CHECK-NEXT:    vmsr p0, r1
 ; CHECK-NEXT:    vmov r2, r1, d1
+; CHECK-NEXT:    vpsel q2, q2, q0
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    mov r7, r3
 ; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    lsll r4, r5, #1
 ; CHECK-NEXT:    lsll r6, r7, #1
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vmov q0[2], q0[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    vmov q0[3], q0[1], r7, r5
 ; CHECK-NEXT:    adr.w r7, .LCPI13_1
-; CHECK-NEXT:    vldrw.u32 q4, [r7]
-; CHECK-NEXT:    vpsel q3, q2, q3
+; CHECK-NEXT:    vldrw.u32 q3, [r7]
 ; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    vand q4, q1, q4
-; CHECK-NEXT:    lsll r4, r5, #2
-; CHECK-NEXT:    vmov r7, s16
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csetm r7, eq
-; CHECK-NEXT:    bfi r6, r7, #0, #8
-; CHECK-NEXT:    vmov r7, s18
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csetm r7, eq
-; CHECK-NEXT:    bfi r6, r7, #8, #8
-; CHECK-NEXT:    adr.w r7, .LCPI13_2
-; CHECK-NEXT:    vmsr p0, r6
-; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vpsel q0, q2, q0
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    veor q0, q2, q0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    lsll r4, r5, #2
 ; CHECK-NEXT:    vmov r7, s12
 ; CHECK-NEXT:    cmp r7, #0
 ; CHECK-NEXT:    csetm r7, eq
@@ -2217,15 +2199,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #2
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q2, q0
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_3
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_2
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #3
 ; CHECK-NEXT:    vmov r7, s12
@@ -2240,15 +2222,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #3
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_4
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_3
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #4
 ; CHECK-NEXT:    vmov r7, s12
@@ -2263,15 +2245,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #4
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_5
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_4
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #5
 ; CHECK-NEXT:    vmov r7, s12
@@ -2286,15 +2268,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #5
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_6
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_5
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #6
 ; CHECK-NEXT:    vmov r7, s12
@@ -2309,15 +2291,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #6
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_7
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_6
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #7
 ; CHECK-NEXT:    vmov r7, s12
@@ -2332,15 +2314,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #7
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_8
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_7
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #8
 ; CHECK-NEXT:    vmov r7, s12
@@ -2355,15 +2337,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #8
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_9
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_8
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #9
 ; CHECK-NEXT:    vmov r7, s12
@@ -2378,15 +2360,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #9
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_10
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_9
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #10
 ; CHECK-NEXT:    vmov r7, s12
@@ -2401,15 +2383,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #10
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_11
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_10
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #11
 ; CHECK-NEXT:    vmov r7, s12
@@ -2424,15 +2406,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #11
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_12
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_11
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #12
 ; CHECK-NEXT:    vmov r7, s12
@@ -2447,15 +2429,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #12
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_13
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_12
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #13
 ; CHECK-NEXT:    vmov r7, s12
@@ -2470,15 +2452,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #13
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_14
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_13
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #14
 ; CHECK-NEXT:    vmov r7, s12
@@ -2493,15 +2475,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #14
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_15
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_14
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #15
 ; CHECK-NEXT:    vmov r7, s12
@@ -2516,15 +2498,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #15
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_16
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_15
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #16
 ; CHECK-NEXT:    vmov r7, s12
@@ -2539,15 +2521,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #16
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_17
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_16
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #17
 ; CHECK-NEXT:    vmov r7, s12
@@ -2562,15 +2544,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #17
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_18
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_17
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #18
 ; CHECK-NEXT:    vmov r7, s12
@@ -2585,15 +2567,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #18
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_19
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_18
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #19
 ; CHECK-NEXT:    vmov r7, s12
@@ -2608,15 +2590,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #19
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_20
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_19
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #20
 ; CHECK-NEXT:    vmov r7, s12
@@ -2631,15 +2613,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #20
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_21
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_20
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #21
 ; CHECK-NEXT:    vmov r7, s12
@@ -2654,15 +2636,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #21
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_22
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_21
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #22
 ; CHECK-NEXT:    vmov r7, s12
@@ -2677,15 +2659,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #22
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_23
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_22
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #23
 ; CHECK-NEXT:    vmov r7, s12
@@ -2700,15 +2682,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #23
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr.w r7, .LCPI13_24
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr.w r7, .LCPI13_23
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #24
 ; CHECK-NEXT:    vmov r7, s12
@@ -2723,15 +2705,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #24
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_25
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_24
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #25
 ; CHECK-NEXT:    vmov r7, s12
@@ -2746,15 +2728,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #25
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_26
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_25
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #26
 ; CHECK-NEXT:    vmov r7, s12
@@ -2769,15 +2751,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #26
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_27
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_26
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #27
 ; CHECK-NEXT:    vmov r7, s12
@@ -2792,15 +2774,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #27
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_28
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_27
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #28
 ; CHECK-NEXT:    vmov r7, s12
@@ -2815,15 +2797,15 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #28
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_29
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_28
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #29
 ; CHECK-NEXT:    vmov r7, s12
@@ -2838,19 +2820,19 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #29
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
 ; CHECK-NEXT:    movs r6, #0
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_30
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_29
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    mov r4, r2
 ; CHECK-NEXT:    mov r5, r1
-; CHECK-NEXT:    lsll r2, r1, #31
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r5, #30
 ; CHECK-NEXT:    vmov r7, s12
+; CHECK-NEXT:    lsll r2, r1, #31
 ; CHECK-NEXT:    cmp r7, #0
 ; CHECK-NEXT:    csetm r7, eq
 ; CHECK-NEXT:    bfi r6, r7, #0, #8
@@ -2862,41 +2844,53 @@ define <2 x i32> @clmul_v2i32(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    vmsr p0, r6
 ; CHECK-NEXT:    mov r6, r0
 ; CHECK-NEXT:    lsll r6, r7, #30
-; CHECK-NEXT:    lsll r0, r3, #31
-; CHECK-NEXT:    vmov q3[2], q3[0], r6, r4
-; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
-; CHECK-NEXT:    adr r7, .LCPI13_31
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r6, r4
+; CHECK-NEXT:    movs r6, #0
+; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    adr r7, .LCPI13_30
 ; CHECK-NEXT:    vldrw.u32 q3, [r7]
+; CHECK-NEXT:    veor q2, q0, q2
+; CHECK-NEXT:    lsll r0, r3, #31
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    vmov r7, s12
+; CHECK-NEXT:    cmp r7, #0
+; CHECK-NEXT:    csetm r7, eq
+; CHECK-NEXT:    bfi r6, r7, #0, #8
+; CHECK-NEXT:    vmov r7, s14
+; CHECK-NEXT:    cmp r7, #0
+; CHECK-NEXT:    csetm r7, eq
+; CHECK-NEXT:    bfi r6, r7, #8, #8
+; CHECK-NEXT:    vmsr p0, r6
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r0, r2
+; CHECK-NEXT:    adr r0, .LCPI13_31
+; CHECK-NEXT:    vmov q2[3], q2[1], r3, r1
+; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q1, q1, q3
-; CHECK-NEXT:    vmov r7, s4
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csetm r7, eq
-; CHECK-NEXT:    bfi r12, r7, #0, #8
-; CHECK-NEXT:    vmov r7, s6
-; CHECK-NEXT:    vmov q1[2], q1[0], r0, r2
-; CHECK-NEXT:    vmov q1[3], q1[1], r3, r1
-; CHECK-NEXT:    cmp r7, #0
-; CHECK-NEXT:    csetm r7, eq
-; CHECK-NEXT:    bfi r12, r7, #8, #8
+; CHECK-NEXT:    vmov r0, s4
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r12, r0, #0, #8
+; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r12, r0, #8, #8
 ; CHECK-NEXT:    vmsr p0, r12
-; CHECK-NEXT:    vpsel q1, q2, q1
-; CHECK-NEXT:    veor q0, q0, q1
-; CHECK-NEXT:    vpop {d8, d9}
-; CHECK-NEXT:    add sp, #4
+; CHECK-NEXT:    vpsel q0, q0, q2
 ; CHECK-NEXT:    pop {r4, r5, r6, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI13_0:
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI13_1:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI13_2:
 ; CHECK-NEXT:    .long 4 @ 0x4
@@ -3079,6 +3073,7 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    lsll r2, r7, #1
+; CHECK-NEXT:    vpsel q2, q2, q0
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    lsll r4, r5, #1
@@ -3089,24 +3084,9 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    vmov q3[3], q3[1], r5, r7
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    vand q4, q1, q4
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r4, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s18
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r4, r2, #8, #8
-; CHECK-NEXT:    adr.w r2, .LCPI14_67
-; CHECK-NEXT:    vmsr p0, r4
-; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q0
-; CHECK-NEXT:    veor q3, q4, q3
-; CHECK-NEXT:    vldrw.u32 q4, [r2]
-; CHECK-NEXT:    vand q4, q1, q4
 ; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r4, r2, #0, #8
@@ -3119,16 +3099,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #2
 ; CHECK-NEXT:    lsll r4, r7, #2
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_68
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_67
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3142,16 +3122,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #3
 ; CHECK-NEXT:    lsll r4, r7, #3
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_69
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_68
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3165,16 +3145,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #4
 ; CHECK-NEXT:    lsll r4, r7, #4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_70
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_69
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3188,16 +3168,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #5
 ; CHECK-NEXT:    lsll r4, r7, #5
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_71
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_70
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3211,16 +3191,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #6
 ; CHECK-NEXT:    lsll r4, r7, #6
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_72
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_71
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3234,16 +3214,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #7
 ; CHECK-NEXT:    lsll r4, r7, #7
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_73
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_72
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3257,16 +3237,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #8
 ; CHECK-NEXT:    lsll r4, r7, #8
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_74
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_73
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3280,16 +3260,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #9
 ; CHECK-NEXT:    lsll r4, r7, #9
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_75
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_74
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3303,16 +3283,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #10
 ; CHECK-NEXT:    lsll r4, r7, #10
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_11
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_10
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3326,16 +3306,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #11
 ; CHECK-NEXT:    lsll r4, r7, #11
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_12
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_11
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3349,16 +3329,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #12
 ; CHECK-NEXT:    lsll r4, r7, #12
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_13
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_12
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3372,16 +3352,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #13
 ; CHECK-NEXT:    lsll r4, r7, #13
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_14
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_13
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3395,16 +3375,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #14
 ; CHECK-NEXT:    lsll r4, r7, #14
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_15
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_14
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3418,16 +3398,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #15
 ; CHECK-NEXT:    lsll r4, r7, #15
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_16
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_15
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3441,16 +3421,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #16
 ; CHECK-NEXT:    lsll r4, r7, #16
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_17
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_16
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3464,16 +3444,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #17
 ; CHECK-NEXT:    lsll r4, r7, #17
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_18
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_17
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3487,16 +3467,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #18
 ; CHECK-NEXT:    lsll r4, r7, #18
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_19
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_18
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3510,16 +3490,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #19
 ; CHECK-NEXT:    lsll r4, r7, #19
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_20
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_19
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3533,16 +3513,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #20
 ; CHECK-NEXT:    lsll r4, r7, #20
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_21
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_20
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3556,16 +3536,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #21
 ; CHECK-NEXT:    lsll r4, r7, #21
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_22
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_21
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3579,16 +3559,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #22
 ; CHECK-NEXT:    lsll r4, r7, #22
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_23
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_22
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3602,16 +3582,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #23
 ; CHECK-NEXT:    lsll r4, r7, #23
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_24
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_23
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3625,16 +3605,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #24
 ; CHECK-NEXT:    lsll r4, r7, #24
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_25
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_24
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3648,16 +3628,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #25
 ; CHECK-NEXT:    lsll r4, r7, #25
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_26
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_25
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3671,16 +3651,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #26
 ; CHECK-NEXT:    lsll r4, r7, #26
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_27
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_26
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3694,16 +3674,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #27
 ; CHECK-NEXT:    lsll r4, r7, #27
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_28
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_27
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3717,16 +3697,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #28
 ; CHECK-NEXT:    lsll r4, r7, #28
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_29
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_28
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3740,16 +3720,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #29
 ; CHECK-NEXT:    lsll r4, r7, #29
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_30
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_29
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -3763,13 +3743,13 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r5, #30
 ; CHECK-NEXT:    lsll r4, r7, #30
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI14_31
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r5
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI14_30
 ; CHECK-NEXT:    movs r4, #0
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    veor q3, q3, q4
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r5
+; CHECK-NEXT:    veor q3, q2, q3
 ; CHECK-NEXT:    vand q4, q1, q4
 ; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
@@ -3784,34 +3764,34 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r2, r3, #31
 ; CHECK-NEXT:    lsll r4, r1, #31
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    vmov q3[3], q3[1], r1, r3
+; CHECK-NEXT:    adr.w r1, .LCPI14_31
+; CHECK-NEXT:    vldrw.u32 q4, [r1]
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q4[3], q4[1], r1, r3
-; CHECK-NEXT:    adr.w r1, .LCPI14_32
-; CHECK-NEXT:    vpsel q4, q2, q4
-; CHECK-NEXT:    veor q4, q3, q4
-; CHECK-NEXT:    vldrw.u32 q3, [r1]
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmov r1, s13
-; CHECK-NEXT:    vldr s12, .LCPI14_76
-; CHECK-NEXT:    vmov.f32 s13, s0
-; CHECK-NEXT:    vmov.f32 s14, s12
+; CHECK-NEXT:    veor q3, q2, q3
+; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    vmov r1, s16
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #0, #8
-; CHECK-NEXT:    vmov r1, s15
-; CHECK-NEXT:    vmov.f32 s15, s2
+; CHECK-NEXT:    vmov r1, s18
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
-; CHECK-NEXT:    adr.w r1, .LCPI14_34
+; CHECK-NEXT:    adr.w r1, .LCPI14_33
+; CHECK-NEXT:    vldrw.u32 q4, [r1]
 ; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vpsel q0, q2, q3
-; CHECK-NEXT:    veor q0, q4, q0
-; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vpsel q3, q2, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    vldr s8, .LCPI14_75
 ; CHECK-NEXT:    vmov r1, s17
+; CHECK-NEXT:    vmov.f32 s9, s0
+; CHECK-NEXT:    vmov.f32 s10, s8
+; CHECK-NEXT:    vmov.f32 s11, s2
+; CHECK-NEXT:    veor q0, q3, q2
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #0, #8
@@ -3820,16 +3800,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #1
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #1
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_35
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_34
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3839,16 +3819,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #2
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #2
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_36
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_35
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3858,16 +3838,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #3
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #3
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_37
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_36
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3877,16 +3857,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #4
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #4
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_38
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_37
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3896,16 +3876,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #5
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #5
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_39
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_38
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3915,16 +3895,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #6
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #6
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_40
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_39
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3934,16 +3914,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #7
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #7
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_41
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_40
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3953,16 +3933,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #8
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #8
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_42
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_41
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3972,16 +3952,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #9
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #9
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_43
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_42
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -3991,16 +3971,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #10
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #10
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_44
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_43
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4010,16 +3990,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #11
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #11
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_45
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_44
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4029,16 +4009,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #12
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #12
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_46
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_45
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4048,16 +4028,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #13
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #13
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_47
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_46
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4067,23 +4047,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #14
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #14
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    b.w .LBB14_2
-; CHECK-NEXT:    .p2align 2
-; CHECK-NEXT:  @ %bb.1:
-; CHECK-NEXT:  .LCPI14_76:
-; CHECK-NEXT:    .long 0x00000000 @ float 0
-; CHECK-NEXT:    .p2align 1
-; CHECK-NEXT:  .LBB14_2:
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_48
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_47
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4091,18 +4064,25 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    vmov r1, s19
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
+; CHECK-NEXT:    b.w .LBB14_2
+; CHECK-NEXT:    .p2align 2
+; CHECK-NEXT:  @ %bb.1:
+; CHECK-NEXT:  .LCPI14_75:
+; CHECK-NEXT:    .long 0x00000000 @ float 0
+; CHECK-NEXT:    .p2align 1
+; CHECK-NEXT:  .LBB14_2:
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #15
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #15
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_49
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_48
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4112,16 +4092,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #16
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #16
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_50
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_49
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4131,16 +4111,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #17
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #17
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_51
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_50
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4150,16 +4130,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #18
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #18
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_52
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_51
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4169,16 +4149,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #19
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #19
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_53
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_52
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4188,16 +4168,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #20
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #20
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_54
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_53
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4207,16 +4187,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #21
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #21
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_55
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_54
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4226,29 +4206,43 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #22
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #22
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_56
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_55
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    b.w .LBB14_14
+; CHECK-NEXT:    vpsel q0, q0, q3
+; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
+; CHECK-NEXT:    vmov r1, s17
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    csetm r1, eq
+; CHECK-NEXT:    bfi r2, r1, #0, #8
+; CHECK-NEXT:    vmov r1, s19
+; CHECK-NEXT:    cmp r1, #0
+; CHECK-NEXT:    csetm r1, eq
+; CHECK-NEXT:    bfi r2, r1, #8, #8
+; CHECK-NEXT:    lsl.w r1, r12, #23
+; CHECK-NEXT:    vmov s11, r1
+; CHECK-NEXT:    lsls r1, r0, #23
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_56
+; CHECK-NEXT:    b.w .LBB14_13
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.3:
 ; CHECK-NEXT:  .LCPI14_65:
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.4:
 ; CHECK-NEXT:  .LCPI14_66:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.5:
@@ -4306,35 +4300,14 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .long 512 @ 0x200
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  @ %bb.13:
-; CHECK-NEXT:  .LCPI14_75:
-; CHECK-NEXT:    .long 1024 @ 0x400
-; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1024 @ 0x400
-; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 1
-; CHECK-NEXT:  .LBB14_14:
-; CHECK-NEXT:    vand q4, q1, q4
-; CHECK-NEXT:    vmov r1, s17
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    csetm r1, eq
-; CHECK-NEXT:    bfi r2, r1, #0, #8
-; CHECK-NEXT:    vmov r1, s19
-; CHECK-NEXT:    cmp r1, #0
-; CHECK-NEXT:    csetm r1, eq
-; CHECK-NEXT:    bfi r2, r1, #8, #8
-; CHECK-NEXT:    lsl.w r1, r12, #23
-; CHECK-NEXT:    vmov s15, r1
-; CHECK-NEXT:    lsls r1, r0, #23
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_57
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:  .LBB14_13:
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4344,16 +4317,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #24
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #24
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_58
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_57
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4363,16 +4336,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #25
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #25
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_59
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_58
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4382,16 +4355,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #26
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #26
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_60
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_59
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4401,16 +4374,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #27
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #27
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_61
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_60
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4420,16 +4393,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #28
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #28
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr.w r1, .LCPI14_62
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_61
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4439,16 +4412,16 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #29
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #29
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr r1, .LCPI14_63
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr.w r1, .LCPI14_62
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
 ; CHECK-NEXT:    vand q4, q1, q4
+; CHECK-NEXT:    veor q3, q0, q2
 ; CHECK-NEXT:    vmov r1, s17
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
@@ -4458,34 +4431,53 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    csetm r1, eq
 ; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #30
-; CHECK-NEXT:    vmov s15, r1
+; CHECK-NEXT:    vmov s11, r1
 ; CHECK-NEXT:    lsls r1, r0, #30
-; CHECK-NEXT:    vmov s13, r1
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vpsel q4, q2, q3
-; CHECK-NEXT:    adr r1, .LCPI14_64
-; CHECK-NEXT:    veor q0, q0, q4
+; CHECK-NEXT:    vmov s9, r1
+; CHECK-NEXT:    adr r1, .LCPI14_63
 ; CHECK-NEXT:    vldrw.u32 q4, [r1]
+; CHECK-NEXT:    vmsr p0, r2
+; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q3
+; CHECK-NEXT:    vand q4, q1, q4
 ; CHECK-NEXT:    lsls r0, r0, #31
-; CHECK-NEXT:    vand q1, q1, q4
-; CHECK-NEXT:    vmov s13, r0
-; CHECK-NEXT:    vmov r1, s5
+; CHECK-NEXT:    vmov r1, s17
+; CHECK-NEXT:    veor q3, q0, q2
+; CHECK-NEXT:    vmov s9, r0
+; CHECK-NEXT:    adr r0, .LCPI14_64
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
-; CHECK-NEXT:    bfi lr, r1, #0, #8
-; CHECK-NEXT:    vmov r1, s7
+; CHECK-NEXT:    bfi r2, r1, #0, #8
+; CHECK-NEXT:    vmov r1, s19
 ; CHECK-NEXT:    cmp r1, #0
 ; CHECK-NEXT:    csetm r1, eq
-; CHECK-NEXT:    bfi lr, r1, #8, #8
+; CHECK-NEXT:    bfi r2, r1, #8, #8
 ; CHECK-NEXT:    lsl.w r1, r12, #31
+; CHECK-NEXT:    vmsr p0, r2
+; CHECK-NEXT:    vmov s11, r1
+; CHECK-NEXT:    vpsel q0, q0, q3
+; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    veor q2, q0, q2
+; CHECK-NEXT:    vand q1, q1, q3
+; CHECK-NEXT:    vmov r0, s5
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi lr, r0, #0, #8
+; CHECK-NEXT:    vmov r0, s7
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi lr, r0, #8, #8
 ; CHECK-NEXT:    vmsr p0, lr
-; CHECK-NEXT:    vmov s15, r1
-; CHECK-NEXT:    vpsel q1, q2, q3
-; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    vpsel q0, q0, q2
 ; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  @ %bb.15:
+; CHECK-NEXT:  @ %bb.14:
+; CHECK-NEXT:  .LCPI14_10:
+; CHECK-NEXT:    .long 1024 @ 0x400
+; CHECK-NEXT:    .long 0 @ 0x0
+; CHECK-NEXT:    .long 1024 @ 0x400
+; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI14_11:
 ; CHECK-NEXT:    .long 2048 @ 0x800
 ; CHECK-NEXT:    .long 0 @ 0x0
@@ -4591,7 +4583,7 @@ define <2 x i64> @clmul_v2i64(<2 x i64> %x, <2 x i64> %y) {
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .long 2147483648 @ 0x80000000
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:  .LCPI14_32:
+; CHECK-NEXT:  .LCPI14_33:
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
@@ -7418,8 +7410,6 @@ define <2 x i64> @clmul_v2i64_zext(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    adr.w r0, .LCPI21_0
 ; CHECK-NEXT:    movs r2, #0
 ; CHECK-NEXT:    vldrw.u32 q2, [r0]
@@ -7427,742 +7417,741 @@ define <2 x i64> @clmul_v2i64_zext(<2 x i32> %x, <2 x i32> %y) {
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    movs r1, #0
+; CHECK-NEXT:    vmov.i32 q3, #0x0
 ; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s10
-; CHECK-NEXT:    vmov.i32 q2, #0x0
+; CHECK-NEXT:    vmov.i64 q2, #0xffffffff
+; CHECK-NEXT:    vand q2, q0, q2
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    vmov r0, s0
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    lsll r0, r3, #1
-; CHECK-NEXT:    mov r4, r2
+; CHECK-NEXT:    mov r2, r12
+; CHECK-NEXT:    lsll r2, r3, #1
+; CHECK-NEXT:    vpsel q2, q3, q2
+; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r4, r5, #1
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_1
-; CHECK-NEXT:    vldrw.u32 q4, [r0]
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_1
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    vand q4, q1, q4
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    vmov r0, s16
 ; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q0, q2, q0
 ; CHECK-NEXT:    lsll r4, r5, #2
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s18
-; CHECK-NEXT:    vmov.i64 q4, #0xffffffff
-; CHECK-NEXT:    vand q0, q0, q4
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    adr.w r0, .LCPI21_2
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    lsll r2, r3, #2
 ; CHECK-NEXT:    vpsel q0, q2, q0
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_2
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #2
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_3
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #3
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_4
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #3
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_3
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #4
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #4
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_5
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_4
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #5
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #5
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_6
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #5
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_5
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #6
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #6
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_7
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #6
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_6
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #7
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #7
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_8
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #7
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_7
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #8
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #8
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_9
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #8
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_8
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #9
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #9
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_10
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #9
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_9
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #10
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #10
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_11
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #10
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_10
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #11
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #11
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_12
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #11
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_11
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #12
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #12
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_13
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #12
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_12
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #13
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #13
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_14
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #13
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_13
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #14
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #14
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_15
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #14
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_14
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #15
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #15
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_16
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #15
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_15
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #16
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #16
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_17
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #16
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_16
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #17
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #17
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_18
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #17
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_17
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #18
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #18
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_19
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #18
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_18
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #19
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #19
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_20
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #19
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_19
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #20
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #20
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_21
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #20
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_20
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #21
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #21
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_22
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #21
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_21
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #22
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #22
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_23
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #22
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_22
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #23
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #23
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI21_24
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #23
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI21_23
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #24
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #24
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_25
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #24
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_24
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #25
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #25
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_26
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #25
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_25
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #26
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #26
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_27
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #26
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_26
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #27
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #27
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_28
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #27
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_27
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #28
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #28
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_29
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #28
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_28
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #29
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #29
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_30
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #29
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_29
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    lsll r2, r1, #31
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #30
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #30
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI21_31
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #30
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI21_30
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    veor q2, q0, q2
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    lsll r0, r5, #31
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    lsll r12, r3, #31
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r0, r12
+; CHECK-NEXT:    adr r0, .LCPI21_31
 ; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q1, q1, q3
 ; CHECK-NEXT:    vmov r0, s4
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
+; CHECK-NEXT:    bfi r1, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s6
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r12, r3, #31
-; CHECK-NEXT:    vmov q1[2], q1[0], r2, r12
-; CHECK-NEXT:    vmov q1[3], q1[1], r1, r3
-; CHECK-NEXT:    vpsel q1, q2, q1
-; CHECK-NEXT:    veor q0, q0, q1
-; CHECK-NEXT:    vpop {d8, d9}
+; CHECK-NEXT:    bfi r1, r0, #8, #8
+; CHECK-NEXT:    vmsr p0, r1
+; CHECK-NEXT:    vpsel q0, q0, q2
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI21_0:
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI21_1:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI21_2:
 ; CHECK-NEXT:    .long 4 @ 0x4
@@ -8327,854 +8316,803 @@ define <4 x i64> @clmul_v4i64_zext(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r8, lr}
 ; CHECK-NEXT:    .vsave {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    vpush {d8, d9, d10, d11, d12, d13, d14, d15}
-; CHECK-NEXT:    .pad #512
-; CHECK-NEXT:    sub.w sp, sp, #512
-; CHECK-NEXT:    vmov q6, q0
+; CHECK-NEXT:    .pad #496
+; CHECK-NEXT:    sub sp, #496
+; CHECK-NEXT:    vmov q2, q0
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vmov.f32 s18, s25
+; CHECK-NEXT:    vmov.f32 s14, s9
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vmov r0, s24
-; CHECK-NEXT:    vmov q7, q1
-; CHECK-NEXT:    vmov.f32 s30, s29
-; CHECK-NEXT:    vstrw.32 q1, [sp, #480] @ 16-byte Spill
-; CHECK-NEXT:    vmov.i32 q3, #0x0
+; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    vmov q6, q1
 ; CHECK-NEXT:    vmov.f32 s16, s24
 ; CHECK-NEXT:    mov.w lr, #0
-; CHECK-NEXT:    vmov r12, s18
+; CHECK-NEXT:    vmov.f32 s18, s25
+; CHECK-NEXT:    vmov.f32 s12, s8
+; CHECK-NEXT:    vmov r12, s14
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    lsll r4, r5, #2
+; CHECK-NEXT:    lsll r4, r5, #1
 ; CHECK-NEXT:    mov r2, r12
-; CHECK-NEXT:    lsll r2, r3, #2
+; CHECK-NEXT:    lsll r2, r3, #1
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_32
-; CHECK-NEXT:    vldrw.u32 q2, [r2]
+; CHECK-NEXT:    vldrw.u32 q1, [r2]
 ; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    vstrw.32 q2, [sp, #496] @ 16-byte Spill
-; CHECK-NEXT:    vand q2, q7, q2
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    vand q5, q4, q1
+; CHECK-NEXT:    vstrw.32 q1, [sp, #480] @ 16-byte Spill
+; CHECK-NEXT:    vmov r2, s20
+; CHECK-NEXT:    vmov.i64 q1, #0xffffffff
+; CHECK-NEXT:    vand q3, q3, q1
+; CHECK-NEXT:    vmov.i32 q1, #0x0
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    lsll r4, r5, #1
+; CHECK-NEXT:    lsll r4, r5, #2
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    adr.w r2, .LCPI22_33
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q3, q1, q3
+; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    veor q0, q3, q0
+; CHECK-NEXT:    vand q5, q4, q1
+; CHECK-NEXT:    vstrw.32 q1, [sp, #464] @ 16-byte Spill
+; CHECK-NEXT:    vmov r2, s20
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r2, r3, #1
-; CHECK-NEXT:    vpsel q5, q3, q0
-; CHECK-NEXT:    vmov q1[2], q1[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI22_33
-; CHECK-NEXT:    vldrw.u32 q0, [r2]
-; CHECK-NEXT:    vmov q1[3], q1[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #2
+; CHECK-NEXT:    vpsel q3, q3, q0
+; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI22_34
+; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    vand q2, q7, q0
-; CHECK-NEXT:    vstrw.32 q0, [sp, #464] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vmov r2, s20
+; CHECK-NEXT:    vstrw.32 q1, [sp, #448] @ 16-byte Spill
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #3
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #8, #8
-; CHECK-NEXT:    adr.w r2, .LCPI22_34
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q1
-; CHECK-NEXT:    vldrw.u32 q1, [r2]
-; CHECK-NEXT:    vand q2, q7, q1
-; CHECK-NEXT:    vstrw.32 q1, [sp, #448] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
-; CHECK-NEXT:    vmov.i64 q1, #0xffffffff
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
-; CHECK-NEXT:    vand q2, q4, q1
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r2, r3, #3
-; CHECK-NEXT:    veor q0, q2, q0
-; CHECK-NEXT:    veor q4, q0, q5
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_35
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #432] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #4
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #4
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_36
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #416] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #5
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #5
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_37
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #400] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #6
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #6
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_38
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #384] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #7
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #7
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_39
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #368] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #8
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #8
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_40
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #352] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #9
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #9
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_41
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #336] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #10
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #10
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_42
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #320] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #11
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #11
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_43
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #304] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #12
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #12
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_44
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #288] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #13
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #13
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_45
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #272] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #14
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #14
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_14
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #256] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #15
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #15
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_15
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #240] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #16
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_16
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #224] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #17
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_17
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #208] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #18
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_18
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #192] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #19
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_19
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #176] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #20
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_20
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #160] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #21
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #21
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_21
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #144] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #22
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_22
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #128] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #23
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #23
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_23
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #112] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #24
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #24
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_24
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #96] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #25
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #25
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_25
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #80] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #26
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #26
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_26
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #64] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #27
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #27
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_27
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #48] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #28
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #28
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_28
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #32] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #29
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #29
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_29
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    vldrw.u32 q1, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q5, q4, q1
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q1
+; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    vstrw.32 q1, [sp, #16] @ 16-byte Spill
-; CHECK-NEXT:    vmov r2, s8
+; CHECK-NEXT:    veor q0, q3, q0
 ; CHECK-NEXT:    lsll r4, r5, #30
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s22
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r2, r3, #30
-; CHECK-NEXT:    veor q4, q4, q0
+; CHECK-NEXT:    vpsel q3, q3, q0
 ; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI22_30
+; CHECK-NEXT:    vldrw.u32 q7, [r2]
 ; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    veor q1, q3, q0
 ; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vand q0, q4, q7
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    vand q2, q7, q5
+; CHECK-NEXT:    vmov r2, s0
 ; CHECK-NEXT:    lsll r0, r5, #31
-; CHECK-NEXT:    vmov r2, s8
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s10
+; CHECK-NEXT:    vmov r2, s2
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    movs r2, #0
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q0, q3, q0
 ; CHECK-NEXT:    lsll r12, r3, #31
-; CHECK-NEXT:    veor q2, q4, q0
-; CHECK-NEXT:    vmov q0[2], q0[0], r0, r12
+; CHECK-NEXT:    vpsel q0, q3, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r0, r12
 ; CHECK-NEXT:    adr.w r0, .LCPI22_31
-; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
-; CHECK-NEXT:    vldrw.u32 q4, [r0]
-; CHECK-NEXT:    vand q1, q7, q4
-; CHECK-NEXT:    vmov r0, s4
+; CHECK-NEXT:    vldrw.u32 q5, [r0]
+; CHECK-NEXT:    vmov q1[3], q1[1], r5, r3
+; CHECK-NEXT:    veor q1, q0, q1
+; CHECK-NEXT:    vmov.i64 q3, #0xffffffff
+; CHECK-NEXT:    vand q4, q4, q5
+; CHECK-NEXT:    vmov r0, s16
+; CHECK-NEXT:    vmov.f32 s16, s26
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s6
+; CHECK-NEXT:    vmov r0, s18
+; CHECK-NEXT:    vmov.f32 s18, s27
+; CHECK-NEXT:    vand q4, q4, q3
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vpsel q0, q3, q0
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vldrw.u32 q6, [sp, #480] @ 16-byte Reload
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov.f32 s4, s10
+; CHECK-NEXT:    vmov.f32 s6, s11
 ; CHECK-NEXT:    vstrw.32 q0, [sp] @ 16-byte Spill
-; CHECK-NEXT:    vmov.f32 s0, s26
-; CHECK-NEXT:    vmov.f32 s2, s27
-; CHECK-NEXT:    vmov.i64 q6, #0xffffffff
-; CHECK-NEXT:    vand q1, q0, q6
-; CHECK-NEXT:    vmov r3, s7
-; CHECK-NEXT:    vmov r1, s5
-; CHECK-NEXT:    vmov r4, s0
-; CHECK-NEXT:    vmov r12, s2
-; CHECK-NEXT:    vldrw.u32 q0, [sp, #480] @ 16-byte Reload
-; CHECK-NEXT:    vmov.f32 s0, s2
-; CHECK-NEXT:    vmov.f32 s2, s3
-; CHECK-NEXT:    vand q0, q0, q6
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #496] @ 16-byte Reload
-; CHECK-NEXT:    vand q5, q0, q5
-; CHECK-NEXT:    vand q6, q0, q6
+; CHECK-NEXT:    vand q0, q1, q3
+; CHECK-NEXT:    vand q6, q4, q6
+; CHECK-NEXT:    vmov r3, s3
+; CHECK-NEXT:    vmov r1, s1
+; CHECK-NEXT:    vmov r4, s4
+; CHECK-NEXT:    vmov r12, s6
 ; CHECK-NEXT:    mov r7, r3
 ; CHECK-NEXT:    mov r5, r1
 ; CHECK-NEXT:    mov r2, r4
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    lsll r2, r5, #2
 ; CHECK-NEXT:    lsll r0, r7, #2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
-; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r5, r7
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    vmov q1[3], q1[1], r5, r7
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q7, [sp, #464] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
 ; CHECK-NEXT:    lsll r0, r5, #1
 ; CHECK-NEXT:    lsll r2, r7, #1
-; CHECK-NEXT:    vand q7, q0, q7
-; CHECK-NEXT:    vmov q6[2], q6[0], r2, r0
-; CHECK-NEXT:    vmov r0, s28
-; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vpsel q2, q3, q2
-; CHECK-NEXT:    vmov q6[3], q6[1], r7, r5
-; CHECK-NEXT:    mov r5, r3
-; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s30
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q7, [sp, #448] @ 16-byte Reload
-; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vpsel q6, q3, q6
-; CHECK-NEXT:    vand q7, q0, q7
-; CHECK-NEXT:    vmov r0, s28
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s30
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q1, q3, q1
-; CHECK-NEXT:    lsll r0, r5, #3
-; CHECK-NEXT:    veor q1, q1, q6
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #432] @ 16-byte Reload
-; CHECK-NEXT:    lsll r2, r7, #3
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vand q6, q0, q6
 ; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
 ; CHECK-NEXT:    vmov r0, s24
 ; CHECK-NEXT:    movs r2, #0
@@ -9185,368 +9123,418 @@ define <4 x i64> @clmul_v4i64_zext(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov.i32 q6, #0x0
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r2, r0, #8, #8
+; CHECK-NEXT:    vmsr p0, r2
+; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q6, q0
+; CHECK-NEXT:    vldrw.u32 q6, [sp, #464] @ 16-byte Reload
+; CHECK-NEXT:    veor q2, q0, q2
+; CHECK-NEXT:    vand q6, q4, q6
+; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r2, r0, #0, #8
+; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r2, r0, #8, #8
+; CHECK-NEXT:    vmsr p0, r2
+; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #448] @ 16-byte Reload
+; CHECK-NEXT:    veor q1, q0, q1
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r2, r0, #0, #8
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #416] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #432] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
+; CHECK-NEXT:    lsll r0, r5, #3
+; CHECK-NEXT:    lsll r2, r7, #3
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    movs r2, #0
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
+; CHECK-NEXT:    mov r5, r3
+; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r2, r0, #0, #8
+; CHECK-NEXT:    vmov r0, s10
+; CHECK-NEXT:    cmp r0, #0
+; CHECK-NEXT:    csetm r0, eq
+; CHECK-NEXT:    bfi r2, r0, #8, #8
+; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    vmsr p0, r2
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #416] @ 16-byte Reload
+; CHECK-NEXT:    mov r2, r4
 ; CHECK-NEXT:    lsll r0, r5, #4
 ; CHECK-NEXT:    lsll r2, r7, #4
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #400] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #400] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #5
 ; CHECK-NEXT:    lsll r2, r7, #5
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #384] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #384] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #6
 ; CHECK-NEXT:    lsll r2, r7, #6
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #368] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #368] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #7
 ; CHECK-NEXT:    lsll r2, r7, #7
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #352] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #352] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #8
 ; CHECK-NEXT:    lsll r2, r7, #8
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #336] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #336] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #9
 ; CHECK-NEXT:    lsll r2, r7, #9
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #320] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #320] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #10
 ; CHECK-NEXT:    lsll r2, r7, #10
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #304] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #304] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #11
 ; CHECK-NEXT:    lsll r2, r7, #11
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #288] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #288] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #12
 ; CHECK-NEXT:    lsll r2, r7, #12
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #272] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #272] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #13
 ; CHECK-NEXT:    lsll r2, r7, #13
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #256] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #256] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #14
 ; CHECK-NEXT:    lsll r2, r7, #14
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #240] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #240] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #15
 ; CHECK-NEXT:    lsll r2, r7, #15
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #224] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #224] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #16
 ; CHECK-NEXT:    lsll r2, r7, #16
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #208] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #208] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #17
 ; CHECK-NEXT:    lsll r2, r7, #17
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #192] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #192] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #18
 ; CHECK-NEXT:    lsll r2, r7, #18
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #176] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #176] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #19
 ; CHECK-NEXT:    lsll r2, r7, #19
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    b.w .LBB22_15
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI22_32:
-; CHECK-NEXT:    .long 4 @ 0x4
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 4 @ 0x4
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.2:
@@ -9558,9 +9546,9 @@ define <4 x i64> @clmul_v4i64_zext(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.3:
 ; CHECK-NEXT:  .LCPI22_34:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 4 @ 0x4
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 4 @ 0x4
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.4:
@@ -9641,265 +9629,266 @@ define <4 x i64> @clmul_v4i64_zext(<4 x i32> %x, <4 x i32> %y) {
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 1
 ; CHECK-NEXT:  .LBB22_15:
+; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #160] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #160] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #20
 ; CHECK-NEXT:    lsll r2, r7, #20
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #144] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #144] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #21
 ; CHECK-NEXT:    lsll r2, r7, #21
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #128] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #128] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #22
 ; CHECK-NEXT:    lsll r2, r7, #22
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #112] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #112] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #23
 ; CHECK-NEXT:    lsll r2, r7, #23
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #96] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #96] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #24
 ; CHECK-NEXT:    lsll r2, r7, #24
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #80] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #80] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #25
 ; CHECK-NEXT:    lsll r2, r7, #25
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #64] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #64] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #26
 ; CHECK-NEXT:    lsll r2, r7, #26
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #48] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #48] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #27
 ; CHECK-NEXT:    lsll r2, r7, #27
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #32] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #32] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #28
 ; CHECK-NEXT:    lsll r2, r7, #28
-; CHECK-NEXT:    vand q6, q0, q6
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vldrw.u32 q6, [sp, #16] @ 16-byte Reload
+; CHECK-NEXT:    vldrw.u32 q2, [sp, #16] @ 16-byte Reload
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
-; CHECK-NEXT:    vand q6, q0, q6
 ; CHECK-NEXT:    lsll r0, r5, #29
 ; CHECK-NEXT:    lsll r2, r7, #29
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s24
+; CHECK-NEXT:    vand q2, q4, q2
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    mov r5, r3
 ; CHECK-NEXT:    mov r7, r1
-; CHECK-NEXT:    vand q0, q0, q4
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s26
+; CHECK-NEXT:    vmov r0, s10
+; CHECK-NEXT:    vand q2, q4, q7
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
 ; CHECK-NEXT:    mov r0, r12
 ; CHECK-NEXT:    vmsr p0, r2
 ; CHECK-NEXT:    mov r2, r4
-; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    lsll r0, r5, #30
 ; CHECK-NEXT:    lsll r2, r7, #30
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r2, r0
-; CHECK-NEXT:    vmov r0, s20
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r2, r0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    movs r2, #0
-; CHECK-NEXT:    vmov q2[3], q2[1], r7, r5
+; CHECK-NEXT:    vmov q1[3], q1[1], r7, r5
 ; CHECK-NEXT:    lsll r12, r3, #31
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    lsll r4, r1, #31
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s22
+; CHECK-NEXT:    vmov r0, s10
+; CHECK-NEXT:    vand q2, q4, q5
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    vmov r0, s0
+; CHECK-NEXT:    vmov r0, s8
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vpsel q2, q3, q2
-; CHECK-NEXT:    veor q1, q1, q2
-; CHECK-NEXT:    vmov q2[2], q2[0], r4, r12
-; CHECK-NEXT:    vmov q2[3], q2[1], r1, r3
+; CHECK-NEXT:    vpsel q0, q0, q1
+; CHECK-NEXT:    vmov q1[2], q1[0], r4, r12
+; CHECK-NEXT:    vmov q1[3], q1[1], r1, r3
+; CHECK-NEXT:    veor q1, q0, q1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi lr, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s2
+; CHECK-NEXT:    vmov r0, s10
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi lr, r0, #8, #8
 ; CHECK-NEXT:    vmsr p0, lr
-; CHECK-NEXT:    vpsel q0, q3, q2
-; CHECK-NEXT:    veor q1, q1, q0
+; CHECK-NEXT:    vpsel q1, q0, q1
 ; CHECK-NEXT:    vldrw.u32 q0, [sp] @ 16-byte Reload
-; CHECK-NEXT:    add.w sp, sp, #512
+; CHECK-NEXT:    add sp, #496
 ; CHECK-NEXT:    vpop {d8, d9, d10, d11, d12, d13, d14, d15}
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r8, pc}
 ; CHECK-NEXT:    .p2align 4
@@ -13086,8 +13075,6 @@ define <2 x i32> @clmulr_v2i32(<2 x i32> %a, <2 x i32> %b) nounwind {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    adr.w r0, .LCPI30_0
 ; CHECK-NEXT:    movs r2, #0
 ; CHECK-NEXT:    vldrw.u32 q2, [r0]
@@ -13095,748 +13082,747 @@ define <2 x i32> @clmulr_v2i32(<2 x i32> %a, <2 x i32> %b) nounwind {
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    movs r1, #0
+; CHECK-NEXT:    vmov.i32 q3, #0x0
 ; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s10
-; CHECK-NEXT:    vmov.i32 q2, #0x0
+; CHECK-NEXT:    vmov.i64 q2, #0xffffffff
+; CHECK-NEXT:    vand q2, q0, q2
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    vmov r0, s0
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    lsll r0, r3, #1
-; CHECK-NEXT:    mov r4, r2
+; CHECK-NEXT:    mov r2, r12
+; CHECK-NEXT:    lsll r2, r3, #1
+; CHECK-NEXT:    vpsel q2, q3, q2
+; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r4, r5, #1
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_1
-; CHECK-NEXT:    vldrw.u32 q4, [r0]
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_1
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    vand q4, q1, q4
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    vmov r0, s16
 ; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q0, q2, q0
 ; CHECK-NEXT:    lsll r4, r5, #2
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s18
-; CHECK-NEXT:    vmov.i64 q4, #0xffffffff
-; CHECK-NEXT:    vand q0, q0, q4
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    adr.w r0, .LCPI30_2
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    lsll r2, r3, #2
 ; CHECK-NEXT:    vpsel q0, q2, q0
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_2
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #2
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_3
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #3
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_4
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #3
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_3
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #4
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #4
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_5
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_4
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #5
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #5
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_6
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #5
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_5
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #6
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #6
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_7
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #6
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_6
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #7
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #7
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_8
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #7
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_7
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #8
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #8
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_9
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #8
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_8
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #9
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #9
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_10
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #9
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_9
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #10
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #10
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_11
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #10
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_10
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #11
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #11
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_12
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #11
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_11
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #12
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #12
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_13
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #12
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_12
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #13
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #13
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_14
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #13
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_13
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #14
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #14
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_15
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #14
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_14
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #15
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #15
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_16
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #15
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_15
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #16
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #16
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_17
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #16
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_16
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #17
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #17
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_18
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #17
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_17
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #18
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #18
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_19
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #18
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_18
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #19
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #19
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_20
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #19
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_19
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #20
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #20
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_21
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #20
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_20
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #21
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #21
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_22
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #21
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_21
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #22
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #22
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_23
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #22
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_22
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #23
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #23
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI30_24
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #23
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI30_23
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #24
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #24
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_25
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #24
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_24
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #25
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #25
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_26
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #25
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_25
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #26
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #26
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_27
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #26
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_26
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #27
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #27
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_28
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #27
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_27
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #28
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #28
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_29
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #28
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_28
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #29
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #29
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_30
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #29
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_29
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    lsll r2, r1, #31
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #30
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #30
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI30_31
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #30
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI30_30
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    veor q2, q0, q2
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    lsll r0, r5, #31
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    lsll r12, r3, #31
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r0, r12
+; CHECK-NEXT:    adr r0, .LCPI30_31
 ; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q1, q1, q3
 ; CHECK-NEXT:    vmov r0, s4
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
+; CHECK-NEXT:    bfi r1, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s6
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r12, r3, #31
-; CHECK-NEXT:    vmov q1[2], q1[0], r2, r12
-; CHECK-NEXT:    vmov q1[3], q1[1], r1, r3
-; CHECK-NEXT:    vpsel q1, q2, q1
-; CHECK-NEXT:    veor q0, q0, q1
+; CHECK-NEXT:    bfi r1, r0, #8, #8
+; CHECK-NEXT:    vmsr p0, r1
+; CHECK-NEXT:    vpsel q0, q0, q2
 ; CHECK-NEXT:    vmov r0, r1, d1
 ; CHECK-NEXT:    vmov r2, r3, d0
 ; CHECK-NEXT:    lsrl r0, r1, #31
 ; CHECK-NEXT:    lsrl r2, r3, #31
 ; CHECK-NEXT:    vmov q0[2], q0[0], r2, r0
 ; CHECK-NEXT:    vmov q0[3], q0[1], r3, r1
-; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI30_0:
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI30_1:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI30_2:
 ; CHECK-NEXT:    .long 4 @ 0x4
@@ -14001,8 +13987,8 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, r7, r9, lr}
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r9, lr}
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11}
+; CHECK-NEXT:    .vsave {d8, d9}
+; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vrev64.8 q2, q0
 ; CHECK-NEXT:    mov.w lr, #8
 ; CHECK-NEXT:    vbrsr.8 q2, q2, lr
@@ -14014,8 +14000,8 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    mov r7, r5
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    mov r1, r9
-; CHECK-NEXT:    lsll r2, r1, #2
-; CHECK-NEXT:    lsll r4, r7, #2
+; CHECK-NEXT:    lsll r2, r1, #1
+; CHECK-NEXT:    lsll r4, r7, #1
 ; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    movs r4, #0
 ; CHECK-NEXT:    vmov q3[3], q3[1], r7, r1
@@ -14034,736 +14020,737 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r4, r2, #8, #8
+; CHECK-NEXT:    adr.w r2, .LCPI31_66
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r4
+; CHECK-NEXT:    movs r4, #0
+; CHECK-NEXT:    vpsel q1, q1, q2
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r4, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s18
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r4, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r4
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    lsll r2, r7, #1
-; CHECK-NEXT:    lsll r4, r3, #1
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI31_66
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
-; CHECK-NEXT:    vmov q4[3], q4[1], r3, r7
+; CHECK-NEXT:    lsll r2, r7, #2
+; CHECK-NEXT:    lsll r4, r3, #2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI31_67
+; CHECK-NEXT:    vmov q3[3], q3[1], r3, r7
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q1, q3
-; CHECK-NEXT:    vand q5, q0, q5
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    mov r7, r5
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    lsll r4, r7, #3
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #8, #8
-; CHECK-NEXT:    adr.w r2, .LCPI31_67
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q4
-; CHECK-NEXT:    vand q5, q0, q5
-; CHECK-NEXT:    vmov r2, s20
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q5, q1, q2
 ; CHECK-NEXT:    lsll r2, r3, #3
-; CHECK-NEXT:    veor q4, q5, q4
-; CHECK-NEXT:    veor q3, q4, q3
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_68
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #4
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #4
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_69
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #5
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #5
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_70
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #6
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #6
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_71
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #7
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #7
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_72
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #8
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #8
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_73
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #9
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #9
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_74
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #10
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #10
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_10
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #11
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #11
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_11
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #12
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #12
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_12
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #13
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #13
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_13
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #14
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #14
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_14
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #15
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #15
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_15
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #16
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #16
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_16
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #17
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #17
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_17
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #18
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #18
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_18
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #19
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #19
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_19
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #20
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #20
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_20
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #21
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #21
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_21
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #22
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #22
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_22
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #23
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #23
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_23
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #24
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #24
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_24
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #25
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #25
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_25
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #26
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #26
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_26
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #27
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #27
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_27
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #28
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #28
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_28
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #29
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #29
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_29
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #30
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #30
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_30
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    lsll r4, r5, #31
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    lsll r2, r9, #31
-; CHECK-NEXT:    vpsel q4, q1, q4
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_31
-; CHECK-NEXT:    vmov q4[3], q4[1], r5, r9
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
-; CHECK-NEXT:    vand q5, q0, q5
-; CHECK-NEXT:    vmov r2, s20
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r5, r9
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    adr.w r2, .LCPI31_33
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q4
-; CHECK-NEXT:    veor q4, q3, q4
-; CHECK-NEXT:    vmov.f32 s13, s8
-; CHECK-NEXT:    vmov.f32 s15, s10
-; CHECK-NEXT:    vldrw.u32 q2, [r2]
-; CHECK-NEXT:    vldr s12, .LCPI31_75
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmov r2, s9
-; CHECK-NEXT:    vmov.f32 s14, s12
+; CHECK-NEXT:    vpsel q3, q1, q3
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vldr s4, .LCPI31_75
+; CHECK-NEXT:    vmov r2, s17
+; CHECK-NEXT:    vmov.f32 s5, s8
+; CHECK-NEXT:    vmov.f32 s6, s4
+; CHECK-NEXT:    vmov.f32 s7, s10
+; CHECK-NEXT:    veor q2, q3, q1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s11
+; CHECK-NEXT:    vmov r2, s19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #1
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q2, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #1
-; CHECK-NEXT:    veor q2, q4, q2
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_34
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14773,16 +14760,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #2
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #2
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_35
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14792,16 +14779,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #3
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #3
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_36
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14811,16 +14798,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #4
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #4
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_37
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14830,16 +14817,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #5
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #5
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_38
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14849,16 +14836,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #6
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #6
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_39
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14868,16 +14855,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #7
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #7
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_40
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14887,16 +14874,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #8
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #8
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_41
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14906,16 +14893,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #9
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #9
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_42
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14925,16 +14912,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #10
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #10
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_43
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14944,16 +14931,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #11
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #11
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_44
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14963,16 +14950,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #12
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #12
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_45
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -14982,16 +14969,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #13
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #13
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_46
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15001,16 +14988,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #14
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #14
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_47
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15018,8 +15005,6 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    vmov r2, s19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #8, #8
-; CHECK-NEXT:    lsl.w r2, r12, #15
 ; CHECK-NEXT:    b.w .LBB31_2
 ; CHECK-NEXT:    .p2align 2
 ; CHECK-NEXT:  @ %bb.1:
@@ -15027,16 +15012,18 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    .long 0x00000000 @ float 0
 ; CHECK-NEXT:    .p2align 1
 ; CHECK-NEXT:  .LBB31_2:
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    lsl.w r2, r12, #15
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #15
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_48
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15046,16 +15033,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #16
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #16
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_49
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15065,16 +15052,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #17
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #17
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_50
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15084,16 +15071,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #18
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #18
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_51
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15103,16 +15090,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #19
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #19
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_52
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15122,16 +15109,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #20
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #20
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_53
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15141,16 +15128,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #21
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #21
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_54
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15160,16 +15147,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #22
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #22
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_55
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15179,27 +15166,26 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #23
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #23
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_56
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #0, #8
 ; CHECK-NEXT:    b.w .LBB31_13
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.3:
 ; CHECK-NEXT:  .LCPI31_65:
-; CHECK-NEXT:    .long 4 @ 0x4
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 4 @ 0x4
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.4:
@@ -15211,9 +15197,9 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.5:
 ; CHECK-NEXT:  .LCPI31_67:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 4 @ 0x4
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 4 @ 0x4
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.6:
@@ -15266,21 +15252,22 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 1
 ; CHECK-NEXT:  .LBB31_13:
+; CHECK-NEXT:    bfi r3, r2, #0, #8
 ; CHECK-NEXT:    vmov r2, s19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #24
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #24
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_57
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15290,16 +15277,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #25
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #25
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_58
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15309,16 +15296,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #26
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #26
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_59
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15328,16 +15315,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #27
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #27
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_60
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15347,16 +15334,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #28
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #28
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_61
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15366,16 +15353,16 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #29
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #29
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI31_62
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -15385,18 +15372,20 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #30
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #30
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr r2, .LCPI31_63
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
-; CHECK-NEXT:    lsls r0, r0, #31
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    lsls r0, r0, #31
 ; CHECK-NEXT:    vmov r2, s17
+; CHECK-NEXT:    veor q3, q2, q1
+; CHECK-NEXT:    vmov s5, r0
+; CHECK-NEXT:    adr r0, .LCPI31_64
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
@@ -15406,13 +15395,11 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #31
 ; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s13, r0
-; CHECK-NEXT:    adr r0, .LCPI31_64
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vldrw.u32 q4, [r0]
-; CHECK-NEXT:    vmov s15, r2
-; CHECK-NEXT:    vand q0, q0, q4
+; CHECK-NEXT:    vmov s7, r2
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    veor q1, q2, q1
+; CHECK-NEXT:    vand q0, q0, q3
 ; CHECK-NEXT:    vmov r0, s1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
@@ -15422,11 +15409,10 @@ define <2 x i64> @clmulr_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r1, r0, #8, #8
 ; CHECK-NEXT:    vmsr p0, r1
-; CHECK-NEXT:    vpsel q0, q1, q3
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vpsel q0, q2, q1
 ; CHECK-NEXT:    vrev64.8 q1, q0
 ; CHECK-NEXT:    vbrsr.8 q0, q1, lr
-; CHECK-NEXT:    vpop {d8, d9, d10, d11}
+; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r9, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.14:
@@ -16531,8 +16517,6 @@ define <2 x i32> @clmulh_v2i32(<2 x i32> %a, <2 x i32> %b) nounwind {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-NEXT:    push {r4, r5, r7, lr}
-; CHECK-NEXT:    .vsave {d8, d9}
-; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    adr.w r0, .LCPI38_0
 ; CHECK-NEXT:    movs r2, #0
 ; CHECK-NEXT:    vldrw.u32 q2, [r0]
@@ -16540,746 +16524,745 @@ define <2 x i32> @clmulh_v2i32(<2 x i32> %a, <2 x i32> %b) nounwind {
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q2, q1, q2
-; CHECK-NEXT:    movs r1, #0
+; CHECK-NEXT:    vmov.i32 q3, #0x0
 ; CHECK-NEXT:    vmov r0, s8
+; CHECK-NEXT:    movs r1, #0
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s10
-; CHECK-NEXT:    vmov.i32 q2, #0x0
+; CHECK-NEXT:    vmov.i64 q2, #0xffffffff
+; CHECK-NEXT:    vand q2, q0, q2
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r2, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    vmov r0, s0
 ; CHECK-NEXT:    vmsr p0, r2
-; CHECK-NEXT:    vmov r2, s0
-; CHECK-NEXT:    lsll r0, r3, #1
-; CHECK-NEXT:    mov r4, r2
+; CHECK-NEXT:    mov r2, r12
+; CHECK-NEXT:    lsll r2, r3, #1
+; CHECK-NEXT:    vpsel q2, q3, q2
+; CHECK-NEXT:    mov r4, r0
 ; CHECK-NEXT:    lsll r4, r5, #1
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_1
-; CHECK-NEXT:    vldrw.u32 q4, [r0]
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    vmov q0[2], q0[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_1
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q0[3], q0[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    vand q4, q1, q4
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    vmov r0, s16
 ; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q0, q2, q0
 ; CHECK-NEXT:    lsll r4, r5, #2
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s18
-; CHECK-NEXT:    vmov.i64 q4, #0xffffffff
-; CHECK-NEXT:    vand q0, q0, q4
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    adr.w r0, .LCPI38_2
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    lsll r2, r3, #2
 ; CHECK-NEXT:    vpsel q0, q2, q0
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
-; CHECK-NEXT:    vand q3, q1, q3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
-; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_2
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #2
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_3
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #3
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #3
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_4
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #3
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_3
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #4
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #4
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_5
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #4
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_4
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #5
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #5
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_6
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #5
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_5
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #6
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #6
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_7
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #6
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_6
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #7
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #7
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_8
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #7
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_7
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #8
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #8
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_9
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #8
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_8
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #9
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #9
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_10
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #9
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_9
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #10
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #10
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_11
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #10
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_10
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #11
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #11
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_12
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #11
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_11
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #12
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #12
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_13
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #12
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_12
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #13
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #13
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_14
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #13
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_13
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #14
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #14
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_15
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #14
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_14
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #15
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #15
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_16
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #15
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_15
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #16
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #16
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_17
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #16
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_16
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #17
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #17
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_18
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #17
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_17
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #18
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #18
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_19
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #18
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_18
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #19
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #19
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_20
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #19
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_19
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #20
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #20
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_21
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #20
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_20
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #21
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #21
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_22
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #21
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_21
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #22
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #22
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_23
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #22
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_22
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #23
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #23
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr.w r0, .LCPI38_24
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #23
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI38_23
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #24
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #24
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_25
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #24
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_24
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #25
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #25
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_26
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #25
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_25
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #26
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #26
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_27
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #26
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_26
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #27
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #27
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_28
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #27
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_27
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #28
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #28
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_29
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #28
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_28
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #29
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #29
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_30
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #29
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_29
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    mov r4, r2
-; CHECK-NEXT:    veor q0, q0, q3
-; CHECK-NEXT:    vldrw.u32 q3, [r0]
 ; CHECK-NEXT:    movs r5, #0
-; CHECK-NEXT:    lsll r2, r1, #31
 ; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    lsll r4, r5, #30
-; CHECK-NEXT:    vmov r0, s12
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
-; CHECK-NEXT:    vmov r0, s14
-; CHECK-NEXT:    cmp r0, #0
-; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    mov r0, r12
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r0, r3, #30
-; CHECK-NEXT:    vmov q3[2], q3[0], r4, r0
-; CHECK-NEXT:    adr r0, .LCPI38_31
-; CHECK-NEXT:    vmov q3[3], q3[1], r5, r3
+; CHECK-NEXT:    lsll r2, r3, #30
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r4, r2
+; CHECK-NEXT:    adr r2, .LCPI38_30
+; CHECK-NEXT:    vldrw.u32 q3, [r2]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q2, q3
-; CHECK-NEXT:    veor q0, q0, q3
+; CHECK-NEXT:    movs r5, #0
+; CHECK-NEXT:    vand q3, q1, q3
+; CHECK-NEXT:    veor q2, q0, q2
+; CHECK-NEXT:    vmov r2, s12
+; CHECK-NEXT:    lsll r0, r5, #31
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s14
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    lsll r12, r3, #31
+; CHECK-NEXT:    vpsel q0, q0, q2
+; CHECK-NEXT:    vmov q2[2], q2[0], r0, r12
+; CHECK-NEXT:    adr r0, .LCPI38_31
 ; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    vmov q2[3], q2[1], r5, r3
+; CHECK-NEXT:    veor q2, q0, q2
 ; CHECK-NEXT:    vand q1, q1, q3
 ; CHECK-NEXT:    vmov r0, s4
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #0, #8
+; CHECK-NEXT:    bfi r1, r0, #0, #8
 ; CHECK-NEXT:    vmov r0, s6
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
-; CHECK-NEXT:    bfi r3, r0, #8, #8
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    lsll r12, r3, #31
-; CHECK-NEXT:    vmov q1[2], q1[0], r2, r12
-; CHECK-NEXT:    vmov q1[3], q1[1], r1, r3
-; CHECK-NEXT:    vpsel q1, q2, q1
-; CHECK-NEXT:    veor q1, q0, q1
+; CHECK-NEXT:    bfi r1, r0, #8, #8
+; CHECK-NEXT:    vmsr p0, r1
+; CHECK-NEXT:    vpsel q1, q0, q2
 ; CHECK-NEXT:    vldr s1, .LCPI38_32
 ; CHECK-NEXT:    vmov.f32 s0, s5
 ; CHECK-NEXT:    vmov.f32 s2, s7
 ; CHECK-NEXT:    vmov.f32 s3, s1
-; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.1:
 ; CHECK-NEXT:  .LCPI38_0:
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 2 @ 0x2
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI38_1:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 2 @ 0x2
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:  .LCPI38_2:
 ; CHECK-NEXT:    .long 4 @ 0x4
@@ -17446,8 +17429,8 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK:       @ %bb.0:
 ; CHECK-NEXT:    .save {r4, r5, r6, r7, r9, lr}
 ; CHECK-NEXT:    push.w {r4, r5, r6, r7, r9, lr}
-; CHECK-NEXT:    .vsave {d8, d9, d10, d11}
-; CHECK-NEXT:    vpush {d8, d9, d10, d11}
+; CHECK-NEXT:    .vsave {d8, d9}
+; CHECK-NEXT:    vpush {d8, d9}
 ; CHECK-NEXT:    vrev64.8 q2, q0
 ; CHECK-NEXT:    mov.w lr, #8
 ; CHECK-NEXT:    vbrsr.8 q2, q2, lr
@@ -17459,8 +17442,8 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    mov r7, r5
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    mov r1, r9
-; CHECK-NEXT:    lsll r2, r1, #2
-; CHECK-NEXT:    lsll r4, r7, #2
+; CHECK-NEXT:    lsll r2, r1, #1
+; CHECK-NEXT:    lsll r4, r7, #1
 ; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    movs r4, #0
 ; CHECK-NEXT:    vmov q3[3], q3[1], r7, r1
@@ -17479,736 +17462,737 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r4, r2, #8, #8
+; CHECK-NEXT:    adr.w r2, .LCPI39_66
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r4
+; CHECK-NEXT:    movs r4, #0
+; CHECK-NEXT:    vpsel q1, q1, q2
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r4, r2, #0, #8
+; CHECK-NEXT:    vmov r2, s18
+; CHECK-NEXT:    cmp r2, #0
+; CHECK-NEXT:    csetm r2, eq
+; CHECK-NEXT:    bfi r4, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r4
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    lsll r2, r7, #1
-; CHECK-NEXT:    lsll r4, r3, #1
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
-; CHECK-NEXT:    adr.w r2, .LCPI39_66
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
-; CHECK-NEXT:    vmov q4[3], q4[1], r3, r7
+; CHECK-NEXT:    lsll r2, r7, #2
+; CHECK-NEXT:    lsll r4, r3, #2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
+; CHECK-NEXT:    adr.w r2, .LCPI39_67
+; CHECK-NEXT:    vmov q3[3], q3[1], r3, r7
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q3, q1, q3
-; CHECK-NEXT:    vand q5, q0, q5
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    mov r7, r5
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    lsll r4, r7, #3
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #8, #8
-; CHECK-NEXT:    adr.w r2, .LCPI39_67
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q4
-; CHECK-NEXT:    vand q5, q0, q5
-; CHECK-NEXT:    vmov r2, s20
-; CHECK-NEXT:    cmp r2, #0
-; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q5, q1, q2
 ; CHECK-NEXT:    lsll r2, r3, #3
-; CHECK-NEXT:    veor q4, q5, q4
-; CHECK-NEXT:    veor q3, q4, q3
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_68
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #4
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #4
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_69
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #5
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #5
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_70
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #6
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #6
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_71
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #7
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #7
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_72
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #8
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #8
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_73
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #9
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #9
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_74
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #10
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #10
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_75
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #11
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #11
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_11
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #12
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #12
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_12
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #13
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #13
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_13
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #14
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #14
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_14
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #15
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #15
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_15
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #16
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #16
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_16
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #17
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #17
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_17
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #18
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #18
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_18
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #19
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #19
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_19
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #20
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #20
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_20
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #21
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #21
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_21
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #22
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #22
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_22
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #23
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #23
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_23
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #24
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #24
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_24
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #25
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #25
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_25
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #26
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #26
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_26
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #27
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #27
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_27
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #28
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #28
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_28
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #29
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #29
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_29
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
+; CHECK-NEXT:    vand q4, q0, q4
 ; CHECK-NEXT:    mov r7, r5
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vmov r2, s16
+; CHECK-NEXT:    veor q3, q1, q3
 ; CHECK-NEXT:    lsll r4, r7, #30
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    mov r3, r9
-; CHECK-NEXT:    vpsel q4, q1, q4
 ; CHECK-NEXT:    lsll r2, r3, #30
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_30
-; CHECK-NEXT:    vmov q4[3], q4[1], r7, r3
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r7, r3
 ; CHECK-NEXT:    movs r3, #0
 ; CHECK-NEXT:    mov r4, r0
-; CHECK-NEXT:    vand q5, q0, q5
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    lsll r4, r5, #31
-; CHECK-NEXT:    vmov r2, s20
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    mov r2, r12
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    lsll r2, r9, #31
-; CHECK-NEXT:    vpsel q4, q1, q4
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    veor q3, q3, q4
-; CHECK-NEXT:    vmov q4[2], q4[0], r4, r2
+; CHECK-NEXT:    vpsel q1, q1, q3
+; CHECK-NEXT:    vmov q3[2], q3[0], r4, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_31
-; CHECK-NEXT:    vmov q4[3], q4[1], r5, r9
-; CHECK-NEXT:    vldrw.u32 q5, [r2]
-; CHECK-NEXT:    vand q5, q0, q5
-; CHECK-NEXT:    vmov r2, s20
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmov q3[3], q3[1], r5, r9
+; CHECK-NEXT:    veor q3, q1, q3
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vmov r2, s16
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s22
+; CHECK-NEXT:    vmov r2, s18
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    adr.w r2, .LCPI39_33
+; CHECK-NEXT:    vldrw.u32 q4, [r2]
 ; CHECK-NEXT:    vmsr p0, r3
 ; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q4
-; CHECK-NEXT:    veor q4, q3, q4
-; CHECK-NEXT:    vmov.f32 s13, s8
-; CHECK-NEXT:    vmov.f32 s15, s10
-; CHECK-NEXT:    vldrw.u32 q2, [r2]
-; CHECK-NEXT:    vldr s12, .LCPI39_76
-; CHECK-NEXT:    vand q2, q0, q2
-; CHECK-NEXT:    vmov r2, s9
-; CHECK-NEXT:    vmov.f32 s14, s12
+; CHECK-NEXT:    vpsel q3, q1, q3
+; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    vldr s4, .LCPI39_76
+; CHECK-NEXT:    vmov r2, s17
+; CHECK-NEXT:    vmov.f32 s5, s8
+; CHECK-NEXT:    vmov.f32 s6, s4
+; CHECK-NEXT:    vmov.f32 s7, s10
+; CHECK-NEXT:    veor q2, q3, q1
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
-; CHECK-NEXT:    vmov r2, s11
+; CHECK-NEXT:    vmov r2, s19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #1
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q2, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #1
-; CHECK-NEXT:    veor q2, q4, q2
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_34
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q3, q2
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18218,16 +18202,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #2
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #2
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_35
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18237,16 +18221,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #3
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #3
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_36
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18256,16 +18240,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #4
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #4
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_37
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18275,16 +18259,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #5
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #5
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_38
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18294,16 +18278,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #6
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #6
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_39
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18313,16 +18297,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #7
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #7
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_40
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18332,16 +18316,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #8
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #8
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_41
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18351,16 +18335,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #9
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #9
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_42
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18370,16 +18354,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #10
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #10
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_43
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18389,16 +18373,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #11
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #11
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_44
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18408,16 +18392,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #12
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #12
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_45
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18427,16 +18411,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #13
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #13
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_46
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18446,16 +18430,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #14
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #14
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_47
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18463,8 +18447,6 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    vmov r2, s19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #8, #8
-; CHECK-NEXT:    lsl.w r2, r12, #15
 ; CHECK-NEXT:    b.w .LBB39_2
 ; CHECK-NEXT:    .p2align 2
 ; CHECK-NEXT:  @ %bb.1:
@@ -18472,16 +18454,18 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    .long 0x00000000 @ float 0
 ; CHECK-NEXT:    .p2align 1
 ; CHECK-NEXT:  .LBB39_2:
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    bfi r3, r2, #8, #8
+; CHECK-NEXT:    lsl.w r2, r12, #15
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #15
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_48
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18491,16 +18475,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #16
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #16
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_49
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18510,16 +18494,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #17
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #17
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_50
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18529,16 +18513,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #18
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #18
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_51
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18548,16 +18532,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #19
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #19
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_52
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18567,16 +18551,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #20
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #20
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_53
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18586,16 +18570,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #21
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #21
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_54
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18605,16 +18589,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #22
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #22
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_55
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18624,27 +18608,26 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #23
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #23
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_56
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
-; CHECK-NEXT:    bfi r3, r2, #0, #8
 ; CHECK-NEXT:    b.w .LBB39_14
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.3:
 ; CHECK-NEXT:  .LCPI39_65:
-; CHECK-NEXT:    .long 4 @ 0x4
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 4 @ 0x4
+; CHECK-NEXT:    .long 1 @ 0x1
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.4:
@@ -18656,9 +18639,9 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.5:
 ; CHECK-NEXT:  .LCPI39_67:
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 4 @ 0x4
 ; CHECK-NEXT:    .long 0 @ 0x0
-; CHECK-NEXT:    .long 1 @ 0x1
+; CHECK-NEXT:    .long 4 @ 0x4
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.6:
@@ -18718,21 +18701,22 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    .long 0 @ 0x0
 ; CHECK-NEXT:    .p2align 1
 ; CHECK-NEXT:  .LBB39_14:
+; CHECK-NEXT:    bfi r3, r2, #0, #8
 ; CHECK-NEXT:    vmov r2, s19
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #24
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #24
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_57
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18742,16 +18726,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #25
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #25
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_58
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18761,16 +18745,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #26
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #26
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_59
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18780,16 +18764,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #27
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #27
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_60
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18799,16 +18783,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #28
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #28
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_61
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18818,16 +18802,16 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #29
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #29
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr.w r2, .LCPI39_62
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    veor q3, q2, q1
 ; CHECK-NEXT:    vmov r2, s17
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
@@ -18837,18 +18821,20 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #30
-; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    movs r3, #0
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s15, r2
+; CHECK-NEXT:    vmov s7, r2
 ; CHECK-NEXT:    lsls r2, r0, #30
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vmov s13, r2
+; CHECK-NEXT:    vmov s5, r2
 ; CHECK-NEXT:    adr r2, .LCPI39_63
 ; CHECK-NEXT:    vldrw.u32 q4, [r2]
-; CHECK-NEXT:    lsls r0, r0, #31
+; CHECK-NEXT:    vmsr p0, r3
+; CHECK-NEXT:    movs r3, #0
+; CHECK-NEXT:    vpsel q2, q2, q3
 ; CHECK-NEXT:    vand q4, q0, q4
+; CHECK-NEXT:    lsls r0, r0, #31
 ; CHECK-NEXT:    vmov r2, s17
+; CHECK-NEXT:    veor q3, q2, q1
+; CHECK-NEXT:    vmov s5, r0
+; CHECK-NEXT:    adr r0, .LCPI39_64
 ; CHECK-NEXT:    cmp r2, #0
 ; CHECK-NEXT:    csetm r2, eq
 ; CHECK-NEXT:    bfi r3, r2, #0, #8
@@ -18858,13 +18844,11 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    bfi r3, r2, #8, #8
 ; CHECK-NEXT:    lsl.w r2, r12, #31
 ; CHECK-NEXT:    vmsr p0, r3
-; CHECK-NEXT:    vpsel q4, q1, q3
-; CHECK-NEXT:    vmov s13, r0
-; CHECK-NEXT:    adr r0, .LCPI39_64
-; CHECK-NEXT:    veor q2, q2, q4
-; CHECK-NEXT:    vldrw.u32 q4, [r0]
-; CHECK-NEXT:    vmov s15, r2
-; CHECK-NEXT:    vand q0, q0, q4
+; CHECK-NEXT:    vmov s7, r2
+; CHECK-NEXT:    vpsel q2, q2, q3
+; CHECK-NEXT:    vldrw.u32 q3, [r0]
+; CHECK-NEXT:    veor q1, q2, q1
+; CHECK-NEXT:    vand q0, q0, q3
 ; CHECK-NEXT:    vmov r0, s1
 ; CHECK-NEXT:    cmp r0, #0
 ; CHECK-NEXT:    csetm r0, eq
@@ -18874,8 +18858,7 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    csetm r0, eq
 ; CHECK-NEXT:    bfi r1, r0, #8, #8
 ; CHECK-NEXT:    vmsr p0, r1
-; CHECK-NEXT:    vpsel q0, q1, q3
-; CHECK-NEXT:    veor q0, q2, q0
+; CHECK-NEXT:    vpsel q0, q2, q1
 ; CHECK-NEXT:    vrev64.8 q1, q0
 ; CHECK-NEXT:    vbrsr.8 q0, q1, lr
 ; CHECK-NEXT:    vmov r0, r1, d1
@@ -18884,7 +18867,7 @@ define <2 x i64> @clmulh_v2i64(<2 x i64> %a, <2 x i64> %b) nounwind {
 ; CHECK-NEXT:    lsrl r2, r3, #1
 ; CHECK-NEXT:    vmov q0[2], q0[0], r2, r0
 ; CHECK-NEXT:    vmov q0[3], q0[1], r3, r1
-; CHECK-NEXT:    vpop {d8, d9, d10, d11}
+; CHECK-NEXT:    vpop {d8, d9}
 ; CHECK-NEXT:    pop.w {r4, r5, r6, r7, r9, pc}
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  @ %bb.15:

--- a/llvm/test/CodeGen/X86/vector-lzcnt-512.ll
+++ b/llvm/test/CodeGen/X86/vector-lzcnt-512.ll
@@ -367,14 +367,14 @@ define <32 x i16> @testv32i16(<32 x i16> %in) nounwind {
 ;
 ; AVX512BW-LABEL: testv32i16:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm1
-; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestnmb %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm2 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
-; AVX512BW-NEXT:    # zmm2 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
-; AVX512BW-NEXT:    vpshufb %zmm0, %zmm2, %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    vpshufb %zmm1, %zmm2, %zmm1
-; AVX512BW-NEXT:    vpaddb %zmm1, %zmm3, %zmm1
+; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm1 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
+; AVX512BW-NEXT:    # zmm1 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+; AVX512BW-NEXT:    vpshufb %zmm0, %zmm1, %zmm2
+; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm3
+; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm3, %zmm3
+; AVX512BW-NEXT:    vpshufb %zmm3, %zmm1, %zmm1
+; AVX512BW-NEXT:    vptestnmb %zmm3, %zmm3, %k1
+; AVX512BW-NEXT:    vpaddb %zmm2, %zmm1, %zmm1 {%k1}
 ; AVX512BW-NEXT:    vptestnmb %zmm0, %zmm0, %k0
 ; AVX512BW-NEXT:    vpmovm2b %k0, %zmm0
 ; AVX512BW-NEXT:    vpsrlw $8, %zmm0, %zmm0
@@ -451,14 +451,14 @@ define <32 x i16> @testv32i16u(<32 x i16> %in) nounwind {
 ;
 ; AVX512BW-LABEL: testv32i16u:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm1
-; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestnmb %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm2 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
-; AVX512BW-NEXT:    # zmm2 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
-; AVX512BW-NEXT:    vpshufb %zmm0, %zmm2, %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    vpshufb %zmm1, %zmm2, %zmm1
-; AVX512BW-NEXT:    vpaddb %zmm1, %zmm3, %zmm1
+; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm1 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
+; AVX512BW-NEXT:    # zmm1 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+; AVX512BW-NEXT:    vpshufb %zmm0, %zmm1, %zmm2
+; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm3
+; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm3, %zmm3
+; AVX512BW-NEXT:    vpshufb %zmm3, %zmm1, %zmm1
+; AVX512BW-NEXT:    vptestnmb %zmm3, %zmm3, %k1
+; AVX512BW-NEXT:    vpaddb %zmm2, %zmm1, %zmm1 {%k1}
 ; AVX512BW-NEXT:    vptestnmb %zmm0, %zmm0, %k0
 ; AVX512BW-NEXT:    vpmovm2b %k0, %zmm0
 ; AVX512BW-NEXT:    vpsrlw $8, %zmm0, %zmm0
@@ -555,14 +555,14 @@ define <64 x i8> @testv64i8(<64 x i8> %in) nounwind {
 ;
 ; AVX512BW-LABEL: testv64i8:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm1
-; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestnmb %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm2 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
-; AVX512BW-NEXT:    # zmm2 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
-; AVX512BW-NEXT:    vpshufb %zmm0, %zmm2, %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vpshufb %zmm1, %zmm2, %zmm1
-; AVX512BW-NEXT:    vpaddb %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm1 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
+; AVX512BW-NEXT:    # zmm1 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+; AVX512BW-NEXT:    vpshufb %zmm0, %zmm1, %zmm2
+; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm3
+; AVX512BW-NEXT:    vpshufb %zmm3, %zmm1, %zmm0
+; AVX512BW-NEXT:    vptestnmb %zmm3, %zmm3, %k1
+; AVX512BW-NEXT:    vpaddb %zmm2, %zmm0, %zmm0 {%k1}
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512DQ-LABEL: testv64i8:
@@ -643,14 +643,14 @@ define <64 x i8> @testv64i8u(<64 x i8> %in) nounwind {
 ;
 ; AVX512BW-LABEL: testv64i8u:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm1
-; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestnmb %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm2 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
-; AVX512BW-NEXT:    # zmm2 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
-; AVX512BW-NEXT:    vpshufb %zmm0, %zmm2, %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vpshufb %zmm1, %zmm2, %zmm1
-; AVX512BW-NEXT:    vpaddb %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vbroadcasti32x4 {{.*#+}} zmm1 = [4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0,4,3,2,2,1,1,1,1,0,0,0,0,0,0,0,0]
+; AVX512BW-NEXT:    # zmm1 = mem[0,1,2,3,0,1,2,3,0,1,2,3,0,1,2,3]
+; AVX512BW-NEXT:    vpshufb %zmm0, %zmm1, %zmm2
+; AVX512BW-NEXT:    vpsrlw $4, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpandd {{\.?LCPI[0-9]+_[0-9]+}}(%rip){1to16}, %zmm0, %zmm3
+; AVX512BW-NEXT:    vpshufb %zmm3, %zmm1, %zmm0
+; AVX512BW-NEXT:    vptestnmb %zmm3, %zmm3, %k1
+; AVX512BW-NEXT:    vpaddb %zmm2, %zmm0, %zmm0 {%k1}
 ; AVX512BW-NEXT:    retq
 ;
 ; AVX512DQ-LABEL: testv64i8u:


### PR DESCRIPTION
This works better with the DemandedElts mask to match hidden identity constants (zero in particular.....).

I need this for the ongoing work to improve VECREDUCE simplification to match identity elements (legalisation pads with identity elements) in an expanded reduction shuffle chain.

The Thumb2 CLMUL expanded codegen is already a monster - I've tried a few things to try and simplify it but we're emitting more FREEZE nodes due to a BINOP(VSELECT()) -> VSELECT(BINOP(FREEZE(),FREEZE())) fold that now fires, and gets stuck trying to freeze a number of ARMISD nodes. TBH, I'd much prefer not to try to shave this yak until we've improved FREEZE(OP()) -> OP(FREEZE(),FREEZE(),....) folding.