### PR TITLE
[CodeGen] Add initial multi-def rematerialization support

### DIFF
--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -29,11 +29,14 @@ namespace llvm {
 ///
 /// At the moment this supports rematerializing registers that meet all of the
 /// following constraints.
-/// 1. The register is virtual and has a single defining instruction.
-/// 2. The single defining instruction is deemed rematerializable by the TII and
-///    doesn't have any physical register use that is both non-constant and
+/// 1. The register is virtual.
+/// 2. The register is defined within a single region---potentially over
+///    multiple MIs---and isn't used by a MI that is not defining part of the
+///    register before its last defining MI.
+/// 3. All defining instructions are deemed rematerializable by the TII and
+///    don't have any physical register use that is both non-constant and
 ///    non-ignorable.
-/// 3. The register has at least one non-debug use that is inside or at a region
+/// 4. The register has at least one non-debug use that is inside or at a region
 ///    boundary (see below for what we consider to be a region).
 ///
 /// Rematerializable registers (represented by \ref Rematerializer::Reg) form a
@@ -89,47 +92,59 @@ namespace llvm {
 /// In its nomenclature, the rematerializer differentiates between "original
 /// registers" (registers that were present when it analyzed the function) and
 /// rematerializations of these original registers. Rematerializations have an
-/// "origin" which is the index of the original regiser they were rematerialized
-/// from (transitivity applies; a rematerialization and all of its own
-/// rematerializations have the same origin). Semantically, only original
-/// registers have rematerializations.
+/// "origin" which is the index of the original register they were
+/// rematerialized from (transitivity applies; a rematerialization and all of
+/// its own rematerializations have the same origin). Semantically, only
+/// original registers have rematerializations.
+///
+/// Dealing with sub-registers is complicated, we have to handle dead-defs,
+/// undef flags, and connected components
 class Rematerializer {
 public:
   /// Index type for rematerializable registers.
   using RegisterIdx = unsigned;
 
-  /// A rematerializable register defined by a single machine instruction.
+  /// A rematerializable register, potentially defined by multiple instructions.
   ///
   /// A rematerializable register has a set of dependencies, which correspond
-  /// to the unique read register operands of its defining instruction and which
-  /// can themselves be rematerializable. Operand indices corresponding to
-  /// unrematerializable dependencies are managed by and queried from the
-  /// rematerializer, whereas rematerializable ones are part of this struct and
-  /// identified through their register index.
+  /// to the unique read register operands of its defining instruction(s) and
+  /// which can themselves be rematerializable. Operands of defining
+  /// instructions corresponding to unrematerializable dependencies are managed
+  /// by and queried from the rematerializer, whereas rematerializable ones are
+  /// part of this struct and identified through their register index.
   ///
   /// A rematerializable register also has an arbitrary number of users in an
   /// arbitrary number of regions, potentially including its own defining
   /// region. When rematerializations lead to operand changes in users, a
   /// register may find itself without any user left, at which point the
-  /// rematerializer deletes it (setting its defining MI to nullptr).
+  /// rematerializer deletes it (emptying \ref Reg::Defs).
   struct Reg {
-    /// Single MI defining the rematerializable register.
-    MachineInstr *DefMI;
-    /// Defining region of \p DefMI.
+    /// All instructions that define the register, in program order.
+    SmallVector<MachineInstr *, 1> Defs;
+    /// Defining region of the register.
     unsigned DefRegion;
     /// The rematerializable register's lane bitmask.
     LaneBitmask Mask;
 
     using RegionUsers = SmallDenseSet<MachineInstr *, 4>;
-    /// Uses of the register, mapped by region.
+    /// Uses of the register, mapped by region. Users that also define a part of
+    /// the register are considered defs and not accounted for here.
     SmallDenseMap<unsigned, RegionUsers, 2> Uses;
+
     /// This register's rematerializable dependencies, one per unique
-    /// rematerializable register operand.
+    /// rematerializable register operand over all definitions.
     SmallVector<RegisterIdx, 2> Dependencies;
 
-    /// Returns the rematerializable register from its defining instruction.
+    MachineInstr *getFirstDef() const { return Defs.front(); }
+    MachineInstr *getLastDef() const { return Defs.back(); }
+
+    /// Returns the rematerializable register from one of its defining
+    /// instructions.
     Register getDefReg() const {
-      assert(DefMI && "defining instruction was deleted");
+      const MachineInstr *DefMI = getFirstDef();
+      assert(DefMI && "defining instruction(s) were deleted");
+      if (!DefMI->getOperand(0).isDef())
+        dbgs() << *DefMI;
       assert(DefMI->getOperand(0).isDef() && "not a register def");
       return DefMI->getOperand(0).getReg();
     }
@@ -144,17 +159,28 @@ public:
       return Uses.size() > 1 || Uses.begin()->first != DefRegion;
     }
 
+    /// Returns the index of \p DefMI in the register's definitions order.
+    /// Returns the number of definitions if \p DefMI is not a definition of the
+    /// register.
+    unsigned getDefIdx(MachineInstr *DefMI) const {
+      return std::distance(Defs.begin(), find(Defs, DefMI));
+    }
+
     /// Returns the first and last user of the register in region \p UseRegion.
     /// If the register has no user in the region, returns a pair of nullptr's.
     LLVM_ABI std::pair<MachineInstr *, MachineInstr *>
     getRegionUseBounds(unsigned UseRegion, const LiveIntervals &LIS) const;
 
-    bool isAlive() const { return DefMI; }
+    bool isAlive() const { return !Defs.empty(); }
 
   private:
     void addUser(MachineInstr *MI, unsigned Region);
     void addUsers(const RegionUsers &NewUsers, unsigned Region);
     void eraseUser(MachineInstr *MI, unsigned Region);
+
+    /// Erases user \p MI from region \p Region if it exists. Returns whether \p
+    /// MI was actually deleted.
+    bool tryEraseUser(MachineInstr *MI, unsigned Region);
 
     friend Rematerializer;
   };
@@ -375,12 +401,15 @@ public:
                    MachineBasicBlock::iterator InsertPos,
                    SmallVectorImpl<RegisterIdx> &&Dependencies);
 
-  /// Re-creates a previously deleted register \p RegIdx before \p InsertPos,
-  /// which must be in the register's original defining region. \p DefReg must
-  /// be the original virtual register that \p RegIdx used to define.
-  /// Dependencies are assumed to already exist in the MIR.
+  /// Re-creates each defining instruction of a previously deleted register \p
+  /// RegIdx before each position in \p Positions (one position per defining
+  /// instruction, in the same order). Positions must be in the same region as
+  /// the deleted register, and earlier than all uses of the register in the
+  /// region. \p DefReg must be the original virtual register that \p RegIdx
+  /// used to define. Rematerializable dependencies are assumed to already exist
+  /// in the MIR.
   LLVM_ABI void recreateReg(RegisterIdx RegIdx,
-                            MachineBasicBlock::iterator InsertPos,
+                            ArrayRef<MachineBasicBlock::iterator> Positions,
                             Register DefReg);
 
   /// Transfers all users of register \p FromRegIdx in region \p UseRegion to \p
@@ -424,8 +453,8 @@ public:
 
   LLVM_ABI Printable printDependencyDAG(RegisterIdx RootIdx) const;
   LLVM_ABI Printable printID(RegisterIdx RegIdx) const;
-  LLVM_ABI Printable printRematReg(RegisterIdx RegIdx,
-                                   bool SkipRegions = false) const;
+  LLVM_ABI Printable printRematReg(RegisterIdx RegIdx, bool SkipRegions = false,
+                                   unsigned DefIdx = 0) const;
   LLVM_ABI Printable printRegUsers(RegisterIdx RegIdx) const;
   LLVM_ABI Printable
   printUser(const MachineInstr *MI,
@@ -492,7 +521,7 @@ private:
   void postRematerialization(RegisterIdx ModelRegIdx, RegisterIdx RematRegIdx);
 
   /// Common pre-processing step before deleting a register \p DeleteRegIdx. The
-  /// register's defining instruction must still be alive.
+  /// register must still have alive definitions.
   void preDeletion(RegisterIdx DeleteRegIdx);
 
   /// Extends \p LI over \p Mask to be live at \p UdeIdx.
@@ -527,8 +556,7 @@ private:
 
   /// Determines whether \p MI is considered rematerializable. This further
   /// restricts constraints imposed by the TII on rematerializable instructions,
-  /// requiring for example that the defined register is virtual and only
-  /// defined once.
+  /// requiring for example that the defined register is virtual.
   bool isMIRematerializable(const MachineInstr &MI) const;
 
   /// Implementation of \ref Rematerializer::transferUser that doesn't update
@@ -570,14 +598,14 @@ private:
     RegisterIdx Idx;
     /// Original register.
     Register DefReg;
-    /// Original definition of the register. The underlying MI no longer exist
-    /// at rollback time, but may be referenced as re-creation position for
+    /// Original definitions of the register. The underlying MIs no longer exist
+    /// at rollback time, but may be referenced as re-creation positions for
     /// previously deleted registers.
-    MachineInstr *DefMI;
+    SmallVector<MachineInstr *, 1> Defs;
 
     LLVM_ABI DeadReg(RegisterIdx Idx, const Rematerializer &Remater)
         : Idx(Idx), DefReg(Remater.getReg(Idx).getDefReg()),
-          DefMI(Remater.getReg(Idx).DefMI) {}
+          Defs(Remater.getReg(Idx).Defs) {}
   };
 
   /// An insertion position in the MIR, either a MachineInstr* to insert before
@@ -587,8 +615,9 @@ private:
   /// Original registers that have been deleted, in order of deletion.
   SmallVector<DeadReg> DeadRegs;
   /// Re-creation positions for all original registers that have been deleted,
-  /// in register deletion order. A position is either a MachineInstr* that
-  /// existed in the MIR at the time the rollbacker was attached to the
+  /// one per defining instruction, in program order for any given register and
+  /// in register deletion order overall. A position is either a MachineInstr*
+  /// that existed in the MIR at the time the rollbacker was attached to the
   /// rematerializer, or a MachineBasicBlock*.
   SmallVector<InsertBeforePos> Positions;
   /// Maps all re-creation positions that exist in \ref Positions to the indices

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -142,10 +142,7 @@ public:
     /// instructions.
     Register getDefReg() const {
       const MachineInstr *DefMI = getFirstDef();
-      assert(DefMI && "defining instruction(s) were deleted");
-      if (!DefMI->getOperand(0).isDef())
-        dbgs() << *DefMI;
-      assert(DefMI->getOperand(0).isDef() && "not a register def");
+      assert(DefMI && DefMI->getOperand(0).isDef() && "not a register def");
       return DefMI->getOperand(0).getReg();
     }
 

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CODEGEN_REMATERIALIZER_H
 #define LLVM_CODEGEN_REMATERIALIZER_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/CodeGen/LiveIntervals.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -28,11 +29,14 @@ namespace llvm {
 ///
 /// At the moment this supports rematerializing registers that meet all of the
 /// following constraints.
-/// 1. The register is virtual and has a single defining instruction.
-/// 2. The single defining instruction is deemed rematerializable by the TII and
-///    doesn't have any physical register use that is both non-constant and
+/// 1. The register is virtual.
+/// 2. The register is defined within a single region---potentially over
+///    multiple MIs---and isn't used by a MI that is not defining part of the
+///    register before its last defining MI.
+/// 3. All defining instructions are deemed rematerializable by the TII and
+///    don't have any physical register use that is both non-constant and
 ///    non-ignorable.
-/// 3. The register has at least one non-debug use that is inside or at a region
+/// 4. The register has at least one non-debug use that is inside or at a region
 ///    boundary (see below for what we consider to be a region).
 ///
 /// Rematerializable registers (represented by \ref Rematerializer::Reg) form a
@@ -96,37 +100,44 @@ public:
   /// Index type for rematerializable registers.
   using RegisterIdx = unsigned;
 
-  /// A rematerializable register defined by a single machine instruction.
+  /// A rematerializable register, potentially defined by multiple instructions.
   ///
   /// A rematerializable register has a set of dependencies, which correspond
-  /// to the unique read register operands of its defining instruction and which
-  /// can themselves be rematerializable. Operand indices corresponding to
-  /// unrematerializable dependencies are managed by and queried from the
-  /// rematerializer, whereas rematerializable ones are part of this struct and
-  /// identified through their register index.
+  /// to the unique read register operands of its defining instruction(s) and
+  /// which can themselves be rematerializable. Operands of defining
+  /// instructions corresponding to unrematerializable dependencies are managed
+  /// by and queried from the rematerializer, whereas rematerializable ones are
+  /// part of this struct and identified through their register index.
   ///
   /// A rematerializable register also has an arbitrary number of users in an
   /// arbitrary number of regions, potentially including its own defining
   /// region. When rematerializations lead to operand changes in users, a
   /// register may find itself without any user left, at which point the
-  /// rematerializer deletes it (setting its defining MI to nullptr).
+  /// rematerializer deletes it (emptying \ref Reg::Defs).
   struct Reg {
-    /// Single MI defining the rematerializable register.
-    MachineInstr *DefMI;
-    /// Defining region of \p DefMI.
+    /// All instructions that define the register, in program order.
+    SmallVector<MachineInstr *, 1> Defs;
+    /// Defining region of the register.
     unsigned DefRegion;
     /// The rematerializable register's lane bitmask.
     LaneBitmask Mask;
 
     using RegionUsers = SmallDenseSet<MachineInstr *, 4>;
-    /// Uses of the register, mapped by region.
+    /// Uses of the register, mapped by region. Users that also define a part of
+    /// the register are considered defs and not accounted for here.
     SmallDenseMap<unsigned, RegionUsers, 2> Uses;
+
     /// This register's rematerializable dependencies, one per unique
-    /// rematerializable register operand.
+    /// rematerializable register operand over all definitions.
     SmallVector<RegisterIdx, 2> Dependencies;
 
-    /// Returns the rematerializable register from its defining instruction.
+    MachineInstr *getFirstDef() const { return Defs.front(); }
+    MachineInstr *getLastDef() const { return Defs.back(); }
+
+    /// Returns the rematerializable register from one of its defining
+    /// instructions.
     Register getDefReg() const {
+      const MachineInstr *DefMI = getFirstDef();
       assert(DefMI && "defining instruction was deleted");
       assert(DefMI->getOperand(0).isDef() && "not a register def");
       return DefMI->getOperand(0).getReg();
@@ -147,12 +158,16 @@ public:
     std::pair<MachineInstr *, MachineInstr *>
     getRegionUseBounds(unsigned UseRegion, const LiveIntervals &LIS) const;
 
-    bool isAlive() const { return DefMI; }
+    bool isAlive() const { return !Defs.empty(); }
 
   private:
     void addUser(MachineInstr *MI, unsigned Region);
     void addUsers(const RegionUsers &NewUsers, unsigned Region);
     void eraseUser(MachineInstr *MI, unsigned Region);
+
+    /// Erases user \p MI from region \p Region if it exists. Returns whether \p
+    /// MI was actually deleted.
+    bool tryEraseUser(MachineInstr *MI, unsigned Region);
 
     friend Rematerializer;
   };
@@ -355,13 +370,15 @@ public:
                                MachineBasicBlock::iterator InsertPos,
                                SmallVectorImpl<RegisterIdx> &&Dependencies);
 
-  /// Re-creates a previously deleted register \p RegIdx before \p InsertPos.
-  /// The position must be in the same region as the deleted register, and
-  /// earlier than all uses of the register in the region. \p DefReg must be the
-  /// original virtual register that \p RegIdx used to define. Sets the new
-  /// register's rematerializable dependencies to \p Dependencies (these are
-  /// assumed to already exist in the MIR).
-  void recreateReg(RegisterIdx RegIdx, MachineBasicBlock::iterator InsertPos,
+  /// Re-creates each defining instruction of a previously deleted register \p
+  /// RegIdx before each position in \p Positions (one position per defining
+  /// instruction, in the same order). Positions must be in the same region as
+  /// the deleted register, and earlier than all uses of the register in the
+  /// region. \p DefReg must be the original virtual register that \p RegIdx
+  /// used to define. Sets the new register's rematerializable dependencies to
+  /// \p Dependencies (these are assumed to already exist in the MIR).
+  void recreateReg(RegisterIdx RegIdx,
+                   ArrayRef<MachineBasicBlock::iterator> Positions,
                    Register DefReg,
                    SmallVectorImpl<RegisterIdx> &&Dependencies);
 
@@ -476,8 +493,7 @@ private:
 
   /// Determines whether \p MI is considered rematerializable. This further
   /// restricts constraints imposed by the TII on rematerializable instructions,
-  /// requiring for example that the defined register is virtual and only
-  /// defined once.
+  /// requiring for example that the defined register is virtual.
   bool isMIRematerializable(const MachineInstr &MI) const;
 
   /// Implementation of \ref Rematerializer::transferUser that doesn't update
@@ -513,33 +529,48 @@ public:
                                     RegisterIdx RegIdx) override;
 
 private:
+  /// Identifies a single defining MI (second element, by index) of a
+  /// rematerializable register (first element, by index handle).
+  using RematMI = std::pair<RegisterIdx, unsigned>;
+
   struct RollbackInfo {
     /// Original register.
     Register DefReg;
     /// Original dependencies.
-    SmallVector<RegisterIdx, 2> Dependencies;
-    /// Position to re-create the register before in case of rollback. This
-    /// becomes invalid if it originally points to an MI that is deleted later
-    /// as a consequence of other rematerializations. In such cases \ref
-    /// NextRegIdx is guaranteed to be an actual register index from which the
-    /// rollback logic will determine a valid insert position before which to
-    /// re-create this register.
-    MachineBasicBlock::iterator InsertPos;
-    /// If \ref InsertPos points to an MI defining a rematerializable register,
-    /// stores its index. Otherwise equals \ref Rematerializer::NoReg.
-    RegisterIdx NextRegIdx;
+    SmallVector<Rematerializer::RegisterIdx, 2> Dependencies;
 
-    RollbackInfo(const Rematerializer::Reg &Reg, RegisterIdx NextRegIdx);
+    /// Information about the original position of a register.
+    struct Position {
+      /// Position to re-create the MI before in case of rollback. This becomes
+      /// invalid if it originally points to an MI that is deleted later as a
+      /// consequence of rematerializations. In such cases \ref NextRegIdx is
+      /// guaranteed to be an actual register index from which the rollback
+      /// logic will determine a valid insert position before which to re-create
+      /// this register.
+      MachineBasicBlock::iterator InsertBefore;
+      /// If \ref InsertBefore points to an MI defining a rematerializable
+      /// register, references the register's specific definition that it maps
+      /// to. Otherwise the register index (first element) is \ref
+      /// Rematerializer::NoReg.
+      RematMI NextRematMI;
+    };
+
+    /// Re-insertion positions for each of the register's defining MI, in
+    /// program order.
+    SmallVector<Position, 1> Positions;
+
+    RollbackInfo(const Rematerializer::Reg &Reg,
+                 SmallVector<Position, 1> &&Positions);
   };
 
   /// Original registers that have been deleted, in order of deletion.
   MapVector<RegisterIdx, RollbackInfo> DeadRegs;
   /// When there are two ajacent rematerializable MIs in the original
-  /// instruction order and the later one is deleted, stores a mapping from the
-  /// earlier one's register index to the later one's register index. If the
-  /// earlier one is then deleted, this makes it possible to rematerialize it at
-  /// the correct position after the later one is re-created.
-  DenseMap<RegisterIdx, RegisterIdx> AdjacentDeletedMIs;
+  /// instruction order and the latter one is deleted, stores a mapping from the
+  /// earlier one to the latter one. If the earlier one is then deleted, this
+  /// makes it possible to rematerialize it at the correct position after the
+  /// latter one is re-created.
+  DenseMap<RematMI, RematMI> AdjacentDeletedMIs;
   /// Registers which have been rematerialized (from original index to
   /// rematerialized index).
   DenseMap<RegisterIdx, Rematerializer::RematsOf> Rematerializations;

--- a/llvm/include/llvm/CodeGen/Rematerializer.h
+++ b/llvm/include/llvm/CodeGen/Rematerializer.h
@@ -32,7 +32,11 @@ namespace llvm {
 /// 1. The register is virtual.
 /// 2. The register is defined within a single region---potentially over
 ///    multiple MIs---and isn't used by a MI that is not defining part of the
-///    register before its last defining MI.
+///    register before its last defining MI. This restriction essentially means
+///    that, if the rematerializer only ever rematerializes all the defs of a
+///    register together, it can treat all virtual registers as having a "single
+///    value" (the one after the last def). Relaxing this restriction would
+///    require it to track VNInfos individually rather that virtual registers.
 /// 3. All defining instructions are deemed rematerializable by the TII and
 ///    don't have any physical register use that is both non-constant and
 ///    non-ignorable.

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -195,10 +195,6 @@ void Rematerializer::transferUserImpl(RegisterIdx FromRegIdx,
     // Other defining MIs might already be using the new register.
     IsNewDep = !is_contained(UserDeps, ToRegIdx);
 
-    auto MOIsFromReg = [FromReg](MachineOperand &MO) {
-      return MO.getReg() == FromReg;
-    };
-
     // If any other defining instruction of the rematerializable user still uses
     // the original register, we should not remove it from dependencies and may
     // need to add a new dependency if it is the first time the new register is
@@ -206,10 +202,12 @@ void Rematerializer::transferUserImpl(RegisterIdx FromRegIdx,
     for (MachineInstr *DefMI : UserReg.Defs) {
       if (DefMI == &UserMI)
         continue;
-      if (any_of(DefMI->all_uses(), MOIsFromReg)) {
-        if (IsNewDep)
-          UserDeps.push_back(ToRegIdx);
-        return;
+      for (const MachineOperand &MO : DefMI->all_uses()) {
+        if (MO.getReg() == FromReg) {
+          if (IsNewDep)
+            UserDeps.push_back(ToRegIdx);
+          return;
+        }
       }
     }
   }

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -193,7 +193,7 @@ void Rematerializer::transferUserImpl(RegisterIdx FromRegIdx,
   bool IsNewDep = true;
   if (UserReg.Defs.size() > 1) {
     // Other defining MIs might already be using the new register.
-    IsNewDep = find(UserDeps, ToRegIdx) == UserDeps.end();
+    IsNewDep = !is_contained(UserDeps, ToRegIdx);
 
     auto MOIsFromReg = [FromReg](MachineOperand &MO) {
       return MO.getReg() == FromReg;

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -22,6 +22,7 @@
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/MC/LaneBitmask.h"
 #include "llvm/Support/Debug.h"
 #include <optional>
 
@@ -158,27 +159,62 @@ void Rematerializer::transferUserImpl(RegisterIdx FromRegIdx,
   assert(FromRegIdx != ToRegIdx && "identical registers");
   assert(getOriginOrSelf(FromRegIdx) == getOriginOrSelf(ToRegIdx) &&
          "unrelated registers");
+  assert(any_of(getReg(FromRegIdx).Uses,
+                [&](const auto RegionUsers) {
+                  return RegionUsers.second.contains(&UserMI);
+                }) &&
+         "not a user");
 
   LLVM_DEBUG(dbgs() << "User transfer from " << printID(FromRegIdx) << " to "
                     << printID(ToRegIdx) << ": " << printUser(&UserMI) << '\n');
 
-  UserMI.substituteRegister(getReg(FromRegIdx).getDefReg(),
-                            getReg(ToRegIdx).getDefReg(), 0, TRI);
+  Register FromReg = getReg(FromRegIdx).getDefReg(),
+           ToReg = getReg(ToRegIdx).getDefReg();
+  UserMI.substituteRegister(FromReg, ToReg, 0, TRI);
   LISUpdates.insert(FromRegIdx);
   LISUpdates.insert(ToRegIdx);
 
-  // If the user is rematerializable, we must change its dependency to the
-  // new register.
-  if (RegisterIdx UserRegIdx = getDefRegIdx(UserMI); UserRegIdx != NoReg) {
-    // Look for the user's dependency that matches the register.
-    for (RegisterIdx &DepRegIdx : Regs[UserRegIdx].Dependencies) {
-      if (DepRegIdx == FromRegIdx) {
-        DepRegIdx = ToRegIdx;
+  RegisterIdx UserRegIdx = getDefRegIdx(UserMI);
+  if (UserRegIdx == NoReg)
+    return;
+
+  // When the user is rematerializable, we must reflect the change in its
+  // dependencies.
+  Reg &UserReg = Regs[UserRegIdx];
+  SmallVectorImpl<RegisterIdx> &UserDeps = Regs[UserRegIdx].Dependencies;
+  bool IsNewDep = true;
+  if (UserReg.Defs.size() > 1) {
+    // Other defining MIs might already be using the new register.
+    IsNewDep = find(UserDeps, ToRegIdx) == UserDeps.end();
+
+    auto MOIsFromReg = [FromReg](MachineOperand &MO) {
+      return MO.getReg() == FromReg;
+    };
+
+    // If any other defining instruction of the rematerializable user still uses
+    // the original register, we should not remove it from dependencies and may
+    // need to add a new dependency if it is the first time the new register is
+    // used by defining instructions.
+    for (MachineInstr *DefMI : UserReg.Defs) {
+      if (DefMI == &UserMI)
+        continue;
+      if (any_of(DefMI->all_uses(), MOIsFromReg)) {
+        if (IsNewDep)
+          UserDeps.push_back(ToRegIdx);
         return;
       }
     }
-    llvm_unreachable("broken dependency");
   }
+
+  // No other defining instruction has the original register as user. This
+  // either removes a dependency if the new register was previously used, or is
+  // a simple replacement if not.
+  unsigned *FindFromReg = find(UserDeps, FromRegIdx);
+  assert(FindFromReg != UserDeps.end() && "broken dependency");
+  if (IsNewDep)
+    *FindFromReg = ToRegIdx;
+  else
+    UserReg.Dependencies.erase(FindFromReg);
 }
 
 void Rematerializer::updateLiveIntervals() {
@@ -190,9 +226,6 @@ void Rematerializer::updateLiveIntervals() {
     Register DefReg = UpdateReg.getDefReg();
     if (LIS.hasInterval(DefReg))
       LIS.removeInterval(DefReg);
-    // Rematerializable registers have a single definition by construction so
-    // re-creating their interval cannot yield a live interval with multiple
-    // connected components.
     LIS.createAndComputeVirtRegInterval(DefReg);
 
     LLVM_DEBUG({
@@ -255,7 +288,7 @@ RegisterIdx Rematerializer::findRematInRegion(RegisterIdx RegIdx,
     if (RematReg.DefRegion != Region || RematReg.Uses.empty())
       continue;
     SlotIndex RematRegSlot =
-        LIS.getInstructionIndex(*RematReg.DefMI).getRegSlot();
+        LIS.getInstructionIndex(*RematReg.getLastDef()).getRegSlot();
     if (RematRegSlot < Before &&
         (BestRegIdx == NoReg || RematRegSlot > BestSlot)) {
       BestSlot = RematRegSlot;
@@ -278,12 +311,15 @@ void Rematerializer::deleteRegIfUnused(RegisterIdx RootIdx) {
     // A deleted register's dependencies may be deletable too.
     const Reg &DeleteReg = getReg(DepDAG.pop_back_val());
     for (RegisterIdx DepRegIdx : DeleteReg.Dependencies) {
-      // All dependencies loose a user (the deleted register).
+      // All dependencies lose a user (the deleted register).
       Reg &DepReg = Regs[DepRegIdx];
-      DepReg.eraseUser(DeleteReg.DefMI, DeleteReg.DefRegion);
-      if (DepReg.Uses.empty()) {
-        DeleteOrder.insert(DepRegIdx);
-        DepDAG.push_back(DepRegIdx);
+      for (MachineInstr *DefMI : DeleteReg.Defs) {
+        if (DepReg.tryEraseUser(DefMI, DeleteReg.DefRegion) &&
+            DepReg.Uses.empty()) {
+          DeleteOrder.insert(DepRegIdx);
+          DepDAG.push_back(DepRegIdx);
+          break;
+        }
       }
     }
   } while (!DepDAG.empty());
@@ -316,15 +352,18 @@ void Rematerializer::deleteReg(RegisterIdx RegIdx) {
   noteRegDeleted(RegIdx);
 
   Reg &DeleteReg = Regs[RegIdx];
-  assert(DeleteReg.DefMI && "register was already deleted");
-  // It is not possible for the deleted instruction to be the upper region
-  // boundary since we don't ever consider them rematerializable.
+  assert(DeleteReg.getFirstDef() && "register was already deleted");
+
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;
-  if (RegionBegin == DeleteReg.DefMI)
-    RegionBegin = std::next(MachineBasicBlock::iterator(DeleteReg.DefMI));
-  LIS.RemoveMachineInstrFromMaps(*DeleteReg.DefMI);
-  DeleteReg.DefMI->eraseFromParent();
-  DeleteReg.DefMI = nullptr;
+  for (MachineInstr *DefMI : DeleteReg.Defs) {
+    // It is not possible for the deleted instruction to be the upper region
+    // boundary since we don't ever consider them rematerializable.
+    if (RegionBegin == DefMI)
+      RegionBegin = std::next(MachineBasicBlock::iterator(DefMI));
+    LIS.RemoveMachineInstrFromMaps(*DefMI);
+    DefMI->eraseFromParent();
+  }
+  DeleteReg.Defs.clear();
 }
 
 Rematerializer::Rematerializer(MachineFunction &MF,
@@ -406,32 +445,68 @@ void Rematerializer::addRegIfRematerializable(
   assert(!SeenRegs[VirtRegIdx] && "register already seen");
   Register DefReg = Register::index2VirtReg(VirtRegIdx);
   SeenRegs.set(VirtRegIdx);
-
-  MachineOperand *MO = MRI.getOneDef(DefReg);
-  if (!MO)
-    return;
-  MachineInstr &DefMI = *MO->getParent();
-  if (!isMIRematerializable(DefMI))
-    return;
-  auto DefRegion = MIRegion.find(&DefMI);
-  if (DefRegion == MIRegion.end())
-    return;
-
   Reg RematReg;
-  RematReg.DefMI = &DefMI;
-  RematReg.DefRegion = DefRegion->second;
-  unsigned SubIdx = DefMI.getOperand(0).getSubReg();
-  RematReg.Mask = SubIdx ? TRI.getSubRegIndexLaneMask(SubIdx)
-                         : MRI.getMaxLaneMaskForVReg(DefReg);
+
+  // Check that the register's definitions can be rematerialized.
+  SmallPtrSet<MachineInstr *, 1> DefSet;
+  for (MachineOperand &MO : MRI.def_operands(DefReg)) {
+    MachineInstr &DefMI = *MO.getParent();
+    // If a single MI has multiple defs for the same register, we don't need to
+    // redo MI-based checks.
+    if (!DefSet.insert(&DefMI).second)
+      continue;
+
+    // The defining MI must be rematerializable and in the same region as all
+    // other defining MIs.
+    if (!isMIRematerializable(DefMI))
+      return;
+    auto DefRegion = MIRegion.find(&DefMI);
+    if (DefRegion == MIRegion.end())
+      return;
+    if (RematReg.Defs.empty())
+      RematReg.DefRegion = DefRegion->getSecond();
+    else if (RematReg.DefRegion != DefRegion->getSecond())
+      return;
+    RematReg.Defs.push_back(&DefMI);
+  }
+  if (RematReg.Defs.empty())
+    return;
+
+  // Order defining MIs by slot index.
+  sort(RematReg.Defs, [&](MachineInstr *LHS, MachineInstr *RHS) {
+    return LIS.getInstructionIndex(*LHS) < LIS.getInstructionIndex(*RHS);
+  });
+  SlotIndex LastDefSlot = LIS.getInstructionIndex(*RematReg.getLastDef());
+
+  // Set the register's mask to all active lanes after the last def.
+  const LiveInterval &DefLI = LIS.getInterval(DefReg);
+  SlotIndex AfterLastDef = LastDefSlot.getRegSlot();
+  if (DefLI.hasSubRanges()) {
+    for (const LiveInterval::SubRange &SR : DefLI.subranges())
+      if (SR.liveAt(AfterLastDef))
+        RematReg.Mask |= SR.LaneMask;
+  } else {
+    RematReg.Mask = MRI.getMaxLaneMaskForVReg(DefReg);
+  }
 
   // Collect the candidate's direct users, both rematerializable and
-  // unrematerializable. MIs outside provided regions cannot be tracked so the
-  // registers they use are not safely rematerializable.
+  // unrematerializable.
+  const bool MoreThanOneDef = RematReg.Defs.size() > 1;
   for (MachineInstr &UseMI : MRI.use_nodbg_instructions(DefReg)) {
-    if (auto UseRegion = MIRegion.find(&UseMI); UseRegion != MIRegion.end())
-      RematReg.addUser(&UseMI, UseRegion->second);
-    else
+    // We are only interested in users that do not define part of the register.
+    if (DefSet.contains(&UseMI))
+      continue;
+    // MIs outside provided regions cannot be tracked so the registers they use
+    // are not safely rematerializable.
+    auto UseRegion = MIRegion.find(&UseMI);
+    if (UseRegion == MIRegion.end())
       return;
+    // Disallow reads before the last def.
+    if (MoreThanOneDef && RematReg.DefRegion == UseRegion->second &&
+        LastDefSlot > LIS.getInstructionIndex(UseMI))
+      return;
+
+    RematReg.addUser(&UseMI, UseRegion->second);
   }
   if (RematReg.Uses.empty())
     return;
@@ -441,22 +516,37 @@ void Rematerializer::addRegIfRematerializable(
   // it once.
   SmallDenseSet<Register, 4> AllDepRegs;
   SmallMapVector<Register, LaneBitmask, 2> UnrematDeps;
-  for (const MachineOperand &MO : DefMI.all_uses()) {
-    Register DepReg = getRegDependency(MO);
-    if (!DepReg || !AllDepRegs.insert(DepReg).second)
-      continue;
-    unsigned DepRegIdx = DepReg.virtRegIndex();
-    if (!SeenRegs[DepRegIdx])
-      addRegIfRematerializable(DepRegIdx, MIRegion, SeenRegs);
-    if (auto DepIt = RegToIdx.find(DepReg); DepIt != RegToIdx.end()) {
-      RematReg.Dependencies.push_back(DepIt->second);
-    } else {
-      LaneBitmask &CurrentMask =
-          UnrematDeps.try_emplace(DepReg, LaneBitmask::getNone()).first->second;
-      LaneBitmask Mask = MO.getSubReg()
-                             ? TRI.getSubRegIndexLaneMask(MO.getSubReg())
-                             : MRI.getMaxLaneMaskForVReg(DepReg);
-      CurrentMask |= Mask;
+  for (auto [DefIdx, DefMI] : enumerate(RematReg.Defs)) {
+    for (const MachineOperand &MO : DefMI->all_uses()) {
+      Register DepReg = getRegDependency(MO);
+      if (!DepReg || DepReg == DefReg || !AllDepRegs.insert(DepReg).second)
+        continue;
+      unsigned DepRegIdx = DepReg.virtRegIndex();
+      if (!SeenRegs[DepRegIdx])
+        addRegIfRematerializable(DepRegIdx, MIRegion, SeenRegs);
+      if (auto DepIt = RegToIdx.find(DepReg); DepIt != RegToIdx.end()) {
+        RematReg.Dependencies.push_back(DepIt->second);
+      } else {
+        LaneBitmask &CurrentMask =
+            UnrematDeps.try_emplace(DepReg, LaneBitmask::getNone())
+                .first->second;
+        if (MoreThanOneDef && CurrentMask.none()) {
+          // A def of an unrematerializable operand between the defs of the
+          // rematerializable register makes the latter unrematerializable.
+          SlotIndex FirstDefSlot =
+              LIS.getInstructionIndex(*RematReg.getFirstDef());
+          for (MachineOperand &UnrematMODef : MRI.def_operands(DepReg)) {
+            MachineInstr &UnrematDefMI = *UnrematMODef.getParent();
+            SlotIndex UnrematDefSlot = LIS.getInstructionIndex(UnrematDefMI);
+            if (UnrematDefSlot > FirstDefSlot || UnrematDefSlot < LastDefSlot)
+              return;
+          }
+        }
+        LaneBitmask Mask = MO.getSubReg()
+                               ? TRI.getSubRegIndexLaneMask(MO.getSubReg())
+                               : MRI.getMaxLaneMaskForVReg(DepReg);
+        CurrentMask |= Mask;
+      }
     }
   }
 
@@ -471,7 +561,6 @@ bool Rematerializer::isMIRematerializable(const MachineInstr &MI) const {
     return false;
 
   assert(MI.getOperand(0).getReg().isVirtual() && "should be virtual");
-  assert(MRI.hasOneDef(MI.getOperand(0).getReg()) && "should have single def");
 
   for (const MachineOperand &MO : MI.all_uses()) {
     // We can't remat physreg uses, unless it is a constant or an ignorable
@@ -488,7 +577,7 @@ bool Rematerializer::isMIRematerializable(const MachineInstr &MI) const {
 
 RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
   if (!MI.getNumOperands() || !MI.getOperand(0).isReg() ||
-      MI.getOperand(0).readsReg())
+      !MI.getOperand(0).isDef())
     return NoReg;
   Register Reg = MI.getOperand(0).getReg();
   auto UserRegIt = RegToIdx.find(Reg);
@@ -507,6 +596,7 @@ Rematerializer::rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
   Reg &FromReg = Regs[RegIdx];
   NewReg.Mask = FromReg.Mask;
   NewReg.DefRegion = UseRegion;
+  NewReg.Defs.reserve(FromReg.Defs.size());
   NewReg.Dependencies = std::move(Dependencies);
 
   // Track rematerialization link between registers. Origins are always
@@ -519,9 +609,10 @@ Rematerializer::rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
   // Use the TII to rematerialize the defining instruction with a new defined
   // register.
   Register NewDefReg = MRI.cloneVirtualRegister(FromReg.getDefReg());
-  TII.reMaterialize(*RegionMBB[UseRegion], InsertPos, NewDefReg, 0,
-                    *FromReg.DefMI);
-  NewReg.DefMI = &*std::prev(InsertPos);
+  for (const MachineInstr *DefMI : FromReg.Defs) {
+    TII.reMaterialize(*RegionMBB[UseRegion], InsertPos, NewDefReg, 0, *DefMI);
+    NewReg.Defs.push_back(&*std::prev(InsertPos));
+  }
   RegToIdx.insert({NewDefReg, NewRegIdx});
   postRematerialization(RegIdx, NewRegIdx);
 
@@ -531,10 +622,9 @@ Rematerializer::rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
   return NewRegIdx;
 }
 
-void Rematerializer::recreateReg(RegisterIdx RegIdx,
-                                 MachineBasicBlock::iterator InsertPos,
-                                 Register DefReg,
-                                 SmallVectorImpl<RegisterIdx> &&Dependencies) {
+void Rematerializer::recreateReg(
+    RegisterIdx RegIdx, ArrayRef<MachineBasicBlock::iterator> Positions,
+    Register DefReg, SmallVectorImpl<RegisterIdx> &&Dependencies) {
   assert(RegToIdx.contains(DefReg) && "unknown defined register");
   assert(RegToIdx.at(DefReg) == RegIdx && "incorrect defined register");
   assert(!getReg(RegIdx).isAlive() && "register is still alive");
@@ -558,11 +648,12 @@ void Rematerializer::recreateReg(RegisterIdx RegIdx,
     assert(getReg(getOriginOf(RegIdx)).isAlive() && "expected alive origin");
     ModelRegIdx = getOriginOf(RegIdx);
   }
-  const MachineInstr &ModelDefMI = *getReg(ModelRegIdx).DefMI;
-
-  TII.reMaterialize(*RegionMBB[OriginReg.DefRegion], InsertPos, DefReg, 0,
-                    ModelDefMI);
-  OriginReg.DefMI = &*std::prev(InsertPos);
+  const Reg &ModelReg = getReg(ModelRegIdx);
+  for (auto [DefMI, InsertPos] : zip_equal(ModelReg.Defs, Positions)) {
+    TII.reMaterialize(*RegionMBB[OriginReg.DefRegion], InsertPos, DefReg, 0,
+                      *DefMI);
+    OriginReg.Defs.push_back(&*std::prev(InsertPos));
+  }
   postRematerialization(ModelRegIdx, RegIdx);
   LLVM_DEBUG(dbgs() << "** Recreated " << printID(RegIdx) << " as "
                     << printRematReg(RegIdx) << '\n');
@@ -570,13 +661,17 @@ void Rematerializer::recreateReg(RegisterIdx RegIdx,
 
 void Rematerializer::postRematerialization(RegisterIdx ModelRegIdx,
                                            RegisterIdx RematRegIdx) {
+  Reg &ModelReg = Regs[ModelRegIdx], &RematReg = Regs[RematRegIdx];
+  for (MachineInstr *DefMI : RematReg.Defs)
+    LIS.InsertMachineInstrInMaps(*DefMI);
 
   // The start of the new register's region may have changed.
-  Reg &ModelReg = Regs[ModelRegIdx], &RematReg = Regs[RematRegIdx];
-  LIS.InsertMachineInstrInMaps(*RematReg.DefMI);
-  MachineBasicBlock::iterator &RegionBegin = Regions[RematReg.DefRegion].first;
-  if (RegionBegin == std::next(MachineBasicBlock::iterator(RematReg.DefMI)))
-    RegionBegin = RematReg.DefMI;
+  MachineInstr &FirstDefMI = *RematReg.getFirstDef();
+  auto &[RegionBegin, RegionEnd] = Regions[RematReg.DefRegion];
+  if (RegionBegin == RegionEnd ||
+      (!RegionBegin->isDebugInstr() && LIS.getInstructionIndex(*RegionBegin) >
+                                           LIS.getInstructionIndex(FirstDefMI)))
+    RegionBegin = FirstDefMI.getIterator();
 
   // Replace dependencies as needed in the rematerialized MI. All dependencies
   // of the latter gain a new user.
@@ -585,15 +680,25 @@ void Rematerializer::postRematerialization(RegisterIdx ModelRegIdx,
     LLVM_DEBUG(dbgs() << "  Dependency: " << printID(OldDepRegIdx) << " -> "
                       << printID(NewDepRegIdx) << '\n');
 
+    const bool DifferentDep = OldDepRegIdx != NewDepRegIdx;
     Reg &NewDepReg = Regs[NewDepRegIdx];
-    if (OldDepRegIdx != NewDepRegIdx) {
-      Reg &OldDepReg = Regs[OldDepRegIdx];
-      RematReg.DefMI->substituteRegister(OldDepReg.getDefReg(),
-                                         NewDepReg.getDefReg(), 0, TRI);
-      LISUpdates.insert(OldDepRegIdx);
+    Register OldReg = getReg(OldDepRegIdx).getDefReg();
+    Register NewReg = NewDepReg.getDefReg();
+    for (MachineInstr *DefMI : RematReg.Defs) {
+      bool HasReg = false;
+      for (MachineOperand &MO : DefMI->operands()) {
+        if (!MO.isReg() || MO.getReg() != OldReg)
+          continue;
+        if (DifferentDep)
+          MO.substVirtReg(NewReg, 0, TRI);
+        HasReg = true;
+      }
+      if (HasReg)
+        NewDepReg.addUser(DefMI, RematReg.DefRegion);
     }
-    NewDepReg.addUser(RematReg.DefMI, RematReg.DefRegion);
-    LISUpdates.insert(NewDepRegIdx);
+    LISUpdates.insert(OldDepRegIdx);
+    if (DifferentDep)
+      LISUpdates.insert(NewDepRegIdx);
   }
 }
 
@@ -643,6 +748,15 @@ void Rematerializer::Reg::eraseUser(MachineInstr *MI, unsigned Region) {
     RUsers.erase(MI);
 }
 
+bool Rematerializer::Reg::tryEraseUser(MachineInstr *MI, unsigned Region) {
+  auto RegionUsers = Uses.find(Region);
+  if (RegionUsers == Uses.end() || !RegionUsers->getSecond().erase(MI))
+    return false;
+  if (RegionUsers->getSecond().empty())
+    Uses.erase(Region);
+  return true;
+}
+
 Printable Rematerializer::printDependencyDAG(RegisterIdx RootIdx) const {
   return Printable([&, RootIdx](raw_ostream &OS) {
     DenseMap<RegisterIdx, unsigned> RegDepths;
@@ -675,12 +789,10 @@ Printable Rematerializer::printID(RegisterIdx RegIdx) const {
   return Printable([&, RegIdx](raw_ostream &OS) {
     const Reg &PrintReg = getReg(RegIdx);
     OS << '(' << RegIdx << '/';
-    if (!PrintReg.isAlive()) {
+    if (!PrintReg.isAlive())
       OS << "<dead>";
-    } else {
-      OS << printReg(PrintReg.getDefReg(), &TRI,
-                     PrintReg.DefMI->getOperand(0).getSubReg(), &MRI);
-    }
+    else
+      OS << printReg(PrintReg.getDefReg(), &TRI, 0, &MRI);
     OS << ")[" << PrintReg.DefRegion << "]";
   });
 }
@@ -731,10 +843,15 @@ Printable Rematerializer::printRematReg(RegisterIdx RegIdx,
       OS << "] ";
     }
     if (PrintReg.isAlive()) {
-      PrintReg.DefMI->print(OS, /*IsStandalone=*/true, /*SkipOpers=*/false,
-                            /*SkipDebugLoc=*/false, /*AddNewLine=*/false);
+      OS << ' ';
+      PrintReg.getFirstDef()->print(OS, /*IsStandalone=*/true,
+                                    /*SkipOpers=*/false,
+                                    /*SkipDebugLoc=*/false,
+                                    /*AddNewLine=*/false);
       OS << " @ ";
-      LIS.getInstructionIndex(*PrintReg.DefMI).print(OS);
+      LIS.getInstructionIndex(*PrintReg.getFirstDef()).print(OS);
+      if (PrintReg.Defs.size() > 1)
+        OS << " [...other defs...]";
     }
   });
 }
@@ -771,9 +888,9 @@ Printable Rematerializer::printUser(const MachineInstr *MI,
 }
 
 Rollbacker::RollbackInfo::RollbackInfo(const Rematerializer::Reg &Reg,
-                                       RegisterIdx NextRegIdx)
+                                       SmallVector<Position, 1> &&Positions)
     : DefReg(Reg.getDefReg()), Dependencies(Reg.Dependencies),
-      InsertPos(std::next(Reg.DefMI->getIterator())), NextRegIdx(NextRegIdx) {}
+      Positions(std::move(Positions)) {}
 
 void Rollbacker::rematerializerNoteRegCreated(const Rematerializer &Remater,
                                               RegisterIdx RegIdx) {
@@ -788,32 +905,59 @@ void Rollbacker::rematerializerNoteRegDeleted(const Rematerializer &Remater,
     return;
   const Rematerializer::Reg &Reg = Remater.getReg(RegIdx);
 
-  // If the MI that was originally after the one defining the register is
-  // rematerializable, derive its corresponding register index.
-  RegisterIdx NextRegIdx = Rematerializer::NoReg;
-  auto KnownNextRegIdx = AdjacentDeletedMIs.find(RegIdx);
-  if (KnownNextRegIdx != AdjacentDeletedMIs.end()) {
-    NextRegIdx = KnownNextRegIdx->second;
-  } else {
-    MachineBasicBlock::iterator InsertPos = std::next(Reg.DefMI->getIterator());
-    if (InsertPos != Reg.DefMI->getParent()->end())
-      NextRegIdx = Remater.getDefRegIdx(*InsertPos);
-  }
-  DeadRegs.try_emplace(RegIdx, Reg, NextRegIdx);
+  SmallVector<RollbackInfo::Position, 1> Positions(Reg.Defs.size());
+  for (const auto [DefIdx, DefMI] : enumerate(Reg.Defs)) {
+    RematMI ThisDef(RegIdx, static_cast<unsigned>(DefIdx));
+    RollbackInfo::Position &Pos = Positions[DefIdx];
+    Pos.InsertBefore = std::next(DefMI->getIterator());
+    auto &[NextRegIdx, NextDefIdx] = Pos.NextRematMI;
 
-  // Keep track of adjacent rematerializable MIs to allow re-creation in the
-  // same exact order regardless of rematerialization order.
-  MachineBasicBlock::iterator DefMI = Reg.DefMI->getIterator();
-  if (Reg.DefMI->getParent()->begin() != DefMI) {
-    RegisterIdx PrevRegIdx = Remater.getDefRegIdx(*std::prev(DefMI));
-    if (PrevRegIdx != Rematerializer::NoReg) {
-      // The key might already be in the map, which indicates that there were
-      // originally instructions in between the MIs which have since then been
-      // deleted. In these cases we leave the value untouched, as we care about
-      // MIs that were adjacent in the original instruction order.
-      AdjacentDeletedMIs.try_emplace(PrevRegIdx, RegIdx);
+    // If the MI that was originally after the one defining the register is
+    // rematerializable, derive its corresponding register and definition index.
+    NextRegIdx = Rematerializer::NoReg;
+    auto KnownNextRegIdx = AdjacentDeletedMIs.find(ThisDef);
+    if (KnownNextRegIdx != AdjacentDeletedMIs.end()) {
+      Pos.NextRematMI = KnownNextRegIdx->second;
+    } else {
+      if (Pos.InsertBefore != DefMI->getParent()->end()) {
+        const MachineInstr *NextMI = &*Pos.InsertBefore;
+        NextRegIdx = Remater.getDefRegIdx(*NextMI);
+        if (NextRegIdx == RegIdx) {
+          // Defining instructions are stored in program order so when the next
+          // instruction defines the same register as the one that is being
+          // deleted it is necessarily the next defining MI in the vector.
+          assert(Reg.Defs[DefIdx + 1] == NextMI && "inconsistent def MI");
+          NextDefIdx = DefIdx + 1;
+        } else if (NextRegIdx != Rematerializer::NoReg) {
+          const Rematerializer::Reg &NextReg = Remater.getReg(NextRegIdx);
+          NextDefIdx =
+              std::distance(NextReg.Defs.begin(), find(NextReg.Defs, NextMI));
+          assert(NextDefIdx != NextReg.Defs.size() && "cannot find def");
+        }
+      }
+    }
+
+    // Keep track of adjacent rematerializable MIs to allow re-creation in the
+    // same exact order regardless of rematerialization order.
+    if (DefMI->getParent()->begin() != DefMI->getIterator()) {
+      const MachineInstr *PrevMI = &*std::prev(DefMI->getIterator());
+      RegisterIdx PrevRegIdx = Remater.getDefRegIdx(*PrevMI);
+      if (PrevRegIdx != Rematerializer::NoReg) {
+        const Rematerializer::Reg &PrevReg = Remater.getReg(PrevRegIdx);
+        unsigned PrevDefIdx =
+            std::distance(PrevReg.Defs.begin(), find(PrevReg.Defs, PrevMI));
+        assert(PrevDefIdx != PrevReg.Defs.size() && "cannot find def");
+
+        // The key might already be in the map, which indicates that there were
+        // originally instructions in between the MIs which have since then been
+        // deleted. In these cases we leave the value untouched, as we care
+        // about MIs that were adjacent in the original instruction order.
+        AdjacentDeletedMIs.try_emplace({PrevRegIdx, PrevDefIdx}, ThisDef);
+      }
     }
   }
+
+  DeadRegs.try_emplace(RegIdx, Reg, std::move(Positions));
 }
 
 void Rollbacker::rollback(Rematerializer &Remater) {
@@ -823,25 +967,28 @@ void Rollbacker::rollback(Rematerializer &Remater) {
   for (auto &[RegIdx, Info] : DeadRegs) {
     assert(!Remater.getReg(RegIdx).isAlive() && "register should be dead");
 
-    // The MI that was originally just after the MI defining the register we
-    // are trying to re-create may have been deleted. In such cases, we can
-    // re-create at that MI's own insert position (and apply the same logic
-    // recursively).
-    MachineBasicBlock::iterator InsertPos = Info.InsertPos;
-    RegisterIdx NextRegIdx = Info.NextRegIdx;
-    while (NextRegIdx != Rematerializer::NoReg) {
-      const Rematerializer::Reg &MaybeAliveReg = Remater.getReg(NextRegIdx);
-      // When the next MI is alive (including when it was dead and already
-      // re-created), we must use it as the position to insert before.
-      if (MaybeAliveReg.isAlive()) {
-        InsertPos = MaybeAliveReg.DefMI->getIterator();
-        break;
+    SmallVector<MachineBasicBlock::iterator, 1> Positions;
+    // Make a copy here because we may modify it.
+    for (RollbackInfo::Position Pos : Info.Positions) {
+      auto &[NextRegIdx, NextDefIdx] = Pos.NextRematMI;
+
+      // The MI that was originally just after the MI defining the register we
+      // are trying to re-create may have been deleted. In such cases, we can
+      // re-create at that MI's own insert position (and apply the same logic
+      // recursively).
+      while (NextRegIdx != Rematerializer::NoReg) {
+        const Rematerializer::Reg &MaybeAliveReg = Remater.getReg(NextRegIdx);
+        // When the next MI is alive (including when it was dead and already
+        // re-created), we must use it as the position to insert before.
+        if (MaybeAliveReg.isAlive()) {
+          Pos.InsertBefore = MaybeAliveReg.Defs[NextDefIdx]->getIterator();
+          break;
+        }
+        Pos = DeadRegs.at(NextRegIdx).Positions[NextDefIdx];
       }
-      RollbackInfo NextInfo = DeadRegs.at(NextRegIdx);
-      InsertPos = NextInfo.InsertPos;
-      NextRegIdx = NextInfo.NextRegIdx;
+      Positions.push_back(Pos.InsertBefore);
     }
-    Remater.recreateReg(RegIdx, InsertPos, Info.DefReg,
+    Remater.recreateReg(RegIdx, Positions, Info.DefReg,
                         std::move(Info.Dependencies));
   }
 

--- a/llvm/lib/CodeGen/Rematerializer.cpp
+++ b/llvm/lib/CodeGen/Rematerializer.cpp
@@ -18,13 +18,14 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/CodeGen/LiveIntervals.h"
+#include "llvm/CodeGen/LiveRangeEdit.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/MC/LaneBitmask.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/ErrorHandling.h"
 #include <optional>
 
 #define DEBUG_TYPE "rematerializer"
@@ -178,21 +179,50 @@ void Rematerializer::transferUserImpl(RegisterIdx FromRegIdx,
   LLVM_DEBUG(dbgs() << "User transfer from " << printID(FromRegIdx) << " to "
                     << printID(ToRegIdx) << ": " << printUser(&UserMI) << '\n');
 
-  UserMI.substituteRegister(getReg(FromRegIdx).getDefReg(),
-                            getReg(ToRegIdx).getDefReg(), 0, TRI);
+  Register FromReg = getReg(FromRegIdx).getDefReg();
+  UserMI.substituteRegister(FromReg, getReg(ToRegIdx).getDefReg(), 0, TRI);
 
-  // If the user is rematerializable, we must change its dependency to the
-  // new register.
-  if (RegisterIdx UserRegIdx = getDefRegIdx(UserMI); UserRegIdx != NoReg) {
-    // Look for the user's dependency that matches the register.
-    for (RegisterIdx &DepRegIdx : Regs[UserRegIdx].Dependencies) {
-      if (DepRegIdx == FromRegIdx) {
-        DepRegIdx = ToRegIdx;
+  RegisterIdx UserRegIdx = getDefRegIdx(UserMI);
+  if (UserRegIdx == NoReg)
+    return;
+
+  // When the user is rematerializable, we must reflect the change in its
+  // dependencies.
+  Reg &UserReg = Regs[UserRegIdx];
+  SmallVectorImpl<RegisterIdx> &UserDeps = Regs[UserRegIdx].Dependencies;
+  bool IsNewDep = true;
+  if (UserReg.Defs.size() > 1) {
+    // Other defining MIs might already be using the new register.
+    IsNewDep = find(UserDeps, ToRegIdx) == UserDeps.end();
+
+    auto MOIsFromReg = [FromReg](MachineOperand &MO) {
+      return MO.getReg() == FromReg;
+    };
+
+    // If any other defining instruction of the rematerializable user still uses
+    // the original register, we should not remove it from dependencies and may
+    // need to add a new dependency if it is the first time the new register is
+    // used by defining instructions.
+    for (MachineInstr *DefMI : UserReg.Defs) {
+      if (DefMI == &UserMI)
+        continue;
+      if (any_of(DefMI->all_uses(), MOIsFromReg)) {
+        if (IsNewDep)
+          UserDeps.push_back(ToRegIdx);
         return;
       }
     }
-    llvm_unreachable("broken dependency");
   }
+
+  // No other defining instruction has the original register as user. This
+  // either removes a dependency if the new register was previously used, or is
+  // a simple replacement if not.
+  unsigned *FindFromReg = find(UserDeps, FromRegIdx);
+  assert(FindFromReg != UserDeps.end() && "broken dependency");
+  if (IsNewDep)
+    *FindFromReg = ToRegIdx;
+  else
+    UserReg.Dependencies.erase(FindFromReg);
 }
 
 bool Rematerializer::isMOIdenticalAtUses(MachineOperand &MO,
@@ -234,7 +264,7 @@ RegisterIdx Rematerializer::findRematInRegion(RegisterIdx RegIdx,
     if (RematReg.DefRegion != Region || RematReg.Uses.empty())
       continue;
     SlotIndex RematRegSlot =
-        LIS.getInstructionIndex(*RematReg.DefMI).getRegSlot();
+        LIS.getInstructionIndex(*RematReg.getLastDef()).getRegSlot();
     if (RematRegSlot < Before &&
         (BestRegIdx == NoReg || RematRegSlot > BestSlot)) {
       BestSlot = RematRegSlot;
@@ -257,10 +287,17 @@ void Rematerializer::deleteReg(RegisterIdx RootIdx) {
     for (RegisterIdx DepRegIdx : DeleteReg.Dependencies) {
       // All dependencies lose a user (the deleted register).
       Reg &DepReg = Regs[DepRegIdx];
-      DepReg.eraseUser(DeleteReg.DefMI, DeleteReg.DefRegion);
-      if (DepReg.Uses.empty()) {
-        DeleteOrder.push_back(DepRegIdx);
-        DepDAG.push_back(DepRegIdx);
+      for (MachineInstr *DefMI : DeleteReg.Defs) {
+        if (DepReg.tryEraseUser(DefMI, DeleteReg.DefRegion) &&
+            DepReg.Uses.empty()) {
+          // The if condition will only be true at most once for any given
+          // register because, once the dependency no longer has any user,
+          // tryEraseUser will always produce false. We can therefore safely use
+          // vectors instead of sets for determining deletable registers.
+          DeleteOrder.push_back(DepRegIdx);
+          DepDAG.push_back(DepRegIdx);
+          break;
+        }
       }
     }
   } while (!DepDAG.empty());
@@ -269,10 +306,12 @@ void Rematerializer::deleteReg(RegisterIdx RootIdx) {
     preDeletion(RegIdx);
     Reg &DeleteReg = Regs[RegIdx];
     Register DefReg = DeleteReg.getDefReg();
-    LIS.RemoveMachineInstrFromMaps(*DeleteReg.DefMI);
-    DeleteReg.DefMI->eraseFromParent();
-    DeleteReg.DefMI = nullptr;
+    for (MachineInstr *DefMI : reverse(DeleteReg.Defs)) {
+      LIS.RemoveMachineInstrFromMaps(*DefMI);
+      DefMI->eraseFromParent();
+    }
     LIS.removeInterval(DefReg);
+    DeleteReg.Defs.clear();
   }
 
   SmallSet<RegisterIdx, 8> ShrinkRematRegs;
@@ -357,16 +396,27 @@ void Rematerializer::DeadDefDelegate::LRE_WillEraseInstruction(
   // All rematerializable dependencies must be notified.
   Reg &DeleteReg = Remater.Regs[RegIdx];
   for (RegisterIdx DepRegIdx : DeleteReg.Dependencies)
-    Remater.Regs[DepRegIdx].eraseUser(MI, DeleteReg.DefRegion);
+    Remater.Regs[DepRegIdx].tryEraseUser(MI, DeleteReg.DefRegion);
 
-  assert(DeleteReg.isAlive() && "register must be alive");
+  // The constraint that no other register reads any intermediate value of a
+  // register defined over multiple MI implies that the live range editor will
+  // either not touch or fully delete rematerializable registers i.e., if this
+  // is called for any defining instruction of a rematerializable register, this
+  // will be called for every definition of the register. Furthermore, def/use
+  // order between defining instructions ensures this will be called from last
+  // definition to first definition. When the last definition / first MI
+  // deletion happens, we want to reflect the deletion in our internal
+  // data-structures and notify any rematerializer listener.
+  if (!DeleteReg.isAlive())
+    return;
+  assert(DeleteReg.getLastDef() == MI && "last def should be deleted first");
   assert(DeleteReg.Uses.empty() && "register should no longer have uses");
 
-  // The live-range editor will delete the defining instruction from the MIR
-  // as well as the register's live-range, so we just need to nullify the def
-  // internally.
+  // The live-reange editor will delete all defining instructions from the MIR
+  // as well as the register's live-range, so we just need to clear out the defs
+  // vector.
   Remater.preDeletion(RegIdx);
-  DeleteReg.DefMI = nullptr;
+  DeleteReg.Defs.clear();
 }
 
 void Rematerializer::preDeletion(RegisterIdx DeleteRegIdx) {
@@ -379,8 +429,11 @@ void Rematerializer::preDeletion(RegisterIdx DeleteRegIdx) {
   // instruction to be the upper region boundary since we don't ever consider
   // them rematerializable.
   MachineBasicBlock::iterator &RegionBegin = Regions[DeleteReg.DefRegion].first;
-  if (RegionBegin == DeleteReg.DefMI)
+  for (MachineInstr *DefMI : DeleteReg.Defs) {
+    if (RegionBegin != DefMI)
+      break;
     ++RegionBegin;
+  }
 
   if (isOriginalRegister(DeleteRegIdx))
     return;
@@ -472,32 +525,76 @@ void Rematerializer::addRegIfRematerializable(
   assert(!SeenRegs[VirtRegIdx] && "register already seen");
   Register DefReg = Register::index2VirtReg(VirtRegIdx);
   SeenRegs.set(VirtRegIdx);
-
-  MachineOperand *MO = MRI.getOneDef(DefReg);
-  if (!MO)
-    return;
-  MachineInstr &DefMI = *MO->getParent();
-  if (!isMIRematerializable(DefMI))
-    return;
-  auto DefRegion = MIRegion.find(&DefMI);
-  if (DefRegion == MIRegion.end())
-    return;
-
   Reg RematReg;
-  RematReg.DefMI = &DefMI;
-  RematReg.DefRegion = DefRegion->second;
-  unsigned SubIdx = DefMI.getOperand(0).getSubReg();
-  RematReg.Mask = SubIdx ? TRI.getSubRegIndexLaneMask(SubIdx)
-                         : MRI.getMaxLaneMaskForVReg(DefReg);
+
+  // Check that the register's definitions can be rematerialized.
+  SmallPtrSet<MachineInstr *, 1> DefSet;
+  for (MachineOperand &MO : MRI.def_operands(DefReg)) {
+    MachineInstr &DefMI = *MO.getParent();
+    // If a single MI has multiple defs for the same register, we don't need to
+    // redo MI-based checks.
+    if (!DefSet.insert(&DefMI).second)
+      continue;
+
+    // The defining MI must be rematerializable and in the same region as all
+    // other defining MIs.
+    if (!isMIRematerializable(DefMI))
+      return;
+    auto DefRegion = MIRegion.find(&DefMI);
+    if (DefRegion == MIRegion.end())
+      return;
+    if (RematReg.Defs.empty())
+      RematReg.DefRegion = DefRegion->getSecond();
+    else if (RematReg.DefRegion != DefRegion->getSecond())
+      return;
+    RematReg.Defs.push_back(&DefMI);
+  }
+  if (RematReg.Defs.empty())
+    return;
+
+  // Order defining MIs by slot index.
+  sort(RematReg.Defs, [&](MachineInstr *LHS, MachineInstr *RHS) {
+    return LIS.getInstructionIndex(*LHS) < LIS.getInstructionIndex(*RHS);
+  });
+  // None of the non-first register defintions can be marked undef.
+  for (const MachineInstr *DefMI : drop_begin(RematReg.Defs)) {
+    for (const MachineOperand &DefMO : DefMI->all_defs()) {
+      if (DefMO.getReg() == DefReg && DefMO.isUndef())
+        return;
+    }
+  }
+
+  SlotIndex LastDefSlot = LIS.getInstructionIndex(*RematReg.getLastDef());
+
+  // Set the register's mask to all active lanes after the last def.
+  const LiveInterval &DefLI = LIS.getInterval(DefReg);
+  SlotIndex AfterLastDef = LastDefSlot.getRegSlot();
+  if (DefLI.hasSubRanges()) {
+    for (const LiveInterval::SubRange &SR : DefLI.subranges())
+      if (SR.liveAt(AfterLastDef))
+        RematReg.Mask |= SR.LaneMask;
+  } else {
+    RematReg.Mask = MRI.getMaxLaneMaskForVReg(DefReg);
+  }
 
   // Collect the candidate's direct users, both rematerializable and
-  // unrematerializable. MIs outside provided regions cannot be tracked so the
-  // registers they use are not safely rematerializable.
+  // unrematerializable.
+  const bool MoreThanOneDef = RematReg.Defs.size() > 1;
   for (MachineInstr &UseMI : MRI.use_nodbg_instructions(DefReg)) {
-    if (auto UseRegion = MIRegion.find(&UseMI); UseRegion != MIRegion.end())
-      RematReg.addUser(&UseMI, UseRegion->second);
-    else
+    // We are only interested in users that do not define part of the register.
+    if (DefSet.contains(&UseMI))
+      continue;
+    // MIs outside provided regions cannot be tracked so the registers they use
+    // are not safely rematerializable.
+    auto UseRegion = MIRegion.find(&UseMI);
+    if (UseRegion == MIRegion.end())
       return;
+    // Disallow reads before the last def.
+    if (MoreThanOneDef && RematReg.DefRegion == UseRegion->second &&
+        LastDefSlot > LIS.getInstructionIndex(UseMI))
+      return;
+
+    RematReg.addUser(&UseMI, UseRegion->second);
   }
   if (RematReg.Uses.empty())
     return;
@@ -507,22 +604,39 @@ void Rematerializer::addRegIfRematerializable(
   // it once.
   SmallSetVector<RegisterIdx, 2> RematDeps;
   SmallMapVector<Register, LaneBitmask, 2> UnrematDeps;
-  for (const MachineOperand &MO : DefMI.all_uses()) {
-    Register DepReg = getRegDependency(MO);
-    if (!DepReg)
-      continue;
-    unsigned DepRegIdx = DepReg.virtRegIndex();
-    if (!SeenRegs[DepRegIdx])
-      addRegIfRematerializable(DepRegIdx, MIRegion, SeenRegs);
-    if (auto DepIt = RegToIdx.find(DepReg); DepIt != RegToIdx.end()) {
-      RematDeps.insert(DepIt->second);
-    } else {
-      LaneBitmask &CurrentMask =
-          UnrematDeps.try_emplace(DepReg, LaneBitmask::getNone()).first->second;
-      LaneBitmask Mask = MO.getSubReg()
-                             ? TRI.getSubRegIndexLaneMask(MO.getSubReg())
-                             : MRI.getMaxLaneMaskForVReg(DepReg);
-      CurrentMask |= Mask;
+  for (const MachineInstr *DefMI : RematReg.Defs) {
+    for (const MachineOperand &MO : DefMI->all_uses()) {
+      Register DepReg = getRegDependency(MO);
+      if (!DepReg || DepReg == DefReg)
+        continue;
+      unsigned DepRegIdx = DepReg.virtRegIndex();
+      if (!SeenRegs[DepRegIdx])
+        addRegIfRematerializable(DepRegIdx, MIRegion, SeenRegs);
+      if (auto DepIt = RegToIdx.find(DepReg); DepIt != RegToIdx.end()) {
+        RematDeps.insert(DepIt->second);
+      } else {
+        LaneBitmask &CurrentMask =
+            UnrematDeps.try_emplace(DepReg, LaneBitmask::getNone())
+                .first->second;
+        LaneBitmask Mask = MO.getSubReg()
+                               ? TRI.getSubRegIndexLaneMask(MO.getSubReg())
+                               : MRI.getMaxLaneMaskForVReg(DepReg);
+        CurrentMask |= Mask;
+      }
+    }
+  }
+
+  if (MoreThanOneDef) {
+    // A def of an unrematerializable dependency between the defs of the
+    // register under consideration makes the latter unrematerializable.
+    SlotIndex FirstDefSlot = LIS.getInstructionIndex(*RematReg.getFirstDef());
+    for (const auto &[UnrematDepReg, _] : UnrematDeps) {
+      for (MachineOperand &UnrematMODef : MRI.def_operands(UnrematDepReg)) {
+        MachineInstr &UnrematDefMI = *UnrematMODef.getParent();
+        SlotIndex UnrematDefSlot = LIS.getInstructionIndex(UnrematDefMI);
+        if (UnrematDefSlot > FirstDefSlot || UnrematDefSlot < LastDefSlot)
+          return;
+      }
     }
   }
 
@@ -538,7 +652,6 @@ bool Rematerializer::isMIRematerializable(const MachineInstr &MI) const {
     return false;
 
   assert(MI.getOperand(0).getReg().isVirtual() && "should be virtual");
-  assert(MRI.hasOneDef(MI.getOperand(0).getReg()) && "should have single def");
 
   for (const MachineOperand &MO : MI.all_uses()) {
     // We can't remat physreg uses, unless it is a constant or an ignorable
@@ -555,7 +668,7 @@ bool Rematerializer::isMIRematerializable(const MachineInstr &MI) const {
 
 RegisterIdx Rematerializer::getDefRegIdx(const MachineInstr &MI) const {
   if (!MI.getNumOperands() || !MI.getOperand(0).isReg() ||
-      MI.getOperand(0).readsReg())
+      !MI.getOperand(0).isDef())
     return NoReg;
   Register Reg = MI.getOperand(0).getReg();
   auto UserRegIt = RegToIdx.find(Reg);
@@ -574,6 +687,7 @@ Rematerializer::rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
   Reg &FromReg = Regs[RegIdx];
   NewReg.Mask = FromReg.Mask;
   NewReg.DefRegion = UseRegion;
+  NewReg.Defs.reserve(FromReg.Defs.size());
   NewReg.Dependencies = std::move(Dependencies);
 
   // Track rematerialization link between registers. Origins are always
@@ -586,9 +700,10 @@ Rematerializer::rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
   // Use the TII to rematerialize the defining instruction with a new defined
   // register.
   Register NewDefReg = MRI.cloneVirtualRegister(FromReg.getDefReg());
-  TII.reMaterialize(*RegionMBB[UseRegion], InsertPos, NewDefReg, 0,
-                    *FromReg.DefMI);
-  NewReg.DefMI = &*std::prev(InsertPos);
+  for (const MachineInstr *DefMI : FromReg.Defs) {
+    TII.reMaterialize(*RegionMBB[UseRegion], InsertPos, NewDefReg, 0, *DefMI);
+    NewReg.Defs.push_back(&*std::prev(InsertPos));
+  }
   RegToIdx.insert({NewDefReg, NewRegIdx});
   postRematerialization(RegIdx, NewRegIdx);
 
@@ -598,13 +713,12 @@ Rematerializer::rematerializeReg(RegisterIdx RegIdx, unsigned UseRegion,
   return NewRegIdx;
 }
 
-void Rematerializer::recreateReg(RegisterIdx RegIdx,
-                                 MachineBasicBlock::iterator InsertPos,
-                                 Register DefReg) {
+void Rematerializer::recreateReg(
+    RegisterIdx RegIdx, ArrayRef<MachineBasicBlock::iterator> Positions,
+    Register DefReg) {
   assert(RegToIdx.contains(DefReg) && "unknown defined register");
   assert(RegToIdx.at(DefReg) == RegIdx && "incorrect defined register");
   assert(!getReg(RegIdx).isAlive() && "register is still alive");
-
   Reg &OriginReg = Regs[RegIdx];
 
   // Re-establish the link between origin and rematerialization if necessary.
@@ -623,11 +737,13 @@ void Rematerializer::recreateReg(RegisterIdx RegIdx,
     assert(getReg(getOriginOf(RegIdx)).isAlive() && "expected alive origin");
     ModelRegIdx = getOriginOf(RegIdx);
   }
-  const MachineInstr &ModelDefMI = *getReg(ModelRegIdx).DefMI;
+  const Reg &ModelReg = getReg(ModelRegIdx);
 
-  TII.reMaterialize(*RegionMBB[OriginReg.DefRegion], InsertPos, DefReg, 0,
-                    ModelDefMI);
-  OriginReg.DefMI = &*std::prev(InsertPos);
+  for (auto [DefMI, InsertPos] : zip_equal(ModelReg.Defs, Positions)) {
+    TII.reMaterialize(*RegionMBB[OriginReg.DefRegion], InsertPos, DefReg, 0,
+                      *DefMI);
+    OriginReg.Defs.push_back(&*std::prev(InsertPos));
+  }
   postRematerialization(ModelRegIdx, RegIdx);
   LLVM_DEBUG(dbgs() << "** Recreated " << printID(RegIdx) << " as "
                     << printRematReg(RegIdx) << '\n');
@@ -637,15 +753,22 @@ void Rematerializer::postRematerialization(RegisterIdx ModelRegIdx,
                                            RegisterIdx RematRegIdx) {
   Reg &ModelReg = Regs[ModelRegIdx], &RematReg = Regs[RematRegIdx];
 
+  SlotIndex UseIdx;
+  for (MachineInstr *DefMI : RematReg.Defs)
+    UseIdx = LIS.InsertMachineInstrInMaps(*DefMI);
+  UseIdx = UseIdx.getRegSlot();
+
   // The rematerialization has no user at this point so its interval will
   // initially be empty.
-  SlotIndex UseIdx = LIS.InsertMachineInstrInMaps(*RematReg.DefMI).getRegSlot();
   LIS.createAndComputeVirtRegInterval(RematReg.getDefReg());
 
   // The start of the new register's region may have changed.
-  MachineBasicBlock::iterator &RegionBegin = Regions[RematReg.DefRegion].first;
-  if (RegionBegin == std::next(MachineBasicBlock::iterator(RematReg.DefMI)))
-    RegionBegin = RematReg.DefMI;
+  MachineInstr &FirstDefMI = *RematReg.getFirstDef();
+  auto &[RegionBegin, RegionEnd] = Regions[RematReg.DefRegion];
+  if (RegionBegin == RegionEnd ||
+      (!RegionBegin->isDebugInstr() && LIS.getInstructionIndex(*RegionBegin) >
+                                           LIS.getInstructionIndex(FirstDefMI)))
+    RegionBegin = FirstDefMI.getIterator();
 
   // Replace dependencies as needed in the rematerialized MI. All dependencies
   // of the latter gain a new user.
@@ -653,15 +776,25 @@ void Rematerializer::postRematerialization(RegisterIdx ModelRegIdx,
   for (const auto &[OldDepRegIdx, NewDepRegIdx] : ZipedDeps) {
     LLVM_DEBUG(dbgs() << "  Dependency: " << printID(OldDepRegIdx) << " -> "
                       << printID(NewDepRegIdx) << '\n');
+    Register OldReg = getReg(OldDepRegIdx).getDefReg();
+    Register NewReg = getReg(NewDepRegIdx).getDefReg();
 
-    Reg &NewDepReg = Regs[NewDepRegIdx];
-    if (OldDepRegIdx != NewDepRegIdx) {
-      Reg &OldDepReg = Regs[OldDepRegIdx];
-      RematReg.DefMI->substituteRegister(OldDepReg.getDefReg(),
-                                         NewDepReg.getDefReg(), 0, TRI);
+    SmallVector<MachineInstr *, 2> DefsUsingNewDep;
+    for (MachineInstr *DefMI : RematReg.Defs) {
+      bool NewDefHasReg = false;
+      for (MachineOperand &MO : DefMI->operands()) {
+        if (!MO.isReg() || MO.getReg() != OldReg)
+          continue;
+        NewDefHasReg = true;
+        DefsUsingNewDep.push_back(DefMI);
+        if (OldDepRegIdx != NewDepRegIdx)
+          MO.substVirtReg(NewReg, 0, TRI);
+      }
+      if (NewDefHasReg)
+        Regs[NewDepRegIdx].addUser(DefMI, RematReg.DefRegion);
     }
-    NewDepReg.addUser(RematReg.DefMI, RematReg.DefRegion);
-    extendToNewUsers(NewDepRegIdx, RematReg.DefMI);
+    assert(!DefsUsingNewDep.empty() && "no user of dependency");
+    extendToNewUsers(NewDepRegIdx, DefsUsingNewDep);
   }
 
   // Unrematerializable dependencies always gain a new user after a
@@ -715,12 +848,18 @@ void Rematerializer::extendToNewUsers(RegisterIdx RegIdx,
     extendInterval(LI, RegMask, UseIdx);
   }
 
+  // Rematerializable registers are never read by instructions not defining them
+  // until after their last def, so adding a user to them ensures their last
+  // definition is alive. All potential other definitions are read by the last
+  // definition and are therefore already alive by construction.
   LLVM_DEBUG({
-    if (ExtendReg.DefMI->getOperand(0).isDead())
+    if (ExtendReg.getLastDef()->getOperand(0).isDead())
       dbgs() << "Clearing dead flag for "
-             << printRematReg(RegIdx, /*SkipRegions=*/false) << '\n';
+             << printRematReg(RegIdx, /*SkipRegions=*/false,
+                              /*DefIdx=*/ExtendReg.Defs.size() - 1)
+             << '\n';
   });
-  ExtendReg.DefMI->getOperand(0).setIsDead(false);
+  ExtendReg.getLastDef()->getOperand(0).setIsDead(false);
 }
 
 void Rematerializer::extendInterval(LiveInterval &LI, LaneBitmask Mask,
@@ -840,6 +979,15 @@ void Rematerializer::Reg::eraseUser(MachineInstr *MI, unsigned Region) {
     RUsers.erase(MI);
 }
 
+bool Rematerializer::Reg::tryEraseUser(MachineInstr *MI, unsigned Region) {
+  auto RegionUsers = Uses.find(Region);
+  if (RegionUsers == Uses.end() || !RegionUsers->getSecond().erase(MI))
+    return false;
+  if (RegionUsers->getSecond().empty())
+    Uses.erase(Region);
+  return true;
+}
+
 Printable Rematerializer::printDependencyDAG(RegisterIdx RootIdx) const {
   return Printable([&, RootIdx](raw_ostream &OS) {
     DenseMap<RegisterIdx, unsigned> RegDepths;
@@ -872,19 +1020,17 @@ Printable Rematerializer::printID(RegisterIdx RegIdx) const {
   return Printable([&, RegIdx](raw_ostream &OS) {
     const Reg &PrintReg = getReg(RegIdx);
     OS << '(' << RegIdx << '/';
-    if (!PrintReg.isAlive()) {
+    if (!PrintReg.isAlive())
       OS << "<dead>";
-    } else {
-      OS << printReg(PrintReg.getDefReg(), &TRI,
-                     PrintReg.DefMI->getOperand(0).getSubReg(), &MRI);
-    }
+    else
+      OS << printReg(PrintReg.getDefReg(), &TRI, 0, &MRI);
     OS << ")[" << PrintReg.DefRegion << "]";
   });
 }
 
-Printable Rematerializer::printRematReg(RegisterIdx RegIdx,
-                                        bool SkipRegions) const {
-  return Printable([&, RegIdx, SkipRegions](raw_ostream &OS) {
+Printable Rematerializer::printRematReg(RegisterIdx RegIdx, bool SkipRegions,
+                                        unsigned DefIdx) const {
+  return Printable([&, RegIdx, SkipRegions, DefIdx](raw_ostream &OS) {
     const Reg &PrintReg = getReg(RegIdx);
     OS << printID(RegIdx);
     if (!SkipRegions) {
@@ -928,10 +1074,13 @@ Printable Rematerializer::printRematReg(RegisterIdx RegIdx,
       OS << "] ";
     }
     if (PrintReg.isAlive()) {
-      PrintReg.DefMI->print(OS, /*IsStandalone=*/true, /*SkipOpers=*/false,
-                            /*SkipDebugLoc=*/false, /*AddNewLine=*/false);
+      assert(DefIdx < PrintReg.Defs.size() && "out-of-bound def");
+      MachineInstr &PrintDef = *PrintReg.Defs[DefIdx];
+      OS << "(def. " << DefIdx + 1 << " / " << PrintReg.Defs.size() << ") ";
+      PrintDef.print(OS, /*IsStandalone=*/true, /*SkipOpers=*/false,
+                     /*SkipDebugLoc=*/false, /*AddNewLine=*/false);
       OS << " @ ";
-      LIS.getInstructionIndex(*PrintReg.DefMI).print(OS);
+      LIS.getInstructionIndex(PrintDef).print(OS);
     }
   });
 }
@@ -980,28 +1129,55 @@ void Rollbacker::rematerializerNoteRegWillBeDeleted(
   if (RollingBack)
     return;
 
-  // Find a valid re-creation position after the register's definition.
-  MachineInstr *DefMI = Remater.getReg(RegIdx).DefMI;
-  MachineBasicBlock *ParentMBB = DefMI->getParent();
-  MachineBasicBlock::iterator ValidPos = std::next(DefMI->getIterator());
-  while (ValidPos != ParentMBB->end() && isRollbackableMI(*ValidPos, Remater))
-    ValidPos = std::next(ValidPos);
+  const Rematerializer::Reg &Reg = Remater.getReg(RegIdx);
+  MachineBasicBlock *ParentMBB = Reg.getFirstDef()->getParent();
+  MachineBasicBlock::iterator LastValidPos;
+
+  auto GetNextValidPosAfterDef =
+      [&](unsigned DefIdx) -> MachineBasicBlock::iterator {
+    const MachineInstr *NextDef =
+        DefIdx + 1 < Reg.Defs.size() ? Reg.Defs[DefIdx + 1] : nullptr;
+    MachineBasicBlock::iterator ValidPos =
+        std::next(Reg.Defs[DefIdx]->getIterator());
+
+    while (ValidPos != ParentMBB->end()) {
+      // When there are no valid insert positions between the current and next
+      // definition of the register about to be deleted, the first valid insert
+      // position for the current definition is the same as for the next
+      // definition.
+      const MachineInstr &CandMI = *ValidPos;
+      if (NextDef && &CandMI == NextDef)
+        return LastValidPos;
+      if (!isRollbackableMI(CandMI, Remater))
+        break;
+
+      // Move to the next candidate position.
+      ValidPos = std::next(ValidPos);
+    }
+
+    LastValidPos = ValidPos;
+    return ValidPos;
+  };
 
   if (Remater.isRematerializedRegister(RegIdx)) {
     // Rematerializations will not be re-created. Previously deleted registers
-    // that reference this register's defining instruction as their re-creation
+    // that reference this register's defining instructions as their re-creation
     // position should instead be re-created at a valid position after the
-    // deleted MI.
-    invalidatePosition(DefMI, ValidPos);
+    // deleted MIs.
+    for (unsigned I = Reg.Defs.size(); I > 0; --I)
+      invalidatePosition(Reg.Defs[I - 1], GetNextValidPosAfterDef(I - 1));
     return;
   }
 
-  // Original registers can be re-created. Add a re-creation position for the
+  // Original registers can be re-created. Add a re-creation position for each
   // definition of the rematerializable register.
   DeadRegs.push_back(DeadReg(RegIdx, Remater));
-  const InsertBeforePos InsertPos = makePos(ValidPos, ParentMBB);
-  PosToIdx[InsertPos].insert(Positions.size());
-  Positions.push_back(InsertPos);
+  for (unsigned I = Reg.Defs.size(); I > 0; --I) {
+    const InsertBeforePos InsertPos =
+        makePos(GetNextValidPosAfterDef(I - 1), ParentMBB);
+    PosToIdx[InsertPos].insert(Positions.size());
+    Positions.push_back(InsertPos);
+  }
 }
 
 void Rollbacker::rematerializerNoteMIWillBeDeleted(
@@ -1036,27 +1212,31 @@ void Rollbacker::rollback(Rematerializer &Remater) {
       // It is possible the register was permanently deleted as a consequence of
       // dead-def elimination.
       Rematerializations.erase(Reg.Idx);
-      --PositionIndex;
+      PositionIndex -= Reg.Defs.size();
       continue;
     }
-
     assert(!Remater.getReg(Reg.Idx).isAlive() && "register should be dead");
 
-    // Determine re-creation position for the register's definition.
-    MachineBasicBlock::iterator InsertPosition;
-    InsertBeforePos Pos = Positions[--PositionIndex];
-    if (auto *MBB = dyn_cast<MachineBasicBlock *>(Pos)) {
-      InsertPosition = MBB->end();
-    } else {
-      auto *MI = cast<MachineInstr *>(Pos);
-      InsertPosition = Replacements.lookup_or(MI, MI)->getIterator();
+    // Determine re-creation positions for all the deleted register's defs.
+    SmallVector<MachineBasicBlock::iterator, 1> InsertPositions;
+    for (unsigned I = 0, E = Reg.Defs.size(); I < E; ++I) {
+      InsertBeforePos Pos = Positions[--PositionIndex];
+      if (auto *MBB = dyn_cast<MachineBasicBlock *>(Pos)) {
+        InsertPositions.push_back(MBB->end());
+      } else {
+        auto *MI = cast<MachineInstr *>(Pos);
+        MachineInstr *InsertBeforeMI = Replacements.lookup_or(MI, MI);
+        InsertPositions.push_back(InsertBeforeMI->getIterator());
+      }
     }
 
-    Remater.recreateReg(Reg.Idx, InsertPosition, Reg.DefReg);
+    Remater.recreateReg(Reg.Idx, InsertPositions, Reg.DefReg);
 
     const Rematerializer::Reg &RecreateReg = Remater.getReg(Reg.Idx);
-    if (!Replacements.insert({Reg.DefMI, RecreateReg.DefMI}).second)
-      llvm_unreachable("duplicate deleted MI");
+    for (const auto [OldDef, NewDef] : zip_equal(Reg.Defs, RecreateReg.Defs)) {
+      assert(!Replacements.contains(OldDef) && "duplicate deleted MI");
+      Replacements[OldDef] = NewDef;
+    }
   }
 
   // Rollback rematerializations.

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1520,7 +1520,7 @@ bool PreRARematStage::initGCNSchedStage() {
       continue;
     SlotIndex UseIdx = DAG.LIS->getInstructionIndex(*UseMI).getRegSlot(true);
     SlotIndex RefIdx =
-        DAG.LIS->getInstructionIndex(*CandReg.DefMI).getRegSlot(true);
+        DAG.LIS->getInstructionIndex(*CandReg.getLastDef()).getRegSlot(true);
     if (llvm::any_of(CandReg.Dependencies, [&](RegisterIdx DepRegIdx) {
           const Rematerializer::Reg &DepReg = Remater.getReg(DepRegIdx);
           Register DepDefReg = DepReg.getDefReg();

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1563,7 +1563,7 @@ bool PreRARematStage::initGCNSchedStage() {
       continue;
     SlotIndex UseIdx = DAG.LIS->getInstructionIndex(*UseMI).getRegSlot(true);
     SlotIndex RefIdx =
-        DAG.LIS->getInstructionIndex(*CandReg.DefMI).getRegSlot(true);
+        DAG.LIS->getInstructionIndex(*CandReg.getLastDef()).getRegSlot(true);
     if (llvm::any_of(CandReg.Dependencies, [&](RegisterIdx DepRegIdx) {
           const Rematerializer::Reg &DepReg = Remater.getReg(DepRegIdx);
           Register DepDefReg = DepReg.getDefReg();

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -147,7 +147,72 @@ bool SIInstrInfo::isReMaterializableImpl(
       return true;
   }
 
-  return TargetInstrInfo::isReMaterializableImpl(MI);
+  // Everything below copied from TargetInstrInfo::isReMaterializableImpl. The
+  // only difference is that we allow operations that perform read-modify-write
+  // on sub-registers.
+
+  // Remat clients assume operand 0 is the defined register.
+  if (!MI.getNumOperands() || !MI.getOperand(0).isReg())
+    return false;
+  Register DefReg = MI.getOperand(0).getReg();
+
+  const MachineFunction &MF = *MI.getMF();
+
+  // A load from a fixed stack slot can be rematerialized. This may be
+  // redundant with subsequent checks, but it's target-independent,
+  // simple, and a common case.
+  int FrameIdx = 0;
+  if (isLoadFromStackSlot(MI, FrameIdx) &&
+      MF.getFrameInfo().isImmutableObjectIndex(FrameIdx))
+    return true;
+
+  // Avoid instructions obviously unsafe for remat.
+  if (MI.isNotDuplicable() || MI.mayStore() || MI.mayRaiseFPException() ||
+      MI.hasUnmodeledSideEffects())
+    return false;
+
+  // Don't remat inline asm. We have no idea how expensive it is
+  // even if it's side effect free.
+  if (MI.isInlineAsm())
+    return false;
+
+  // Avoid instructions which load from potentially varying memory.
+  if (MI.mayLoad() && !MI.isDereferenceableInvariantLoad())
+    return false;
+
+  const MachineRegisterInfo &MRI = MF.getRegInfo();
+
+  // If any of the registers accessed are non-constant, conservatively assume
+  // the instruction is not rematerializable.
+  for (const MachineOperand &MO : MI.operands()) {
+    if (!MO.isReg())
+      continue;
+    Register Reg = MO.getReg();
+    if (Reg == 0)
+      continue;
+
+    // Check for a well-behaved physical register.
+    if (Reg.isPhysical()) {
+      if (MO.isUse()) {
+        // If the physreg has no defs anywhere, it's just an ambient register
+        // and we can freely move its uses. Alternatively, if it's allocatable,
+        // it could get allocated to something with a def during allocation.
+        if (!MRI.isConstantPhysReg(Reg))
+          return false;
+      } else {
+        // A physreg def. We can't remat it.
+        return false;
+      }
+      continue;
+    }
+
+    // Only allow one virtual-register def.  There may be multiple defs of the
+    // same virtual register, though.
+    if (MO.isDef() && Reg != DefReg)
+      return false;
+  }
+
+  return true;
 }
 
 // Returns true if the result of a VALU instruction depends on exec.

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -181,7 +181,72 @@ bool SIInstrInfo::isReMaterializableImpl(
       return true;
   }
 
-  return TargetInstrInfo::isReMaterializableImpl(MI);
+  // Everything below copied from TargetInstrInfo::isReMaterializableImpl. The
+  // only difference is that we allow operations that perform read-modify-write
+  // on sub-registers.
+
+  // Remat clients assume operand 0 is the defined register.
+  if (!MI.getNumOperands() || !MI.getOperand(0).isReg())
+    return false;
+  Register DefReg = MI.getOperand(0).getReg();
+
+  const MachineFunction &MF = *MI.getMF();
+
+  // A load from a fixed stack slot can be rematerialized. This may be
+  // redundant with subsequent checks, but it's target-independent,
+  // simple, and a common case.
+  int FrameIdx = 0;
+  if (isLoadFromStackSlot(MI, FrameIdx) &&
+      MF.getFrameInfo().isImmutableObjectIndex(FrameIdx))
+    return true;
+
+  // Avoid instructions obviously unsafe for remat.
+  if (MI.isNotDuplicable() || MI.mayStore() || MI.mayRaiseFPException() ||
+      MI.hasUnmodeledSideEffects())
+    return false;
+
+  // Don't remat inline asm. We have no idea how expensive it is
+  // even if it's side effect free.
+  if (MI.isInlineAsm())
+    return false;
+
+  // Avoid instructions which load from potentially varying memory.
+  if (MI.mayLoad() && !MI.isDereferenceableInvariantLoad())
+    return false;
+
+  const MachineRegisterInfo &MRI = MF.getRegInfo();
+
+  // If any of the registers accessed are non-constant, conservatively assume
+  // the instruction is not rematerializable.
+  for (const MachineOperand &MO : MI.operands()) {
+    if (!MO.isReg())
+      continue;
+    Register Reg = MO.getReg();
+    if (Reg == 0)
+      continue;
+
+    // Check for a well-behaved physical register.
+    if (Reg.isPhysical()) {
+      if (MO.isUse()) {
+        // If the physreg has no defs anywhere, it's just an ambient register
+        // and we can freely move its uses. Alternatively, if it's allocatable,
+        // it could get allocated to something with a def during allocation.
+        if (!MRI.isConstantPhysReg(Reg))
+          return false;
+      } else {
+        // A physreg def. We can't remat it.
+        return false;
+      }
+      continue;
+    }
+
+    // Only allow one virtual-register def.  There may be multiple defs of the
+    // same virtual register, though.
+    if (MO.isDef() && Reg != DefReg)
+      return false;
+  }
+
+  return true;
 }
 
 // Returns true if the result of a VALU instruction depends on exec.

--- a/llvm/test/CodeGen/AMDGPU/machine-scheduler-sink-trivial-remats.mir
+++ b/llvm/test/CodeGen/AMDGPU/machine-scheduler-sink-trivial-remats.mir
@@ -12299,26 +12299,26 @@ body:             |
   ; GFX908-NEXT:   [[DEF28:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF29:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF30:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GFX908-NEXT:   [[DEF31:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_22:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF24]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_23:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_22:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub0, implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_23:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF24]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_26:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub2, implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF29]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_30:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF31]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF29]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_30:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[DEF31:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   S_BRANCH %bb.1
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_1]], implicit [[V_CVT_I32_F32_e32_6]]
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_31:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub0, implicit $exec, implicit $mode
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_31]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF]].sub0, implicit [[DEF]].sub2
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF24]], implicit [[DEF28]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF25]], implicit [[DEF29]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_24]], implicit [[V_CVT_I32_F32_e32_29]], implicit [[DEF26]], implicit [[DEF30]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_25]], implicit [[V_CVT_I32_F32_e32_30]], implicit [[DEF27]], implicit [[DEF31]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF]].sub0, implicit [[DEF]].sub2
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_31:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF31]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_31]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF31]], implicit [[DEF27]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF24]], implicit [[DEF28]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_24]], implicit [[V_CVT_I32_F32_e32_29]], implicit [[DEF25]], implicit [[DEF29]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_25]], implicit [[V_CVT_I32_F32_e32_30]], implicit [[DEF26]], implicit [[DEF30]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_2]], implicit [[V_CVT_I32_F32_e32_7]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_3]], implicit [[V_CVT_I32_F32_e32_8]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_4]], implicit [[V_CVT_I32_F32_e32_9]]
@@ -12911,7 +12911,7 @@ body:             |
   ; GFX908-NEXT:   [[DEF30:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF31:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_23:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF29]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub2, implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_26:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF31]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   undef [[V_CVT_I32_F32_e32_1:%[0-9]+]].sub0:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub0, implicit $exec, implicit $mode
@@ -12920,13 +12920,13 @@ body:             |
   ; GFX908-NEXT: bb.1:
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_2]], implicit [[V_CVT_I32_F32_e32_7]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_3]], implicit [[V_CVT_I32_F32_e32_8]]
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub2, implicit $exec, implicit $mode
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_1]].sub0, implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF]].sub0, implicit [[DEF]].sub2
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_1]].sub0, implicit [[V_CVT_I32_F32_e32_24]], implicit [[DEF]].sub0, implicit [[DEF]].sub2
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF29]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_30:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF1]], implicit [[DEF28]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_24]], implicit [[DEF25]], implicit [[DEF29]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF1]], implicit [[DEF28]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF25]], implicit [[DEF29]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_29]], implicit [[V_CVT_I32_F32_e32_25]], implicit [[DEF26]], implicit [[DEF30]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_30]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF27]], implicit [[DEF31]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_4]], implicit [[V_CVT_I32_F32_e32_9]]

--- a/llvm/test/CodeGen/AMDGPU/machine-scheduler-sink-trivial-remats.mir
+++ b/llvm/test/CodeGen/AMDGPU/machine-scheduler-sink-trivial-remats.mir
@@ -12843,7 +12843,7 @@ body:             |
   ; GFX908-NEXT:   [[COPY:%[0-9]+]]:sgpr_64(p4) = COPY $sgpr0_sgpr1
   ; GFX908-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32(s32) = COPY $vgpr0
   ; GFX908-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]]:sreg_64_xexec = S_LOAD_DWORDX2_IMM [[COPY]](p4), 52, 0 :: (dereferenceable invariant load (s64), align 4, addrspace 4)
-  ; GFX908-NEXT:   undef [[DEF:%[0-9]+]].sub0:vreg_64 = IMPLICIT_DEF
+  ; GFX908-NEXT:   undef [[DEF:%[0-9]+]].sub1:vreg_64 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF1:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF2:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF3:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
@@ -12860,10 +12860,8 @@ body:             |
   ; GFX908-NEXT:   [[DEF14:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF15:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF16:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GFX908-NEXT:   [[DEF17:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GFX908-NEXT:   dead [[V_CVT_I32_F32_e32_:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF17]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   undef [[V_CVT_I32_F32_e32_1:%[0-9]+]].sub0:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub0, implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_1:%[0-9]+]].sub1:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF1]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   dead [[V_CVT_I32_F32_e32_:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF16]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_1:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF1]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_2:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF2]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_3:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF3]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_4:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF4]], implicit $exec, implicit $mode
@@ -12878,7 +12876,8 @@ body:             |
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_13:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF13]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_14:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF14]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_15:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF15]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_16:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF16]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[DEF17:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_16:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF17]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[DEF18:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_17:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF18]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[DEF19:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
@@ -12890,19 +12889,20 @@ body:             |
   ; GFX908-NEXT:   [[DEF22:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_21:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF22]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[DEF23:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_22:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF23]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[DEF24:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF25:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF26:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF27:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   [[DEF28:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_22:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF23]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_23:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF24]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_26:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub1, implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_26:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
   ; GFX908-NEXT:   dead [[V_CMP_GT_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_GT_U32_e64 [[S_LOAD_DWORDX2_IMM]].sub0, [[COPY1]](s32), implicit $exec
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[DEF:%[0-9]+]].sub1:vreg_64 = IMPLICIT_DEF
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[DEF:%[0-9]+]].sub0:vreg_64 = IMPLICIT_DEF
   ; GFX908-NEXT:   undef [[S_MOV_B32_:%[0-9]+]].sub1:sreg_64 = S_MOV_B32 0
   ; GFX908-NEXT:   dead [[DEF29:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-NEXT:   dead undef [[S_MOV_B32_:%[0-9]+]].sub0:sreg_64 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
@@ -12911,26 +12911,26 @@ body:             |
   ; GFX908-NEXT:   S_BRANCH %bb.1
   ; GFX908-NEXT: {{  $}}
   ; GFX908-NEXT: bb.1:
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_1]], implicit [[V_CVT_I32_F32_e32_6]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_2]], implicit [[V_CVT_I32_F32_e32_7]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_3]], implicit [[V_CVT_I32_F32_e32_8]]
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub1, implicit $exec, implicit $mode
-  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_1]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF]].sub0, implicit [[DEF]].sub1
+  ; GFX908-NEXT:   undef [[V_CVT_I32_F32_e32_29:%[0-9]+]].sub0:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF]].sub0, implicit $exec, implicit $mode
+  ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]].sub1:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_29]], implicit [[V_CVT_I32_F32_e32_24]], implicit [[DEF]].sub0, implicit [[DEF]].sub1
   ; GFX908-NEXT:   [[V_CVT_I32_F32_e32_30:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF31]], implicit $exec, implicit $mode
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_24]], implicit [[DEF1]], implicit [[DEF25]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_25]], implicit [[DEF24]], implicit [[DEF26]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_29]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF30]], implicit [[DEF27]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_30]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF31]], implicit [[DEF28]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_25]], implicit [[DEF30]], implicit [[DEF25]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF23]], implicit [[DEF26]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_30]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF31]], implicit [[DEF27]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF24]], implicit [[DEF28]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_3]], implicit [[V_CVT_I32_F32_e32_8]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_4]], implicit [[V_CVT_I32_F32_e32_9]]
   ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_5]], implicit [[V_CVT_I32_F32_e32_10]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_6]], implicit [[V_CVT_I32_F32_e32_11]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_12]], implicit [[V_CVT_I32_F32_e32_13]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_14]], implicit [[V_CVT_I32_F32_e32_15]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_14]], implicit [[V_CVT_I32_F32_e32_15]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_16]], implicit [[V_CVT_I32_F32_e32_17]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_18]], implicit [[V_CVT_I32_F32_e32_19]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_20]], implicit [[V_CVT_I32_F32_e32_21]]
