### PR TITLE
[SPIRV] Allow casting between CodeSectionINTEL and Generic storage classes

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -312,9 +312,6 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       .legalIf(all(typeInSet(0, allPtrs), typeInSet(1, allIntScalars)));
 
   getActionDefinitionsBuilder(G_ADDRSPACE_CAST)
-      .unsupportedIf(
-          LegalityPredicates::any(all(typeIs(0, p9), typeIsNot(1, p9)),
-                                  all(typeIsNot(0, p9), typeIs(1, p9))))
       .legalForCartesianProduct(allPtrs, allPtrs);
 
   // Should we be legalizing bad scalar sizes like s5 here instead

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -236,6 +236,7 @@ constexpr bool isGenericCastablePtr(SPIRV::StorageClass::StorageClass SC) {
   case SPIRV::StorageClass::Workgroup:
   case SPIRV::StorageClass::CrossWorkgroup:
   case SPIRV::StorageClass::Function:
+  case SPIRV::StorageClass::CodeSectionINTEL:
     return true;
   default:
     return false;

--- a/llvm/test/CodeGen/SPIRV/GlobalISel/fn-ptr-addrspacecast.ll
+++ b/llvm/test/CodeGen/SPIRV/GlobalISel/fn-ptr-addrspacecast.ll
@@ -1,6 +1,7 @@
 ; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
 
 ; TODO: Update when spirv-val accepts casts from CodeSectionINTEL to Generic
+; https://github.com/KhronosGroup/SPIRV-Tools/issues/6700
 ; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - -filetype=obj | spirv-val %}
 
 define void @addrspacecast(ptr addrspace(9) %a) {
@@ -12,5 +13,17 @@ define void @addrspacecast(ptr addrspace(9) %a) {
 
   %res1 = addrspacecast ptr addrspace(9) %a to ptr addrspace(4)
   store i8 0, ptr addrspace(4) %res1
+  ret void
+}
+
+define void @addrspacecast_two(ptr addrspace(4) %b) {
+; CHECK: %[[#FnParam2:]] = OpFunctionParameter %[[#Int8GenericPtr]]
+; CHECK: OpGenericCastToPtr %[[#Int8FnPtr]] %[[#FnParam2]]
+
+  %res2 = addrspacecast ptr addrspace(4) %b to ptr addrspace(9)
+  %cmp = icmp eq ptr addrspace(9) %res2, null
+  %res3 = sext i1 %cmp to i8
+  store i8 %res3, ptr addrspace(4) %b
+
   ret void
 }

--- a/llvm/test/CodeGen/SPIRV/GlobalISel/fn-ptr-addrspacecast.ll
+++ b/llvm/test/CodeGen/SPIRV/GlobalISel/fn-ptr-addrspacecast.ll
@@ -1,8 +1,15 @@
-; RUN: not llc --global-isel %s -filetype=null 2>&1 | FileCheck %s
-target triple = "spirv64"
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - | FileCheck %s
+
+; TODO: Update when spirv-val accepts casts from CodeSectionINTEL to Generic
+; RUNx: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_function_pointers %s -o - -filetype=obj | spirv-val %}
 
 define void @addrspacecast(ptr addrspace(9) %a) {
-; CHECK: unable to legalize instruction: %{{.*}}:pid(p4) = G_ADDRSPACE_CAST %{{.*}}:pid(p9)
+; CHECK: %[[#Int8:]] = OpTypeInt 8 0
+; CHECK: %[[#Int8FnPtr:]] = OpTypePointer CodeSectionINTEL %[[#Int8]]
+; CHECK: %[[#Int8GenericPtr:]] = OpTypePointer Generic %[[#Int8]]
+; CHECK: %[[#FnParam:]] = OpFunctionParameter %[[#Int8FnPtr]]
+; CHECK: OpPtrCastToGeneric %[[#Int8GenericPtr]] %[[#FnParam]]
+
   %res1 = addrspacecast ptr addrspace(9) %a to ptr addrspace(4)
   store i8 0, ptr addrspace(4) %res1
   ret void


### PR DESCRIPTION
In the previous versions of the SPV_INTEL_function_pointers [spec](https://github.com/intel/llvm/blob/sycl/sycl/doc/design/spirv-extensions/SPV_INTEL_function_pointers.asciidoc), casts between the CodeSectionINTEL storage class (used for function pointers) and the Generic storage class were illegal. 

The spec was updated a few months ago, and the new version allows the cast, specifying `CodeSectionIntel` as one of the overloaded storage classes that can be represented by Generic, alongside `WorkGroup`, etc. I also confirmed with a spec author that one of the intentions of the spec updates was to allow the cast.

Update the SPIR-V backend to allow the cast. This is basically required to use function pointers in real world use cases.