### PR TITLE
[CIR] Lower member-pointer casts in constant emitter

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -538,20 +538,22 @@ def CIR_DataMemberAttr : CIR_ValueLikeAttr<"DataMember", "data_member"> {
   let parameters = (ins AttributeSelfTypeParameter<
                             "", "cir::DataMemberType">:$type,
                         OptionalParameter<
-                            "std::optional<unsigned>">:$member_index);
+                            "std::optional<int64_t>">:$offset);
   let description = [{
     A data member attribute is a literal attribute that represents a constant
     pointer-to-data-member value.
 
-    The `member_index` parameter represents the index of the pointed-to member
-    within its containing record. It is an optional parameter; lack of this
-    parameter indicates a null pointer-to-data-member value.
+    The `offset` parameter is the byte offset of the pointed-to member from
+    the start of its containing record.  It is an optional parameter; lack
+    of this parameter indicates a null pointer-to-data-member value.
 
     Example:
     ```
-    #ptr = #cir.data_member<1> : !cir.data_member<!s32i in !rec_22Point22>
+    #ptr = #cir.data_member<offset = 4>
+        : !cir.data_member<!s32i in !rec_22Point22>
 
-    #null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_22Point22>
+    #null = #cir.data_member<null>
+        : !cir.data_member<!s32i in !rec_22Point22>
     ```
   }];
 
@@ -560,8 +562,8 @@ def CIR_DataMemberAttr : CIR_ValueLikeAttr<"DataMember", "data_member"> {
       return $_get(type.getContext(), type, std::nullopt);
     }]>,
     AttrBuilderWithInferredContext<(ins "cir::DataMemberType":$type,
-                                        "unsigned":$member_index), [{
-      return $_get(type.getContext(), type, member_index);
+                                        "int64_t":$offset), [{
+      return $_get(type.getContext(), type, offset);
     }]>,
   ];
 
