### PR TITLE
[compiler-rt] Use `size_t` rather than `int` for first argument to `__atomic_load_c` et al.

### DIFF
--- a/compiler-rt/lib/builtins/atomic.c
+++ b/compiler-rt/lib/builtins/atomic.c
@@ -185,7 +185,7 @@ bool __atomic_is_lock_free_c(size_t size, void *ptr) {
 
 /// An atomic load operation.  This is atomic with respect to the source
 /// pointer only.
-void __atomic_load_c(int size, void *src, void *dest, int model) {
+void __atomic_load_c(size_t size, void *src, void *dest, int model) {
 #define LOCK_FREE_ACTION(type)                                                 \
   *((type *)dest) = __c11_atomic_load((_Atomic(type) *)src, model);            \
   return;
@@ -199,7 +199,7 @@ void __atomic_load_c(int size, void *src, void *dest, int model) {
 
 /// An atomic store operation.  This is atomic with respect to the destination
 /// pointer only.
-void __atomic_store_c(int size, void *dest, void *src, int model) {
+void __atomic_store_c(size_t size, void *dest, void *src, int model) {
 #define LOCK_FREE_ACTION(type)                                                 \
   __c11_atomic_store((_Atomic(type) *)dest, *(type *)src, model);              \
   return;
@@ -216,7 +216,7 @@ void __atomic_store_c(int size, void *dest, void *src, int model) {
 /// they  are not, then this stores the current value from *ptr in *expected.
 ///
 /// This function returns 1 if the exchange takes place or 0 if it fails.
-int __atomic_compare_exchange_c(int size, void *ptr, void *expected,
+int __atomic_compare_exchange_c(size_t size, void *ptr, void *expected,
                                 void *desired, int success, int failure) {
 #define LOCK_FREE_ACTION(type)                                                 \
   return __c11_atomic_compare_exchange_strong(                                 \
@@ -238,7 +238,8 @@ int __atomic_compare_exchange_c(int size, void *ptr, void *expected,
 
 /// Performs an atomic exchange operation between two pointers.  This is atomic
 /// with respect to the target address.
-void __atomic_exchange_c(int size, void *ptr, void *val, void *old, int model) {
+void __atomic_exchange_c(size_t size, void *ptr, void *val, void *old,
+                         int model) {
 #define LOCK_FREE_ACTION(type)                                                 \
   *(type *)old =                                                               \
       __c11_atomic_exchange((_Atomic(type) *)ptr, *(type *)val, model);        \

--- a/compiler-rt/test/builtins/Unit/atomic_test.c
+++ b/compiler-rt/test/builtins/Unit/atomic_test.c
@@ -34,23 +34,23 @@
 bool __atomic_is_lock_free_c(size_t size, void *ptr)
     EXTERNAL_NAME(__atomic_is_lock_free);
 
-void __atomic_load_c(int size, void *src, void *dest,
-                     int model) EXTERNAL_NAME(__atomic_load);
+void __atomic_load_c(size_t size, void *src, void *dest, int model)
+    EXTERNAL_NAME(__atomic_load);
 
 uint8_t __atomic_load_1(uint8_t *src, int model);
 uint16_t __atomic_load_2(uint16_t *src, int model);
 uint32_t __atomic_load_4(uint32_t *src, int model);
 uint64_t __atomic_load_8(uint64_t *src, int model);
 
-void __atomic_store_c(int size, void *dest, const void *src,
-                      int model) EXTERNAL_NAME(__atomic_store);
+void __atomic_store_c(size_t size, void *dest, const void *src, int model)
+    EXTERNAL_NAME(__atomic_store);
 
 void __atomic_store_1(uint8_t *dest, uint8_t val, int model);
 void __atomic_store_2(uint16_t *dest, uint16_t val, int model);
 void __atomic_store_4(uint32_t *dest, uint32_t val, int model);
 void __atomic_store_8(uint64_t *dest, uint64_t val, int model);
 
-void __atomic_exchange_c(int size, void *ptr, const void *val, void *old,
+void __atomic_exchange_c(size_t size, void *ptr, const void *val, void *old,
                          int model) EXTERNAL_NAME(__atomic_exchange);
 
 uint8_t __atomic_exchange_1(uint8_t *dest, uint8_t val, int model);
@@ -58,7 +58,7 @@ uint16_t __atomic_exchange_2(uint16_t *dest, uint16_t val, int model);
 uint32_t __atomic_exchange_4(uint32_t *dest, uint32_t val, int model);
 uint64_t __atomic_exchange_8(uint64_t *dest, uint64_t val, int model);
 
-int __atomic_compare_exchange_c(int size, void *ptr, void *expected,
+int __atomic_compare_exchange_c(size_t size, void *ptr, void *expected,
                                 const void *desired, int success, int failure)
     EXTERNAL_NAME(__atomic_compare_exchange);
 


### PR DESCRIPTION
I noticed this discrepancy in emscripten when trying to test 128 bit atomics under wasm64: https://github.com/emscripten-core/emscripten/pull/26937

The LLVM CodeGen appears to use `size_t` in this position when it generates calls to these functions.

This doesn't effect other platforms I imagine because they don't require signature checking at the linker level.

This doesn't effect wasm32 where size_t and int are the same size.