### PR TITLE
[scudo] Add test for initFlags()

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/flags_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/flags_test.cpp
@@ -121,6 +121,19 @@ TEST(ScudoFlagsTest, AllocatorFlags) {
   EXPECT_EQ(2048, Flags.quarantine_max_chunk_size);
 }
 
+TEST(ScudoFlagsTest, InitFlagsEnv) {
+  const char *OldValue = getenv("SCUDO_ALLOCATION_RING_BUFFER_SIZE");
+  setenv("SCUDO_ALLOCATION_RING_BUFFER_SIZE", "123", 1);
+  scudo::initFlags();
+  scudo::Flags *F = scudo::getFlags();
+  EXPECT_EQ(123, F->allocation_ring_buffer_size);
+  if (OldValue) {
+    setenv("SCUDO_ALLOCATION_RING_BUFFER_SIZE", OldValue, 1);
+  } else {
+    unsetenv("SCUDO_ALLOCATION_RING_BUFFER_SIZE");
+  }
+}
+
 #ifdef GWP_ASAN_HOOKS
 TEST(ScudoFlagsTest, GWPASanFlags) {
   scudo::FlagParser Parser;


### PR DESCRIPTION
Add a test case to verify that initFlags() correctly reads the SCUDO_ALLOCATION_RING_BUFFER_SIZE environment variable and updates the corresponding flag. This increases line coverage for flags.cpp to 100%.