### PR TITLE
[clang-format] Stop indenting the closing brace for the initializer

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1543,7 +1543,7 @@ ContinuationIndenter::getNewLineColumn(const LineState &State) {
            Current.MatchingParen->getPreviousNonComment()->is(
                TT_StartOfName)) ||
           (State.Stack.size() == 3 &&
-           State.Stack[1].precedence == prec::Assignment)) {
+           State.Stack[1].Precedence == prec::Assignment)) {
         return State.FirstIndent;
       }
       return State.Stack[State.Stack.size() - 2].LastSpace;
@@ -1997,7 +1997,7 @@ void ContinuationIndenter::moveStatePastFakeLParens(LineState &State,
     NewParenState.UnindentOperator = false;
     NewParenState.NoLineBreak =
         NewParenState.NoLineBreak || CurrentState.NoLineBreakInOperand;
-    NewParenState.precedence = PrecedenceLevel;
+    NewParenState.Precedence = PrecedenceLevel;
 
     // Don't propagate AvoidBinPacking into subexpressions of arg/param lists.
     if (PrecedenceLevel > prec::Comma)

--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1528,8 +1528,26 @@ ContinuationIndenter::getNewLineColumn(const LineState &State) {
       State.Stack.size() > 1) {
     if (Current.closesBlockOrBlockTypeList(Style))
       return State.Stack[State.Stack.size() - 2].NestedBlockIndent;
-    if (Current.MatchingParen && Current.MatchingParen->is(BK_BracedInit))
+    if (Current.MatchingParen && Current.MatchingParen->is(BK_BracedInit)) {
+      // The brace should line up with the start of the line in this case. The
+      // stack depth is checked to make sure that the brace is at the top
+      // level. It should contain the levels for the top, the assignment if
+      // there is an equal sign, and the braces.
+      //
+      // SomeStruct //
+      //     s = {
+      //         "xxxxxxxxxxxxx",
+      // };
+      if ((State.Stack.size() == 2 &&
+           Current.MatchingParen->getPreviousNonComment() &&
+           Current.MatchingParen->getPreviousNonComment()->is(
+               TT_StartOfName)) ||
+          (State.Stack.size() == 3 &&
+           State.Stack[1].precedence == prec::Assignment)) {
+        return State.FirstIndent;
+      }
       return State.Stack[State.Stack.size() - 2].LastSpace;
+    }
     return State.FirstIndent;
   }
   // Indent a closing parenthesis at the previous level if followed by a semi,
@@ -1979,6 +1997,7 @@ void ContinuationIndenter::moveStatePastFakeLParens(LineState &State,
     NewParenState.UnindentOperator = false;
     NewParenState.NoLineBreak =
         NewParenState.NoLineBreak || CurrentState.NoLineBreakInOperand;
+    NewParenState.precedence = PrecedenceLevel;
 
     // Don't propagate AvoidBinPacking into subexpressions of arg/param lists.
     if (PrecedenceLevel > prec::Comma)

--- a/clang/lib/Format/ContinuationIndenter.h
+++ b/clang/lib/Format/ContinuationIndenter.h
@@ -303,7 +303,7 @@ struct ParenState {
 
   /// The precedence. The outermost level and the levels corresponding to tokens
   /// have prec::Unknown.
-  prec::Level precedence = prec::Unknown;
+  prec::Level Precedence = prec::Unknown;
 
   /// Whether a newline needs to be inserted before the block's closing
   /// brace.

--- a/clang/lib/Format/ContinuationIndenter.h
+++ b/clang/lib/Format/ContinuationIndenter.h
@@ -301,6 +301,10 @@ struct ParenState {
   /// Used to align further variables if necessary.
   unsigned VariablePos = 0;
 
+  /// The precedence. The outermost level and the levels corresponding to tokens
+  /// have prec::Unknown.
+  prec::Level precedence = prec::Unknown;
+
   /// Whether a newline needs to be inserted before the block's closing
   /// brace.
   ///

--- a/clang/unittests/Format/AlignBracketsTest.cpp
+++ b/clang/unittests/Format/AlignBracketsTest.cpp
@@ -608,6 +608,25 @@ TEST_F(AlignBracketsTest, AlignAfterOpenBracketBlockIndentInitializers) {
                "    {baz},\n"
                "};",
                Style);
+  // The closing brace should be at the start of the line.
+  verifyFormat("SomeStruct //\n"
+               "    s = SomeStruct{\n"
+               "        \"xxxxxxxxxxxxx\",\n"
+               "        \"yyyyyyyyyyyyy\",\n"
+               "        \"zzzzzzzzzzzzz\",\n"
+               "};");
+  verifyFormat("SomeStruct //\n"
+               "    s{\n"
+               "        \"xxxxxxxxxxxxx\",\n"
+               "        \"yyyyyyyyyyyyy\",\n"
+               "        \"zzzzzzzzzzzzz\",\n"
+               "};");
+  verifyFormat("SomeStruct //\n"
+               "    s = SomeStruct{\n"
+               "        \"xxxxxxxxxxxxx\",\n"
+               "        \"yyyyyyyyyyyyy\",\n"
+               "        \"zzzzzzzzzzzzz\",\n"
+               "};");
 }
 
 TEST_F(AlignBracketsTest, AllowAllArgumentsOnNextLineDontAlign) {

--- a/clang/unittests/Format/AlignBracketsTest.cpp
+++ b/clang/unittests/Format/AlignBracketsTest.cpp
@@ -622,10 +622,38 @@ TEST_F(AlignBracketsTest, AlignAfterOpenBracketBlockIndentInitializers) {
                "        \"zzzzzzzzzzzzz\",\n"
                "};");
   verifyFormat("SomeStruct //\n"
-               "    s = SomeStruct{\n"
+               "    s = SomeStruct::SomeStruct{\n"
                "        \"xxxxxxxxxxxxx\",\n"
                "        \"yyyyyyyyyyyyy\",\n"
                "        \"zzzzzzzzzzzzz\",\n"
+               "};");
+  verifyFormat("void x() {\n"
+               "  SomeStruct //\n"
+               "      s = SomeStruct{\n"
+               "          \"xxxxxxxxxxxxx\",\n"
+               "          \"yyyyyyyyyyyyy\",\n"
+               "          \"zzzzzzzzzzzzz\",\n"
+               "  };\n"
+               "}");
+  verifyFormat("void x() {\n"
+               "  SomeStruct //\n"
+               "      s{\n"
+               "          \"xxxxxxxxxxxxx\",\n"
+               "          \"yyyyyyyyyyyyy\",\n"
+               "          \"zzzzzzzzzzzzz\",\n"
+               "  };\n"
+               "}");
+  verifyFormat("SomeArrayT //\n"
+               "    a[3] = {\n"
+               "        {\n"
+               "            foo,\n"
+               "            bar,\n"
+               "        },\n"
+               "        {\n"
+               "            foo,\n"
+               "            bar,\n"
+               "        },\n"
+               "        SomeArrayT{},\n"
                "};");
 }
 


### PR DESCRIPTION
new

```C++
SomeStruct //
    s = {
        "xxxxxxxxxxxxx",
};
```

old

```C++
SomeStruct //
    s = {
        "xxxxxxxxxxxxx",
    };
```