### PR TITLE
[NFC][IR] Use `isa<ConstantPointerNull>` instead of `isNullValue` for pointer null checks

### DIFF
--- a/llvm/include/llvm/IR/Constants.h
+++ b/llvm/include/llvm/IR/Constants.h
@@ -1248,7 +1248,7 @@ public:
 
   /// Whether there is any non-null address discriminator.
   bool hasAddressDiscriminator() const {
-    return !getAddrDiscriminator()->isNullValue();
+    return !isa<ConstantPointerNull>(getAddrDiscriminator());
   }
 
   Constant *getDeactivationSymbol() const {

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -1694,9 +1694,9 @@ static void writeConstantInternal(raw_ostream &Out, const Constant *CV,
     unsigned NumOpsToWrite = 2;
     if (!CPA->getOperand(2)->isNullValue())
       NumOpsToWrite = 3;
-    if (!CPA->getOperand(3)->isNullValue())
+    if (!isa<ConstantPointerNull>(CPA->getOperand(3)))
       NumOpsToWrite = 4;
-    if (!CPA->getOperand(4)->isNullValue())
+    if (!isa<ConstantPointerNull>(CPA->getOperand(4)))
       NumOpsToWrite = 5;
 
     ListSeparator LS;

--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -2210,7 +2210,7 @@ Value *DSOLocalEquivalent::handleOperandChangeImpl(Value *From, Value *To) {
 
   // If the argument is replaced with a null value, just replace this constant
   // with a null value.
-  if (cast<Constant>(To)->isNullValue())
+  if (isa<ConstantPointerNull>(To))
     return To;
 
   // The replacement could be a bitcast or an alias to another function. We can
@@ -2354,7 +2354,7 @@ bool ConstantPtrAuth::isKnownCompatibleWith(const Value *Key,
                                             const DataLayout &DL) const {
   // This function may only be validly called to analyze a ptrauth operation
   // with no deactivation symbol, so if we have one it isn't compatible.
-  if (!getDeactivationSymbol()->isNullValue())
+  if (!isa<ConstantPointerNull>(getDeactivationSymbol()))
     return false;
 
   // If the keys are different, there's no chance for this to be compatible.

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2864,7 +2864,7 @@ void Verifier::visitConstantPtrAuth(const ConstantPtrAuth *CPA) {
         "signed ptrauth constant deactivation symbol must be a pointer");
 
   Check(isa<GlobalValue>(CPA->getDeactivationSymbol()) ||
-            CPA->getDeactivationSymbol()->isNullValue(),
+            isa<ConstantPointerNull>(CPA->getDeactivationSymbol()),
         "signed ptrauth constant deactivation symbol must be a global value "
         "or null");
 }


### PR DESCRIPTION
This PR replaces `isNullValue()` with `isa<ConstantPointerNull>()` in core IR files where the check is semantically testing for a null pointer rather than a generic zero value. This makes the intent explicit and prepares for future     non-zero null pointer support.

---

The PR was assisted by AI but I reviewed all the changes.