### PR TITLE
[libc] Build with -Wshadow

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -305,6 +305,12 @@ function(_get_common_compile_options output_var flags)
       list(APPEND compile_options "-Wthread-safety")
       list(APPEND compile_options "-Wglobal-constructors")
     endif()
+
+    # Older Clang versions emit false positive shadow warnings for lambda captures
+    # inside static member functions (fixed in Clang 22, see PR #157667 and #165919).
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "22.0.0")
+      list(APPEND compile_options "-Wshadow")
+    endif()
   elseif(MSVC)
     list(APPEND compile_options "/EHs-c-")
     list(APPEND compile_options "/GR-")

--- a/libc/src/__support/math/sqrtf128.h
+++ b/libc/src/__support/math/sqrtf128.h
@@ -60,6 +60,8 @@ namespace math {
 
 namespace sqrtf128_internal {
 
+using FPBits = fputil::FPBits<float128>;
+
 template <typename T, typename U = T>
 LIBC_INLINE LIBC_CONSTEXPR T prod_hi(T, U);
 

--- a/libc/src/__support/math/sqrtf128.h
+++ b/libc/src/__support/math/sqrtf128.h
@@ -60,8 +60,6 @@ namespace math {
 
 namespace sqrtf128_internal {
 
-using FPBits = fputil::FPBits<float128>;
-
 template <typename T, typename U = T>
 LIBC_INLINE LIBC_CONSTEXPR T prod_hi(T, U);
 


### PR DESCRIPTION
This relands https://github.com/llvm/llvm-project/pull/196519. It now only enables the warning for
clang 22 and newer, since older versions had false positives.