### PR TITLE
[lldb] Use current breakpoint location in TestBreakpointLocationDot.py (NFC)

### DIFF
--- a/lldb/test/API/commands/breakpoint/location-dot/TestBreakpointLocationDot.py
+++ b/lldb/test/API/commands/breakpoint/location-dot/TestBreakpointLocationDot.py
@@ -6,29 +6,29 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     def test_disable_enable(self):
         self.build()
-        _, _, _, bp = lldbutil.run_to_source_breakpoint(
+        _, _, thread, bp = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        self.assertEqual(bp.GetNumLocations(), 1)
-        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
+        loc_id = self._stop_location_id(thread)
+        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
         self.expect("breakpoint disable .", startstr="1 breakpoints disabled.")
-        self.assertFalse(bp.GetLocationAtIndex(0).IsEnabled())
+        self.assertFalse(bp.FindLocationByID(loc_id).IsEnabled())
         self.expect("breakpoint enable .", startstr="1 breakpoints enabled.")
-        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
+        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
 
     def test_delete(self):
         self.build()
-        _, _, _, bp = lldbutil.run_to_source_breakpoint(
+        _, _, thread, bp = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
+        loc_id = self._stop_location_id(thread)
         self.expect(
             "breakpoint delete .",
             startstr="0 breakpoints deleted; 1 breakpoint locations disabled",
         )
-        self.assertEqual(bp.GetNumLocations(), 1)
-        self.assertFalse(bp.GetLocationAtIndex(0).IsEnabled())
+        self.assertFalse(bp.FindLocationByID(loc_id).IsEnabled())
 
     def test_error_not_breakpoint_stop(self):
         self.build()
@@ -36,8 +36,8 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        self.assertEqual(bp.GetNumLocations(), 1)
-        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
+        loc_id = self._stop_location_id(thread)
+        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
         thread.StepOver()
         self.assertNotEqual(thread.stop_reason, lldb.eStopReasonBreakpoint)
         self.expect(
@@ -45,10 +45,20 @@ class TestCase(TestBase):
             error=True,
             startstr="error: current thread is not stopped at a breakpoint",
         )
-        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
+        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
 
     def test_error_no_process(self):
         self.build()
         target = self.createTestTarget()
         target.BreakpointCreateByLocation("main.c", 2)
         self.expect("breakpoint disable .", error=True, substrs=["no current thread"])
+
+    def _stop_location_id(self, thread: lldb.SBThread) -> int:
+        # At a breakpoint stop, the stop reason data has the following structure:
+        #   [bp1_id, loc1_id, bp2_id, loc2_id, ...]
+        self.assertEqual(
+            thread.GetStopReasonDataCount(),
+            2,
+            "stop should be for one breakpoint only",
+        )
+        return thread.GetStopReasonDataAtIndex(1)

--- a/lldb/test/API/commands/breakpoint/location-dot/TestBreakpointLocationDot.py
+++ b/lldb/test/API/commands/breakpoint/location-dot/TestBreakpointLocationDot.py
@@ -10,11 +10,12 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        self.assertTrue(bp.FindLocationByID(1).IsEnabled())
+        self.assertEqual(bp.GetNumLocations(), 1)
+        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
         self.expect("breakpoint disable .", startstr="1 breakpoints disabled.")
-        self.assertFalse(bp.FindLocationByID(1).IsEnabled())
+        self.assertFalse(bp.GetLocationAtIndex(0).IsEnabled())
         self.expect("breakpoint enable .", startstr="1 breakpoints enabled.")
-        self.assertTrue(bp.FindLocationByID(1).IsEnabled())
+        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
 
     def test_delete(self):
         self.build()
@@ -26,7 +27,8 @@ class TestCase(TestBase):
             "breakpoint delete .",
             startstr="0 breakpoints deleted; 1 breakpoint locations disabled",
         )
-        self.assertFalse(bp.FindLocationByID(1).IsEnabled())
+        self.assertEqual(bp.GetNumLocations(), 1)
+        self.assertFalse(bp.GetLocationAtIndex(0).IsEnabled())
 
     def test_error_not_breakpoint_stop(self):
         self.build()
@@ -34,7 +36,8 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        self.assertTrue(bp.FindLocationByID(1).IsEnabled())
+        self.assertEqual(bp.GetNumLocations(), 1)
+        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
         thread.StepOver()
         self.assertNotEqual(thread.stop_reason, lldb.eStopReasonBreakpoint)
         self.expect(
@@ -42,7 +45,7 @@ class TestCase(TestBase):
             error=True,
             startstr="error: current thread is not stopped at a breakpoint",
         )
-        self.assertTrue(bp.FindLocationByID(1).IsEnabled())
+        self.assertTrue(bp.GetLocationAtIndex(0).IsEnabled())
 
     def test_error_no_process(self):
         self.build()

--- a/lldb/test/API/commands/breakpoint/location-dot/TestBreakpointLocationDot.py
+++ b/lldb/test/API/commands/breakpoint/location-dot/TestBreakpointLocationDot.py
@@ -10,12 +10,12 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        loc_id = self._stop_location_id(thread)
-        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
+        loc = self._stop_location(thread, bp)
+        self.assertTrue(loc.IsEnabled())
         self.expect("breakpoint disable .", startstr="1 breakpoints disabled.")
-        self.assertFalse(bp.FindLocationByID(loc_id).IsEnabled())
+        self.assertFalse(loc.IsEnabled())
         self.expect("breakpoint enable .", startstr="1 breakpoints enabled.")
-        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
+        self.assertTrue(loc.IsEnabled())
 
     def test_delete(self):
         self.build()
@@ -23,12 +23,12 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        loc_id = self._stop_location_id(thread)
+        loc = self._stop_location(thread, bp)
         self.expect(
             "breakpoint delete .",
             startstr="0 breakpoints deleted; 1 breakpoint locations disabled",
         )
-        self.assertFalse(bp.FindLocationByID(loc_id).IsEnabled())
+        self.assertFalse(loc.IsEnabled())
 
     def test_error_not_breakpoint_stop(self):
         self.build()
@@ -36,8 +36,8 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.c")
         )
 