-  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_11]], implicit [[V_CVT_I32_F32_e32_12]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_13]], implicit [[V_CVT_I32_F32_e32_14]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_13]], implicit [[V_CVT_I32_F32_e32_14]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_15]], implicit [[V_CVT_I32_F32_e32_16]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_17]], implicit [[V_CVT_I32_F32_e32_18]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_19]], implicit [[V_CVT_I32_F32_e32_20]]
+  ; GFX908-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_21]]
   ; GFX908-NEXT:   S_ENDPGM 0
   ;
   ; GFX908-GCNTRACKERS-LABEL: name: remat_virtual_vgpr_subreg_def
@@ -12985,22 +12985,22 @@ body:             |
   ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_20:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF20]], implicit $exec, implicit $mode
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF21:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_21:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF21]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   undef [[DEF22:%[0-9]+]].sub0:vreg_64 = IMPLICIT_DEF
+  ; GFX908-GCNTRACKERS-NEXT:   undef [[DEF22:%[0-9]+]].sub1:vreg_64 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF23:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF24:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF25:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF26:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF27:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   [[DEF28:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; GFX908-GCNTRACKERS-NEXT:   undef [[V_CVT_I32_F32_e32_22:%[0-9]+]].sub0:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF22]].sub0, implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_22:%[0-9]+]].sub1:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF23]], implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_22:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF23]], implicit $exec, implicit $mode
   ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_23:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF24]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_26:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_24:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF22]].sub1, implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_25:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF25]], implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_26:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF26]], implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_27:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF27]], implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF28]], implicit $exec, implicit $mode
   ; GFX908-GCNTRACKERS-NEXT:   dead [[V_CMP_GT_U32_e64_:%[0-9]+]]:sreg_64 = V_CMP_GT_U32_e64 [[S_LOAD_DWORDX2_IMM]].sub0, [[COPY1]](s32), implicit $exec
