### PR TITLE
[clang] fix crash on alias templates with extraneous template parameter lists

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -13892,13 +13892,22 @@ Decl *Sema::ActOnAliasDeclaration(Scope *S, AccessSpecifier AS,
     TypeAliasTemplateDecl *OldDecl = nullptr;
     TemplateParameterList *OldTemplateParams = nullptr;
 
+    TemplateParameterList *TemplateParams = TemplateParamLists[0];
     if (TemplateParamLists.size() != 1) {
       Diag(UsingLoc, diag::err_alias_template_extra_headers)
         << SourceRange(TemplateParamLists[1]->getTemplateLoc(),
          TemplateParamLists[TemplateParamLists.size()-1]->getRAngleLoc());
       Invalid = true;
+
+      // Recover by picking the last non-empty template parameter list.
+      auto It = llvm::find_if(
+          llvm::reverse(TemplateParamLists),
+          [](TemplateParameterList *TPL) { return !TPL->empty(); });
+      assert(It != TemplateParamLists.rend() &&
+             "if all template parameter lists were empty, this should have "
+             "been rejected as an explicit specialization");
+      TemplateParams = *It;
     }
-    TemplateParameterList *TemplateParams = TemplateParamLists[0];
 
     // Check that we can declare a template here.
     if (CheckTemplateDeclScope(S, TemplateParams))

--- a/clang/test/AST/ast-dump-invalid.cpp
+++ b/clang/test/AST/ast-dump-invalid.cpp
@@ -67,5 +67,5 @@ template<typename T> class A;
 template<typename T>
 template<typename U> using InvalidAlias = A<U>;
 // CHECK:      TypeAliasTemplateDecl {{.*}} invalid InvalidAlias
-// CHECK-NEXT: |-TemplateTypeParmDecl {{.*}} typename depth 0 index 0 T
+// CHECK-NEXT: |-TemplateTypeParmDecl {{.*}} typename depth 1 index 0 U
 }

--- a/clang/test/SemaTemplate/alias-templates.cpp
+++ b/clang/test/SemaTemplate/alias-templates.cpp
@@ -320,3 +320,10 @@ namespace OuterSubstFailure {
   };
   template struct A<void>; // expected-note {{requested here}}
 } // namespace OuterSubstFailure
+
+namespace ExtraneousTemplateParameterLists1 {
+  template <> template <class T> using A = T;
+  // expected-error@-1 {{extraneous template parameter list}}
+  template <class T> template <> using B = T;
+  // expected-error@-1 {{extraneous template parameter list}}
+} // namespace ExtraneousTemplateParameterLists1


### PR DESCRIPTION
Recovers by picking a non-empty template parameter list as the current list.

This fixes a regression introduced by #195303, which has never been released, so there are no release notes.

Fixes #197398