### PR TITLE
[CIR] Allow local goto within cleanup regions

### DIFF
--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -729,6 +729,27 @@ public:
     CleanupExit(mlir::Operation *op, int id) : exitOp(op), destinationId(id) {}
   };
 
+  // Determine whether a goto operation transfers control to a label that
+  // exists somewhere inside the given region (or any of its nested regions).
+  // Label names are unique within a function, so finding a matching cir.label
+  // inside the region implies that the goto definitely targets that label and
+  // therefore stays within the region. If no match is found, the goto either
+  // exits the region or its target is unknown; in either case the caller must
+  // treat it as exiting the region.
+  static bool gotoTargetsLabelInRegion(cir::GotoOp gotoOp,
+                                       mlir::Region &region) {
+    llvm::StringRef targetLabel = gotoOp.getLabel();
+    bool found = false;
+    region.walk([&](cir::LabelOp labelOp) {
+      if (labelOp.getLabel() == targetLabel) {
+        found = true;
+        return mlir::WalkResult::interrupt();
+      }
+      return mlir::WalkResult::advance();
+    });
+    return found;
+  }
+
   // Collect all operations that exit a cleanup scope body. Return, goto, break,
   // and continue can all require branches through the cleanup region. When a
   // loop is encountered, only return and goto are collected because break and
@@ -739,9 +760,11 @@ public:
   // any return, goto, break, or continue from the nested cleanup will also
   // branch through the outer cleanup.
   //
-  // Note that goto statements may not necessarily exit the cleanup scope, but
-  // for now we conservatively assume that they do. We'll need more nuanced
-  // handling of that when multi-exit flattening is implemented.
+  // A goto is only treated as an exit if its target label is not somewhere
+  // inside the cleanup body region. Gotos whose target label is within the
+  // cleanup body stay inside the cleanup scope and need no special handling
+  // during flattening; they are simply inlined along with the rest of the
+  // body region.
   //
   // This function assigns unique destination IDs to each exit, which are
   // used when multi-exit cleanup scopes are flattened.
@@ -757,14 +780,26 @@ public:
         exits.emplace_back(terminator, nextId++);
     }
 
+    // Helper to decide whether a goto needs to be treated as an exit from
+    // the cleanup scope being flattened. If the goto targets a label inside
+    // the cleanup body region, control stays within the cleanup and we leave
+    // the goto in place.
+    auto gotoExitsCleanup = [&](cir::GotoOp gotoOp) {
+      return !gotoTargetsLabelInRegion(gotoOp, cleanupBodyRegion);
+    };
+
     // Lambda to walk a loop and collect only returns and gotos.
     // Break and continue inside loops are handled by the loop itself.
     // Loops don't require special handling for nested switch or cleanup scopes
     // because break and continue never branch out of the loop.
     auto collectExitsInLoop = [&](mlir::Operation *loopOp) {
       loopOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *nestedOp) {
-        if (isa<cir::ReturnOp, cir::GotoOp>(nestedOp))
+        if (isa<cir::ReturnOp>(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
+        } else if (auto gotoOp = dyn_cast<cir::GotoOp>(nestedOp)) {
+          if (gotoExitsCleanup(gotoOp))
+            exits.emplace_back(gotoOp, nextId++);
+        }
         return mlir::WalkResult::advance();
       });
     };
@@ -787,8 +822,11 @@ public:
         } else if (isa<cir::LoopOpInterface>(nestedOp)) {
           collectExitsInLoop(nestedOp);
           return mlir::WalkResult::skip();
-        } else if (isa<cir::ReturnOp, cir::GotoOp, cir::ContinueOp>(nestedOp)) {
+        } else if (isa<cir::ReturnOp, cir::ContinueOp>(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
+        } else if (auto gotoOp = dyn_cast<cir::GotoOp>(nestedOp)) {
+          if (gotoExitsCleanup(gotoOp))
+            exits.emplace_back(gotoOp, nextId++);
         }
         return mlir::WalkResult::advance();
       });