-  ; GFX908-GCNTRACKERS-NEXT:   [[DEF22:%[0-9]+]].sub1:vreg_64 = IMPLICIT_DEF
+  ; GFX908-GCNTRACKERS-NEXT:   [[DEF22:%[0-9]+]].sub0:vreg_64 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   undef [[S_MOV_B32_:%[0-9]+]].sub1:sreg_64 = S_MOV_B32 0
   ; GFX908-GCNTRACKERS-NEXT:   dead [[DEF29:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
   ; GFX908-GCNTRACKERS-NEXT:   dead undef [[S_MOV_B32_:%[0-9]+]].sub0:sreg_64 = COPY [[S_LOAD_DWORDX2_IMM]].sub1
@@ -13011,14 +13011,14 @@ body:             |
   ; GFX908-GCNTRACKERS-NEXT: bb.1:
   ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_1]], implicit [[V_CVT_I32_F32_e32_6]]
   ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_2]], implicit [[V_CVT_I32_F32_e32_7]]
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_28:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF22]].sub1, implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF22]].sub0, implicit [[DEF22]].sub1
+  ; GFX908-GCNTRACKERS-NEXT:   undef [[V_CVT_I32_F32_e32_29:%[0-9]+]].sub0:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF22]].sub0, implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_29:%[0-9]+]].sub1:vreg_64 = nofpexcept V_CVT_I32_F32_e32 [[DEF30]], implicit $exec, implicit $mode
+  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_29]], implicit [[V_CVT_I32_F32_e32_24]], implicit [[DEF22]].sub0, implicit [[DEF22]].sub1
   ; GFX908-GCNTRACKERS-NEXT:   [[V_CVT_I32_F32_e32_30:%[0-9]+]]:vgpr_32 = nofpexcept V_CVT_I32_F32_e32 [[DEF31]], implicit $exec, implicit $mode