@@ -571,12 +573,12 @@ def CIR_DataMemberAttr : CIR_ValueLikeAttr<"DataMember", "data_member"> {
   let genVerifyDecl = 1;
 
   let assemblyFormat = [{
-    `<` ($member_index^):(`null`)? `>`
+    `<` (`offset` `=` $offset^):(`null`)? `>`
   }];
 
   let extraClassDeclaration = [{
     bool isNullPtr() const {
-      return !getMemberIndex().has_value();
+      return !getOffset().has_value();
     }
   }];
 }

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -269,8 +269,8 @@ public:
   // ---------------------------
 
   cir::DataMemberAttr getDataMemberAttr(cir::DataMemberType ty,
-                                        unsigned memberIndex) {
-    return cir::DataMemberAttr::get(ty, memberIndex);
+                                        clang::CharUnits offset) {
+    return cir::DataMemberAttr::get(ty, offset.getQuantity());
   }
 
   cir::DataMemberAttr getNullDataMemberAttr(cir::DataMemberType ty) {

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -64,6 +64,13 @@ public:
   virtual cir::MethodAttr buildVirtualMethodAttr(cir::MethodType methodTy,
                                                  const CXXMethodDecl *md) = 0;
 
+  /// Convert a constant member-pointer attribute to the destination
+  /// member-pointer type implied by \p e.  Handles
+  /// CK_BaseToDerivedMemberPointer, CK_DerivedToBaseMemberPointer, and
+  /// CK_ReinterpretMemberPointer.
+  virtual mlir::Attribute emitMemberPointerConversion(const CastExpr *e,
+                                                      mlir::Attribute src) = 0;
+
 public:
   /// Similar to AddedStructorArgs, but only notes the number of additional
   /// arguments.

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -933,11 +933,21 @@ public:
     switch (e->getCastKind()) {
     case CK_ToUnion:
     case CK_AddressSpaceConversion:
-    case CK_ReinterpretMemberPointer:
-    case CK_DerivedToBaseMemberPointer:
-    case CK_BaseToDerivedMemberPointer:
       cgm.errorNYI(e->getBeginLoc(), "ConstExprEmitter::VisitCastExpr");
       return {};
+
+    case CK_ReinterpretMemberPointer:
+      // Under Itanium, a reinterpret of a member pointer is a no-op on the
+      // underlying representation -- just re-emit with the destination type.
+      return emitter.tryEmitPrivate(subExpr, destType);
+
+    case CK_DerivedToBaseMemberPointer:
+    case CK_BaseToDerivedMemberPointer: {
+      mlir::Attribute src = emitter.tryEmitPrivate(subExpr, subExpr->getType());
+      if (!src)
+        return {};
+      return cgm.getCXXABI().emitMemberPointerConversion(e, src);
+    }
 
     case CK_LValueToRValue:
     case CK_AtomicToNonAtomic:
@@ -1907,13 +1917,15 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     if (!memberDecl)
       return builder.getZeroInitAttr(cgm.convertType(destType));
 
-    if (value.isMemberPointerToDerivedMember()) {
-      cgm.errorNYI(
-          "ConstExprEmitter::tryEmitPrivate member pointer to derived member");
-      return {};
-    }
-
     if (auto const *cxxDecl = dyn_cast<CXXMethodDecl>(memberDecl)) {
+      // Member function pointers with a derived-member path adjustment use
+      // a different ABI representation (this-adjustment in a separate
+      // field of the {fnptr, adj} struct); not yet supported here.
+      if (value.isMemberPointerToDerivedMember()) {
+        cgm.errorNYI(
+            "member function pointer to derived member with path adjustment");
+        return {};
+      }
       auto ty = mlir::cast<cir::MethodType>(cgm.convertType(destType));
       if (cxxDecl->isVirtual())
         return cgm.getCXXABI().buildVirtualMethodAttr(ty, cxxDecl);
@@ -1929,6 +1941,8 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     const ASTContext &astContext = cgm.getASTContext();
     CharUnits offset =
         astContext.toCharUnitsFromBits(astContext.getFieldOffset(fieldDecl));
+    if (value.isMemberPointerToDerivedMember())
+      offset += astContext.getMemberPointerPathAdjustment(value);
     return builder.getDataMemberAttr(cirTy, offset);
   }
   case APValue::LValue:

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -1926,7 +1926,10 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     auto cirTy = mlir::cast<cir::DataMemberType>(cgm.convertType(destType));
 
     const auto *fieldDecl = cast<FieldDecl>(memberDecl);
-    return builder.getDataMemberAttr(cirTy, fieldDecl->getFieldIndex());
+    const ASTContext &astContext = cgm.getASTContext();
+    CharUnits offset =
+        astContext.toCharUnitsFromBits(astContext.getFieldOffset(fieldDecl));
+    return builder.getDataMemberAttr(cirTy, offset);
   }
   case APValue::LValue:
     return ConstantLValueEmitter(*this, value, destType).tryEmit();

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -190,6 +190,9 @@ public:
   cir::MethodAttr buildVirtualMethodAttr(cir::MethodType methodTy,
                                          const CXXMethodDecl *md) override;
 
+  mlir::Attribute emitMemberPointerConversion(const CastExpr *e,
+                                              mlir::Attribute src) override;
+
   Address initializeArrayCookie(CIRGenFunction &cgf, Address newPtr,
                                 mlir::Value numElements, const CXXNewExpr *e,
                                 QualType elementType) override;
@@ -2398,6 +2401,81 @@ CIRGenItaniumCXXABI::buildVirtualMethodAttr(cir::MethodType methodTy,
 
   return cir::MethodAttr::get(methodTy, vtableOffset);
 }
+
+/// Returns the non-virtual base-class offset (in CharUnits) accumulated
+/// while walking the path of a member-pointer cast.  Mirrors classic
+/// CodeGen's CodeGenModule::computeNonVirtualBaseClassOffset.
+static CharUnits
+computeNonVirtualBaseClassOffset(const ASTContext &astContext,
+                                 const CXXRecordDecl *derivedClass,
+                                 CastExpr::path_const_iterator pathBegin,
+                                 CastExpr::path_const_iterator pathEnd) {
+  CharUnits offset = CharUnits::Zero();
+  const CXXRecordDecl *rd = derivedClass;
+  for (auto it = pathBegin; it != pathEnd; ++it) {
+    const CXXBaseSpecifier *base = *it;
+    assert(!base->isVirtual() && "virtual base in member-pointer cast path");
+    const ASTRecordLayout &layout = astContext.getASTRecordLayout(rd);
+    const auto *baseDecl = base->getType()->castAsCXXRecordDecl();
+    offset += layout.getBaseClassOffset(baseDecl);
+    rd = baseDecl;
+  }
+  return offset;
+}
+
+mlir::Attribute
+CIRGenItaniumCXXABI::emitMemberPointerConversion(const CastExpr *e,
+                                                 mlir::Attribute src) {
+  assert(e->getCastKind() == CK_DerivedToBaseMemberPointer ||
+         e->getCastKind() == CK_BaseToDerivedMemberPointer ||
+         e->getCastKind() == CK_ReinterpretMemberPointer);
+
+  // Member function pointers go through a different ABI representation
+  // (a {fnptr, this_adjustment} struct in Itanium); cast handling for them
+  // is not yet implemented here.
+  if (mlir::isa<cir::MethodAttr>(src)) {
+    cgm.errorNYI(e->getBeginLoc(),
+                 "emitMemberPointerConversion for member function pointer");
+    return {};
+  }
+
+  auto dataMember = mlir::cast<cir::DataMemberAttr>(src);
+  auto destTy = mlir::cast<cir::DataMemberType>(cgm.convertType(e->getType()));
+
+  // Under Itanium, reinterprets don't change representation; just retype.
+  if (e->getCastKind() == CK_ReinterpretMemberPointer) {
+    if (dataMember.isNullPtr())
+      return cgm.getBuilder().getNullDataMemberAttr(destTy);
+    return cir::DataMemberAttr::get(destTy, *dataMember.getOffset());
+  }
+
+  // Null member-pointer maps to null member-pointer.
+  if (dataMember.isNullPtr())
+    return cgm.getBuilder().getNullDataMemberAttr(destTy);
+
+  // Compute the non-virtual base-class offset adjustment from the cast's
+  // path.  For both cast directions the path is walked starting from the
+  // derived class (the "Derived MP" side); the sign of the adjustment is
+  // chosen below.
+  QualType derivedType = (e->getCastKind() == CK_DerivedToBaseMemberPointer)
+                             ? e->getSubExpr()->getType()
+                             : e->getType();
+  const CXXRecordDecl *derivedClass =
+      derivedType->castAs<MemberPointerType>()->getMostRecentCXXRecordDecl();
+  CharUnits adjustment = computeNonVirtualBaseClassOffset(
+      cgm.getASTContext(), derivedClass, e->path_begin(), e->path_end());
+
+  if (adjustment.isZero())
+    return cir::DataMemberAttr::get(destTy, *dataMember.getOffset());
+
+  int64_t srcOffset = *dataMember.getOffset();
+  int64_t adj = adjustment.getQuantity();
+  int64_t destOffset = (e->getCastKind() == CK_DerivedToBaseMemberPointer)
+                           ? srcOffset - adj
+                           : srcOffset + adj;
+  return cir::DataMemberAttr::get(destTy, destOffset);
+}
+
 /// The Itanium ABI always places an offset to the complete object
 /// at entry -2 in the vtable.
 void CIRGenItaniumCXXABI::emitVirtualObjectDelete(

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2194,8 +2194,10 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
   // Otherwise, a member data pointer.
   auto ty = mlir::cast<cir::DataMemberType>(convertType(e->getType()));
   const auto *fieldDecl = cast<FieldDecl>(decl);
-  return cir::ConstantOp::create(
-      builder, loc, builder.getDataMemberAttr(ty, fieldDecl->getFieldIndex()));
+  CharUnits offset =
+      astContext.toCharUnitsFromBits(astContext.getFieldOffset(fieldDecl));
+  return cir::ConstantOp::create(builder, loc,
+                                 builder.getDataMemberAttr(ty, offset));
 }
 
 void CIRGenModule::emitDeclContext(const DeclContext *dc) {

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -435,28 +435,14 @@ ConstComplexAttr::verify(function_ref<InFlightDiagnostic()> emitError,
 
 LogicalResult
 DataMemberAttr::verify(function_ref<InFlightDiagnostic()> emitError,
-                       cir::DataMemberType ty,
-                       std::optional<unsigned> memberIndex) {
-  // DataMemberAttr without a given index represents a null value.
-  if (!memberIndex.has_value())
+                       cir::DataMemberType ty, std::optional<int64_t> offset) {
+  // DataMemberAttr without a given offset represents a null value.
+  if (!offset.has_value())
     return success();
 
-  cir::RecordType recTy = ty.getClassTy();
-  if (recTy.isIncomplete())
+  if (*offset < 0)
     return emitError()
-           << "incomplete 'cir.record' cannot be used to build a non-null "
-              "data member pointer";
-
-  unsigned memberIndexValue = memberIndex.value();
-  if (memberIndexValue >= recTy.getNumElements())
-    return emitError()
-           << "member index of a #cir.data_member attribute is out of range";
-
-  mlir::Type memberTy = recTy.getMembers()[memberIndexValue];
-  if (memberTy != ty.getMemberTy())
-    return emitError()
-           << "member type of a #cir.data_member attribute must match the "
-              "attribute type";
+           << "offset of a #cir.data_member attribute must be non-negative";
 
   return success();
 }

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -398,8 +398,7 @@ static mlir::TypedAttr lowerInitialValue(const LowerModule *lowerModule,
                                          mlir::Attribute initVal) {
   if (mlir::isa<cir::DataMemberType>(ty)) {
     auto dataMemberVal = mlir::cast_if_present<cir::DataMemberAttr>(initVal);
-    return lowerModule->getCXXABI().lowerDataMemberConstant(dataMemberVal,
-                                                            layout, tc);
+    return lowerModule->getCXXABI().lowerDataMemberConstant(dataMemberVal, tc);
   }
   if (mlir::isa<cir::MethodType>(ty)) {
     auto methodVal = mlir::cast_if_present<cir::MethodAttr>(initVal);

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/CIRCXXABI.h
@@ -54,7 +54,6 @@ public:
   /// type. The returned constant is represented as an attribute as well.
   virtual mlir::TypedAttr
   lowerDataMemberConstant(cir::DataMemberAttr attr,
-                          const mlir::DataLayout &layout,
                           const mlir::TypeConverter &typeConverter) const = 0;
 
   /// Lower the given member function pointer constant to a constant of the ABI

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -52,7 +52,7 @@ public:
                   const mlir::TypeConverter &typeConverter) const override;
 
   mlir::TypedAttr lowerDataMemberConstant(
-      cir::DataMemberAttr attr, const mlir::DataLayout &layout,
+      cir::DataMemberAttr attr,
       const mlir::TypeConverter &typeConverter) const override;
 
   mlir::TypedAttr
@@ -192,22 +192,12 @@ mlir::Type LowerItaniumCXXABI::lowerMethodType(
 }
 
 mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
-    cir::DataMemberAttr attr, const mlir::DataLayout &layout,
-    const mlir::TypeConverter &typeConverter) const {
-  int64_t memberOffset;
-  if (attr.isNullPtr()) {
-    // Itanium C++ ABI 2.3:
-    //   A NULL pointer is represented as -1.
-    memberOffset = -1;
-  } else {
-    // Itanium C++ ABI 2.3:
-    //   A pointer to data member is an offset from the base address of
-    //   the class object containing it, represented as a ptrdiff_t
-    unsigned memberIndex = attr.getMemberIndex().value();
-    memberOffset =
-        attr.getType().getClassTy().getElementOffset(layout, memberIndex);
-  }
-
+    cir::DataMemberAttr attr, const mlir::TypeConverter &typeConverter) const {
+  // Itanium C++ ABI 2.3:
+  //   A pointer to data member is an offset from the base address of the
+  //   class object containing it, represented as a ptrdiff_t.  A NULL
+  //   pointer is represented as -1.
+  int64_t memberOffset = attr.isNullPtr() ? -1 : *attr.getOffset();
   mlir::Type abiTy = lowerDataMemberType(attr.getType(), typeConverter);
   return cir::IntAttr::get(abiTy, memberOffset);
 }

--- a/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
+++ b/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
@@ -55,7 +55,7 @@ Trivial t;
 // LLVM-DAG: @t = global %struct.Trivial { i32 0, double 0.000000e+00, i64 -1 }, align 8
 
 Trivial t_init{1,2.2, &Other::x};
-// CIR-BEFORE-DAG: cir.global external @t_init = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<0> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial {alignment = 8 : i64}
+// CIR-BEFORE-DAG: cir.global external @t_init = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<offset = 0> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial {alignment = 8 : i64}
 // CIR-AFTER-DAG: cir.global external @t_init = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.int<0> : !s64i}> : !rec_Trivial {alignment = 8 : i64}
 // LLVM-DAG: @t_init = global %struct.Trivial { i32 1, double 2.200000e+00, i64 0 }, align 8
 
@@ -84,7 +84,7 @@ extern "C" void local() {
   // LLVM: call void @llvm.memcpy.p0.p0.i64(ptr {{.*}}%[[MPT_INIT]], ptr {{.*}}@__const.local.localMpt_init, i64 32, i1 false)
 
   Trivial localT_init{1,2.2, &Other::x};
-  // CIR-BEFORE: %[[T_INIT_VAL:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<0> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial
+  // CIR-BEFORE: %[[T_INIT_VAL:.*]] = cir.const #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.200000e+00> : !cir.double, #cir.data_member<offset = 0> : !cir.data_member<!s32i in !rec_Other>}> : !rec_Trivial
   // CIR-BEFORE: cir.store align(8) %[[T_INIT_VAL]], %[[T_INIT]] : !rec_Trivial, !cir.ptr<!rec_Trivial>
 
   // CIR-AFTER: %[[T_INIT_VAL:.*]] = cir.get_global @__const.local.localT_init : !cir.ptr<!rec_Trivial>

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-conversions.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-conversions.cpp
@@ -1,0 +1,70 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir -mmlir -mlir-print-ir-before=cir-cxxabi-lowering %s -o %t.cir 2> %t-before.cir
+// RUN: FileCheck --check-prefix=CIR-BEFORE --input-file=%t-before.cir %s
+// RUN: FileCheck --check-prefix=CIR-AFTER --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -Wno-unused-value -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct Base { int x; };
+struct Derived : Base { double y; };
+
+// BaseToDerivedMemberPointer, single inheritance with Base at offset 0 in
+// Derived.  The cast adjustment is zero in this case.
+int Derived::*b2d_simple = &Derived::x;
+// CIR-BEFORE: cir.global external @b2d_simple = #cir.data_member<offset = 0> : !cir.data_member<!s32i in !rec_Derived>
+// CIR-AFTER: cir.global external @b2d_simple = #cir.int<0> : !s64i
+// LLVM: @b2d_simple = global i64 0
+// OGCG: @b2d_simple = global i64 0
+
+struct A { double a; };
+struct B { int b; };
+struct M : A, B { };
+
+// BaseToDerivedMemberPointer with a non-zero path adjustment.  B is at
+// offset 8 in M (after A's double), and B::b is at offset 0 in B, so the
+// resolved offset of B::b viewed as a member of M is 8.
+int M::*b2d_multi = &M::b;
+// CIR-BEFORE: cir.global external @b2d_multi = #cir.data_member<offset = 8> : !cir.data_member<!s32i in !rec_M>
+// CIR-AFTER: cir.global external @b2d_multi = #cir.int<8> : !s64i
+// LLVM: @b2d_multi = global i64 8
+// OGCG: @b2d_multi = global i64 8
+
+// DerivedToBaseMemberPointer subtracts the adjustment, giving B::b at
+// offset 0 in B.
+int B::*d2b = (int B::*)&M::b;
+// CIR-BEFORE: cir.global external @d2b = #cir.data_member<offset = 0> : !cir.data_member<!s32i in !rec_B>
+// CIR-AFTER: cir.global external @d2b = #cir.int<0> : !s64i
+// LLVM: @d2b = global i64 0
+// OGCG: @d2b = global i64 0
+
+struct Foo { int x; int y; };
+struct Bar { float a; int b; };
+
+// ReinterpretMemberPointer doesn't change the representation under
+// Itanium -- Bar::b is at offset 4 in Bar, and the reinterpret as int
+// Foo::* keeps the offset at 4.
+int Foo::*reint = reinterpret_cast<int Foo::*>(&Bar::b);
+// CIR-BEFORE: cir.global external @reint = #cir.data_member<offset = 4> : !cir.data_member<!s32i in !rec_Foo>
+// CIR-AFTER: cir.global external @reint = #cir.int<4> : !s64i
+// LLVM: @reint = global i64 4
+// OGCG: @reint = global i64 4
+
+// Null preserves null through all three cast kinds.
+int Derived::*b2d_null = (int Derived::*)(int Base::*)nullptr;
+// CIR-BEFORE: cir.global external @b2d_null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_Derived>
+// CIR-AFTER: cir.global external @b2d_null = #cir.int<-1> : !s64i
+// LLVM: @b2d_null = global i64 -1
+// OGCG: @b2d_null = global i64 -1
+
+int B::*d2b_null = (int B::*)(int M::*)nullptr;
+// CIR-BEFORE: cir.global external @d2b_null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_B>
+// CIR-AFTER: cir.global external @d2b_null = #cir.int<-1> : !s64i
+// LLVM: @d2b_null = global i64 -1
+// OGCG: @d2b_null = global i64 -1
+
+int Foo::*reint_null = reinterpret_cast<int Foo::*>((int Bar::*)nullptr);
+// CIR-BEFORE: cir.global external @reint_null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_Foo>
+// CIR-AFTER: cir.global external @reint_null = #cir.int<-1> : !s64i
+// LLVM: @reint_null = global i64 -1
+// OGCG: @reint_null = global i64 -1

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -19,7 +19,7 @@ int Point::*ptr_none = nullptr;
 // OGCG: @ptr_none = global i64 -1
 
 int Point::*pt_member = &Point::z;
-// CIR-BEFORE: cir.global external @pt_member = #cir.data_member<2> : !cir.data_member<!s32i in !rec_Point>
+// CIR-BEFORE: cir.global external @pt_member = #cir.data_member<offset = 8> : !cir.data_member<!s32i in !rec_Point>
 // CIR-AFTER: cir.global external @pt_member = #cir.int<8> : !s64i
 // LLVM: @pt_member = global i64 8
 // OGCG: @pt_member = global i64 8
@@ -54,7 +54,7 @@ int Point::*pt_member_nested_region = test1();
 
 // CIR-BEFORE: cir.func {{.*}} @_Z5test1v() -> !cir.data_member<!s32i in !rec_Point> attributes {{{.*}}nothrow} {
 // CIR-BEFORE:   %[[RETVAL:.*]] = cir.alloca !cir.data_member<!s32i in !rec_Point>, !cir.ptr<!cir.data_member<!s32i in !rec_Point>>, ["__retval"]
-// CIR-BEFORE:   %[[MEMBER:.*]] = cir.const #cir.data_member<1> : !cir.data_member<!s32i in !rec_Point>
+// CIR-BEFORE:   %[[MEMBER:.*]] = cir.const #cir.data_member<offset = 4> : !cir.data_member<!s32i in !rec_Point>
 // CIR-BEFORE:   cir.store %[[MEMBER]], %[[RETVAL]] : !cir.data_member<!s32i in !rec_Point>, !cir.ptr<!cir.data_member<!s32i in !rec_Point>>
 // CIR-BEFORE:   %[[RET:.*]] = cir.load %[[RETVAL]] : !cir.ptr<!cir.data_member<!s32i in !rec_Point>>, !cir.data_member<!s32i in !rec_Point>
 // CIR-BEFORE:   cir.return %[[RET]] : !cir.data_member<!s32i in !rec_Point>

--- a/clang/test/CIR/IR/invalid-data-member.cir
+++ b/clang/test/CIR/IR/invalid-data-member.cir
@@ -2,29 +2,12 @@
 
 // -----
 
-!u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
+!u16i = !cir.int<u, 16>
 !struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
 
-// expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
-#invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
-
-// -----
-
-!u16i = !cir.int<u, 16>
-!incomplete_struct = !cir.record<struct "Incomplete" incomplete>
-
-// expected-error@+1 {{incomplete 'cir.record' cannot be used to build a non-null data member pointer}}
-#incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>
-
-// -----
-
-!u16i = !cir.int<u, 16>
-!u32i = !cir.int<u, 32>
-!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
-
-// expected-error@+1 {{member index of a #cir.data_member attribute is out of range}}
-#invalid_member_ty = #cir.data_member<2> : !cir.data_member<!u32i in !struct1>
+// expected-error@+1 {{offset of a #cir.data_member attribute must be non-negative}}
+#negative_offset = #cir.data_member<offset = -1> : !cir.data_member<!u32i in !struct1>
 
 // -----
 


### PR DESCRIPTION


Superseded: stacked branch `cir-data-member-cast-stacked` replaces this PR (offset-based cast on `main`). See the new PR linked from the compare stack.