@@ -807,8 +845,11 @@ public:
         // the nested cleanup.
         if (!ignoreBreak && isa<cir::BreakOp>(op)) {
           exits.emplace_back(op, nextId++);
-        } else if (isa<cir::ContinueOp, cir::ReturnOp, cir::GotoOp>(op)) {
+        } else if (isa<cir::ContinueOp, cir::ReturnOp>(op)) {
           exits.emplace_back(op, nextId++);
+        } else if (auto gotoOp = dyn_cast<cir::GotoOp>(op)) {
+          if (gotoExitsCleanup(gotoOp))
+            exits.emplace_back(gotoOp, nextId++);
         } else if (isa<cir::CleanupScopeOp>(op)) {
           // Recurse into nested cleanup's body region.
           collectExitsInCleanup(cast<cir::CleanupScopeOp>(op).getBodyRegion(),
@@ -972,15 +1013,14 @@ public:
           return mlir::success();
         })
         .Case<cir::GotoOp>([&](auto gotoOp) {
-          // Correct goto handling requires determining whether the goto
-          // branches out of the cleanup scope or stays within it.
-          // Although the goto necessarily exits the cleanup scope in the
-          // case where it is the only exit from the scope, it is left
-          // as unimplemented for now so that it can be generalized when
-          // multi-exit flattening is implemented.
+          // Gotos that target a label within the cleanup body region are
+          // filtered out by collectExits and never reach this code, so any
+          // goto that does reach here transfers control out of the cleanup
+          // scope. Branching out of a cleanup scope through a goto isn't
+          // yet supported.
           cir::UnreachableOp::create(rewriter, loc);
-          return gotoOp.emitError(
-              "goto in cleanup scope is not yet implemented");
+          return gotoOp.emitError("goto out of cleanup scope is not yet "
+                                  "implemented");
         })
         .Default([&](mlir::Operation *op) {
           cir::UnreachableOp::create(rewriter, loc);

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -739,15 +739,13 @@ public:
   static bool gotoTargetsLabelInRegion(cir::GotoOp gotoOp,
                                        mlir::Region &region) {
     llvm::StringRef targetLabel = gotoOp.getLabel();
-    bool found = false;
-    region.walk([&](cir::LabelOp labelOp) {
-      if (labelOp.getLabel() == targetLabel) {
-        found = true;
-        return mlir::WalkResult::interrupt();
-      }
-      return mlir::WalkResult::advance();
-    });
-    return found;
+    return region
+        .walk([&](cir::LabelOp labelOp) {
+          if (labelOp.getLabel() == targetLabel)
+            return mlir::WalkResult::interrupt();
+          return mlir::WalkResult::advance();
+        })
+        .wasInterrupted();
   }
 
   // Collect all operations that exit a cleanup scope body. Return, goto, break,
@@ -780,12 +778,13 @@ public:
         exits.emplace_back(terminator, nextId++);
     }
 
-    // Helper to decide whether a goto needs to be treated as an exit from
-    // the cleanup scope being flattened. If the goto targets a label inside
-    // the cleanup body region, control stays within the cleanup and we leave
-    // the goto in place.
-    auto gotoExitsCleanup = [&](cir::GotoOp gotoOp) {
-      return !gotoTargetsLabelInRegion(gotoOp, cleanupBodyRegion);
+    // Helper to decide whether an op is a goto that needs to be treated as an
+    // exit from the cleanup scope being flattened. If op is a goto and targets
+    // a label inside the cleanup body region, control stays within the cleanup
+    // and we leave the goto in place.
+    auto isGotoThatExitsCleanup = [&](mlir::Operation *op) {
+      auto gotoOp = dyn_cast<cir::GotoOp>(op);
+      return gotoOp && !gotoTargetsLabelInRegion(gotoOp, cleanupBodyRegion);
     };
 
     // Lambda to walk a loop and collect only returns and gotos.
@@ -796,9 +795,8 @@ public:
       loopOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *nestedOp) {
         if (isa<cir::ReturnOp>(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
-        } else if (auto gotoOp = dyn_cast<cir::GotoOp>(nestedOp)) {
-          if (gotoExitsCleanup(gotoOp))
-            exits.emplace_back(gotoOp, nextId++);
+        } else if (isGotoThatExitsCleanup(nestedOp)) {
+          exits.emplace_back(nestedOp, nextId++);
         }
         return mlir::WalkResult::advance();
       });
@@ -824,9 +822,8 @@ public:
           return mlir::WalkResult::skip();
         } else if (isa<cir::ReturnOp, cir::ContinueOp>(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
-        } else if (auto gotoOp = dyn_cast<cir::GotoOp>(nestedOp)) {
-          if (gotoExitsCleanup(gotoOp))
-            exits.emplace_back(gotoOp, nextId++);
+        } else if (isGotoThatExitsCleanup(nestedOp)) {
+          exits.emplace_back(nestedOp, nextId++);
         }
         return mlir::WalkResult::advance();
       });