-  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_24]], implicit [[DEF23]], implicit [[DEF25]]
-  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_25]], implicit [[DEF24]], implicit [[DEF26]]
-  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_29]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF30]], implicit [[DEF27]]
-  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_30]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF31]], implicit [[DEF28]]
+  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_25]], implicit [[DEF30]], implicit [[DEF25]]
+  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_22]], implicit [[V_CVT_I32_F32_e32_26]], implicit [[DEF23]], implicit [[DEF26]]
+  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_30]], implicit [[V_CVT_I32_F32_e32_27]], implicit [[DEF31]], implicit [[DEF27]]
+  ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_23]], implicit [[V_CVT_I32_F32_e32_28]], implicit [[DEF24]], implicit [[DEF28]]
   ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_3]], implicit [[V_CVT_I32_F32_e32_8]]
   ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_4]], implicit [[V_CVT_I32_F32_e32_9]]
   ; GFX908-GCNTRACKERS-NEXT:   S_NOP 0, implicit [[V_CVT_I32_F32_e32_5]], implicit [[V_CVT_I32_F32_e32_10]]

--- a/llvm/test/CodeGen/AMDGPU/sched_mfma_rewrite_copies.mir
+++ b/llvm/test/CodeGen/AMDGPU/sched_mfma_rewrite_copies.mir
@@ -5277,14 +5277,14 @@ body:             |
   ; CHECK-NEXT:   [[DEF13:%[0-9]+]]:vreg_128_align2 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF14:%[0-9]+]]:vreg_64_align2 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF15:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   undef [[AV_MOV_:%[0-9]+]].sub0:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub1:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub2:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub3:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   undef [[AV_MOV_:%[0-9]+]].sub0:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub1:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub2:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub3:vreg_128_align2 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
   ; CHECK-NEXT:   [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_:%[0-9]+]]:vreg_128_align2 = contract nofpexcept V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 [[DEF11]], [[DEF12]], [[AV_MOV_]], 4, 4, [[DEF14]].sub0, [[DEF15]], 0, 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_1:%[0-9]+]]:vreg_128_align2 = contract nofpexcept V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 [[DEF11]], [[DEF12]], [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_]], 4, 4, [[DEF14]].sub0, [[DEF15]], 0, 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_2:%[0-9]+]]:vreg_128_align2 = contract nofpexcept V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 [[DEF11]], [[DEF12]], [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_1]], 4, 4, [[DEF14]].sub0, [[DEF15]], 0, 0, implicit $mode, implicit $exec
