### PR TITLE
[lldb] Fix TestBuiltinDebugTrap.py on ARM platform

### DIFF
--- a/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
+++ b/lldb/test/API/functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
@@ -54,10 +54,13 @@ class BuiltinDebugTrapTestCase(TestBase):
         # "global" is now 10.
         self.assertEqual(global_value.GetValueAsUnsigned(), 10)
 
-        # Change the handling of SIGILL on x86-64 Linux - do not pass it
-        # to the inferior, but stop and notify lldb. If we don't do this,
-        # the inferior will receive the SIGILL and be terminated.
-        if self.getArchitecture() == "x86_64" and platform == "linux":
+        # Change the handling of SIGILL on Linux - do not pass it to the
+        # inferior, but stop and notify lldb. If we don't do this, the
+        # inferior will receive the SIGILL and be terminated. On x86_64,
+        # __builtin_trap() emits UD2; on ARM it emits UDF — both generate
+        # SIGILL. AArch64 uses BRK #1 (SIGTRAP, already suppressed by
+        # default), so this is harmless there.
+        if platform == "linux":
             self.runCmd("process handle -p false SIGILL")
 
         # We should be at the same point as before -- cannot advance


### PR DESCRIPTION
The workaround for x86_64 which changed the handling of SIGILL signals is also required on 32-bit ARM platforms, because __builtin_trap(), which compiles to a UDF instruction, also generates SIGILL. If we don't change the handling here, the inferior is killed and the stop reason is "none".

The failure is here: https://lab.llvm.org/buildbot/#/builders/18/builds/25948