### PR TITLE
[z/OS] Fix z/OS ASAN test failure

### DIFF
--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -390,6 +390,10 @@ ZOSArchiveMemberHeader::ZOSArchiveMemberHeader(const Archive *Parent,
                                                uint64_t Size, Error *Err)
     : ArchiveMemberHeader(Parent, RawHeaderPtr, Size, Err) {
   ErrorAsOutParameter ErrAsOutParam(Err);
+  // If the base class constructor already detected an error
+  // do not attempt to read header fields
+  if (Err && *Err)
+    return;
   setMemberHeaderStrings(Err, Size);
 }
 


### PR DESCRIPTION
Fix test failure when running `zos-archive-read.test` under asan. 

AddressSanitizer detected a heap-buffer-overflow in `ebcdicFieldToASCII()` when reading z/OS archive headers. The issue occurred because `ZOSArchiveMemberHeader::setMemberHeaderStrings` was called even when the base `ArchiveMemberHeader` constructor had already set an error, causing reads past the end of fixed-size EBCDIC fields. Fixed by checking for constructor errors before calling `setMemberHeaderStrings`.

Original PR: #187110