@@ -5377,12 +5377,12 @@ body:             |
   ; CHECK-NEXT:   [[DEF13:%[0-9]+]]:vreg_128_align2 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF14:%[0-9]+]]:vreg_64_align2 = IMPLICIT_DEF
   ; CHECK-NEXT:   [[DEF15:%[0-9]+]]:vgpr_32 = IMPLICIT_DEF
-  ; CHECK-NEXT:   undef [[AV_MOV_:%[0-9]+]].sub0_sub1:vreg_128_align2 = AV_MOV_B64_IMM_PSEUDO 0, implicit $exec
-  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub2_sub3:vreg_128_align2 = AV_MOV_B64_IMM_PSEUDO 0, implicit $exec
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   undef [[AV_MOV_:%[0-9]+]].sub0_sub1:vreg_128_align2 = AV_MOV_B64_IMM_PSEUDO 0, implicit $exec
+  ; CHECK-NEXT:   [[AV_MOV_:%[0-9]+]].sub2_sub3:vreg_128_align2 = AV_MOV_B64_IMM_PSEUDO 0, implicit $exec
   ; CHECK-NEXT:   [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_:%[0-9]+]]:vreg_128_align2 = contract nofpexcept V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 [[DEF11]], [[DEF12]], [[AV_MOV_]], 4, 4, [[DEF14]].sub0, [[DEF15]], 0, 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_1:%[0-9]+]]:vreg_128_align2 = contract nofpexcept V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 [[DEF11]], [[DEF12]], [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_]], 4, 4, [[DEF14]].sub0, [[DEF15]], 0, 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_2:%[0-9]+]]:vreg_128_align2 = contract nofpexcept V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 [[DEF11]], [[DEF12]], [[V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64_1]], 4, 4, [[DEF14]].sub0, [[DEF15]], 0, 0, implicit $mode, implicit $exec

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -162,6 +162,11 @@ body:             |
 #define EXPECT_NUM_USERS(RegIdx, N)                                            \
   EXPECT_EQ(RW.getNumUsers(RegIdx), static_cast<unsigned>(N))
 
