### PR TITLE
[clang-sycl-linker] Remove dead and unnecessary check for no symbols image

### DIFF
--- a/clang/test/Tooling/clang-sycl-linker.ll
+++ b/clang/test/Tooling/clang-sycl-linker.ll
@@ -75,7 +75,7 @@
 ;
 ; Input with no entry points still produces an offload image.
 ; RUN: llvm-as %t/no-entry-points.ll -o %t/no-entry-points.bc
-; RUN: clang-sycl-linker --dry-run -triple=spirv64 %t/no-entry-points.bc -o %t/no-entry-points.out
+; RUN: clang-sycl-linker -triple=spirv64 %t/no-entry-points.bc -o %t/no-entry-points.out
 ; RUN: llvm-objdump --offloading %t/no-entry-points.out | FileCheck %s --check-prefix=NO-ENTRY-POINTS
 ; NO-ENTRY-POINTS: OFFLOADING IMAGE [0]:
 ; NO-ENTRY-POINTS: producer        sycl

--- a/clang/test/Tooling/clang-sycl-linker.ll
+++ b/clang/test/Tooling/clang-sycl-linker.ll
@@ -72,6 +72,13 @@
 ; RUN: not clang-sycl-linker --dry-run %t/input1.bc %t/input2.bc -o a.out 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=NOTARGET
 ; NOTARGET: Target triple must be specified
+;
+; Input with no entry points still produces an offload image.
+; RUN: llvm-as %t/no-entry-points.ll -o %t/no-entry-points.bc
+; RUN: clang-sycl-linker --dry-run -triple=spirv64 %t/no-entry-points.bc -o %t/no-entry-points.out
+; RUN: llvm-objdump --offloading %t/no-entry-points.out | FileCheck %s --check-prefix=NO-ENTRY-POINTS
+; NO-ENTRY-POINTS: OFFLOADING IMAGE [0]:
+; NO-ENTRY-POINTS: producer        sycl
 
 ;--- input1.ll
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
@@ -92,3 +99,11 @@ define spir_kernel void @kernel_b() #0 {
 }
 
 attributes #0 = { "sycl-module-id"="TU2.cpp" }
+
+;--- no-entry-points.ll
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spirv64"
+
+define spir_func i32 @helper() {
+  ret i32 0
+}

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -698,8 +698,6 @@ Error runSYCLLink(ArrayRef<std::string> Files, const ArgList &Args) {
   // Collect all images to be packed into a single OffloadBinary.
   SmallVector<OffloadingImage> Images;
   for (SplitModule &SI : SplitModules) {
-    if (SI.Symbols.empty())
-      continue;
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileOrErr =
         llvm::MemoryBuffer::getFileOrSTDIN(SI.ModuleFilePath);
     if (std::error_code EC = FileOrErr.getError()) {


### PR DESCRIPTION
 The `if (SI.Symbols.empty()) continue;` guard in `runSYCLLink` was unreachable: `collectEntryPoints` always calls `llvm::offloading::sycl::writeSymbolTable`, which emits at least a 4-byte `SymbolTableHeader` (`Count=0`) even when the input has no entry points.
The check could never fire and was misleading suggesting that modules without kernels would be dropped.
I checked other similar tools and did not find logic to filter out images, if there are no entry points. This doesn't look like responsibility of clang-sycl-linker.
If this scenario is required, we can consider adding it later with a proper check.