### PR TITLE
[AArch64][ISel] Improve lowering for clmul.nxv8i16(zext, zext)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2072,9 +2072,8 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
     if (Subtarget->hasBF16())
       setPartialReduceMLAAction(ISD::PARTIAL_REDUCE_FMLA, MVT::nxv4f32,
                                 MVT::nxv8bf16, Legal);
+    setOperationAction(ISD::CLMUL, MVT::nxv2i64, Custom);
   }
-
-  setOperationAction(ISD::CLMUL, MVT::nxv2i64, Custom);
 
   // Handle non-aliasing elements mask
   if (Subtarget->hasSVE2() ||
@@ -8111,14 +8110,16 @@ SDValue AArch64TargetLowering::LowerCLMUL(SDValue Op, SelectionDAG &DAG) const {
   if (VT == MVT::nxv2i64) {
     // Lower to (.d pmullb(.s, .s)) for clmul.nxv2i64(zext(nxv2i32),
     // zext(nxv2i32))
-    if (Subtarget->isSVEorStreamingSVEAvailable() &&
-        (Subtarget->hasSVE2() || Subtarget->hasSME()) &&
+    if ((Subtarget->hasSVE2() || Subtarget->hasSME()) &&
         DAG.MaskedValueIsZero(Op.getOperand(0), HiWordMask) &&
-        DAG.MaskedValueIsZero(Op.getOperand(1), HiWordMask))
-      return MakePMULLB(
-          DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv4i32, Op.getOperand(0)),
-          DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv4i32, Op.getOperand(1)),
-          MVT::nxv4i32);
+        DAG.MaskedValueIsZero(Op.getOperand(1), HiWordMask)) {
+      SDValue OpA =
+          DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv4i32, Op.getOperand(0));
+      SDValue OpB =
+          DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv4i32, Op.getOperand(1));
+      return DAG.getNode(AArch64ISD::NVCAST, DL, VT,
+                         MakePMULLB(OpA, OpB, MVT::nxv4i32));
+    }
     // Lower to (.q pmullb(.d, .d)) for clmul.nxv2i64(nxv2i64, nxv2i64)
     if (Subtarget->hasSVEAES() &&
         (Subtarget->isSVEAvailable() || Subtarget->hasSSVE_AES()))
@@ -8135,7 +8136,8 @@ SDValue AArch64TargetLowering::LowerCLMUL(SDValue Op, SelectionDAG &DAG) const {
     // Lower to pmullb for clmul.nxv8i16(zext(nxv8i8), zext(nxv8i8))
     if (DAG.MaskedValueIsZero(Op.getOperand(0), HiWordMask) &&
         DAG.MaskedValueIsZero(Op.getOperand(1), HiWordMask))
-      return MakePMULLB(OpA, OpB, MVT::nxv16i8);
+      return DAG.getNode(AArch64ISD::NVCAST, DL, VT,
+                         MakePMULLB(OpA, OpB, MVT::nxv16i8));
 
     // clmul.i16(a, b) = xor(pmullb(a_lo, b_lo),
     //                       lsl(xor(pmul(a_hi, b_lo),

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2053,7 +2053,7 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
       setPartialReduceMLAAction(MLAOps, MVT::nxv8i16, MVT::nxv16i8, Legal);
 
       setOperationAction(ISD::CLMUL, {MVT::nxv16i8, MVT::nxv4i32}, Legal);
-      setOperationAction(ISD::CLMUL, {MVT::nxv8i16, MVT::nxv2i64}, Custom);
+      setOperationAction(ISD::CLMUL, MVT::nxv8i16, Custom);
 
       setPartialReduceMLAAction(ISD::PARTIAL_REDUCE_FMLA, MVT::nxv4f32,
                                 MVT::nxv8f16, Legal);
@@ -2074,9 +2074,7 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
                                 MVT::nxv8bf16, Legal);
   }
 
