### PR TITLE
[libclc] Add optimized DPP scan functions for AMDGPU

### DIFF
--- a/libclc/clc/lib/amdgpu/subgroup/clc_amdgpu_permlanex16.inc
+++ b/libclc/clc/lib/amdgpu/subgroup/clc_amdgpu_permlanex16.inc
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Typed wrappers around __builtin_amdgcn_permlanex16 as it does not natively
+// handle non-integer types.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(__CLC_SCALAR)
+
+#if (defined(__CLC_GENSIZE) && __CLC_GENSIZE <= 32) ||                         \
+    (defined(__CLC_FPSIZE) && __CLC_FPSIZE <= 32)
+
+static _CLC_OVERLOAD __CLC_GENTYPE __clc_amdgpu_permlanex16(__CLC_GENTYPE old,
+                                                            __CLC_GENTYPE src,
+                                                            uint sel_lo,
+                                                            uint sel_hi) {
+  uint o = (uint)__CLC_AS_U_GENTYPE(old);
+  uint s = (uint)__CLC_AS_U_GENTYPE(src);
+  uint r = __builtin_amdgcn_permlanex16(o, s, sel_lo, sel_hi, 0, 0);
+  return __CLC_AS_GENTYPE((__CLC_U_GENTYPE)r);
+}
+
+#elif (defined(__CLC_GENSIZE) && __CLC_GENSIZE == 64) ||                       \
+    (defined(__CLC_FPSIZE) && __CLC_FPSIZE == 64)
+
+static _CLC_OVERLOAD __CLC_GENTYPE __clc_amdgpu_permlanex16(__CLC_GENTYPE old,
+                                                            __CLC_GENTYPE src,
+                                                            uint sel_lo,
+                                                            uint sel_hi) {
+  uint2 o = __builtin_astype((__CLC_U_GENTYPE)old, uint2);
+  uint2 s = __builtin_astype((__CLC_U_GENTYPE)src, uint2);
+  uint2 r;
+  r.lo = __builtin_amdgcn_permlanex16(o.lo, s.lo, sel_lo, sel_hi, 0, 0);
+  r.hi = __builtin_amdgcn_permlanex16(o.hi, s.hi, sel_lo, sel_hi, 0, 0);
+  return (__CLC_GENTYPE)__builtin_astype(r, __CLC_U_GENTYPE);
+}
+
+#endif
+
+#endif // __CLC_SCALAR

--- a/libclc/clc/lib/amdgpu/subgroup/clc_sub_group_scan.cl
+++ b/libclc/clc/lib/amdgpu/subgroup/clc_sub_group_scan.cl
@@ -15,6 +15,12 @@
 #include "clc/subgroup/clc_sub_group_scan.h"
 #include "clc/subgroup/clc_subgroup.h"
 
+#define DPP_ROW_SHR 0x110
+#define DPP_ROW_BCAST15 0x142
+#define DPP_ROW_BCAST31 0x143
+#define DPP_ID_PERM 0xE4
+
+// ds_swizzle constants and helpers for the fallback path.
 #define QUAD_PERM (1 << 15)
 
 // The first basic swizzle mode (when offset[15] == 1) allows full data sharing
@@ -36,6 +42,15 @@
 
 #define __CLC_BODY "clc_amdgpu_ds_swizzle.inc"
 #include "clc/math/gentype.inc"
+
+// permlanex16 typed wrappers (GFX10+ only).
+#if __has_builtin(__builtin_amdgcn_permlanex16)
+#define __CLC_BODY "clc_amdgpu_permlanex16.inc"
+#include "clc/integer/gentype.inc"
+
+#define __CLC_BODY "clc_amdgpu_permlanex16.inc"
+#include "clc/math/gentype.inc"
+#endif
 
 //------------------------------------------------------------------------------
 //  Integer and fp add

--- a/libclc/clc/lib/amdgpu/subgroup/clc_sub_group_scan.inc
+++ b/libclc/clc/lib/amdgpu/subgroup/clc_sub_group_scan.inc
@@ -19,6 +19,58 @@
 #define __CLC_GEN_MAX INFINITY
 #endif
 
