### PR TITLE
Revert "[AMDGPU] Only src0 and mandatory literals can use literal64"

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -5156,14 +5156,6 @@ bool AMDGPUAsmParser::validateVOPLiteral(const MCInst &Inst,
         return false;
       }
 
-      // Only src0 can use lit64 in VOP* encoding.
-      if (!IsForcedFP64 && (IsForcedLit64 || !IsValid32Op) &&
-          OpIdx != getNamedOperandIdx(Opcode, OpName::src0)) {
-        Error(getOperandLoc(Operands, OpIdx),
-              "invalid operand for instruction");
-        return false;
-      }
-
       if (IsFP64 && IsValid32Op && !IsForcedFP64)
         Value = Hi_32(Value);
 

--- a/llvm/test/MC/AMDGPU/gfx1250_asm_vop2_err.s
+++ b/llvm/test/MC/AMDGPU/gfx1250_asm_vop2_err.s
@@ -27,18 +27,3 @@ v_mul_u64 v[4:5], v[2:3], v[8:9] clamp
 // GFX1250-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
 // GFX1250-ERR-NEXT:{{^}}v_mul_u64 v[4:5], v[2:3], v[8:9] clamp
 // GFX1250-ERR-NEXT:{{^}}                                 ^
-
-v_add_f64 v[4:5], v[8:9], 0xffffffff1
-// GFX1250-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
-// GFX1250-ERR-NEXT:{{^}}v_add_f64 v[4:5], v[8:9], 0xffffffff1
-// GFX1250-ERR-NEXT:{{^}}                          ^
-
-v_add_f64 v[4:5], v[8:9], lit64(101.0)
-// GFX1250-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
-// GFX1250-ERR-NEXT:{{^}}v_add_f64 v[4:5], v[8:9], lit64(101.0)
-// GFX1250-ERR-NEXT:{{^}}                                ^
-
-v_add_f64 v[4:5], v[8:9], lit64(1.0)
-// GFX1250-ERR: :[[@LINE-1]]:{{[0-9]+}}: error: invalid operand for instruction
-// GFX1250-ERR-NEXT:{{^}}v_add_f64 v[4:5], v[8:9], lit64(1.0)
-// GFX1250-ERR-NEXT:{{^}}                                ^


### PR DESCRIPTION
Reverts llvm/llvm-project#196456

https://lab.llvm.org/buildbot/#/builders/175/builds/38947

Causes test failures on some buildbots in MC/AMDGPU/literals.s.