### PR TITLE
[AArch64] Keep MMO when converting gather lane to LDRSui.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -8235,7 +8235,8 @@ generateGatherLanePattern(MachineInstr &Root,
                 NewRegister)
             .addReg(SrcRegister)
             .addImm(Lane)
-            .addReg(OffsetRegister, getKillRegState(OffsetRegisterKillState));
+            .addReg(OffsetRegister, getKillRegState(OffsetRegisterKillState))
+            .setMemRefs(OriginalInstr->memoperands());
     InstrIdxForVirtReg.insert(std::make_pair(NewRegister, InsInstrs.size()));
     InsInstrs.push_back(LoadIndexIntoRegister);
     return NewRegister;
@@ -8243,9 +8244,9 @@ generateGatherLanePattern(MachineInstr &Root,
 
   // Helper to create load instruction based on the NumLanes in the NEON
   // register we are rewriting.
-  auto CreateLDRInstruction = [&](unsigned NumLanes, Register DestReg,
-                                  Register OffsetReg,
-                                  bool KillState) -> MachineInstrBuilder {
+  auto CreateLDRInstruction =
+      [&](unsigned NumLanes, Register DestReg, Register OffsetReg,
+          ArrayRef<MachineMemOperand *> MMOs) -> MachineInstrBuilder {
     unsigned Opcode;
     switch (NumLanes) {
     case 4:
@@ -8264,7 +8265,8 @@ generateGatherLanePattern(MachineInstr &Root,
     // Immediate offset load
     return BuildMI(MF, MIMetadata(Root), TII->get(Opcode), DestReg)
         .addReg(OffsetReg)
-        .addImm(0);
+        .addImm(0)
+        .setMemRefs(MMOs);
   };
 
   // Load the remaining lanes into register 0.
@@ -8294,7 +8296,7 @@ generateGatherLanePattern(MachineInstr &Root,
   MachineInstrBuilder MiddleIndexLoadInstr =
       CreateLDRInstruction(NumLanes, DestRegForMiddleIndex,
                            OriginalSplitToLoadOffsetOperand.getReg(),
-                           OriginalSplitToLoadOffsetOperand.isKill());
+                           OriginalSplitLoad->memoperands());
 
   InstrIdxForVirtReg.insert(
       std::make_pair(DestRegForMiddleIndex, InsInstrs.size()));

--- a/llvm/test/CodeGen/AArch64/complex-deinterleaving-uniform-cases.ll
+++ b/llvm/test/CodeGen/AArch64/complex-deinterleaving-uniform-cases.ll
@@ -201,88 +201,88 @@ entry:
 define <12 x float> @abp90c12(<12 x float> %a, <12 x float> %b, <12 x float> %c) {
 ; CHECK-LABEL: abp90c12:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    // kill: def $s1 killed $s1 def $q1
-; CHECK-NEXT:    // kill: def $s3 killed $s3 def $q3
 ; CHECK-NEXT:    // kill: def $s0 killed $s0 def $q0
+; CHECK-NEXT:    // kill: def $s1 killed $s1 def $q1
 ; CHECK-NEXT:    // kill: def $s2 killed $s2 def $q2
+; CHECK-NEXT:    // kill: def $s3 killed $s3 def $q3
 ; CHECK-NEXT:    ldr s17, [sp, #32]
-; CHECK-NEXT:    // kill: def $s5 killed $s5 def $q5
-; CHECK-NEXT:    add x9, sp, #48
-; CHECK-NEXT:    add x10, sp, #64
-; CHECK-NEXT:    mov v1.s[1], v3.s[0]
-; CHECK-NEXT:    mov v0.s[1], v2.s[0]
 ; CHECK-NEXT:    // kill: def $s4 killed $s4 def $q4
-; CHECK-NEXT:    add x11, sp, #72
-; CHECK-NEXT:    ld1 { v17.s }[1], [x9]
-; CHECK-NEXT:    ldr s18, [x10]
-; CHECK-NEXT:    add x9, sp, #80
-; CHECK-NEXT:    add x10, sp, #56
+; CHECK-NEXT:    add x10, sp, #48
+; CHECK-NEXT:    add x11, sp, #64
+; CHECK-NEXT:    mov v0.s[1], v2.s[0]
+; CHECK-NEXT:    mov v1.s[1], v3.s[0]
+; CHECK-NEXT:    // kill: def $s5 killed $s5 def $q5
 ; CHECK-NEXT:    // kill: def $s6 killed $s6 def $q6
-; CHECK-NEXT:    // kill: def $s7 killed $s7 def $q7
-; CHECK-NEXT:    ldr s16, [sp, #8]
 ; CHECK-NEXT:    ldr s3, [sp, #96]
-; CHECK-NEXT:    ld1 { v18.s }[1], [x9]
-; CHECK-NEXT:    add x9, sp, #88
+; CHECK-NEXT:    ld1 { v17.s }[1], [x10]
+; CHECK-NEXT:    add x10, sp, #72
+; CHECK-NEXT:    ldr s16, [sp, #8]
+; CHECK-NEXT:    ldr s18, [x10]
+; CHECK-NEXT:    add x10, sp, #56
+; CHECK-NEXT:    // kill: def $s7 killed $s7 def $q7
 ; CHECK-NEXT:    ldr s2, [sp]
-; CHECK-NEXT:    mov v1.s[2], v5.s[0]
-; CHECK-NEXT:    ldr s5, [sp, #40]
+; CHECK-NEXT:    add x9, sp, #16
 ; CHECK-NEXT:    mov v0.s[2], v4.s[0]
+; CHECK-NEXT:    ldr s4, [x11]
+; CHECK-NEXT:    mov v1.s[2], v5.s[0]
+; CHECK-NEXT:    add x11, sp, #80
+; CHECK-NEXT:    ldr s5, [sp, #40]
+; CHECK-NEXT:    ld1 { v2.s }[1], [x9]
+; CHECK-NEXT:    ld1 { v4.s }[1], [x11]
+; CHECK-NEXT:    add x11, sp, #88
+; CHECK-NEXT:    add x9, sp, #168
 ; CHECK-NEXT:    ld1 { v5.s }[1], [x10]
-; CHECK-NEXT:    ldr s19, [x11]
-; CHECK-NEXT:    add x10, sp, #144
-; CHECK-NEXT:    zip1 v4.2d, v17.2d, v18.2d
-; CHECK-NEXT:    add x11, sp, #160
-; CHECK-NEXT:    ldr s18, [sp, #136]
-; CHECK-NEXT:    ld1 { v19.s }[1], [x9]
+; CHECK-NEXT:    ld1 { v18.s }[1], [x11]
+; CHECK-NEXT:    add x11, sp, #112
 ; CHECK-NEXT:    mov v0.s[3], v6.s[0]
-; CHECK-NEXT:    ldr s6, [sp, #128]
 ; CHECK-NEXT:    mov v1.s[3], v7.s[0]
-; CHECK-NEXT:    add x9, sp, #24
-; CHECK-NEXT:    ldr s7, [sp, #104]
-; CHECK-NEXT:    ld1 { v16.s }[1], [x9]
-; CHECK-NEXT:    add x9, sp, #112
-; CHECK-NEXT:    ld1 { v6.s }[1], [x10]
-; CHECK-NEXT:    zip1 v5.2d, v5.2d, v19.2d
-; CHECK-NEXT:    add x10, sp, #120
-; CHECK-NEXT:    ld1 { v3.s }[1], [x9]
+; CHECK-NEXT:    add x10, sp, #24
+; CHECK-NEXT:    ld1 { v3.s }[1], [x11]
+; CHECK-NEXT:    zip1 v4.2d, v17.2d, v4.2d
+; CHECK-NEXT:    add x11, sp, #120
+; CHECK-NEXT:    zip1 v6.2d, v5.2d, v18.2d
+; CHECK-NEXT:    ldr s5, [sp, #104]
+; CHECK-NEXT:    ld1 { v16.s }[1], [x10]
+; CHECK-NEXT:    add x10, sp, #160
+; CHECK-NEXT:    ldr s7, [sp, #128]
+; CHECK-NEXT:    ldr s18, [sp, #192]
+; CHECK-NEXT:    ld1 { v5.s }[1], [x11]
+; CHECK-NEXT:    ldr s17, [x10]
+; CHECK-NEXT:    add x10, sp, #144
+; CHECK-NEXT:    add x11, sp, #176
 ; CHECK-NEXT:    ld1 { v7.s }[1], [x10]
-; CHECK-NEXT:    ldr s17, [x11]
-; CHECK-NEXT:    add x9, sp, #176
-; CHECK-NEXT:    add x10, sp, #16
-; CHECK-NEXT:    add x11, sp, #168
-; CHECK-NEXT:    ld1 { v17.s }[1], [x9]
-; CHECK-NEXT:    ld1 { v2.s }[1], [x10]
-; CHECK-NEXT:    add x9, sp, #152
-; CHECK-NEXT:    fmul v19.4s, v5.4s, v1.4s
-; CHECK-NEXT:    fmul v20.4s, v7.4s, v16.4s
-; CHECK-NEXT:    fmul v16.4s, v3.4s, v16.4s
+; CHECK-NEXT:    ldr s21, [x9]
+; CHECK-NEXT:    ld1 { v17.s }[1], [x11]
+; CHECK-NEXT:    fmul v19.4s, v6.4s, v1.4s
 ; CHECK-NEXT:    fmul v1.4s, v4.4s, v1.4s
+; CHECK-NEXT:    fmul v20.4s, v5.4s, v16.4s
+; CHECK-NEXT:    fmul v16.4s, v3.4s, v16.4s
+; CHECK-NEXT:    add x9, sp, #208
+; CHECK-NEXT:    add x10, sp, #152
+; CHECK-NEXT:    add x11, sp, #184
 ; CHECK-NEXT:    ld1 { v18.s }[1], [x9]
-; CHECK-NEXT:    ldr s21, [x11]
-; CHECK-NEXT:    zip1 v6.2d, v6.2d, v17.2d
-; CHECK-NEXT:    ldr s17, [sp, #192]
-; CHECK-NEXT:    add x9, sp, #184
-; CHECK-NEXT:    add x10, sp, #208
-; CHECK-NEXT:    ld1 { v21.s }[1], [x9]
-; CHECK-NEXT:    add x9, sp, #216
+; CHECK-NEXT:    zip1 v7.2d, v7.2d, v17.2d
+; CHECK-NEXT:    ldr s17, [sp, #136]
+; CHECK-NEXT:    ld1 { v21.s }[1], [x11]
 ; CHECK-NEXT:    fneg v19.4s, v19.4s
+; CHECK-NEXT:    fmla v1.4s, v0.4s, v6.4s
+; CHECK-NEXT:    add x9, sp, #216
 ; CHECK-NEXT:    fneg v20.4s, v20.4s
-; CHECK-NEXT:    fmla v16.4s, v2.4s, v7.4s
-; CHECK-NEXT:    fmla v1.4s, v0.4s, v5.4s
+; CHECK-NEXT:    fmla v16.4s, v2.4s, v5.4s
 ; CHECK-NEXT:    ld1 { v17.s }[1], [x10]
 ; CHECK-NEXT:    ldr s5, [sp, #200]
-; CHECK-NEXT:    zip1 v7.2d, v18.2d, v21.2d
-; CHECK-NEXT:    ld1 { v5.s }[1], [x9]
+; CHECK-NEXT:    zip1 v6.2d, v17.2d, v21.2d
 ; CHECK-NEXT:    fmla v19.4s, v0.4s, v4.4s
+; CHECK-NEXT:    fsub v0.4s, v7.4s, v1.4s
 ; CHECK-NEXT:    fmla v20.4s, v2.4s, v3.4s
-; CHECK-NEXT:    fsub v0.4s, v6.4s, v1.4s
-; CHECK-NEXT:    fsub v1.4s, v17.4s, v16.4s
-; CHECK-NEXT:    fadd v2.4s, v7.4s, v19.4s
+; CHECK-NEXT:    fsub v1.4s, v18.4s, v16.4s
+; CHECK-NEXT:    ld1 { v5.s }[1], [x9]
+; CHECK-NEXT:    fadd v2.4s, v6.4s, v19.4s
 ; CHECK-NEXT:    fadd v3.4s, v5.4s, v20.4s
 ; CHECK-NEXT:    ext v4.16b, v0.16b, v1.16b, #12
 ; CHECK-NEXT:    ext v5.16b, v2.16b, v3.16b, #12
-; CHECK-NEXT:    trn2 v1.4s, v1.4s, v3.4s
 ; CHECK-NEXT:    ext v4.16b, v0.16b, v4.16b, #12
+; CHECK-NEXT:    trn2 v1.4s, v1.4s, v3.4s
 ; CHECK-NEXT:    ext v5.16b, v2.16b, v5.16b, #8
 ; CHECK-NEXT:    rev64 v4.4s, v4.4s
 ; CHECK-NEXT:    trn2 v3.4s, v4.4s, v5.4s

--- a/llvm/test/CodeGen/AArch64/concat-vector.ll
+++ b/llvm/test/CodeGen/AArch64/concat-vector.ll
@@ -180,14 +180,23 @@ define <16 x i8> @concat_v16s8_v4s8(ptr %ptr) {
 }
 
 define <16 x i8> @concat_v16s8_v4s8_load(ptr %ptrA, ptr %ptrB, ptr %ptrC, ptr %ptrD) {
-; CHECK-LABEL: concat_v16s8_v4s8_load:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    ldr s0, [x0]
-; CHECK-NEXT:    ld1 { v0.s }[1], [x1]
-; CHECK-NEXT:    ldr s1, [x2]
-; CHECK-NEXT:    ld1 { v1.s }[1], [x3]
-; CHECK-NEXT:    zip1 v0.2d, v0.2d, v1.2d
-; CHECK-NEXT:    ret
+; CHECK-SD-LABEL: concat_v16s8_v4s8_load:
+; CHECK-SD:       // %bb.0:
+; CHECK-SD-NEXT:    ldr s0, [x2]
+; CHECK-SD-NEXT:    ldr s1, [x0]
+; CHECK-SD-NEXT:    ld1 { v0.s }[1], [x3]
+; CHECK-SD-NEXT:    ld1 { v1.s }[1], [x1]
+; CHECK-SD-NEXT:    zip1 v0.2d, v1.2d, v0.2d
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: concat_v16s8_v4s8_load:
+; CHECK-GI:       // %bb.0:
+; CHECK-GI-NEXT:    ldr s0, [x0]
+; CHECK-GI-NEXT:    ldr s1, [x2]
+; CHECK-GI-NEXT:    ld1 { v0.s }[1], [x1]
+; CHECK-GI-NEXT:    ld1 { v1.s }[1], [x3]
+; CHECK-GI-NEXT:    zip1 v0.2d, v0.2d, v1.2d
+; CHECK-GI-NEXT:    ret
     %A = load <4 x i8>, ptr %ptrA
     %B = load <4 x i8>, ptr %ptrB
     %C = load <4 x i8>, ptr %ptrC

--- a/llvm/test/CodeGen/AArch64/fp-maximumnum-minimumnum.ll
+++ b/llvm/test/CodeGen/AArch64/fp-maximumnum-minimumnum.ll
@@ -1683,42 +1683,42 @@ define <9 x half> @max_v9f16(<9 x half> %a, <9 x half> %b) {
 ; CHECK-FP16-NEXT:    // kill: def $h0 killed $h0 def $q0
 ; CHECK-FP16-NEXT:    // kill: def $h1 killed $h1 def $q1
 ; CHECK-FP16-NEXT:    // kill: def $h2 killed $h2 def $q2
-; CHECK-FP16-NEXT:    add x9, sp, #16
 ; CHECK-FP16-NEXT:    // kill: def $h3 killed $h3 def $q3
 ; CHECK-FP16-NEXT:    // kill: def $h4 killed $h4 def $q4
-; CHECK-FP16-NEXT:    add x10, sp, #40
+; CHECK-FP16-NEXT:    add x9, sp, #40
+; CHECK-FP16-NEXT:    add x10, sp, #48
 ; CHECK-FP16-NEXT:    // kill: def $h5 killed $h5 def $q5
 ; CHECK-FP16-NEXT:    // kill: def $h6 killed $h6 def $q6
 ; CHECK-FP16-NEXT:    // kill: def $h7 killed $h7 def $q7
 ; CHECK-FP16-NEXT:    mov v0.h[1], v1.h[0]
 ; CHECK-FP16-NEXT:    ldr h1, [sp, #8]
+; CHECK-FP16-NEXT:    mov v0.h[2], v2.h[0]
+; CHECK-FP16-NEXT:    ldr h2, [x9]
+; CHECK-FP16-NEXT:    add x9, sp, #16
 ; CHECK-FP16-NEXT:    ld1 { v1.h }[1], [x9]
 ; CHECK-FP16-NEXT:    add x9, sp, #24
-; CHECK-FP16-NEXT:    mov v0.h[2], v2.h[0]
+; CHECK-FP16-NEXT:    ld1 { v2.h }[1], [x10]
+; CHECK-FP16-NEXT:    add x10, sp, #56
+; CHECK-FP16-NEXT:    mov v0.h[3], v3.h[0]
 ; CHECK-FP16-NEXT:    ld1 { v1.h }[2], [x9]
 ; CHECK-FP16-NEXT:    add x9, sp, #32
-; CHECK-FP16-NEXT:    mov v0.h[3], v3.h[0]
-; CHECK-FP16-NEXT:    ld1 { v1.h }[3], [x9]
-; CHECK-FP16-NEXT:    ldr h2, [x10]
-; CHECK-FP16-NEXT:    add x9, sp, #48
+; CHECK-FP16-NEXT:    ld1 { v2.h }[2], [x10]
+; CHECK-FP16-NEXT:    add x10, sp, #64
 ; CHECK-FP16-NEXT:    ldr h3, [sp, #72]
-; CHECK-FP16-NEXT:    ld1 { v2.h }[1], [x9]
-; CHECK-FP16-NEXT:    add x9, sp, #56
+; CHECK-FP16-NEXT:    ld1 { v1.h }[3], [x9]
 ; CHECK-FP16-NEXT:    fminnm v3.8h, v3.8h, v3.8h
 ; CHECK-FP16-NEXT:    mov v0.h[4], v4.h[0]
-; CHECK-FP16-NEXT:    ld1 { v2.h }[2], [x9]
-; CHECK-FP16-NEXT:    add x9, sp, #64
-; CHECK-FP16-NEXT:    mov v0.h[5], v5.h[0]
-; CHECK-FP16-NEXT:    ld1 { v2.h }[3], [x9]
+; CHECK-FP16-NEXT:    ld1 { v2.h }[3], [x10]
 ; CHECK-FP16-NEXT:    zip1 v1.2d, v1.2d, v2.2d
 ; CHECK-FP16-NEXT:    ldr h2, [sp]
-; CHECK-FP16-NEXT:    mov v0.h[6], v6.h[0]
+; CHECK-FP16-NEXT:    mov v0.h[5], v5.h[0]
 ; CHECK-FP16-NEXT:    fminnm v2.8h, v2.8h, v2.8h
 ; CHECK-FP16-NEXT:    fminnm v1.8h, v1.8h, v1.8h
-; CHECK-FP16-NEXT:    mov v0.h[7], v7.h[0]
+; CHECK-FP16-NEXT:    mov v0.h[6], v6.h[0]
 ; CHECK-FP16-NEXT:    fmaxnm v2.8h, v2.8h, v3.8h
-; CHECK-FP16-NEXT:    fminnm v0.8h, v0.8h, v0.8h
+; CHECK-FP16-NEXT:    mov v0.h[7], v7.h[0]
 ; CHECK-FP16-NEXT:    str h2, [x8, #16]
+; CHECK-FP16-NEXT:    fminnm v0.8h, v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fmaxnm v0.8h, v0.8h, v1.8h
 ; CHECK-FP16-NEXT:    str q0, [x8]
 ; CHECK-FP16-NEXT:    ret
@@ -2326,42 +2326,42 @@ define <9 x half> @min_v9f16(<9 x half> %a, <9 x half> %b) {
 ; CHECK-FP16-NEXT:    // kill: def $h0 killed $h0 def $q0
 ; CHECK-FP16-NEXT:    // kill: def $h1 killed $h1 def $q1
 ; CHECK-FP16-NEXT:    // kill: def $h2 killed $h2 def $q2
-; CHECK-FP16-NEXT:    add x9, sp, #16
 ; CHECK-FP16-NEXT:    // kill: def $h3 killed $h3 def $q3
 ; CHECK-FP16-NEXT:    // kill: def $h4 killed $h4 def $q4
-; CHECK-FP16-NEXT:    add x10, sp, #40
+; CHECK-FP16-NEXT:    add x9, sp, #40
+; CHECK-FP16-NEXT:    add x10, sp, #48
 ; CHECK-FP16-NEXT:    // kill: def $h5 killed $h5 def $q5
 ; CHECK-FP16-NEXT:    // kill: def $h6 killed $h6 def $q6
 ; CHECK-FP16-NEXT:    // kill: def $h7 killed $h7 def $q7
 ; CHECK-FP16-NEXT:    mov v0.h[1], v1.h[0]
 ; CHECK-FP16-NEXT:    ldr h1, [sp, #8]
+; CHECK-FP16-NEXT:    mov v0.h[2], v2.h[0]
+; CHECK-FP16-NEXT:    ldr h2, [x9]
+; CHECK-FP16-NEXT:    add x9, sp, #16
 ; CHECK-FP16-NEXT:    ld1 { v1.h }[1], [x9]
 ; CHECK-FP16-NEXT:    add x9, sp, #24
-; CHECK-FP16-NEXT:    mov v0.h[2], v2.h[0]
+; CHECK-FP16-NEXT:    ld1 { v2.h }[1], [x10]
+; CHECK-FP16-NEXT:    add x10, sp, #56
+; CHECK-FP16-NEXT:    mov v0.h[3], v3.h[0]
 ; CHECK-FP16-NEXT:    ld1 { v1.h }[2], [x9]
 ; CHECK-FP16-NEXT:    add x9, sp, #32
-; CHECK-FP16-NEXT:    mov v0.h[3], v3.h[0]
-; CHECK-FP16-NEXT:    ld1 { v1.h }[3], [x9]
-; CHECK-FP16-NEXT:    ldr h2, [x10]
-; CHECK-FP16-NEXT:    add x9, sp, #48
+; CHECK-FP16-NEXT:    ld1 { v2.h }[2], [x10]
+; CHECK-FP16-NEXT:    add x10, sp, #64
 ; CHECK-FP16-NEXT:    ldr h3, [sp, #72]
-; CHECK-FP16-NEXT:    ld1 { v2.h }[1], [x9]
-; CHECK-FP16-NEXT:    add x9, sp, #56
+; CHECK-FP16-NEXT:    ld1 { v1.h }[3], [x9]
 ; CHECK-FP16-NEXT:    fminnm v3.8h, v3.8h, v3.8h
 ; CHECK-FP16-NEXT:    mov v0.h[4], v4.h[0]
-; CHECK-FP16-NEXT:    ld1 { v2.h }[2], [x9]
-; CHECK-FP16-NEXT:    add x9, sp, #64
-; CHECK-FP16-NEXT:    mov v0.h[5], v5.h[0]
-; CHECK-FP16-NEXT:    ld1 { v2.h }[3], [x9]
+; CHECK-FP16-NEXT:    ld1 { v2.h }[3], [x10]
 ; CHECK-FP16-NEXT:    zip1 v1.2d, v1.2d, v2.2d
 ; CHECK-FP16-NEXT:    ldr h2, [sp]
-; CHECK-FP16-NEXT:    mov v0.h[6], v6.h[0]
+; CHECK-FP16-NEXT:    mov v0.h[5], v5.h[0]
 ; CHECK-FP16-NEXT:    fminnm v2.8h, v2.8h, v2.8h
 ; CHECK-FP16-NEXT:    fminnm v1.8h, v1.8h, v1.8h
-; CHECK-FP16-NEXT:    mov v0.h[7], v7.h[0]
+; CHECK-FP16-NEXT:    mov v0.h[6], v6.h[0]
 ; CHECK-FP16-NEXT:    fminnm v2.8h, v2.8h, v3.8h
-; CHECK-FP16-NEXT:    fminnm v0.8h, v0.8h, v0.8h
+; CHECK-FP16-NEXT:    mov v0.h[7], v7.h[0]
 ; CHECK-FP16-NEXT:    str h2, [x8, #16]
+; CHECK-FP16-NEXT:    fminnm v0.8h, v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fminnm v0.8h, v0.8h, v1.8h
 ; CHECK-FP16-NEXT:    str q0, [x8]
 ; CHECK-FP16-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/fsh.ll
+++ b/llvm/test/CodeGen/AArch64/fsh.ll
@@ -2396,64 +2396,64 @@ define <7 x i32> @fshl_v7i32(<7 x i32> %a, <7 x i32> %b, <7 x i32> %c) {
 ;
 ; CHECK-GI-LABEL: fshl_v7i32:
 ; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr s5, [sp, #80]
-; CHECK-GI-NEXT:    ldr s16, [sp, #88]
-; CHECK-GI-NEXT:    fmov s19, w0
 ; CHECK-GI-NEXT:    ldr s1, [sp, #48]
 ; CHECK-GI-NEXT:    ldr s7, [sp, #56]
+; CHECK-GI-NEXT:    add x9, sp, #64
+; CHECK-GI-NEXT:    ldr s5, [sp, #80]
+; CHECK-GI-NEXT:    ldr s16, [sp, #88]
 ; CHECK-GI-NEXT:    add x8, sp, #56
+; CHECK-GI-NEXT:    mov v1.s[1], v7.s[0]
+; CHECK-GI-NEXT:    ldr s6, [sp]
+; CHECK-GI-NEXT:    ldr s7, [sp, #64]
 ; CHECK-GI-NEXT:    mov v5.s[1], v16.s[0]
 ; CHECK-GI-NEXT:    fmov s16, w7
-; CHECK-GI-NEXT:    ldr s6, [sp]
-; CHECK-GI-NEXT:    mov v1.s[1], v7.s[0]
-; CHECK-GI-NEXT:    ldr s17, [sp, #64]
-; CHECK-GI-NEXT:    ldr s7, [sp, #48]
+; CHECK-GI-NEXT:    ldr s17, [sp, #48]
+; CHECK-GI-NEXT:    ldr s18, [x9]
+; CHECK-GI-NEXT:    add x10, sp, #72
+; CHECK-GI-NEXT:    ldr s19, [sp, #96]
+; CHECK-GI-NEXT:    ld1 { v17.s }[1], [x8]
 ; CHECK-GI-NEXT:    ldr s4, [sp, #8]
 ; CHECK-GI-NEXT:    ldr s0, [sp, #24]
-; CHECK-GI-NEXT:    ldr s3, [sp, #32]
 ; CHECK-GI-NEXT:    mov v16.s[1], v6.s[0]
-; CHECK-GI-NEXT:    ldr s6, [sp, #96]
-; CHECK-GI-NEXT:    add x9, sp, #64
-; CHECK-GI-NEXT:    ld1 { v7.s }[1], [x8]
-; CHECK-GI-NEXT:    ldr s18, [x9]
-; CHECK-GI-NEXT:    mov v19.s[1], w1
-; CHECK-GI-NEXT:    mov v5.s[2], v6.s[0]
-; CHECK-GI-NEXT:    movi v6.2d, #0xffffffffffffffff
-; CHECK-GI-NEXT:    mov v1.s[2], v17.s[0]
-; CHECK-GI-NEXT:    ldr s17, [sp, #72]
-; CHECK-GI-NEXT:    add x8, sp, #72
+; CHECK-GI-NEXT:    mov v1.s[2], v7.s[0]
+; CHECK-GI-NEXT:    fmov s7, w0
+; CHECK-GI-NEXT:    ld1 { v18.s }[1], [x10]
+; CHECK-GI-NEXT:    ldr s3, [sp, #32]
+; CHECK-GI-NEXT:    ldr s6, [sp, #72]
+; CHECK-GI-NEXT:    mov v5.s[2], v19.s[0]
+; CHECK-GI-NEXT:    movi v19.2d, #0xffffffffffffffff
 ; CHECK-GI-NEXT:    ldr s20, [sp, #80]
-; CHECK-GI-NEXT:    mov v16.s[2], v4.s[0]
+; CHECK-GI-NEXT:    mov v7.s[1], w1
 ; CHECK-GI-NEXT:    mov v0.s[1], v3.s[0]
-; CHECK-GI-NEXT:    ld1 { v18.s }[1], [x8]
 ; CHECK-GI-NEXT:    add x8, sp, #88
+; CHECK-GI-NEXT:    mov v16.s[2], v4.s[0]
+; CHECK-GI-NEXT:    mov v1.s[3], v6.s[0]
+; CHECK-GI-NEXT:    zip1 v6.2d, v17.2d, v18.2d
+; CHECK-GI-NEXT:    fmov s17, w4
 ; CHECK-GI-NEXT:    movi v4.4s, #31
 ; CHECK-GI-NEXT:    ldr s2, [sp, #16]
-; CHECK-GI-NEXT:    eor v5.16b, v5.16b, v6.16b
-; CHECK-GI-NEXT:    fmov s6, w4
-; CHECK-GI-NEXT:    mov v1.s[3], v17.s[0]
 ; CHECK-GI-NEXT:    ldr s3, [sp, #40]
 ; CHECK-GI-NEXT:    ld1 { v20.s }[1], [x8]
-; CHECK-GI-NEXT:    mov v19.s[2], w2
-; CHECK-GI-NEXT:    zip1 v7.2d, v7.2d, v18.2d
-; CHECK-GI-NEXT:    mov v16.s[3], v2.s[0]
+; CHECK-GI-NEXT:    eor v5.16b, v5.16b, v19.16b
+; CHECK-GI-NEXT:    mov v7.s[2], w2
 ; CHECK-GI-NEXT:    add x8, sp, #96
-; CHECK-GI-NEXT:    mov v6.s[1], w5
+; CHECK-GI-NEXT:    mov v17.s[1], w5
+; CHECK-GI-NEXT:    mov v16.s[3], v2.s[0]
 ; CHECK-GI-NEXT:    mov v0.s[2], v3.s[0]
-; CHECK-GI-NEXT:    and v2.16b, v5.16b, v4.16b
 ; CHECK-GI-NEXT:    bic v1.16b, v4.16b, v1.16b
 ; CHECK-GI-NEXT:    ld1 { v20.s }[2], [x8]
-; CHECK-GI-NEXT:    mov v19.s[3], w3
-; CHECK-GI-NEXT:    and v3.16b, v7.16b, v4.16b
+; CHECK-GI-NEXT:    and v2.16b, v5.16b, v4.16b
+; CHECK-GI-NEXT:    and v3.16b, v6.16b, v4.16b
+; CHECK-GI-NEXT:    mov v7.s[3], w3
+; CHECK-GI-NEXT:    mov v17.s[2], w6
 ; CHECK-GI-NEXT:    ushr v5.4s, v16.4s, #1
-; CHECK-GI-NEXT:    neg v2.4s, v2.4s
-; CHECK-GI-NEXT:    mov v6.s[2], w6
 ; CHECK-GI-NEXT:    neg v1.4s, v1.4s
 ; CHECK-GI-NEXT:    and v4.16b, v20.16b, v4.16b
 ; CHECK-GI-NEXT:    ushr v0.4s, v0.4s, #1
-; CHECK-GI-NEXT:    ushl v3.4s, v19.4s, v3.4s
+; CHECK-GI-NEXT:    neg v2.4s, v2.4s
+; CHECK-GI-NEXT:    ushl v3.4s, v7.4s, v3.4s
 ; CHECK-GI-NEXT:    ushl v1.4s, v5.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v4.4s, v6.4s, v4.4s
+; CHECK-GI-NEXT:    ushl v4.4s, v17.4s, v4.4s
 ; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v2.4s
 ; CHECK-GI-NEXT:    orr v1.16b, v3.16b, v1.16b
 ; CHECK-GI-NEXT:    orr v0.16b, v4.16b, v0.16b
@@ -2536,62 +2536,62 @@ define <7 x i32> @fshr_v7i32(<7 x i32> %a, <7 x i32> %b, <7 x i32> %c) {
 ; CHECK-GI-LABEL: fshr_v7i32:
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr s1, [sp, #48]
-; CHECK-GI-NEXT:    ldr s16, [sp, #56]
-; CHECK-GI-NEXT:    add x8, sp, #56
-; CHECK-GI-NEXT:    ldr s17, [sp, #80]
-; CHECK-GI-NEXT:    ldr s18, [sp, #88]
+; CHECK-GI-NEXT:    ldr s17, [sp, #56]
 ; CHECK-GI-NEXT:    add x9, sp, #64
-; CHECK-GI-NEXT:    mov v1.s[1], v16.s[0]
-; CHECK-GI-NEXT:    fmov s16, w0
-; CHECK-GI-NEXT:    ldr s5, [sp, #48]
-; CHECK-GI-NEXT:    mov v17.s[1], v18.s[0]
-; CHECK-GI-NEXT:    fmov s18, w7
+; CHECK-GI-NEXT:    ldr s18, [sp, #80]
+; CHECK-GI-NEXT:    ldr s19, [sp, #88]
+; CHECK-GI-NEXT:    add x8, sp, #56
+; CHECK-GI-NEXT:    mov v1.s[1], v17.s[0]
+; CHECK-GI-NEXT:    fmov s17, w0
 ; CHECK-GI-NEXT:    ldr s4, [sp]
-; CHECK-GI-NEXT:    ld1 { v5.s }[1], [x8]
-; CHECK-GI-NEXT:    ldr s6, [x9]
+; CHECK-GI-NEXT:    mov v18.s[1], v19.s[0]
+; CHECK-GI-NEXT:    fmov s19, w7
+; CHECK-GI-NEXT:    ldr s7, [sp, #48]
+; CHECK-GI-NEXT:    ldr s16, [x9]
 ; CHECK-GI-NEXT:    add x10, sp, #72
-; CHECK-GI-NEXT:    mov v16.s[1], w1
 ; CHECK-GI-NEXT:    ldr s20, [sp, #80]
-; CHECK-GI-NEXT:    ldr s7, [sp, #64]
-; CHECK-GI-NEXT:    mov v18.s[1], v4.s[0]
+; CHECK-GI-NEXT:    mov v17.s[1], w1
+; CHECK-GI-NEXT:    ldr s6, [sp, #64]
+; CHECK-GI-NEXT:    add x9, sp, #88
+; CHECK-GI-NEXT:    mov v19.s[1], v4.s[0]
 ; CHECK-GI-NEXT:    fmov s4, w4
-; CHECK-GI-NEXT:    add x8, sp, #88
-; CHECK-GI-NEXT:    ld1 { v6.s }[1], [x10]
+; CHECK-GI-NEXT:    ld1 { v7.s }[1], [x8]
+; CHECK-GI-NEXT:    ld1 { v16.s }[1], [x10]
 ; CHECK-GI-NEXT:    ldr s21, [sp, #96]
-; CHECK-GI-NEXT:    ld1 { v20.s }[1], [x8]
-; CHECK-GI-NEXT:    mov v1.s[2], v7.s[0]
+; CHECK-GI-NEXT:    ld1 { v20.s }[1], [x9]
+; CHECK-GI-NEXT:    mov v1.s[2], v6.s[0]
 ; CHECK-GI-NEXT:    ldr s3, [sp, #8]
 ; CHECK-GI-NEXT:    ldr s0, [sp, #24]
-; CHECK-GI-NEXT:    mov v16.s[2], w2
+; CHECK-GI-NEXT:    mov v17.s[2], w2
 ; CHECK-GI-NEXT:    mov v4.s[1], w5
 ; CHECK-GI-NEXT:    ldr s2, [sp, #32]
-; CHECK-GI-NEXT:    zip1 v5.2d, v5.2d, v6.2d
-; CHECK-GI-NEXT:    movi v6.4s, #31
+; CHECK-GI-NEXT:    zip1 v6.2d, v7.2d, v16.2d
+; CHECK-GI-NEXT:    movi v7.4s, #31
 ; CHECK-GI-NEXT:    add x8, sp, #96
-; CHECK-GI-NEXT:    mov v17.s[2], v21.s[0]
-; CHECK-GI-NEXT:    movi v7.2d, #0xffffffffffffffff
-; CHECK-GI-NEXT:    ldr s19, [sp, #72]
+; CHECK-GI-NEXT:    mov v18.s[2], v21.s[0]
+; CHECK-GI-NEXT:    movi v16.2d, #0xffffffffffffffff
+; CHECK-GI-NEXT:    ldr s5, [sp, #72]
 ; CHECK-GI-NEXT:    ld1 { v20.s }[2], [x8]
-; CHECK-GI-NEXT:    mov v18.s[2], v3.s[0]
+; CHECK-GI-NEXT:    mov v19.s[2], v3.s[0]
 ; CHECK-GI-NEXT:    mov v0.s[1], v2.s[0]
-; CHECK-GI-NEXT:    mov v1.s[3], v19.s[0]
-; CHECK-GI-NEXT:    mov v16.s[3], w3
+; CHECK-GI-NEXT:    mov v1.s[3], v5.s[0]
+; CHECK-GI-NEXT:    mov v17.s[3], w3
 ; CHECK-GI-NEXT:    mov v4.s[2], w6
 ; CHECK-GI-NEXT:    ldr s2, [sp, #16]
-; CHECK-GI-NEXT:    and v3.16b, v5.16b, v6.16b
+; CHECK-GI-NEXT:    and v3.16b, v6.16b, v7.16b
 ; CHECK-GI-NEXT:    ldr s5, [sp, #40]
-; CHECK-GI-NEXT:    and v19.16b, v20.16b, v6.16b
-; CHECK-GI-NEXT:    eor v7.16b, v17.16b, v7.16b
-; CHECK-GI-NEXT:    mov v18.s[3], v2.s[0]
+; CHECK-GI-NEXT:    and v6.16b, v20.16b, v7.16b
+; CHECK-GI-NEXT:    eor v16.16b, v18.16b, v16.16b
+; CHECK-GI-NEXT:    mov v19.s[3], v2.s[0]
 ; CHECK-GI-NEXT:    mov v0.s[2], v5.s[0]
-; CHECK-GI-NEXT:    bic v1.16b, v6.16b, v1.16b
-; CHECK-GI-NEXT:    shl v2.4s, v16.4s, #1
+; CHECK-GI-NEXT:    bic v1.16b, v7.16b, v1.16b
+; CHECK-GI-NEXT:    shl v2.4s, v17.4s, #1
 ; CHECK-GI-NEXT:    neg v3.4s, v3.4s
-; CHECK-GI-NEXT:    and v5.16b, v7.16b, v6.16b
+; CHECK-GI-NEXT:    and v5.16b, v16.16b, v7.16b
 ; CHECK-GI-NEXT:    shl v4.4s, v4.4s, #1
-; CHECK-GI-NEXT:    neg v6.4s, v19.4s
+; CHECK-GI-NEXT:    neg v6.4s, v6.4s
 ; CHECK-GI-NEXT:    ushl v1.4s, v2.4s, v1.4s
-; CHECK-GI-NEXT:    ushl v2.4s, v18.4s, v3.4s
+; CHECK-GI-NEXT:    ushl v2.4s, v19.4s, v3.4s
 ; CHECK-GI-NEXT:    ushl v3.4s, v4.4s, v5.4s
 ; CHECK-GI-NEXT:    ushl v0.4s, v0.4s, v6.4s
 ; CHECK-GI-NEXT:    orr v1.16b, v1.16b, v2.16b

--- a/llvm/test/CodeGen/AArch64/llvm.frexp.ll
+++ b/llvm/test/CodeGen/AArch64/llvm.frexp.ll
@@ -697,17 +697,17 @@ define { <4 x float>, <4 x i32> } @test_frexp_v4f32_v4i32(<4 x float> %a) nounwi
 ; CHECK-NEXT:    mov s0, v0.s[3]
 ; CHECK-NEXT:    str q1, [sp] // 16-byte Spill
 ; CHECK-NEXT:    bl frexpf
+; CHECK-NEXT:    ldr q3, [sp] // 16-byte Reload
 ; CHECK-NEXT:    ldr s1, [sp, #44]
-; CHECK-NEXT:    ldr q2, [sp] // 16-byte Reload
 ; CHECK-NEXT:    // kill: def $s0 killed $s0 def $q0
-; CHECK-NEXT:    mov v2.s[3], v0.s[0]
+; CHECK-NEXT:    ldr s2, [x20]
+; CHECK-NEXT:    mov v3.s[3], v0.s[0]
 ; CHECK-NEXT:    ld1 { v1.s }[1], [x19]
-; CHECK-NEXT:    ldr s0, [x20]
-; CHECK-NEXT:    ld1 { v0.s }[1], [x21]
+; CHECK-NEXT:    ld1 { v2.s }[1], [x21]
 ; CHECK-NEXT:    ldp x20, x19, [sp, #64] // 16-byte Folded Reload
 ; CHECK-NEXT:    ldp x30, x21, [sp, #48] // 16-byte Folded Reload
-; CHECK-NEXT:    zip1 v1.2d, v1.2d, v0.2d
-; CHECK-NEXT:    mov v0.16b, v2.16b
+; CHECK-NEXT:    zip1 v1.2d, v1.2d, v2.2d
+; CHECK-NEXT:    mov v0.16b, v3.16b
 ; CHECK-NEXT:    add sp, sp, #80
 ; CHECK-NEXT:    ret
 ;
@@ -872,8 +872,8 @@ define <4 x i32> @test_frexp_v4f32_v4i32_only_use_exp(<4 x float> %a) nounwind {
 ; CHECK-NEXT:    mov s0, v0.s[3]
 ; CHECK-NEXT:    bl frexpf
 ; CHECK-NEXT:    ldr s0, [sp, #28]
-; CHECK-NEXT:    ld1 { v0.s }[1], [x19]
 ; CHECK-NEXT:    ldr s1, [x20]
+; CHECK-NEXT:    ld1 { v0.s }[1], [x19]
 ; CHECK-NEXT:    ld1 { v1.s }[1], [x21]
 ; CHECK-NEXT:    ldp x20, x19, [sp, #48] // 16-byte Folded Reload
 ; CHECK-NEXT:    ldp x30, x21, [sp, #32] // 16-byte Folded Reload

--- a/llvm/test/CodeGen/AArch64/neon-dotreduce.ll
+++ b/llvm/test/CodeGen/AArch64/neon-dotreduce.ll
@@ -8048,200 +8048,200 @@ define i32 @test_sdot_v48i8_double_nomla(<48 x i8> %a, <48 x i8> %b, <48 x i8> %
 ; CHECK-SD-NEXT:    str x29, [sp, #-16]! // 8-byte Folded Spill
 ; CHECK-SD-NEXT:    .cfi_def_cfa_offset 16
 ; CHECK-SD-NEXT:    .cfi_offset w29, -16
-; CHECK-SD-NEXT:    ldr b0, [sp, #208]
+; CHECK-SD-NEXT:    add x8, sp, #272
+; CHECK-SD-NEXT:    ldr b4, [sp, #208]
+; CHECK-SD-NEXT:    fmov s0, w0
+; CHECK-SD-NEXT:    ldr b5, [x8]
 ; CHECK-SD-NEXT:    add x8, sp, #216
-; CHECK-SD-NEXT:    add x9, sp, #272
-; CHECK-SD-NEXT:    ldr b2, [sp, #80]
-; CHECK-SD-NEXT:    ldr b4, [sp, #976]
-; CHECK-SD-NEXT:    ldr b6, [sp, #720]
-; CHECK-SD-NEXT:    ld1 { v0.b }[1], [x8]
+; CHECK-SD-NEXT:    add x9, sp, #280
+; CHECK-SD-NEXT:    ld1 { v4.b }[1], [x8]
 ; CHECK-SD-NEXT:    add x8, sp, #224
-; CHECK-SD-NEXT:    fmov s16, w0
-; CHECK-SD-NEXT:    ldr b17, [sp, #848]
-; CHECK-SD-NEXT:    add x10, sp, #24
-; CHECK-SD-NEXT:    movi v19.2d, #0000000000000000
-; CHECK-SD-NEXT:    ld1 { v0.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #232
-; CHECK-SD-NEXT:    mov v16.b[1], w1
-; CHECK-SD-NEXT:    ld1 { v0.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #240
-; CHECK-SD-NEXT:    mov v16.b[2], w2
-; CHECK-SD-NEXT:    ld1 { v0.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #248
-; CHECK-SD-NEXT:    mov v16.b[3], w3
-; CHECK-SD-NEXT:    ld1 { v0.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #256
-; CHECK-SD-NEXT:    ld1 { v0.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #264
-; CHECK-SD-NEXT:    mov v16.b[4], w4
-; CHECK-SD-NEXT:    ld1 { v0.b }[7], [x8]
-; CHECK-SD-NEXT:    ldr b1, [x9]
-; CHECK-SD-NEXT:    add x8, sp, #280
-; CHECK-SD-NEXT:    add x9, sp, #88
-; CHECK-SD-NEXT:    mov v16.b[5], w5
-; CHECK-SD-NEXT:    ld1 { v1.b }[1], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #288
-; CHECK-SD-NEXT:    ld1 { v1.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #296
-; CHECK-SD-NEXT:    mov v16.b[6], w6
-; CHECK-SD-NEXT:    ld1 { v1.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #304
-; CHECK-SD-NEXT:    mov v16.b[7], w7
-; CHECK-SD-NEXT:    ld1 { v1.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #312
-; CHECK-SD-NEXT:    ld1 { v1.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #320
-; CHECK-SD-NEXT:    ld1 { v1.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #328
-; CHECK-SD-NEXT:    ld1 { v1.b }[7], [x8]
-; CHECK-SD-NEXT:    ld1 { v2.b }[1], [x9]
-; CHECK-SD-NEXT:    add x8, sp, #96
-; CHECK-SD-NEXT:    add x9, sp, #144
-; CHECK-SD-NEXT:    ld1 { v2.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #104
-; CHECK-SD-NEXT:    zip1 v0.2d, v0.2d, v1.2d
-; CHECK-SD-NEXT:    movi v1.16b, #1
-; CHECK-SD-NEXT:    ld1 { v2.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #112
-; CHECK-SD-NEXT:    ld1 { v2.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #120
-; CHECK-SD-NEXT:    ld1 { v2.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #128
-; CHECK-SD-NEXT:    ld1 { v2.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #136
-; CHECK-SD-NEXT:    ld1 { v2.b }[7], [x8]
-; CHECK-SD-NEXT:    ldr b3, [x9]
-; CHECK-SD-NEXT:    add x8, sp, #152
-; CHECK-SD-NEXT:    add x9, sp, #984
-; CHECK-SD-NEXT:    ld1 { v3.b }[1], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #160
-; CHECK-SD-NEXT:    ld1 { v3.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #168
-; CHECK-SD-NEXT:    ld1 { v3.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #176
-; CHECK-SD-NEXT:    ld1 { v3.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #184
-; CHECK-SD-NEXT:    ld1 { v3.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #192
-; CHECK-SD-NEXT:    ld1 { v3.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #200
-; CHECK-SD-NEXT:    ld1 { v3.b }[7], [x8]
-; CHECK-SD-NEXT:    ld1 { v4.b }[1], [x9]
-; CHECK-SD-NEXT:    add x8, sp, #992
-; CHECK-SD-NEXT:    add x9, sp, #1040
+; CHECK-SD-NEXT:    add x12, sp, #256
+; CHECK-SD-NEXT:    mov v0.b[1], w1
+; CHECK-SD-NEXT:    ld1 { v5.b }[1], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #288
+; CHECK-SD-NEXT:    ldr b6, [sp, #976]
+; CHECK-SD-NEXT:    add x13, sp, #984
+; CHECK-SD-NEXT:    add x10, sp, #264
 ; CHECK-SD-NEXT:    ld1 { v4.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1000
-; CHECK-SD-NEXT:    zip1 v2.2d, v2.2d, v3.2d
+; CHECK-SD-NEXT:    add x8, sp, #232
+; CHECK-SD-NEXT:    ldr b7, [sp, #720]
+; CHECK-SD-NEXT:    ld1 { v5.b }[2], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #296
+; CHECK-SD-NEXT:    ld1 { v6.b }[1], [x13]
+; CHECK-SD-NEXT:    mov v0.b[2], w2
+; CHECK-SD-NEXT:    add x13, sp, #784
+; CHECK-SD-NEXT:    add x11, sp, #328
 ; CHECK-SD-NEXT:    ld1 { v4.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1008
+; CHECK-SD-NEXT:    add x8, sp, #240
+; CHECK-SD-NEXT:    ldr b17, [x13]
+; CHECK-SD-NEXT:    ld1 { v5.b }[3], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #304
+; CHECK-SD-NEXT:    add x13, sp, #1064
+; CHECK-SD-NEXT:    add x14, sp, #1080
+; CHECK-SD-NEXT:    movi v1.16b, #1
+; CHECK-SD-NEXT:    movi v2.2d, #0000000000000000
 ; CHECK-SD-NEXT:    ld1 { v4.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1016
+; CHECK-SD-NEXT:    add x8, sp, #248
+; CHECK-SD-NEXT:    mov v0.b[3], w3
+; CHECK-SD-NEXT:    ld1 { v5.b }[4], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #312
+; CHECK-SD-NEXT:    movi v3.2d, #0000000000000000
 ; CHECK-SD-NEXT:    ld1 { v4.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1024
-; CHECK-SD-NEXT:    ld1 { v4.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1032
-; CHECK-SD-NEXT:    ld1 { v4.b }[7], [x8]
-; CHECK-SD-NEXT:    ldr b5, [x9]
-; CHECK-SD-NEXT:    add x8, sp, #1048
-; CHECK-SD-NEXT:    add x9, sp, #728
-; CHECK-SD-NEXT:    ld1 { v5.b }[1], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1056
-; CHECK-SD-NEXT:    ld1 { v5.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1064
-; CHECK-SD-NEXT:    ld1 { v5.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1072
-; CHECK-SD-NEXT:    ld1 { v5.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1080
-; CHECK-SD-NEXT:    ld1 { v5.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1088
-; CHECK-SD-NEXT:    ld1 { v5.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #1096
-; CHECK-SD-NEXT:    ld1 { v5.b }[7], [x8]
-; CHECK-SD-NEXT:    ld1 { v6.b }[1], [x9]
-; CHECK-SD-NEXT:    add x8, sp, #736
-; CHECK-SD-NEXT:    add x9, sp, #784
-; CHECK-SD-NEXT:    ld1 { v6.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #744
-; CHECK-SD-NEXT:    zip1 v4.2d, v4.2d, v5.2d
-; CHECK-SD-NEXT:    movi v5.2d, #0000000000000000
-; CHECK-SD-NEXT:    ld1 { v6.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #752
-; CHECK-SD-NEXT:    sdot v19.4s, v4.16b, v1.16b
-; CHECK-SD-NEXT:    sdot v5.4s, v0.16b, v1.16b
-; CHECK-SD-NEXT:    ld1 { v6.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #760
-; CHECK-SD-NEXT:    ld1 { v6.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #768
-; CHECK-SD-NEXT:    ld1 { v6.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #776
-; CHECK-SD-NEXT:    ld1 { v6.b }[7], [x8]
-; CHECK-SD-NEXT:    ldr b7, [x9]
-; CHECK-SD-NEXT:    add x8, sp, #792
-; CHECK-SD-NEXT:    add x9, sp, #856
-; CHECK-SD-NEXT:    ld1 { v7.b }[1], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #800
-; CHECK-SD-NEXT:    ld1 { v7.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #808
-; CHECK-SD-NEXT:    ld1 { v7.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #816
-; CHECK-SD-NEXT:    ld1 { v7.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #824
-; CHECK-SD-NEXT:    ld1 { v7.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #832
-; CHECK-SD-NEXT:    ld1 { v7.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #840
-; CHECK-SD-NEXT:    ld1 { v7.b }[7], [x8]
-; CHECK-SD-NEXT:    ld1 { v17.b }[1], [x9]
-; CHECK-SD-NEXT:    add x8, sp, #864
+; CHECK-SD-NEXT:    add x8, sp, #320
+; CHECK-SD-NEXT:    mov v0.b[4], w4
+; CHECK-SD-NEXT:    ld1 { v5.b }[5], [x9]
 ; CHECK-SD-NEXT:    add x9, sp, #16
-; CHECK-SD-NEXT:    ld1 { v16.b }[8], [x9]
-; CHECK-SD-NEXT:    add x9, sp, #912
-; CHECK-SD-NEXT:    ld1 { v17.b }[2], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #872
-; CHECK-SD-NEXT:    zip1 v0.2d, v6.2d, v7.2d
-; CHECK-SD-NEXT:    ld1 { v16.b }[9], [x10]
-; CHECK-SD-NEXT:    ld1 { v17.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #880
-; CHECK-SD-NEXT:    sdot v19.4s, v0.16b, v1.16b
-; CHECK-SD-NEXT:    ld1 { v17.b }[4], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #888
-; CHECK-SD-NEXT:    ld1 { v17.b }[5], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #896
-; CHECK-SD-NEXT:    ld1 { v17.b }[6], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #904
-; CHECK-SD-NEXT:    ld1 { v17.b }[7], [x8]
-; CHECK-SD-NEXT:    ldr b18, [x9]
-; CHECK-SD-NEXT:    add x8, sp, #920
-; CHECK-SD-NEXT:    ld1 { v18.b }[1], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #32
-; CHECK-SD-NEXT:    ld1 { v16.b }[10], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #928
-; CHECK-SD-NEXT:    ld1 { v18.b }[2], [x8]
+; CHECK-SD-NEXT:    ld1 { v4.b }[6], [x12]
+; CHECK-SD-NEXT:    add x12, sp, #1040
+; CHECK-SD-NEXT:    ldr b16, [x12]
+; CHECK-SD-NEXT:    add x12, sp, #1048
+; CHECK-SD-NEXT:    ld1 { v5.b }[6], [x8]
+; CHECK-SD-NEXT:    mov v0.b[5], w5
+; CHECK-SD-NEXT:    add x8, sp, #24
+; CHECK-SD-NEXT:    ld1 { v16.b }[1], [x12]
+; CHECK-SD-NEXT:    ld1 { v4.b }[7], [x10]
+; CHECK-SD-NEXT:    add x10, sp, #992
+; CHECK-SD-NEXT:    add x12, sp, #1056
+; CHECK-SD-NEXT:    ld1 { v6.b }[2], [x10]
+; CHECK-SD-NEXT:    add x10, sp, #728
+; CHECK-SD-NEXT:    ld1 { v7.b }[1], [x10]
+; CHECK-SD-NEXT:    ld1 { v5.b }[7], [x11]
+; CHECK-SD-NEXT:    add x11, sp, #1000
+; CHECK-SD-NEXT:    ld1 { v16.b }[2], [x12]
+; CHECK-SD-NEXT:    add x12, sp, #792
+; CHECK-SD-NEXT:    mov v0.b[6], w6
+; CHECK-SD-NEXT:    ld1 { v17.b }[1], [x12]
+; CHECK-SD-NEXT:    ld1 { v6.b }[3], [x11]
+; CHECK-SD-NEXT:    add x12, sp, #736
+; CHECK-SD-NEXT:    ld1 { v7.b }[2], [x12]
+; CHECK-SD-NEXT:    add x10, sp, #1008
+; CHECK-SD-NEXT:    add x11, sp, #1072
+; CHECK-SD-NEXT:    ld1 { v16.b }[3], [x13]
+; CHECK-SD-NEXT:    add x13, sp, #800
+; CHECK-SD-NEXT:    zip1 v5.2d, v4.2d, v5.2d
+; CHECK-SD-NEXT:    ld1 { v17.b }[2], [x13]
+; CHECK-SD-NEXT:    ld1 { v6.b }[4], [x10]
+; CHECK-SD-NEXT:    add x13, sp, #808
+; CHECK-SD-NEXT:    mov v0.b[7], w7
+; CHECK-SD-NEXT:    add x10, sp, #1016
+; CHECK-SD-NEXT:    add x12, sp, #32
+; CHECK-SD-NEXT:    ld1 { v16.b }[4], [x11]
+; CHECK-SD-NEXT:    add x11, sp, #744
+; CHECK-SD-NEXT:    ldr b4, [sp, #80]
+; CHECK-SD-NEXT:    ld1 { v7.b }[3], [x11]
+; CHECK-SD-NEXT:    ld1 { v17.b }[3], [x13]
+; CHECK-SD-NEXT:    ld1 { v6.b }[5], [x10]
+; CHECK-SD-NEXT:    add x10, sp, #752
+; CHECK-SD-NEXT:    add x11, sp, #816
+; CHECK-SD-NEXT:    add x13, sp, #1088
+; CHECK-SD-NEXT:    ld1 { v16.b }[5], [x14]
+; CHECK-SD-NEXT:    ld1 { v0.b }[8], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #1024
+; CHECK-SD-NEXT:    ld1 { v7.b }[4], [x10]
+; CHECK-SD-NEXT:    ld1 { v17.b }[4], [x11]
+; CHECK-SD-NEXT:    ld1 { v6.b }[6], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #760
+; CHECK-SD-NEXT:    add x10, sp, #824
+; CHECK-SD-NEXT:    add x11, sp, #1096
+; CHECK-SD-NEXT:    ld1 { v16.b }[6], [x13]
+; CHECK-SD-NEXT:    ld1 { v0.b }[9], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #1032
+; CHECK-SD-NEXT:    ld1 { v7.b }[5], [x9]
+; CHECK-SD-NEXT:    ld1 { v17.b }[5], [x10]
+; CHECK-SD-NEXT:    ld1 { v6.b }[7], [x8]
+; CHECK-SD-NEXT:    add x9, sp, #768
+; CHECK-SD-NEXT:    add x10, sp, #832
 ; CHECK-SD-NEXT:    add x8, sp, #40
-; CHECK-SD-NEXT:    ld1 { v16.b }[11], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #936
-; CHECK-SD-NEXT:    ld1 { v18.b }[3], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #48
-; CHECK-SD-NEXT:    ld1 { v16.b }[12], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #944
-; CHECK-SD-NEXT:    ld1 { v18.b }[4], [x8]
+; CHECK-SD-NEXT:    ld1 { v16.b }[7], [x11]
+; CHECK-SD-NEXT:    ld1 { v0.b }[10], [x12]
+; CHECK-SD-NEXT:    add x12, sp, #144
+; CHECK-SD-NEXT:    ld1 { v7.b }[6], [x9]
+; CHECK-SD-NEXT:    ld1 { v17.b }[6], [x10]
+; CHECK-SD-NEXT:    add x9, sp, #776
+; CHECK-SD-NEXT:    add x10, sp, #840
+; CHECK-SD-NEXT:    sdot v3.4s, v5.16b, v1.16b
+; CHECK-SD-NEXT:    ldr b5, [x12]
+; CHECK-SD-NEXT:    zip1 v6.2d, v6.2d, v16.2d
+; CHECK-SD-NEXT:    ld1 { v0.b }[11], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #88
+; CHECK-SD-NEXT:    ld1 { v7.b }[7], [x9]
+; CHECK-SD-NEXT:    ld1 { v17.b }[7], [x10]
+; CHECK-SD-NEXT:    add x10, sp, #912
+; CHECK-SD-NEXT:    ldr b16, [x10]
+; CHECK-SD-NEXT:    add x9, sp, #152
+; CHECK-SD-NEXT:    ld1 { v4.b }[1], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #856
+; CHECK-SD-NEXT:    add x10, sp, #920
+; CHECK-SD-NEXT:    add x11, sp, #48
+; CHECK-SD-NEXT:    sdot v2.4s, v6.16b, v1.16b
+; CHECK-SD-NEXT:    zip1 v6.2d, v7.2d, v17.2d
+; CHECK-SD-NEXT:    ldr b7, [sp, #848]
+; CHECK-SD-NEXT:    ld1 { v5.b }[1], [x9]
+; CHECK-SD-NEXT:    ld1 { v16.b }[1], [x10]
+; CHECK-SD-NEXT:    ld1 { v0.b }[12], [x11]
+; CHECK-SD-NEXT:    ld1 { v7.b }[1], [x8]
+; CHECK-SD-NEXT:    add x9, sp, #96
+; CHECK-SD-NEXT:    add x10, sp, #160
+; CHECK-SD-NEXT:    ld1 { v4.b }[2], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #864
+; CHECK-SD-NEXT:    add x11, sp, #928
 ; CHECK-SD-NEXT:    add x8, sp, #56
-; CHECK-SD-NEXT:    ld1 { v16.b }[13], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #952
-; CHECK-SD-NEXT:    ld1 { v18.b }[5], [x8]
+; CHECK-SD-NEXT:    ld1 { v5.b }[2], [x10]
+; CHECK-SD-NEXT:    ld1 { v16.b }[2], [x11]
+; CHECK-SD-NEXT:    ld1 { v7.b }[2], [x9]
+; CHECK-SD-NEXT:    ld1 { v0.b }[13], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #104
+; CHECK-SD-NEXT:    add x9, sp, #168
+; CHECK-SD-NEXT:    ld1 { v4.b }[3], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #872
+; CHECK-SD-NEXT:    add x10, sp, #936
+; CHECK-SD-NEXT:    ld1 { v5.b }[3], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #112
+; CHECK-SD-NEXT:    ld1 { v7.b }[3], [x8]
+; CHECK-SD-NEXT:    ld1 { v16.b }[3], [x10]
+; CHECK-SD-NEXT:    add x10, sp, #176
+; CHECK-SD-NEXT:    ld1 { v4.b }[4], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #880
+; CHECK-SD-NEXT:    add x11, sp, #944
 ; CHECK-SD-NEXT:    add x8, sp, #64
-; CHECK-SD-NEXT:    ld1 { v16.b }[14], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #960
-; CHECK-SD-NEXT:    ld1 { v18.b }[6], [x8]
+; CHECK-SD-NEXT:    ld1 { v5.b }[4], [x10]
+; CHECK-SD-NEXT:    add x10, sp, #952
+; CHECK-SD-NEXT:    ld1 { v7.b }[4], [x9]
+; CHECK-SD-NEXT:    ld1 { v16.b }[4], [x11]
+; CHECK-SD-NEXT:    ld1 { v0.b }[14], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #120
+; CHECK-SD-NEXT:    add x9, sp, #184
+; CHECK-SD-NEXT:    add x11, sp, #960
+; CHECK-SD-NEXT:    ld1 { v4.b }[5], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #888
+; CHECK-SD-NEXT:    ld1 { v5.b }[5], [x9]
+; CHECK-SD-NEXT:    ld1 { v7.b }[5], [x8]
+; CHECK-SD-NEXT:    ld1 { v16.b }[5], [x10]
+; CHECK-SD-NEXT:    add x9, sp, #128
+; CHECK-SD-NEXT:    add x10, sp, #192
 ; CHECK-SD-NEXT:    add x8, sp, #72
-; CHECK-SD-NEXT:    ld1 { v16.b }[15], [x8]
-; CHECK-SD-NEXT:    add x8, sp, #968
-; CHECK-SD-NEXT:    ld1 { v18.b }[7], [x8]
-; CHECK-SD-NEXT:    sdot v5.4s, v16.16b, v1.16b
-; CHECK-SD-NEXT:    zip1 v0.2d, v17.2d, v18.2d
-; CHECK-SD-NEXT:    sdot v5.4s, v2.16b, v1.16b
-; CHECK-SD-NEXT:    sdot v19.4s, v0.16b, v1.16b
-; CHECK-SD-NEXT:    add v0.4s, v5.4s, v19.4s
+; CHECK-SD-NEXT:    sdot v2.4s, v6.16b, v1.16b
+; CHECK-SD-NEXT:    ld1 { v4.b }[6], [x9]
+; CHECK-SD-NEXT:    add x9, sp, #896
+; CHECK-SD-NEXT:    ld1 { v5.b }[6], [x10]
+; CHECK-SD-NEXT:    ld1 { v7.b }[6], [x9]
+; CHECK-SD-NEXT:    ld1 { v16.b }[6], [x11]
+; CHECK-SD-NEXT:    ld1 { v0.b }[15], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #136
+; CHECK-SD-NEXT:    add x9, sp, #200
+; CHECK-SD-NEXT:    add x10, sp, #968
+; CHECK-SD-NEXT:    ld1 { v4.b }[7], [x8]
+; CHECK-SD-NEXT:    add x8, sp, #904
+; CHECK-SD-NEXT:    ld1 { v5.b }[7], [x9]
+; CHECK-SD-NEXT:    ld1 { v7.b }[7], [x8]
+; CHECK-SD-NEXT:    ld1 { v16.b }[7], [x10]
+; CHECK-SD-NEXT:    sdot v3.4s, v0.16b, v1.16b
+; CHECK-SD-NEXT:    zip1 v0.2d, v4.2d, v5.2d
+; CHECK-SD-NEXT:    zip1 v4.2d, v7.2d, v16.2d
+; CHECK-SD-NEXT:    sdot v3.4s, v0.16b, v1.16b
+; CHECK-SD-NEXT:    sdot v2.4s, v4.16b, v1.16b
+; CHECK-SD-NEXT:    add v0.4s, v3.4s, v2.4s
 ; CHECK-SD-NEXT:    addv s0, v0.4s
 ; CHECK-SD-NEXT:    fmov w0, s0
 ; CHECK-SD-NEXT:    ldr x29, [sp], #16 // 8-byte Folded Reload

--- a/llvm/test/CodeGen/AArch64/nontemporal-store.ll
+++ b/llvm/test/CodeGen/AArch64/nontemporal-store.ll
@@ -683,43 +683,43 @@ define void @test_stnp_v17f32(<17 x float> %v, ptr %ptr) {
 ;
 ; CHECK-BE-LABEL: test_stnp_v17f32:
 ; CHECK-BE:       // %bb.0: // %entry
-; CHECK-BE-NEXT:    // kill: def $s1 killed $s1 def $q1
-; CHECK-BE-NEXT:    // kill: def $s0 killed $s0 def $q0
 ; CHECK-BE-NEXT:    // kill: def $s4 killed $s4 def $q4
+; CHECK-BE-NEXT:    // kill: def $s0 killed $s0 def $q0
 ; CHECK-BE-NEXT:    // kill: def $s5 killed $s5 def $q5
-; CHECK-BE-NEXT:    add x8, sp, #12
-; CHECK-BE-NEXT:    add x9, sp, #20
-; CHECK-BE-NEXT:    ldr s16, [sp, #36]
-; CHECK-BE-NEXT:    mov v0.s[1], v1.s[0]
-; CHECK-BE-NEXT:    ldr s1, [sp, #4]
-; CHECK-BE-NEXT:    mov v4.s[1], v5.s[0]
-; CHECK-BE-NEXT:    add x10, sp, #52
+; CHECK-BE-NEXT:    // kill: def $s1 killed $s1 def $q1
+; CHECK-BE-NEXT:    add x9, sp, #52
+; CHECK-BE-NEXT:    add x10, sp, #20
 ; CHECK-BE-NEXT:    // kill: def $s6 killed $s6 def $q6
 ; CHECK-BE-NEXT:    // kill: def $s2 killed $s2 def $q2
+; CHECK-BE-NEXT:    add x8, sp, #12
+; CHECK-BE-NEXT:    mov v0.s[1], v1.s[0]
+; CHECK-BE-NEXT:    mov v4.s[1], v5.s[0]
+; CHECK-BE-NEXT:    ldr s5, [sp, #36]
+; CHECK-BE-NEXT:    ldr s16, [x9]
+; CHECK-BE-NEXT:    ldr s1, [sp, #4]
+; CHECK-BE-NEXT:    ldr s17, [x10]
+; CHECK-BE-NEXT:    add x9, sp, #44
+; CHECK-BE-NEXT:    add x10, sp, #60
 ; CHECK-BE-NEXT:    // kill: def $s7 killed $s7 def $q7
 ; CHECK-BE-NEXT:    // kill: def $s3 killed $s3 def $q3
-; CHECK-BE-NEXT:    ld1 { v1.s }[1], [x8]
-; CHECK-BE-NEXT:    ldr s5, [x9]
-; CHECK-BE-NEXT:    add x8, sp, #28
-; CHECK-BE-NEXT:    add x9, sp, #44
-; CHECK-BE-NEXT:    ld1 { v5.s }[1], [x8]
-; CHECK-BE-NEXT:    ld1 { v16.s }[1], [x9]
-; CHECK-BE-NEXT:    ldr s17, [x10]
-; CHECK-BE-NEXT:    add x8, sp, #60
+; CHECK-BE-NEXT:    ld1 { v5.s }[1], [x9]
+; CHECK-BE-NEXT:    add x9, sp, #28
+; CHECK-BE-NEXT:    ld1 { v16.s }[1], [x10]
 ; CHECK-BE-NEXT:    mov v4.s[2], v6.s[0]
 ; CHECK-BE-NEXT:    mov v0.s[2], v2.s[0]
-; CHECK-BE-NEXT:    ld1 { v17.s }[1], [x8]
-; CHECK-BE-NEXT:    ldr s2, [sp, #68]
-; CHECK-BE-NEXT:    add x8, x0, #32
-; CHECK-BE-NEXT:    zip1 v1.2d, v1.2d, v5.2d
-; CHECK-BE-NEXT:    add x9, x0, #48
-; CHECK-BE-NEXT:    str s2, [x0, #64]
-; CHECK-BE-NEXT:    zip1 v5.2d, v16.2d, v17.2d
+; CHECK-BE-NEXT:    ld1 { v1.s }[1], [x8]
+; CHECK-BE-NEXT:    ld1 { v17.s }[1], [x9]
+; CHECK-BE-NEXT:    add x8, x0, #48
+; CHECK-BE-NEXT:    add x9, x0, #32
+; CHECK-BE-NEXT:    zip1 v2.2d, v5.2d, v16.2d
+; CHECK-BE-NEXT:    ldr s5, [sp, #68]
+; CHECK-BE-NEXT:    zip1 v1.2d, v1.2d, v17.2d
 ; CHECK-BE-NEXT:    mov v4.s[3], v7.s[0]
 ; CHECK-BE-NEXT:    mov v0.s[3], v3.s[0]
-; CHECK-BE-NEXT:    st1 { v1.4s }, [x8]
+; CHECK-BE-NEXT:    str s5, [x0, #64]
+; CHECK-BE-NEXT:    st1 { v2.4s }, [x8]
 ; CHECK-BE-NEXT:    add x8, x0, #16
-; CHECK-BE-NEXT:    st1 { v5.4s }, [x9]
+; CHECK-BE-NEXT:    st1 { v1.4s }, [x9]
 ; CHECK-BE-NEXT:    st1 { v4.4s }, [x8]
 ; CHECK-BE-NEXT:    st1 { v0.4s }, [x0]
 ; CHECK-BE-NEXT:    ret


### PR DESCRIPTION
We were losing the MMO when converting the load. Make sure we copy them over, which apparently alters codegen more than I expected and helps keep postinc generation after #196305.