### PR TITLE
[libc] Annex K: Add constraint handler unit test class

### DIFF
--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -221,3 +221,14 @@ add_header_library(
     libc.src.__support.macros.properties.architectures
     libc.src.errno.errno
 )
+
+add_header_library(
+  ConstraintHandlerCheckingTest
+  HDRS
+    ConstraintHandlerCheckingTest.h
+  DEPENDS
+    libc.hdr.types.constraint_handler_t
+    libc.hdr.types.errno_t
+    libc.src.stdlib.set_constraint_handler_s
+    libc.src.string.string_utils
+)

--- a/libc/test/UnitTest/ConstraintHandlerCheckingTest.h
+++ b/libc/test/UnitTest/ConstraintHandlerCheckingTest.h
@@ -1,0 +1,44 @@
+//===-- ConstraintHandlerCheckingTest.h ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TEST_UNITTEST_CONSTRAINTHANDLERCHECKINGTEST_H
+#define LLVM_LIBC_TEST_UNITTEST_CONSTRAINTHANDLERCHECKINGTEST_H
+
+#include "hdr/types/constraint_handler_t.h"
+#include "hdr/types/errno_t.h"
+#include "src/stdlib/set_constraint_handler_s.h"
+#include "src/string/string_utils.h"
+#include "test/UnitTest/Test.h"
+
+namespace {
+
+char buffer[300];
+
+void local_constraint_handler(const char *__restrict msg,
+                              void *__restrict /*ptr*/, errno_t /*error*/) {
+  LIBC_NAMESPACE::internal::strlcpy(buffer, msg, sizeof(buffer));
+}
+
+} // anonymous namespace
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace testing {
+
+class ConstraintHandlerCheckingTest : public Test {
+public:
+  void SetUp() override {
+    Test::SetUp();
+    LIBC_NAMESPACE::set_constraint_handler_s(local_constraint_handler);
+  }
+};
+
+} // namespace testing
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_TEST_UNITTEST_CONSTRAINTHANDLERCHECKINGTEST_H


### PR DESCRIPTION
This unit test class will be useful for the tests related to Annex K. The functions in Annex K may call a constraint handler, so this new unit test class will facilitate the checks that the constraint handling mechanism is working as expected.