### PR TITLE
[CIR] Lower 'init' functions for global TLS

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -129,6 +129,12 @@ struct LoweringPreparePass
   /// Get the declaration for the 'wrapper' function for a global-TLS variable.
   cir::FuncOp getOrCreateThreadLocalWrapper(CIRBaseBuilderTy &builder,
                                             cir::GlobalOp op);
+  // Function that generates the guard global variable, get-global, and 'if'
+  // condition for global TLS init function generation. This inserts an 'if'
+  // with the store at the beginning of the 'then' region, so inserts into the
+  // body should happen after that.
+  cir::IfOp buildGlobalTlsGuardCheck(CIRBaseBuilderTy &builder,
+                                     mlir::Location loc, cir::GlobalOp guard);
   /// Handle the dtor region by registering destructor with __cxa_atexit
   cir::FuncOp getOrCreateDtorFunc(CIRBaseBuilderTy &builder, cir::GlobalOp op,
                                   mlir::Region &dtorRegion,
@@ -180,6 +186,10 @@ struct LoweringPreparePass
 
   /// Get or create the __init_tls function.
   cir::FuncOp getTlsInitFn();
+
+  // Create the __tls_guard variable.
+  cir::GlobalOp createGlobalThreadLocalGuard(CIRBaseBuilderTy &builder,
+                                             mlir::Location loc);
 
   /// Create a guard global variable for a static local.
   cir::GlobalOp createGuardGlobalOp(CIRBaseBuilderTy &builder,
@@ -377,6 +387,9 @@ struct LoweringPreparePass
     entryBB.getOperations().splice(entryBB.end(), dtorBlock.getOperations(),
                                    dtorBlock.begin(),
                                    std::prev(dtorBlock.end()));
+    // make sure we leave the insert location after the operations we just
+    // inserted.
+    builder.setInsertionPointToEnd(&entryBB);
   }
 
   /// Emit the guarded initialization for a static local variable.
@@ -1143,21 +1156,42 @@ LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(cir::GlobalOp op) {
   // the function entry, and discard extra blocks (which contain only
   // unreachable terminators from EH cleanup paths).
   mlir::Block *entryBB = f.addEntryBlock();
+  builder.setInsertionPointToStart(entryBB);
+
+  // If this is a global TLS variable (that is, declared at namespace scope), we
+  // have to emit the guard variable here.
+  bool needsTlsGuard = op.getDynTlsRefs() && op.getDynTlsRefs()->getGuardName();
+  if (needsTlsGuard) {
+    cir::IfOp guardIf = buildGlobalTlsGuardCheck(
+        builder, op.getLoc(),
+        getOrCreateStaticLocalDeclGuardAddress(
+            builder, op, op.getDynTlsRefs()->getGuardName().getValue(),
+            /*isLocalVarDecl=*/false,
+            /*useInt8GuardVariable=*/op.hasInternalLinkage()));
+    builder.setInsertionPointToEnd(&guardIf.getThenRegion().front());
+  }
+
   if (!op.getCtorRegion().empty()) {
     mlir::Block &block = op.getCtorRegion().front();
-    entryBB->getOperations().splice(entryBB->begin(), block.getOperations(),
-                                    block.begin(), std::prev(block.end()));
+    mlir::Block *insertBlock = builder.getBlock();
+    insertBlock->getOperations().splice(insertBlock->end(),
+                                        block.getOperations(), block.begin(),
+                                        std::prev(block.end()));
   }
 
   // Register the destructor call with __cxa_atexit
   mlir::Region &dtorRegion = op.getDtorRegion();
   if (!dtorRegion.empty()) {
     assert(!cir::MissingFeatures::astVarDeclInterface());
-    assert(!cir::MissingFeatures::opGlobalThreadLocal());
 
     emitGlobalGuardedDtorRegion(builder, op, dtorRegion,
-                                op.getTlsModel().has_value(), *entryBB);
+                                op.getTlsModel().has_value(),
+                                *builder.getBlock());
   }
+
+  // If we're actually in the 'if' above, create a yield.
+  if (needsTlsGuard)
+    cir::YieldOp::create(builder, op.getLoc());
 
   // Replace cir.yield with cir.return
   builder.setInsertionPointToEnd(entryBB);
@@ -1710,9 +1744,57 @@ void LoweringPreparePass::buildGlobalCtorDtorList() {
   }
 }
 
