### PR TITLE
[flang][acc] Support walking through acc.compute_region ins

### DIFF
--- a/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h
+++ b/flang/include/flang/Optimizer/OpenACC/Support/FIROpenACCUtils.h
@@ -91,7 +91,9 @@ createOrGetReductionRecipe(mlir::OpBuilder &builder, mlir::Location loc,
 
 /// Walks through operations that forward or view their operand and returns
 /// the original defining value. This strips operations like fir.convert,
-/// ViewLikeOpInterface, and optionally fir.declare/hlfir.declare.
+/// ViewLikeOpInterface, and optionally fir.declare/hlfir.declare. Block
+/// arguments of `acc.compute_region` are unwrapped to the corresponding
+/// `ins` operand.
 /// \param value The value to trace back to its origin
 /// \param stripDeclare If true (default), also strips declare operations
 /// \return The original value after stripping all intermediate operations

--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCUtils.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCUtils.cpp
@@ -616,6 +616,18 @@ mlir::Value fir::acc::getOriginalDef(mlir::Value value, bool stripDeclare) {
   mlir::Value currentValue = value;
 
   while (currentValue) {
+    if (auto blockArg = mlir::dyn_cast<mlir::BlockArgument>(currentValue)) {
+      if (auto computeRegion =
+              mlir::dyn_cast_if_present<mlir::acc::ComputeRegionOp>(
+                  blockArg.getOwner()->getParentOp())) {
+        if (mlir::Value operand = computeRegion.getOperand(blockArg)) {
+          currentValue = operand;
+          continue;
+        }
+      }
+      break;
+    }
+
     auto *definingOp = currentValue.getDefiningOp();
     if (!definingOp)
       break;


### PR DESCRIPTION
Since acc.compute_region is IsolatedFromAbove, its values are threaded through block arguments. But the implementations using getOriginalDef want to see the original variable input in order to make their assessment.