### PR TITLE
Fix failure for clang/test/Frontend/rewrite-includes-bom.c for zOS

### DIFF
--- a/clang/test/Frontend/rewrite-includes-bom.c
+++ b/clang/test/Frontend/rewrite-includes-bom.c
@@ -1,6 +1,6 @@
-// RUN: cat %S/Inputs/rewrite-includes-bom.h | od -t x1 | grep -q 'ef[[:space:]]*bb[[:space:]]*bf'
+// RUN: cat %S/Inputs/rewrite-includes-bom.h | od -t x1 | grep -qi 'ef[[:space:]]*bb[[:space:]]*bf'
 // RUN: %clang_cc1 -E -frewrite-includes -I %S/Inputs %s -o %t.c
-// RUN: cat %t.c | od -t x1 | not grep -q 'ef[[:space:]]*bb[[:space:]]*bf'
+// RUN: cat %t.c | od -t x1 | not grep -qi 'ef[[:space:]]*bb[[:space:]]*bf'
 // RUN: %clang_cc1 -fsyntax-only -verify %t.c
 // expected-no-diagnostics
 // UNSUPPORTED: system-windows


### PR DESCRIPTION
This test is failing on zOS due to the lowercase HEX characters in the BOM. This PR changes the test to do a case-insensitive search.