### PR TITLE
[clang] make evaluation of type constraint a SFINAE context

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -587,6 +587,8 @@ Bug Fixes to C++ Support
 - Fixed a crash when diagnosing an invalid static member function with an explicit object parameter (#GH177741)
 - Clang incorrectly instantiated variable specializations outside of the immediate context. (#GH54439)
 - Fixed a crash when pack expansions are used as arguments for non-pack parameters of built-in templates. (#GH180307)
+- Fix a problem where a substitution failure when evaluating a type requirement
+  could directly make the program ill-formed.
 - Fix a problem where pack index expressions where incorrectly being regarded as equivalent.
 - Fixed a bug where captured variables in non-mutable lambdas were incorrectly treated as mutable
   when used inside decltype in the return type. (#GH180460)

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -7995,6 +7995,8 @@ Sema::BuildExprRequirement(
     assert(TC && "Type Constraint cannot be null here");
     auto *IDC = TC->getImmediatelyDeclaredConstraint();
     assert(IDC && "ImmediatelyDeclaredConstraint can't be null here.");
+
+    SFINAETrap Trap(*this);
     ExprResult Constraint = SubstExpr(IDC, MLTAL);
     bool HasError = Constraint.isInvalid();
     if (!HasError) {
@@ -8004,6 +8006,8 @@ Sema::BuildExprRequirement(
         HasError = true;
     }
     if (HasError) {
+      // FIXME: Capture diagnostics from the SFINAE trap and store them in the
+      // requirement.
       return new (Context) concepts::ExprRequirement(
           createSubstDiagAt(IDC->getExprLoc(),
                             [&](llvm::raw_ostream &OS) {

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1329,7 +1329,12 @@ namespace {
                          SourceLocation Loc, DeclarationName Entity,
                          bool BailOutOnIncomplete = false)
         : inherited(SemaRef), TemplateArgs(TemplateArgs), Loc(Loc),
-          Entity(Entity), BailOutOnIncomplete(BailOutOnIncomplete) {}
+          Entity(Entity), BailOutOnIncomplete(BailOutOnIncomplete) {
+      assert((!SemaRef.CodeSynthesisContexts.empty() ||
+              SemaRef.isSFINAEContext()) &&
+             "Cannot perform an instantiation without some context on the "
+             "instantiation stack");
+    }
 
     void setEvaluateConstraints(bool B) {
       EvaluateConstraints = B;
@@ -2844,13 +2849,8 @@ TemplateInstantiator::TransformNestedRequirement(
 
 TypeSourceInfo *Sema::SubstType(TypeSourceInfo *T,
                                 const MultiLevelTemplateArgumentList &Args,
-                                SourceLocation Loc,
-                                DeclarationName Entity,
+                                SourceLocation Loc, DeclarationName Entity,
                                 bool AllowDeducedTST) {
-  assert((!CodeSynthesisContexts.empty() || isSFINAEContext()) &&
-         "Cannot perform an instantiation without some context on the "
-         "instantiation stack");
-
   if (!T->getType()->isInstantiationDependentType() &&
       !T->getType()->isVariablyModifiedType())
     return T;
@@ -2862,12 +2862,7 @@ TypeSourceInfo *Sema::SubstType(TypeSourceInfo *T,
 
 TypeSourceInfo *Sema::SubstType(TypeLoc TL,
                                 const MultiLevelTemplateArgumentList &Args,
-                                SourceLocation Loc,
-                                DeclarationName Entity) {
-  assert((!CodeSynthesisContexts.empty() || isSFINAEContext()) &&
-         "Cannot perform an instantiation without some context on the "
-         "instantiation stack");
-
+                                SourceLocation Loc, DeclarationName Entity) {
   if (TL.getType().isNull())
     return nullptr;
 
@@ -2895,10 +2890,6 @@ QualType Sema::SubstType(QualType T,
                          const MultiLevelTemplateArgumentList &TemplateArgs,
                          SourceLocation Loc, DeclarationName Entity,
                          bool *IsIncompleteSubstitution) {
-  assert((!CodeSynthesisContexts.empty() || isSFINAEContext()) &&
-         "Cannot perform an instantiation without some context on the "
-         "instantiation stack");
-
   // If T is not a dependent type or a variably-modified type, there
   // is nothing to do.
   if (!T->isInstantiationDependentType() && !T->isVariablyModifiedType())
@@ -2935,17 +2926,10 @@ static bool NeedsInstantiationAsFunctionType(TypeSourceInfo *T) {
   return false;
 }
 
-TypeSourceInfo *Sema::SubstFunctionDeclType(TypeSourceInfo *T,
-                                const MultiLevelTemplateArgumentList &Args,
-                                SourceLocation Loc,
-                                DeclarationName Entity,
-                                CXXRecordDecl *ThisContext,
-                                Qualifiers ThisTypeQuals,
-                                bool EvaluateConstraints) {
-  assert((!CodeSynthesisContexts.empty() || isSFINAEContext()) &&
-         "Cannot perform an instantiation without some context on the "
-         "instantiation stack");
-
+TypeSourceInfo *Sema::SubstFunctionDeclType(
+    TypeSourceInfo *T, const MultiLevelTemplateArgumentList &Args,
+    SourceLocation Loc, DeclarationName Entity, CXXRecordDecl *ThisContext,
+    Qualifiers ThisTypeQuals, bool EvaluateConstraints) {
   if (!NeedsInstantiationAsFunctionType(T))
     return T;
 
@@ -3259,10 +3243,6 @@ bool Sema::SubstParmTypes(
     SmallVectorImpl<QualType> &ParamTypes,
     SmallVectorImpl<ParmVarDecl *> *OutParams,
     ExtParameterInfoBuilder &ParamInfos) {
-  assert((!CodeSynthesisContexts.empty() || isSFINAEContext()) &&
-         "Cannot perform an instantiation without some context on the "
-         "instantiation stack");
-
   TemplateInstantiator Instantiator(*this, TemplateArgs, Loc,
                                     DeclarationName());
   return Instantiator.TransformFunctionTypeParams(

--- a/clang/test/SemaTemplate/instantiate-requires-expr.cpp
+++ b/clang/test/SemaTemplate/instantiate-requires-expr.cpp
@@ -309,3 +309,24 @@ struct test {
 test<three> x;
 
 }
+
+namespace SusbtitutionFailureInArguments1 {
+  template <class T1, class T2 = typename T1::type>
+    concept C = sizeof(T1) == sizeof(T2);
+
+  template<class>
+    requires requires { { 0 } -> C; }
+    void f();
+
+  // FIXME: We should explain the substitution failure in a note.
+  template<class T>
+    requires requires { { T() } -> C; } // expected-note {{because 'C<expr-type>' would be invalid}}
+    void g();
+  // expected-note@-1 {{ignored: constraints not satisfied}}
+  template void g<int>();
+  // expected-error@-1 {{does not refer to a function template}}
+
+  // FIXME: static_assert should gain support for explaining non-satisfied requirements.
+  static_assert(requires { { 0 } -> C; });
+  // expected-error@-1 {{static assertion failed due to requirement 'requires { { <<error-expression>> } -> C; }'}}
+} // namespace SubstitutionFailureInArguments1


### PR DESCRIPTION
Otherwise, errors when substituting a type constraint could unintentionally make the program ill-formed.

This also strenghtens the assert which checks, when we are instantiating templates, that we either have a code synthesis context, or that we are in a SFINAE context.