-  if (Subtarget->hasSVEAES() &&
-      (Subtarget->isSVEAvailable() || Subtarget->hasSSVE_AES()))
-    setOperationAction(ISD::CLMUL, MVT::nxv2i64, Legal);
+  setOperationAction(ISD::CLMUL, MVT::nxv2i64, Custom);
 
   // Handle non-aliasing elements mask
   if (Subtarget->hasSVE2() ||
@@ -8095,49 +8093,55 @@ SDValue AArch64TargetLowering::LowerFMA(SDValue Op, SelectionDAG &DAG) const {
   return convertFromScalableVector(DAG, VT, ScalableRes);
 }
 
-static SDValue LowerCLMUL(SDValue Op, SelectionDAG &DAG) {
+SDValue AArch64TargetLowering::LowerCLMUL(SDValue Op, SelectionDAG &DAG) const {
   EVT VT = Op.getValueType();
   SDLoc DL(Op);
   assert((VT == MVT::i64 || VT == MVT::i32 || VT == MVT::i16 || VT == MVT::i8 ||
           VT == MVT::nxv8i16 || VT == MVT::nxv2i64) &&
          "Unexpected Type");
-  SDValue OpA = Op.getOperand(0);
-  SDValue OpB = Op.getOperand(1);
-  auto IsZextedFromHalfTy = [&](SDValue Op) {
-    uint64_t FullSize = VT.getScalarSizeInBits();
-    uint64_t HalfSize = FullSize / 2;
-    APInt HiWordMask = APInt::getBitsSet(FullSize, HalfSize, FullSize);
-    return DAG.MaskedValueIsZero(Op, HiWordMask);
-  };
-  auto MakePMULLB = [&](SDValue OpA, SDValue OpB) {
-    EVT NewVT = EVT::getVectorVT(
-        *DAG.getContext(),
-        VT.getVectorElementType().getHalfSizedIntegerVT(*DAG.getContext()),
-        VT.getVectorElementCount() * 2);
-    OpA = DAG.getNode(AArch64ISD::NVCAST, DL, NewVT, OpA);
-    OpB = DAG.getNode(AArch64ISD::NVCAST, DL, NewVT, OpB);
+  uint64_t ScalarSize = VT.getScalarSizeInBits();
+  APInt HiWordMask = APInt::getBitsSet(ScalarSize, ScalarSize / 2, ScalarSize);
+
+  auto MakePMULLB = [&](SDValue OpA, SDValue OpB, EVT NewVT) {
     SDValue PMULLB =
         DAG.getTargetConstant(Intrinsic::aarch64_sve_pmullb_pair, DL, MVT::i64);
     return DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, NewVT, PMULLB, OpA, OpB);
   };
 
   if (VT == MVT::nxv2i64) {
-    if (IsZextedFromHalfTy(OpA) && IsZextedFromHalfTy(OpB))
-      return MakePMULLB(OpA, OpB);
+    // Lower to (.d pmullb(.s, .s)) for clmul.nxv2i64(zext(nxv2i32),
+    // zext(nxv2i32))
+    if (Subtarget->isSVEorStreamingSVEAvailable() &&
+        (Subtarget->hasSVE2() || Subtarget->hasSME()) &&
+        DAG.MaskedValueIsZero(Op.getOperand(0), HiWordMask) &&
+        DAG.MaskedValueIsZero(Op.getOperand(1), HiWordMask))
+      return MakePMULLB(
+          DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv4i32, Op.getOperand(0)),
+          DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv4i32, Op.getOperand(1)),
+          MVT::nxv4i32);
+    // Lower to (.q pmullb(.d, .d)) for clmul.nxv2i64(nxv2i64, nxv2i64)
+    if (Subtarget->hasSVEAES() &&
+        (Subtarget->isSVEAvailable() || Subtarget->hasSSVE_AES()))
+      return Op;
     return SDValue();
   }
 
   if (VT == MVT::nxv8i16) {
-    if (IsZextedFromHalfTy(OpA) && IsZextedFromHalfTy(OpB))
-      return MakePMULLB(OpA, OpB);
+    SDValue OpA =
+        DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv16i8, Op.getOperand(0));
+    SDValue OpB =
+        DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv16i8, Op.getOperand(1));
+
+    // Lower to pmullb for clmul.nxv8i16(zext(nxv8i8), zext(nxv8i8))
+    if (DAG.MaskedValueIsZero(Op.getOperand(0), HiWordMask) &&
+        DAG.MaskedValueIsZero(Op.getOperand(1), HiWordMask))
+      return MakePMULLB(OpA, OpB, MVT::nxv16i8);
 
     // clmul.i16(a, b) = xor(pmullb(a_lo, b_lo),
     //                       lsl(xor(pmul(a_hi, b_lo),
     //                               pmul(a_lo, b_hi)),
     //                           8))
     // Bitcast to i8 for byte-wise PMUL and PMULLB.