+/// Expects that register RegIdx in the rematerializer has a total of N
+/// dependencies.
+#define EXPECT_NUM_DEPENDENCIES(RegIdx, N)                                     \
+  EXPECT_EQ(RW->getReg(RegIdx).Dependencies.size(), static_cast<unsigned>(N))
+
 /// Expects that register RegIdx in the rematerializer has no users.
 #define EXPECT_NO_USERS(RegIdx) EXPECT_NUM_USERS(RegIdx, 0)
 
@@ -485,21 +490,217 @@ TEST_F(RematerializerTest, SubRegRematSupport) {
     Rematerializer::DependencyReuseInfo DRI;
 
     const unsigned MBB0 = 0, MBB1 = 1;
-    const RegisterIdx Cst2 = 0;
+    const RegisterIdx Cst01 = 0, Cst2 = 1, Cst99 = 2;
 
-    // - %01 is not rematerializable because it has multiplie definitions.
     // - %34 is not rematerializable because it is defined over multiple
     // regions.
     // - %56 is not rematerializable because the second defining MI is
     // unrematerializable due to the implicit def.
     // - %78 is not rematerializable because it is read by an MI not defining it
     // before its last definition.
-    // - %99 is not rematerializable because it has multiplie definitions.
+    EXPECT_EQ(RW->getNumRegs(), 3U);
 
-    RegisterIdx RematCst2 = RW->rematerializeToRegion(Cst2, MBB1, DRI);
-    RW.moveMIs(MBB0, MBB1, 1);
+    auto CheckBasicRemat = [&](RegisterIdx RegIdx,
+                               unsigned NumExpectDefs) -> void {
+      Rematerializer::DependencyReuseInfo DRI;
+      EXPECT_EQ(RW->getReg(RegIdx).Defs.size(), NumExpectDefs);
+      const RegisterIdx Remat = RW->rematerializeToRegion(RegIdx, MBB1, DRI);
+      RW.moveMIs(MBB0, MBB1, NumExpectDefs);
+      ASSERT_REGION_SIZES();
+      EXPECT_REMAT(Remat, RegIdx, MBB1, 1);
+    };
+
+    CheckBasicRemat(Cst01, 2);
+    CheckBasicRemat(Cst2, 1);
+    CheckBasicRemat(Cst99, 2);
+  });
+}
+
+/// Checks that the user transfer logic works correctly when different defining
+/// MIs of the same rematerializable register start dependening on different
+/// versions (original and rematerialized) of the same register.
+TEST_F(RematerializerTest, SubRegUserTransfer) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %01.sub0:sreg_64 = S_MOV_B32 0
+    %01.sub1:sreg_64 = S_MOV_B32 1    
+    
+  bb.1:
+    undef %23.sub0:sreg_64 = S_MOV_B32 %01.sub0
+    %23.sub1:sreg_64 = S_MOV_B32 %01.sub1
+    S_NOP 0, implicit %23
+  
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    Rematerializer::DependencyReuseInfo DRI;
+    Rollbacker Rollback;
+    RW->addListener(&Rollback);
+
+    const unsigned MBB1 = 1;
+    const RegisterIdx Cst01 = 0, Cst23 = 1;
+    EXPECT_EQ(RW->getReg(Cst01).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst23).Defs.size(), 2U);
+    MachineInstr *Cst23FirstDef = RW->getReg(Cst23).Defs[0];
+    MachineInstr *Cst23SecondDef = RW->getReg(Cst23).Defs[1];
+
+    // Create a rematerialization of %01 just before %23.
+    const RegisterIdx RematCst01 =
+        RW->rematerializeToPos(Cst01, MBB1, Cst23FirstDef, DRI);
+    EXPECT_NUM_USERS(Cst01, 2);
+    EXPECT_NUM_USERS(RematCst01, 0);
+    EXPECT_NUM_USERS(Cst23, 1);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 1);
+
+    // Have the first def of %23 use the rematerialization of %01 (the second
+    // def still uses %01). This transfers a user to the rematerialization of
+    // %01 and adds the rematerialization of %01 as a rematerializable
+    // dependency to %23.
+    RW->transferUser(Cst01, RematCst01, MBB1, *Cst23FirstDef);
+    EXPECT_NUM_USERS(Cst01, 1);
+    EXPECT_NUM_USERS(RematCst01, 1);
+    EXPECT_NUM_USERS(Cst23, 1);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 2);
+
+    // Have the second def of %23 use the rematerialization of %01 as well. This
+    // transfers a user to the rematerialization of %01 and removes %01 as a
+    // rematerializable dependency of %23.
+    RW->transferUser(Cst01, RematCst01, MBB1, *Cst23SecondDef);
+    EXPECT_NUM_USERS(Cst01, 0);
+    EXPECT_NUM_USERS(RematCst01, 2);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 1);
+
+    // Rollback should restore everything to its original state.
+    Rollback.rollback(*RW);
+    EXPECT_NUM_USERS(Cst01, 2);
+    EXPECT_NUM_USERS(RematCst01, 0);
+    EXPECT_NUM_USERS(Cst23, 1);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 1);
+  });
+}
+
+TEST_F(RematerializerTest, SubRegRollback) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %01.sub0:sreg_64 = S_MOV_B32 0
+    %unremat0:vgpr_32 = nofpexcept V_CVT_I32_F64_e32 0, implicit $exec, implicit $mode, implicit-def $m0
+    %01.sub1:sreg_64 = S_MOV_B32 1    
+    %unremat1:vgpr_32 = nofpexcept V_CVT_I32_F64_e32 1, implicit $exec, implicit $mode, implicit-def $m0
+  
+  bb.1:
+    undef %23.sub0:sreg_64 = S_MOV_B32 2
+    %23.sub1:sreg_64 = S_MOV_B32 3
+
+  bb.2:
+    undef %45.sub0:sreg_64 = S_MOV_B32 4
+    undef %67.sub0:sreg_64 = S_MOV_B32 6
+    %45.sub1:sreg_64 = S_MOV_B32 5
+    %67.sub1:sreg_64 = S_MOV_B32 7
+
+  bb.3:
+    S_NOP 0, implicit %01, implicit %23, implicit %45, implicit %67
+    S_NOP 0, implicit %unremat0, implicit %unremat1 
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    Rematerializer::DependencyReuseInfo DRI;
+    Rollbacker Rollback;
+    RW->addListener(&Rollback);
+
+    const unsigned MBB0 = 0, MBB1 = 1, MBB2 = 2, MBB3 = 3;
+    const RegisterIdx Cst01 = 0, Cst23 = 1, Cst45 = 2, Cst67 = 3;
+
+    EXPECT_EQ(RW->getReg(Cst01).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst23).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst45).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst67).Defs.size(), 2U);
+
+    auto GetNextMI = [&](MachineInstr *MI) -> MachineInstr * {
+      return &*std::next(MI->getIterator());
+    };
+
+    auto GetDefMI = [&](RegisterIdx RegIdx, unsigned DefIdx) -> MachineInstr * {
+      return RW->getReg(RegIdx).Defs[DefIdx];
+    };
+
+    // Rematerialize and rollback %01.
+    MachineInstr *Unremat0 = GetNextMI(GetDefMI(Cst01, 0));
+    MachineInstr *Unremat1 = GetNextMI(GetDefMI(Cst01, 1));
+    const RegisterIdx RematCst01 =
+        RW->rematerializeToRegion(Cst01, MBB3, DRI.clear());
+    RW.moveMIs(MBB0, MBB3, 2);
     ASSERT_REGION_SIZES();
