### PR TITLE
[AIX][clang][compiler_rt] rename libatomic archive to libclang_rt

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -715,7 +715,8 @@ AIX Support
   (instead of `all`) which only extracts static init from archive members which
   would otherwise be referenced.
   (See https://www.ibm.com/docs/en/aix/7.2.0?topic=l-ld-command for details).
-- The driver now uses ``-lcompiler_rt`` instead of ``-latomic`` to avoid conflicts
+- The driver now uses ``-lcompiler_rt`` instead of ``-latomic``, and the compiler-rt
+  archive has been renamed from ``libatomic.a`` to ``libcompiler_rt.a`` to avoid conflicts
   between the LLVM libatomic and the GNU libatomic from the AIX toolbox as they share
   the same library name.
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -716,7 +716,8 @@ AIX Support
   would otherwise be referenced.
   (See https://www.ibm.com/docs/en/aix/7.2.0?topic=l-ld-command for details).
 - The driver now uses ``-lcompiler_rt`` instead of ``-latomic`` to avoid conflicts
-  with the GNU libatomic library in the AIX toolbox.
+  between the LLVM libatomic and the GNU libatomic from the AIX toolbox as they share
+  the same library name.
 
 NetBSD Support
 ^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -715,6 +715,8 @@ AIX Support
   (instead of `all`) which only extracts static init from archive members which
   would otherwise be referenced.
   (See https://www.ibm.com/docs/en/aix/7.2.0?topic=l-ld-command for details).
+- The driver now uses ``-lcompiler_rt`` instead of ``-latomic`` to avoid conflicts
+  with the GNU libatomic library in the AIX toolbox.
 
 NetBSD Support
 ^^^^^^^^^^^^^^

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -971,7 +971,10 @@ void ToolChain::addFortranRuntimeLibs(const ArgList &Args,
     if ((OMPRuntime == Driver::OMPRT_OMP &&
          RuntimeLib == ToolChain::RLT_Libgcc) &&
         !getTriple().isKnownWindowsMSVCEnvironment()) {
-      CmdArgs.push_back("-latomic");
+      if (getTriple().isOSAIX())
+        CmdArgs.push_back("-lcompiler_rt");
+      else
+        CmdArgs.push_back("-latomic");
     }
   }
 }

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -594,7 +594,7 @@ void AIX::addProfileRTLibs(const llvm::opt::ArgList &Args,
             Args.getLastArgNoClaim(options::OPT_fprofile_update_EQ)) {
       StringRef Val = A->getValue();
       if (Val == "atomic" || Val == "prefer-atomic")
-        CmdArgs.push_back("-latomic");
+        CmdArgs.push_back("-lcompiler_rt");
     }
   }
 

--- a/clang/test/Driver/fprofile-update.c
+++ b/clang/test/Driver/fprofile-update.c
@@ -18,5 +18,5 @@
 // RUN: %clang -### %s --target=powerpc-unknown-aix -fprofile-generate -fprofile-update=prefer-atomic 2>&1 | FileCheck %s --check-prefix=AIX
 // RUN: %clang -### %s --target=powerpc-unknown-aix -fprofile-generate 2>&1 | FileCheck %s --check-prefix=AIX-NOATOMIC
 // RUN: %clang -### %s --target=powerpc-unknown-aix -fprofile-generate -fprofile-update=single 2>&1 | FileCheck %s --check-prefix=AIX-NOATOMIC
-// AIX: "-latomic"
-// AIX-NOATOMIC-NOT: "-latomic"
+// AIX: "-lcompiler_rt"
+// AIX-NOATOMIC-NOT: "-lcompiler_rt"

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -1113,10 +1113,10 @@ if(COMPILER_RT_BUILD_STANDALONE_LIBATOMIC)
     endif()
   endforeach()
   # FIXME: On AIX, we have to archive built shared libraries into a static
-  # archive, i.e., libatomic.a. Once cmake adds support of such usage for AIX,
+  # archive, i.e., libcompiler_rt.a. Once cmake adds support of such usage for AIX,
   # this ad-hoc part can be removed.
   if(OS_NAME MATCHES "AIX")
-    archive_aix_libatomic(clang_rt.atomic libatomic
+    archive_aix_libatomic(clang_rt.atomic libcompiler_rt
                           ARCHS ${BUILTIN_SUPPORTED_ARCH}
                           PARENT_TARGET builtins-standalone-atomic)
   endif()


### PR DESCRIPTION
This PR implements the following on AIX to avoid conflicts between LLVM libatomic and the GNU libatomic in the AIX toolbox as they share the same library name:

- Updates the clang driver to use `-lcompiler_rt` instead of `-latomic`
- Renames the compiler-rt archive from `libatomic.a` to `libcompiler_rt.a`

Only the archive and not the shared object (`libatomic.so.1`) is renamed because renaming one component is enough to distinguish between the LLVM and GNU libatomic libraries. This also allows us to add additional shared objects to the `libcompiler_rt.a` archive in the future if needed.