-    OpA = DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv16i8, OpA);
-    OpB = DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv16i8, OpB);
 
     // Form adjacent byte pairs {a_hi, b_hi} and {b_lo, a_lo}. PMUL then
     // computes {a_hi * b_lo, b_hi * a_lo}, and EORBT xors those pairs.
@@ -8150,7 +8154,7 @@ static SDValue LowerCLMUL(SDValue Op, SelectionDAG &DAG) {
     EORBT = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, MVT::nxv16i8, EORBT, PMUL,
                         PMUL, PMUL);
 
-    SDValue PMULLB = MakePMULLB(OpA, OpB);
+    SDValue PMULLB = MakePMULLB(OpA, OpB, MVT::nxv16i8);
 
     SDValue EORTB =
         DAG.getTargetConstant(Intrinsic::aarch64_sve_eortb, DL, MVT::i64);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2053,7 +2053,7 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
       setPartialReduceMLAAction(MLAOps, MVT::nxv8i16, MVT::nxv16i8, Legal);
 
       setOperationAction(ISD::CLMUL, {MVT::nxv16i8, MVT::nxv4i32}, Legal);
-      setOperationAction(ISD::CLMUL, {MVT::nxv8i16}, Custom);
+      setOperationAction(ISD::CLMUL, {MVT::nxv8i16, MVT::nxv2i64}, Custom);
 
       setPartialReduceMLAAction(ISD::PARTIAL_REDUCE_FMLA, MVT::nxv4f32,
                                 MVT::nxv8f16, Legal);
@@ -8099,16 +8099,42 @@ static SDValue LowerCLMUL(SDValue Op, SelectionDAG &DAG) {
   EVT VT = Op.getValueType();
   SDLoc DL(Op);
   assert((VT == MVT::i64 || VT == MVT::i32 || VT == MVT::i16 || VT == MVT::i8 ||
-          VT == MVT::nxv8i16) &&
+          VT == MVT::nxv8i16 || VT == MVT::nxv2i64) &&
          "Unexpected Type");
+  SDValue OpA = Op.getOperand(0);
+  SDValue OpB = Op.getOperand(1);
+  auto IsZextedFromHalfTy = [&](SDValue Op) {
+    uint64_t FullSize = VT.getScalarSizeInBits();
+    uint64_t HalfSize = FullSize / 2;
+    APInt HiWordMask = APInt::getBitsSet(FullSize, HalfSize, FullSize);
+    return DAG.MaskedValueIsZero(Op, HiWordMask);
+  };
+  auto MakePMULLB = [&](SDValue OpA, SDValue OpB) {
+    EVT NewVT = EVT::getVectorVT(
+        *DAG.getContext(),
+        VT.getVectorElementType().getHalfSizedIntegerVT(*DAG.getContext()),
+        VT.getVectorElementCount() * 2);
+    OpA = DAG.getNode(AArch64ISD::NVCAST, DL, NewVT, OpA);
+    OpB = DAG.getNode(AArch64ISD::NVCAST, DL, NewVT, OpB);
+    SDValue PMULLB =
+        DAG.getTargetConstant(Intrinsic::aarch64_sve_pmullb_pair, DL, MVT::i64);
+    return DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, NewVT, PMULLB, OpA, OpB);
+  };
+
+  if (VT == MVT::nxv2i64) {
+    if (IsZextedFromHalfTy(OpA) && IsZextedFromHalfTy(OpB))
+      return MakePMULLB(OpA, OpB);
+    return SDValue();
+  }
 
   if (VT == MVT::nxv8i16) {
+    if (IsZextedFromHalfTy(OpA) && IsZextedFromHalfTy(OpB))
+      return MakePMULLB(OpA, OpB);
+
     // clmul.i16(a, b) = xor(pmullb(a_lo, b_lo),
     //                       lsl(xor(pmul(a_hi, b_lo),
     //                               pmul(a_lo, b_hi)),
     //                           8))
-    SDValue OpA = Op.getOperand(0);
-    SDValue OpB = Op.getOperand(1);
     // Bitcast to i8 for byte-wise PMUL and PMULLB.
     OpA = DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv16i8, OpA);
     OpB = DAG.getNode(AArch64ISD::NVCAST, DL, MVT::nxv16i8, OpB);
