### PR TITLE
[MemoryBuiltins][NFC] Allow users to retrieve detailed (de)allocation info

### DIFF
--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -309,7 +309,7 @@ private:
   OffsetSpan combineOffsetRange(OffsetSpan LHS, OffsetSpan RHS);
   OffsetSpan computeImpl(Value *V);
   OffsetSpan computeValue(Value *V);
-  bool CheckedZextOrTrunc(APInt &I);
+  bool checkedZextOrTrunc(APInt &I);
 };
 
 /// SizeOffsetValue - Used by \p ObjectSizeOffsetEvaluator, which works with

--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -85,6 +85,11 @@ LLVM_ABI bool isLibFreeFunction(const Function *F, const LibFunc TLIFn);
 LLVM_ABI Value *getFreedOperand(const CallBase *CB,
                                 const TargetLibraryInfo *TLI);
 
+/// If this if a call to a free function, return the freed operand number, or
+/// -1.
+LLVM_ABI int getFreedOperandNo(const CallBase *CB,
+                               const TargetLibraryInfo *TLI);
+
 //===----------------------------------------------------------------------===//
 //  Properties of allocation functions
 //
@@ -130,6 +135,43 @@ LLVM_ABI Constant *getInitialValueOfAllocation(const Value *V,
 /// of functions.
 LLVM_ABI std::optional<StringRef>
 getAllocationFamily(const Value *I, const TargetLibraryInfo *TLI);
+
+/// Description of an allocation call. Note that some elements might be
+/// null/negative.
+struct AllocationCallInfo {
+  /// The name of the allocation family, e.g., malloc.
+  std::optional<StringRef> Family;
+  /// The known initial value, usually 0, UndefValue, or unknown (=nullptr).
+  Constant *InitialValue = nullptr;
+  /// The total size is the product of the SizeLHS and SizeRHS argument values,
+  /// if both are non-negative, otherwise it is simply the argument with a
+  /// non-negative value.
+  int SizeLHSArgNo = -1, SizeRHSArgNo = -1;
+  /// The requested alignment is encoded in this argument.
+  int AlignmentArgNo = -1;
+};
+
+/// Return all known information about the allocation call \p CB.
+LLVM_ABI std::optional<AllocationCallInfo>
+getAllocationCallInfo(const CallBase *CB, const TargetLibraryInfo *TLI,
+                      Type *InitialValueTy);
+
+/// Description of an allocation call. Note that some elements might be
+/// null/negative.
+struct DeallocationCallInfo {
+  /// The name of the allocation family, e.g., malloc.
+  std::optional<StringRef> Family;
+  /// The freed operand is passed in this argument.
+  int FreedOperandArgNo = -1;
+  /// The total size is encoded in this argument.
+  int SizeArgNo = -1;
+  /// The requested alignment is encoded in this argument.
+  int AlignmentArgNo = -1;
+};
+
+/// Return all known information about the dellocation call \p CB.
+LLVM_ABI std::optional<DeallocationCallInfo>
+getDeallocationCallInfo(const CallBase *CB, const TargetLibraryInfo *TLI);
 
 //===----------------------------------------------------------------------===//
 //  Utility functions to compute size of objects.

--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -85,6 +85,11 @@ LLVM_ABI bool isLibFreeFunction(const Function *F, const LibFunc TLIFn);
 LLVM_ABI Value *getFreedOperand(const CallBase *CB,
                                 const TargetLibraryInfo *TLI);
 
+/// If this if a call to a free function, return the freed operand number, or
+/// -1.
+LLVM_ABI int getFreedOperandNo(const CallBase *CB,
+                               const TargetLibraryInfo *TLI);
+
 //===----------------------------------------------------------------------===//
 //  Properties of allocation functions
 //
@@ -130,6 +135,43 @@ LLVM_ABI Constant *getInitialValueOfAllocation(const Value *V,
 /// of functions.
 LLVM_ABI std::optional<StringRef>
 getAllocationFamily(const Value *I, const TargetLibraryInfo *TLI);
+
+/// Description of an allocation call. Note that some elements might be
+/// null/negative.
+struct AllocationCallInfo {
+  /// The name of the allocation family, e.g., malloc.
+  std::optional<StringRef> Family;
+  /// The known initial value, usually 0, UndefValue, or unknown (=nullptr).
+  Constant *InitialValue = nullptr;
+  /// The total size is the product of the SizeLHS and SizeRHS argument values,
+  /// if both are non-negative, otherwise it is simply the argument with a
+  /// non-negative value.
+  int SizeLHSArgNo = -1, SizeRHSArgNo = -1;
+  /// The requested alignment is encoded in this argument.
+  int AlignmentArgNo = -1;
+};
+
+/// Return all known information about the allocation call \p CB.
+LLVM_ABI std::optional<AllocationCallInfo>
+getAllocationCallInfo(const CallBase *CB, const TargetLibraryInfo *TLI,
+                      Type *InitialValueTy);
+
+/// Description of a deallocation call. Note that some elements might be
+/// null/negative.
+struct DeallocationCallInfo {
+  /// The name of the allocation family, e.g., malloc.
+  std::optional<StringRef> Family;
+  /// The freed operand is passed in this argument.
+  int FreedOperandArgNo = -1;
+  /// The total size is encoded in this argument.
+  int SizeArgNo = -1;
+  /// The requested alignment is encoded in this argument.
+  int AlignmentArgNo = -1;
+};
+
+/// Return all known information about the deallocation call \p CB.
+LLVM_ABI std::optional<DeallocationCallInfo>
+getDeallocationCallInfo(const CallBase *CB, const TargetLibraryInfo *TLI);
 
 //===----------------------------------------------------------------------===//
 //  Utility functions to compute size of objects.

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1969,6 +1969,10 @@ public:
   /// operand value. Otherwise, return nullptr.
   LLVM_ABI Value *getArgOperandWithAttribute(Attribute::AttrKind Kind) const;
 
+  /// If one of the arguments has the specified attribute, returns its
+  /// operand number. Otherwise, return -1.
+  LLVM_ABI int getArgOperandNoWithAttribute(Attribute::AttrKind Kind) const;
+
   /// Return true if the call should not be treated as a call to a
   /// builtin.
   bool isNoBuiltin() const {

--- a/llvm/include/llvm/IR/InstrTypes.h
+++ b/llvm/include/llvm/IR/InstrTypes.h
@@ -1902,6 +1902,10 @@ public:
   /// operand value. Otherwise, return nullptr.
   LLVM_ABI Value *getArgOperandWithAttribute(Attribute::AttrKind Kind) const;
 
+  /// If one of the arguments has the specified attribute, returns its
+  /// operand number. Otherwise, return -1.
+  LLVM_ABI int getArgOperandNoWithAttribute(Attribute::AttrKind Kind) const;
+
   /// Return true if the call should not be treated as a call to a
   /// builtin.
   bool isNoBuiltin() const {

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -56,6 +56,7 @@ static cl::opt<unsigned> ObjectSizeOffsetVisitorMaxVisitInstructions(
              "look at"),
     cl::init(100));
 
+// clang-format off
 enum AllocType : uint8_t {
   OpNewLike          = 1<<0, // allocates; never returns null
   MallocLike         = 1<<1, // allocates; may return null
@@ -75,8 +76,9 @@ enum class MallocFamily {
   MSVCArrayNew,       // new[](unsigned int)
   VecMalloc,
 };
+// clang-format on
 
-StringRef mangledNameForMallocFamily(const MallocFamily &Family) {
+static StringRef mangledNameForMallocFamily(const MallocFamily &Family) {
   switch (Family) {
   case MallocFamily::Malloc:
     return "malloc";
@@ -113,42 +115,42 @@ struct AllocFnsTy {
 // FIXME: certain users need more information. E.g., SimplifyLibCalls needs to
 // know which functions are nounwind, noalias, nocapture parameters, etc.
 static const std::pair<LibFunc, AllocFnsTy> AllocationFnData[] = {
-    {LibFunc_Znwj,                              {OpNewLike,        1,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned int)
-    {LibFunc_ZnwjRKSt9nothrow_t,                {MallocLike,       2,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned int, nothrow)
-    {LibFunc_ZnwjSt11align_val_t,               {OpNewLike,        2,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned int, align_val_t)
-    {LibFunc_ZnwjSt11align_val_tRKSt9nothrow_t, {MallocLike,       3,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned int, align_val_t, nothrow)
-    {LibFunc_Znwm,                              {OpNewLike,        1,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned long)
-    {LibFunc_Znwm12__hot_cold_t,                  {OpNewLike,        2, 0,  -1, -1, MallocFamily::CPPNew}},             // new(unsigned long, __hot_cold_t)
-    {LibFunc_ZnwmRKSt9nothrow_t,                {MallocLike,       2,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned long, nothrow)
-    {LibFunc_ZnwmRKSt9nothrow_t12__hot_cold_t,      {MallocLike,       3, 0,  -1, -1, MallocFamily::CPPNew}},             // new(unsigned long, nothrow, __hot_cold_t)
-    {LibFunc_ZnwmSt11align_val_t,               {OpNewLike,        2,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned long, align_val_t)
-    {LibFunc_ZnwmSt11align_val_t12__hot_cold_t,   {OpNewLike,        3, 0,  -1, 1, MallocFamily::CPPNewAligned}},       // new(unsigned long, align_val_t, __hot_cold_t)
-    {LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t, {MallocLike,       3,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned long, align_val_t, nothrow)
-    {LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t, {MallocLike,  4, 0,  -1, 1, MallocFamily::CPPNewAligned}},            // new(unsigned long, align_val_t, nothrow, __hot_cold_t)
-    {LibFunc_Znaj,                              {OpNewLike,        1,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned int)
-    {LibFunc_ZnajRKSt9nothrow_t,                {MallocLike,       2,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned int, nothrow)
-    {LibFunc_ZnajSt11align_val_t,               {OpNewLike,        2,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned int, align_val_t)
-    {LibFunc_ZnajSt11align_val_tRKSt9nothrow_t, {MallocLike,       3,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned int, align_val_t, nothrow)
-    {LibFunc_Znam,                              {OpNewLike,        1,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned long)
-    {LibFunc_Znam12__hot_cold_t,                  {OpNewLike,        2, 0,  -1, -1, MallocFamily::CPPNew}},             // new[](unsigned long, __hot_cold_t)
-    {LibFunc_ZnamRKSt9nothrow_t,                {MallocLike,       2,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned long, nothrow)
-    {LibFunc_ZnamRKSt9nothrow_t12__hot_cold_t,      {MallocLike,       3, 0,  -1, -1, MallocFamily::CPPNew}},             // new[](unsigned long, nothrow, __hot_cold_t)
-    {LibFunc_ZnamSt11align_val_t,               {OpNewLike,        2,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned long, align_val_t)
-    {LibFunc_ZnamSt11align_val_t12__hot_cold_t,   {OpNewLike,        3, 0,  -1, 1, MallocFamily::CPPNewAligned}},       // new[](unsigned long, align_val_t, __hot_cold_t)
-    {LibFunc_ZnamSt11align_val_tRKSt9nothrow_t, {MallocLike,       3,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned long, align_val_t, nothrow)
-    {LibFunc_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t, {MallocLike,  4, 0,  -1, 1, MallocFamily::CPPNewAligned}},            // new[](unsigned long, align_val_t, nothrow, __hot_cold_t)
-    {LibFunc_msvc_new_int,                      {OpNewLike,        1,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned int)
-    {LibFunc_msvc_new_int_nothrow,              {MallocLike,       2,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned int, nothrow)
-    {LibFunc_msvc_new_longlong,                 {OpNewLike,        1,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned long long)
-    {LibFunc_msvc_new_longlong_nothrow,         {MallocLike,       2,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned long long, nothrow)
-    {LibFunc_msvc_new_array_int,                {OpNewLike,        1,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned int)
-    {LibFunc_msvc_new_array_int_nothrow,        {MallocLike,       2,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned int, nothrow)
-    {LibFunc_msvc_new_array_longlong,           {OpNewLike,        1,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned long long)
-    {LibFunc_msvc_new_array_longlong_nothrow,   {MallocLike,       2,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned long long, nothrow)
-    {LibFunc_strdup,                            {StrDupLike,       1, -1, -1, -1, MallocFamily::Malloc}},
-    {LibFunc_dunder_strdup,                     {StrDupLike,       1, -1, -1, -1, MallocFamily::Malloc}},
-    {LibFunc_strndup,                           {StrDupLike,       2,  1, -1, -1, MallocFamily::Malloc}},
-    {LibFunc_dunder_strndup,                    {StrDupLike,       2,  1, -1, -1, MallocFamily::Malloc}},
+    {LibFunc_Znwj,                                            {OpNewLike,  1,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned int)
+    {LibFunc_ZnwjRKSt9nothrow_t,                              {MallocLike, 2,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned int, nothrow)
+    {LibFunc_ZnwjSt11align_val_t,                             {OpNewLike,  2,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned int, align_val_t)
+    {LibFunc_ZnwjSt11align_val_tRKSt9nothrow_t,               {MallocLike, 3,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned int, align_val_t, nothrow)
+    {LibFunc_Znwm,                                            {OpNewLike,  1,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned long)
+    {LibFunc_Znwm12__hot_cold_t,                              {OpNewLike,  2,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned long, __hot_cold_t)
+    {LibFunc_ZnwmRKSt9nothrow_t,                              {MallocLike, 2,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned long, nothrow)
+    {LibFunc_ZnwmRKSt9nothrow_t12__hot_cold_t,                {MallocLike, 3,  0, -1, -1, MallocFamily::CPPNew}},             // new(unsigned long, nothrow, __hot_cold_t)
+    {LibFunc_ZnwmSt11align_val_t,                             {OpNewLike,  2,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned long, align_val_t)
+    {LibFunc_ZnwmSt11align_val_t12__hot_cold_t,               {OpNewLike,  3,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned long, align_val_t, __hot_cold_t)
+    {LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t,               {MallocLike, 3,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned long, align_val_t, nothrow)
+    {LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t, {MallocLike, 4,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new(unsigned long, align_val_t, nothrow, __hot_cold_t)
+    {LibFunc_Znaj,                                            {OpNewLike,  1,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned int)
+    {LibFunc_ZnajRKSt9nothrow_t,                              {MallocLike, 2,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned int, nothrow)
+    {LibFunc_ZnajSt11align_val_t,                             {OpNewLike,  2,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned int, align_val_t)
+    {LibFunc_ZnajSt11align_val_tRKSt9nothrow_t,               {MallocLike, 3,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned int, align_val_t, nothrow)
+    {LibFunc_Znam,                                            {OpNewLike,  1,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned long)
+    {LibFunc_Znam12__hot_cold_t,                              {OpNewLike,  2,  0, -1, -1, MallocFamily::CPPNew}},             // new[](unsigned long, __hot_cold_t)
+    {LibFunc_ZnamRKSt9nothrow_t,                              {MallocLike, 2,  0, -1, -1, MallocFamily::CPPNewArray}},        // new[](unsigned long, nothrow)
+    {LibFunc_ZnamRKSt9nothrow_t12__hot_cold_t,                {MallocLike, 3,  0, -1, -1, MallocFamily::CPPNew}},             // new[](unsigned long, nothrow, __hot_cold_t)
+    {LibFunc_ZnamSt11align_val_t,                             {OpNewLike,  2,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned long, align_val_t)
+    {LibFunc_ZnamSt11align_val_t12__hot_cold_t,               {OpNewLike,  3,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new[](unsigned long, align_val_t, __hot_cold_t)
+    {LibFunc_ZnamSt11align_val_tRKSt9nothrow_t,               {MallocLike, 3,  0, -1,  1, MallocFamily::CPPNewArrayAligned}}, // new[](unsigned long, align_val_t, nothrow)
+    {LibFunc_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t, {MallocLike, 4,  0, -1,  1, MallocFamily::CPPNewAligned}},      // new[](unsigned long, align_val_t, nothrow, __hot_cold_t)
+    {LibFunc_msvc_new_int,                                    {OpNewLike,  1,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned int)
+    {LibFunc_msvc_new_int_nothrow,                            {MallocLike, 2,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned int, nothrow)
+    {LibFunc_msvc_new_longlong,                               {OpNewLike,  1,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned long long)
+    {LibFunc_msvc_new_longlong_nothrow,                       {MallocLike, 2,  0, -1, -1, MallocFamily::MSVCNew}},            // new(unsigned long long, nothrow)
+    {LibFunc_msvc_new_array_int,                              {OpNewLike,  1,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned int)
+    {LibFunc_msvc_new_array_int_nothrow,                      {MallocLike, 2,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned int, nothrow)
+    {LibFunc_msvc_new_array_longlong,                         {OpNewLike,  1,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned long long)
+    {LibFunc_msvc_new_array_longlong_nothrow,                 {MallocLike, 2,  0, -1, -1, MallocFamily::MSVCArrayNew}},       // new[](unsigned long long, nothrow)
+    {LibFunc_strdup,                                          {StrDupLike, 1, -1, -1, -1, MallocFamily::Malloc}},
+    {LibFunc_dunder_strdup,                                   {StrDupLike, 1, -1, -1, -1, MallocFamily::Malloc}},
+    {LibFunc_strndup,                                         {StrDupLike, 2,  1, -1, -1, MallocFamily::Malloc}},
+    {LibFunc_dunder_strndup,                                  {StrDupLike, 2,  1, -1, -1, MallocFamily::Malloc}},
 };
 // clang-format on
 
@@ -182,10 +184,10 @@ getAllocationDataForFunction(const Function *Callee, AllocType AllocTy,
   if (!TLI || !TLI->getLibFunc(*Callee, TLIFn) || !TLI->has(TLIFn))
     return std::nullopt;
 
-  const auto *Iter = find_if(
-      AllocationFnData, [TLIFn](const std::pair<LibFunc, AllocFnsTy> &P) {
-        return P.first == TLIFn;
-      });
+  const auto *Iter = find_if(AllocationFnData,
+                             [TLIFn](const std::pair<LibFunc, AllocFnsTy> &P) {
+                               return P.first == TLIFn;
+                             });
 
   if (Iter == std::end(AllocationFnData))
     return std::nullopt;
@@ -201,11 +203,9 @@ getAllocationDataForFunction(const Function *Callee, AllocType AllocTy,
 
   if (FTy->getReturnType()->isPointerTy() &&
       FTy->getNumParams() == FnData->NumParams &&
-      (FstParam < 0 ||
-       (FTy->getParamType(FstParam)->isIntegerTy(32) ||
-        FTy->getParamType(FstParam)->isIntegerTy(64))) &&
-      (SndParam < 0 ||
-       FTy->getParamType(SndParam)->isIntegerTy(32) ||
+      (FstParam < 0 || (FTy->getParamType(FstParam)->isIntegerTy(32) ||
+                        FTy->getParamType(FstParam)->isIntegerTy(64))) &&
+      (SndParam < 0 || FTy->getParamType(SndParam)->isIntegerTy(32) ||
        FTy->getParamType(SndParam)->isIntegerTy(64)))
     return *FnData;
   return std::nullopt;
@@ -293,7 +293,8 @@ bool llvm::isAllocationFn(
 
 /// Tests if a value is a call or invoke to a library function that
 /// allocates memory similar to malloc or calloc.
-bool llvm::isMallocOrCallocLikeFn(const Value *V, const TargetLibraryInfo *TLI) {
+bool llvm::isMallocOrCallocLikeFn(const Value *V,
+                                  const TargetLibraryInfo *TLI) {
   // TODO: Function behavior does not match name.
   return getAllocationData(V, MallocOrOpNewLike, TLI).has_value();
 }
@@ -342,7 +343,7 @@ Value *llvm::getAllocAlignment(const CallBase *V,
 /// trouble with APInt size issues. This function handles resizing + overflow
 /// checks for us. Check and zext or trunc \p I depending on IntTyBits and
 /// I's value.
-static bool CheckedZextOrTrunc(APInt &I, unsigned IntTyBits) {
+static bool checkedZextOrTrunc(APInt &I, unsigned IntTyBits) {
   // More bits than we can handle. Checking the bit width isn't necessary, but
   // it's faster than checking active bits, and should give `false` in the
   // vast majority of cases.
@@ -376,7 +377,7 @@ llvm::getAllocSize(const CallBase *CB, const TargetLibraryInfo *TLI,
     // Strndup limits strlen.
     if (FnData->FstParam > 0) {
       const ConstantInt *Arg =
-        dyn_cast<ConstantInt>(Mapper(CB->getArgOperand(FnData->FstParam)));
+          dyn_cast<ConstantInt>(Mapper(CB->getArgOperand(FnData->FstParam)));
       if (!Arg)
         return std::nullopt;
 
@@ -388,12 +389,12 @@ llvm::getAllocSize(const CallBase *CB, const TargetLibraryInfo *TLI,
   }
 
   const ConstantInt *Arg =
-    dyn_cast<ConstantInt>(Mapper(CB->getArgOperand(FnData->FstParam)));
+      dyn_cast<ConstantInt>(Mapper(CB->getArgOperand(FnData->FstParam)));
   if (!Arg)
     return std::nullopt;
 
   APInt Size = Arg->getValue();
-  if (!CheckedZextOrTrunc(Size, IntTyBits))
+  if (!checkedZextOrTrunc(Size, IntTyBits))
     return std::nullopt;
 
   // Size is determined by just 1 parameter.
@@ -405,7 +406,7 @@ llvm::getAllocSize(const CallBase *CB, const TargetLibraryInfo *TLI,
     return std::nullopt;
 
   APInt NumElems = Arg->getValue();
-  if (!CheckedZextOrTrunc(NumElems, IntTyBits))
+  if (!checkedZextOrTrunc(NumElems, IntTyBits))
     return std::nullopt;
 
   bool Overflow;
@@ -477,8 +478,8 @@ static const std::pair<LibFunc, FreeFnsTy> FreeFnData[] = {
 };
 // clang-format on
 
-std::optional<FreeFnsTy> getFreeFunctionDataForFunction(const Function *Callee,
-                                                        const LibFunc TLIFn) {
+static std::optional<FreeFnsTy>
+getFreeFunctionDataForFunction(const Function *Callee, const LibFunc TLIFn) {
   const auto *Iter =
       find_if(FreeFnData, [TLIFn](const std::pair<LibFunc, FreeFnsTy> &P) {
         return P.first == TLIFn;
@@ -664,10 +665,11 @@ Value *llvm::lowerObjectSizeCall(
   auto *ResultType = cast<IntegerType>(ObjectSize->getType());
   bool StaticOnly = cast<ConstantInt>(ObjectSize->getArgOperand(3))->isZero();
   if (StaticOnly) {
-    // FIXME: Does it make sense to just return a failure value if the size won't
-    // fit in the output and `!MustSucceed`?
+    // FIXME: Does it make sense to just return a failure value if the size
+    // won't fit in the output and `!MustSucceed`?
     uint64_t Size;
-    if (getObjectSize(ObjectSize->getArgOperand(0), Size, DL, TLI, EvalOptions) &&
+    if (getObjectSize(ObjectSize->getArgOperand(0), Size, DL, TLI,
+                      EvalOptions) &&
         isUIntN(ResultType->getBitWidth(), Size))
       return ConstantInt::get(ResultType, Size);
   } else {
@@ -723,15 +725,14 @@ combinePossibleConstantValues(std::optional<APInt> LHS,
     return std::nullopt;
   if (EvalMode == ObjectSizeOpts::Mode::Max)
     return LHS->sge(*RHS) ? *LHS : *RHS;
-  else
-    return LHS->sle(*RHS) ? *LHS : *RHS;
+  return LHS->sle(*RHS) ? *LHS : *RHS;
 }
 
 static std::optional<APInt> aggregatePossibleConstantValuesImpl(
     const Value *V, ObjectSizeOpts::Mode EvalMode, unsigned BitWidth,
-    unsigned recursionDepth) {
-  constexpr unsigned maxRecursionDepth = 4;
-  if (recursionDepth == maxRecursionDepth)
+    unsigned RecursionDepth) {
+  constexpr unsigned MaxRecursionDepth = 4;
+  if (RecursionDepth == MaxRecursionDepth)
     return std::nullopt;
 
   if (const auto *CI = dyn_cast<ConstantInt>(V)) {
@@ -739,19 +740,19 @@ static std::optional<APInt> aggregatePossibleConstantValuesImpl(
   } else if (const auto *SI = dyn_cast<SelectInst>(V)) {
     return combinePossibleConstantValues(
         aggregatePossibleConstantValuesImpl(SI->getTrueValue(), EvalMode,
-                                            BitWidth, recursionDepth + 1),
+                                            BitWidth, RecursionDepth + 1),
         aggregatePossibleConstantValuesImpl(SI->getFalseValue(), EvalMode,
-                                            BitWidth, recursionDepth + 1),
+                                            BitWidth, RecursionDepth + 1),
         EvalMode);
   } else if (const auto *PN = dyn_cast<PHINode>(V)) {
     unsigned Count = PN->getNumIncomingValues();
     if (Count == 0)
       return std::nullopt;
     auto Acc = aggregatePossibleConstantValuesImpl(
-        PN->getIncomingValue(0), EvalMode, BitWidth, recursionDepth + 1);
+        PN->getIncomingValue(0), EvalMode, BitWidth, RecursionDepth + 1);
     for (unsigned I = 1; Acc && I < Count; ++I) {
       auto Tmp = aggregatePossibleConstantValuesImpl(
-          PN->getIncomingValue(I), EvalMode, BitWidth, recursionDepth + 1);
+          PN->getIncomingValue(I), EvalMode, BitWidth, RecursionDepth + 1);
       Acc = combinePossibleConstantValues(Acc, Tmp, EvalMode);
     }
     return Acc;
@@ -869,9 +870,9 @@ OffsetSpan ObjectSizeOffsetVisitor::computeImpl(Value *V) {
   // the argument index type size and apply the offset, as required.
   if (IndexTypeSizeChanged) {
     if (ORT.knownBefore() &&
-        !::CheckedZextOrTrunc(ORT.Before, InitialIntTyBits))
+        !::checkedZextOrTrunc(ORT.Before, InitialIntTyBits))
       ORT.Before = APInt();
-    if (ORT.knownAfter() && !::CheckedZextOrTrunc(ORT.After, InitialIntTyBits))
+    if (ORT.knownAfter() && !::checkedZextOrTrunc(ORT.After, InitialIntTyBits))
       ORT.After = APInt();
   }
   // If the computed bound is "unknown" we cannot add the stripped offset.
@@ -936,8 +937,8 @@ OffsetSpan ObjectSizeOffsetVisitor::computeValue(Value *V) {
   return ObjectSizeOffsetVisitor::unknown();
 }
 
-bool ObjectSizeOffsetVisitor::CheckedZextOrTrunc(APInt &I) {
-  return ::CheckedZextOrTrunc(I, IntTyBits);
+bool ObjectSizeOffsetVisitor::checkedZextOrTrunc(APInt &I) {
+  return ::checkedZextOrTrunc(I, IntTyBits);
 }
 
 OffsetSpan ObjectSizeOffsetVisitor::visitAllocaInst(AllocaInst &I) {
@@ -956,7 +957,7 @@ OffsetSpan ObjectSizeOffsetVisitor::visitAllocaInst(AllocaInst &I) {
           ArraySize, Options.EvalMode,
           ArraySize->getType()->getScalarSizeInBits())) {
     APInt NumElems = *PossibleSize;
-    if (!CheckedZextOrTrunc(NumElems))
+    if (!checkedZextOrTrunc(NumElems))
       return ObjectSizeOffsetVisitor::unknown();
 
     bool Overflow;
@@ -971,7 +972,7 @@ OffsetSpan ObjectSizeOffsetVisitor::visitAllocaInst(AllocaInst &I) {
 OffsetSpan ObjectSizeOffsetVisitor::visitArgument(Argument &A) {
   Type *MemoryTy = A.getPointeeInMemoryValueType();
   // No interprocedural analysis is done at the moment.
-  if (!MemoryTy|| !MemoryTy->isSized()) {
+  if (!MemoryTy || !MemoryTy->isSized()) {
     ++ObjectVisitorArgument;
     return ObjectSizeOffsetVisitor::unknown();
   }
@@ -1310,8 +1311,7 @@ SizeOffsetValue ObjectSizeOffsetEvaluator::compute_(Value *V) {
   } else if (isa<Argument>(V) ||
              (isa<ConstantExpr>(V) &&
               cast<ConstantExpr>(V)->getOpcode() == Instruction::IntToPtr) ||
-             isa<GlobalAlias>(V) ||
-             isa<GlobalVariable>(V)) {
+             isa<GlobalAlias>(V) || isa<GlobalVariable>(V)) {
     // Ignore values where we cannot do more than ObjectSizeVisitor.
     Result = ObjectSizeOffsetEvaluator::unknown();
   } else {
@@ -1396,7 +1396,7 @@ SizeOffsetValue ObjectSizeOffsetEvaluator::visitLoadInst(LoadInst &LI) {
 
 SizeOffsetValue ObjectSizeOffsetEvaluator::visitPHINode(PHINode &PHI) {
   // Create 2 PHIs: one for size and another for offset.
-  PHINode *SizePHI   = Builder.CreatePHI(IntTy, PHI.getNumIncomingValues());
+  PHINode *SizePHI = Builder.CreatePHI(IntTy, PHI.getNumIncomingValues());
   PHINode *OffsetPHI = Builder.CreatePHI(IntTy, PHI.getNumIncomingValues());
 
   // Insert right away in the cache to handle recursive PHIs.

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -101,13 +101,23 @@ static StringRef mangledNameForMallocFamily(const MallocFamily &Family) {
 }
 
 struct AllocFnsTy {
+  AllocFnsTy() {}
+  AllocFnsTy(AllocType AllocTy, unsigned NumParams, int FstParam, int SndParam,
+             int AlignParam, MallocFamily Family)
+      : AllocTy(AllocTy), NumParams(NumParams), FstParam(FstParam),
+        SndParam(SndParam), AlignParam(AlignParam),
+        Family(Family) {}
+
+  // TODO: Replace AllocTy with the family (String or enum). Right now these
+  // encode overlapping information and use different sources.
   AllocType AllocTy;
-  unsigned NumParams;
-  // First and Second size parameters (or -1 if unused)
-  int FstParam, SndParam;
-  // Alignment parameter for aligned_alloc and aligned new
-  int AlignParam;
-  // Name of default allocator function to group malloc/free calls by family
+  // The number of parameters of this alloca function.
+  int NumParams = -1;
+  // First and Second size parameters (or -1 if unused).
+  int FstParam = -1, SndParam = -1;
+  // Alignment parameter for aligned_alloc and aligned new.
+  int AlignParam = -1;
+  // Name of default allocator function to group malloc/free calls by family.
   MallocFamily Family;
 };
 
@@ -251,8 +261,8 @@ getAllocationSize(const CallBase *CB, const TargetLibraryInfo *TLI) {
   Result.NumParams = CB->arg_size();
   Result.FstParam = Args.first;
   Result.SndParam = Args.second.value_or(-1);
-  // Allocsize has no way to specify an alignment argument
-  Result.AlignParam = -1;
+  // AllocAlign defines the alignment parameter.
+  Result.AlignParam = CB->getArgOperandNoWithAttribute(Attribute::AllocAlign);
   return Result;
 }
 
@@ -439,42 +449,62 @@ Constant *llvm::getInitialValueOfAllocation(const Value *V,
   return nullptr;
 }
 
+std::optional<AllocationCallInfo>
+llvm::getAllocationCallInfo(const CallBase *CB, const TargetLibraryInfo *TLI,
+                            Type *InitialValueTy) {
+  std::optional<AllocFnsTy> FnData = getAllocationSize(CB, TLI);
+  if (!FnData)
+    return std::nullopt;
+
+  AllocationCallInfo ACI{};
+  ACI.Family = getAllocationFamily(CB, TLI);
+  ACI.AlignmentArgNo = FnData->AlignParam;
+  ACI.SizeLHSArgNo = FnData->FstParam;
+  ACI.SizeRHSArgNo = FnData->SndParam;
+  ACI.InitialValue = getInitialValueOfAllocation(CB, TLI, InitialValueTy);
+  return ACI;
+}
+
 struct FreeFnsTy {
   unsigned NumParams;
+  // Size parameter, or -1 if not available.
+  int SizeParam;
+  // Alignment parameter for aligned_alloc and aligned new
+  int AlignParam;
   // Name of default allocator function to group malloc/free calls by family
   MallocFamily Family;
 };
 
 // clang-format off
 static const std::pair<LibFunc, FreeFnsTy> FreeFnData[] = {
-    {LibFunc_ZdlPv,                              {1, MallocFamily::CPPNew}},             // operator delete(void*)
-    {LibFunc_ZdaPv,                              {1, MallocFamily::CPPNewArray}},        // operator delete[](void*)
-    {LibFunc_msvc_delete_ptr32,                  {1, MallocFamily::MSVCNew}},            // operator delete(void*)
-    {LibFunc_msvc_delete_ptr64,                  {1, MallocFamily::MSVCNew}},            // operator delete(void*)
-    {LibFunc_msvc_delete_array_ptr32,            {1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
-    {LibFunc_msvc_delete_array_ptr64,            {1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
-    {LibFunc_ZdlPvj,                             {2, MallocFamily::CPPNew}},             // delete(void*, uint)
-    {LibFunc_ZdlPvm,                             {2, MallocFamily::CPPNew}},             // delete(void*, ulong)
-    {LibFunc_ZdlPvRKSt9nothrow_t,                {2, MallocFamily::CPPNew}},             // delete(void*, nothrow)
-    {LibFunc_ZdlPvSt11align_val_t,               {2, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t)
-    {LibFunc_ZdaPvj,                             {2, MallocFamily::CPPNewArray}},        // delete[](void*, uint)
-    {LibFunc_ZdaPvm,                             {2, MallocFamily::CPPNewArray}},        // delete[](void*, ulong)
-    {LibFunc_ZdaPvRKSt9nothrow_t,                {2, MallocFamily::CPPNewArray}},        // delete[](void*, nothrow)
-    {LibFunc_ZdaPvSt11align_val_t,               {2, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t)
-    {LibFunc_msvc_delete_ptr32_int,              {2, MallocFamily::MSVCNew}},            // delete(void*, uint)
-    {LibFunc_msvc_delete_ptr64_longlong,         {2, MallocFamily::MSVCNew}},            // delete(void*, ulonglong)
-    {LibFunc_msvc_delete_ptr32_nothrow,          {2, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
-    {LibFunc_msvc_delete_ptr64_nothrow,          {2, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
-    {LibFunc_msvc_delete_array_ptr32_int,        {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, uint)
-    {LibFunc_msvc_delete_array_ptr64_longlong,   {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, ulonglong)
-    {LibFunc_msvc_delete_array_ptr32_nothrow,    {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
-    {LibFunc_msvc_delete_array_ptr64_nothrow,    {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
-    {LibFunc_ZdlPvSt11align_val_tRKSt9nothrow_t, {3, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t, nothrow)
-    {LibFunc_ZdaPvSt11align_val_tRKSt9nothrow_t, {3, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t, nothrow)
-    {LibFunc_ZdlPvjSt11align_val_t,              {3, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned int, align_val_t)
-    {LibFunc_ZdlPvmSt11align_val_t,              {3, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned long, align_val_t)
-    {LibFunc_ZdaPvjSt11align_val_t,              {3, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned int, align_val_t)
-    {LibFunc_ZdaPvmSt11align_val_t,              {3, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned long, align_val_t)
+    {LibFunc_ZdlPv,                              {1, -1, -1, MallocFamily::CPPNew}},             // operator delete(void*) 
+    {LibFunc_ZdaPv,                              {1, -1, -1, MallocFamily::CPPNewArray}},        // operator delete[](void*)
+    {LibFunc_msvc_delete_ptr32,                  {1, -1, -1, MallocFamily::MSVCNew}},            // operator delete(void*)
+    {LibFunc_msvc_delete_ptr64,                  {1, -1, -1, MallocFamily::MSVCNew}},            // operator delete(void*)
+    {LibFunc_msvc_delete_array_ptr32,            {1, -1, -1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
+    {LibFunc_msvc_delete_array_ptr64,            {1, -1, -1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
+    {LibFunc_ZdlPvj,                             {2,  1, -1, MallocFamily::CPPNew}},             // delete(void*, uint)
+    {LibFunc_ZdlPvm,                             {2,  1, -1, MallocFamily::CPPNew}},             // delete(void*, ulong)
+    {LibFunc_ZdlPvRKSt9nothrow_t,                {2, -1, -1, MallocFamily::CPPNew}},             // delete(void*, nothrow)
+    {LibFunc_ZdlPvSt11align_val_t,               {2, -1,  1, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t)
+    {LibFunc_ZdaPvj,                             {2,  1, -1, MallocFamily::CPPNewArray}},        // delete[](void*, uint)
+    {LibFunc_ZdaPvm,                             {2,  1, -1, MallocFamily::CPPNewArray}},        // delete[](void*, ulong)
+    {LibFunc_ZdaPvRKSt9nothrow_t,                {2, -1, -1, MallocFamily::CPPNewArray}},        // delete[](void*, nothrow)
+    {LibFunc_ZdaPvSt11align_val_t,               {2, -1,  1, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t)
+    {LibFunc_msvc_delete_ptr32_int,              {2,  1, -1, MallocFamily::MSVCNew}},            // delete(void*, uint)
+    {LibFunc_msvc_delete_ptr64_longlong,         {2,  1, -1, MallocFamily::MSVCNew}},            // delete(void*, ulonglong)
+    {LibFunc_msvc_delete_ptr32_nothrow,          {2, -1, -1, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
+    {LibFunc_msvc_delete_ptr64_nothrow,          {2, -1, -1, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
+    {LibFunc_msvc_delete_array_ptr32_int,        {2,  1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, uint)
+    {LibFunc_msvc_delete_array_ptr64_longlong,   {2,  1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, ulonglong)
+    {LibFunc_msvc_delete_array_ptr32_nothrow,    {2, -1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
+    {LibFunc_msvc_delete_array_ptr64_nothrow,    {2, -1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
+    {LibFunc_ZdlPvSt11align_val_tRKSt9nothrow_t, {3, -1,  1, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t, nothrow)
+    {LibFunc_ZdaPvSt11align_val_tRKSt9nothrow_t, {3, -1,  1, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t, nothrow)
+    {LibFunc_ZdlPvjSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned int, align_val_t)
+    {LibFunc_ZdlPvmSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned long, align_val_t)
+    {LibFunc_ZdaPvjSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned int, align_val_t)
+    {LibFunc_ZdaPvmSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned long, align_val_t)
 };
 // clang-format on
 
@@ -535,20 +565,71 @@ bool llvm::isLibFreeFunction(const Function *F, const LibFunc TLIFn) {
   return true;
 }
 
-Value *llvm::getFreedOperand(const CallBase *CB, const TargetLibraryInfo *TLI) {
+int llvm::getFreedOperandNo(const CallBase *CB, const TargetLibraryInfo *TLI) {
   if (const Function *Callee = getCalledFunction(CB)) {
     LibFunc TLIFn;
     if (TLI && TLI->getLibFunc(*Callee, TLIFn) && TLI->has(TLIFn) &&
         isLibFreeFunction(Callee, TLIFn)) {
       // All currently supported free functions free the first argument.
-      return CB->getArgOperand(0);
+      return 0;
     }
   }
 
   if (checkFnAllocKind(CB, AllocFnKind::Free))
-    return CB->getArgOperandWithAttribute(Attribute::AllocatedPointer);
+    return CB->getArgOperandNoWithAttribute(Attribute::AllocatedPointer);
 
+  return -1;
+}
+
+Value *llvm::getFreedOperand(const CallBase *CB, const TargetLibraryInfo *TLI) {
+  int Index = getFreedOperandNo(CB, TLI);
+  if (Index >= 0)
+    return CB->getArgOperand(Index);
   return nullptr;
+}
+
+std::optional<DeallocationCallInfo>
+llvm::getDeallocationCallInfo(const CallBase *CB,
+                              const TargetLibraryInfo *TLI) {
+  const Function *Callee = getCalledFunction(CB);
+  if (!Callee)
+    return std::nullopt;
+
+  LibFunc TLIFn;
+  DeallocationCallInfo DCI{};
+  if (TLI && TLI->getLibFunc(*Callee, TLIFn) && TLI->has(TLIFn) &&
+      isLibFreeFunction(Callee, TLIFn)) {
+    // Callee is some known library function.
+    std::optional<FreeFnsTy> FnData =
+        getFreeFunctionDataForFunction(Callee, TLIFn);
+    if (FnData) {
+      DCI.Family = mangledNameForMallocFamily(FnData->Family);
+      DCI.FreedOperandArgNo = 0;
+      DCI.SizeArgNo = FnData->SizeParam;
+      DCI.AlignmentArgNo = FnData->AlignParam;
+      return DCI;
+    }
+  }
+
+  // Fallback, check arguments.
+  if (checkFnAllocKind(CB, AllocFnKind::Free))
+    DCI.FreedOperandArgNo =
+        CB->getArgOperandNoWithAttribute(Attribute::AllocatedPointer);
+  if (DCI.FreedOperandArgNo < 0)
+    return std::nullopt;
+
+  DCI.Family = getAllocationFamily(CB, TLI);
+
+  Attribute Attr = CB->getFnAttr(Attribute::AllocSize);
+  if (Attr != Attribute()) {
+    std::pair<unsigned, std::optional<unsigned>> Args = Attr.getAllocSizeArgs();
+    if (Args.first >= 0 && !Args.second) 
+      DCI.SizeArgNo = Args.first;
+  }
+
+  DCI.AlignmentArgNo = CB->getArgOperandNoWithAttribute(Attribute::AllocAlign);
+
+  return DCI;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -251,8 +251,8 @@ getAllocationSize(const CallBase *CB, const TargetLibraryInfo *TLI) {
   Result.NumParams = CB->arg_size();
   Result.FstParam = Args.first;
   Result.SndParam = Args.second.value_or(-1);
-  // Allocsize has no way to specify an alignment argument
-  Result.AlignParam = -1;
+  // AllocAlign defines the alignment parameter.
+  Result.AlignParam = CB->getArgOperandNoWithAttribute(Attribute::AllocAlign);
   return Result;
 }
 
@@ -439,42 +439,62 @@ Constant *llvm::getInitialValueOfAllocation(const Value *V,
   return nullptr;
 }
 
+std::optional<AllocationCallInfo>
+llvm::getAllocationCallInfo(const CallBase *CB, const TargetLibraryInfo *TLI,
+                            Type *InitialValueTy) {
+  std::optional<AllocFnsTy> FnData = getAllocationSize(CB, TLI);
+  if (!FnData)
+    return std::nullopt;
+
+  AllocationCallInfo ACI{};
+  ACI.Family = getAllocationFamily(CB, TLI);
+  ACI.AlignmentArgNo = FnData->AlignParam;
+  ACI.SizeLHSArgNo = FnData->FstParam;
+  ACI.SizeRHSArgNo = FnData->SndParam;
+  ACI.InitialValue = getInitialValueOfAllocation(CB, TLI, InitialValueTy);
+  return ACI;
+}
+
 struct FreeFnsTy {
   unsigned NumParams;
+  // Size parameter, or -1 if not available.
+  int SizeParam;
+  // Alignment parameter for aligned_alloc and aligned new
+  int AlignParam;
   // Name of default allocator function to group malloc/free calls by family
   MallocFamily Family;
 };
 
 // clang-format off
 static const std::pair<LibFunc, FreeFnsTy> FreeFnData[] = {
-    {LibFunc_ZdlPv,                              {1, MallocFamily::CPPNew}},             // operator delete(void*)
-    {LibFunc_ZdaPv,                              {1, MallocFamily::CPPNewArray}},        // operator delete[](void*)
-    {LibFunc_msvc_delete_ptr32,                  {1, MallocFamily::MSVCNew}},            // operator delete(void*)
-    {LibFunc_msvc_delete_ptr64,                  {1, MallocFamily::MSVCNew}},            // operator delete(void*)
-    {LibFunc_msvc_delete_array_ptr32,            {1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
-    {LibFunc_msvc_delete_array_ptr64,            {1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
-    {LibFunc_ZdlPvj,                             {2, MallocFamily::CPPNew}},             // delete(void*, uint)
-    {LibFunc_ZdlPvm,                             {2, MallocFamily::CPPNew}},             // delete(void*, ulong)
-    {LibFunc_ZdlPvRKSt9nothrow_t,                {2, MallocFamily::CPPNew}},             // delete(void*, nothrow)
-    {LibFunc_ZdlPvSt11align_val_t,               {2, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t)
-    {LibFunc_ZdaPvj,                             {2, MallocFamily::CPPNewArray}},        // delete[](void*, uint)
-    {LibFunc_ZdaPvm,                             {2, MallocFamily::CPPNewArray}},        // delete[](void*, ulong)
-    {LibFunc_ZdaPvRKSt9nothrow_t,                {2, MallocFamily::CPPNewArray}},        // delete[](void*, nothrow)
-    {LibFunc_ZdaPvSt11align_val_t,               {2, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t)
-    {LibFunc_msvc_delete_ptr32_int,              {2, MallocFamily::MSVCNew}},            // delete(void*, uint)
-    {LibFunc_msvc_delete_ptr64_longlong,         {2, MallocFamily::MSVCNew}},            // delete(void*, ulonglong)
-    {LibFunc_msvc_delete_ptr32_nothrow,          {2, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
-    {LibFunc_msvc_delete_ptr64_nothrow,          {2, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
-    {LibFunc_msvc_delete_array_ptr32_int,        {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, uint)
-    {LibFunc_msvc_delete_array_ptr64_longlong,   {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, ulonglong)
-    {LibFunc_msvc_delete_array_ptr32_nothrow,    {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
-    {LibFunc_msvc_delete_array_ptr64_nothrow,    {2, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
-    {LibFunc_ZdlPvSt11align_val_tRKSt9nothrow_t, {3, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t, nothrow)
-    {LibFunc_ZdaPvSt11align_val_tRKSt9nothrow_t, {3, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t, nothrow)
-    {LibFunc_ZdlPvjSt11align_val_t,              {3, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned int, align_val_t)
-    {LibFunc_ZdlPvmSt11align_val_t,              {3, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned long, align_val_t)
-    {LibFunc_ZdaPvjSt11align_val_t,              {3, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned int, align_val_t)
-    {LibFunc_ZdaPvmSt11align_val_t,              {3, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned long, align_val_t)
+    {LibFunc_ZdlPv,                              {1, -1, -1, MallocFamily::CPPNew}},             // operator delete(void*) 
+    {LibFunc_ZdaPv,                              {1, -1, -1, MallocFamily::CPPNewArray}},        // operator delete[](void*)
+    {LibFunc_msvc_delete_ptr32,                  {1, -1, -1, MallocFamily::MSVCNew}},            // operator delete(void*)
+    {LibFunc_msvc_delete_ptr64,                  {1, -1, -1, MallocFamily::MSVCNew}},            // operator delete(void*)
+    {LibFunc_msvc_delete_array_ptr32,            {1, -1, -1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
+    {LibFunc_msvc_delete_array_ptr64,            {1, -1, -1, MallocFamily::MSVCArrayNew}},       // operator delete[](void*)
+    {LibFunc_ZdlPvj,                             {2,  1, -1, MallocFamily::CPPNew}},             // delete(void*, uint)
+    {LibFunc_ZdlPvm,                             {2,  1, -1, MallocFamily::CPPNew}},             // delete(void*, ulong)
+    {LibFunc_ZdlPvRKSt9nothrow_t,                {2, -1, -1, MallocFamily::CPPNew}},             // delete(void*, nothrow)
+    {LibFunc_ZdlPvSt11align_val_t,               {2, -1,  1, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t)
+    {LibFunc_ZdaPvj,                             {2,  1, -1, MallocFamily::CPPNewArray}},        // delete[](void*, uint)
+    {LibFunc_ZdaPvm,                             {2,  1, -1, MallocFamily::CPPNewArray}},        // delete[](void*, ulong)
+    {LibFunc_ZdaPvRKSt9nothrow_t,                {2, -1, -1, MallocFamily::CPPNewArray}},        // delete[](void*, nothrow)
+    {LibFunc_ZdaPvSt11align_val_t,               {2, -1,  1, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t)
+    {LibFunc_msvc_delete_ptr32_int,              {2,  1, -1, MallocFamily::MSVCNew}},            // delete(void*, uint)
+    {LibFunc_msvc_delete_ptr64_longlong,         {2,  1, -1, MallocFamily::MSVCNew}},            // delete(void*, ulonglong)
+    {LibFunc_msvc_delete_ptr32_nothrow,          {2, -1, -1, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
+    {LibFunc_msvc_delete_ptr64_nothrow,          {2, -1, -1, MallocFamily::MSVCNew}},            // delete(void*, nothrow)
+    {LibFunc_msvc_delete_array_ptr32_int,        {2,  1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, uint)
+    {LibFunc_msvc_delete_array_ptr64_longlong,   {2,  1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, ulonglong)
+    {LibFunc_msvc_delete_array_ptr32_nothrow,    {2, -1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
+    {LibFunc_msvc_delete_array_ptr64_nothrow,    {2, -1, -1, MallocFamily::MSVCArrayNew}},       // delete[](void*, nothrow)
+    {LibFunc_ZdlPvSt11align_val_tRKSt9nothrow_t, {3, -1,  1, MallocFamily::CPPNewAligned}},      // delete(void*, align_val_t, nothrow)
+    {LibFunc_ZdaPvSt11align_val_tRKSt9nothrow_t, {3, -1,  1, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, align_val_t, nothrow)
+    {LibFunc_ZdlPvjSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned int, align_val_t)
+    {LibFunc_ZdlPvmSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewAligned}},      // delete(void*, unsigned long, align_val_t)
+    {LibFunc_ZdaPvjSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned int, align_val_t)
+    {LibFunc_ZdaPvmSt11align_val_t,              {3,  1,  2, MallocFamily::CPPNewArrayAligned}}, // delete[](void*, unsigned long, align_val_t)
 };
 // clang-format on
 
@@ -535,20 +555,64 @@ bool llvm::isLibFreeFunction(const Function *F, const LibFunc TLIFn) {
   return true;
 }
 
-Value *llvm::getFreedOperand(const CallBase *CB, const TargetLibraryInfo *TLI) {
+int llvm::getFreedOperandNo(const CallBase *CB, const TargetLibraryInfo *TLI) {
   if (const Function *Callee = getCalledFunction(CB)) {
     LibFunc TLIFn;
     if (TLI && TLI->getLibFunc(*Callee, TLIFn) && TLI->has(TLIFn) &&
         isLibFreeFunction(Callee, TLIFn)) {
       // All currently supported free functions free the first argument.
-      return CB->getArgOperand(0);
+      return 0;
     }
   }
 
   if (checkFnAllocKind(CB, AllocFnKind::Free))
-    return CB->getArgOperandWithAttribute(Attribute::AllocatedPointer);
+    return CB->getArgOperandNoWithAttribute(Attribute::AllocatedPointer);
 
+  return -1;
+}
+
+Value *llvm::getFreedOperand(const CallBase *CB, const TargetLibraryInfo *TLI) {
+  int Index = getFreedOperandNo(CB, TLI);
+  if (Index >= 0)
+    return CB->getArgOperand(Index);
   return nullptr;
+}
+
+std::optional<DeallocationCallInfo>
+llvm::getDeallocationCallInfo(const CallBase *CB,
+                              const TargetLibraryInfo *TLI) {
+  const Function *Callee = getCalledFunction(CB);
+  if (!Callee)
+    return std::nullopt;
+
+  LibFunc TLIFn;
+  DeallocationCallInfo DCI{};
+  if (TLI && TLI->getLibFunc(*Callee, TLIFn) && TLI->has(TLIFn) &&
+      isLibFreeFunction(Callee, TLIFn)) {
+    // Callee is some known library function.
+    std::optional<FreeFnsTy> FnData =
+        getFreeFunctionDataForFunction(Callee, TLIFn);
+    if (FnData) {
+      DCI.Family = mangledNameForMallocFamily(FnData->Family);
+      DCI.FreedOperandArgNo = 0;
+      DCI.SizeArgNo = FnData->SizeParam;
+      DCI.AlignmentArgNo = FnData->AlignParam;
+      return DCI;
+    }
+  }
+
+  // Fallback, check arguments.
+  if (checkFnAllocKind(CB, AllocFnKind::Free))
+    DCI.FreedOperandArgNo =
+        CB->getArgOperandNoWithAttribute(Attribute::AllocatedPointer);
+  if (DCI.FreedOperandArgNo < 0)
+    return std::nullopt;
+
+  DCI.Family = getAllocationFamily(CB, TLI);
+  DCI.SizeArgNo = CB->getArgOperandNoWithAttribute(Attribute::AllocSize);
+  DCI.AlignmentArgNo = CB->getArgOperandNoWithAttribute(Attribute::AllocAlign);
+
+  return DCI;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -397,15 +397,22 @@ bool CallBase::isReturnNonNull() const {
   return false;
 }
 
-Value *CallBase::getArgOperandWithAttribute(Attribute::AttrKind Kind) const {
+int CallBase::getArgOperandNoWithAttribute(Attribute::AttrKind Kind) const {
   unsigned Index;
 
   if (Attrs.hasAttrSomewhere(Kind, &Index))
-    return getArgOperand(Index - AttributeList::FirstArgIndex);
+    return (Index - AttributeList::FirstArgIndex);
   if (const Function *F = getCalledFunction())
     if (F->getAttributes().hasAttrSomewhere(Kind, &Index))
-      return getArgOperand(Index - AttributeList::FirstArgIndex);
+      return (Index - AttributeList::FirstArgIndex);
 
+  return -1;
+}
+
+Value *CallBase::getArgOperandWithAttribute(Attribute::AttrKind Kind) const {
+  int Index = getArgOperandNoWithAttribute(Kind);
+  if (Index >= 0)
+    return getArgOperand(Index);
   return nullptr;
 }
 

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -400,15 +400,22 @@ bool CallBase::isReturnNonNull() const {
   return false;
 }
 
-Value *CallBase::getArgOperandWithAttribute(Attribute::AttrKind Kind) const {
+int CallBase::getArgOperandNoWithAttribute(Attribute::AttrKind Kind) const {
   unsigned Index;
 
   if (Attrs.hasAttrSomewhere(Kind, &Index))
-    return getArgOperand(Index - AttributeList::FirstArgIndex);
+    return (Index - AttributeList::FirstArgIndex);
   if (const Function *F = getCalledFunction())
     if (F->getAttributes().hasAttrSomewhere(Kind, &Index))
-      return getArgOperand(Index - AttributeList::FirstArgIndex);
+      return (Index - AttributeList::FirstArgIndex);
 
+  return -1;
+}
+
+Value *CallBase::getArgOperandWithAttribute(Attribute::AttrKind Kind) const {
+  int Index = getArgOperandNoWithAttribute(Kind);
+  if (Index >= 0)
+    return getArgOperand(Index);
   return nullptr;
 }
 


### PR DESCRIPTION
There are some helpers to inspect a value or call but not all
information about the (de)allocation are made available outside of
MemoryBuiltins.cpp. The two new functions allow users a more in-depth
view of (de)allocations through a single API.