### PR TITLE
[LifetimeSafety] Fix a crash on calling a function with `lifetime_capture_by` with an invalid parameter

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4216,6 +4216,8 @@ void Sema::checkLifetimeCaptureBy(FunctionDecl *FD, bool IsMemberFunction,
 
     Expr *Captured = const_cast<Expr *>(GetArgAt(ArgIdx));
     for (int CapturingParamIdx : Attr->params()) {
+      if (CapturingParamIdx == LifetimeCaptureByAttr::Invalid)
+        continue;
       // lifetime_capture_by(this) case is handled in the lifetimebound expr
       // initialization codepath.
       if (CapturingParamIdx == LifetimeCaptureByAttr::This &&

--- a/clang/test/SemaCXX/attr-lifetime-capture-by.cpp
+++ b/clang/test/SemaCXX/attr-lifetime-capture-by.cpp
@@ -33,6 +33,8 @@ void unknown_param_name(const int& unknown, // expected-error {{parameter cannot
                         const int& s [[clang::lifetime_capture_by(unknown)]]);
 void global_param_name(const int& global, // expected-error {{parameter cannot be named 'global' while using 'lifetime_capture_by(global)'}}
                        const int& s [[clang::lifetime_capture_by(global)]]);
+void no_such_param(int i [[clang::lifetime_capture_by(no_such_param)]]); // expected-error {{'lifetime_capture_by' attribute argument 'no_such_param' is not a known function parameter; must be a function parameter, 'this', 'global' or 'unknown'}}
+void use_no_such_param() { no_such_param(0); }
 struct T {
   void member(
     const int &x [[clang::lifetime_capture_by(s)]],


### PR DESCRIPTION
On creating the attribute, all of the parameters are in an invalid state. If later not replaced (with a valid argument, such as `global`, `this`, or any variable), the code will iterate over what it assumes are completely valid arguments.

With this PR we just skip the argument handling for the invalid ones.

Fixes #197508