### PR TITLE
[LifetimeSafety] Fix a crash in lifetimbound verification on assignment methods 

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -399,7 +399,7 @@ public:
     if (!isa<FunctionDecl>(FD))
       return;
     if (const auto *MD = dyn_cast<CXXMethodDecl>(FD);
-        MD && implicitObjectParamIsLifetimeBound(MD) &&
+        MD && getImplicitObjectParamLifetimeBoundAttr(MD) &&
         !VerifiedLiftimeboundEscapes.contains(MD))
       SemaHelper->reportLifetimeboundViolation(MD);
     for (const ParmVarDecl *PVD : cast<FunctionDecl>(FD)->parameters()) {

--- a/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-lifetimebound.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-lifetimebound-violation -verify %s
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-lifetimebound-violation -Wno-dangling -verify %s
 
 #include "Inputs/lifetime-analysis.h"
 
@@ -129,5 +129,18 @@ struct ThisAndMixedParams {
       const MyObj &c [[clang::lifetimebound]]) const // expected-warning {{could not verify that the return value can be lifetime bound to 'c'}}
       [[clang::lifetimebound]] {                     // expected-warning {{could not verify that the return value can be lifetime bound to the implicit this parameter}}
     return cond() ? lb(a) : not_lb(b);
+  }
+};
+
+struct AssignmentCorr {
+  AssignmentCorr& operator=(const AssignmentCorr& other) {
+    return *this;
+  }
+};
+
+struct AssignementIncorr {
+  AssignementIncorr& operator=(const AssignementIncorr& other) {
+    AssignementIncorr tmp;
+    return tmp;
   }
 };


### PR DESCRIPTION
The problem was that `implicitObjectParamIsLifetimeBound` could also return true if the function we are analyzing is an assignment operator with a few conditions.
https://github.com/llvm/llvm-project/blob/67284454ae951d1c9702f0ac784447eede59386d/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp#L33-L49

Since there would be nowhere to extract the attribute from nonetheless, I think we should ignore that check.