### PR TITLE
[compiler-rt][profile][test] Match clang_rt.profile CRT model on MSVC

### DIFF
--- a/compiler-rt/test/profile/CMakeLists.txt
+++ b/compiler-rt/test/profile/CMakeLists.txt
@@ -22,6 +22,17 @@ pythonize_bool(LLVM_ENABLE_CURL)
 foreach(arch ${PROFILE_TEST_ARCH})
   set(PROFILE_TEST_TARGET_ARCH ${arch})
   get_test_cc_for_arch(${arch} PROFILE_TEST_TARGET_CC PROFILE_TEST_TARGET_CFLAGS)
+  # On MSVC, Profile-* tests must link with the same CRT model as the
+  # clang_rt.profile static archive they exercise. When that archive pulls
+  # in RTInterception / RTSanitizerCommon object libraries, those are built
+  # with MultiThreadedDLL (/MD), so the .objs reference __imp_* symbols;
+  # the test binary defaults to /MT and fails to link (LNK2019 __imp__stricmp
+  # from interception_win.cpp, LNK4098 default-lib conflicts). Match the
+  # DLL CRT here so test executables link against the same runtime.
+  if(MSVC AND COMPILER_RT_HAS_INTERCEPTION AND NOT COMPILER_RT_PROFILE_BAREMETAL)
+    string(APPEND PROFILE_TEST_TARGET_CFLAGS
+           " -D_MT -D_DLL -Wl,-nodefaultlib:libcmt,-defaultlib:msvcrt,-defaultlib:oldnames")
+  endif()
   set(CONFIG_NAME Profile-${arch})
   configure_lit_site_cfg(
     ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in


### PR DESCRIPTION
On MSVC, Profile-* tests must link with the same CRT model as the
clang_rt.profile static archive they exercise. When that archive pulls
in RTInterception / RTSanitizerCommon object libraries, those are built
with MultiThreadedDLL (/MD), so the .objs reference `__imp_*` symbols.
The test binary defaults to /MT and fails to link with LNK2019
(`__imp__stricmp` from `interception_win.cpp`) and LNK4098 default-lib
conflicts.

Match the DLL CRT on the test side so test executables and the static
archive use the same runtime. The change is gated on
`COMPILER_RT_HAS_INTERCEPTION` and `!COMPILER_RT_PROFILE_BAREMETAL`, so
configurations that don't pull interception into profile are unaffected.

Split out as NFC from #177665 per review feedback.