-    EXPECT_REMAT(RematCst2, Cst2, MBB1, 1);
+    EXPECT_REMAT(RematCst01, Cst01, MBB3, 1);
+
+    // Rollback must re-create MIs in the same order.
+    Rollback.rollback(*RW);
+    RW.moveMIs(MBB3, MBB0, 2);
+    ASSERT_REGION_SIZES();
+    EXPECT_EQ(Unremat0, GetNextMI(GetDefMI(Cst01, 0)));
+    EXPECT_EQ(Unremat1, GetNextMI(GetDefMI(Cst01, 1)));
+
+    // Rematerialize and rollback %23.
+    MachineBasicBlock::iterator EndOfMBB1 =
+        std::next(GetDefMI(Cst23, 1)->getIterator());
+    const RegisterIdx RematCst23 =
+        RW->rematerializeToRegion(Cst23, MBB3, DRI.clear());
+    RW.moveMIs(MBB1, MBB3, 2);
+    ASSERT_REGION_SIZES();
+    EXPECT_REMAT(RematCst23, Cst23, MBB3, 1);
+
+    // Rollback must re-create MIs in the same order.
+    Rollback.rollback(*RW);
+    RW.moveMIs(MBB3, MBB1, 2);
+    ASSERT_REGION_SIZES();
+    MachineInstr *Cst23Def0 = GetDefMI(Cst23, 0);
+    MachineInstr *Cst23Def1 = GetDefMI(Cst23, 1);
+    EXPECT_EQ(Cst23Def1, GetNextMI(Cst23Def0));
+    EXPECT_EQ(EndOfMBB1, std::next(Cst23Def1->getIterator()));
+
+    // Rematerialize and rollback %45 and %67.
+    MachineBasicBlock::iterator EndOfMBB2 =
+        std::next(GetDefMI(Cst67, 1)->getIterator());
+    const RegisterIdx RematCst45 =
+        RW->rematerializeToRegion(Cst45, MBB3, DRI.clear());
+    const RegisterIdx RematCst67 =
+        RW->rematerializeToRegion(Cst67, MBB3, DRI.clear());
+    RW.moveMIs(MBB2, MBB3, 4);
+    ASSERT_REGION_SIZES();
+    EXPECT_REMAT(RematCst45, Cst45, MBB3, 1);
+    EXPECT_REMAT(RematCst67, Cst67, MBB3, 1);
+
+    // Rollback must re-create MIs in the same order.
+    Rollback.rollback(*RW);
+    RW.moveMIs(MBB3, MBB2, 4);
+    ASSERT_REGION_SIZES();
+    MachineInstr *Cst45Def0 = GetDefMI(Cst45, 0);
+    MachineInstr *Cst67Def0 = GetDefMI(Cst67, 0);
+    MachineInstr *Cst45Def1 = GetDefMI(Cst45, 1);
+    MachineInstr *Cst67Def1 = GetDefMI(Cst67, 1);
+    EXPECT_EQ(Cst67Def0, GetNextMI(Cst45Def0));
+    EXPECT_EQ(Cst45Def1, GetNextMI(Cst67Def0));
+    EXPECT_EQ(Cst67Def1, GetNextMI(Cst45Def1));
+    EXPECT_EQ(EndOfMBB2, std::next(Cst67Def1->getIterator()));
+  });
+}
+
+/// Checks that instructions which use a rematerializable register as their
+/// first operand (here the KILL pseudo) are not treated as defining
+/// instructions for that register.
+TEST_F(RematerializerTest, FirstOperandNotDef) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %0.sub0:sgpr_64 = S_MOV_B32 0
+    KILL %0
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    Rematerializer::DependencyReuseInfo DRI;
+
+    const RegisterIdx Cst0 = 0;
+    EXPECT_EQ(RW->getNumRegs(), 1U);
+    EXPECT_EQ(RW->getReg(Cst0).Defs.size(), 1U);
+    EXPECT_NUM_USERS(Cst0, 1);
   });
 }
 