@@ -847,9 +844,8 @@ public:
           exits.emplace_back(op, nextId++);
         } else if (isa<cir::ContinueOp, cir::ReturnOp>(op)) {
           exits.emplace_back(op, nextId++);
-        } else if (auto gotoOp = dyn_cast<cir::GotoOp>(op)) {
-          if (gotoExitsCleanup(gotoOp))
-            exits.emplace_back(gotoOp, nextId++);
+        } else if (isGotoThatExitsCleanup(op)) {
+          exits.emplace_back(op, nextId++);
         } else if (isa<cir::CleanupScopeOp>(op)) {
           // Recurse into nested cleanup's body region.
           collectExitsInCleanup(cast<cir::CleanupScopeOp>(op).getBodyRegion(),

--- a/clang/test/CIR/CodeGen/cleanup-scope-goto-within.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-scope-goto-within.cpp
@@ -1,0 +1,166 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+struct StructWithDestructor {
+  ~StructWithDestructor();
+};
+
+void use(StructWithDestructor &a);
+
+void test_goto_within_cleanup(bool cond) {
+  StructWithDestructor a;
+  if (cond)
+    goto end;
+  use(a);
+end:
+  use(a);
+}
+
+// CIR-LABEL: cir.func {{.*}} @_Z24test_goto_within_cleanupb
+// CIR:         %[[A_ADDR:.*]] = cir.alloca !rec_StructWithDestructor, !cir.ptr<!rec_StructWithDestructor>, ["a"]
+// CIR:         cir.cleanup.scope {
+// CIR:           cir.scope {
+// CIR:             cir.if {{.*}} {
+// CIR:               cir.goto "end"
+// CIR:             }
+// CIR:           }
+// CIR:           cir.call @_Z3useR20StructWithDestructor(%[[A_ADDR]])
+// CIR:           cir.br ^[[BB_LABEL:bb[0-9]+]]
+// CIR:         ^[[BB_LABEL]]:
+// CIR:           cir.label "end"
+// CIR:           cir.call @_Z3useR20StructWithDestructor(%[[A_ADDR]])
+// CIR:           cir.yield
+// CIR:         } cleanup normal {
+// CIR:           cir.call @_ZN20StructWithDestructorD1Ev(%[[A_ADDR]])
+// CIR:           cir.yield
+// CIR:         }
+// CIR:         cir.return
+
+// LLVM-LABEL: define dso_local void @_Z24test_goto_within_cleanupb(i1 noundef %{{.*}})
+// LLVM:         %[[COND_ADDR:.*]] = alloca i8
+// LLVM:         %[[A_ADDR:.*]] = alloca %struct.StructWithDestructor
+// LLVM:         %[[COND_BYTE:.*]] = load i8, ptr %[[COND_ADDR]]
+// LLVM:         %[[COND_BIT:.*]] = trunc i8 %[[COND_BYTE]] to i1
+// LLVM:         br i1 %[[COND_BIT]], label %[[GOTO_BB:.*]], label %[[FALLTHROUGH:.*]]
+// LLVM:       [[GOTO_BB]]:
+// LLVM:         br label %[[LABEL_BB:[0-9]+]]
+// LLVM:       [[FALLTHROUGH]]:
+// LLVM:         br label %[[USE_BB:.*]]
+// LLVM:       [[USE_BB]]:
+// LLVM:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// LLVM:         br label %[[LABEL_BB]]
+// LLVM:       [[LABEL_BB]]:
+// LLVM:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// LLVM:         br label %[[CLEANUP:.*]]
+// LLVM:       [[CLEANUP]]:
+// LLVM:         call void @_ZN20StructWithDestructorD1Ev(ptr {{.*}} %[[A_ADDR]])
+// LLVM-NOT:     call void @_ZN20StructWithDestructorD1Ev
+// LLVM:         ret void
+
+// OGCG-LABEL: define dso_local void @_Z24test_goto_within_cleanupb(i1 noundef zeroext %cond)
+// OGCG:         %[[A_ADDR:.*]] = alloca %struct.StructWithDestructor
+// OGCG:         br i1 %{{.*}}, label %if.then, label %if.end
+// OGCG:       if.then:
+// OGCG:         br label %end
+// OGCG:       if.end:
+// OGCG:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// OGCG:         br label %end
+// OGCG:       end:
+// OGCG:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// OGCG:         call void @_ZN20StructWithDestructorD1Ev(ptr {{.*}} %[[A_ADDR]])
+// OGCG-NOT:     call void @_ZN20StructWithDestructorD1Ev
+// OGCG:         ret void
+
+void test_goto_jump_into_nested_op(bool cond1, bool cond2) {
+  StructWithDestructor a;
+  if (cond1)
+    goto skip;
+  use(a);
+  if (cond2) {
+skip:
+    use(a);
+  }
+}
+
+// CIR-LABEL: cir.func {{.*}} @_Z29test_goto_jump_into_nested_opbb
+// CIR:         %[[A_ADDR:.*]] = cir.alloca !rec_StructWithDestructor, !cir.ptr<!rec_StructWithDestructor>, ["a"]
+// CIR:         cir.cleanup.scope {
+// CIR:           cir.scope {
+// CIR:             cir.if {{.*}} {
+// CIR:               cir.goto "skip"
+// CIR:             }
+// CIR:           }
+// CIR:           cir.call @_Z3useR20StructWithDestructor(%[[A_ADDR]])
+// CIR:           cir.scope {
+// CIR:             cir.if {{.*}} {
+// CIR:               cir.br ^[[BB_LABEL:bb[0-9]+]]
+// CIR:             ^[[BB_LABEL]]:
+// CIR:               cir.label "skip"
+// CIR:               cir.call @_Z3useR20StructWithDestructor(%[[A_ADDR]])
+// CIR:               cir.yield
+// CIR:             }
+// CIR:           }
+// CIR:           cir.yield
+// CIR:         } cleanup normal {
+// CIR:           cir.call @_ZN20StructWithDestructorD1Ev(%[[A_ADDR]])
+// CIR:           cir.yield
+// CIR:         }
+// CIR:         cir.return
+
+// LLVM-LABEL: define dso_local void @_Z29test_goto_jump_into_nested_opbb(i1 noundef %{{.*}}, i1 noundef %{{.*}})
+// LLVM:         %[[COND1_ADDR:.*]] = alloca i8
+// LLVM:         %[[COND2_ADDR:.*]] = alloca i8
+// LLVM:         %[[A_ADDR:.*]] = alloca %struct.StructWithDestructor
+// LLVM:         %[[COND1_BYTE:.*]] = load i8, ptr %[[COND1_ADDR]]
+// LLVM:         %[[COND1_BIT:.*]] = trunc i8 %[[COND1_BYTE]] to i1
+// LLVM:         br i1 %[[COND1_BIT]], label %[[GOTO_BB:.*]], label %[[FALLTHROUGH:.*]]
+// LLVM:       [[GOTO_BB]]:
+// LLVM:         br label %[[SKIP_BB:[0-9]+]]
+// LLVM:       [[FALLTHROUGH]]:
+// LLVM:         br label %[[USE_BB:.*]]
+// LLVM:       [[USE_BB]]:
+// LLVM:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// LLVM:         br label %[[COND2_BB:.*]]
+// LLVM:       [[COND2_BB]]:
+// LLVM:         %[[COND2_BYTE:.*]] = load i8, ptr %[[COND2_ADDR]]
+// LLVM:         %[[COND2_BIT:.*]] = trunc i8 %[[COND2_BYTE]] to i1
+// LLVM:         br i1 %[[COND2_BIT]], label %[[GOTO_BB2:.*]], label %[[MERGE:.*]]
+// LLVM:       [[GOTO_BB2]]:
+// LLVM:         br label %[[SKIP_BB]]
+// LLVM:       [[SKIP_BB]]:
+// LLVM:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// LLVM:         br label %[[MERGE]]
+// LLVM:       [[MERGE]]:
+// LLVM:         br label %[[CLEANUP:.*]]
+// LLVM:       [[CLEANUP]]:
+// LLVM:         call void @_ZN20StructWithDestructorD1Ev(ptr {{.*}} %[[A_ADDR]])
+// LLVM-NOT:     call void @_ZN20StructWithDestructorD1Ev
+// LLVM:         ret void
+
+// OGCG-LABEL: define dso_local void @_Z29test_goto_jump_into_nested_opbb(i1 noundef zeroext %cond1, i1 noundef zeroext %cond2)
+// OGCG:         %[[COND1_ADDR:.*]] = alloca i8
+// OGCG:         %[[COND2_ADDR:.*]] = alloca i8
+// OGCG:         %[[A_ADDR:.*]] = alloca %struct.StructWithDestructor
+// OGCG:         %[[COND1_BYTE:.*]] = load i8, ptr %[[COND1_ADDR]]
+// OGCG:         %[[COND1_BIT:.*]] = icmp ne i8 %[[COND1_BYTE]], 0
+// OGCG:         br i1 %[[COND1_BIT]], label %if.then, label %if.end
+// OGCG:       if.then:
+// OGCG:         br label %skip
+// OGCG:       if.end:
+// OGCG:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// OGCG:         %[[COND2_BYTE:.*]] = load i8, ptr %[[COND2_ADDR]]
+// OGCG:         %[[COND2_BIT:.*]] = icmp ne i8 %[[COND2_BYTE]], 0
+// OGCG:         br i1 %[[COND2_BIT]], label %if.then{{[0-9]+}}, label %[[ENDIF:if\.end[0-9]+]]
+// OGCG:       if.then{{[0-9]+}}:
+// OGCG:         br label %skip
+// OGCG:       skip:
+// OGCG:         call void @_Z3useR20StructWithDestructor(ptr {{.*}} %[[A_ADDR]])
+// OGCG:         br label %[[ENDIF]]
+// OGCG:       [[ENDIF]]:
+// OGCG:         call void @_ZN20StructWithDestructorD1Ev(ptr {{.*}} %[[A_ADDR]])
+// OGCG-NOT:     call void @_ZN20StructWithDestructorD1Ev
+// OGCG:         ret void

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-nyi.cir
@@ -8,13 +8,13 @@
 // Test that we issue a diagnostic for a single goto out of a cleanup scope.
 // Strictly speaking, we could handle this case, but it's left unimplemented
 // because when we handle multiple exits we'll need to do something to determine
-// whether gotos branch out of the cleanup scope or stay within it.
+// how to dispatch through the cleanup destination slot to the goto's target.
 cir.func @test_goto_out_of_cleanup() {
   %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
   cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
   cir.cleanup.scope {
     cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
-    // expected-error @below {{goto in cleanup scope is not yet implemented}}
+    // expected-error @below {{goto out of cleanup scope is not yet implemented}}
     cir.goto "exit"
   } cleanup normal {
     cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
@@ -26,7 +26,9 @@ cir.func @test_goto_out_of_cleanup() {
   cir.return
 }
 
-// Test goto inside nested cleanup scopes.
+// Test goto inside nested cleanup scopes. The goto's target is outside both
+// cleanup scopes, so it must branch out through both and is reported as
+// not yet implemented when the inner cleanup is flattened.
 cir.func @test_goto_in_nested_cleanup() {
   %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
   %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
@@ -37,7 +39,7 @@ cir.func @test_goto_in_nested_cleanup() {
       %cond = cir.call @shouldGoto() : () -> !cir.bool
       cir.brcond %cond ^bb_goto, ^bb_normal
     ^bb_goto:
-      // expected-error @below {{goto in cleanup scope is not yet implemented}}
+      // expected-error @below {{goto out of cleanup scope is not yet implemented}}
       cir.goto "target"
     ^bb_normal:
       cir.yield

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
@@ -532,9 +532,119 @@ cir.func @test_nested_cleanup_break_in_switch() {
 // CHECK:       ^[[DONE]]:
 // CHECK:         cir.return
 
+// Test that a goto inside the cleanup body that targets a label also inside
+// the cleanup body is left alone by flattening. The cleanup's only exit is
+// the yield at the end of the body, so the cleanup runs once after the goto's
+// destination is reached.
+cir.func @test_goto_within_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    %cond = cir.call @shouldGoto() : () -> !cir.bool
+    cir.brcond %cond ^bb_goto, ^bb_other
+  ^bb_goto:
+    cir.goto "internal_label"
+  ^bb_other:
+    cir.call @doSomething(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.br ^bb_label
+  ^bb_label:
+    cir.label "internal_label"
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_goto_within_cleanup()
+// CHECK:         %[[ALLOCA:.*]] = cir.alloca !rec_SomeClass
+// CHECK:         cir.call @ctor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:       ^[[BODY]]:
+// CHECK:         %[[COND:.*]] = cir.call @shouldGoto
+// CHECK:         cir.brcond %[[COND]] ^[[GOTO_BB:bb[0-9]+]], ^[[OTHER_BB:bb[0-9]+]]
+// CHECK:       ^[[GOTO_BB]]:
+// CHECK:         cir.goto "internal_label"
+// CHECK:       ^[[OTHER_BB]]:
+// CHECK:         cir.call @doSomething(%[[ALLOCA]])
+// CHECK:         cir.br ^[[LABEL_BB:bb[0-9]+]]
+// CHECK:       ^[[LABEL_BB]]:
+// CHECK:         cir.label "internal_label"
+// CHECK:         cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[ALLOCA]])
+// CHECK:         cir.br ^[[DONE:bb[0-9]+]]
+// CHECK:       ^[[DONE]]:
+// CHECK:         cir.return
+
+// Test a goto inside a nested cleanup scope whose target label is inside the
+// same nested cleanup body. Neither cleanup needs to handle the goto as an
+// exit; the inner cleanup runs once after the goto's destination is reached
+// and the outer cleanup runs once on normal exit from the inner cleanup.
+cir.func @test_goto_within_nested_cleanup() {
+  %0 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c1", init] {alignment = 4 : i64}
+  %1 = cir.alloca !rec_SomeClass, !cir.ptr<!rec_SomeClass>, ["c2", init] {alignment = 4 : i64}
+  cir.call @ctor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+  cir.cleanup.scope {
+    cir.call @ctor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.cleanup.scope {
+      %cond = cir.call @shouldGoto() : () -> !cir.bool
+      cir.brcond %cond ^bb_goto, ^bb_other
+    ^bb_goto:
+      cir.goto "inner_label"
+    ^bb_other:
+      cir.call @doSomething(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.br ^bb_label
+    ^bb_label:
+      cir.label "inner_label"
+      cir.yield
+    } cleanup normal {
+      cir.call @dtor(%1) : (!cir.ptr<!rec_SomeClass>) -> ()
+      cir.yield
+    }
+    cir.yield
+  } cleanup normal {
+    cir.call @dtor(%0) : (!cir.ptr<!rec_SomeClass>) -> ()
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func @test_goto_within_nested_cleanup()
+// CHECK:         %[[A1:.*]] = cir.alloca !rec_SomeClass{{.*}}["c1"
+// CHECK:         %[[A2:.*]] = cir.alloca !rec_SomeClass{{.*}}["c2"
+// CHECK:         cir.call @ctor(%[[A1]])
+// CHECK:         cir.br ^[[OUTER_BODY:bb[0-9]+]]
+// CHECK:       ^[[OUTER_BODY]]:
+// CHECK:         cir.call @ctor(%[[A2]])
+// CHECK:         cir.br ^[[INNER_BODY:bb[0-9]+]]
+// CHECK:       ^[[INNER_BODY]]:
+// CHECK:         %[[COND:.*]] = cir.call @shouldGoto
+// CHECK:         cir.brcond %[[COND]] ^[[GOTO_BB:bb[0-9]+]], ^[[OTHER_BB:bb[0-9]+]]
+// CHECK:       ^[[GOTO_BB]]:
+// CHECK:         cir.goto "inner_label"
+// CHECK:       ^[[OTHER_BB]]:
+// CHECK:         cir.call @doSomething(%[[A2]])
+// CHECK:         cir.br ^[[LABEL_BB:bb[0-9]+]]
+// CHECK:       ^[[LABEL_BB]]:
+// CHECK:         cir.label "inner_label"
+// CHECK:         cir.br ^[[INNER_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[INNER_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[A2]])
+// CHECK:         cir.br ^[[INNER_DONE:bb[0-9]+]]
+// CHECK:       ^[[INNER_DONE]]:
+// CHECK:         cir.br ^[[OUTER_CLEANUP:bb[0-9]+]]
+// CHECK:       ^[[OUTER_CLEANUP]]:
+// CHECK:         cir.call @dtor(%[[A1]])
+// CHECK:         cir.br ^[[OUTER_DONE:bb[0-9]+]]
+// CHECK:       ^[[OUTER_DONE]]:
+// CHECK:         cir.return
+
 cir.func private @get() -> !s32i
 cir.func private @ctor(!cir.ptr<!rec_SomeClass>)
 cir.func private @dtor(!cir.ptr<!rec_SomeClass>)
 cir.func private @doSomething(!cir.ptr<!rec_SomeClass>)
 cir.func private @shouldBreak() -> !cir.bool
 cir.func private @shouldContinue() -> !cir.bool
+cir.func private @shouldGoto() -> !cir.bool


### PR DESCRIPTION
Until now, CIR's FlattenCFG pass reported an NYI error any time a goto operation was found within a cleanup scope region. This change loosens that restriction to allow goto operations that transfer to another block within the same cleanup region. This case doesn't require any change in the cleanup scope flattening. It just has to be detected and ignored. The goto will be lowered as it is when no cleanup scope is present.

We are still reporting an NYI error in cases where a goto operation branches out of the cleanup scope. That will be implemented in a follow-up change.

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh