### PR TITLE
[llvm][ADT] Fix overload resolution in `to_vector` / `to_vector_of` for `bool` containers

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -1323,20 +1323,22 @@ using ValueTypeFromRangeType =
 /// when you want to iterate a range and then sort the results.
 template <unsigned Size, typename R>
 SmallVector<ValueTypeFromRangeType<R>, Size> to_vector(R &&Range) {
-  return {adl_begin(Range), adl_end(Range)};
+  return SmallVector<ValueTypeFromRangeType<R>, Size>(adl_begin(Range),
+                                                      adl_end(Range));
 }
 template <typename R>
 SmallVector<ValueTypeFromRangeType<R>> to_vector(R &&Range) {
-  return {adl_begin(Range), adl_end(Range)};
+  return SmallVector<ValueTypeFromRangeType<R>>(adl_begin(Range),
+                                                adl_end(Range));
 }
 
 template <typename Out, unsigned Size, typename R>
 SmallVector<Out, Size> to_vector_of(R &&Range) {
-  return {adl_begin(Range), adl_end(Range)};
+  return SmallVector<Out, Size>(adl_begin(Range), adl_end(Range));
 }
 
 template <typename Out, typename R> SmallVector<Out> to_vector_of(R &&Range) {
-  return {adl_begin(Range), adl_end(Range)};
+  return SmallVector<Out>(adl_begin(Range), adl_end(Range));
 }
 
 // Explicit instantiations

--- a/llvm/unittests/ADT/SmallVectorTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorTest.cpp
@@ -1241,9 +1241,7 @@ TEST(SmallVectorTest, ToVector) {
     SmallVector<bool> V = {true, false, true};
     ArrayRef<bool> ref = V;
     auto copy = to_vector(ref);
-    EXPECT_EQ(V.size(), copy.size());
-    for (size_t I = 0; I < V.size(); ++I)
-      EXPECT_EQ(V[I], copy[I]);
+    EXPECT_THAT(copy, testing::ElementsAre(true, false, true));
   }
 }
 

--- a/llvm/unittests/ADT/SmallVectorTest.cpp
+++ b/llvm/unittests/ADT/SmallVectorTest.cpp
@@ -1237,6 +1237,14 @@ TEST(SmallVectorTest, ToVector) {
     IntVector = to_vector<3>(V);
     EXPECT_THAT(IntVector, testing::ElementsAre(1, 2, 3));
   }
+  {
+    SmallVector<bool> V = {true, false, true};
+    ArrayRef<bool> ref = V;
+    auto copy = to_vector(ref);
+    EXPECT_EQ(V.size(), copy.size());
+    for (size_t I = 0; I < V.size(); ++I)
+      EXPECT_EQ(V[I], copy[I]);
+  }
 }
 
 struct To {


### PR DESCRIPTION
`to_vector` and `to_vector_of` used to return a braced initializer list: `return {adl_begin(Range), adl_end(Range)};`

For non-`bool` element types this resolved to the iterator-pair constructor `SmallVector<T>(ItTy First, ItTy Last)` as intended. However, for `bool` element types, overload resolution preferred the `SmallVector<bool>(std::initializer_list<bool>)` constructor, because every pointer type has an implicit conversion to `bool` (the same one that makes `if (ptr)` work).

In the worst case, code such as `llvm::to_vector(array_ref_of_bool)` miscompiled. When compiling with warnings, such code would error out:
```
In file included from llvm-project/llvm/include/llvm/ADT/ArrayRef.h:14:
llvm-project/llvm/include/llvm/ADT/SmallVector.h:1330:11: error: type 'decltype(adl_detail::begin_impl(std::forward<llvm::ArrayRef<bool> &>(range)))' (aka 'const bool *') cannot be narrowed to 'bool' in initializer list [-Wc++11-narrowing]
 1330 |   return {adl_begin(Range), adl_end(Range)};
      |           ^~~~~~~~~~~~~~~~
llvm-project/llvm/unittests/ADT/SmallVectorTest.cpp:1243:17: note: in instantiation of function template specialization 'llvm::to_vector<llvm::ArrayRef<bool> &>' requested here
 1243 |     auto copy = to_vector(ref);
      |                 ^
llvm-project/llvm/include/llvm/ADT/SmallVector.h:1330:11: note: insert an explicit cast to silence this issue
 1330 |   return {adl_begin(Range), adl_end(Range)};
      |           ^~~~~~~~~~~~~~~~
      |           static_cast<bool>( )
```

Switch the returns to direct-initialization, which selects the iterator-pair constructor regardless of the element type.

Assisted-by: claude-opus-4.7-thinking-xhigh
