### PR TITLE
[flang][cuda] Use wider cudaMemcpy2D rows for descriptor transfers

### DIFF
--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -30,9 +30,9 @@ struct Memcpy2DLayout {
   std::size_t pitchBytes;
 };
 
-// Get cudaMemcpy2D layout information if both descriptors have equal element
-// counts and regular positive-stride layouts. Returns a nullopt otherwise to
-// fallback on the runtime assignment.
+// Get cudaMemcpy2D layout information for a descriptor that can be represented
+// as fixed-pitch rows of widthBytes. Returns nullopt for layouts that need the
+// general runtime assignment path.
 static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
     const Descriptor &desc, std::size_t widthBytes) {
   if (desc.rank() == 0 || desc.Elements() == 0) {
@@ -84,6 +84,8 @@ static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
   return layout;
 }
 
+// Collect candidate row widths from the descriptor's leading contiguous
+// dimensions, starting with one element.
 static int GetContiguousLeadingBytes(
     const Descriptor &desc, std::size_t *bytes) {
   const auto elemBytes = desc.ElementBytes();
@@ -109,6 +111,8 @@ static int GetContiguousLeadingBytes(
   return count;
 }
 
+// Choose the largest row width that is contiguous in both descriptors, so
+// leading-dimension slices can be copied as wider cudaMemcpy2D rows.
 static std::size_t GetMemcpy2DWidthBytes(
     const Descriptor &dst, const Descriptor &src) {
   std::size_t dstBytes[maxRank + 1];
@@ -125,6 +129,8 @@ static std::size_t GetMemcpy2DWidthBytes(
   return 0;
 }
 
+// Try to use cudaMemcpy2D for a memcpy of two descriptors, returning true if
+// successful. False if the 2D data transfer is not possible.
 static bool DoMemcpy2D(const Descriptor &dst, const Descriptor &src,
     cudaMemcpyKind kind, const char *sourceFile, int sourceLine) {
   if (dst.ElementBytes() != src.ElementBytes() ||

--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -84,13 +84,57 @@ static std::optional<Memcpy2DLayout> GetMemcpy2DLayout(
   return layout;
 }
 
+static int GetContiguousLeadingBytes(
+    const Descriptor &desc, std::size_t *bytes) {
+  const auto elemBytes = desc.ElementBytes();
+  if (elemBytes == 0) {
+    return 0;
+  }
+
+  int count = 0;
+  bytes[count++] = elemBytes;
+  std::size_t contiguousBytes = elemBytes;
+  for (int j = 0; j < desc.rank(); ++j) {
+    const auto &dim = desc.GetDimension(j);
+    if (dim.Extent() != 1 &&
+        (dim.ByteStride() < 0 ||
+            static_cast<std::size_t>(dim.ByteStride()) != contiguousBytes)) {
+      break;
+    }
+    contiguousBytes *= dim.Extent();
+    if (contiguousBytes != bytes[count - 1]) {
+      bytes[count++] = contiguousBytes;
+    }
+  }
+  return count;
+}
+
+static std::size_t GetMemcpy2DWidthBytes(
+    const Descriptor &dst, const Descriptor &src) {
+  std::size_t dstBytes[maxRank + 1];
+  std::size_t srcBytes[maxRank + 1];
+  const int dstCount = GetContiguousLeadingBytes(dst, dstBytes);
+  const int srcCount = GetContiguousLeadingBytes(src, srcBytes);
+  for (int j = dstCount - 1; j >= 0; --j) {
+    for (int k = srcCount - 1; k >= 0; --k) {
+      if (dstBytes[j] == srcBytes[k]) {
+        return dstBytes[j];
+      }
+    }
+  }
+  return 0;
+}
+
 static bool DoMemcpy2D(const Descriptor &dst, const Descriptor &src,
     cudaMemcpyKind kind, const char *sourceFile, int sourceLine) {
   if (dst.ElementBytes() != src.ElementBytes() ||
       dst.Elements() != src.Elements())
     return false;
 
-  std::size_t widthBytes = dst.ElementBytes();
+  std::size_t widthBytes = GetMemcpy2DWidthBytes(dst, src);
+  if (widthBytes == 0) {
+    return false;
+  }
   auto dstLayout = GetMemcpy2DLayout(dst, widthBytes);
   auto srcLayout = GetMemcpy2DLayout(src, widthBytes);
   if (!dstLayout || !srcLayout) {

--- a/flang-rt/unittests/Runtime/CUDA/Memory.cpp
+++ b/flang-rt/unittests/Runtime/CUDA/Memory.cpp
@@ -160,3 +160,80 @@ TEST(MemoryCUFTest, CUFDataTransferDescDescStrided) {
     EXPECT_EQ(recvStorage[i * stride + 1], -2);
   }
 }
+
+TEST(MemoryCUFTest, CUFDataTransferDescDescLeadingSlice) {
+  using Fortran::common::TypeCategory;
+  static constexpr int nx{8};
+  static constexpr int ny{4};
+  static constexpr int nz{3};
+  static constexpr int elements{nx * ny * nz};
+  SubscriptValue sliceExtent[]{nx - 2, ny, nz};
+
+  std::int32_t hostStorage[elements]{};
+  for (int k{0}; k < nz; ++k) {
+    for (int j{0}; j < ny; ++j) {
+      for (int i{1}; i < nx - 1; ++i) {
+        hostStorage[i + nx * (j + ny * k)] = i + 10 * j + 100 * k;
+      }
+    }
+  }
+
+  std::int32_t *devStorage{
+      static_cast<std::int32_t *>(RTNAME(CUFMemAlloc)(sizeof(hostStorage),
+          kMemTypeDevice, __FILE__, __LINE__))};
+  ASSERT_NE(devStorage, nullptr);
+  cudaMemset(devStorage, 0xff, sizeof(hostStorage));
+
+  StaticDescriptor<3> hostStaticDesc;
+  Descriptor &hostDesc{hostStaticDesc.descriptor()};
+  hostDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      hostStorage + 1, 3, sliceExtent);
+  hostDesc.GetDimension(0).SetByteStride(sizeof(std::int32_t));
+  hostDesc.GetDimension(1).SetByteStride(nx * sizeof(std::int32_t));
+  hostDesc.GetDimension(2).SetByteStride(nx * ny * sizeof(std::int32_t));
+
+  StaticDescriptor<3> devStaticDesc;
+  Descriptor &devDesc{devStaticDesc.descriptor()};
+  devDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      devStorage + 1, 3, sliceExtent);
+  devDesc.GetDimension(0).SetByteStride(sizeof(std::int32_t));
+  devDesc.GetDimension(1).SetByteStride(nx * sizeof(std::int32_t));
+  devDesc.GetDimension(2).SetByteStride(nx * ny * sizeof(std::int32_t));
+
+  RTNAME(CUFDataTransferDescDesc)
+  (&devDesc, &hostDesc, kHostToDevice, __FILE__, __LINE__);
+
+  std::int32_t result[elements]{};
+  RTNAME(CUFDataTransferPtrPtr)
+  (result, devStorage, sizeof(result), kDeviceToHost, __FILE__, __LINE__);
+
+  std::int32_t recvStorage[elements]{};
+  for (int i{0}; i < elements; ++i) {
+    recvStorage[i] = -2;
+  }
+  StaticDescriptor<3> recvStaticDesc;
+  Descriptor &recvDesc{recvStaticDesc.descriptor()};
+  recvDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      recvStorage + 1, 3, sliceExtent);
+  recvDesc.GetDimension(0).SetByteStride(sizeof(std::int32_t));
+  recvDesc.GetDimension(1).SetByteStride(nx * sizeof(std::int32_t));
+  recvDesc.GetDimension(2).SetByteStride(nx * ny * sizeof(std::int32_t));
+  RTNAME(CUFDataTransferDescDesc)
+  (&recvDesc, &devDesc, kDeviceToHost, __FILE__, __LINE__);
+
+  RTNAME(CUFMemFree)(devStorage, kMemTypeDevice, __FILE__, __LINE__);
+
+  for (int k{0}; k < nz; ++k) {
+    for (int j{0}; j < ny; ++j) {
+      EXPECT_EQ(result[nx * (j + ny * k)], -1);
+      EXPECT_EQ(result[nx - 1 + nx * (j + ny * k)], -1);
+      EXPECT_EQ(recvStorage[nx * (j + ny * k)], -2);
+      EXPECT_EQ(recvStorage[nx - 1 + nx * (j + ny * k)], -2);
+      for (int i{1}; i < nx - 1; ++i) {
+        const int index{i + nx * (j + ny * k)};
+        EXPECT_EQ(result[index], hostStorage[index]);
+        EXPECT_EQ(recvStorage[index], hostStorage[index]);
+      }
+    }
+  }
+}

--- a/flang-rt/unittests/Runtime/CUDA/Memory.cpp
+++ b/flang-rt/unittests/Runtime/CUDA/Memory.cpp
@@ -161,6 +161,74 @@ TEST(MemoryCUFTest, CUFDataTransferDescDescStrided) {
   }
 }
 
+TEST(MemoryCUFTest, CUFDataTransferDescDescLeadingSliceRank2) {
+  using Fortran::common::TypeCategory;
+  static constexpr int nx{8};
+  static constexpr int ny{4};
+  static constexpr int elements{nx * ny};
+  SubscriptValue sliceExtent[]{nx - 2, ny};
+
+  std::int32_t hostStorage[elements]{};
+  for (int j{0}; j < ny; ++j) {
+    for (int i{1}; i < nx - 1; ++i) {
+      hostStorage[i + nx * j] = i + 10 * j;
+    }
+  }
+
+  std::int32_t *devStorage{static_cast<std::int32_t *>(RTNAME(CUFMemAlloc)(
+      sizeof(hostStorage), kMemTypeDevice, __FILE__, __LINE__))};
+  ASSERT_NE(devStorage, nullptr);
+  cudaMemset(devStorage, 0xff, sizeof(hostStorage));
+
+  StaticDescriptor<2> hostStaticDesc;
+  Descriptor &hostDesc{hostStaticDesc.descriptor()};
+  hostDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      hostStorage + 1, 2, sliceExtent);
+  hostDesc.GetDimension(0).SetByteStride(sizeof(std::int32_t));
+  hostDesc.GetDimension(1).SetByteStride(nx * sizeof(std::int32_t));
+
+  StaticDescriptor<2> devStaticDesc;
+  Descriptor &devDesc{devStaticDesc.descriptor()};
+  devDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      devStorage + 1, 2, sliceExtent);
+  devDesc.GetDimension(0).SetByteStride(sizeof(std::int32_t));
+  devDesc.GetDimension(1).SetByteStride(nx * sizeof(std::int32_t));
+
+  RTNAME(CUFDataTransferDescDesc)
+  (&devDesc, &hostDesc, kHostToDevice, __FILE__, __LINE__);
+
+  std::int32_t result[elements]{};
+  RTNAME(CUFDataTransferPtrPtr)
+  (result, devStorage, sizeof(result), kDeviceToHost, __FILE__, __LINE__);
+
+  std::int32_t recvStorage[elements]{};
+  for (int i{0}; i < elements; ++i) {
+    recvStorage[i] = -2;
+  }
+  StaticDescriptor<2> recvStaticDesc;
+  Descriptor &recvDesc{recvStaticDesc.descriptor()};
+  recvDesc.Establish(TypeCode{TypeCategory::Integer, 4}, sizeof(std::int32_t),
+      recvStorage + 1, 2, sliceExtent);
+  recvDesc.GetDimension(0).SetByteStride(sizeof(std::int32_t));
+  recvDesc.GetDimension(1).SetByteStride(nx * sizeof(std::int32_t));
+  RTNAME(CUFDataTransferDescDesc)
+  (&recvDesc, &devDesc, kDeviceToHost, __FILE__, __LINE__);
+
+  RTNAME(CUFMemFree)(devStorage, kMemTypeDevice, __FILE__, __LINE__);
+
+  for (int j{0}; j < ny; ++j) {
+    EXPECT_EQ(result[nx * j], -1);
+    EXPECT_EQ(result[nx - 1 + nx * j], -1);
+    EXPECT_EQ(recvStorage[nx * j], -2);
+    EXPECT_EQ(recvStorage[nx - 1 + nx * j], -2);
+    for (int i{1}; i < nx - 1; ++i) {
+      const int index{i + nx * j};
+      EXPECT_EQ(result[index], hostStorage[index]);
+      EXPECT_EQ(recvStorage[index], hostStorage[index]);
+    }
+  }
+}
+
 TEST(MemoryCUFTest, CUFDataTransferDescDescLeadingSlice) {
   using Fortran::common::TypeCategory;
   static constexpr int nx{8};

--- a/flang-rt/unittests/Runtime/CUDA/Memory.cpp
+++ b/flang-rt/unittests/Runtime/CUDA/Memory.cpp
@@ -178,9 +178,8 @@ TEST(MemoryCUFTest, CUFDataTransferDescDescLeadingSlice) {
     }
   }
 
-  std::int32_t *devStorage{
-      static_cast<std::int32_t *>(RTNAME(CUFMemAlloc)(sizeof(hostStorage),
-          kMemTypeDevice, __FILE__, __LINE__))};
+  std::int32_t *devStorage{static_cast<std::int32_t *>(RTNAME(CUFMemAlloc)(
+      sizeof(hostStorage), kMemTypeDevice, __FILE__, __LINE__))};
   ASSERT_NE(devStorage, nullptr);
   cudaMemset(devStorage, 0xff, sizeof(hostStorage));
 


### PR DESCRIPTION
Extend the CUDA descriptor transfer fast path to choose the largest common contiguous leading block, allowing slices like a(2:nx-1,:,:) to copy full rows with cudaMemcpy2D. Add runtime coverage for both strided element transfers and leading-dimension slice transfers.

This will make example like the one below use the fast path. 

```fortran
program test2d
  implicit none
  integer, parameter :: nx=128, ny=128, nz=128
  real :: a(nx,ny,nz)
  real, device :: a_d(nx,ny,nz)

  a = 0.0
  a_d(2:nx-1,:,:) = a(2:nx-1,:,:)
  
end
```