### PR TITLE
[BOLT] Gate PointerAuthCFIFixup unit test on AArch64 target availability

### DIFF
--- a/bolt/unittests/Passes/PointerAuthCFIFixup.cpp
+++ b/bolt/unittests/Passes/PointerAuthCFIFixup.cpp
@@ -122,6 +122,9 @@ protected:
 };
 } // namespace
 
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(PassTester);
+
+#ifdef AARCH64_AVAILABLE
 TEST_P(PassTester, ExampleTest) {
   if (GetParam() != Triple::aarch64)
     GTEST_SKIP();
@@ -332,6 +335,7 @@ TEST_P(PassTester, fillUnknownStubsEmpty) {
   // BB2 should be set to BF.initialRAState (false).
   EXPECT_FALSE(*RAState);
 }
+#endif // AARCH64_AVAILABLE
 
 #ifdef AARCH64_AVAILABLE
 INSTANTIATE_TEST_SUITE_P(AArch64, PassTester,


### PR DESCRIPTION
The test bodies reference AArch64:: namespace identifiers (ADDSXri, X0) which fail to compile when AArch64 is not in LLVM_TARGETS_TO_BUILD. Wrap all TEST_P bodies in #ifdef AARCH64_AVAILABLE and add GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST to suppress GoogleTest's uninstantiated suite error when no target instantiates the tests.