+#if __has_builtin(__builtin_amdgcn_update_dpp)
+
+_CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __CLC_FUNCTION_INCLUSIVE(__CLC_GENTYPE x) {
+  __CLC_GENTYPE id = (__CLC_GENTYPE)__CLC_SUBGROUP_SCAN_ID_VAL;
+
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, x, DPP_ROW_SHR | 1, 0xf, 0xf, 0));
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, x, DPP_ROW_SHR | 2, 0xf, 0xf, 0));
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, x, DPP_ROW_SHR | 4, 0xf, 0xf, 0));
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, x, DPP_ROW_SHR | 8, 0xf, 0xf, 0));
+
+#if __has_builtin(__builtin_amdgcn_permlanex16)
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, __clc_amdgpu_permlanex16(id, x, -1, -1),
+                                 DPP_ID_PERM, 0xa, 0xf, 0));
+  if (__builtin_amdgcn_wavefrontsize() == 64) {
+    __CLC_GENTYPE lane31 = __clc_sub_group_broadcast(x, 31);
+    x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                   id, lane31, DPP_ID_PERM, 0xc, 0xf, 0));
+  }
+#else
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, x, DPP_ROW_BCAST15, 0xa, 0xf, 0));
+  x = __CLC_FUNCTION_IMPL(x, (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+                                 id, x, DPP_ROW_BCAST31, 0xc, 0xf, 0));
+#endif
+
+  return x;
+}
+
+_CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __CLC_FUNCTION_EXCLUSIVE(__CLC_GENTYPE x) {
+  __CLC_GENTYPE s = __CLC_FUNCTION_INCLUSIVE(x);
+  __CLC_GENTYPE id = (__CLC_GENTYPE)__CLC_SUBGROUP_SCAN_ID_VAL;
+
+  __CLC_GENTYPE r = (__CLC_GENTYPE)__builtin_amdgcn_update_dpp(
+      id, s, DPP_ROW_SHR | 1, 0xf, 0xf, 0);
+
+  uint l = __clc_get_sub_group_local_id();
+  r = (l == 16) ? __clc_sub_group_broadcast(s, 15) : r;
+  if (__builtin_amdgcn_wavefrontsize() == 64) {
+    r = (l == 32) ? __clc_sub_group_broadcast(s, 31) : r;
+    r = (l == 48) ? __clc_sub_group_broadcast(s, 47) : r;
+  }
+
+  return r;
+}
+
+#else // !__has_builtin(__builtin_amdgcn_update_dpp)
+
 _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __CLC_FUNCTION_INCLUSIVE(__CLC_GENTYPE x) {
   uint l = __clc_get_sub_group_local_id();
 
@@ -76,6 +128,8 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __CLC_FUNCTION_EXCLUSIVE(__CLC_GENTYPE x) {
 
   return (l == 0) ? __CLC_SUBGROUP_SCAN_ID_VAL : s;
 }
+
+#endif // __has_builtin(__builtin_amdgcn_update_dpp)
 
 #undef __CLC_GEN_MIN
 #undef __CLC_GEN_MAX


### PR DESCRIPTION
Summary:
This uses the update_dpp function to efficiently provide scans. DPP
allows for swizzling within a group of 16, so we do four of those,
followed by a permlane on GFX10, or a native DPP shift on GFX9.

 Right now these are not actually used because we do not compile for
 multiple targets yet, but I verified them by setting
 `CMAKE_CLC_FLAGS=mcpu=gfx1030` or similar. The intention is to have
 these waiting as a motivational implementation once we start doing
 variable builds.

 The output is optimal as far as I am aware. Here is the example for
 gfx1030 generation:

 ```asm
_Z28sub_group_scan_inclusive_addi:      ; @_Z28sub_group_scan_inclusive_addi
; %bb.0:
	s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
	v_mov_b32_e32 v1, 0
	s_mov_b32 s4, s33
	s_mov_b32 s33, s32
	s_mov_b32 s33, s4
	v_add_nc_u32_dpp v0, v0, v0 row_shr:1 row_mask:0xf bank_mask:0xf bound_ctrl:1
	v_add_nc_u32_dpp v0, v0, v0 row_shr:2 row_mask:0xf bank_mask:0xf bound_ctrl:1
	v_add_nc_u32_dpp v0, v0, v0 row_shr:4 row_mask:0xf bank_mask:0xf bound_ctrl:1
	v_add_nc_u32_dpp v0, v0, v0 row_shr:8 row_mask:0xf bank_mask:0xf bound_ctrl:1
	v_permlanex16_b32 v1, v0, -1, -1
	v_add_nc_u32_dpp v0, v1, v0 quad_perm:[0,1,2,3] row_mask:0xa bank_mask:0xf
	s_setpc_b64 s[30:31]
 ```