@@ -8124,10 +8150,7 @@ static SDValue LowerCLMUL(SDValue Op, SelectionDAG &DAG) {
     EORBT = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, MVT::nxv16i8, EORBT, PMUL,
                         PMUL, PMUL);
 
-    SDValue PMULLB =
-        DAG.getTargetConstant(Intrinsic::aarch64_sve_pmullb_pair, DL, MVT::i64);
-    PMULLB = DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, MVT::nxv16i8, PMULLB, OpA,
-                         OpB);
+    SDValue PMULLB = MakePMULLB(OpA, OpB);
 
     SDValue EORTB =
         DAG.getTargetConstant(Intrinsic::aarch64_sve_eortb, DL, MVT::i64);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -631,6 +631,7 @@ private:
   SDValue LowerABS(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFMUL(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerFMA(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerCLMUL(SDValue Op, SelectionDAG &DAG) const;
 
   SDValue LowerMGATHER(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerMSCATTER(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/test/CodeGen/AArch64/clmul-scalable.ll
+++ b/llvm/test/CodeGen/AArch64/clmul-scalable.ll
@@ -1866,9 +1866,7 @@ define <vscale x 2 x i64> @clmul_nxv2i64_zext(<vscale x 2 x i32> %x, <vscale x 2
 ; CHECK-SME-STREAMING-SSVE-AES:       // %bb.0:
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    and z0.d, z0.d, #0xffffffff
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    and z1.d, z1.d, #0xffffffff
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    pmullt z2.q, z0.d, z1.d
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    pmullb z0.q, z0.d, z1.d
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    trn1 z0.d, z0.d, z2.d
+; CHECK-SME-STREAMING-SSVE-AES-NEXT:    pmullb z0.d, z0.s, z1.s
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    ret
 ;
 ; CHECK-SVE2-LABEL: clmul_nxv2i64_zext:
@@ -1882,9 +1880,7 @@ define <vscale x 2 x i64> @clmul_nxv2i64_zext(<vscale x 2 x i32> %x, <vscale x 2
 ; CHECK-SVE2-AES:       // %bb.0:
 ; CHECK-SVE2-AES-NEXT:    and z0.d, z0.d, #0xffffffff
 ; CHECK-SVE2-AES-NEXT:    and z1.d, z1.d, #0xffffffff
-; CHECK-SVE2-AES-NEXT:    pmullt z2.q, z0.d, z1.d
-; CHECK-SVE2-AES-NEXT:    pmullb z0.q, z0.d, z1.d
-; CHECK-SVE2-AES-NEXT:    trn1 z0.d, z0.d, z2.d
+; CHECK-SVE2-AES-NEXT:    pmullb z0.d, z0.s, z1.s
 ; CHECK-SVE2-AES-NEXT:    ret
   %zextx = zext <vscale x 2 x i32> %x to <vscale x 2 x i64>
   %zexty = zext <vscale x 2 x i32> %y to <vscale x 2 x i64>

--- a/llvm/test/CodeGen/AArch64/clmul-scalable.ll
+++ b/llvm/test/CodeGen/AArch64/clmul-scalable.ll
@@ -1497,48 +1497,28 @@ define <vscale x 8 x i16> @clmul_nxv8i16_zext(<vscale x 8 x i8> %x, <vscale x 8 
 ; CHECK-SME-STREAMING:       // %bb.0:
 ; CHECK-SME-STREAMING-NEXT:    and z0.h, z0.h, #0xff
 ; CHECK-SME-STREAMING-NEXT:    and z1.h, z1.h, #0xff
-; CHECK-SME-STREAMING-NEXT:    trn1 z2.b, z1.b, z0.b
-; CHECK-SME-STREAMING-NEXT:    trn2 z3.b, z0.b, z1.b
 ; CHECK-SME-STREAMING-NEXT:    pmullb z0.h, z0.b, z1.b
-; CHECK-SME-STREAMING-NEXT:    pmul z1.b, z3.b, z2.b
-; CHECK-SME-STREAMING-NEXT:    eorbt z1.b, z1.b, z1.b
-; CHECK-SME-STREAMING-NEXT:    eortb z0.b, z0.b, z1.b
 ; CHECK-SME-STREAMING-NEXT:    ret
 ;
 ; CHECK-SME-STREAMING-SSVE-AES-LABEL: clmul_nxv8i16_zext:
 ; CHECK-SME-STREAMING-SSVE-AES:       // %bb.0:
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    and z0.h, z0.h, #0xff
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    and z1.h, z1.h, #0xff
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    trn1 z2.b, z1.b, z0.b
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    trn2 z3.b, z0.b, z1.b
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    pmullb z0.h, z0.b, z1.b
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    pmul z1.b, z3.b, z2.b
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    eorbt z1.b, z1.b, z1.b
-; CHECK-SME-STREAMING-SSVE-AES-NEXT:    eortb z0.b, z0.b, z1.b
 ; CHECK-SME-STREAMING-SSVE-AES-NEXT:    ret
 ;
 ; CHECK-SVE2-LABEL: clmul_nxv8i16_zext:
 ; CHECK-SVE2:       // %bb.0:
 ; CHECK-SVE2-NEXT:    and z0.h, z0.h, #0xff
 ; CHECK-SVE2-NEXT:    and z1.h, z1.h, #0xff
-; CHECK-SVE2-NEXT:    trn1 z2.b, z1.b, z0.b
-; CHECK-SVE2-NEXT:    trn2 z3.b, z0.b, z1.b
 ; CHECK-SVE2-NEXT:    pmullb z0.h, z0.b, z1.b
-; CHECK-SVE2-NEXT:    pmul z1.b, z3.b, z2.b
-; CHECK-SVE2-NEXT:    eorbt z1.b, z1.b, z1.b
-; CHECK-SVE2-NEXT:    eortb z0.b, z0.b, z1.b
 ; CHECK-SVE2-NEXT:    ret
 ;
 ; CHECK-SVE2-AES-LABEL: clmul_nxv8i16_zext:
 ; CHECK-SVE2-AES:       // %bb.0:
 ; CHECK-SVE2-AES-NEXT:    and z0.h, z0.h, #0xff
 ; CHECK-SVE2-AES-NEXT:    and z1.h, z1.h, #0xff
-; CHECK-SVE2-AES-NEXT:    trn1 z2.b, z1.b, z0.b
-; CHECK-SVE2-AES-NEXT:    trn2 z3.b, z0.b, z1.b
 ; CHECK-SVE2-AES-NEXT:    pmullb z0.h, z0.b, z1.b
-; CHECK-SVE2-AES-NEXT:    pmul z1.b, z3.b, z2.b
-; CHECK-SVE2-AES-NEXT:    eorbt z1.b, z1.b, z1.b
-; CHECK-SVE2-AES-NEXT:    eortb z0.b, z0.b, z1.b
 ; CHECK-SVE2-AES-NEXT:    ret
   %zextx = zext <vscale x 8 x i8> %x to <vscale x 8 x i16>
   %zexty = zext <vscale x 8 x i8> %y to <vscale x 8 x i16>
@@ -1877,119 +1857,9 @@ define <vscale x 2 x i64> @clmul_nxv2i64_zext(<vscale x 2 x i32> %x, <vscale x 2
 ;
 ; CHECK-SME-STREAMING-LABEL: clmul_nxv2i64_zext:
 ; CHECK-SME-STREAMING:       // %bb.0:
-; CHECK-SME-STREAMING-NEXT:    movprfx z2, z0
-; CHECK-SME-STREAMING-NEXT:    and z2.d, z2.d, #0xffffffff
-; CHECK-SME-STREAMING-NEXT:    movprfx z0, z1
-; CHECK-SME-STREAMING-NEXT:    and z0.d, z0.d, #0x2
-; CHECK-SME-STREAMING-NEXT:    movprfx z3, z1
-; CHECK-SME-STREAMING-NEXT:    and z3.d, z3.d, #0x1
-; CHECK-SME-STREAMING-NEXT:    movprfx z4, z1
-; CHECK-SME-STREAMING-NEXT:    and z4.d, z4.d, #0x8
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x4
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x10
-; CHECK-SME-STREAMING-NEXT:    mul z0.d, z2.d, z0.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z4.d
-; CHECK-SME-STREAMING-NEXT:    mul z5.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    eor z0.d, z3.d, z0.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z3, z1
-; CHECK-SME-STREAMING-NEXT:    and z3.d, z3.d, #0x20
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z5.d, z4.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x80
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x40
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x200
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x100
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x800
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x400
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x2000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x1000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x8000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x4000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x20000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x10000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x80000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x40000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x200000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x100000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x800000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x400000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x2000000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x1000000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x8000000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x4000000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x20000000
-; CHECK-SME-STREAMING-NEXT:    movprfx z6, z1
-; CHECK-SME-STREAMING-NEXT:    and z6.d, z6.d, #0x10000000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SME-STREAMING-NEXT:    movprfx z5, z1
-; CHECK-SME-STREAMING-NEXT:    and z5.d, z5.d, #0x80000000
-; CHECK-SME-STREAMING-NEXT:    and z1.d, z1.d, #0x40000000
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SME-STREAMING-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SME-STREAMING-NEXT:    mul z1.d, z2.d, z1.d
-; CHECK-SME-STREAMING-NEXT:    eor3 z0.d, z0.d, z1.d, z3.d
+; CHECK-SME-STREAMING-NEXT:    and z0.d, z0.d, #0xffffffff
+; CHECK-SME-STREAMING-NEXT:    and z1.d, z1.d, #0xffffffff
+; CHECK-SME-STREAMING-NEXT:    pmullb z0.d, z0.s, z1.s
 ; CHECK-SME-STREAMING-NEXT:    ret
 ;
 ; CHECK-SME-STREAMING-SSVE-AES-LABEL: clmul_nxv2i64_zext:
@@ -2003,119 +1873,9 @@ define <vscale x 2 x i64> @clmul_nxv2i64_zext(<vscale x 2 x i32> %x, <vscale x 2
 ;
 ; CHECK-SVE2-LABEL: clmul_nxv2i64_zext:
 ; CHECK-SVE2:       // %bb.0:
-; CHECK-SVE2-NEXT:    movprfx z2, z0
-; CHECK-SVE2-NEXT:    and z2.d, z2.d, #0xffffffff
-; CHECK-SVE2-NEXT:    movprfx z0, z1
-; CHECK-SVE2-NEXT:    and z0.d, z0.d, #0x2
-; CHECK-SVE2-NEXT:    movprfx z3, z1
-; CHECK-SVE2-NEXT:    and z3.d, z3.d, #0x1
-; CHECK-SVE2-NEXT:    movprfx z4, z1
-; CHECK-SVE2-NEXT:    and z4.d, z4.d, #0x8
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x4
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x10
-; CHECK-SVE2-NEXT:    mul z0.d, z2.d, z0.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z3.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z4.d
-; CHECK-SVE2-NEXT:    mul z5.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    eor z0.d, z3.d, z0.d
-; CHECK-SVE2-NEXT:    movprfx z3, z1
-; CHECK-SVE2-NEXT:    and z3.d, z3.d, #0x20
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z5.d, z4.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z3.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x80
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x40
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x200
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x100
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x800
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x400
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x2000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x1000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x8000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x4000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x20000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x10000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x80000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x40000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x200000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x100000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x800000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x400000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x2000000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x1000000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x8000000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x4000000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x20000000
-; CHECK-SVE2-NEXT:    movprfx z6, z1
-; CHECK-SVE2-NEXT:    and z6.d, z6.d, #0x10000000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z4.d, z2.d, z6.d
-; CHECK-SVE2-NEXT:    movprfx z5, z1
-; CHECK-SVE2-NEXT:    and z5.d, z5.d, #0x80000000
-; CHECK-SVE2-NEXT:    and z1.d, z1.d, #0x40000000
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z4.d, z3.d
-; CHECK-SVE2-NEXT:    mul z3.d, z2.d, z5.d
-; CHECK-SVE2-NEXT:    mul z1.d, z2.d, z1.d
-; CHECK-SVE2-NEXT:    eor3 z0.d, z0.d, z1.d, z3.d
+; CHECK-SVE2-NEXT:    and z0.d, z0.d, #0xffffffff
+; CHECK-SVE2-NEXT:    and z1.d, z1.d, #0xffffffff
+; CHECK-SVE2-NEXT:    pmullb z0.d, z0.s, z1.s
 ; CHECK-SVE2-NEXT:    ret
 ;
 ; CHECK-SVE2-AES-LABEL: clmul_nxv2i64_zext:


### PR DESCRIPTION
Since only the lower bits of the clmul operands are non-zero, we can just use pmullb for simpler lowering. This enables optimal lowering for targets that have +sve2 or +sme in the i16 and i64 cases.