### PR TITLE
[CIR] Route lambda and thunk aggregate returns through return slot

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -909,6 +909,15 @@ void CIRGenFunction::emitForwardingCallToLambda(
       callOperator->getType()->castAs<FunctionProtoType>();
   QualType resultType = fpt->getReturnType();
   ReturnValueSlot returnSlot;
+  // This should also be tracking volatile, unused, and externally destructed.
+  assert(!cir::MissingFeatures::returnValueSlotFeatures());
+  // For aggregate returns, write the callee's result directly into the
+  // static invoker's return slot.  Otherwise emitReturnOfRValue below would
+  // aggregate-copy a temporary into returnValue, which is incorrect for
+  // types without a trivial copy/move (e.g. std::string) -- and trips an
+  // assertion in emitAggregateCopy.
+  if (!resultType->isVoidType() && hasAggregateEvaluationKind(resultType))
+    returnSlot = ReturnValueSlot(returnValue);
 
   // We don't need to separately arrange the call arguments because
   // the call can't be variadic anyway --- it's impossible to forward
@@ -919,9 +928,10 @@ void CIRGenFunction::emitForwardingCallToLambda(
       CIRGenCallee::forDirect(calleePtr, GlobalDecl(callOperator));
   RValue rv = emitCall(calleeFnInfo, callee, returnSlot, callArgs);
 
-  // If necessary, copy the returned value into the slot.
-  if (!resultType->isVoidType() && returnSlot.isNull()) {
-    if (getLangOpts().ObjCAutoRefCount && resultType->isObjCRetainableType())
+  // Forward the returned value through the function's return slot.
+  if (!resultType->isVoidType()) {
+    if (returnSlot.isNull() && getLangOpts().ObjCAutoRefCount &&
+        resultType->isObjCRetainableType())
       cgm.errorNYI(callOperator->getSourceRange(),
                    "emitForwardingCallToLambda: ObjCAutoRefCount");
     emitReturnOfRValue(*currSrcLoc, rv, resultType);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -1253,9 +1253,16 @@ void CIRGenFunction::emitReturnOfRValue(mlir::Location loc, RValue rv,
   if (rv.isScalar()) {
     builder.createStore(loc, rv.getValue(), returnValue);
   } else if (rv.isAggregate()) {
-    LValue dest = makeAddrLValue(returnValue, ty);
-    LValue src = makeAddrLValue(rv.getAggregateAddress(), ty);
-    emitAggregateCopy(dest, src, ty, getOverlapForReturnValue());
+    Address rvAddr = rv.getAggregateAddress();
+    // If the aggregate is already in the return slot (e.g. a callee was
+    // invoked through a ReturnValueSlot bound to returnValue), the copy is
+    // a no-op.  Calling emitAggregateCopy here would also incorrectly
+    // require the type to have a trivial copy/move.
+    if (rvAddr.getPointer() != returnValue.getPointer()) {
+      LValue dest = makeAddrLValue(returnValue, ty);
+      LValue src = makeAddrLValue(rvAddr, ty);
+      emitAggregateCopy(dest, src, ty, getOverlapForReturnValue());
+    }
   } else {
     cgm.errorNYI(loc, "emitReturnOfRValue: complex return type");
   }

--- a/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenVTables.cpp
@@ -752,9 +752,18 @@ void CIRGenFunction::emitCallAndReturnForThunk(cir::FuncOp callee,
   else
     assert(!cir::MissingFeatures::opCallMustTail());
 
-  // Emit return.
-  if (!resultType->isVoidType() && slot.isNull())
-    cgm.getCXXABI().emitReturnFromThunk(*this, rv, resultType);
+  // Emit return.  For aggregate returns the call has already written the
+  // result through the slot bound to returnValue above; emit the
+  // corresponding load+return here rather than leaving the function to
+  // fall off the end and have LexicalScope::emitImplicitReturn drop a
+  // `cir.trap` / `cir.unreachable` in its place (which would silently
+  // discard the result we just stored).
+  if (!resultType->isVoidType()) {
+    if (slot.isNull())
+      cgm.getCXXABI().emitReturnFromThunk(*this, rv, resultType);
+    else
+      emitReturnOfRValue(loc, rv, resultType);
+  }
 
   // Disable final ARC autorelease.
   assert(!cir::MissingFeatures::objCLifetime());

--- a/clang/test/CIR/CodeGen/lambda-static-invoker-agg-return.cpp
+++ b/clang/test/CIR/CodeGen/lambda-static-invoker-agg-return.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct S {
+  int x;
+  S();
+  S(const S &);
+  S &operator=(const S &);
+};
+
+S make_s();
+
+S agg_invoker() {
+  auto *fn = +[](int i) -> S { return make_s(); };
+  return fn(3);
+}
+
+// CIR-LABEL: cir.func no_inline internal private dso_local @_ZZ11agg_invokervEN3$_08__invokeEi
+// CIR-SAME:    (%[[I_ARG:.*]]: !s32i {{.*}}) -> !rec_S
+// CIR:         %[[I_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init]
+// CIR:         %[[RETVAL:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["__retval"]
+// CIR:         %[[UNUSED:.*]] = cir.alloca !rec_anon{{[^,]*}}, {{.*}} ["unused.capture"]
+// CIR-NOT:     cir.alloca {{.*}} ["agg.tmp
+// CIR:         cir.store %[[I_ARG]], %[[I_ALLOCA]]
+// CIR:         %[[I:.*]] = cir.load{{.*}} %[[I_ALLOCA]]
+// CIR:         %[[CALL:.*]] = cir.call @_ZZ11agg_invokervENK3$_0clEi(%[[UNUSED]], %[[I]]){{.*}} -> !rec_S
+// CIR-NOT:     cir.copy
+// CIR:         cir.store{{.*}} %[[CALL]], %[[RETVAL]]
+// CIR:         %[[RET:.*]] = cir.load %[[RETVAL]]
+// CIR:         cir.return %[[RET]]
+
+// LLVM-LABEL: define internal %struct.S @"_ZZ11agg_invokervEN3$_08__invokeEi"
+// LLVM-SAME:    (i32 {{[^,)]*}} %[[I_ARG:[^,)]+]])
+// LLVM:         %[[I_ALLOCA:.*]] = alloca i32
+// LLVM:         %[[RETVAL:.*]] = alloca %struct.S
+// LLVM:         %[[UNUSED:.*]] = alloca %class.anon
+// LLVM:         store i32 %[[I_ARG]], ptr %[[I_ALLOCA]]
+// LLVM:         %[[I:.*]] = load i32, ptr %[[I_ALLOCA]]
+// LLVM:         %[[CALL:.*]] = call %struct.S @"_ZZ11agg_invokervENK3$_0clEi"(ptr {{.*}} %[[UNUSED]], i32 {{.*}} %[[I]])
+// LLVM:         store %struct.S %[[CALL]], ptr %[[RETVAL]]
+// LLVM:         %[[RET:.*]] = load %struct.S, ptr %[[RETVAL]]
+// LLVM:         ret %struct.S %[[RET]]
+
+// OGCG-LABEL: define internal void @"_ZZ11agg_invokervEN3$_08__invokeEi"
+// OGCG-SAME:    (ptr {{.*}} sret(%struct.S) {{[^,]*}} %[[AGG_RESULT:[^,]+]], i32 {{[^,)]*}} %[[I_ARG:[^,)]+]])
+// OGCG:         call void @"_ZZ11agg_invokervENK3$_0clEi"(ptr {{.*}} sret(%struct.S) {{[^,]*}} %[[AGG_RESULT]], ptr {{.*}} %[[UNUSED:.*]], i32 {{.*}})
+// OGCG:         ret void

--- a/clang/test/CIR/CodeGen/thunks.cpp
+++ b/clang/test/CIR/CodeGen/thunks.cpp
@@ -91,6 +91,33 @@ void C::g(int x) {}
 
 } // namespace Test4
 
+namespace Test5 {
+// Non-virtual this-adjusting thunk for a method that returns an aggregate
+// with no trivial copy/move.
+
+struct NonTrivial {
+  int x;
+  NonTrivial();
+  NonTrivial(const NonTrivial &);
+  NonTrivial &operator=(const NonTrivial &);
+};
+
+struct A {
+  virtual NonTrivial h();
+};
+
+struct B {
+  virtual NonTrivial h();
+};
+
+struct C : A, B {
+  NonTrivial h() override;
+};
+
+NonTrivial C::h() { return NonTrivial(); }
+
+} // namespace Test5
+
 namespace CovariantReturn {
 // Covariant return with virtual inheritance: return-adjusting thunks use a
 // null check for pointer returns (classic PerformReturnAdjustment).
@@ -132,6 +159,12 @@ void C::f(int x, ...) {}
 // CIR-DAG: cir.global "private" external @_ZTVN5Test21CE = #cir.vtable<{
 // CIR-DAG:   #cir.global_view<@_ZN5Test21C1gEv> : !cir.ptr<!u8i>
 // CIR-DAG:   #cir.global_view<@_ZThn8_N5Test21C1gEv> : !cir.ptr<!u8i>
+
+// Test5 vtable: C's vtable references the aggregate-return thunk for B's
+// entry.
+// CIR-DAG: cir.global "private" external @_ZTVN5Test51CE = #cir.vtable<{
+// CIR-DAG:   #cir.global_view<@_ZN5Test51C1hEv> : !cir.ptr<!u8i>
+// CIR-DAG:   #cir.global_view<@_ZThn8_N5Test51C1hEv> : !cir.ptr<!u8i>
 
 // Test4 vtable: C's vtable references the thunk for B's entry.
 // CIR-DAG: cir.global "private" external @_ZTVN5Test41CE = #cir.vtable<{
@@ -213,6 +246,26 @@ void C::f(int x, ...) {}
 // CIR:   cir.call @_ZN5Test41C1gEi(%[[T4_RESULT]], %[[T4_ARG]])
 // CIR:   cir.return
 
+// --- Test5: aggregate non-trivial return type thunk ---
+
+// CIR: cir.func {{.*}} @_ZN5Test51C1hEv
+
+// CIR: cir.func {{.*}} @_ZThn8_N5Test51C1hEv(%arg0: !cir.ptr<
+// CIR:   %[[T5_THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
+// CIR:   %[[T5_RETVAL:.*]] = cir.alloca !rec_Test5{{.*}}NonTrivial, {{.*}} ["__retval"]
+// CIR:   cir.store %arg0, %[[T5_THIS_ADDR]]
+// CIR:   %[[T5_THIS:.*]] = cir.load %[[T5_THIS_ADDR]]
+// CIR:   %[[T5_CAST:.*]] = cir.cast bitcast %[[T5_THIS]] : !cir.ptr<{{.*}}> -> !cir.ptr<!u8i>
+// CIR:   %[[T5_OFFSET:.*]] = cir.const #cir.int<-8> : !s64i
+// CIR:   %[[T5_ADJUSTED:.*]] = cir.ptr_stride %[[T5_CAST]], %[[T5_OFFSET]]
+// CIR:   %[[T5_RESULT:.*]] = cir.cast bitcast %[[T5_ADJUSTED]] : !cir.ptr<!u8i> -> !cir.ptr<
+// CIR:   %[[T5_CALL:.*]] = cir.call @_ZN5Test51C1hEv(%[[T5_RESULT]]){{.*}} -> !rec_Test5{{.*}}NonTrivial
+// CIR:   cir.store {{.*}} %[[T5_CALL]], %[[T5_RETVAL]]
+// CIR:   %[[T5_RET_VAL:.*]] = cir.load %[[T5_RETVAL]]
+// CIR:   cir.return %[[T5_RET_VAL]]
+// CIR-NOT: cir.trap
+// CIR-NOT: cir.unreachable
+
 // --- CovariantReturn: return adjustment with null check on pointer return ---
 
 // CIR-LABEL: cir.func {{.*}} @_ZTch0_v0_n32_N15CovariantReturn1C1fEv
@@ -252,6 +305,11 @@ void C::f(int x, ...) {}
 // LLVM-SAME: [3 x ptr] [ptr inttoptr (i64 -8 to ptr), ptr null, ptr @_ZThn8_N5Test41C1gEi]
 // LLVM-SAME: }
 
+// LLVM: @_ZTVN5Test51CE = global { [3 x ptr], [3 x ptr] } {
+// LLVM-SAME: [3 x ptr] [ptr null, ptr null, ptr @_ZN5Test51C1hEv],
+// LLVM-SAME: [3 x ptr] [ptr inttoptr (i64 -8 to ptr), ptr null, ptr @_ZThn8_N5Test51C1hEv]
+// LLVM-SAME: }
+
 // LLVM: define {{.*}} void @_ZThn8_N5Test11C1fEv(ptr{{.*}})
 // LLVM:   %[[L1_THIS:.*]] = load ptr, ptr
 // LLVM:   %[[L1_ADJ:.*]] = getelementptr i8, ptr %[[L1_THIS]], i64 -8
@@ -277,6 +335,14 @@ void C::f(int x, ...) {}
 // LLVM:   %[[L4_ADJ:.*]] = getelementptr i8, ptr %[[L4_THIS]], i64 -8
 // LLVM:   %[[L4_ARG:.*]] = load i32, ptr
 // LLVM:   call void @_ZN5Test41C1gEi(ptr{{.*}} %[[L4_ADJ]], i32{{.*}} %[[L4_ARG]])
+
+// LLVM: define {{.*}} %"struct.Test5::NonTrivial" @_ZThn8_N5Test51C1hEv(ptr{{.*}})
+// LLVM:   %[[L5_THIS:.*]] = load ptr, ptr
+// LLVM:   %[[L5_ADJ:.*]] = getelementptr i8, ptr %[[L5_THIS]], i64 -8
+// LLVM:   %[[L5_RET:.*]] = call{{.*}} %"struct.Test5::NonTrivial" @_ZN5Test51C1hEv(ptr{{.*}} %[[L5_ADJ]])
+// LLVM:   store %"struct.Test5::NonTrivial" %[[L5_RET]], ptr
+// LLVM:   load %"struct.Test5::NonTrivial", ptr
+// LLVM:   ret %"struct.Test5::NonTrivial"
 
 // LLVM-LABEL: define {{.*}} @_ZTch0_v0_n32_N15CovariantReturn1C1fEv
 // LLVM:       call {{.*}} @_ZN15CovariantReturn1C1fEv
@@ -308,6 +374,11 @@ void C::f(int x, ...) {}
 // OGCG-SAME: [3 x ptr] [ptr inttoptr (i64 -8 to ptr), ptr null, ptr @_ZThn8_N5Test41C1gEi]
 // OGCG-SAME: }
 
+// OGCG: @_ZTVN5Test51CE = unnamed_addr constant { [3 x ptr], [3 x ptr] } {
+// OGCG-SAME: [3 x ptr] [ptr null, ptr null, ptr @_ZN5Test51C1hEv],
+// OGCG-SAME: [3 x ptr] [ptr inttoptr (i64 -8 to ptr), ptr null, ptr @_ZThn8_N5Test51C1hEv]
+// OGCG-SAME: }
+
 // OGCG: define {{.*}} void @_ZThn8_N5Test11C1fEv(ptr{{.*}})
 // OGCG:   %[[O1_THIS:.*]] = load ptr, ptr
 // OGCG:   %[[O1_ADJ:.*]] = getelementptr inbounds i8, ptr %[[O1_THIS]], i64 -8
@@ -333,6 +404,11 @@ void C::f(int x, ...) {}
 // OGCG:   %[[O4_ADJ:.*]] = getelementptr inbounds i8, ptr %[[O4_THIS]], i64 -8
 // OGCG:   %[[O4_ARG:.*]] = load i32, ptr
 // OGCG:   {{.*}}call void @_ZN5Test41C1gEi(ptr{{.*}} %[[O4_ADJ]], i32{{.*}} %[[O4_ARG]])
+
+// OGCG: define {{.*}} void @_ZThn8_N5Test51C1hEv(ptr {{[^,]*}}sret(%"struct.Test5::NonTrivial"){{[^,]*}}, ptr{{.*}})
+// OGCG:   %[[O5_THIS:.*]] = load ptr, ptr
+// OGCG:   %[[O5_ADJ:.*]] = getelementptr inbounds i8, ptr %[[O5_THIS]], i64 -8
+// OGCG:   {{.*}}call void @_ZN5Test51C1hEv(ptr {{.*}}sret(%"struct.Test5::NonTrivial"){{.*}}, ptr{{.*}} %[[O5_ADJ]])
 
 // OGCG-LABEL: define {{.*}} @_ZTch0_v0_n32_N15CovariantReturn1C1fEv
 // OGCG:       {{.*}}call {{.*}} @_ZN15CovariantReturn1C1fEv


### PR DESCRIPTION
Two related forwarding-call paths -- the captureless lambda
static-invoker `emitForwardingCallToLambda` in `CIRGenClass.cpp` and
vtable thunk emission `emitCallAndReturnForThunk` in
`CIRGenVTables.cpp` -- both forward a callee's return value up to
their own caller.  When the callee returns an aggregate, both must
bind their `ReturnValueSlot` to `returnValue` so the result lands in
the function's return slot directly, and both must emit a
`cir.return` that loads from it.

The lambda path was leaving the slot empty, materializing a
temporary, and then asking `emitReturnOfRValue` to aggregate-copy it
into `returnValue`.  For non-trivial aggregates (e.g.
`std::basic_string`) this hits the "Trying to aggregate-copy a type
without a trivial copy/move constructor" assertion in
`emitAggregateCopy`.  The thunk path was already binding the slot
but never emitted the follow-up `cir.return`, so
`LexicalScope::emitImplicitReturn` ended the function with
`cir.trap` (-O0) or `cir.unreachable` (-O1+) -- silently discarding
the just-stored result.  Any vtable call through a second-base-class
virtual function returning a non-trivial aggregate would therefore
trap or return garbage at runtime.  No existing test caught this;
thunks tests only cover primitive returns.

Both paths get the same fix: bind the slot on the aggregate path,
route the non-void exit through `emitReturnOfRValue` unconditionally,
and short-circuit the self-copy when the rvalue already sits at
`returnValue`.  The lambda fix unblocks 24 libcxx `std/` failures
in the C++26 `<format>` subtree (`format.tuple`,
`format.range.fmtmap` / `fmtstr` / `fmtset`,
`container.adaptors.format`) where lambdas returning
`std::basic_string` are converted to function pointers; the thunk
fix is correctness-only.
