### PR TITLE
[flang] Corrected constant folding for IEEE_OTHER in IEEE_SUPPORT_ROUNDING

### DIFF
--- a/flang/lib/Evaluate/fold-logical.cpp
+++ b/flang/lib/Evaluate/fold-logical.cpp
@@ -930,7 +930,8 @@ Expr<Type<TypeCategory::Logical, KIND>> FoldIntrinsicFunction(
     if (context.targetCharacteristics().ieeeFeatures().test(
             IeeeFeature::Rounding)) {
       if (auto mode{GetRoundingMode(args[0])}) {
-        return Expr<T>{mode != common::RoundingMode::TiesAwayFromZero};
+        return Expr<T>{mode >= common::RoundingMode::ToZero &&
+            mode < common::RoundingMode::TiesAwayFromZero};
       }
     }
   } else if (name == "__builtin_ieee_support_sqrt") {

--- a/flang/lib/Evaluate/fold-logical.cpp
+++ b/flang/lib/Evaluate/fold-logical.cpp
@@ -930,8 +930,7 @@ Expr<Type<TypeCategory::Logical, KIND>> FoldIntrinsicFunction(
     if (context.targetCharacteristics().ieeeFeatures().test(
             IeeeFeature::Rounding)) {
       if (auto mode{GetRoundingMode(args[0])}) {
-        return Expr<T>{mode >= common::RoundingMode::ToZero &&
-            mode < common::RoundingMode::TiesAwayFromZero};
+        return Expr<T>{mode < common::RoundingMode::TiesAwayFromZero};
       }
     }
   } else if (name == "__builtin_ieee_support_sqrt") {

--- a/flang/test/Evaluate/fold-ieee.f90
+++ b/flang/test/Evaluate/fold-ieee.f90
@@ -51,6 +51,8 @@ module m
   logical, parameter :: test_rd_u_all = ieee_support_rounding(ieee_up)
   logical, parameter :: test_rd_u_4 = ieee_support_rounding(ieee_up, 1.)
   logical, parameter :: test_rd_u_8 = ieee_support_rounding(ieee_up, 1.d0)
+  logical, parameter :: test_rd_aw_not = .not. ieee_support_rounding(ieee_away)
+  logical, parameter :: test_rd_ot_not = .not. ieee_support_rounding(ieee_other)
   logical, parameter :: test_sq_all = ieee_support_sqrt()
   logical, parameter :: test_sq_4 = ieee_support_sqrt(1.)
   logical, parameter :: test_sq_8 = ieee_support_sqrt(1.d0)


### PR DESCRIPTION
Modified to report expected value of FALSE for constant folded IEEE_OTHER support.

This fixes issue #197486.
