### PR TITLE
Revert "[lldb][windows] enable TestMultipleTargets.py and TestSBCommandReturnObject.py (#197251)

### DIFF
--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -12,6 +12,9 @@ class TestSBCommandReturnObject(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfNoSBHeaders
+    @expectedFailureAll(
+        oslist=["windows"], archs=["i[3-6]86", "x86_64"], bugnumber="llvm.org/pr43570"
+    )
     @skipIfHostIncompatibleWithTarget
     def test_sb_command_return_object(self):
         self.driver_exe = self.getBuildArtifact("command-return-object")

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -15,6 +15,9 @@ class TestMultipleTargets(TestBase):
 
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])
     @skipIfNoSBHeaders
+    @expectedFailureAll(
+        oslist=["windows"], archs=["i[3-6]86", "x86_64"], bugnumber="llvm.org/pr20282"
+    )
     @expectedFlakeyNetBSD
     @skipIfHostIncompatibleWithTarget
     def test_multiple_targets(self):


### PR DESCRIPTION
This reverts commit 2273935d40a336f065bc3628e6077ca53bdbfae6.