### PR TITLE
[X86] Improve lowering of i32/i64 minmax reductions

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -29691,8 +29691,7 @@ static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
   unsigned NumSrcElts = SrcVT.getVectorNumElements();
   for (unsigned NumElts = NumSrcElts; NumElts != 1; NumElts /= 2) {
     // Scalarize the last 2 elements if the vector binop isn't legal.
-    if (NumElts == 2 &&
-        (!Subtarget.hasAVX() || BinOp == ISD::UMIN || BinOp == ISD::UMAX) &&
+    if (NumElts == 2 && !Subtarget.hasAVX512() &&
         !TLI.isOperationLegal(BinOp, SrcVT) && TLI.isTypeLegal(ExtractVT)) {
       return DAG.getNode(BinOp, DL, ExtractVT,
                          DAG.getExtractVectorElt(DL, ExtractVT, Src, 0),

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -29690,8 +29690,9 @@ static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
   // Expand 128-bit shuffle tree + reduction binops.
   unsigned NumSrcElts = SrcVT.getVectorNumElements();
   for (unsigned NumElts = NumSrcElts; NumElts != 1; NumElts /= 2) {
-    // SSE only - scalarize the last 2 elements if the vector binop isn't legal.
-    if (NumElts == 2 && !Subtarget.hasAVX() &&
+    // Scalarize the last 2 elements if the vector binop isn't legal.
+    if (NumElts == 2 &&
+        (!Subtarget.hasAVX() || BinOp == ISD::UMIN || BinOp == ISD::UMAX) &&
         !TLI.isOperationLegal(BinOp, SrcVT) && TLI.isTypeLegal(ExtractVT)) {
       return DAG.getNode(BinOp, DL, ExtractVT,
                          DAG.getExtractVectorElt(DL, ExtractVT, Src, 0),

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -1166,7 +1166,8 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
 
     // SSE2 can use basic vector unrolling.
     // SSE41 can use PHMINPOS to perform v16i8/v8i16 minmax reductions.
-    for (auto VT : {MVT::v16i8, MVT::v8i16}) {
+    // Fallback to ReplaceNodeResults for vXi64 reductions on 32-bit targets.
+    for (auto VT : {MVT::v16i8, MVT::v8i16, MVT::v4i32, MVT::v2i64, MVT::i64}) {
       setOperationAction(ISD::VECREDUCE_SMAX, VT, Custom);
       setOperationAction(ISD::VECREDUCE_SMIN, VT, Custom);
       setOperationAction(ISD::VECREDUCE_UMAX, VT, Custom);
@@ -1421,15 +1422,6 @@ X86TargetLowering::X86TargetLowering(const X86TargetMachine &TM,
     for (auto VT : { MVT::v8i16, MVT::v4i32, MVT::v2i64 }) {
       setOperationAction(ISD::SIGN_EXTEND_VECTOR_INREG, VT, Legal);
       setOperationAction(ISD::ZERO_EXTEND_VECTOR_INREG, VT, Legal);
-    }
-
-    // Allow v4i32/v2i64 minmax reductions with SSE41 vector comparison,
-    // select and minmax handling.
-    for (auto VT : { MVT::v4i32, MVT::v2i64 }) {
-      setOperationAction(ISD::VECREDUCE_SMAX, VT, Custom);
-      setOperationAction(ISD::VECREDUCE_SMIN, VT, Custom);
-      setOperationAction(ISD::VECREDUCE_UMAX, VT, Custom);
-      setOperationAction(ISD::VECREDUCE_UMIN, VT, Custom);
     }
 
     // SSE41 also has vector sign/zero extending loads, PMOV[SZ]X
@@ -29680,6 +29672,7 @@ static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
   SDValue Src = Op.getOperand(0);
   EVT SrcVT = Src.getValueType();
   EVT SrcSVT = SrcVT.getScalarType();
+  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
   SDLoc DL(Op);
 
   if (SrcSVT != ExtractVT || (SrcVT.getSizeInBits() % 128) != 0)
@@ -29697,6 +29690,14 @@ static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
   // Expand 128-bit shuffle tree + reduction binops.
   unsigned NumSrcElts = SrcVT.getVectorNumElements();
   for (unsigned NumElts = NumSrcElts; NumElts != 1; NumElts /= 2) {
+    // SSE only - scalarize the last 2 elements if the vector binop isn't legal.
+    if (NumElts == 2 && !Subtarget.hasAVX() &&
+        !TLI.isOperationLegal(BinOp, SrcVT) && TLI.isTypeLegal(ExtractVT)) {
+      return DAG.getNode(BinOp, DL, ExtractVT,
+                         DAG.getExtractVectorElt(DL, ExtractVT, Src, 0),
+                         DAG.getExtractVectorElt(DL, ExtractVT, Src, 1));
+    }
+
     SmallVector<int, 16> Mask(NumSrcElts, -1);
     std::iota(Mask.begin(), Mask.begin() + (NumElts / 2), NumElts / 2);
     SDValue Upper =
@@ -35332,6 +35333,15 @@ void X86TargetLowering::ReplaceNodeResults(SDNode *N,
       SDValue Res = DAG.getNode(ISD::CONCAT_VECTORS, dl, VT, Lo, Hi);
       Results.push_back(Res);
     }
+    return;
+  }
+  case ISD::VECREDUCE_SMAX:
+  case ISD::VECREDUCE_SMIN:
+  case ISD::VECREDUCE_UMAX:
+  case ISD::VECREDUCE_UMIN: {
+    assert(N->getValueType(0) == MVT::i64 && "Unexpected vector reduction");
+    if (SDValue Res = LowerMINMAX_REDUCE(SDValue(N, 0), Subtarget, DAG))
+      Results.push_back(Res);
     return;
   }
   case ISD::FP_TO_SINT_SAT:
@@ -47106,10 +47116,6 @@ static SDValue createPSADBW(SelectionDAG &DAG, SDValue N0, SDValue N1,
 // ISD::VECREDUCE_SMIN/SMAX/UMIN/UMAX.
 static SDValue combineMinMaxReduction(SDNode *Extract, SelectionDAG &DAG,
                                       const X86Subtarget &Subtarget) {
-  EVT ExtractVT = Extract->getValueType(0);
-  if (!DAG.getTargetLoweringInfo().isTypeLegal(ExtractVT))
-    return SDValue();
-
   // Check for SMAX/SMIN/UMAX/UMIN horizontal reduction patterns.
   ISD::NodeType BinOp;
   SDValue Src = DAG.matchBinOpReduction(
@@ -47139,7 +47145,7 @@ static SDValue combineMinMaxReduction(SDNode *Extract, SelectionDAG &DAG,
     llvm_unreachable("Unexpected reduction");
   }
 
-  return DAG.getNode(RdxOp, SDLoc(Extract), ExtractVT, Src);
+  return DAG.getNode(RdxOp, SDLoc(Extract), Extract->getValueType(0), Src);
 }
 
 // Attempt to replace an all_of/any_of/parity style horizontal reduction with a MOVMSK.

--- a/llvm/test/CodeGen/X86/horizontal-reduce-smax.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-smax.ll
@@ -75,10 +75,10 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX1OR2-LABEL: test_reduce_v2i64:
 ; X64-AVX1OR2:       ## %bb.0:
-; X64-AVX1OR2-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1OR2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX1OR2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1OR2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1OR2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1OR2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1OR2-NEXT:    cmpq %rax, %rcx
+; X64-AVX1OR2-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX1OR2-NEXT:    retq
 ;
 ; X64-AVX512-LABEL: test_reduce_v2i64:
@@ -507,10 +507,10 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -519,10 +519,10 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1193,10 +1193,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1207,10 +1207,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/horizontal-reduce-smax.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-smax.ll
@@ -13,13 +13,13 @@
 ; 128-bit Vectors
 ;
 
-define i64 @test_reduce_v2i64(<2 x i64> %a0) {
+define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v2i64:
 ; X86-SSE2:       ## %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,0,2147483648,0]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -67,11 +67,10 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
 ;
 ; X64-SSE42-LABEL: test_reduce_v2i64:
 ; X64-SSE42:       ## %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE42-NEXT:    movq %xmm0, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1OR2-LABEL: test_reduce_v2i64:
@@ -95,7 +94,7 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
   ret i64 %4
 }
 
-define i32 @test_reduce_v4i32(<4 x i32> %a0) {
+define i32 @test_reduce_v4i32(<4 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -171,7 +170,7 @@ define i32 @test_reduce_v4i32(<4 x i32> %a0) {
   ret i32 %7
 }
 
-define i16 @test_reduce_v8i16(<8 x i16> %a0) {
+define i16 @test_reduce_v8i16(<8 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -255,7 +254,7 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v16i8(<16 x i8> %a0) {
+define i8 @test_reduce_v16i8(<16 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -270,21 +269,18 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -332,14 +328,11 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -396,7 +389,7 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; 256-bit Vectors
 ;
 
-define i64 @test_reduce_v4i64(<4 x i64> %a0) {
+define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,0,2147483648,0]
@@ -415,9 +408,9 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -503,11 +496,10 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v4i64:
@@ -553,7 +545,7 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
   ret i64 %7
 }
 
-define i32 @test_reduce_v8i32(<8 x i32> %a0) {
+define i32 @test_reduce_v8i32(<8 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
@@ -686,7 +678,7 @@ define i32 @test_reduce_v8i32(<8 x i32> %a0) {
   ret i32 %10
 }
 
-define i16 @test_reduce_v16i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pmaxsw %xmm1, %xmm0
@@ -810,7 +802,7 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
   ret i16 %13
 }
 
-define i8 @test_reduce_v32i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
@@ -830,21 +822,18 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -915,14 +904,11 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm1, %xmm2
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
 ; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X64-SSE2-NEXT:    pand %xmm2, %xmm1
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movd %xmm2, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1003,13 +989,13 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; 512-bit Vectors
 ;
 
-define i64 @test_reduce_v8i64(<8 x i64> %a0) {
+define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,0,2147483648,0]
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm3, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm6
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm7
@@ -1019,42 +1005,42 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm6
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm6, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm5
-; X86-SSE2-NEXT:    por %xmm0, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm3, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE2-NEXT:    pand %xmm5, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm3, %xmm5
+; X86-SSE2-NEXT:    por %xmm1, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE2-NEXT:    movdqa %xmm3, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm1, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm3
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE2-NEXT:    pand %xmm1, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
+; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm3, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm3, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
-; X86-SSE2-NEXT:    por %xmm5, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm3
 ; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm3
@@ -1191,11 +1177,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X64-SSE42-NEXT:    movapd %xmm2, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v8i64:
@@ -1253,7 +1238,7 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
   ret i64 %10
 }
 
-define i32 @test_reduce_v16i32(<16 x i32> %a0) {
+define i32 @test_reduce_v16i32(<16 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
@@ -1423,7 +1408,7 @@ define i32 @test_reduce_v16i32(<16 x i32> %a0) {
   ret i32 %13
 }
 
-define i16 @test_reduce_v32i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pmaxsw %xmm3, %xmm1
@@ -1568,7 +1553,7 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
   ret i16 %16
 }
 
-define i8 @test_reduce_v64i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
@@ -1598,21 +1583,18 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1699,14 +1681,11 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1798,7 +1777,7 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; Partial Vector Reductions
 ;
 
-define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1885,7 +1864,7 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
   ret i16 %10
 }
 
-define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1972,7 +1951,7 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1987,21 +1966,18 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2050,14 +2026,11 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2112,7 +2085,7 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
   ret i8 %13
 }
 
-define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -2127,21 +2100,18 @@ define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2190,14 +2160,11 @@ define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/horizontal-reduce-smin.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-smin.ll
@@ -13,13 +13,13 @@
 ; 128-bit Vectors
 ;
 
-define i64 @test_reduce_v2i64(<2 x i64> %a0) {
+define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v2i64:
 ; X86-SSE2:       ## %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,0,2147483648,0]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -68,12 +68,10 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
 ;
 ; X64-SSE42-LABEL: test_reduce_v2i64:
 ; X64-SSE42:       ## %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE42-NEXT:    movq %xmm0, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1OR2-LABEL: test_reduce_v2i64:
@@ -97,7 +95,7 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
   ret i64 %4
 }
 
-define i32 @test_reduce_v4i32(<4 x i32> %a0) {
+define i32 @test_reduce_v4i32(<4 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -173,7 +171,7 @@ define i32 @test_reduce_v4i32(<4 x i32> %a0) {
   ret i32 %7
 }
 
-define i16 @test_reduce_v8i16(<8 x i16> %a0) {
+define i16 @test_reduce_v8i16(<8 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -257,7 +255,7 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v16i8(<16 x i8> %a0) {
+define i8 @test_reduce_v16i8(<16 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -272,21 +270,18 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -334,14 +329,11 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -398,7 +390,7 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; 256-bit Vectors
 ;
 
-define i64 @test_reduce_v4i64(<4 x i64> %a0) {
+define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,0,2147483648,0]
@@ -417,9 +409,9 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm4
@@ -507,11 +499,10 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v4i64:
@@ -557,7 +548,7 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
   ret i64 %7
 }
 
-define i32 @test_reduce_v8i32(<8 x i32> %a0) {
+define i32 @test_reduce_v8i32(<8 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
@@ -690,7 +681,7 @@ define i32 @test_reduce_v8i32(<8 x i32> %a0) {
   ret i32 %10
 }
 
-define i16 @test_reduce_v16i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pminsw %xmm1, %xmm0
@@ -814,7 +805,7 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
   ret i16 %13
 }
 
-define i8 @test_reduce_v32i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
@@ -834,21 +825,18 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -919,14 +907,11 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm1, %xmm2
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
 ; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X64-SSE2-NEXT:    pand %xmm2, %xmm1
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movd %xmm2, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1007,13 +992,13 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; 512-bit Vectors
 ;
 
-define i64 @test_reduce_v8i64(<8 x i64> %a0) {
+define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,0,2147483648,0]
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm3, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm6
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm7
@@ -1023,42 +1008,42 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm6
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm6, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm3, %xmm5
-; X86-SSE2-NEXT:    por %xmm1, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm3
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm3
-; X86-SSE2-NEXT:    movdqa %xmm3, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm3, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    pand %xmm5, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm5
+; X86-SSE2-NEXT:    por %xmm0, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm3, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm3
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm3
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE2-NEXT:    pand %xmm2, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm3, %xmm2
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm3
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm3
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
+; X86-SSE2-NEXT:    por %xmm5, %xmm0
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm4, %xmm3
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm3
@@ -1195,11 +1180,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v8i64:
@@ -1257,7 +1241,7 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
   ret i64 %10
 }
 
-define i32 @test_reduce_v16i32(<16 x i32> %a0) {
+define i32 @test_reduce_v16i32(<16 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
@@ -1427,7 +1411,7 @@ define i32 @test_reduce_v16i32(<16 x i32> %a0) {
   ret i32 %13
 }
 
-define i16 @test_reduce_v32i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pminsw %xmm3, %xmm1
@@ -1572,7 +1556,7 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
   ret i16 %16
 }
 
-define i8 @test_reduce_v64i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
@@ -1602,21 +1586,18 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1703,14 +1684,11 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1802,7 +1780,7 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; Partial Vector Reductions
 ;
 
-define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1889,7 +1867,7 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
   ret i16 %10
 }
 
-define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1976,7 +1954,7 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1991,21 +1969,18 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2054,14 +2029,11 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2116,7 +2088,7 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
   ret i8 %13
 }
 
-define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -2131,21 +2103,18 @@ define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2194,14 +2163,11 @@ define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/horizontal-reduce-smin.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-smin.ll
@@ -76,10 +76,10 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX1OR2-LABEL: test_reduce_v2i64:
 ; X64-AVX1OR2:       ## %bb.0:
-; X64-AVX1OR2-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1OR2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX1OR2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1OR2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1OR2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1OR2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1OR2-NEXT:    cmpq %rax, %rcx
+; X64-AVX1OR2-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX1OR2-NEXT:    retq
 ;
 ; X64-AVX512-LABEL: test_reduce_v2i64:
@@ -510,10 +510,10 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -522,10 +522,10 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1196,10 +1196,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm2, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1210,10 +1210,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/horizontal-reduce-umax.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-umax.ll
@@ -13,13 +13,13 @@
 ; 128-bit Vectors
 ;
 
-define i64 @test_reduce_v2i64(<2 x i64> %a0) {
+define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v2i64:
 ; X86-SSE2:       ## %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -40,37 +40,37 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
 ; X86-SSE42-LABEL: test_reduce_v2i64:
 ; X86-SSE42:       ## %bb.0:
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm2, %xmm3
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X86-SSE42-NEXT:    movd %xmm2, %eax
-; X86-SSE42-NEXT:    pextrd $1, %xmm2, %edx
+; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
+; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
+; X86-SSE42-NEXT:    movd %xmm3, %eax
+; X86-SSE42-NEXT:    pextrd $1, %xmm3, %edx
 ; X86-SSE42-NEXT:    retl
 ;
 ; X86-AVX1-LABEL: test_reduce_v2i64:
 ; X86-AVX1:       ## %bb.0:
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX1-NEXT:    ## xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX1-NEXT:    ## xmm1 = mem[0,0]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    retl
 ;
 ; X86-AVX2-LABEL: test_reduce_v2i64:
 ; X86-AVX2:       ## %bb.0:
-; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    retl
@@ -86,14 +86,10 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
 ;
 ; X64-SSE42-LABEL: test_reduce_v2i64:
 ; X64-SSE42:       ## %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm2 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    pxor %xmm2, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm2
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE42-NEXT:    movq %xmm3, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE42-NEXT:    movq %xmm0, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v2i64:
@@ -132,7 +128,7 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
   ret i64 %4
 }
 
-define i32 @test_reduce_v4i32(<4 x i32> %a0) {
+define i32 @test_reduce_v4i32(<4 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [2147483648,2147483648,2147483648,2147483648]
@@ -214,7 +210,7 @@ define i32 @test_reduce_v4i32(<4 x i32> %a0) {
   ret i32 %7
 }
 
-define i16 @test_reduce_v8i16(<8 x i16> %a0) {
+define i16 @test_reduce_v8i16(<8 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -223,11 +219,10 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
-; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movd %xmm1, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -259,11 +254,10 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
-; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -318,7 +312,7 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v16i8(<16 x i8> %a0) {
+define i8 @test_reduce_v16i8(<16 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -443,7 +437,7 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; 256-bit Vectors
 ;
 
-define i64 @test_reduce_v4i64(<4 x i64> %a0) {
+define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
@@ -462,9 +456,9 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -491,9 +485,9 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm2, %xmm3
 ; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
@@ -510,11 +504,11 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm4
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
 ; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -528,11 +522,11 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm4
 ; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
 ; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -565,19 +559,16 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X64-SSE42-LABEL: test_reduce_v4i64:
 ; X64-SSE42:       ## %bb.0:
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm4
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm2, %xmm3
+; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [9223372036854775808,9223372036854775808]
+; X64-SSE42-NEXT:    movdqa %xmm1, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm2, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v4i64:
@@ -634,7 +625,7 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
   ret i64 %7
 }
 
-define i32 @test_reduce_v8i32(<8 x i32> %a0) {
+define i32 @test_reduce_v8i32(<8 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,2147483648,2147483648,2147483648]
@@ -779,7 +770,7 @@ define i32 @test_reduce_v8i32(<8 x i32> %a0) {
   ret i32 %10
 }
 
-define i16 @test_reduce_v16i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
@@ -790,11 +781,10 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrld $16, %xmm0
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X86-SSE2-NEXT:    movd %xmm1, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -845,11 +835,10 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrld $16, %xmm0
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -917,7 +906,7 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
   ret i16 %13
 }
 
-define i8 @test_reduce_v32i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pmaxub %xmm1, %xmm0
@@ -1076,13 +1065,13 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; 512-bit Vectors
 ;
 
-define i64 @test_reduce_v8i64(<8 x i64> %a0) {
+define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm3, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm6
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm7
@@ -1092,42 +1081,42 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm6
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm6, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm5
-; X86-SSE2-NEXT:    por %xmm0, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm3, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE2-NEXT:    pand %xmm5, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm3, %xmm5
+; X86-SSE2-NEXT:    por %xmm1, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE2-NEXT:    movdqa %xmm3, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm1, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm3
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE2-NEXT:    pand %xmm1, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
+; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm3, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm3, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
-; X86-SSE2-NEXT:    por %xmm5, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm3
 ; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm3
@@ -1149,26 +1138,27 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-SSE42:       ## %bb.0:
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm4
 ; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm3, %xmm6
 ; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm4
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm4
 ; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
 ; X86-SSE42-NEXT:    movapd %xmm3, %xmm1
 ; X86-SSE42-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
 ; X86-SSE42-NEXT:    movapd %xmm2, %xmm0
 ; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
+; X86-SSE42-NEXT:    movapd %xmm3, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm1, %xmm5
 ; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
@@ -1178,27 +1168,27 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ;
 ; X86-AVX1-LABEL: test_reduce_v8i64:
 ; X86-AVX1:       ## %bb.0:
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm3
 ; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
 ; X86-AVX1-NEXT:    ## xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm3
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm4
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm5
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm5, %xmm4
-; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm3, %xmm4
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm5, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm6, %xmm4
+; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm5, %xmm3, %xmm3
 ; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm5
+; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -1216,11 +1206,11 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm4
 ; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
 ; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -1298,17 +1288,14 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X64-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
-; X64-SSE42-NEXT:    movapd %xmm2, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X64-SSE42-NEXT:    xorpd %xmm2, %xmm5
+; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm5
+; X64-SSE42-NEXT:    movdqa %xmm5, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm1, %xmm5
-; X64-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v8i64:
@@ -1383,7 +1370,7 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
   ret i64 %10
 }
 
-define i32 @test_reduce_v16i32(<16 x i32> %a0) {
+define i32 @test_reduce_v16i32(<16 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
@@ -1577,7 +1564,7 @@ define i32 @test_reduce_v16i32(<16 x i32> %a0) {
   ret i32 %13
 }
 
-define i16 @test_reduce_v32i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    psubusw %xmm0, %xmm2
@@ -1592,11 +1579,10 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrld $16, %xmm0
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X86-SSE2-NEXT:    movd %xmm1, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1657,11 +1643,10 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrld $16, %xmm0
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1740,7 +1725,7 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
   ret i16 %16
 }
 
-define i8 @test_reduce_v64i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pmaxub %xmm3, %xmm1
@@ -1920,7 +1905,7 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; Partial Vector Reductions
 ;
 
-define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1929,11 +1914,10 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
-; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movd %xmm1, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1966,11 +1950,10 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
-; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2028,7 +2011,7 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
   ret i16 %10
 }
 
-define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -2037,11 +2020,10 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
-; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movd %xmm1, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2074,11 +2056,10 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
-; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2136,7 +2117,7 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -2261,7 +2242,7 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
   ret i8 %13
 }
 
-define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]

--- a/llvm/test/CodeGen/X86/horizontal-reduce-umax.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-umax.ll
@@ -94,25 +94,18 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX1-LABEL: test_reduce_v2i64:
 ; X64-AVX1:       ## %bb.0:
-; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX1-NEXT:    ## xmm1 = mem[0,0]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    retq
 ;
 ; X64-AVX2-LABEL: test_reduce_v2i64:
 ; X64-AVX2:       ## %bb.0:
-; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    retq
 ;
 ; X64-AVX512-LABEL: test_reduce_v2i64:
@@ -577,15 +570,13 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [9223372036854775808,9223372036854775808]
 ; X64-AVX1-NEXT:    ## xmm2 = mem[0,0]
 ; X64-AVX1-NEXT:    vpxor %xmm2, %xmm1, %xmm3
-; X64-AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm4
-; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm2
+; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
+; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -594,15 +585,13 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [9223372036854775808,9223372036854775808]
 ; X64-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm3
-; X64-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X64-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm2
+; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
+; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1316,12 +1305,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm3, %xmm2, %xmm3
-; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1334,15 +1321,13 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vblendvpd %ymm3, %ymm0, %ymm1, %ymm0
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm3
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X64-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm2
+; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
+; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/horizontal-reduce-umin.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-umin.ll
@@ -13,13 +13,13 @@
 ; 128-bit Vectors
 ;
 
-define i64 @test_reduce_v2i64(<2 x i64> %a0) {
+define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v2i64:
 ; X86-SSE2:       ## %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -40,38 +40,38 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
 ; X86-SSE42-LABEL: test_reduce_v2i64:
 ; X86-SSE42:       ## %bb.0:
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
 ; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm0, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X86-SSE42-NEXT:    movd %xmm2, %eax
-; X86-SSE42-NEXT:    pextrd $1, %xmm2, %edx
+; X86-SSE42-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE42-NEXT:    pxor %xmm0, %xmm2
+; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
+; X86-SSE42-NEXT:    movd %xmm3, %eax
+; X86-SSE42-NEXT:    pextrd $1, %xmm3, %edx
 ; X86-SSE42-NEXT:    retl
 ;
 ; X86-AVX1-LABEL: test_reduce_v2i64:
 ; X86-AVX1:       ## %bb.0:
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX1-NEXT:    ## xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX1-NEXT:    ## xmm1 = mem[0,0]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    retl
 ;
 ; X86-AVX2-LABEL: test_reduce_v2i64:
 ; X86-AVX2:       ## %bb.0:
-; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    retl
@@ -87,15 +87,10 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
 ;
 ; X64-SSE42-LABEL: test_reduce_v2i64:
 ; X64-SSE42:       ## %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE42-NEXT:    pxor %xmm0, %xmm2
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE42-NEXT:    movq %xmm3, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE42-NEXT:    movq %xmm0, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v2i64:
@@ -134,7 +129,7 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) {
   ret i64 %4
 }
 
-define i32 @test_reduce_v4i32(<4 x i32> %a0) {
+define i32 @test_reduce_v4i32(<4 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [2147483648,2147483648,2147483648,2147483648]
@@ -216,7 +211,7 @@ define i32 @test_reduce_v4i32(<4 x i32> %a0) {
   ret i32 %7
 }
 
-define i16 @test_reduce_v8i16(<8 x i16> %a0) {
+define i16 @test_reduce_v8i16(<8 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -227,12 +222,10 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -260,12 +253,10 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -295,7 +286,7 @@ define i16 @test_reduce_v8i16(<8 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v16i8(<16 x i8> %a0) {
+define i8 @test_reduce_v16i8(<16 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -385,7 +376,7 @@ define i8 @test_reduce_v16i8(<16 x i8> %a0) {
 ; 256-bit Vectors
 ;
 
-define i64 @test_reduce_v4i64(<4 x i64> %a0) {
+define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v4i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
@@ -404,9 +395,9 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm4
@@ -434,9 +425,9 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm2, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm3, %xmm2
 ; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm2
 ; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
@@ -454,11 +445,11 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X86-AVX1-NEXT:    vxorps %xmm1, %xmm3, %xmm4
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm2, %xmm1
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -466,17 +457,17 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ;
 ; X86-AVX2-LABEL: test_reduce_v4i64:
 ; X86-AVX2:       ## %bb.0:
-; X86-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
-; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm4
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm3
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm4
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
+; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -509,21 +500,16 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
 ; X64-SSE42-LABEL: test_reduce_v4i64:
 ; X64-SSE42:       ## %bb.0:
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm4
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [9223372036854775808,9223372036854775808]
+; X64-SSE42-NEXT:    movdqa %xmm2, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm1, %xmm0
+; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm2, %xmm3
-; X64-SSE42-NEXT:    pcmpgtq %xmm0, %xmm3
-; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v4i64:
@@ -580,7 +566,7 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) {
   ret i64 %7
 }
 
-define i32 @test_reduce_v8i32(<8 x i32> %a0) {
+define i32 @test_reduce_v8i32(<8 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
@@ -725,7 +711,7 @@ define i32 @test_reduce_v8i32(<8 x i32> %a0) {
   ret i32 %10
 }
 
-define i16 @test_reduce_v16i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
@@ -739,12 +725,10 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -789,12 +773,10 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -851,7 +833,7 @@ define i16 @test_reduce_v16i16(<16 x i16> %a0) {
   ret i16 %13
 }
 
-define i8 @test_reduce_v32i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pminub %xmm1, %xmm0
@@ -990,13 +972,13 @@ define i8 @test_reduce_v32i8(<32 x i8> %a0) {
 ; 512-bit Vectors
 ;
 
-define i64 @test_reduce_v8i64(<8 x i64> %a0) {
+define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v8i64:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm3, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm6
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
 ; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm7
@@ -1006,42 +988,42 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm6
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm6, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm3, %xmm5
-; X86-SSE2-NEXT:    por %xmm1, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm3
-; X86-SSE2-NEXT:    pxor %xmm4, %xmm3
-; X86-SSE2-NEXT:    movdqa %xmm3, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm3, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    pand %xmm5, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm5
+; X86-SSE2-NEXT:    por %xmm0, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm3, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm3
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm3
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE2-NEXT:    pand %xmm2, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm3, %xmm2
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm3
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm3
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
+; X86-SSE2-NEXT:    por %xmm5, %xmm0
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm4, %xmm3
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm3
@@ -1061,32 +1043,32 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ;
 ; X86-SSE42-LABEL: test_reduce_v8i64:
 ; X86-SSE42:       ## %bb.0:
-; X86-SSE42-NEXT:    movdqa %xmm0, %xmm4
-; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    movdqa %xmm0, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm4, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm2
+; X86-SSE42-NEXT:    movapd %xmm2, %xmm5
+; X86-SSE42-NEXT:    xorpd %xmm4, %xmm5
 ; X86-SSE42-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm4, %xmm6
 ; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X86-SSE42-NEXT:    movdqa %xmm4, %xmm1
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm1
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
-; X86-SSE42-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE42-NEXT:    xorpd %xmm5, %xmm1
 ; X86-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
+; X86-SSE42-NEXT:    movapd %xmm3, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm1, %xmm5
-; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm5
-; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm1, %xmm4
+; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm4
+; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
 ; X86-SSE42-NEXT:    movd %xmm1, %eax
 ; X86-SSE42-NEXT:    pextrd $1, %xmm1, %edx
@@ -1094,27 +1076,27 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ;
 ; X86-AVX1-LABEL: test_reduce_v8i64:
 ; X86-AVX1:       ## %bb.0:
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
 ; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
 ; X86-AVX1-NEXT:    ## xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm3, %xmm4
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm5
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm5, %xmm6
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm6, %xmm4
-; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm3, %xmm5, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm4
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm5
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm5, %xmm4
-; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm3
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm4
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
+; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm3
 ; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm5
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm5
+; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
 ; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -1127,16 +1109,16 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ; X86-AVX2-NEXT:    vpxor %ymm2, %ymm1, %ymm4
 ; X86-AVX2-NEXT:    vpcmpgtq %ymm3, %ymm4, %ymm3
 ; X86-AVX2-NEXT:    vblendvpd %ymm3, %ymm0, %ymm1, %ymm0
-; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm4
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm3
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -1198,34 +1180,30 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
 ;
 ; X64-SSE42-LABEL: test_reduce_v8i64:
 ; X64-SSE42:       ## %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm5
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [9223372036854775808,9223372036854775808]
+; X64-SSE42-NEXT:    movdqa %xmm0, %xmm4
+; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [9223372036854775808,9223372036854775808]
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm6
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm6
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm6
 ; X64-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm2
-; X64-SSE42-NEXT:    movapd %xmm2, %xmm5
-; X64-SSE42-NEXT:    xorpd %xmm4, %xmm5
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
+; X64-SSE42-NEXT:    movapd %xmm2, %xmm4
+; X64-SSE42-NEXT:    xorpd %xmm5, %xmm4
 ; X64-SSE42-NEXT:    movdqa %xmm1, %xmm6
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm6
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm6
 ; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
+; X64-SSE42-NEXT:    xorpd %xmm3, %xmm5
+; X64-SSE42-NEXT:    pcmpgtq %xmm4, %xmm5
+; X64-SSE42-NEXT:    movdqa %xmm5, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm1, %xmm4
-; X64-SSE42-NEXT:    pcmpgtq %xmm0, %xmm4
-; X64-SSE42-NEXT:    movdqa %xmm4, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X64-AVX1-LABEL: test_reduce_v8i64:
@@ -1300,7 +1278,7 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) {
   ret i64 %10
 }
 
-define i32 @test_reduce_v16i32(<16 x i32> %a0) {
+define i32 @test_reduce_v16i32(<16 x i32> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i32:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
@@ -1494,7 +1472,7 @@ define i32 @test_reduce_v16i32(<16 x i32> %a0) {
   ret i32 %13
 }
 
-define i16 @test_reduce_v32i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
@@ -1514,12 +1492,10 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1576,12 +1552,10 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1649,7 +1623,7 @@ define i16 @test_reduce_v32i16(<32 x i16> %a0) {
   ret i16 %16
 }
 
-define i8 @test_reduce_v64i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pminub %xmm3, %xmm1
@@ -1809,7 +1783,7 @@ define i8 @test_reduce_v64i8(<64 x i8> %a0) {
 ; Partial Vector Reductions
 ;
 
-define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
+define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v16i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1820,12 +1794,10 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1854,12 +1826,10 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1890,7 +1860,7 @@ define i16 @test_reduce_v16i16_v8i16(<16 x i16> %a0) {
   ret i16 %10
 }
 
-define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
+define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i16_v8i16:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -1901,12 +1871,10 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -1935,12 +1903,10 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    ## kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -1971,7 +1937,7 @@ define i16 @test_reduce_v32i16_v8i16(<32 x i16> %a0) {
   ret i16 %10
 }
 
-define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
+define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v32i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
@@ -2059,7 +2025,7 @@ define i8 @test_reduce_v32i8_v16i8(<32 x i8> %a0) {
   ret i8 %13
 }
 
-define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) {
+define i8 @test_reduce_v64i8_v16i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-LABEL: test_reduce_v64i8_v16i8:
 ; X86-SSE2:       ## %bb.0:
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]

--- a/llvm/test/CodeGen/X86/horizontal-reduce-umin.ll
+++ b/llvm/test/CodeGen/X86/horizontal-reduce-umin.ll
@@ -95,25 +95,18 @@ define i64 @test_reduce_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX1-LABEL: test_reduce_v2i64:
 ; X64-AVX1:       ## %bb.0:
-; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX1-NEXT:    ## xmm1 = mem[0,0]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    retq
 ;
 ; X64-AVX2-LABEL: test_reduce_v2i64:
 ; X64-AVX2:       ## %bb.0:
-; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    retq
 ;
 ; X64-AVX512-LABEL: test_reduce_v2i64:
@@ -518,15 +511,13 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    ## xmm1 = mem[0,0]
 ; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm2
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm4
-; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -535,15 +526,13 @@ define i64 @test_reduce_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
 ; X64-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
 ; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1224,12 +1213,10 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1242,15 +1229,13 @@ define i64 @test_reduce_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vblendvpd %ymm3, %ymm0, %ymm1, %ymm0
 ; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm3
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
 ; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
 ; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/intrinsic-cttz-elts.ll
+++ b/llvm/test/CodeGen/X86/intrinsic-cttz-elts.ll
@@ -21,11 +21,10 @@ define i8 @ctz_v8i16(<8 x i16> %a) {
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; CHECK-NEXT:    psubusw %xmm0, %xmm1
 ; CHECK-NEXT:    paddw %xmm0, %xmm1
-; CHECK-NEXT:    movdqa %xmm1, %xmm0
-; CHECK-NEXT:    psrld $16, %xmm0
-; CHECK-NEXT:    psubusw %xmm1, %xmm0
-; CHECK-NEXT:    paddw %xmm1, %xmm0
-; CHECK-NEXT:    movd %xmm0, %ecx
+; CHECK-NEXT:    pextrw $1, %xmm1, %ecx
+; CHECK-NEXT:    movd %xmm1, %eax
+; CHECK-NEXT:    cmpw %cx, %ax
+; CHECK-NEXT:    cmoval %eax, %ecx
 ; CHECK-NEXT:    movl $8, %eax
 ; CHECK-NEXT:    subl %ecx, %eax
 ; CHECK-NEXT:    # kill: def $al killed $al killed $eax
@@ -90,11 +89,10 @@ define i8 @ctz_v8i16_poison(<8 x i16> %a) {
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; CHECK-NEXT:    psubusw %xmm0, %xmm1
 ; CHECK-NEXT:    paddw %xmm0, %xmm1
-; CHECK-NEXT:    movdqa %xmm1, %xmm0
-; CHECK-NEXT:    psrld $16, %xmm0
-; CHECK-NEXT:    psubusw %xmm1, %xmm0
-; CHECK-NEXT:    paddw %xmm1, %xmm0
-; CHECK-NEXT:    movd %xmm0, %ecx
+; CHECK-NEXT:    pextrw $1, %xmm1, %ecx
+; CHECK-NEXT:    movd %xmm1, %eax
+; CHECK-NEXT:    cmpw %cx, %ax
+; CHECK-NEXT:    cmoval %eax, %ecx
 ; CHECK-NEXT:    movl $8, %eax
 ; CHECK-NEXT:    subl %ecx, %eax
 ; CHECK-NEXT:    # kill: def $al killed $al killed $eax

--- a/llvm/test/CodeGen/X86/vector-extract-last-active.ll
+++ b/llvm/test/CodeGen/X86/vector-extract-last-active.ll
@@ -164,11 +164,10 @@ define i32 @extract_last_active_v8i32(<8 x i32> %a, <8 x i1> %c) {
 ; CHECK-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; CHECK-NEXT:    psubusw %xmm0, %xmm1
 ; CHECK-NEXT:    paddw %xmm0, %xmm1
-; CHECK-NEXT:    movdqa %xmm1, %xmm0
-; CHECK-NEXT:    psrld $16, %xmm0
-; CHECK-NEXT:    psubusw %xmm1, %xmm0
-; CHECK-NEXT:    paddw %xmm1, %xmm0
-; CHECK-NEXT:    movd %xmm0, %ecx
+; CHECK-NEXT:    pextrw $1, %xmm1, %ecx
+; CHECK-NEXT:    movd %xmm1, %edx
+; CHECK-NEXT:    cmpw %cx, %dx
+; CHECK-NEXT:    cmoval %edx, %ecx
 ; CHECK-NEXT:    andl $7, %ecx
 ; CHECK-NEXT:    orl -40(%rsp,%rcx,4), %eax
 ; CHECK-NEXT:    retq

--- a/llvm/test/CodeGen/X86/vector-reduce-smax.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-smax.ll
@@ -99,10 +99,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX-LABEL: test_v2i64:
 ; X64-AVX:       # %bb.0:
-; X64-AVX-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX-NEXT:    vmovq %xmm0, %rax
+; X64-AVX-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX-NEXT:    cmpq %rax, %rcx
+; X64-AVX-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX-NEXT:    retq
 ;
 ; AVX512BW-LABEL: test_v2i64:
@@ -285,10 +285,10 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -310,10 +310,10 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -659,10 +659,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -688,10 +688,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1337,10 +1337,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm4, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1381,10 +1381,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovgq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-smax.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-smax.ll
@@ -19,10 +19,10 @@
 define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_v2i64:
 ; X86-SSE2:       # %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,0,2147483648,0]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -52,10 +52,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-LABEL: test_v2i64:
 ; X86-SSE41:       # %bb.0:
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
 ; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm0 = [2147483648,2147483648]
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
 ; X86-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE41-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
@@ -70,25 +70,13 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pextrd $1, %xmm2, %edx
 ; X86-SSE41-NEXT:    retl
 ;
-; X64-SSE41-LABEL: test_v2i64:
-; X64-SSE41:       # %bb.0:
-; X64-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm0 = [2147483648,2147483648]
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE41-NEXT:    pxor %xmm0, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm2, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm5, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm2, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE41-NEXT:    movq %xmm3, %rax
-; X64-SSE41-NEXT:    retq
+; X64-SSE4-LABEL: test_v2i64:
+; X64-SSE4:       # %bb.0:
+; X64-SSE4-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE4-NEXT:    movq %xmm0, %rcx
+; X64-SSE4-NEXT:    cmpq %rax, %rcx
+; X64-SSE4-NEXT:    cmovgq %rcx, %rax
+; X64-SSE4-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v2i64:
 ; X86-SSE42:       # %bb.0:
@@ -99,15 +87,6 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    movd %xmm2, %eax
 ; X86-SSE42-NEXT:    pextrd $1, %xmm2, %edx
 ; X86-SSE42-NEXT:    retl
-;
-; X64-SSE42-LABEL: test_v2i64:
-; X64-SSE42:       # %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
-; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX-LABEL: test_v2i64:
 ; X86-AVX:       # %bb.0:
@@ -164,9 +143,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -225,11 +204,11 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm4, %xmm0
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm3
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
 ; X86-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
@@ -245,34 +224,23 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE41-LABEL: test_v4i64:
 ; X64-SSE41:       # %bb.0:
 ; X64-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm3 = [2147483648,2147483648]
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm2, %xmm4
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE41-NEXT:    movdqa %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm5[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm2, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm4
+; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm0 = [2147483648,2147483648]
+; X64-SSE41-NEXT:    movdqa %xmm1, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm2, %xmm0
+; X64-SSE41-NEXT:    movdqa %xmm0, %xmm4
 ; X64-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm4[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm3, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    pand %xmm5, %xmm3
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm3, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE41-NEXT:    movq %xmm2, %rax
+; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE41-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE41-NEXT:    movq %xmm1, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v4i64:
@@ -293,11 +261,10 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v4i64:
@@ -381,56 +348,56 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $16, %esp
+; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,0,2147483648,0]
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm4
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm4
+; X86-SSE2-NEXT:    pand %xmm4, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
+; X86-SSE2-NEXT:    por %xmm1, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm7
-; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm4
-; X86-SSE2-NEXT:    pand %xmm4, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm4
-; X86-SSE2-NEXT:    por %xmm0, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm1, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
+; X86-SSE2-NEXT:    pand %xmm1, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
+; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm5
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm5, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm5, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm4
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
-; X86-SSE2-NEXT:    por %xmm4, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -511,60 +478,60 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    andl $-16, %esp
 ; X86-SSE41-NEXT:    subl $16, %esp
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm4 = [2147483648,2147483648]
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm4
+; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm5 = [2147483648,2147483648]
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm5
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm1
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm1
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm7
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm7, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm3
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm6
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm3
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm4, %xmm2
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm1
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
+; X86-SSE41-NEXT:    movapd %xmm2, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pcmpgtd %xmm1, %xmm3
+; X86-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm1, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
+; X86-SSE41-NEXT:    pxor %xmm1, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
 ; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm4[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -603,31 +570,20 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm6, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
-; X64-SSE41-NEXT:    movapd %xmm2, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm4[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm2, %xmm5
+; X64-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm5
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm4, %xmm1
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm1, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm5
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm5, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm4
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm4, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm5, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE41-NEXT:    movq %xmm3, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v8i64:
@@ -669,11 +625,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    movapd %xmm2, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v8i64:
@@ -774,124 +729,128 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $32, %esp
-; X86-SSE2-NEXT:    movaps %xmm2, (%esp) # 16-byte Spill
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
-; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,0,2147483648,0]
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm4
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    movaps %xmm0, (%esp) # 16-byte Spill
 ; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm4
-; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm7
-; X86-SSE2-NEXT:    pand %xmm4, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm4
-; X86-SSE2-NEXT:    por %xmm1, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm6
-; X86-SSE2-NEXT:    pand %xmm1, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm7, %xmm1
-; X86-SSE2-NEXT:    por %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm1
+; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,0,2147483648,0]
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm0
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[0,0,2,2]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm4
+; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE2-NEXT:    pand %xmm4, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm4
+; X86-SSE2-NEXT:    por %xmm5, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm5
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm1[0,0,2,2]
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm1[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm0, %xmm5
-; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm6, %xmm5
 ; X86-SSE2-NEXT:    por %xmm2, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm6
+; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm1
+; X86-SSE2-NEXT:    pand %xmm1, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm1
+; X86-SSE2-NEXT:    por %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm7, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm4
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm0, %xmm4
+; X86-SSE2-NEXT:    pand %xmm4, %xmm7
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
+; X86-SSE2-NEXT:    por %xmm7, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa (%esp), %xmm7 # 16-byte Reload
-; X86-SSE2-NEXT:    movdqa %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa (%esp), %xmm5 # 16-byte Reload
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
 ; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pand %xmm2, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm6
-; X86-SSE2-NEXT:    pand %xmm6, %xmm7
-; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm2
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm6
-; X86-SSE2-NEXT:    por %xmm7, %xmm6
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm0
-; X86-SSE2-NEXT:    por %xmm5, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE2-NEXT:    pand %xmm2, %xmm6
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm5
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm2
+; X86-SSE2-NEXT:    por %xmm6, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm2, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm5, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm4
-; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
-; X86-SSE2-NEXT:    por %xmm4, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm4
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm5
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm4
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm4
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm4, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pand %xmm5, %xmm2
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm5
+; X86-SSE2-NEXT:    por %xmm2, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm0, %xmm3
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm4
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm2, %xmm0
+; X86-SSE2-NEXT:    pand %xmm0, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
+; X86-SSE2-NEXT:    por %xmm5, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm3
@@ -900,9 +859,9 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm2, %xmm3
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm4[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm3, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movd %xmm2, %eax
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,1,1]
 ; X86-SSE2-NEXT:    movd %xmm0, %edx
@@ -1029,32 +988,31 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pushl %ebp
 ; X86-SSE41-NEXT:    movl %esp, %ebp
 ; X86-SSE41-NEXT:    andl $-16, %esp
-; X86-SSE41-NEXT:    subl $48, %esp
-; X86-SSE41-NEXT:    movaps %xmm2, (%esp) # 16-byte Spill
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm2
-; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm4 = [2147483648,2147483648]
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm6
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    subl $32, %esp
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm3
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm5
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm5
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm7
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm7, %xmm0
-; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm5
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm6
-; X86-SSE41-NEXT:    movapd %xmm6, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movaps %xmm0, (%esp) # 16-byte Spill
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm7
+; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm4
+; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm5 = [2147483648,2147483648]
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm7, %xmm6
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm1
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm1
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[0,0,2,2]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm4
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm1
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
@@ -1063,89 +1021,88 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm7
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE41-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,0,2,2]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm1
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm6
+; X86-SSE41-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm1, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm1, %xmm7
 ; X86-SSE41-NEXT:    movdqa 56(%ebp), %xmm1
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm7
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm4
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa (%esp), %xmm6 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm2
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa (%esp), %xmm7 # 16-byte Reload
+; X86-SSE41-NEXT:    movdqa %xmm7, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm2
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm3
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm1, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm2
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm6
+; X86-SSE41-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm3
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm7
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm2
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm1
 ; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm7, %xmm2
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm3
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm6
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm2, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm6 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm2
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm2, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm5
-; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm2
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm2, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm4, %xmm2
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
+; X86-SSE41-NEXT:    pxor %xmm1, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
 ; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm4[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -1236,31 +1193,20 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm2, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm6
-; X64-SSE41-NEXT:    movapd %xmm6, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm6, %xmm9
+; X64-SSE41-NEXT:    movapd %xmm9, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm9
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm9[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm2, %xmm1
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm1, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE41-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm9
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm9, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm3
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm9
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm9[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE41-NEXT:    movq %xmm7, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v16i64:
@@ -1271,31 +1217,31 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    subl $16, %esp
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE42-NEXT:    movdqa 72(%ebp), %xmm4
-; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm5
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
+; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm4
+; X86-SSE42-NEXT:    movdqa 40(%ebp), %xmm5
+; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
+; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm4
+; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm1
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
 ; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm2
 ; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm3
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm4
-; X86-SSE42-NEXT:    movdqa 40(%ebp), %xmm3
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X86-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm4
 ; X86-SSE42-NEXT:    movapd %xmm2, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm4
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
 ; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
@@ -1330,11 +1276,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    movapd %xmm6, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm7, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm7, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE42-NEXT:    movq %xmm7, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v16i64:
@@ -1343,25 +1288,25 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-AVX1-NEXT:    movl %esp, %ebp
 ; X86-AVX1-NEXT:    andl $-32, %esp
 ; X86-AVX1-NEXT:    subl $32, %esp
-; X86-AVX1-NEXT:    vmovdqa 8(%ebp), %xmm3
-; X86-AVX1-NEXT:    vmovdqa 24(%ebp), %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm5
-; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm1, %xmm3, %xmm3
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm5
-; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm2, %xmm5
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm6
-; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm1, %xmm4, %xmm1
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm3
+; X86-AVX1-NEXT:    vmovdqa 8(%ebp), %xmm4
+; X86-AVX1-NEXT:    vmovdqa 24(%ebp), %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm3, %xmm6
+; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm3, %xmm5, %xmm3
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm5
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm7
+; X86-AVX1-NEXT:    vblendvpd %xmm7, %xmm6, %xmm5, %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm5, %xmm6
+; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm5, %xmm3, %xmm3
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm5
+; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm1, %xmm4, %xmm1
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm4
 ; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm2, %xmm0
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm5, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm5, %xmm3, %xmm1
-; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
@@ -2798,21 +2743,18 @@ define i8 @test_v16i8(<16 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2837,14 +2779,11 @@ define i8 @test_v16i8(<16 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2939,21 +2878,18 @@ define i8 @test_v32i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2983,14 +2919,11 @@ define i8 @test_v32i8(<32 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm1, %xmm2
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
 ; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X64-SSE2-NEXT:    pand %xmm2, %xmm1
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movd %xmm2, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -3142,21 +3075,18 @@ define i8 @test_v64i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -3198,14 +3128,11 @@ define i8 @test_v64i8(<64 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -3403,21 +3330,18 @@ define i8 @test_v128i8(<128 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -3479,14 +3403,11 @@ define i8 @test_v128i8(<128 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm1, %xmm2
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
 ; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
-; X64-SSE2-NEXT:    pand %xmm2, %xmm1
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movd %xmm2, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovgl %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-smin.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-smin.ll
@@ -100,10 +100,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX-LABEL: test_v2i64:
 ; X64-AVX:       # %bb.0:
-; X64-AVX-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX-NEXT:    vmovq %xmm0, %rax
+; X64-AVX-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX-NEXT:    cmpq %rax, %rcx
+; X64-AVX-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX-NEXT:    retq
 ;
 ; AVX512BW-LABEL: test_v2i64:
@@ -287,10 +287,10 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -312,10 +312,10 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -659,10 +659,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm2, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -688,10 +688,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1331,10 +1331,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm4, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1375,10 +1375,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovlq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-smin.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-smin.ll
@@ -19,10 +19,10 @@
 define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_v2i64:
 ; X86-SSE2:       # %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,0,2147483648,0]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -52,10 +52,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-LABEL: test_v2i64:
 ; X86-SSE41:       # %bb.0:
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
 ; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm0 = [2147483648,2147483648]
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
 ; X86-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -70,25 +70,13 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pextrd $1, %xmm2, %edx
 ; X86-SSE41-NEXT:    retl
 ;
-; X64-SSE41-LABEL: test_v2i64:
-; X64-SSE41:       # %bb.0:
-; X64-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm0 = [2147483648,2147483648]
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE41-NEXT:    pxor %xmm0, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm0, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm2, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm5, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm2, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE41-NEXT:    movq %xmm3, %rax
-; X64-SSE41-NEXT:    retq
+; X64-SSE4-LABEL: test_v2i64:
+; X64-SSE4:       # %bb.0:
+; X64-SSE4-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE4-NEXT:    movq %xmm0, %rcx
+; X64-SSE4-NEXT:    cmpq %rax, %rcx
+; X64-SSE4-NEXT:    cmovlq %rcx, %rax
+; X64-SSE4-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v2i64:
 ; X86-SSE42:       # %bb.0:
@@ -100,16 +88,6 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    movd %xmm2, %eax
 ; X86-SSE42-NEXT:    pextrd $1, %xmm2, %edx
 ; X86-SSE42-NEXT:    retl
-;
-; X64-SSE42-LABEL: test_v2i64:
-; X64-SSE42:       # %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
-; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX-LABEL: test_v2i64:
 ; X86-AVX:       # %bb.0:
@@ -166,9 +144,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm4
@@ -226,9 +204,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm4, %xmm0
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm3
 ; X86-SSE41-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
@@ -246,33 +224,23 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE41-LABEL: test_v4i64:
 ; X64-SSE41:       # %bb.0:
 ; X64-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm3 = [2147483648,2147483648]
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm4
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE41-NEXT:    movdqa %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm5[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm2, %xmm3
-; X64-SSE41-NEXT:    movdqa %xmm3, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm0 = [2147483648,2147483648]
+; X64-SSE41-NEXT:    movdqa %xmm2, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm1, %xmm0
+; X64-SSE41-NEXT:    movdqa %xmm0, %xmm4
+; X64-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm4[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm3, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    pand %xmm5, %xmm3
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm3, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE41-NEXT:    movq %xmm2, %rax
+; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE41-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE41-NEXT:    movq %xmm1, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v4i64:
@@ -295,11 +263,10 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v4i64:
@@ -383,56 +350,56 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $16, %esp
-; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,0,2147483648,0]
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm4
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm6, %xmm4
-; X86-SSE2-NEXT:    pand %xmm4, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
-; X86-SSE2-NEXT:    por %xmm1, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm5, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm7
+; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm4
+; X86-SSE2-NEXT:    pand %xmm4, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm4
+; X86-SSE2-NEXT:    por %xmm0, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pand %xmm2, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm2
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm5
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm4, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm4
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
+; X86-SSE2-NEXT:    por %xmm4, %xmm0
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -513,60 +480,59 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    andl $-16, %esp
 ; X86-SSE41-NEXT:    subl $16, %esp
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm4
-; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm5 = [2147483648,2147483648]
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm4, %xmm6
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm6
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm6, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm4 = [2147483648,2147483648]
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm5
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm6
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm4, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm5, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm4
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm4, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm1, %xmm5
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm7
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm3
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm6
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm3, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm2, %xmm3
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm3
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm1
+; X86-SSE41-NEXT:    pcmpgtd %xmm3, %xmm1
+; X86-SSE41-NEXT:    pcmpeqd %xmm3, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm3, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
+; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
 ; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm5[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm4[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -604,31 +570,20 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm6, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm1
-; X64-SSE41-NEXT:    pcmpgtd %xmm4, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm1[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm4, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm3, %xmm5
+; X64-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm4, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm4, %xmm5
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm5[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm1, %xmm4
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm4, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm5
-; X64-SSE41-NEXT:    movdqa %xmm5, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm4
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm4, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm5, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE41-NEXT:    movq %xmm3, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v8i64:
@@ -670,11 +625,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v8i64:
@@ -774,127 +728,124 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pushl %ebp
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
-; X86-SSE2-NEXT:    subl $48, %esp
-; X86-SSE2-NEXT:    movaps %xmm1, (%esp) # 16-byte Spill
+; X86-SSE2-NEXT:    subl $16, %esp
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm5
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm6
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,0,2147483648,0]
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm7
+; X86-SSE2-NEXT:    pcmpeqd %xmm5, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm4
-; X86-SSE2-NEXT:    pand %xmm4, %xmm2
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
-; X86-SSE2-NEXT:    por %xmm2, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm4, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE2-NEXT:    pand %xmm5, %xmm0
+; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm0, %xmm5
+; X86-SSE2-NEXT:    pand %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm0
+; X86-SSE2-NEXT:    pandn %xmm0, %xmm5
+; X86-SSE2-NEXT:    por %xmm1, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm6, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm7
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm1, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pand %xmm7, %xmm2
+; X86-SSE2-NEXT:    pandn %xmm6, %xmm7
+; X86-SSE2-NEXT:    por %xmm2, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm7, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm1
+; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm1, %xmm0
+; X86-SSE2-NEXT:    pand %xmm0, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm7, %xmm0
+; X86-SSE2-NEXT:    por %xmm5, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm5, %xmm0
-; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm2
-; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm7
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm0
-; X86-SSE2-NEXT:    por %xmm7, %xmm0
-; X86-SSE2-NEXT:    movdqa (%esp), %xmm4 # 16-byte Reload
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm5
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm7
 ; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm2
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,1,3,3]
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm1, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm4
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm5
-; X86-SSE2-NEXT:    por %xmm4, %xmm5
+; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm4
+; X86-SSE2-NEXT:    pandn %xmm6, %xmm2
+; X86-SSE2-NEXT:    por %xmm4, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm6
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm6, %xmm1
+; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm7, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm4
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm1, %xmm4
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm4, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pand %xmm1, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm7, %xmm1
 ; X86-SSE2-NEXT:    por %xmm5, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm4 # 16-byte Reload
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm2
-; X86-SSE2-NEXT:    pandn %xmm4, %xmm5
-; X86-SSE2-NEXT:    por %xmm2, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm5, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
+; X86-SSE2-NEXT:    pand %xmm4, %xmm2
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm4
+; X86-SSE2-NEXT:    por %xmm2, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm5, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm5, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm1
+; X86-SSE2-NEXT:    pand %xmm1, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm1
+; X86-SSE2-NEXT:    por %xmm0, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm4
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
-; X86-SSE2-NEXT:    por %xmm5, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
+; X86-SSE2-NEXT:    pxor %xmm0, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm3
@@ -903,9 +854,9 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm2, %xmm3
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm4[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm3, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
-; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movd %xmm2, %eax
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,1,1]
 ; X86-SSE2-NEXT:    movd %xmm0, %edx
@@ -1033,124 +984,120 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    movl %esp, %ebp
 ; X86-SSE41-NEXT:    andl $-16, %esp
 ; X86-SSE41-NEXT:    subl $48, %esp
-; X86-SSE41-NEXT:    movaps %xmm1, (%esp) # 16-byte Spill
+; X86-SSE41-NEXT:    movaps %xmm1, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa 56(%ebp), %xmm1
+; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm6
 ; X86-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm4 = [2147483648,2147483648]
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm5
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm1
+; X86-SSE41-NEXT:    movdqa 56(%ebp), %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm6
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm5
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm6
+; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm6, %xmm1
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE41-NEXT:    movapd %xmm5, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm2
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm1, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm1, %xmm2
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm7
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm7, %xmm0
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm5, (%esp) # 16-byte Spill
+; X86-SSE41-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm1 # 16-byte Reload
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm3
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm2
-; X86-SSE41-NEXT:    movdqa (%esp), %xmm5 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
+; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm7
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm6
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm2
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm3
+; X86-SSE41-NEXT:    movapd %xmm3, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm6
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm7
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    movdqa (%esp), %xmm7 # 16-byte Reload
+; X86-SSE41-NEXT:    movdqa %xmm7, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm3
 ; X86-SSE41-NEXT:    movapd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm7
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm1
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm1
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm3
+; X86-SSE41-NEXT:    movapd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm5 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm5
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
 ; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm4, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
-; X86-SSE41-NEXT:    pmovsxdq %xmm3, %xmm0
+; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm4
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm4, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -1240,31 +1187,20 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm1, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm7
-; X64-SSE41-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm1
-; X64-SSE41-NEXT:    pcmpgtd %xmm2, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm7, %xmm9
+; X64-SSE41-NEXT:    movapd %xmm9, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm2, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm9
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm9[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm1, %xmm2
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm2, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE41-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm9
-; X64-SSE41-NEXT:    movdqa %xmm9, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm3
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm9
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm9[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE41-NEXT:    movq %xmm7, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v16i64:
@@ -1274,26 +1210,26 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    andl $-16, %esp
 ; X86-SSE42-NEXT:    subl $16, %esp
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm4
+; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm4
+; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm3
+; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
+; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm2
+; X86-SSE42-NEXT:    movapd %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm3
 ; X86-SSE42-NEXT:    movdqa 40(%ebp), %xmm4
 ; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
 ; X86-SSE42-NEXT:    movdqa 72(%ebp), %xmm1
 ; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
-; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm5
-; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm5
-; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm3
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X86-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm3
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
 ; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
@@ -1334,11 +1270,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    movapd %xmm7, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm7, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE42-NEXT:    movq %xmm7, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovlq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v16i64:
@@ -1347,25 +1282,25 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-AVX1-NEXT:    movl %esp, %ebp
 ; X86-AVX1-NEXT:    andl $-32, %esp
 ; X86-AVX1-NEXT:    subl $32, %esp
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm5
-; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm3, %xmm4, %xmm3
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm4
-; X86-AVX1-NEXT:    vmovdqa 8(%ebp), %xmm5
-; X86-AVX1-NEXT:    vmovdqa 24(%ebp), %xmm6
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm6, %xmm7
-; X86-AVX1-NEXT:    vblendvpd %xmm7, %xmm4, %xmm6, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm2, %xmm6
-; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm0, %xmm2, %xmm0
+; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm2, %xmm3
+; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm2, %xmm3
+; X86-AVX1-NEXT:    vmovdqa 8(%ebp), %xmm4
+; X86-AVX1-NEXT:    vmovdqa 24(%ebp), %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm6
+; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm1, %xmm4, %xmm4
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm6
+; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm3, %xmm4, %xmm3
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm2, %xmm4
+; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm2, %xmm0
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm5, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm5, %xmm1
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm4, %xmm1
-; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
 ; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
@@ -2802,21 +2737,18 @@ define i8 @test_v16i8(<16 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2841,14 +2773,11 @@ define i8 @test_v16i8(<16 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2943,21 +2872,18 @@ define i8 @test_v32i8(<32 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    retl
 ;
@@ -2987,14 +2913,11 @@ define i8 @test_v32i8(<32 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm1, %xmm2
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
 ; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X64-SSE2-NEXT:    pand %xmm2, %xmm1
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movd %xmm2, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -3146,21 +3069,18 @@ define i8 @test_v64i8(<64 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -3202,14 +3122,11 @@ define i8 @test_v64i8(<64 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -3407,21 +3324,18 @@ define i8 @test_v128i8(<128 x i8> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
 ; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psrld $16, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrlw $8, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pcmpgtb %xmm1, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movd %xmm2, %eax
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
+; X86-SSE2-NEXT:    psrld $16, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtb %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    movd %xmm2, %ecx
+; X86-SSE2-NEXT:    movl %ecx, %eax
+; X86-SSE2-NEXT:    shrl $8, %eax
+; X86-SSE2-NEXT:    cmpb %al, %cl
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -3483,14 +3397,11 @@ define i8 @test_v128i8(<128 x i8> %a0) nounwind {
 ; X64-SSE2-NEXT:    pand %xmm2, %xmm1
 ; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
 ; X64-SSE2-NEXT:    por %xmm1, %xmm2
-; X64-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE2-NEXT:    psrlw $8, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    pcmpgtb %xmm2, %xmm1
-; X64-SSE2-NEXT:    pand %xmm1, %xmm2
-; X64-SSE2-NEXT:    pandn %xmm0, %xmm1
-; X64-SSE2-NEXT:    por %xmm2, %xmm1
-; X64-SSE2-NEXT:    movd %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm2, %ecx
+; X64-SSE2-NEXT:    movl %ecx, %eax
+; X64-SSE2-NEXT:    shrl $8, %eax
+; X64-SSE2-NEXT:    cmpb %al, %cl
+; X64-SSE2-NEXT:    cmovll %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $al killed $al killed $eax
 ; X64-SSE2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-umax.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-umax.ll
@@ -19,10 +19,10 @@
 define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_v2i64:
 ; X86-SSE2:       # %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -52,10 +52,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-LABEL: test_v2i64:
 ; X86-SSE41:       # %bb.0:
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
 ; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm0 = [2147483648,2147483648,2147483648,2147483648]
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
 ; X86-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE41-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
@@ -70,60 +70,36 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pextrd $1, %xmm2, %edx
 ; X86-SSE41-NEXT:    retl
 ;
-; X64-SSE41-LABEL: test_v2i64:
-; X64-SSE41:       # %bb.0:
-; X64-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE41-NEXT:    movdqa {{.*#+}} xmm0 = [9223372039002259456,9223372039002259456]
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE41-NEXT:    pxor %xmm0, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm2, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm5, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm2, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE41-NEXT:    movq %xmm3, %rax
-; X64-SSE41-NEXT:    retq
+; X64-SSE4-LABEL: test_v2i64:
+; X64-SSE4:       # %bb.0:
+; X64-SSE4-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE4-NEXT:    movq %xmm0, %rcx
+; X64-SSE4-NEXT:    cmpq %rax, %rcx
+; X64-SSE4-NEXT:    cmovaq %rcx, %rax
+; X64-SSE4-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v2i64:
 ; X86-SSE42:       # %bb.0:
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm2, %xmm3
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X86-SSE42-NEXT:    movd %xmm2, %eax
-; X86-SSE42-NEXT:    pextrd $1, %xmm2, %edx
+; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
+; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
+; X86-SSE42-NEXT:    movd %xmm3, %eax
+; X86-SSE42-NEXT:    pextrd $1, %xmm3, %edx
 ; X86-SSE42-NEXT:    retl
-;
-; X64-SSE42-LABEL: test_v2i64:
-; X64-SSE42:       # %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm2 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    pxor %xmm2, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm2
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE42-NEXT:    movq %xmm3, %rax
-; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v2i64:
 ; X86-AVX1:       # %bb.0:
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX1-NEXT:    # xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX1-NEXT:    # xmm1 = mem[0,0]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    retl
@@ -142,12 +118,12 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X86-AVX2-LABEL: test_v2i64:
 ; X86-AVX2:       # %bb.0:
-; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    retl
@@ -201,9 +177,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -262,11 +238,11 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm4, %xmm0
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm3
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
 ; X86-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
@@ -282,34 +258,23 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE41-LABEL: test_v4i64:
 ; X64-SSE41:       # %bb.0:
 ; X64-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE41-NEXT:    movdqa {{.*#+}} xmm3 = [9223372039002259456,9223372039002259456]
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm2, %xmm4
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE41-NEXT:    movdqa %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm5[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm2, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm4
+; X64-SSE41-NEXT:    movdqa {{.*#+}} xmm0 = [9223372039002259456,9223372039002259456]
+; X64-SSE41-NEXT:    movdqa %xmm1, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm2, %xmm0
+; X64-SSE41-NEXT:    movdqa %xmm0, %xmm4
 ; X64-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm4[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm3, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    pand %xmm5, %xmm3
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm3, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE41-NEXT:    movq %xmm2, %rax
+; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE41-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE41-NEXT:    movq %xmm1, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v4i64:
@@ -321,9 +286,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm2, %xmm3
 ; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
@@ -334,19 +299,16 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE42-LABEL: test_v4i64:
 ; X64-SSE42:       # %bb.0:
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm4
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm2, %xmm3
+; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [9223372036854775808,9223372036854775808]
+; X64-SSE42-NEXT:    movdqa %xmm1, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm2, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v4i64:
@@ -358,11 +320,11 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm4
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
 ; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -394,11 +356,11 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm4
 ; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
 ; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -452,56 +414,56 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $16, %esp
+; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm4
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm4
+; X86-SSE2-NEXT:    pand %xmm4, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
+; X86-SSE2-NEXT:    por %xmm1, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm7
-; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm4
-; X86-SSE2-NEXT:    pand %xmm4, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm4
-; X86-SSE2-NEXT:    por %xmm0, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm1, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
+; X86-SSE2-NEXT:    pand %xmm1, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
+; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm5
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm5, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm5, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm0
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm4
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
-; X86-SSE2-NEXT:    por %xmm4, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -582,60 +544,60 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    andl $-16, %esp
 ; X86-SSE41-NEXT:    subl $16, %esp
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm4
+; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm5 = [2147483648,2147483648,2147483648,2147483648]
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm5
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm1
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm1
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm7
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm7, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm3
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm6
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm3
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm4, %xmm2
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm1
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
+; X86-SSE41-NEXT:    movapd %xmm2, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pcmpgtd %xmm1, %xmm3
+; X86-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm1, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
+; X86-SSE41-NEXT:    pxor %xmm1, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
 ; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm4[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -674,31 +636,20 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm6, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
-; X64-SSE41-NEXT:    movapd %xmm2, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm4[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm2, %xmm5
+; X64-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm5
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm4, %xmm1
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm1, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm5
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm5, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm4
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm4, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm5, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE41-NEXT:    movq %xmm3, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v8i64:
@@ -710,26 +661,27 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm4
 ; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm4, %xmm6
 ; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE42-NEXT:    movdqa %xmm4, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm3
 ; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
 ; X86-SSE42-NEXT:    movapd %xmm4, %xmm1
 ; X86-SSE42-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
 ; X86-SSE42-NEXT:    movapd %xmm2, %xmm0
 ; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm4
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm1, %xmm5
 ; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
@@ -757,42 +709,39 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
-; X64-SSE42-NEXT:    movapd %xmm2, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X64-SSE42-NEXT:    xorpd %xmm2, %xmm5
+; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm5
+; X64-SSE42-NEXT:    movdqa %xmm5, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm1, %xmm5
-; X64-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v8i64:
 ; X86-AVX1:       # %bb.0:
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm3
 ; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
 ; X86-AVX1-NEXT:    # xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm3
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm4
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm5
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm5, %xmm4
-; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm3, %xmm4
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm5, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm6, %xmm4
+; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm5, %xmm3, %xmm3
 ; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm5
+; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -837,11 +786,11 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm4
 ; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
 ; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -902,124 +851,128 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $32, %esp
-; X86-SSE2-NEXT:    movaps %xmm2, (%esp) # 16-byte Spill
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
-; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm4
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    movaps %xmm0, (%esp) # 16-byte Spill
 ; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm4
-; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm7
-; X86-SSE2-NEXT:    pand %xmm4, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm4
-; X86-SSE2-NEXT:    por %xmm1, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm6
-; X86-SSE2-NEXT:    pand %xmm1, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm7, %xmm1
-; X86-SSE2-NEXT:    por %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm1
+; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,2147483648,2147483648,2147483648]
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm0
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[0,0,2,2]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm4
+; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE2-NEXT:    pand %xmm4, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm4
+; X86-SSE2-NEXT:    por %xmm5, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm5
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm1[0,0,2,2]
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm1[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm0, %xmm5
-; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pandn %xmm6, %xmm5
 ; X86-SSE2-NEXT:    por %xmm2, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm6
+; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm1
+; X86-SSE2-NEXT:    pand %xmm1, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm1
+; X86-SSE2-NEXT:    por %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm7, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm4
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm0, %xmm4
+; X86-SSE2-NEXT:    pand %xmm4, %xmm7
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
+; X86-SSE2-NEXT:    por %xmm7, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa (%esp), %xmm7 # 16-byte Reload
-; X86-SSE2-NEXT:    movdqa %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa (%esp), %xmm5 # 16-byte Reload
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
 ; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pand %xmm2, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm6
-; X86-SSE2-NEXT:    pand %xmm6, %xmm7
-; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm2
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm6
-; X86-SSE2-NEXT:    por %xmm7, %xmm6
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm0
-; X86-SSE2-NEXT:    por %xmm5, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE2-NEXT:    pand %xmm2, %xmm6
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm5
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm2
+; X86-SSE2-NEXT:    por %xmm6, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm2, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm5, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm4
-; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
-; X86-SSE2-NEXT:    por %xmm4, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm4
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm5
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm4
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm4
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm4, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pand %xmm5, %xmm2
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm5
+; X86-SSE2-NEXT:    por %xmm2, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm0, %xmm3
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm4
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm2, %xmm0
+; X86-SSE2-NEXT:    pand %xmm0, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
+; X86-SSE2-NEXT:    por %xmm5, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm3
@@ -1028,9 +981,9 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm2, %xmm3
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm4[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm3, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
+; X86-SSE2-NEXT:    por %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movd %xmm2, %eax
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,1,1]
 ; X86-SSE2-NEXT:    movd %xmm0, %edx
@@ -1157,32 +1110,31 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pushl %ebp
 ; X86-SSE41-NEXT:    movl %esp, %ebp
 ; X86-SSE41-NEXT:    andl $-16, %esp
-; X86-SSE41-NEXT:    subl $48, %esp
-; X86-SSE41-NEXT:    movaps %xmm2, (%esp) # 16-byte Spill
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm2
-; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm6
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    subl $32, %esp
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm3
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm5
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm5
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm7
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm7, %xmm0
-; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm5
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm6
-; X86-SSE41-NEXT:    movapd %xmm6, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movaps %xmm0, (%esp) # 16-byte Spill
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm7
+; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm4
+; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm5 = [2147483648,2147483648,2147483648,2147483648]
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm7, %xmm6
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm6
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm1
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm1
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[0,0,2,2]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm4
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm1
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
@@ -1191,89 +1143,88 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm1
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm7
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE41-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,0,2,2]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm1
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm6
+; X86-SSE41-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm1, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm1, %xmm7
 ; X86-SSE41-NEXT:    movdqa 56(%ebp), %xmm1
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm7
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm4
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa (%esp), %xmm6 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm2
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE41-NEXT:    movdqa (%esp), %xmm7 # 16-byte Reload
+; X86-SSE41-NEXT:    movdqa %xmm7, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm5, %xmm2
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm3
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm1, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm2
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm6
+; X86-SSE41-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm3
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm7
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm2
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm1
 ; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm7, %xmm2
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm3
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm3[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm6
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm2, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm6 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm2
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm2, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm5
-; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm2
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm2, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm4, %xmm2
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
+; X86-SSE41-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
+; X86-SSE41-NEXT:    pxor %xmm1, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
 ; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm4[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -1364,31 +1315,20 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm2, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm6
-; X64-SSE41-NEXT:    movapd %xmm6, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm2[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm6, %xmm9
+; X64-SSE41-NEXT:    movapd %xmm9, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm1, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm1, %xmm9
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm9[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm2, %xmm1
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm1, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE41-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm9
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm9, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm3
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm9
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm9[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE41-NEXT:    movq %xmm7, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v16i64:
@@ -1399,60 +1339,59 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    subl $16, %esp
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm7
-; X86-SSE42-NEXT:    movdqa 40(%ebp), %xmm6
-; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    movdqa %xmm6, %xmm5
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm5
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
-; X86-SSE42-NEXT:    movdqa 72(%ebp), %xmm5
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm6
-; X86-SSE42-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE42-NEXT:    movdqa 72(%ebp), %xmm4
+; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    movdqa %xmm4, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
 ; X86-SSE42-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm7
-; X86-SSE42-NEXT:    movapd 8(%ebp), %xmm1
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE42-NEXT:    movdqa %xmm7, %xmm1
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm4
+; X86-SSE42-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm7
+; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm7, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm6
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm1
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm1
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm7
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm4
+; X86-SSE42-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm6
 ; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm6
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE42-NEXT:    movdqa %xmm6, %xmm2
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm2
+; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm5, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm6
 ; X86-SSE42-NEXT:    movapd %xmm1, %xmm2
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm2
-; X86-SSE42-NEXT:    movapd %xmm7, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X86-SSE42-NEXT:    movapd %xmm5, %xmm2
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm2
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm2
 ; X86-SSE42-NEXT:    movapd %xmm6, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm5
-; X86-SSE42-NEXT:    movapd %xmm5, %xmm2
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm2
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm2
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm2
 ; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm5, %xmm0
+; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
+; X86-SSE42-NEXT:    pxor %xmm1, %xmm5
+; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
 ; X86-SSE42-NEXT:    movd %xmm1, %eax
 ; X86-SSE42-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE42-NEXT:    movl %ebp, %esp
@@ -1501,17 +1440,14 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    xorpd %xmm9, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm6
-; X64-SSE42-NEXT:    movapd %xmm6, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X64-SSE42-NEXT:    xorpd %xmm6, %xmm9
+; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm9
+; X64-SSE42-NEXT:    movdqa %xmm9, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE42-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm1, %xmm9
-; X64-SSE42-NEXT:    pcmpgtq %xmm9, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE42-NEXT:    movq %xmm7, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovaq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v16i64:
@@ -1519,47 +1455,51 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-AVX1-NEXT:    pushl %ebp
 ; X86-AVX1-NEXT:    movl %esp, %ebp
 ; X86-AVX1-NEXT:    andl $-32, %esp
-; X86-AVX1-NEXT:    subl $32, %esp
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm4
+; X86-AVX1-NEXT:    subl $96, %esp
+; X86-AVX1-NEXT:    vmovaps %ymm2, {{[-0-9]+}}(%e{{[sb]}}p) # 32-byte Spill
+; X86-AVX1-NEXT:    vmovaps %ymm0, (%esp) # 32-byte Spill
 ; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm3 = [0,2147483648,0,2147483648]
 ; X86-AVX1-NEXT:    # xmm3 = mem[0,0]
+; X86-AVX1-NEXT:    vmovaps 24(%ebp), %xmm4
 ; X86-AVX1-NEXT:    vxorps %xmm3, %xmm4, %xmm5
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm6
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm6
 ; X86-AVX1-NEXT:    vxorps %xmm3, %xmm6, %xmm7
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm7, %xmm5
 ; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm6, %xmm4, %xmm4
-; X86-AVX1-NEXT:    vxorps 24(%ebp), %xmm3, %xmm6
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm7
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm7, %xmm5
-; X86-AVX1-NEXT:    vpcmpgtq %xmm6, %xmm5, %xmm5
-; X86-AVX1-NEXT:    vmovapd 24(%ebp), %xmm6
-; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm7, %xmm6, %xmm5
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm2, %xmm6
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm0, %xmm7
-; X86-AVX1-NEXT:    vpcmpgtq %xmm6, %xmm7, %xmm6
-; X86-AVX1-NEXT:    vmovaps 8(%ebp), %xmm7
-; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm0, %xmm2, %xmm0
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm7, %xmm2
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm1, %xmm6
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm6, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm7, %xmm1
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm2
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm5, %xmm0
+; X86-AVX1-NEXT:    vmovaps (%esp), %ymm2 # 32-byte Reload
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm7
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm7, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm6, %xmm0
+; X86-AVX1-NEXT:    vblendvpd %xmm0, %xmm7, %xmm5, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm4, %xmm5
 ; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm6
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm6, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm5, %xmm1
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm4, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm4, %xmm5, %xmm1
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm5
+; X86-AVX1-NEXT:    vmovaps 8(%ebp), %xmm6
+; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm4, %xmm4
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm6, %xmm0
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm1, %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm5, %xmm0
+; X86-AVX1-NEXT:    vblendvpd %xmm0, %xmm1, %xmm6, %xmm0
+; X86-AVX1-NEXT:    vmovaps {{[-0-9]+}}(%e{{[sb]}}p), %ymm6 # 32-byte Reload
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm6, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm2, %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm5, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm2, %xmm6, %xmm1
 ; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm3
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm5, %xmm2
+; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm4, %xmm1
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm4, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm2, %xmm3
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    movl %ebp, %esp
@@ -1620,28 +1560,28 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-AVX2-NEXT:    subl $32, %esp
 ; X86-AVX2-NEXT:    vmovdqa 8(%ebp), %ymm4
 ; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [0,2147483648,0,2147483648,0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %ymm3, %ymm4, %ymm5
+; X86-AVX2-NEXT:    vpxor %ymm3, %ymm1, %ymm6
+; X86-AVX2-NEXT:    vpcmpgtq %ymm5, %ymm6, %ymm5
+; X86-AVX2-NEXT:    vblendvpd %ymm5, %ymm1, %ymm4, %ymm1
+; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm1, %ymm4
 ; X86-AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm5
 ; X86-AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm6
 ; X86-AVX2-NEXT:    vpcmpgtq %ymm5, %ymm6, %ymm5
 ; X86-AVX2-NEXT:    vblendvpd %ymm5, %ymm0, %ymm2, %ymm0
-; X86-AVX2-NEXT:    vpxor %ymm3, %ymm4, %ymm2
-; X86-AVX2-NEXT:    vpxor %ymm3, %ymm1, %ymm5
-; X86-AVX2-NEXT:    vpcmpgtq %ymm2, %ymm5, %ymm2
-; X86-AVX2-NEXT:    vblendvpd %ymm2, %ymm1, %ymm4, %ymm1
-; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm1, %ymm2
-; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm0, %ymm4
-; X86-AVX2-NEXT:    vpcmpgtq %ymm2, %ymm4, %ymm2
+; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm0, %ymm2
+; X86-AVX2-NEXT:    vpcmpgtq %ymm4, %ymm2, %ymm2
 ; X86-AVX2-NEXT:    vblendvpd %ymm2, %ymm0, %ymm1, %ymm0
 ; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm1, %xmm2
 ; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm4
 ; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
 ; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
-; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm1, %xmm3
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm2, %xmm3
+; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    movl %ebp, %esp
@@ -2434,11 +2374,10 @@ define i16 @test_v8i16(<8 x i16> %a0) nounwind {
 ; SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,1,1]
 ; SSE2-NEXT:    psubusw %xmm1, %xmm0
 ; SSE2-NEXT:    paddw %xmm1, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrld $16, %xmm1
-; SSE2-NEXT:    psubusw %xmm0, %xmm1
-; SSE2-NEXT:    paddw %xmm0, %xmm1
-; SSE2-NEXT:    movd %xmm1, %eax
+; SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; SSE2-NEXT:    movd %xmm0, %ecx
+; SSE2-NEXT:    cmpw %ax, %cx
+; SSE2-NEXT:    cmoval %ecx, %eax
 ; SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SSE2-NEXT:    ret{{[l|q]}}
 ;
@@ -2506,11 +2445,10 @@ define i16 @test_v16i16(<16 x i16> %a0) nounwind {
 ; SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; SSE2-NEXT:    paddw %xmm0, %xmm1
-; SSE2-NEXT:    movdqa %xmm1, %xmm0
-; SSE2-NEXT:    psrld $16, %xmm0
-; SSE2-NEXT:    psubusw %xmm1, %xmm0
-; SSE2-NEXT:    paddw %xmm1, %xmm0
-; SSE2-NEXT:    movd %xmm0, %eax
+; SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; SSE2-NEXT:    movd %xmm1, %ecx
+; SSE2-NEXT:    cmpw %ax, %cx
+; SSE2-NEXT:    cmoval %ecx, %eax
 ; SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SSE2-NEXT:    ret{{[l|q]}}
 ;
@@ -2598,11 +2536,10 @@ define i16 @test_v32i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrld $16, %xmm0
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X86-SSE2-NEXT:    movd %xmm1, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -2622,11 +2559,10 @@ define i16 @test_v32i16(<32 x i16> %a0) nounwind {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrld $16, %xmm0
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2755,11 +2691,10 @@ define i16 @test_v64i16(<64 x i16> %a0) nounwind {
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X86-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X86-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE2-NEXT:    psrld $16, %xmm0
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X86-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X86-SSE2-NEXT:    movd %xmm1, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmoval %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -2787,11 +2722,10 @@ define i16 @test_v64i16(<64 x i16> %a0) nounwind {
 ; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[1,1,1,1]
 ; X64-SSE2-NEXT:    psubusw %xmm0, %xmm1
 ; X64-SSE2-NEXT:    paddw %xmm0, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE2-NEXT:    psrld $16, %xmm0
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm0
-; X64-SSE2-NEXT:    paddw %xmm1, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm1, %eax
+; X64-SSE2-NEXT:    movd %xmm1, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmoval %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-umax.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-umax.ll
@@ -106,14 +106,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX1-LABEL: test_v2i64:
 ; X64-AVX1:       # %bb.0:
-; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX1-NEXT:    # xmm1 = mem[0,0]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    retq
 ;
 ; X86-AVX2-LABEL: test_v2i64:
@@ -130,13 +126,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX2-LABEL: test_v2i64:
 ; X64-AVX2:       # %bb.0:
-; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    retq
 ;
 ; AVX512BW-LABEL: test_v2i64:
@@ -336,15 +329,13 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [9223372036854775808,9223372036854775808]
 ; X64-AVX1-NEXT:    # xmm2 = mem[0,0]
 ; X64-AVX1-NEXT:    vpxor %xmm2, %xmm1, %xmm3
-; X64-AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm4
-; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpxor %xmm2, %xmm0, %xmm2
+; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
+; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -371,15 +362,13 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [9223372036854775808,9223372036854775808]
 ; X64-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm3
-; X64-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X64-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm2
+; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
+; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -765,12 +754,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm3, %xmm2, %xmm3
-; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -805,15 +792,13 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vblendvpd %ymm3, %ymm0, %ymm1, %ymm0
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
 ; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm3
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X64-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm2
+; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
+; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1543,12 +1528,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vxorpd %xmm4, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm6, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm5, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm4, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm4, %xmm2, %xmm3
-; X64-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1609,12 +1592,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vxorpd %xmm4, %xmm0, %xmm3
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
 ; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm4, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm4, %xmm2, %xmm3
-; X64-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovaq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-umin.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-umin.ll
@@ -107,14 +107,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX1-LABEL: test_v2i64:
 ; X64-AVX1:       # %bb.0:
-; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX1-NEXT:    # xmm1 = mem[0,0]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    retq
 ;
 ; X86-AVX2-LABEL: test_v2i64:
@@ -131,13 +127,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X64-AVX2-LABEL: test_v2i64:
 ; X64-AVX2:       # %bb.0:
-; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    retq
 ;
 ; AVX512BW-LABEL: test_v2i64:
@@ -338,15 +331,13 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    # xmm1 = mem[0,0]
 ; X64-AVX1-NEXT:    vpxor %xmm1, %xmm0, %xmm2
 ; X64-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
-; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm4
-; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X64-AVX1-NEXT:    vpxor %xmm1, %xmm3, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -373,15 +364,13 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
 ; X64-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
 ; X64-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm3
-; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X64-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
 ; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -766,12 +755,10 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -806,15 +793,13 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vblendvpd %ymm3, %ymm0, %ymm1, %ymm0
 ; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
 ; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm3
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
 ; X64-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
 ; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;
@@ -1535,12 +1520,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX1-NEXT:    vxorpd %xmm4, %xmm0, %xmm1
 ; X64-AVX1-NEXT:    vpcmpgtq %xmm6, %xmm1, %xmm1
 ; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm5, %xmm0, %xmm0
-; X64-AVX1-NEXT:    vxorpd %xmm4, %xmm0, %xmm1
-; X64-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-AVX1-NEXT:    vxorpd %xmm4, %xmm2, %xmm3
-; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm3, %xmm1
-; X64-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX1-NEXT:    vmovq %xmm0, %rax
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX1-NEXT:    vzeroupper
 ; X64-AVX1-NEXT:    retq
 ;
@@ -1601,12 +1584,10 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-AVX2-NEXT:    vxorpd %xmm4, %xmm2, %xmm3
 ; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm3, %xmm1
 ; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX2-NEXT:    vxorpd %xmm4, %xmm0, %xmm1
-; X64-AVX2-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X64-AVX2-NEXT:    vxorpd %xmm4, %xmm2, %xmm3
-; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm3, %xmm1
-; X64-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
-; X64-AVX2-NEXT:    vmovq %xmm0, %rax
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovbq %rcx, %rax
 ; X64-AVX2-NEXT:    vzeroupper
 ; X64-AVX2-NEXT:    retq
 ;

--- a/llvm/test/CodeGen/X86/vector-reduce-umin.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-umin.ll
@@ -19,10 +19,10 @@
 define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE2-LABEL: test_v2i64:
 ; X86-SSE2:       # %bb.0:
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm2 = [2147483648,2147483648,2147483648,2147483648]
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm3
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -52,10 +52,10 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-LABEL: test_v2i64:
 ; X86-SSE41:       # %bb.0:
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
 ; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm0 = [2147483648,2147483648,2147483648,2147483648]
 ; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
 ; X86-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
@@ -70,62 +70,37 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pextrd $1, %xmm2, %edx
 ; X86-SSE41-NEXT:    retl
 ;
-; X64-SSE41-LABEL: test_v2i64:
-; X64-SSE41:       # %bb.0:
-; X64-SSE41-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE41-NEXT:    movdqa {{.*#+}} xmm0 = [9223372039002259456,9223372039002259456]
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE41-NEXT:    pxor %xmm0, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm0, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm2, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm5, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm2, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE41-NEXT:    movq %xmm3, %rax
-; X64-SSE41-NEXT:    retq
+; X64-SSE4-LABEL: test_v2i64:
+; X64-SSE4:       # %bb.0:
+; X64-SSE4-NEXT:    pextrq $1, %xmm0, %rax
+; X64-SSE4-NEXT:    movq %xmm0, %rcx
+; X64-SSE4-NEXT:    cmpq %rax, %rcx
+; X64-SSE4-NEXT:    cmovbq %rcx, %rax
+; X64-SSE4-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v2i64:
 ; X86-SSE42:       # %bb.0:
 ; X86-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[2,3,2,3]
 ; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm0, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X86-SSE42-NEXT:    movd %xmm2, %eax
-; X86-SSE42-NEXT:    pextrd $1, %xmm2, %edx
+; X86-SSE42-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE42-NEXT:    pxor %xmm0, %xmm2
+; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
+; X86-SSE42-NEXT:    movd %xmm3, %eax
+; X86-SSE42-NEXT:    pextrd $1, %xmm3, %edx
 ; X86-SSE42-NEXT:    retl
-;
-; X64-SSE42-LABEL: test_v2i64:
-; X64-SSE42:       # %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm2
-; X64-SSE42-NEXT:    pxor %xmm0, %xmm2
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE42-NEXT:    movq %xmm3, %rax
-; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v2i64:
 ; X86-AVX1:       # %bb.0:
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX1-NEXT:    # xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX1-NEXT:    # xmm1 = mem[0,0]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorps %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    retl
@@ -144,12 +119,12 @@ define i64 @test_v2i64(<2 x i64> %a0) nounwind {
 ;
 ; X86-AVX2-LABEL: test_v2i64:
 ; X86-AVX2:       # %bb.0:
-; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vpshufd {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    retl
@@ -203,9 +178,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm3, %xmm0
 ; X86-SSE2-NEXT:    pandn %xmm1, %xmm3
 ; X86-SSE2-NEXT:    por %xmm0, %xmm3
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm2, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm0, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm4
@@ -263,9 +238,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm4, %xmm0
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm2, %xmm3
 ; X86-SSE41-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
@@ -283,33 +258,23 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE41-LABEL: test_v4i64:
 ; X64-SSE41:       # %bb.0:
 ; X64-SSE41-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE41-NEXT:    movdqa {{.*#+}} xmm3 = [9223372039002259456,9223372039002259456]
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE41-NEXT:    movdqa %xmm1, %xmm4
-; X64-SSE41-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE41-NEXT:    movdqa %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm5[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm2, %xmm3
-; X64-SSE41-NEXT:    movdqa %xmm3, %xmm4
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm4
-; X64-SSE41-NEXT:    pmovsxdq %xmm4, %xmm5
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X64-SSE41-NEXT:    movdqa {{.*#+}} xmm0 = [9223372039002259456,9223372039002259456]
+; X64-SSE41-NEXT:    movdqa %xmm2, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE41-NEXT:    pxor %xmm1, %xmm0
+; X64-SSE41-NEXT:    movdqa %xmm0, %xmm4
+; X64-SSE41-NEXT:    pcmpgtd %xmm3, %xmm4
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm4[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm3, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    pand %xmm5, %xmm3
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm3, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE41-NEXT:    movq %xmm2, %rax
+; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE41-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE41-NEXT:    movq %xmm1, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v4i64:
@@ -322,9 +287,9 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm1, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm2, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm2, %xmm0
 ; X86-SSE42-NEXT:    pxor %xmm3, %xmm2
 ; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm2
 ; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
@@ -336,21 +301,16 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X64-SSE42-LABEL: test_v4i64:
 ; X64-SSE42:       # %bb.0:
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [9223372036854775808,9223372036854775808]
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm4
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm4
-; X64-SSE42-NEXT:    movdqa %xmm1, %xmm0
-; X64-SSE42-NEXT:    pxor %xmm3, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm0 = [9223372036854775808,9223372036854775808]
+; X64-SSE42-NEXT:    movdqa %xmm2, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm0, %xmm3
+; X64-SSE42-NEXT:    pxor %xmm1, %xmm0
+; X64-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
-; X64-SSE42-NEXT:    movapd %xmm1, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm3, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm2, %xmm3
-; X64-SSE42-NEXT:    pcmpgtq %xmm0, %xmm3
-; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X64-SSE42-NEXT:    movq %xmm2, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v4i64:
@@ -362,11 +322,11 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ; X86-AVX1-NEXT:    vxorps %xmm1, %xmm3, %xmm4
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm2, %xmm1
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm1, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -392,17 +352,17 @@ define i64 @test_v4i64(<4 x i64> %a0) nounwind {
 ;
 ; X86-AVX2-LABEL: test_v4i64:
 ; X86-AVX2:       # %bb.0:
-; X86-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm1
-; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vpxor %xmm2, %xmm1, %xmm4
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} xmm1 = [0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vextracti128 $1, %ymm0, %xmm3
+; X86-AVX2-NEXT:    vpxor %xmm1, %xmm3, %xmm4
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
+; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm3, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm1, %xmm0, %xmm2
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm1, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -456,56 +416,56 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
 ; X86-SSE2-NEXT:    subl $16, %esp
-; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm4
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm6, %xmm4
-; X86-SSE2-NEXT:    pand %xmm4, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
-; X86-SSE2-NEXT:    por %xmm1, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm5, %xmm1
-; X86-SSE2-NEXT:    pand %xmm1, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm2, %xmm1
-; X86-SSE2-NEXT:    por %xmm0, %xmm1
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm7
+; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm4
+; X86-SSE2-NEXT:    pand %xmm4, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm4
+; X86-SSE2-NEXT:    por %xmm0, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm5
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
 ; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm7
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm7, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pand %xmm2, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm5, %xmm2
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm5
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm4, %xmm0
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm5[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm4
+; X86-SSE2-NEXT:    pandn %xmm2, %xmm0
+; X86-SSE2-NEXT:    por %xmm4, %xmm0
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
 ; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
@@ -586,60 +546,59 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    andl $-16, %esp
 ; X86-SSE41-NEXT:    subl $16, %esp
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm4
-; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm5 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm4, %xmm6
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm6
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm6, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm5
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm6
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm0
-; X86-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm4, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm5, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm4
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm4, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm1, %xmm5
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm2
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm7
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm3
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm3
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm6
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm3
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm3, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm2, %xmm3
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm3
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm1
+; X86-SSE41-NEXT:    pcmpgtd %xmm3, %xmm1
+; X86-SSE41-NEXT:    pcmpeqd %xmm3, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm3, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
+; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
 ; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm5[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm4[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm3, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -677,31 +636,20 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm6, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm1
-; X64-SSE41-NEXT:    pcmpgtd %xmm4, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm1[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm4, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm6, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm3, %xmm5
+; X64-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm4, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm4, %xmm5
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm5[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm1, %xmm4
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm4, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE41-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm5, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm5
-; X64-SSE41-NEXT:    movdqa %xmm5, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm4
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm4, %xmm5
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm5, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE41-NEXT:    movq %xmm3, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v8i64:
@@ -710,33 +658,33 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    movl %esp, %ebp
 ; X86-SSE42-NEXT:    andl $-16, %esp
 ; X86-SSE42-NEXT:    subl $16, %esp
-; X86-SSE42-NEXT:    movdqa %xmm0, %xmm3
+; X86-SSE42-NEXT:    movdqa %xmm0, %xmm4
 ; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm5
-; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    movdqa %xmm0, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
+; X86-SSE42-NEXT:    movapd %xmm2, %xmm4
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm4
 ; X86-SSE42-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm6
 ; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm1
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE42-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm1
 ; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
+; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm4
-; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm1, %xmm3
+; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm3
+; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
 ; X86-SSE42-NEXT:    movd %xmm1, %eax
 ; X86-SSE42-NEXT:    pextrd $1, %xmm1, %edx
@@ -746,59 +694,55 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ;
 ; X64-SSE42-LABEL: test_v8i64:
 ; X64-SSE42:       # %bb.0:
-; X64-SSE42-NEXT:    movdqa %xmm0, %xmm5
-; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [9223372036854775808,9223372036854775808]
+; X64-SSE42-NEXT:    movdqa %xmm0, %xmm4
+; X64-SSE42-NEXT:    movdqa {{.*#+}} xmm5 = [9223372036854775808,9223372036854775808]
 ; X64-SSE42-NEXT:    movdqa %xmm0, %xmm6
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm6
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm6
 ; X64-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm2
-; X64-SSE42-NEXT:    movapd %xmm2, %xmm5
-; X64-SSE42-NEXT:    xorpd %xmm4, %xmm5
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm2
+; X64-SSE42-NEXT:    movapd %xmm2, %xmm4
+; X64-SSE42-NEXT:    xorpd %xmm5, %xmm4
 ; X64-SSE42-NEXT:    movdqa %xmm1, %xmm6
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm6
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm6
 ; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
-; X64-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X64-SSE42-NEXT:    pxor %xmm5, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm3
-; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
+; X64-SSE42-NEXT:    xorpd %xmm3, %xmm5
+; X64-SSE42-NEXT:    pcmpgtq %xmm4, %xmm5
+; X64-SSE42-NEXT:    movdqa %xmm5, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm3
-; X64-SSE42-NEXT:    movapd %xmm3, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm1, %xmm4
-; X64-SSE42-NEXT:    pcmpgtq %xmm0, %xmm4
-; X64-SSE42-NEXT:    movdqa %xmm4, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    pextrq $1, %xmm3, %rax
+; X64-SSE42-NEXT:    movq %xmm3, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v8i64:
 ; X86-AVX1:       # %bb.0:
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm3
 ; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm2 = [0,2147483648,0,2147483648]
 ; X86-AVX1-NEXT:    # xmm2 = mem[0,0]
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm3, %xmm4
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm5
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm5, %xmm6
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm6, %xmm4
-; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm3, %xmm5, %xmm3
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm4
-; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm5
-; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm5, %xmm4
-; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm3
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm4
+; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
+; X86-AVX1-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm3
 ; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm0, %xmm5
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm2, %xmm1, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm5
+; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm1, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm3, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
 ; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX1-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    vzeroupper
@@ -838,16 +782,16 @@ define i64 @test_v8i64(<8 x i64> %a0) nounwind {
 ; X86-AVX2-NEXT:    vpxor %ymm2, %ymm1, %ymm4
 ; X86-AVX2-NEXT:    vpcmpgtq %ymm3, %ymm4, %ymm3
 ; X86-AVX2-NEXT:    vblendvpd %ymm3, %ymm0, %ymm1, %ymm0
-; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm4
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm4, %xmm3
-; X86-AVX2-NEXT:    vblendvpd %xmm3, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm3
-; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm1, %xmm2
-; X86-AVX2-NEXT:    vpcmpgtq %xmm3, %xmm2, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm3
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm4
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm3 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm2, %xmm3, %xmm2
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm3, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    vzeroupper
@@ -907,127 +851,124 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pushl %ebp
 ; X86-SSE2-NEXT:    movl %esp, %ebp
 ; X86-SSE2-NEXT:    andl $-16, %esp
-; X86-SSE2-NEXT:    subl $48, %esp
-; X86-SSE2-NEXT:    movaps %xmm1, (%esp) # 16-byte Spill
+; X86-SSE2-NEXT:    subl $16, %esp
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm4
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm5
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm6
 ; X86-SSE2-NEXT:    movdqa {{.*#+}} xmm3 = [2147483648,2147483648,2147483648,2147483648]
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm7
+; X86-SSE2-NEXT:    pcmpeqd %xmm5, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm4, %xmm0
-; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm4
-; X86-SSE2-NEXT:    pand %xmm4, %xmm2
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm4
-; X86-SSE2-NEXT:    por %xmm2, %xmm4
-; X86-SSE2-NEXT:    movdqa %xmm4, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm0
+; X86-SSE2-NEXT:    pand %xmm5, %xmm0
+; X86-SSE2-NEXT:    movdqa 56(%ebp), %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm0, %xmm5
+; X86-SSE2-NEXT:    pand %xmm5, %xmm1
+; X86-SSE2-NEXT:    movdqa 24(%ebp), %xmm0
+; X86-SSE2-NEXT:    pandn %xmm0, %xmm5
+; X86-SSE2-NEXT:    por %xmm1, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm6, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm7
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm1, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pand %xmm7, %xmm2
+; X86-SSE2-NEXT:    pandn %xmm6, %xmm7
+; X86-SSE2-NEXT:    por %xmm2, %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm7, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm0, %xmm1
+; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm1, %xmm0
+; X86-SSE2-NEXT:    pand %xmm0, %xmm5
+; X86-SSE2-NEXT:    pandn %xmm7, %xmm0
+; X86-SSE2-NEXT:    por %xmm5, %xmm0
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm6, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm2, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm5, %xmm0
-; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm0, %xmm2
-; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm7
-; X86-SSE2-NEXT:    pand %xmm2, %xmm1
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm2
-; X86-SSE2-NEXT:    por %xmm1, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm1, %xmm0
-; X86-SSE2-NEXT:    movdqa 40(%ebp), %xmm6
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pandn %xmm5, %xmm0
-; X86-SSE2-NEXT:    por %xmm7, %xmm0
-; X86-SSE2-NEXT:    movdqa (%esp), %xmm4 # 16-byte Reload
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm5
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm7
 ; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm2
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,1,3,3]
 ; X86-SSE2-NEXT:    pand %xmm5, %xmm1
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm1, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm4
-; X86-SSE2-NEXT:    pandn %xmm6, %xmm5
-; X86-SSE2-NEXT:    por %xmm4, %xmm5
+; X86-SSE2-NEXT:    movdqa 8(%ebp), %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm7[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm4
+; X86-SSE2-NEXT:    pandn %xmm6, %xmm2
+; X86-SSE2-NEXT:    por %xmm4, %xmm2
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm1
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm6
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm6
-; X86-SSE2-NEXT:    movdqa %xmm6, %xmm7
-; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm7
-; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm1, %xmm6
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm6, %xmm1
+; X86-SSE2-NEXT:    movdqa 72(%ebp), %xmm7
+; X86-SSE2-NEXT:    movdqa %xmm7, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpgtd %xmm1, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm1, %xmm4
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm1, %xmm4
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm4, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pand %xmm1, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm0, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm7, %xmm1
 ; X86-SSE2-NEXT:    por %xmm5, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
-; X86-SSE2-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm4 # 16-byte Reload
-; X86-SSE2-NEXT:    movdqa %xmm4, %xmm5
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm5
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE2-NEXT:    movdqa %xmm5, %xmm6
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm6
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm5
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm5[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm7
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm6[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm7, %xmm5
-; X86-SSE2-NEXT:    pand %xmm5, %xmm2
-; X86-SSE2-NEXT:    pandn %xmm4, %xmm5
-; X86-SSE2-NEXT:    por %xmm2, %xmm5
-; X86-SSE2-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
+; X86-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm4, %xmm5
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm6[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm5, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm5
+; X86-SSE2-NEXT:    pand %xmm4, %xmm2
+; X86-SSE2-NEXT:    pandn %xmm1, %xmm4
+; X86-SSE2-NEXT:    por %xmm2, %xmm4
+; X86-SSE2-NEXT:    movdqa %xmm4, %xmm1
+; X86-SSE2-NEXT:    pxor %xmm3, %xmm1
+; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
+; X86-SSE2-NEXT:    pcmpgtd %xmm5, %xmm2
+; X86-SSE2-NEXT:    pcmpeqd %xmm5, %xmm1
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm2[0,0,2,2]
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm6 = xmm1[1,1,3,3]
+; X86-SSE2-NEXT:    pand %xmm5, %xmm6
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[1,1,3,3]
+; X86-SSE2-NEXT:    por %xmm6, %xmm1
+; X86-SSE2-NEXT:    pand %xmm1, %xmm0
+; X86-SSE2-NEXT:    pandn %xmm4, %xmm1
+; X86-SSE2-NEXT:    por %xmm0, %xmm1
 ; X86-SSE2-NEXT:    movdqa %xmm1, %xmm2
 ; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    movdqa %xmm2, %xmm4
-; X86-SSE2-NEXT:    pcmpgtd %xmm0, %xmm4
-; X86-SSE2-NEXT:    pcmpeqd %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[0,0,2,2]
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
-; X86-SSE2-NEXT:    pand %xmm0, %xmm2
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm4[1,1,3,3]
-; X86-SSE2-NEXT:    por %xmm2, %xmm0
-; X86-SSE2-NEXT:    pand %xmm0, %xmm5
-; X86-SSE2-NEXT:    pandn %xmm1, %xmm0
-; X86-SSE2-NEXT:    por %xmm5, %xmm0
-; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm3, %xmm2
-; X86-SSE2-NEXT:    pxor %xmm1, %xmm3
+; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[2,3,2,3]
+; X86-SSE2-NEXT:    pxor %xmm0, %xmm3
 ; X86-SSE2-NEXT:    movdqa %xmm3, %xmm4
 ; X86-SSE2-NEXT:    pcmpgtd %xmm2, %xmm4
 ; X86-SSE2-NEXT:    pcmpeqd %xmm2, %xmm3
@@ -1036,9 +977,9 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE2-NEXT:    pand %xmm2, %xmm3
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm4[1,1,3,3]
 ; X86-SSE2-NEXT:    por %xmm3, %xmm2
-; X86-SSE2-NEXT:    pand %xmm2, %xmm0
-; X86-SSE2-NEXT:    pandn %xmm1, %xmm2
-; X86-SSE2-NEXT:    por %xmm0, %xmm2
+; X86-SSE2-NEXT:    pand %xmm2, %xmm1
+; X86-SSE2-NEXT:    pandn %xmm0, %xmm2
+; X86-SSE2-NEXT:    por %xmm1, %xmm2
 ; X86-SSE2-NEXT:    movd %xmm2, %eax
 ; X86-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,1,1]
 ; X86-SSE2-NEXT:    movd %xmm0, %edx
@@ -1166,124 +1107,120 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE41-NEXT:    movl %esp, %ebp
 ; X86-SSE41-NEXT:    andl $-16, %esp
 ; X86-SSE41-NEXT:    subl $48, %esp
-; X86-SSE41-NEXT:    movaps %xmm1, (%esp) # 16-byte Spill
+; X86-SSE41-NEXT:    movaps %xmm1, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
 ; X86-SSE41-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE41-NEXT:    movdqa 56(%ebp), %xmm1
+; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm6
 ; X86-SSE41-NEXT:    movdqa {{.*#+}} xmm4 = [2147483648,2147483648,2147483648,2147483648]
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm5
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm1
+; X86-SSE41-NEXT:    movdqa 56(%ebp), %xmm5
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm6
 ; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm5
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm7
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm1
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    movdqa 24(%ebp), %xmm6
+; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm3
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm6, %xmm1
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE41-NEXT:    movapd %xmm5, {{[-0-9]+}}(%e{{[sb]}}p) # 16-byte Spill
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm6, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    movdqa 72(%ebp), %xmm2
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm1, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm1, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm1, %xmm2
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm7
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm6
-; X86-SSE41-NEXT:    movdqa %xmm7, %xmm0
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm5
+; X86-SSE41-NEXT:    movapd %xmm5, (%esp) # 16-byte Spill
+; X86-SSE41-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm1 # 16-byte Reload
+; X86-SSE41-NEXT:    movdqa %xmm1, %xmm0
 ; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm3
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm2
-; X86-SSE41-NEXT:    movdqa (%esp), %xmm5 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm3, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm7
+; X86-SSE41-NEXT:    movdqa 40(%ebp), %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm5, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm7
 ; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    movdqa 8(%ebp), %xmm6
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
+; X86-SSE41-NEXT:    movdqa %xmm6, %xmm0
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    movdqa %xmm3, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE41-NEXT:    movdqa %xmm2, %xmm7
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
+; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm2
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm2[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm0, %xmm2
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm2, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm5, %xmm2
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm2
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm3
+; X86-SSE41-NEXT:    movapd %xmm3, %xmm0
+; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm6
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm6
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm6[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm7
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm7, %xmm0
+; X86-SSE41-NEXT:    movdqa (%esp), %xmm7 # 16-byte Reload
+; X86-SSE41-NEXT:    movdqa %xmm7, %xmm2
+; X86-SSE41-NEXT:    pxor %xmm4, %xmm2
 ; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm3
 ; X86-SSE41-NEXT:    movapd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm7
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm7
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm7[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
-; X86-SSE41-NEXT:    movapd %xmm6, %xmm0
+; X86-SSE41-NEXT:    movapd %xmm0, %xmm1
+; X86-SSE41-NEXT:    pcmpgtd %xmm2, %xmm1
+; X86-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm1[0,0,2,2]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm6 = xmm0[1,1,3,3]
+; X86-SSE41-NEXT:    pand %xmm2, %xmm6
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X86-SSE41-NEXT:    por %xmm6, %xmm0
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm3
+; X86-SSE41-NEXT:    movapd %xmm3, %xmm0
 ; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movdqa {{[-0-9]+}}(%e{{[sb]}}p), %xmm5 # 16-byte Reload
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm1
-; X86-SSE41-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    movdqa %xmm5, %xmm1
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm5
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE41-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE41-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE41-NEXT:    movapd %xmm1, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
-; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[0,0,2,2]
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
-; X86-SSE41-NEXT:    pand %xmm0, %xmm1
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
-; X86-SSE41-NEXT:    por %xmm1, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm2
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm2[2,3,2,3]
-; X86-SSE41-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm3[2,3,2,3]
 ; X86-SSE41-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE41-NEXT:    movdqa %xmm4, %xmm3
-; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm3
+; X86-SSE41-NEXT:    movdqa %xmm4, %xmm2
+; X86-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
 ; X86-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
-; X86-SSE41-NEXT:    pmovsxdq %xmm3, %xmm0
+; X86-SSE41-NEXT:    pmovsxdq %xmm2, %xmm0
 ; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
 ; X86-SSE41-NEXT:    pand %xmm0, %xmm4
-; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X86-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
 ; X86-SSE41-NEXT:    por %xmm4, %xmm0
-; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X86-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm1
 ; X86-SSE41-NEXT:    movd %xmm1, %eax
 ; X86-SSE41-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE41-NEXT:    movl %ebp, %esp
@@ -1373,31 +1310,20 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm1, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm5, %xmm7
-; X64-SSE41-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    movapd %xmm0, %xmm1
-; X64-SSE41-NEXT:    pcmpgtd %xmm2, %xmm1
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm3 = xmm1[0,0,2,2]
-; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm0[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm2
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm1[1,1,3,3]
+; X64-SSE41-NEXT:    xorpd %xmm7, %xmm9
+; X64-SSE41-NEXT:    movapd %xmm9, %xmm0
+; X64-SSE41-NEXT:    pcmpgtd %xmm2, %xmm0
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm0[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm2, %xmm9
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm2 = xmm9[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm1, %xmm2
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm0[1,1,3,3]
 ; X64-SSE41-NEXT:    por %xmm2, %xmm0
 ; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE41-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE41-NEXT:    xorpd %xmm9, %xmm0
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE41-NEXT:    pxor %xmm1, %xmm9
-; X64-SSE41-NEXT:    movdqa %xmm9, %xmm2
-; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm2
-; X64-SSE41-NEXT:    pmovsxdq %xmm2, %xmm3
-; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm9
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm9[1,1,3,3]
-; X64-SSE41-NEXT:    pand %xmm3, %xmm4
-; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[1,1,3,3]
-; X64-SSE41-NEXT:    por %xmm4, %xmm0
-; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE41-NEXT:    movq %xmm1, %rax
+; X64-SSE41-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE41-NEXT:    movq %xmm7, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE41-NEXT:    retq
 ;
 ; X86-SSE42-LABEL: test_v16i64:
@@ -1405,65 +1331,63 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-SSE42-NEXT:    pushl %ebp
 ; X86-SSE42-NEXT:    movl %esp, %ebp
 ; X86-SSE42-NEXT:    andl $-16, %esp
-; X86-SSE42-NEXT:    subl $32, %esp
-; X86-SSE42-NEXT:    movaps %xmm1, (%esp) # 16-byte Spill
-; X86-SSE42-NEXT:    movdqa %xmm0, %xmm3
-; X86-SSE42-NEXT:    movdqa 72(%ebp), %xmm5
-; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm6
-; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm4 = [0,2147483648,0,2147483648]
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm7
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm7
+; X86-SSE42-NEXT:    subl $16, %esp
+; X86-SSE42-NEXT:    movdqa %xmm0, %xmm4
+; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm6
+; X86-SSE42-NEXT:    movdqa {{.*#+}} xmm3 = [0,2147483648,0,2147483648]
+; X86-SSE42-NEXT:    movdqa %xmm0, %xmm5
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm5
 ; X86-SSE42-NEXT:    movdqa %xmm6, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm7, %xmm0
-; X86-SSE42-NEXT:    movdqa 24(%ebp), %xmm7
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm6
-; X86-SSE42-NEXT:    movdqa %xmm3, %xmm2
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm2
-; X86-SSE42-NEXT:    movdqa %xmm7, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm1
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm7
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm2
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm2
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm5, %xmm0
+; X86-SSE42-NEXT:    movdqa 56(%ebp), %xmm5
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm4
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm4
 ; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm4, %xmm0
+; X86-SSE42-NEXT:    movdqa 72(%ebp), %xmm4
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
+; X86-SSE42-NEXT:    movapd %xmm6, %xmm2
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm2
+; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
 ; X86-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
 ; X86-SSE42-NEXT:    movdqa 40(%ebp), %xmm2
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm5
-; X86-SSE42-NEXT:    movdqa (%esp), %xmm1 # 16-byte Reload
-; X86-SSE42-NEXT:    movdqa %xmm1, %xmm3
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm3
-; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm3, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
-; X86-SSE42-NEXT:    movapd %xmm2, %xmm1
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm5
-; X86-SSE42-NEXT:    movapd %xmm7, %xmm1
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE42-NEXT:    movapd %xmm6, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm6
-; X86-SSE42-NEXT:    movapd %xmm6, %xmm1
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm1
-; X86-SSE42-NEXT:    movapd %xmm5, %xmm0
-; X86-SSE42-NEXT:    xorpd %xmm4, %xmm0
-; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm5
-; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm5[2,3,2,3]
-; X86-SSE42-NEXT:    movdqa %xmm5, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm4, %xmm0
-; X86-SSE42-NEXT:    pxor %xmm1, %xmm4
-; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm4
+; X86-SSE42-NEXT:    movdqa %xmm1, %xmm6
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm6
+; X86-SSE42-NEXT:    movdqa %xmm2, %xmm0
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm6, %xmm0
+; X86-SSE42-NEXT:    movdqa 8(%ebp), %xmm6
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm1, %xmm2
+; X86-SSE42-NEXT:    movdqa %xmm6, %xmm1
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm1
 ; X86-SSE42-NEXT:    movdqa %xmm4, %xmm0
-; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm1
+; X86-SSE42-NEXT:    pxor %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm4
+; X86-SSE42-NEXT:    movapd %xmm2, %xmm1
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm4
+; X86-SSE42-NEXT:    movapd %xmm5, %xmm1
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm1
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
+; X86-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm4
+; X86-SSE42-NEXT:    movapd %xmm4, %xmm0
+; X86-SSE42-NEXT:    xorpd %xmm3, %xmm0
+; X86-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm4[2,3,2,3]
+; X86-SSE42-NEXT:    pxor %xmm1, %xmm3
+; X86-SSE42-NEXT:    pcmpgtq %xmm0, %xmm3
+; X86-SSE42-NEXT:    movdqa %xmm3, %xmm0
+; X86-SSE42-NEXT:    blendvpd %xmm0, %xmm4, %xmm1
 ; X86-SSE42-NEXT:    movd %xmm1, %eax
 ; X86-SSE42-NEXT:    pextrd $1, %xmm1, %edx
 ; X86-SSE42-NEXT:    movl %ebp, %esp
@@ -1512,18 +1436,14 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X64-SSE42-NEXT:    xorpd %xmm8, %xmm0
 ; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
 ; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm5, %xmm7
-; X64-SSE42-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm8, %xmm0
-; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
-; X64-SSE42-NEXT:    movapd %xmm7, %xmm0
-; X64-SSE42-NEXT:    xorpd %xmm8, %xmm0
-; X64-SSE42-NEXT:    pshufd {{.*#+}} xmm1 = xmm7[2,3,2,3]
-; X64-SSE42-NEXT:    pxor %xmm1, %xmm8
-; X64-SSE42-NEXT:    pcmpgtq %xmm0, %xmm8
+; X64-SSE42-NEXT:    xorpd %xmm7, %xmm8
+; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm8
 ; X64-SSE42-NEXT:    movdqa %xmm8, %xmm0
-; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm7, %xmm1
-; X64-SSE42-NEXT:    movq %xmm1, %rax
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm6, %xmm7
+; X64-SSE42-NEXT:    pextrq $1, %xmm7, %rax
+; X64-SSE42-NEXT:    movq %xmm7, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovbq %rcx, %rax
 ; X64-SSE42-NEXT:    retq
 ;
 ; X86-AVX1-LABEL: test_v16i64:
@@ -1534,44 +1454,44 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-AVX1-NEXT:    subl $32, %esp
 ; X86-AVX1-NEXT:    vmovddup {{.*#+}} xmm3 = [0,2147483648,0,2147483648]
 ; X86-AVX1-NEXT:    # xmm3 = mem[0,0]
-; X86-AVX1-NEXT:    vmovaps 8(%ebp), %xmm4
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm4, %xmm6
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm0, %xmm4
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm2, %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm4, %xmm5, %xmm4
+; X86-AVX1-NEXT:    vblendvpd %xmm4, %xmm0, %xmm2, %xmm4
+; X86-AVX1-NEXT:    vmovaps 8(%ebp), %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm5, %xmm6
 ; X86-AVX1-NEXT:    vxorps %xmm3, %xmm1, %xmm7
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm7, %xmm6, %xmm6
-; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm1, %xmm4, %xmm4
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm0, %xmm6
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm2, %xmm7
-; X86-AVX1-NEXT:    vpcmpgtq %xmm6, %xmm7, %xmm6
-; X86-AVX1-NEXT:    vxorps 24(%ebp), %xmm3, %xmm7
-; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm1, %xmm5
-; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm7, %xmm5
-; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm0, %xmm2, %xmm6
-; X86-AVX1-NEXT:    vmovapd 24(%ebp), %xmm7
-; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm1, %xmm7, %xmm1
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm4, %xmm7
+; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm1, %xmm5, %xmm5
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm5, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm7, %xmm6, %xmm6
+; X86-AVX1-NEXT:    vblendvpd %xmm6, %xmm4, %xmm5, %xmm4
 ; X86-AVX1-NEXT:    vextractf128 $1, %ymm0, %xmm0
 ; X86-AVX1-NEXT:    vxorps %xmm3, %xmm0, %xmm5
 ; X86-AVX1-NEXT:    vextractf128 $1, %ymm2, %xmm2
-; X86-AVX1-NEXT:    vxorps %xmm3, %xmm2, %xmm7
-; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm7, %xmm5
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm2, %xmm6
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm6, %xmm5
+; X86-AVX1-NEXT:    vmovaps 24(%ebp), %xmm6
 ; X86-AVX1-NEXT:    vblendvpd %xmm5, %xmm0, %xmm2, %xmm0
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm6, %xmm2
+; X86-AVX1-NEXT:    vextractf128 $1, %ymm1, %xmm1
+; X86-AVX1-NEXT:    vxorps %xmm3, %xmm1, %xmm5
+; X86-AVX1-NEXT:    vpcmpgtq %xmm5, %xmm2, %xmm2
+; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm6, %xmm1
 ; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
 ; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm5
 ; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm5, %xmm2
 ; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm6, %xmm1
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm4, %xmm2
-; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
-; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm6, %xmm4, %xmm1
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm2
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm4
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm0, %xmm0
-; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm4, %xmm1
 ; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
-; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm1, %xmm3
-; X86-AVX1-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm4, %xmm0, %xmm0
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
+; X86-AVX1-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
+; X86-AVX1-NEXT:    vxorpd %xmm3, %xmm2, %xmm3
+; X86-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm3, %xmm1
+; X86-AVX1-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
 ; X86-AVX1-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX1-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX1-NEXT:    movl %ebp, %esp
@@ -1632,28 +1552,28 @@ define i64 @test_v16i64(<16 x i64> %a0) nounwind {
 ; X86-AVX2-NEXT:    subl $32, %esp
 ; X86-AVX2-NEXT:    vmovdqa 8(%ebp), %ymm4
 ; X86-AVX2-NEXT:    vpbroadcastq {{.*#+}} ymm3 = [0,2147483648,0,2147483648,0,2147483648,0,2147483648]
+; X86-AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm5
+; X86-AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm6
+; X86-AVX2-NEXT:    vpcmpgtq %ymm5, %ymm6, %ymm5
+; X86-AVX2-NEXT:    vblendvpd %ymm5, %ymm0, %ymm2, %ymm0
+; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm0, %ymm2
 ; X86-AVX2-NEXT:    vpxor %ymm3, %ymm1, %ymm5
 ; X86-AVX2-NEXT:    vpxor %ymm3, %ymm4, %ymm6
 ; X86-AVX2-NEXT:    vpcmpgtq %ymm5, %ymm6, %ymm5
 ; X86-AVX2-NEXT:    vblendvpd %ymm5, %ymm1, %ymm4, %ymm1
-; X86-AVX2-NEXT:    vpxor %ymm3, %ymm0, %ymm4
-; X86-AVX2-NEXT:    vpxor %ymm3, %ymm2, %ymm5
-; X86-AVX2-NEXT:    vpcmpgtq %ymm4, %ymm5, %ymm4
-; X86-AVX2-NEXT:    vblendvpd %ymm4, %ymm0, %ymm2, %ymm0
-; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm0, %ymm2
 ; X86-AVX2-NEXT:    vxorpd %ymm3, %ymm1, %ymm4
 ; X86-AVX2-NEXT:    vpcmpgtq %ymm2, %ymm4, %ymm2
 ; X86-AVX2-NEXT:    vblendvpd %ymm2, %ymm0, %ymm1, %ymm0
-; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
-; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
-; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm1, %xmm4
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm4, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
-; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm1 = xmm0[2,3,2,3]
-; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm2
-; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm1, %xmm3
-; X86-AVX2-NEXT:    vpcmpgtq %xmm2, %xmm3, %xmm2
-; X86-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm2
+; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm2, %xmm4
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm4, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
+; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm0, %xmm1
+; X86-AVX2-NEXT:    vshufps {{.*#+}} xmm2 = xmm0[2,3,2,3]
+; X86-AVX2-NEXT:    vxorpd %xmm3, %xmm2, %xmm3
+; X86-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm3, %xmm1
+; X86-AVX2-NEXT:    vblendvpd %xmm1, %xmm0, %xmm2, %xmm0
 ; X86-AVX2-NEXT:    vmovd %xmm0, %eax
 ; X86-AVX2-NEXT:    vpextrd $1, %xmm0, %edx
 ; X86-AVX2-NEXT:    movl %ebp, %esp
@@ -2451,12 +2371,10 @@ define i16 @test_v8i16(<8 x i16> %a0) nounwind {
 ; SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; SSE2-NEXT:    psubw %xmm2, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrld $16, %xmm1
-; SSE2-NEXT:    movdqa %xmm0, %xmm2
-; SSE2-NEXT:    psubusw %xmm1, %xmm2
-; SSE2-NEXT:    psubw %xmm2, %xmm0
-; SSE2-NEXT:    movd %xmm0, %eax
+; SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; SSE2-NEXT:    movd %xmm0, %ecx
+; SSE2-NEXT:    cmpw %ax, %cx
+; SSE2-NEXT:    cmovbl %ecx, %eax
 ; SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SSE2-NEXT:    ret{{[l|q]}}
 ;
@@ -2491,12 +2409,10 @@ define i16 @test_v16i16(<16 x i16> %a0) nounwind {
 ; SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; SSE2-NEXT:    psubw %xmm2, %xmm0
-; SSE2-NEXT:    movdqa %xmm0, %xmm1
-; SSE2-NEXT:    psrld $16, %xmm1
-; SSE2-NEXT:    movdqa %xmm0, %xmm2
-; SSE2-NEXT:    psubusw %xmm1, %xmm2
-; SSE2-NEXT:    psubw %xmm2, %xmm0
-; SSE2-NEXT:    movd %xmm0, %eax
+; SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; SSE2-NEXT:    movd %xmm0, %ecx
+; SSE2-NEXT:    cmpw %ax, %cx
+; SSE2-NEXT:    cmovbl %ecx, %eax
 ; SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; SSE2-NEXT:    ret{{[l|q]}}
 ;
@@ -2565,12 +2481,10 @@ define i16 @test_v32i16(<32 x i16> %a0) nounwind {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -2595,12 +2509,10 @@ define i16 @test_v32i16(<32 x i16> %a0) nounwind {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;
@@ -2706,12 +2618,10 @@ define i16 @test_v64i16(<64 x i16> %a0) nounwind {
 ; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X86-SSE2-NEXT:    psrld $16, %xmm1
-; X86-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X86-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X86-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X86-SSE2-NEXT:    movd %xmm0, %eax
+; X86-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X86-SSE2-NEXT:    movd %xmm0, %ecx
+; X86-SSE2-NEXT:    cmpw %ax, %cx
+; X86-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X86-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X86-SSE2-NEXT:    movl %ebp, %esp
 ; X86-SSE2-NEXT:    popl %ebp
@@ -2748,12 +2658,10 @@ define i16 @test_v64i16(<64 x i16> %a0) nounwind {
 ; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
 ; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
 ; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm1
-; X64-SSE2-NEXT:    psrld $16, %xmm1
-; X64-SSE2-NEXT:    movdqa %xmm0, %xmm2
-; X64-SSE2-NEXT:    psubusw %xmm1, %xmm2
-; X64-SSE2-NEXT:    psubw %xmm2, %xmm0
-; X64-SSE2-NEXT:    movd %xmm0, %eax
+; X64-SSE2-NEXT:    pextrw $1, %xmm0, %eax
+; X64-SSE2-NEXT:    movd %xmm0, %ecx
+; X64-SSE2-NEXT:    cmpw %ax, %cx
+; X64-SSE2-NEXT:    cmovbl %ecx, %eax
 ; X64-SSE2-NEXT:    # kill: def $ax killed $ax killed $eax
 ; X64-SSE2-NEXT:    retq
 ;


### PR DESCRIPTION
Allow 32-bit targets to correctly lower i64 ISD::VECREDUCE min/max nodes via ReplaceNodeResults - this is necessary once we're finally ready for #194473 and remove combineMinMaxReduction entirely

Improve handling of v2iXX reduction stages by consistently preferring binop(extract(),extract()) scalarisation on SSE targets (if the vector binop isn't legal).