+cir::GlobalOp
+LoweringPreparePass::createGlobalThreadLocalGuard(CIRBaseBuilderTy &builder,
+                                                  mlir::Location loc) {
+  mlir::OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(mlirModule.getBody());
+
+  // The TLS Guard is always an Int8Ty.
+  auto guardTy = builder.getSIntNTy(8);
+  cir::GlobalOp g = cir::GlobalOp::create(builder, loc, "__tls_guard", guardTy);
+  g.setLinkageAttr(cir::GlobalLinkageKindAttr::get(
+      builder.getContext(), cir::GlobalLinkageKind::InternalLinkage));
+  g.setAlignment(clang::CharUnits::One().getAsAlign().value());
+  // At the moment, we only have implementation for this mode, as it is the
+  // default.  At one point we might need to load this mode from the module.
+  g.setTlsModel(TLS_Model::GeneralDynamic);
+  // g.setDSOLocal(
+  g.setInitialValueAttr(cir::IntAttr::get(guardTy, 0));
+  return g;
+}
+
+cir::IfOp LoweringPreparePass::buildGlobalTlsGuardCheck(
+    CIRBaseBuilderTy &builder, mlir::Location loc, cir::GlobalOp guard) {
+  cir::GetGlobalOp getGuard = builder.createGetGlobal(guard, /*tls=*/true);
+  mlir::Value getGuardValue = getGuard;
+
+  // Classic codegen always just loads the first byte of the guard instead of
+  // the whole thing. __tls_guard is already only 8 bits, but for the case of
+  // unordered TLS, it gets created as 64 bits.
+  if (guard.getSymType() != builder.getSIntNTy(8))
+    getGuardValue = builder.createBitcast(
+        getGuard, cir::PointerType::get(builder.getSIntNTy(8)));
+
+  mlir::Value guardLoad =
+      builder.createAlignedLoad(loc, getGuardValue, *guard.getAlignment());
+  auto zero = builder.getConstantInt(loc, builder.getSIntNTy(8), 0);
+  auto compare =
+      builder.createCompare(loc, cir::CmpOpKind::eq, guardLoad, zero);
+  return cir::IfOp::create(
+      builder, loc, compare,
+      /*withElseRegion=*/false, [&](mlir::OpBuilder &, mlir::Location loc) {
+        // Classic codegen still does this store as a i8, but it doesn't seem
+        // reasonable to do an i8 store into a 64 bit value?
+        builder.createStore(
+            loc, builder.getConstantInt(loc, guard.getSymType(), 1), getGuard);
+      });
+}
+
 void LoweringPreparePass::buildCXXGlobalTlsFunc() {
   if (globalThreadLocalInitializers.empty())
     return;
+
   // The global-ordered-init function for TLS variables just calls each of the
   // init-functions in order after doing a guard.
 
@@ -1721,9 +1803,20 @@ void LoweringPreparePass::buildCXXGlobalTlsFunc() {
   CIRBaseBuilderTy builder(getContext());
   mlir::Block *entryBB = tlsInit.addEntryBlock();
   builder.setInsertionPointToStart(entryBB);
-  // Note: a followup patch will emit the body here correctly.
+
+  cir::IfOp ifOperation = buildGlobalTlsGuardCheck(
+      builder, loc, createGlobalThreadLocalGuard(builder, loc));
+
+  // Emit the body of the guarded spot.
+  builder.setInsertionPointToEnd(&ifOperation.getThenRegion().front());
+  for (auto initFunc : globalThreadLocalInitializers)
+    builder.createCallOp(loc, initFunc, {});
+  cir::YieldOp::create(builder, loc);
+
+  builder.setInsertionPointAfter(ifOperation);
   cir::ReturnOp::create(builder, loc);
 }
+
 void LoweringPreparePass::buildCXXGlobalInitFunc() {
   if (dynamicInitializers.empty())
     return;

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1161,8 +1161,9 @@ LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(cir::GlobalOp op) {
   // If this is a global TLS variable (that is, declared at namespace scope), we
   // have to emit the guard variable here.
   bool needsTlsGuard = op.getDynTlsRefs() && op.getDynTlsRefs()->getGuardName();
+  cir::IfOp guardIf;
   if (needsTlsGuard) {
-    cir::IfOp guardIf = buildGlobalTlsGuardCheck(
+    guardIf = buildGlobalTlsGuardCheck(
         builder, op.getLoc(),
         getOrCreateStaticLocalDeclGuardAddress(
             builder, op, op.getDynTlsRefs()->getGuardName().getValue(),
@@ -1190,8 +1191,10 @@ LoweringPreparePass::buildCXXGlobalVarDeclInitFunc(cir::GlobalOp op) {
   }
 
   // If we're actually in the 'if' above, create a yield.
-  if (needsTlsGuard)
+  if (needsTlsGuard) {
+    builder.setInsertionPointToEnd(&guardIf.getThenRegion().back());
     cir::YieldOp::create(builder, op.getLoc());
+  }
 
   // Replace cir.yield with cir.return
   builder.setInsertionPointToEnd(entryBB);
@@ -1751,15 +1754,14 @@ LoweringPreparePass::createGlobalThreadLocalGuard(CIRBaseBuilderTy &builder,
   builder.setInsertionPointToStart(mlirModule.getBody());
 
   // The TLS Guard is always an Int8Ty.
-  auto guardTy = builder.getSIntNTy(8);
-  cir::GlobalOp g = cir::GlobalOp::create(builder, loc, "__tls_guard", guardTy);
+  cir::IntType guardTy = builder.getSIntNTy(8);
+  auto g = cir::GlobalOp::create(builder, loc, "__tls_guard", guardTy);
   g.setLinkageAttr(cir::GlobalLinkageKindAttr::get(
       builder.getContext(), cir::GlobalLinkageKind::InternalLinkage));
   g.setAlignment(clang::CharUnits::One().getAsAlign().value());
   // At the moment, we only have implementation for this mode, as it is the
   // default.  At one point we might need to load this mode from the module.
   g.setTlsModel(TLS_Model::GeneralDynamic);
-  // g.setDSOLocal(
   g.setInitialValueAttr(cir::IntAttr::get(guardTy, 0));
   return g;
 }
@@ -1779,7 +1781,7 @@ cir::IfOp LoweringPreparePass::buildGlobalTlsGuardCheck(
   mlir::Value guardLoad =
       builder.createAlignedLoad(loc, getGuardValue, *guard.getAlignment());
   auto zero = builder.getConstantInt(loc, builder.getSIntNTy(8), 0);
-  auto compare =
+  cir::CmpOp compare =
       builder.createCompare(loc, cir::CmpOpKind::eq, guardLoad, zero);
   return cir::IfOp::create(
       builder, loc, compare,
@@ -1809,7 +1811,7 @@ void LoweringPreparePass::buildCXXGlobalTlsFunc() {
 
   // Emit the body of the guarded spot.
   builder.setInsertionPointToEnd(&ifOperation.getThenRegion().front());
-  for (auto initFunc : globalThreadLocalInitializers)
+  for (cir::FuncOp initFunc : globalThreadLocalInitializers)
     builder.createCallOp(loc, initFunc, {});
   cir::YieldOp::create(builder, loc);
 

--- a/clang/test/CIR/CodeGen/global-tls-dyn-init.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-dyn-init.cpp
@@ -10,6 +10,7 @@ struct CtorDtor {
     int i;
 };
 
+// LLVM-BOTH-DAG: @__tls_guard = internal thread_local global i8 0, align 1
 // LLVM-BOTH-DAG: @__dso_handle = external hidden global i8
 // LLVM-BOTH-DAG: @tls_cd = thread_local global %struct.CtorDtor { i32 5 }, align 4
 // LLVM-BOTH-DAG: @tls_cd_dyn = thread_local global %struct.CtorDtor zeroinitializer, align 4
@@ -22,6 +23,7 @@ struct CtorDtor {
 // LLVM-BOTH-DAG: @_ZTH6tls_cd = alias void (), ptr @__tls_init
 
 // Wrappers & aliases.
+// CIR:       cir.global internal tls_dyn @__tls_guard = #cir.int<0> : !s8i {alignment = 1 : i64}
 // CIR-LABEL: cir.func comdat weak_odr private hidden @_ZTW19tls_cd_dyn_not_used() -> !cir.ptr<!rec_CtorDtor> {
 // CIR: cir.call @_ZTH19tls_cd_dyn_not_used() : () -> ()
 // CIR: %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn_not_used : !cir.ptr<!rec_CtorDtor>
@@ -47,6 +49,18 @@ struct CtorDtor {
 // CIR: cir.func @_ZTH6tls_cd() alias(@__tls_init)
 
 // CIR-LABEL: cir.func internal private @__tls_init() {
+// CIR: %[[GET_GUARD:.*]] = cir.get_global thread_local @__tls_guard : !cir.ptr<!s8i>
+// CIR: %[[LOAD_GUARD:.*]] = cir.load align(1) %[[GET_GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[CMP:.*]] = cir.cmp eq %[[LOAD_GUARD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[CMP]] {
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR:   cir.store %[[ONE]], %[[GET_GUARD]] : !s8i, !cir.ptr<!s8i>
+// CIR:   cir.call @[[TLS_CD_INIT:.*]]() : () -> ()
+// CIR:   cir.call @[[TLS_CD_DYN_INIT:.*]]() : () -> ()
+// CIR:   cir.call @[[TLS_CD_REF_INIT:.*]]() : () -> ()
+// CIR:   cir.call @[[TLS_CD_DYN_NOT_USED_INIT:.*]]() : () -> ()
+// CIR:  }
 // CIR:  cir.return
 
 // LLVM: define weak_odr hidden ptr @_ZTW19tls_cd_dyn_not_used() {
@@ -74,6 +88,16 @@ struct CtorDtor {
 // LLVM: }
 //
 // LLVM: define internal void @__tls_init() {
+// LLVM:   %[[GET_GUARD:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @__tls_guard)
+// LLVM:   %[[LOAD_GUARD:.*]] = load i8, ptr %[[GET_GUARD]], align 1
+// LLVM:   %[[IS_UNINIT:.*]] = icmp eq i8 %[[LOAD_GUARD]], 0
+// LLVM:   br i1 %[[IS_UNINIT]]
+// LLVM
+// LLVM:   store i8 1, ptr %[[GET_GUARD]], align 1
+// LLVM:   call void @[[TLS_CD_INIT:.*]]()
+// LLVM:   call void @[[TLS_CD_DYN_INIT:.*]]()
+// LLVM:   call void @[[TLS_CD_REF_INIT:.*]]()
+// LLVM:   call void @[[TLS_CD_DYN_NOT_USED_INIT:.*]]()
 
 thread_local CtorDtor tls_cd = 5;
 // CIR-BEFORE-LPP: cir.global external tls_dyn dyn_tls_refs = <"_ZTW6tls_cd", "_ZTH6tls_cd"> @tls_cd = #cir.const_record<{#cir.int<5> : !s32i}> : !rec_CtorDtor dtor {
@@ -81,7 +105,7 @@ thread_local CtorDtor tls_cd = 5;
 // CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
 // CIR-BEFORE-LPP: }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW6tls_cd", "_ZTH6tls_cd"> @tls_cd = #cir.const_record<{#cir.int<5> : !s32i}> : !rec_CtorDtor
-// CIR: cir.func internal private @[[TLS_CD_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_CD_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd : !cir.ptr<!rec_CtorDtor>
 // CIR:   %[[GET_DTOR:.*]] = cir.get_global @_ZN8CtorDtorD1Ev : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>>
 // CIR:   %[[DTOR_DECAY:.*]] = cir.cast bitcast %[[GET_DTOR]] : !cir.ptr<!cir.func<(!cir.ptr<!rec_CtorDtor>)>> -> !cir.ptr<!cir.func<(!cir.ptr<!void>)>>
@@ -90,7 +114,7 @@ thread_local CtorDtor tls_cd = 5;
 // CIR:   cir.call @__cxa_thread_atexit(%[[DTOR_DECAY]], %[[GLOB_DECAY]], %[[DSOHANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
 // CIR:   cir.return
 //
-// LLVM: define internal void @[[TLS_CD_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_CD_INIT]]() {
 // OGCG: define internal void @[[TLS_CD_INIT:.*]]() {{.*}}{
 // LLVM:   %[[GET_GLOB:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @tls_cd)
 // LLVM:   call void @__cxa_thread_atexit(ptr @_ZN8CtorDtorD1Ev, ptr %[[GET_GLOB]], ptr @__dso_handle)
@@ -107,7 +131,7 @@ thread_local CtorDtor tls_cd_dyn = get_i();
 // CIR-BEFORE-LPP:    cir.call @_ZN8CtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
 // CIR-BEFORE-LPP:  }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW10tls_cd_dyn", "_ZTH10tls_cd_dyn"> @tls_cd_dyn = #cir.zero : !rec_CtorDtor
-// CIR: cir.func internal private @[[TLS_CD_DYN_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_CD_DYN_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn : !cir.ptr<!rec_CtorDtor>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_GLOB]], %[[CALL]])
@@ -119,7 +143,7 @@ thread_local CtorDtor tls_cd_dyn = get_i();
 // CIR:   cir.call @__cxa_thread_atexit(%[[DTOR_DECAY]], %[[GLOB_DECAY]], %[[DSOHANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
 // CIR:   cir.return
 //
-// LLVM: define internal void @[[TLS_CD_DYN_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_CD_DYN_INIT]]() {
 // OGCG: define internal void @[[TLS_CD_DYN_INIT:.*]]() {{.*}} {
 // LLVM:   %[[GET_GLOB:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @tls_cd_dyn)
 // LLVM-BOTH:   %[[CALL:.*]] = call noundef i32 @_Z5get_iv()
@@ -137,13 +161,13 @@ thread_local CtorDtor &tls_cd_ref = tls_cd_dyn;
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !cir.ptr<!rec_CtorDtor>, !cir.ptr<!cir.ptr<!rec_CtorDtor>>
 // CIR-BEFORE-LPP: }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW10tls_cd_ref", "_ZTH10tls_cd_ref"> @tls_cd_ref = #cir.ptr<null> : !cir.ptr<!rec_CtorDtor>
-// CIR: cir.func internal private @[[TLS_CD_REF_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_CD_REF_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_ref : !cir.ptr<!cir.ptr<!rec_CtorDtor>>
 // CIR:   %[[GET_DYN:.*]] = cir.call @_ZTW10tls_cd_dyn() : () -> !cir.ptr<!rec_CtorDtor>
 // CIR:   cir.store align(8) %[[GET_DYN]], %[[GET_GLOB]] : !cir.ptr<!rec_CtorDtor>, !cir.ptr<!cir.ptr<!rec_CtorDtor>>
 // CIR:   cir.return
 //
-// LLVM: define internal void @[[TLS_CD_REF_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_CD_REF_INIT]]() {
 // OGCG: define internal void @[[TLS_CD_REF_INIT:.*]]() {{.*}} {
 // LLVM:   %[[GET_GLOB:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @tls_cd_ref)
 // LLVM-BOTH:   %[[CALL:.*]] = call ptr @_ZTW10tls_cd_dyn()
@@ -167,7 +191,7 @@ thread_local CtorDtor tls_cd_dyn_not_used = get_i();
 // CIR-BEFORE-LPP:   cir.call @_ZN8CtorDtorD1Ev(%[[GET_GLOB]]) : (!cir.ptr<!rec_CtorDtor>) -> ()
 // CIR-BEFORE-LPP: }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW19tls_cd_dyn_not_used", "_ZTH19tls_cd_dyn_not_used"> @tls_cd_dyn_not_used = #cir.zero : !rec_CtorDtor
-// CIR: cir.func internal private @[[TLS_CD_DYN_NOT_USED_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_CD_DYN_NOT_USED_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_cd_dyn_not_used : !cir.ptr<!rec_CtorDtor>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR:   cir.call @_ZN8CtorDtorC1Ei(%[[GET_GLOB]], %[[CALL]])
@@ -179,7 +203,7 @@ thread_local CtorDtor tls_cd_dyn_not_used = get_i();
 // CIR:   cir.call @__cxa_thread_atexit(%[[DTOR_DECAY]], %[[GLOB_DECAY]], %[[DSOHANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
 // CIR:   cir.return
 //
-// LLVM: define internal void @[[TLS_CD_DYN_NOT_USED_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_CD_DYN_NOT_USED_INIT]]() {
 // OGCG: define internal void @[[TLS_CD_DYN_NOT_USED_INIT:.*]]() {{.*}} {
 // LLVM:   %[[GET_GLOB:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @tls_cd_dyn_not_used)
 // LLVM-BOTH:   %[[CALL:.*]] = call noundef i32 @_Z5get_iv()

--- a/clang/test/CIR/CodeGen/global-tls-simple-init.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-simple-init.cpp
@@ -54,12 +54,25 @@ struct CtorDtor {
 
 // Full init of all variables (func names below).
 // CIR-LABEL: cir.func internal private @__tls_init() {
+// CIR: %[[GET_GUARD:.*]] = cir.get_global thread_local @__tls_guard : !cir.ptr<!s8i>
+// CIR: %[[LOAD_GUARD:.*]] = cir.load align(1) %[[GET_GUARD]] : !cir.ptr<!s8i>, !s8i
+// CIR: %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR: %[[CMP:.*]] = cir.cmp eq %[[LOAD_GUARD]], %[[ZERO]] : !s8i
+// CIR: cir.if %[[CMP]] {
+// CIR:   %[[ONE:.*]] = cir.const #cir.int<1> : !s8i
+// CIR:   cir.store %[[ONE]], %[[GET_GUARD]] : !s8i, !cir.ptr<!s8i>
+// CIR:   cir.call @[[TLS_INT_DYN_INIT:.*]]() : () -> ()
+// CIR:   cir.call @[[TLS_INT_REF_INIT:.*]]() : () -> ()
+// CIR:   cir.call @[[TLS_INT_SELF_REF_INIT:.*]]() : () -> ()
+// CIR:   cir.call @[[DEF_INITED_DYN:.*]]() : () -> ()
+// CIR: }
 // CIR: cir.return
 
 // CIR-LABEL: cir.func comdat weak_odr private hidden @_ZTW7tls_int() -> !cir.ptr<!s32i> {
 // CIR: %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int : !cir.ptr<!s32i>
 // CIR: cir.return %[[GET_GLOB]]
 
+// LLVM-BOTH-DAG: @__tls_guard = internal thread_local global i8 0, align 1
 // LLVM-BOTH-DAG: @tls_int = thread_local global i32 5, align 4
 // LLVM-BOTH-DAG: @tls_int_dyn = thread_local global i32 0, align 4
 // LLVM-BOTH-DAG: @tls_int_ref = thread_local global ptr null, align 8
@@ -107,6 +120,17 @@ struct CtorDtor {
 // LLVM:   ret ptr %[[GET_GLOB]]
 
 // LLVM: define internal void @__tls_init() {
+// LLVM:   %[[GET_GUARD:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @__tls_guard)
+// LLVM:   %[[LOAD_GUARD:.*]] = load i8, ptr %[[GET_GUARD]], align 1
+// LLVM:   %[[IS_UNINIT:.*]] = icmp eq i8 %[[LOAD_GUARD]], 0
+// LLVM:   br i1 %[[IS_UNINIT]]
+//
+// LLVM:   store i8 1, ptr %[[GET_GUARD]], align 1
+// LLVM:   call void @[[TLS_INT_DYN_INIT:.*]]()
+// LLVM:   call void @[[TLS_INT_REF_INIT:.*]]()
+// LLVM:   call void @[[TLS_INT_SELF_REF_INIT:.*]]()
+// LLVM:   call void @[[DEF_INITED_DYN:.*]]()
+// LLVM:   br label 
 // LLVM:   ret void
 
 // LLVM: define weak_odr hidden ptr @_ZTW7tls_int() {
@@ -126,12 +150,12 @@ thread_local int tls_int_dyn = get_i();
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP: }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW11tls_int_dyn", "_ZTH11tls_int_dyn"> @tls_int_dyn = #cir.int<0> : !s32i 
-// CIR: cir.func internal private @[[TLS_INT_DYN_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_INT_DYN_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_dyn : !cir.ptr<!s32i>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR:   cir.return
-// LLVM: define internal void @[[TLS_INT_DYN_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_INT_DYN_INIT]]() {
 // OGCG: define internal void @[[TLS_INT_DYN_INIT:.*]]()
 // OGCG:   %[[CALL:.*]] = call noundef i32 @_Z5get_iv()
 // LLVM-BOTH:   %[[GET_GLOB:.*]] = call {{.*}}ptr @llvm.threadlocal.address.p0(ptr {{.*}}@tls_int_dyn)
@@ -146,12 +170,12 @@ thread_local int &tls_int_ref = tls_int_dyn;
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[GET_OTHER]], %[[GET_GLOB]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR-BEFORE-LPP: }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW11tls_int_ref", "_ZTH11tls_int_ref"> @tls_int_ref = #cir.ptr<null> : !cir.ptr<!s32i>
-// CIR: cir.func internal private @[[TLS_INT_REF_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_INT_REF_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_ref : !cir.ptr<!cir.ptr<!s32i>>
 // CIR:   %[[GET_REF:.*]] = cir.call @_ZTW11tls_int_dyn() : () -> !cir.ptr<!s32i>
 // CIR:   cir.store {{.*}}%[[GET_REF]], %[[GET_GLOB]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CIR:   cir.return
-// LLVM: define internal void @[[TLS_INT_REF_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_INT_REF_INIT]]() {
 // OGCG: define internal void @[[TLS_INT_REF_INIT:.*]]()
 // OGCG:   %[[GET_REF:.*]] = call ptr @_ZTW11tls_int_dyn()
 // LLVM-BOTH:   %[[GET_GLOB:.*]] = call {{.*}}ptr @llvm.threadlocal.address.p0(ptr {{.*}}@tls_int_ref)
@@ -174,7 +198,7 @@ thread_local int tls_int_self_init = tls_int_self_init + get_i();
 // CIR-BEFORE-LPP:    cir.store {{.*}}%[[ADD]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP:  }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW17tls_int_self_init", "_ZTH17tls_int_self_init"> @tls_int_self_init = #cir.int<0> : !s32i
-// CIR: cir.func internal private @[[TLS_INT_SELF_REF_INIT:.*]]() {
+// CIR: cir.func internal private @[[TLS_INT_SELF_REF_INIT]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @tls_int_self_init : !cir.ptr<!s32i>
 // CIR:   %[[GET_SELF_FROM_WRAPPER:.*]] = cir.call @_ZTW17tls_int_self_init() : () -> !cir.ptr<!s32i>
 // CIR:   %[[SELF_LOAD:.*]] = cir.load {{.*}}%[[GET_SELF_FROM_WRAPPER]] : !cir.ptr<!s32i>, !s32i
@@ -182,7 +206,7 @@ thread_local int tls_int_self_init = tls_int_self_init + get_i();
 // CIR:   %[[ADD:.*]] = cir.add nsw %[[SELF_LOAD]], %[[CALL]] : !s32i
 // CIR:   cir.store{{.*}} %[[ADD]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR:   cir.return
-// LLVM: define internal void @[[TLS_INT_SELF_REF_INIT:.*]]() {
+// LLVM: define internal void @[[TLS_INT_SELF_REF_INIT]]() {
 // OGCG: define internal void @[[TLS_INT_SELF_REF_INIT:.*]]()
 // LLVM:   %[[GET_GLOB:.*]] = call {{.*}}ptr @llvm.threadlocal.address.p0(ptr {{.*}}@tls_int_self_init)
 // LLVM-BOTH:   %[[GET_SELF_FROM_WRAPPER:.*]] = call ptr @_ZTW17tls_int_self_init()
@@ -209,12 +233,12 @@ extern thread_local int definitely_inited_dyn = get_i();
 // CIR-BEFORE-LPP:   cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR-BEFORE-LPP: }
 // CIR: cir.global external tls_dyn dyn_tls_refs = <"_ZTW21definitely_inited_dyn", "_ZTH21definitely_inited_dyn"> @definitely_inited_dyn = #cir.int<0> : !s32i
-// CIR: cir.func internal private @[[DEF_INITED_DYN:.*]]() {
+// CIR: cir.func internal private @[[DEF_INITED_DYN]]() {
 // CIR:   %[[GET_GLOB:.*]] = cir.get_global thread_local @definitely_inited_dyn : !cir.ptr<!s32i>
 // CIR:   %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR:   cir.store align(4) %[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
 // CIR:   cir.return
-// LLVM: define internal void @[[DEF_INITED_DYN:.*]]() {
+// LLVM: define internal void @[[DEF_INITED_DYN]]() {
 // OGCG: define internal void @[[DEF_INITED_DYN:.*]]()
 // LLVM:   %[[GET_GLOB:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @definitely_inited_dyn)
 // LLVM-BOTH:   %[[CALL:.*]] = call noundef i32 @_Z5get_iv()

--- a/clang/test/CIR/CodeGen/global-tls-templates.cpp
+++ b/clang/test/CIR/CodeGen/global-tls-templates.cpp
@@ -38,6 +38,7 @@ thread_local T tls_templ = {get_i()};
 // Alias: Ctor/Dtor: 
 // CIR: cir.func linkonce_odr @_ZTH9tls_templI8CtorDtorE() alias(@[[CTOR_DTOR_INIT:[^)]*]])
 // TLS Guard: Ctor/Dtor:
+// CIR: cir.global "private" linkonce_odr comdat tls_dyn @_ZGV9tls_templI8CtorDtorE = #cir.int<0> : !s64i
 
 // Wrapper: int
 // CIR-LABEL: cir.func comdat weak_odr private hidden @_ZTW9tls_templIiE() -> !cir.ptr<!s32i>
@@ -48,15 +49,28 @@ thread_local T tls_templ = {get_i()};
 
 // Alias: int
 // CIR: cir.func linkonce_odr @_ZTH9tls_templIiE() alias(@[[INT_INIT:[^)]*]])
+// TLS Guard: int
+// CIR: cir.global "private" linkonce_odr comdat tls_dyn @_ZGV9tls_templIiE = #cir.int<0> : !s64i
 
 // Global: int
 // CIR: cir.global linkonce_odr comdat tls_dyn dyn_tls_refs = <"_ZTW9tls_templIiE", "_ZTH9tls_templIiE", "_ZGV9tls_templIiE"> @_Z9tls_templIiE = #cir.int<0> : !s32i
 
 // Init Func: int
 // CIR:  cir.func internal private @[[INT_INIT]]() {
+// CIR:    %[[GET_GUARD:.*]] = cir.get_global thread_local @_ZGV9tls_templIiE : !cir.ptr<!s64i>
+// CIR:    %[[GUARD_CAST:.*]] = cir.cast bitcast %[[GET_GUARD]] : !cir.ptr<!s64i> -> !cir.ptr<!s8i>
+// CIR:    %[[LOAD_GUARD:.*]] = cir.load align(8) %[[GUARD_CAST]] : !cir.ptr<!s8i>, !s8i
+// CIR:    %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR:    %[[ISUNINIT:.*]] = cir.cmp eq %[[LOAD_GUARD]], %[[ZERO]] : !s8i
+// CIR:    cir.if %[[ISUNINIT]] {
+// CIR:      %[[ONE:.*]] = cir.const #cir.int<1> : !s64i
+// CIR:      cir.store %[[ONE]], %[[GET_GUARD]] : !s64i, !cir.ptr<!s64i>
 // CIR:      %[[GET_GLOB:.*]] = cir.get_global thread_local @_Z9tls_templIiE : !cir.ptr<!s32i>
 // CIR:      %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR:      cir.store {{.*}}%[[CALL]], %[[GET_GLOB]] : !s32i, !cir.ptr<!s32i>
+// CIR:    }
+// CIR:    cir.return
+// CIR:  }
 
 
 // Global: Ctor/Dotr:
@@ -64,6 +78,14 @@ thread_local T tls_templ = {get_i()};
 
 // Init Func: Ctor/Dtor:
 // CIR: cir.func internal private @[[CTOR_DTOR_INIT]]() {
+// CIR:   %[[GET_GUARD:.*]] = cir.get_global thread_local @_ZGV9tls_templI8CtorDtorE : !cir.ptr<!s64i>
+// CIR:    %[[GUARD_CAST:.*]] = cir.cast bitcast %[[GET_GUARD]] : !cir.ptr<!s64i> -> !cir.ptr<!s8i>
+// CIR:    %[[LOAD_GUARD:.*]] = cir.load align(8) %[[GUARD_CAST]] : !cir.ptr<!s8i>, !s8i
+// CIR:    %[[ZERO:.*]] = cir.const #cir.int<0> : !s8i
+// CIR:    %[[ISUNINIT:.*]] = cir.cmp eq %[[LOAD_GUARD]], %[[ZERO]] : !s8i
+// CIR:    cir.if %[[ISUNINIT]] {
+// CIR:     %[[ONE:.*]] = cir.const #cir.int<1> : !s64i
+// CIR:     cir.store %[[ONE]], %[[GET_GUARD]] : !s64i, !cir.ptr<!s64i>
 // CIR:     %[[GET_GLOB:.*]] = cir.get_global thread_local @_Z9tls_templI8CtorDtorE : !cir.ptr<!rec_CtorDtor>
 // CIR:     %[[CALL:.*]] = cir.call @_Z5get_iv() : () -> (!s32i {llvm.noundef})
 // CIR:     cir.call @_ZN8CtorDtorC1Ei(%[[GET_GLOB]], %[[CALL]]) : (!cir.ptr<!rec_CtorDtor> {{.*}}, !s32i {llvm.noundef}) -> ()
@@ -73,9 +95,15 @@ thread_local T tls_templ = {get_i()};
 // CIR:     %[[GLOB_DECAY:.*]] = cir.cast bitcast %[[GET_GLOB:.*]] : !cir.ptr<!rec_CtorDtor> -> !cir.ptr<!void>
 // CIR:     %[[DSO_HANDLE:.*]] = cir.get_global @__dso_handle : !cir.ptr<i8>
 // CIR:     cir.call @__cxa_thread_atexit(%[[DTOR_FPTR]], %[[GLOB_DECAY]], %[[DSO_HANDLE]]) : (!cir.ptr<!cir.func<(!cir.ptr<!void>)>>, !cir.ptr<!void>, !cir.ptr<i8>) -> ()
+// CIR:   }
+// CIR:   cir.return
+// CIR: }
 
 // FIXME: These have inconsistent COMDAT with classic codegen, but we don't
 // currently specify 'comdat' with a name.
+// Guards:
+// LLVM-BOTH-DAG: @_ZGV9tls_templI8CtorDtorE = linkonce_odr thread_local global i64 0, comdat{{.*}}, align 8
+// LLVM-BOTH-DAG: @_ZGV9tls_templIiE = linkonce_odr thread_local global i64 0, comdat{{.*}}, align 8
 // Globals:
 // LLVM-BOTH-DAG: @_Z9tls_templIiE = linkonce_odr thread_local global i32 0, comdat, align 4
 // LLVM-BOTH-DAG: @_Z9tls_templI8CtorDtorE = linkonce_odr thread_local global %struct.CtorDtor zeroinitializer, comdat, align 4
@@ -121,10 +149,13 @@ thread_local T tls_templ = {get_i()};
 //    but ALWAYS treats the load/stores as i8.  This is likely a 'bug' in OGCG, but one that
 //    doesn't really matter at all.
 // LLVM-BOTH: define internal void @[[INT_INIT]]()
+// LLVM:   %[[GET_GUARD:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGV9tls_templIiE)
+// LLVM:   %[[LOAD_GUARD:.*]] = load i8, ptr %[[GET_GUARD]], align 8
 // OGCG:   %[[LOAD_GUARD:.*]] = load i8, ptr @_ZGV9tls_templIiE, align 8
-// OGCG:   %[[ISUNINIT:.*]] = icmp eq i{{.*}} %[[LOAD_GUARD]], 0
-// OGCG:   br i1 %[[ISUNINIT]]
+// LLVM-BOTH:   %[[ISUNINIT:.*]] = icmp eq i{{.*}} %[[LOAD_GUARD]], 0
+// LLVM-BOTH:   br i1 %[[ISUNINIT]]
 //
+// LLVM:   store i64 1, ptr %[[GET_GUARD]], align 8
 // OGCG:   store i8 1, ptr @_ZGV9tls_templIiE, align 8
 // LLVM:   %[[GET_GLOB:.*]] = call {{.*}}ptr @llvm.threadlocal.address.p0(ptr {{.*}}@_Z9tls_templIiE)
 // LLVM:   %[[CALL:.*]] = call noundef i32 @_Z5get_iv()
@@ -133,10 +164,13 @@ thread_local T tls_templ = {get_i()};
 // LLVM-BOTH:   store i32 %[[CALL]], ptr %[[GET_GLOB]]
 
 // LLVM-BOTH: define internal void @[[CTOR_DTOR_INIT]]()
+// LLVM:   %[[GET_GUARD:.*]] = call ptr @llvm.threadlocal.address.p0(ptr @_ZGV9tls_templI8CtorDtorE)
+// LLVM:   %[[LOAD_GUARD:.*]] = load i8, ptr %[[GET_GUARD]], align 8
 // OGCG:   %[[LOAD_GUARD:.*]] = load i8, ptr @_ZGV9tls_templI8CtorDtorE, align 8
-// OGCG:   %[[ISUNINIT:.*]] = icmp eq i{{.*}} %[[LOAD_GUARD]], 0
-// OGCG:   br i1 %[[ISUNINIT]]
+// LLVM-BOTH:   %[[ISUNINIT:.*]] = icmp eq i{{.*}} %[[LOAD_GUARD]], 0
+// LLVM-BOTH:   br i1 %[[ISUNINIT]]
 //
+// LLVM:   store i64 1, ptr %[[GET_GUARD]], align 8
 // OGCG:  store i8 1, ptr @_ZGV9tls_templI8CtorDtorE, align 8
 //
 // LLVM:   %[[GET_GLOB:.*]] = call {{.*}}ptr @llvm.threadlocal.address.p0(ptr {{.*}}@_Z9tls_templI8CtorDtorE)


### PR DESCRIPTION
This is the last patch for global/namespace thread-local variables. This patch emits the final 'init' function, which calls all other init functions, plus does the guard variable for the unordered variants.