### PR TITLE
[Offload] Make 'llvm-offload-binary' use multi-binaries

### DIFF
--- a/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
+++ b/llvm/tools/llvm-offload-binary/llvm-offload-binary.cpp
@@ -85,8 +85,7 @@ static Error writeFile(StringRef Filename, StringRef Data) {
 }
 
 static Error bundleImages() {
-  SmallVector<char, 1024> BinaryData;
-  raw_svector_ostream OS(BinaryData);
+  SmallVector<OffloadBinary::OffloadingImage> AllImages;
   for (StringRef Image : DeviceImages) {
     BumpPtrAllocator Alloc;
     StringSaver Saver(Alloc);
@@ -121,16 +120,16 @@ static Error bundleImages() {
           ImageBinary.StringData[Key] = Value;
         }
       }
-      llvm::SmallString<0> Buffer = OffloadBinary::write(ImageBinary);
-      if (Buffer.size() % OffloadBinary::getAlignment() != 0)
-        return createStringError(inconvertibleErrorCode(),
-                                 "Offload binary has invalid size alignment");
-      OS << Buffer;
+      AllImages.emplace_back(std::move(ImageBinary));
     }
   }
 
-  if (Error E = writeFile(OutputFile,
-                          StringRef(BinaryData.begin(), BinaryData.size())))
+  SmallString<0> Buffer = OffloadBinary::write(AllImages);
+  if (Buffer.size() % OffloadBinary::getAlignment() != 0)
+    return createStringError(inconvertibleErrorCode(),
+                             "Offload binary has invalid size alignment");
+
+  if (Error E = writeFile(OutputFile, StringRef(Buffer.data(), Buffer.size())))
     return E;
   return Error::success();
 }


### PR DESCRIPTION
Summary:
There's two ways you can put multiple binaries in the section. Either
use the version two multi-binary support or just concatenate them. This
PR changes the llvm-offload-binary tool to use the multi-support rather
than directly concatenating them.

The motivation for this is to save space and make it easier to support
compression in the future. Compression would be a flag in the header and
the compression is only really valuable if it can combine the
architecture variants. ELF section compression is a little spotty but
would be another good solution.
