### PR TITLE
[AMDGPU] Set Src2RC64 in VOPProfileMQSAD, NFC

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -424,7 +424,7 @@ defm V_PERM_B32 : VOP3Inst <"v_perm_b32", VOP3_Profile<VOP_I32_I32_I32_I32>, AMD
 def VOPProfileMQSAD : VOP3_Profile<VOP_V4I32_I64_I32_V4I32, VOP3_CLAMP> {
   let HasModifiers = 0;
   // Src2 only accepts VGPRs
-  let Src2RC64 = getVregSrcForVT<v4i32>.ret;
+  let Src2RC64 = getVOP3VRegSrcForVT<Src2VT>.ret;
 }
 
 let SubtargetPredicate = isGFX7Plus in {

--- a/llvm/lib/Target/AMDGPU/VOP3Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP3Instructions.td
@@ -423,6 +423,8 @@ defm V_PERM_B32 : VOP3Inst <"v_perm_b32", VOP3_Profile<VOP_I32_I32_I32_I32>, AMD
 
 def VOPProfileMQSAD : VOP3_Profile<VOP_V4I32_I64_I32_V4I32, VOP3_CLAMP> {
   let HasModifiers = 0;
+  // Src2 only accepts VGPRs
+  let Src2RC64 = getVregSrcForVT<v4i32>.ret;
 }
 
 let SubtargetPredicate = isGFX7Plus in {


### PR DESCRIPTION
 The second operand of v_mqsad_u32_u8 can only be VGPRs. So we explicitly
set Src2RC64 to 'VReg' in VOPProfileMQSAD, making it possible for v4i32 to be
VGPR and/or SGPR in the future.