### PR TITLE
[flang][cuda] Optimize CUDA descriptor transfers for regular strided layouts

### DIFF
--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -32,7 +32,7 @@ struct Memcpy2DLayout {
 
 // Get cudaMemcpy2D layout information if both descriptors have equal element
 // counts and regular positive-stride layouts. Returns a nullopt otherwise to
-// fallback on the runtime assignment. 
+// fallback on the runtime assignment.
 static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
     const Descriptor &desc, std::size_t widthBytes) {
   if (desc.rank() == 0 || desc.Elements() == 0) {

--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -30,6 +30,9 @@ struct Memcpy2DLayout {
   std::size_t pitchBytes;
 };
 
+// Get cudaMemcpy2D layout information if both descriptors have equal element
+// counts and regular positive-stride layouts. Returns a nullopt otherwise to fallback
+// on the runtime assignment. 
 static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
     const Descriptor &desc, std::size_t widthBytes) {
   if (desc.rank() == 0 || desc.Elements() == 0) {

--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -31,8 +31,8 @@ struct Memcpy2DLayout {
 };
 
 // Get cudaMemcpy2D layout information if both descriptors have equal element
-// counts and regular positive-stride layouts. Returns a nullopt otherwise to fallback
-// on the runtime assignment. 
+// counts and regular positive-stride layouts. Returns a nullopt otherwise to
+// fallback on the runtime assignment. 
 static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
     const Descriptor &desc, std::size_t widthBytes) {
   if (desc.rank() == 0 || desc.Elements() == 0) {

--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -18,7 +18,101 @@
 
 #include "cuda_runtime.h"
 
+#include <cstddef>
+#include <optional>
+
 namespace Fortran::runtime::cuda {
+
+struct Memcpy2DLayout {
+  void *base;
+  std::size_t widthBytes;
+  std::size_t height;
+  std::size_t pitchBytes;
+};
+
+static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
+    const Descriptor &desc, std::size_t widthBytes) {
+  if (desc.rank() == 0 || desc.Elements() == 0) {
+    return std::nullopt;
+  }
+  const auto elemBytes = desc.ElementBytes();
+  if (elemBytes == 0 || widthBytes == 0 || widthBytes % elemBytes != 0) {
+    return std::nullopt;
+  }
+  std::size_t contiguousBytes = elemBytes;
+  int rowDim = 0;
+  while (rowDim < desc.rank()) {
+    const auto &dim = desc.GetDimension(rowDim);
+    if (dim.Extent() != 1 &&
+        (dim.ByteStride() < 0 ||
+            static_cast<std::size_t>(dim.ByteStride()) != contiguousBytes)) {
+      break;
+    }
+    contiguousBytes *= dim.Extent();
+    ++rowDim;
+    if (contiguousBytes == widthBytes) {
+      break;
+    }
+  }
+  if (contiguousBytes != widthBytes) {
+    return std::nullopt;
+  }
+  Memcpy2DLayout layout;
+  layout.base = desc.raw().base_addr;
+  layout.widthBytes = widthBytes;
+  layout.height = desc.Elements() * elemBytes / widthBytes;
+  if (rowDim == desc.rank()) {
+    layout.pitchBytes = widthBytes;
+    return layout;
+  }
+  auto pitch = desc.GetDimension(rowDim).ByteStride();
+  if (pitch <= 0 || static_cast<std::size_t>(pitch) < widthBytes) {
+    return std::nullopt;
+  }
+  SubscriptValue expected = pitch;
+  for (int j = rowDim; j < desc.rank(); ++j) {
+    const auto &dim = desc.GetDimension(j);
+    if (dim.Extent() != 1 && dim.ByteStride() != expected) {
+      return std::nullopt;
+    }
+    expected *= dim.Extent();
+  }
+  layout.pitchBytes = static_cast<std::size_t>(pitch);
+  return layout;
+}
+
+static bool DoMemcpy2D(const Descriptor &dst, const Descriptor &src,
+    cudaMemcpyKind kind, const char *sourceFile, int sourceLine) {
+  if (dst.ElementBytes() != src.ElementBytes() ||
+      dst.Elements() != src.Elements())
+    return false;
+
+  std::size_t widthBytes = dst.ElementBytes();
+  auto dstLayout = GetMemcpy2DLayout(dst, widthBytes);
+  auto srcLayout = GetMemcpy2DLayout(src, widthBytes);
+  if (!dstLayout || !srcLayout) {
+    return false;
+  }
+
+  CUDA_REPORT_IF_ERROR_LOC(
+      cudaMemcpy2D(dstLayout->base, dstLayout->pitchBytes, srcLayout->base,
+          srcLayout->pitchBytes, widthBytes, dstLayout->height, kind),
+      sourceFile, sourceLine);
+  return true;
+}
+
+static cudaMemcpyKind GetMemcpyKind(
+    unsigned mode, const char *sourceFile, int sourceLine) {
+  if (mode == kHostToDevice) {
+    return cudaMemcpyHostToDevice;
+  } else if (mode == kDeviceToHost) {
+    return cudaMemcpyDeviceToHost;
+  } else if (mode == kDeviceToDevice) {
+    return cudaMemcpyDeviceToDevice;
+  }
+  Terminator terminator{sourceFile, sourceLine};
+  terminator.Crash("host to host copy not supported");
+}
 
 extern "C" {
 
@@ -124,6 +218,12 @@ void RTDECL(CUFDataTransferDescDesc)(Descriptor *dstDesc, Descriptor *srcDesc,
         srcDesc->raw().base_addr, dstDesc->Elements() * dstDesc->ElementBytes(),
         mode, sourceFile, sourceLine);
   } else {
+    cudaMemcpyKind kind = GetMemcpyKind(mode, sourceFile, sourceLine);
+    // Try to use cudaMemcpy2D first, if it fails, fall back to
+    // Fortran::runtime::Assign.
+    if (DoMemcpy2D(*dstDesc, *srcDesc, kind, sourceFile, sourceLine)) {
+      return;
+    }
     Fortran::runtime::Assign(
         *dstDesc, *srcDesc, terminator, MaybeReallocate, memmoveFct);
   }

--- a/flang-rt/unittests/Runtime/CUDA/Memory.cpp
+++ b/flang-rt/unittests/Runtime/CUDA/Memory.cpp
@@ -102,3 +102,61 @@ TEST(MemoryCUFTest, CUFDataTransferDescDescDstNotAllocated) {
     EXPECT_EQ(*host->ZeroBasedIndexedElement<std::int32_t>(i), (std::int32_t)i);
   }
 }
+
+TEST(MemoryCUFTest, CUFDataTransferDescDescStrided) {
+  using Fortran::common::TypeCategory;
+  static constexpr int elements{10};
+  static constexpr int stride{2};
+  SubscriptValue extent[]{elements};
+
+  std::int32_t hostStorage[elements * stride]{};
+  for (int i{0}; i < elements; ++i) {
+    hostStorage[i * stride] = i;
+    hostStorage[i * stride + 1] = -1;
+  }
+
+  std::int32_t *devStorage{static_cast<std::int32_t *>(RTNAME(CUFMemAlloc)(
+      sizeof(hostStorage), kMemTypeDevice, __FILE__, __LINE__))};
+  ASSERT_NE(devStorage, nullptr);
+  cudaMemset(devStorage, 0xff, sizeof(hostStorage));
+
+  StaticDescriptor<1> hostStaticDesc;
+  Descriptor &hostDesc{hostStaticDesc.descriptor()};
+  hostDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      hostStorage, 1, extent);
+  hostDesc.GetDimension(0).SetByteStride(stride * sizeof(std::int32_t));
+
+  StaticDescriptor<1> devStaticDesc;
+  Descriptor &devDesc{devStaticDesc.descriptor()};
+  devDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      devStorage, 1, extent);
+  devDesc.GetDimension(0).SetByteStride(stride * sizeof(std::int32_t));
+
+  RTNAME(CUFDataTransferDescDesc)
+  (&devDesc, &hostDesc, kHostToDevice, __FILE__, __LINE__);
+
+  std::int32_t result[elements * stride]{};
+  RTNAME(CUFDataTransferPtrPtr)
+  (result, devStorage, sizeof(result), kDeviceToHost, __FILE__, __LINE__);
+
+  std::int32_t recvStorage[elements * stride]{};
+  for (int i{0}; i < elements * stride; ++i) {
+    recvStorage[i] = -2;
+  }
+  StaticDescriptor<1> recvStaticDesc;
+  Descriptor &recvDesc{recvStaticDesc.descriptor()};
+  recvDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      recvStorage, 1, extent);
+  recvDesc.GetDimension(0).SetByteStride(stride * sizeof(std::int32_t));
+  RTNAME(CUFDataTransferDescDesc)
+  (&recvDesc, &devDesc, kDeviceToHost, __FILE__, __LINE__);
+
+  RTNAME(CUFMemFree)(devStorage, kMemTypeDevice, __FILE__, __LINE__);
+
+  for (int i{0}; i < elements; ++i) {
+    EXPECT_EQ(result[i * stride], i);
+    EXPECT_EQ(result[i * stride + 1], -1);
+    EXPECT_EQ(recvStorage[i * stride], i);
+    EXPECT_EQ(recvStorage[i * stride + 1], -2);
+  }
+}


### PR DESCRIPTION
Add a conservative cudaMemcpy2D fast path for descriptor-to-descriptor CUDA transfers when both descriptors have equal element counts and regular positive-stride layouts. This speeds up cases such as component-section transfers while preserving the existing runtime Assign fallback for unsupported layouts, and adds CUDA runtime coverage for strided host/device descriptor copies.