@@ -614,10 +815,10 @@ TEST_F(RematerializerTest, RollbackInvalidInsertPos) {
       RW.moveMIs(MBB1, MBB0, 3);
       ASSERT_REGION_SIZES();
 
-      MachineInstr *DefCst0 = RW->getReg(Cst0).DefMI;
-      MachineInstr *DefCst1 = RW->getReg(Cst1).DefMI;
-      MachineInstr *DefCst2 = RW->getReg(Cst2).DefMI;
-      MachineInstr *DefCst3 = RW->getReg(Cst3).DefMI;
+      MachineInstr *DefCst0 = RW->getReg(Cst0).getFirstDef();
+      MachineInstr *DefCst1 = RW->getReg(Cst1).getFirstDef();
+      MachineInstr *DefCst2 = RW->getReg(Cst2).getFirstDef();
+      MachineInstr *DefCst3 = RW->getReg(Cst3).getFirstDef();
       EXPECT_EQ(GetNextMI(DefCst0), DefCst1);
       EXPECT_EQ(GetNextMI(DefCst1), DefCst2);
       EXPECT_EQ(GetNextMI(DefCst2), DefCst3);

--- a/llvm/unittests/CodeGen/RematerializerTest.cpp
+++ b/llvm/unittests/CodeGen/RematerializerTest.cpp
@@ -191,6 +191,11 @@ body:             |
 #define EXPECT_NUM_USERS(RegIdx, N)                                            \
   EXPECT_EQ(RW.getNumUsers(RegIdx), static_cast<unsigned>(N))
 
+/// Expects that register RegIdx in the rematerializer has a total of N
+/// dependencies.
+#define EXPECT_NUM_DEPENDENCIES(RegIdx, N)                                     \
+  EXPECT_EQ(RW->getReg(RegIdx).Dependencies.size(), static_cast<unsigned>(N))
+
 /// Expects that register RegIdx in the rematerializer has no users.
 #define EXPECT_NO_USERS(RegIdx) EXPECT_NUM_USERS(RegIdx, 0)
 
@@ -508,21 +513,217 @@ TEST_F(RematerializerTest, SubRegRematSupport) {
     Rematerializer::DependencyReuseInfo DRI;
 
     const unsigned MBB0 = 0, MBB1 = 1;
-    const RegisterIdx Cst2 = 0;
+    const RegisterIdx Cst01 = 0, Cst2 = 1, Cst99 = 2;
 
-    // - %01 is not rematerializable because it has multiplie definitions.
     // - %34 is not rematerializable because it is defined over multiple
     // regions.
     // - %56 is not rematerializable because the second defining MI is
     // unrematerializable due to the implicit def.
     // - %78 is not rematerializable because it is read by an MI not defining it
     // before its last definition.
-    // - %99 is not rematerializable because it has multiplie definitions.
+    EXPECT_EQ(RW->getNumRegs(), 3U);
 
-    RegisterIdx RematCst2 = RW->rematerializeToRegion(Cst2, MBB1, DRI);
-    RW.moveMIs(MBB0, MBB1, 1);
+    auto CheckBasicRemat = [&](RegisterIdx RegIdx,
+                               unsigned NumExpectDefs) -> void {
+      Rematerializer::DependencyReuseInfo DRI;
+      EXPECT_EQ(RW->getReg(RegIdx).Defs.size(), NumExpectDefs);
+      const RegisterIdx Remat = RW->rematerializeToRegion(RegIdx, MBB1, DRI);
+      RW.moveMIs(MBB0, MBB1, NumExpectDefs);
+      ASSERT_REGION_SIZES();
+      EXPECT_REMAT(Remat, RegIdx, MBB1, 1);
+    };
+
+    CheckBasicRemat(Cst01, 2);
+    CheckBasicRemat(Cst2, 1);
+    CheckBasicRemat(Cst99, 2);
+  });
+}
+
+/// Checks that the user transfer logic works correctly when different defining
+/// MIs of the same rematerializable register start dependening on different
+/// versions (original and rematerialized) of the same register.
+TEST_F(RematerializerTest, SubRegUserTransfer) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %01.sub0:sreg_64 = S_MOV_B32 0
+    %01.sub1:sreg_64 = S_MOV_B32 1    
+    
+  bb.1:
+    undef %23.sub0:sreg_64 = S_MOV_B32 %01.sub0
+    %23.sub1:sreg_64 = S_MOV_B32 %01.sub1
+    S_NOP 0, implicit %23
+  
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    Rematerializer::DependencyReuseInfo DRI;
+    Rollbacker Rollback;
+    RW->addListener(&Rollback);
+
+    const unsigned MBB1 = 1;
+    const RegisterIdx Cst01 = 0, Cst23 = 1;
+    EXPECT_EQ(RW->getReg(Cst01).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst23).Defs.size(), 2U);
+    MachineInstr *Cst23FirstDef = RW->getReg(Cst23).Defs[0];
+    MachineInstr *Cst23SecondDef = RW->getReg(Cst23).Defs[1];
+
+    // Create a rematerialization of %01 just before %23.
+    const RegisterIdx RematCst01 =
+        RW->rematerializeToPos(Cst01, MBB1, Cst23FirstDef, DRI);
+    EXPECT_NUM_USERS(Cst01, 2);
+    EXPECT_NUM_USERS(RematCst01, 0);
+    EXPECT_NUM_USERS(Cst23, 1);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 1);
+
+    // Have the first def of %23 use the rematerialization of %01 (the second
+    // def still uses %01). This transfers a user to the rematerialization of
+    // %01 and adds the rematerialization of %01 as a rematerializable
+    // dependency to %23.
+    RW->transferUser(Cst01, RematCst01, MBB1, *Cst23FirstDef);
+    EXPECT_NUM_USERS(Cst01, 1);
+    EXPECT_NUM_USERS(RematCst01, 1);
+    EXPECT_NUM_USERS(Cst23, 1);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 2);
+
+    // Have the second def of %23 use the rematerialization of %01 as well. This
+    // transfers a user to the rematerialization of %01 and removes %01 as a
+    // rematerializable dependency of %23.
+    RW->transferUser(Cst01, RematCst01, MBB1, *Cst23SecondDef);
+    EXPECT_NUM_USERS(Cst01, 0);
+    EXPECT_NUM_USERS(RematCst01, 2);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 1);
+
+    // Rollback should restore everything to its original state.
+    Rollback.rollback(*RW);
+    EXPECT_NUM_USERS(Cst01, 2);
+    EXPECT_NUM_USERS(RematCst01, 0);
+    EXPECT_NUM_USERS(Cst23, 1);
+    EXPECT_NUM_DEPENDENCIES(Cst23, 1);
+  });
+}
+
+TEST_F(RematerializerTest, SubRegRollback) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %01.sub0:sreg_64 = S_MOV_B32 0
+    %unremat0:vgpr_32 = nofpexcept V_CVT_I32_F64_e32 0, implicit $exec, implicit $mode, implicit-def $m0
+    %01.sub1:sreg_64 = S_MOV_B32 1    
+    %unremat1:vgpr_32 = nofpexcept V_CVT_I32_F64_e32 1, implicit $exec, implicit $mode, implicit-def $m0
+  
+  bb.1:
+    undef %23.sub0:sreg_64 = S_MOV_B32 2
+    %23.sub1:sreg_64 = S_MOV_B32 3
+
+  bb.2:
+    undef %45.sub0:sreg_64 = S_MOV_B32 4
+    undef %67.sub0:sreg_64 = S_MOV_B32 6
+    %45.sub1:sreg_64 = S_MOV_B32 5
+    %67.sub1:sreg_64 = S_MOV_B32 7
+
+  bb.3:
+    S_NOP 0, implicit %01, implicit %23, implicit %45, implicit %67
+    S_NOP 0, implicit %unremat0, implicit %unremat1 
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    Rematerializer::DependencyReuseInfo DRI;
+    Rollbacker Rollback;
+    RW->addListener(&Rollback);
+
+    const unsigned MBB0 = 0, MBB1 = 1, MBB2 = 2, MBB3 = 3;
+    const RegisterIdx Cst01 = 0, Cst23 = 1, Cst45 = 2, Cst67 = 3;
+
+    EXPECT_EQ(RW->getReg(Cst01).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst23).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst45).Defs.size(), 2U);
+    EXPECT_EQ(RW->getReg(Cst67).Defs.size(), 2U);
+
+    auto GetNextMI = [&](MachineInstr *MI) -> MachineInstr * {
+      return &*std::next(MI->getIterator());
+    };
+
+    auto GetDefMI = [&](RegisterIdx RegIdx, unsigned DefIdx) -> MachineInstr * {
+      return RW->getReg(RegIdx).Defs[DefIdx];
+    };
+
+    // Rematerialize and rollback %01.
+    MachineInstr *Unremat0 = GetNextMI(GetDefMI(Cst01, 0));
+    MachineInstr *Unremat1 = GetNextMI(GetDefMI(Cst01, 1));
+    const RegisterIdx RematCst01 =
+        RW->rematerializeToRegion(Cst01, MBB3, DRI.clear());
+    RW.moveMIs(MBB0, MBB3, 2);
     ASSERT_REGION_SIZES();
-    EXPECT_REMAT(RematCst2, Cst2, MBB1, 1);
+    EXPECT_REMAT(RematCst01, Cst01, MBB3, 1);
+
+    // Rollback must re-create MIs in the same order.
+    Rollback.rollback(*RW);
+    RW.moveMIs(MBB3, MBB0, 2);
+    ASSERT_REGION_SIZES();
+    EXPECT_EQ(Unremat0, GetNextMI(GetDefMI(Cst01, 0)));
+    EXPECT_EQ(Unremat1, GetNextMI(GetDefMI(Cst01, 1)));
+
+    // Rematerialize and rollback %23.
+    MachineBasicBlock::iterator EndOfMBB1 =
+        std::next(GetDefMI(Cst23, 1)->getIterator());
+    const RegisterIdx RematCst23 =
+        RW->rematerializeToRegion(Cst23, MBB3, DRI.clear());
+    RW.moveMIs(MBB1, MBB3, 2);
+    ASSERT_REGION_SIZES();
+    EXPECT_REMAT(RematCst23, Cst23, MBB3, 1);
+
+    // Rollback must re-create MIs in the same order.
+    Rollback.rollback(*RW);
+    RW.moveMIs(MBB3, MBB1, 2);
+    ASSERT_REGION_SIZES();
+    MachineInstr *Cst23Def0 = GetDefMI(Cst23, 0);
+    MachineInstr *Cst23Def1 = GetDefMI(Cst23, 1);
+    EXPECT_EQ(Cst23Def1, GetNextMI(Cst23Def0));
+    EXPECT_EQ(EndOfMBB1, std::next(Cst23Def1->getIterator()));
+
+    // Rematerialize and rollback %45 and %67.
+    MachineBasicBlock::iterator EndOfMBB2 =
+        std::next(GetDefMI(Cst67, 1)->getIterator());
+    const RegisterIdx RematCst45 =
+        RW->rematerializeToRegion(Cst45, MBB3, DRI.clear());
+    const RegisterIdx RematCst67 =
+        RW->rematerializeToRegion(Cst67, MBB3, DRI.clear());
+    RW.moveMIs(MBB2, MBB3, 4);
+    ASSERT_REGION_SIZES();
+    EXPECT_REMAT(RematCst45, Cst45, MBB3, 1);
+    EXPECT_REMAT(RematCst67, Cst67, MBB3, 1);
+
+    // Rollback must re-create MIs in the same order.
+    Rollback.rollback(*RW);
+    RW.moveMIs(MBB3, MBB2, 4);
+    ASSERT_REGION_SIZES();
+    MachineInstr *Cst45Def0 = GetDefMI(Cst45, 0);
+    MachineInstr *Cst67Def0 = GetDefMI(Cst67, 0);
+    MachineInstr *Cst45Def1 = GetDefMI(Cst45, 1);
+    MachineInstr *Cst67Def1 = GetDefMI(Cst67, 1);
+    EXPECT_EQ(Cst67Def0, GetNextMI(Cst45Def0));
+    EXPECT_EQ(Cst45Def1, GetNextMI(Cst67Def0));
+    EXPECT_EQ(Cst67Def1, GetNextMI(Cst45Def1));
+    EXPECT_EQ(EndOfMBB2, std::next(Cst67Def1->getIterator()));
+  });
+}
+
+/// Checks that instructions which use a rematerializable register as their
+/// first operand (here the KILL pseudo) are not treated as defining
+/// instructions for that register.
+TEST_F(RematerializerTest, FirstOperandNotDef) {
+  StringRef MIRBody = R"MIR(
+  bb.0:
+    undef %0.sub0:sgpr_64 = S_MOV_B32 0
+    KILL %0
+    S_ENDPGM 0
+)MIR";
+  rematerializerTest(MIRBody, [](RematerializerWrapper &RW) {
+    Rematerializer::DependencyReuseInfo DRI;
+
+    const RegisterIdx Cst0 = 0;
+    EXPECT_EQ(RW->getNumRegs(), 1U);
+    EXPECT_EQ(RW->getReg(Cst0).Defs.size(), 1U);
+    EXPECT_NUM_USERS(Cst0, 1);
   });
 }
 
@@ -667,8 +868,9 @@ TEST_F(RematerializerTest, DeadDefCascadeDeletion) {
 
         Rematerializer::DependencyReuseInfo DRI;
         const unsigned MBB0 = 0, MBB1 = 1, MBB2 = 2;
-        const RegisterIdx Cst1Die = 1, AddDie = 2, Cst2 = 3, Add = 4;
-        ASSERT_EQ(RW->getNumRegs(), 5U);
+        const RegisterIdx Cst1Die = 1, AddDie = 2, MultidefDontDie = 3,
+                          Cst2 = 4, Add = 5;
+        ASSERT_EQ(RW->getNumRegs(), 6U);
 
         // Rematerialize %addDie along with %cst0Die right after %cst2.
         RW->rematerializeToRegion(AddDie, MBB1, DRI.reuse(Cst1Die));
@@ -676,7 +878,8 @@ TEST_F(RematerializerTest, DeadDefCascadeDeletion) {
 
         // %cst2 and %add are moved to their using region.
         RW->rematerializeToRegion(Cst2, MBB2, DRI.clear());
-        RW->rematerializeToRegion(Add, MBB2, DRI.clear());
+        RW->rematerializeToRegion(Add, MBB2,
+                                  DRI.clear().reuse(MultidefDontDie));
         RW.moveMIs(MBB1, MBB2, 2);
 
         // The rematerialization of %add makes %multidef.sub1 become a dead def.
@@ -694,7 +897,8 @@ TEST_F(RematerializerTest, DeadDefCascadeDeletion) {
         // deleted. It should be re-created at the beginning of its block, as it
         // was initially.
         Rollback.rollback(*RW);
-        EXPECT_EQ(RW->getReg(Cst2).DefMI, &*RW.MF.getBlockNumbered(1)->begin());
+        EXPECT_EQ(RW->getReg(Cst2).getFirstDef(),
+                  &*RW.MF.getBlockNumbered(1)->begin());
         RW.moveMIs(MBB2, MBB1, 2);
         ASSERT_REGION_SIZES();
       },
@@ -812,10 +1016,10 @@ TEST_F(RematerializerTest, RollbackInvalidInsertPos) {
       RW.moveMIs(MBB1, MBB0, 3);
       ASSERT_REGION_SIZES();
 
-      MachineInstr *DefCst0 = RW->getReg(Cst0).DefMI;
-      MachineInstr *DefCst1 = RW->getReg(Cst1).DefMI;
-      MachineInstr *DefCst2 = RW->getReg(Cst2).DefMI;
-      MachineInstr *DefCst3 = RW->getReg(Cst3).DefMI;
+      MachineInstr *DefCst0 = RW->getReg(Cst0).getFirstDef();
+      MachineInstr *DefCst1 = RW->getReg(Cst1).getFirstDef();
+      MachineInstr *DefCst2 = RW->getReg(Cst2).getFirstDef();
+      MachineInstr *DefCst3 = RW->getReg(Cst3).getFirstDef();
       EXPECT_EQ(GetNextMI(DefCst0), DefCst1);
       EXPECT_EQ(GetNextMI(DefCst1), DefCst2);
       EXPECT_EQ(GetNextMI(DefCst2), DefCst3);
@@ -895,22 +1099,25 @@ TEST_F(RematerializerTest, RollbackNextPosIsRemat) {
     // This rematerialization is created right after %2, which is later
     // rematerialized. It is *not* recorded by the rollbacker.
     RegisterIdx RematCst0 = RW->rematerializeToRegion(Cst0, MBB1, DRI.clear());
-    ExpectSeq(RW->getReg(Cst2).DefMI, RW->getReg(RematCst0).DefMI);
-    ExpectSeq(RW->getReg(RematCst0).DefMI, Nop1);
+    ExpectSeq(RW->getReg(Cst2).getFirstDef(),
+              RW->getReg(RematCst0).getFirstDef());
+    ExpectSeq(RW->getReg(RematCst0).getFirstDef(), Nop1);
 
     RW->addListener(&Rollback);
 
     // This rematerialization is created right after %3, which is later
     // rematerialized. It is recorded by the rollbacker.
     RegisterIdx RematCst1 = RW->rematerializeToRegion(Cst1, MBB2, DRI.clear());
-    ExpectSeq(RW->getReg(Cst3).DefMI, RW->getReg(RematCst1).DefMI);
-    ExpectSeq(RW->getReg(RematCst1).DefMI, Nop2);
+    ExpectSeq(RW->getReg(Cst3).getFirstDef(),
+              RW->getReg(RematCst1).getFirstDef());
+    ExpectSeq(RW->getReg(RematCst1).getFirstDef(), Nop2);
 
     RegisterIdx RematCst2 = RW->rematerializeToRegion(Cst2, MBB3, DRI.clear());
     RegisterIdx RematCst3 = RW->rematerializeToRegion(Cst3, MBB3, DRI.clear());
 
-    ExpectSeq(RW->getReg(RematCst2).DefMI, RW->getReg(RematCst3).DefMI);
-    ExpectSeq(RW->getReg(RematCst3).DefMI, Nop3);
+    ExpectSeq(RW->getReg(RematCst2).getFirstDef(),
+              RW->getReg(RematCst3).getFirstDef());
+    ExpectSeq(RW->getReg(RematCst3).getFirstDef(), Nop3);
 
     // After rollback, %2 and %3 should be re-created at the beginning of their
     // respective original region.
@@ -918,11 +1125,12 @@ TEST_F(RematerializerTest, RollbackNextPosIsRemat) {
 
     // The rematerialization of %0 was not recorded so isn't rolled back, %2 is
     // re-created right before it.
-    ExpectSeq(RW->getReg(Cst2).DefMI, RW->getReg(RematCst0).DefMI);
-    ExpectSeq(RW->getReg(RematCst0).DefMI, Nop1);
+    ExpectSeq(RW->getReg(Cst2).getFirstDef(),
+              RW->getReg(RematCst0).getFirstDef());
+    ExpectSeq(RW->getReg(RematCst0).getFirstDef(), Nop1);
 
     // The rematerialization of %1 was recorded so is rolled back, %3 is
     // re-created before the S_NOP in its region.
-    ExpectSeq(RW->getReg(Cst3).DefMI, Nop2);
+    ExpectSeq(RW->getReg(Cst3).getFirstDef(), Nop2);
   });
 }


### PR DESCRIPTION
This significantly improves support for rematerializing registers with more than one definition. In particular, this includes cases where different lanes of a register are defined over multiple instructions.

There are still a few restrictions that can hopefully be relaxed in the future.

- All defining instructions must be part of the same rematerialization region.
- No pure user of the register (i.e., an MI that doesn't also defined a part of the register) must read the register before its last definition.

These constraints ensure that the underlying DAG representation maintained by the rematerializer is still valid, making this a relatively incremental improvement.