-        loc_id = self._stop_location_id(thread)
-        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
+        loc = self._stop_location(thread, bp)
+        self.assertTrue(loc.IsEnabled())
         thread.StepOver()
         self.assertNotEqual(thread.stop_reason, lldb.eStopReasonBreakpoint)
         self.expect(
@@ -45,7 +45,7 @@ class TestCase(TestBase):
             error=True,
             startstr="error: current thread is not stopped at a breakpoint",
         )
-        self.assertTrue(bp.FindLocationByID(loc_id).IsEnabled())
+        self.assertTrue(loc.IsEnabled())
 
     def test_error_no_process(self):
         self.build()
@@ -53,7 +53,9 @@ class TestCase(TestBase):
         target.BreakpointCreateByLocation("main.c", 2)
         self.expect("breakpoint disable .", error=True, substrs=["no current thread"])
 
-    def _stop_location_id(self, thread: lldb.SBThread) -> int:
+    def _stop_location(
+        self, thread: lldb.SBThread, bp: lldb.SBBreakpoint
+    ) -> lldb.SBBreakpointLocation:
         # At a breakpoint stop, the stop reason data has the following structure:
         #   [bp1_id, loc1_id, bp2_id, loc2_id, ...]
         self.assertEqual(
@@ -61,4 +63,5 @@ class TestCase(TestBase):
             2,
             "stop should be for one breakpoint only",
         )
-        return thread.GetStopReasonDataAtIndex(1)
+        loc_id = thread.GetStopReasonDataAtIndex(1)
+        return bp.FindLocationByID(loc_id)


### PR DESCRIPTION
Replaces `FindLocationByID(1)` with `FindLocationByID(loc_id)`. Instead of hard-coding an ID of 1, the location ID is determined from `GetStopReasonDataAtIndex`.

Some of these asserts were failing on a windows CI, because the breakpoint was resolved to **two** locations.