### PR TITLE
[clang-tidy] Add IgnoreMacros option to UseEnumClassCheck

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
@@ -16,11 +16,13 @@ namespace clang::tidy::cppcoreguidelines {
 UseEnumClassCheck::UseEnumClassCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       IgnoreUnscopedEnumsInClasses(
-          Options.get("IgnoreUnscopedEnumsInClasses", false)) {}
+          Options.get("IgnoreUnscopedEnumsInClasses", false)),
+      IgnoreMacros(Options.get("IgnoreMacros", false)) {}
 
 void UseEnumClassCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreUnscopedEnumsInClasses",
                 IgnoreUnscopedEnumsInClasses);
+  Options.store(Opts, "IgnoreMacros", IgnoreMacros);
 }
 
 void UseEnumClassCheck::registerMatchers(MatchFinder *Finder) {
@@ -33,9 +35,12 @@ void UseEnumClassCheck::registerMatchers(MatchFinder *Finder) {
 
 void UseEnumClassCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *UnscopedEnum = Result.Nodes.getNodeAs<EnumDecl>("unscoped_enum");
+  const auto SourceLoc = UnscopedEnum->getLocation();
 
-  diag(UnscopedEnum->getLocation(),
-       "enum %0 is unscoped, use 'enum class' instead")
+  if (IgnoreMacros && SourceLoc.isMacroID())
+    return;
+
+  diag(SourceLoc, "enum %0 is unscoped, use 'enum class' instead")
       << UnscopedEnum;
 }
 

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.cpp
@@ -35,7 +35,7 @@ void UseEnumClassCheck::registerMatchers(MatchFinder *Finder) {
 
 void UseEnumClassCheck::check(const MatchFinder::MatchResult &Result) {
   const auto *UnscopedEnum = Result.Nodes.getNodeAs<EnumDecl>("unscoped_enum");
-  const auto SourceLoc = UnscopedEnum->getLocation();
+  const SourceLocation SourceLoc = UnscopedEnum->getLocation();
 
   if (IgnoreMacros && SourceLoc.isMacroID())
     return;

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.h
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/UseEnumClassCheck.h
@@ -33,6 +33,7 @@ public:
 
 private:
   const bool IgnoreUnscopedEnumsInClasses;
+  const bool IgnoreMacros;
 };
 
 } // namespace clang::tidy::cppcoreguidelines

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -333,6 +333,11 @@ Changes in existing checks
   by fixing a false positive on implicitly generated functions such as
   inherited constructors.
 
+- Improved :doc:`cppcoreguidelines-use-enum-class
+  <clang-tidy/checks/cppcoreguidelines/use-enum-class>` check by adding the
+  `IgnoreMacros` option. When enabled, unscoped ``enum`` declarations within
+  macros are ignored.
+
 - Improved :doc:`llvm-use-ranges
   <clang-tidy/checks/llvm/use-ranges>` check by adding support for the following
   algorithms: ``std::accumulate``, ``std::replace_copy``, and

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/use-enum-class.rst
@@ -33,3 +33,8 @@ Options
 
    When `true`, ignores unscoped ``enum`` declarations in classes.
    Default is `false`.
+
+.. option:: IgnoreMacros
+
+   When `true`, ignores unscoped ``enum`` declarations within macros.
+   Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class-macros.cpp
@@ -1,5 +1,5 @@
 // RUN: %check_clang_tidy -std=c++11-or-later %s cppcoreguidelines-use-enum-class %t -- \
-// RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: false}}" --
+// RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: false}}"
 // RUN: %check_clang_tidy -std=c++11-or-later %s -check-suffixes=IGNORE-MACROS cppcoreguidelines-use-enum-class %t -- \
 // RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: true}}"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class-macros.cpp
@@ -1,0 +1,13 @@
+// RUN: %check_clang_tidy -std=c++11-or-later %s cppcoreguidelines-use-enum-class %t -- \
+// RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: false}}" --
+// RUN: %check_clang_tidy -std=c++11-or-later %s -check-suffixes=IGNORE-MACROS cppcoreguidelines-use-enum-class %t -- \
+// RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: true}}" --
+
+enum UnscopedRegular { A, B, C };
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: enum 'UnscopedRegular' is unscoped, use 'enum class' instead
+// CHECK-MESSAGES-IGNORE-MACROS: :[[@LINE-2]]:6: warning: enum 'UnscopedRegular' is unscoped, use 'enum class' instead
+
+#define NAMED_ENUM enum E { G, H, I };
+
+NAMED_ENUM
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: enum 'E' is unscoped, use 'enum class' instead

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/use-enum-class-macros.cpp
@@ -1,7 +1,7 @@
 // RUN: %check_clang_tidy -std=c++11-or-later %s cppcoreguidelines-use-enum-class %t -- \
 // RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: false}}" --
 // RUN: %check_clang_tidy -std=c++11-or-later %s -check-suffixes=IGNORE-MACROS cppcoreguidelines-use-enum-class %t -- \
-// RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: true}}" --
+// RUN: -config="{CheckOptions: {cppcoreguidelines-use-enum-class.IgnoreMacros: true}}"
 
 enum UnscopedRegular { A, B, C };
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: enum 'UnscopedRegular' is unscoped, use 'enum class' instead


### PR DESCRIPTION
Adds an option to ignore macros for: https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/use-enum-class.html