### PR TITLE
[Instrumentor] Introduce BasePointerIO to communicate base pointer information

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -178,7 +178,8 @@ struct InstrumentationLocation {
     BASIC_BLOCK_POST,
     INSTRUCTION_PRE,
     INSTRUCTION_POST,
-    Last = INSTRUCTION_POST,
+    SPECIAL_VALUE,
+    Last = SPECIAL_VALUE,
   };
 
   /// Construct an instrumentation location that is not instrumenting an
@@ -220,6 +221,8 @@ struct InstrumentationLocation {
       return "instruction_pre";
     case INSTRUCTION_POST:
       return "instruction_post";
+    case SPECIAL_VALUE:
+      return "special_value";
     }
     llvm_unreachable("Invalid kind!");
   }
@@ -237,6 +240,7 @@ struct InstrumentationLocation {
         .Case("basic_block_post", BASIC_BLOCK_POST)
         .Case("instruction_pre", INSTRUCTION_PRE)
         .Case("instruction_post", INSTRUCTION_POST)
+        .Case("special_value", SPECIAL_VALUE)
         .Default(Last);
   }
 
@@ -254,6 +258,7 @@ struct InstrumentationLocation {
     case FUNCTION_POST:
     case BASIC_BLOCK_POST:
     case INSTRUCTION_POST:
+    case SPECIAL_VALUE:
       return false;
     }
     llvm_unreachable("Invalid kind!");
@@ -413,6 +418,15 @@ struct InstrumentationConfig {
     new (Obj) Ty(std::forward<ArgsTy>(Args)...);
     return Obj;
   }
+
+  /// Map to remember underlying objects for pointers.
+  DenseMap<Value *, Value *> UnderlyingObjsMap;
+
+  /// Map to remember base pointer info for values in a specific function.
+  DenseMap<std::pair<Value *, Function *>, Value *> BasePointerInfoMap;
+
+  /// Return the base pointer info for \p V.
+  Value *getBasePointerInfo(Value &V, InstrumentorIRBuilderTy &IIRB);
 
   /// Mapping to remember global strings passed to the runtime.
   DenseMap<StringRef, Constant *> GlobalStringsMap;
@@ -710,6 +724,46 @@ struct UnreachableIO final : public InstructionIO<Instruction::Unreachable> {
   }
 };
 
+// Special instrumentation opportunity for base pointers of memory operations.
+struct BasePointerIO final : public InstrumentationOpportunity {
+  BasePointerIO()
+      : InstrumentationOpportunity(
+            InstrumentationLocation(InstrumentationLocation::SPECIAL_VALUE)) {}
+  virtual ~BasePointerIO() {};
+
+  enum ConfigKind {
+    PassPointer = 0,
+    PassPointerKind,
+    PassId,
+    NumConfig,
+  };
+
+  using ConfigTy = BaseConfigTy<ConfigKind>;
+  ConfigTy Config;
+
+  StringRef getName() const override { return "base_pointer_info"; }
+
+  void init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,
+            ConfigTy *UserConfig = nullptr);
+
+  static Value *getPointerKind(Value &V, Type &Ty, InstrumentationConfig &IConf,
+                               InstrumentorIRBuilderTy &IIRB);
+
+  /// This is necessary to produce a return value that can be used by other IOs.
+  /// No replacement is actually happening.
+  static Value *setValueNoop(Value &V, Value &NewV,
+                             InstrumentationConfig &IConf,
+                             InstrumentorIRBuilderTy &IIRB) {
+    return &NewV;
+  }
+
+  static void populate(InstrumentationConfig &IConf,
+                       InstrumentorIRBuilderTy &IIRB) {
+    auto *BPIO = IConf.allocate<BasePointerIO>();
+    BPIO->init(IConf, IIRB);
+  }
+};
+
 // Module instrumentation opportunity.
 struct ModuleIO final : public InstrumentationOpportunity {
   ModuleIO(bool IsPRE)
@@ -819,6 +873,7 @@ struct StoreIO : public InstructionIO<Instruction::Store> {
     PassPointer = 0,
     ReplacePointer,
     PassPointerAS,
+    PassBasePointerInfo,
     PassStoredValue,
     PassStoredValueSize,
     PassAlignment,
@@ -853,6 +908,9 @@ struct StoreIO : public InstructionIO<Instruction::Store> {
                            InstrumentorIRBuilderTy &IIRB);
   static Value *getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
                              InstrumentorIRBuilderTy &IIRB);
+  static Value *getBasePointerInfo(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB);
   static Value *getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                          InstrumentorIRBuilderTy &IIRB);
   static Value *getValueSize(Value &V, Type &Ty, InstrumentationConfig &IConf,
@@ -895,6 +953,7 @@ struct LoadIO : public InstructionIO<Instruction::Load> {
     PassPointer = 0,
     ReplacePointer,
     PassPointerAS,
+    PassBasePointerInfo,
     PassValue,
     ReplaceValue,
     PassValueSize,
@@ -930,6 +989,9 @@ struct LoadIO : public InstructionIO<Instruction::Load> {
                            InstrumentorIRBuilderTy &IIRB);
   static Value *getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
                              InstrumentorIRBuilderTy &IIRB);
+  static Value *getBasePointerInfo(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB);
   static Value *getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                          InstrumentorIRBuilderTy &IIRB);
   static Value *getValueSize(Value &V, Type &Ty, InstrumentationConfig &IConf,

--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -177,7 +177,8 @@ struct InstrumentationLocation {
     BASIC_BLOCK_POST,
     INSTRUCTION_PRE,
     INSTRUCTION_POST,
-    Last = INSTRUCTION_POST,
+    SPECIAL_VALUE,
+    Last = SPECIAL_VALUE,
   };
 
   /// Construct an instrumentation location that is not instrumenting an
@@ -219,6 +220,8 @@ struct InstrumentationLocation {
       return "instruction_pre";
     case INSTRUCTION_POST:
       return "instruction_post";
+    case SPECIAL_VALUE:
+      return "special_value";
     }
     llvm_unreachable("Invalid kind!");
   }
@@ -236,6 +239,7 @@ struct InstrumentationLocation {
         .Case("basic_block_post", BASIC_BLOCK_POST)
         .Case("instruction_pre", INSTRUCTION_PRE)
         .Case("instruction_post", INSTRUCTION_POST)
+        .Case("special_value", SPECIAL_VALUE)
         .Default(Last);
   }
 
@@ -253,6 +257,7 @@ struct InstrumentationLocation {
     case FUNCTION_POST:
     case BASIC_BLOCK_POST:
     case INSTRUCTION_POST:
+    case SPECIAL_VALUE:
       return false;
     }
     llvm_unreachable("Invalid kind!");
@@ -412,6 +417,15 @@ struct InstrumentationConfig {
     new (Obj) Ty(std::forward<ArgsTy>(Args)...);
     return Obj;
   }
+
+  /// Map to remember underlying objects for pointers.
+  DenseMap<Value *, Value *> UnderlyingObjsMap;
+
+  /// Map to remember base pointer info for values in a specific function.
+  DenseMap<std::pair<Value *, Function *>, Value *> BasePointerInfoMap;
+
+  /// Return the base pointer info for \p V.
+  Value *getBasePointerInfo(Value &V, InstrumentorIRBuilderTy &IIRB);
 
   /// Mapping to remember global strings passed to the runtime.
   DenseMap<StringRef, Constant *> GlobalStringsMap;
@@ -707,6 +721,46 @@ struct UnreachableIO final : public InstructionIO<Instruction::Unreachable> {
   }
 };
 
+// Special instrumentation opportunity for base pointers of memory operations.
+struct BasePointerIO : public InstrumentationOpportunity {
+  BasePointerIO()
+      : InstrumentationOpportunity(
+            InstrumentationLocation(InstrumentationLocation::SPECIAL_VALUE)) {}
+  virtual ~BasePointerIO() {};
+
+  enum ConfigKind {
+    PassPointer = 0,
+    PassPointerKind,
+    PassId,
+    NumConfig,
+  };
+
+  using ConfigTy = BaseConfigTy<ConfigKind>;
+  ConfigTy Config;
+
+  StringRef getName() const override { return "base_pointer_info"; }
+
+  void init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,
+            ConfigTy *UserConfig = nullptr);
+
+  static Value *getPointerKind(Value &V, Type &Ty, InstrumentationConfig &IConf,
+                               InstrumentorIRBuilderTy &IIRB);
+
+  /// This is necessary to produce a return value that can be used by other IOs.
+  /// No replacement is actually happening.
+  static Value *setValueNoop(Value &V, Value &NewV,
+                             InstrumentationConfig &IConf,
+                             InstrumentorIRBuilderTy &IIRB) {
+    return &NewV;
+  }
+
+  static void populate(InstrumentationConfig &IConf,
+                       InstrumentorIRBuilderTy &IIRB) {
+    auto *BPIO = IConf.allocate<BasePointerIO>();
+    BPIO->init(IConf, IIRB);
+  }
+};
+
 // Module instrumentation opportunity.
 struct ModuleIO final : public InstrumentationOpportunity {
   ModuleIO(bool IsPRE)
@@ -816,6 +870,7 @@ struct StoreIO : public InstructionIO<Instruction::Store> {
     PassPointer = 0,
     ReplacePointer,
     PassPointerAS,
+    PassBasePointerInfo,
     PassStoredValue,
     PassStoredValueSize,
     PassAlignment,
@@ -850,6 +905,9 @@ struct StoreIO : public InstructionIO<Instruction::Store> {
                            InstrumentorIRBuilderTy &IIRB);
   static Value *getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
                              InstrumentorIRBuilderTy &IIRB);
+  static Value *getBasePointerInfo(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB);
   static Value *getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                          InstrumentorIRBuilderTy &IIRB);
   static Value *getValueSize(Value &V, Type &Ty, InstrumentationConfig &IConf,
@@ -892,6 +950,7 @@ struct LoadIO : public InstructionIO<Instruction::Load> {
     PassPointer = 0,
     ReplacePointer,
     PassPointerAS,
+    PassBasePointerInfo,
     PassValue,
     ReplaceValue,
     PassValueSize,
@@ -927,6 +986,9 @@ struct LoadIO : public InstructionIO<Instruction::Load> {
                            InstrumentorIRBuilderTy &IIRB);
   static Value *getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
                              InstrumentorIRBuilderTy &IIRB);
+  static Value *getBasePointerInfo(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB);
   static Value *getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                          InstrumentorIRBuilderTy &IIRB);
   static Value *getValueSize(Value &V, Type &Ty, InstrumentationConfig &IConf,

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/iterator.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
@@ -513,6 +514,7 @@ BaseConfigurationOption::createStringOption(InstrumentationConfig &IConf,
 
 void InstrumentationConfig::populate(InstrumentorIRBuilderTy &IIRB) {
   /// List of all instrumentation opportunities.
+  BasePointerIO::populate(*this, IIRB);
   ModuleIO::populate(*this, IIRB);
   GlobalVarIO::populate(*this, IIRB);
   FunctionIO::populate(*this, IIRB);
@@ -525,7 +527,9 @@ void InstrumentationConfig::populate(InstrumentorIRBuilderTy &IIRB) {
 void InstrumentationConfig::addChoice(InstrumentationOpportunity &IO,
                                       LLVMContext &Ctx) {
   auto *&ICPtr = IChoices[IO.getLocationKind()][IO.getName()];
-  if (ICPtr) {
+  if (ICPtr &&
+      (IO.getLocationKind() != InstrumentationLocation::SPECIAL_VALUE ||
+       ICPtr->getLocationKind() != InstrumentationLocation::SPECIAL_VALUE)) {
     Ctx.diagnose(DiagnosticInfoInstrumentation(
         Twine("registered two instrumentation opportunities for the same "
               "location (") +
@@ -533,6 +537,62 @@ void InstrumentationConfig::addChoice(InstrumentationOpportunity &IO,
         DS_Warning));
   }
   ICPtr = &IO;
+}
+
+Value *
+InstrumentationConfig::getBasePointerInfo(Value &V,
+                                          InstrumentorIRBuilderTy &IIRB) {
+  Function *Fn = IIRB.IRB.GetInsertBlock()->getParent();
+
+  Value *VPtr;
+  {
+    Value *&UnderlyingVPtr = UnderlyingObjsMap[&V];
+    if (!UnderlyingVPtr)
+      UnderlyingVPtr = const_cast<Value *>(getUnderlyingObjectAggressive(&V));
+    VPtr = UnderlyingVPtr;
+  }
+
+  Value *&BPI = BasePointerInfoMap[{VPtr, Fn}];
+  if (BPI)
+    return BPI;
+
+  auto *BPIO =
+      IChoices[InstrumentationLocation::SPECIAL_VALUE]["base_pointer_info"];
+  if (!BPIO || !BPIO->Enabled) {
+    IIRB.Ctx.diagnose(DiagnosticInfoInstrumentation(
+        "Base pointer info disabled but required, passing nullptr.",
+        DS_Warning));
+    return BPI = Constant::getNullValue(BPIO->getRetTy(IIRB.Ctx));
+  }
+
+  IRBuilderBase::InsertPointGuard IP(IIRB.IRB);
+  if (auto *BasePtrI = dyn_cast<Instruction>(VPtr)) {
+    std::optional<BasicBlock::iterator> IP =
+        BasePtrI->getInsertionPointAfterDef();
+    if (IP) {
+      IIRB.IRB.SetInsertPoint(*IP);
+    } else {
+      IIRB.Ctx.diagnose(DiagnosticInfoInstrumentation(
+          "Base pointer info could not be placed, passing nullptr.",
+          DS_Warning));
+      return BPI = Constant::getNullValue(BPIO->getRetTy(IIRB.Ctx));
+    }
+  } else if (isa<Constant>(VPtr) || isa<Argument>(VPtr))
+    IIRB.IRB.SetInsertPointPastAllocas(IIRB.IRB.GetInsertBlock()->getParent());
+  else {
+    VPtr->dump();
+    llvm_unreachable("Unexpected base pointer!");
+  }
+  ensureDbgLoc(IIRB.IRB);
+
+  // Use fresh caches for safety, as this function may be called from
+  // another instrumentation opportunity.
+  InstrumentationCaches ICaches;
+  BPI = BPIO->instrument(VPtr, *this, IIRB, ICaches);
+  IIRB.returnAllocas();
+  if (!BPI)
+    BPI = Constant::getNullValue(BPIO->getRetTy(IIRB.Ctx));
+  return BPI;
 }
 
 Value *InstrumentationOpportunity::getIdPre(Value &V, Type &Ty,
@@ -1004,6 +1064,11 @@ void StoreIO::init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,
                              "The address space of the accessed pointer.",
                              IRTArg::NONE, getPointerAS));
   }
+  if (Config.has(PassBasePointerInfo)) {
+    IRTArgs.push_back(IRTArg(IIRB.PtrTy, "base_pointer_info",
+                             "The runtime provided base pointer info.",
+                             IRTArg::NONE, getBasePointerInfo));
+  }
   if (Config.has(PassStoredValue)) {
     IRTArgs.push_back(
         IRTArg(getValueType(IIRB), "value", "The stored value.",
@@ -1066,6 +1131,13 @@ Value *StoreIO::getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
   return getCI(&Ty, SI.getPointerAddressSpace());
 }
 
+Value *StoreIO::getBasePointerInfo(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB) {
+  auto &SI = cast<StoreInst>(V);
+  return IConf.getBasePointerInfo(*SI.getPointerOperand(), IIRB);
+}
+
 Value *StoreIO::getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                          InstrumentorIRBuilderTy &IIRB) {
   auto &SI = cast<StoreInst>(V);
@@ -1126,6 +1198,11 @@ void LoadIO::init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,
     IRTArgs.push_back(IRTArg(IIRB.Int32Ty, "pointer_as",
                              "The address space of the accessed pointer.",
                              IRTArg::NONE, getPointerAS));
+  }
+  if (Config.has(PassBasePointerInfo)) {
+    IRTArgs.push_back(IRTArg(IIRB.PtrTy, "base_pointer_info",
+                             "The runtime provided base pointer info.",
+                             IRTArg::NONE, getBasePointerInfo));
   }
   if (!IsPRE && Config.has(PassValue)) {
     IRTArgs.push_back(
@@ -1191,6 +1268,13 @@ Value *LoadIO::getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
   return getCI(&Ty, LI.getPointerAddressSpace());
 }
 
+Value *LoadIO::getBasePointerInfo(Value &V, Type &Ty,
+                                  InstrumentationConfig &IConf,
+                                  InstrumentorIRBuilderTy &IIRB) {
+  auto &LI = cast<LoadInst>(V);
+  return IConf.getBasePointerInfo(*LI.getPointerOperand(), IIRB);
+}
+
 Value *LoadIO::getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                         InstrumentorIRBuilderTy &IIRB) {
   return &V;
@@ -1232,6 +1316,35 @@ Value *LoadIO::isVolatile(Value &V, Type &Ty, InstrumentationConfig &IConf,
                           InstrumentorIRBuilderTy &IIRB) {
   auto &LI = cast<LoadInst>(V);
   return getCI(&Ty, LI.isVolatile());
+}
+
+void BasePointerIO::init(InstrumentationConfig &IConf,
+                         InstrumentorIRBuilderTy &IIRB, ConfigTy *UserConfig) {
+  if (UserConfig)
+    Config = *UserConfig;
+  if (Config.has(PassPointer))
+    IRTArgs.push_back(IRTArg(IIRB.PtrTy, "base_pointer",
+                             "The base pointer in question.",
+                             IRTArg::REPLACABLE, getValue, setValueNoop));
+  if (Config.has(PassPointerKind))
+    IRTArgs.push_back(IRTArg(
+        IIRB.Int32Ty, "base_pointer_kind",
+        "The base pointer kind (argument, global, instruction, unknown).",
+        IRTArg::NONE, getPointerKind));
+  addCommonArgs(IConf, IIRB.Ctx, Config.has(PassId));
+  IConf.addChoice(*this, IIRB.Ctx);
+}
+
+Value *BasePointerIO::getPointerKind(Value &V, Type &Ty,
+                                     InstrumentationConfig &IConf,
+                                     InstrumentorIRBuilderTy &IIRB) {
+  if (isa<Argument>(V))
+    return getCI(&Ty, 0);
+  if (isa<GlobalValue>(V))
+    return getCI(&Ty, 1);
+  if (isa<Instruction>(V))
+    return getCI(&Ty, 2);
+  return getCI(&Ty, 3);
 }
 
 void ModuleIO::init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/iterator.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
@@ -518,6 +519,7 @@ BaseConfigurationOption::createStringOption(InstrumentationConfig &IConf,
 
 void InstrumentationConfig::populate(InstrumentorIRBuilderTy &IIRB) {
   /// List of all instrumentation opportunities.
+  BasePointerIO::populate(*this, IIRB);
   ModuleIO::populate(*this, IIRB);
   GlobalVarIO::populate(*this, IIRB);
   FunctionIO::populate(*this, IIRB);
@@ -538,6 +540,63 @@ void InstrumentationConfig::addChoice(InstrumentationOpportunity &IO,
         DS_Warning));
   }
   ICPtr = &IO;
+}
+
+Value *
+InstrumentationConfig::getBasePointerInfo(Value &V,
+                                          InstrumentorIRBuilderTy &IIRB) {
+  Function *Fn = IIRB.IRB.GetInsertBlock()->getParent();
+
+  Value *Obj;
+  {
+    Value *&UnderlyingObj = UnderlyingObjsMap[&V];
+    if (!UnderlyingObj)
+      UnderlyingObj = const_cast<Value *>(getUnderlyingObjectAggressive(&V));
+    Obj = UnderlyingObj;
+  }
+
+  Value *&BPI = BasePointerInfoMap[{Obj, Fn}];
+  if (BPI)
+    return BPI;
+
+  auto *BPIO =
+      IChoices[InstrumentationLocation::SPECIAL_VALUE]["base_pointer_info"];
+  if (!BPIO || !BPIO->Enabled) {
+    IIRB.Ctx.diagnose(DiagnosticInfoInstrumentation(
+        "Base pointer info disabled but required, passing nullptr.",
+        DS_Warning));
+    return BPI = Constant::getNullValue(BPIO->getRetTy(IIRB.Ctx));
+  }
+
+  IRBuilderBase::InsertPointGuard IP(IIRB.IRB);
+  if (auto *BasePtrI = dyn_cast<Instruction>(Obj)) {
+    std::optional<BasicBlock::iterator> IP =
+        BasePtrI->getInsertionPointAfterDef();
+    if (IP) {
+      IIRB.IRB.SetInsertPoint(*IP);
+    } else {
+      IIRB.Ctx.diagnose(DiagnosticInfoInstrumentation(
+          "Base pointer info could not be placed, passing nullptr.",
+          DS_Warning));
+      return BPI = Constant::getNullValue(BPIO->getRetTy(IIRB.Ctx));
+    }
+  } else if (isa<Constant>(Obj) || isa<Argument>(Obj)) {
+    IIRB.IRB.SetInsertPointPastAllocas(IIRB.IRB.GetInsertBlock()->getParent());
+  } else {
+    LLVM_DEBUG(Obj->dump());
+    llvm_unreachable("Unexpected base pointer!");
+  }
+  ensureDbgLoc(IIRB.IRB);
+
+  // Use fresh caches for safety, as this function may be called from
+  // another instrumentation opportunity.
+  bool Changed;
+  InstrumentationCaches ICaches;
+  BPI = BPIO->instrument(Obj, Changed, *this, IIRB, ICaches);
+  IIRB.returnAllocas();
+  if (!BPI)
+    BPI = Constant::getNullValue(BPIO->getRetTy(IIRB.Ctx));
+  return BPI;
 }
 
 Value *InstrumentationOpportunity::getIdPre(Value &V, Type &Ty,
@@ -1009,6 +1068,11 @@ void StoreIO::init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,
                              "The address space of the accessed pointer.",
                              IRTArg::NONE, getPointerAS));
   }
+  if (Config.has(PassBasePointerInfo)) {
+    IRTArgs.push_back(IRTArg(IIRB.PtrTy, "base_pointer_info",
+                             "The runtime provided base pointer info.",
+                             IRTArg::NONE, getBasePointerInfo));
+  }
   if (Config.has(PassStoredValue)) {
     IRTArgs.push_back(
         IRTArg(getValueType(IIRB), "value", "The stored value.",
@@ -1071,6 +1135,13 @@ Value *StoreIO::getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
   return getCI(&Ty, SI.getPointerAddressSpace());
 }
 
+Value *StoreIO::getBasePointerInfo(Value &V, Type &Ty,
+                                   InstrumentationConfig &IConf,
+                                   InstrumentorIRBuilderTy &IIRB) {
+  auto &SI = cast<StoreInst>(V);
+  return IConf.getBasePointerInfo(*SI.getPointerOperand(), IIRB);
+}
+
 Value *StoreIO::getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                          InstrumentorIRBuilderTy &IIRB) {
   auto &SI = cast<StoreInst>(V);
@@ -1131,6 +1202,11 @@ void LoadIO::init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,
     IRTArgs.push_back(IRTArg(IIRB.Int32Ty, "pointer_as",
                              "The address space of the accessed pointer.",
                              IRTArg::NONE, getPointerAS));
+  }
+  if (Config.has(PassBasePointerInfo)) {
+    IRTArgs.push_back(IRTArg(IIRB.PtrTy, "base_pointer_info",
+                             "The runtime provided base pointer info.",
+                             IRTArg::NONE, getBasePointerInfo));
   }
   if (!IsPRE && Config.has(PassValue)) {
     IRTArgs.push_back(
@@ -1196,6 +1272,13 @@ Value *LoadIO::getPointerAS(Value &V, Type &Ty, InstrumentationConfig &IConf,
   return getCI(&Ty, LI.getPointerAddressSpace());
 }
 
+Value *LoadIO::getBasePointerInfo(Value &V, Type &Ty,
+                                  InstrumentationConfig &IConf,
+                                  InstrumentorIRBuilderTy &IIRB) {
+  auto &LI = cast<LoadInst>(V);
+  return IConf.getBasePointerInfo(*LI.getPointerOperand(), IIRB);
+}
+
 Value *LoadIO::getValue(Value &V, Type &Ty, InstrumentationConfig &IConf,
                         InstrumentorIRBuilderTy &IIRB) {
   return &V;
@@ -1237,6 +1320,35 @@ Value *LoadIO::isVolatile(Value &V, Type &Ty, InstrumentationConfig &IConf,
                           InstrumentorIRBuilderTy &IIRB) {
   auto &LI = cast<LoadInst>(V);
   return getCI(&Ty, LI.isVolatile());
+}
+
+void BasePointerIO::init(InstrumentationConfig &IConf,
+                         InstrumentorIRBuilderTy &IIRB, ConfigTy *UserConfig) {
+  if (UserConfig)
+    Config = *UserConfig;
+  if (Config.has(PassPointer))
+    IRTArgs.push_back(IRTArg(IIRB.PtrTy, "base_pointer",
+                             "The base pointer in question.",
+                             IRTArg::REPLACABLE, getValue, setValueNoop));
+  if (Config.has(PassPointerKind))
+    IRTArgs.push_back(IRTArg(
+        IIRB.Int32Ty, "base_pointer_kind",
+        "The base pointer kind (argument, global, instruction, unknown).",
+        IRTArg::NONE, getPointerKind));
+  addCommonArgs(IConf, IIRB.Ctx, Config.has(PassId));
+  IConf.addChoice(*this, IIRB.Ctx);
+}
+
+Value *BasePointerIO::getPointerKind(Value &V, Type &Ty,
+                                     InstrumentationConfig &IConf,
+                                     InstrumentorIRBuilderTy &IIRB) {
+  if (isa<Argument>(V))
+    return getCI(&Ty, 0);
+  if (isa<GlobalValue>(V))
+    return getCI(&Ty, 1);
+  if (isa<Instruction>(V))
+    return getCI(&Ty, 2);
+  return getCI(&Ty, 3);
 }
 
 void ModuleIO::init(InstrumentationConfig &IConf, InstrumentorIRBuilderTy &IIRB,

--- a/llvm/test/Instrumentation/Instrumentor/alloca_and_function.ll
+++ b/llvm/test/Instrumentation/Instrumentor/alloca_and_function.ll
@@ -35,10 +35,11 @@ define float @foo(i16 %a, float %b) {
 ; CHECK-NEXT:    [[TMP7:%.*]] = call i64 @__instrumentor_pre_alloca(i64 2, i64 16, i32 3) #[[ATTR1]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = alloca i8, i64 [[TMP7]], align 16
 ; CHECK-NEXT:    [[TMP9:%.*]] = call ptr @__instrumentor_post_alloca(ptr [[TMP8]], i64 2, i64 16, i32 -3) #[[ATTR1]]
+; CHECK-NEXT:    [[TMP15:%.*]] = call ptr @__instrumentor_post_base_pointer_info(ptr [[TMP9]], i32 2, i32 -4) #[[ATTR1]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = zext i16 [[TMP4]] to i64
-; CHECK-NEXT:    [[TMP11:%.*]] = call ptr @__instrumentor_pre_store(ptr [[TMP9]], i32 0, i64 [[TMP10]], i64 2, i64 2, i32 12, i32 0, i8 1, i8 0, i32 4) #[[ATTR1]]
+; CHECK-NEXT:    [[TMP11:%.*]] = call ptr @__instrumentor_pre_store(ptr [[TMP9]], i32 0, ptr [[TMP15]], i64 [[TMP10]], i64 2, i64 2, i32 12, i32 0, i8 1, i8 0, i32 4) #[[ATTR1]]
 ; CHECK-NEXT:    store i16 [[TMP4]], ptr [[TMP11]], align 2
-; CHECK-NEXT:    call void @__instrumentor_post_store(ptr [[TMP9]], i32 0, i64 [[TMP10]], i64 2, i64 2, i32 12, i32 0, i8 1, i8 0, i32 -4) #[[ATTR1]]
+; CHECK-NEXT:    call void @__instrumentor_post_store(ptr [[TMP9]], i32 0, ptr [[TMP15]], i64 [[TMP10]], i64 2, i64 2, i32 12, i32 0, i8 1, i8 0, i32 -4) #[[ATTR1]]
 ; CHECK-NEXT:    call void @use(ptr [[TMP9]])
 ; CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[TMP0]], ptr @__instrumentor_value_pack, i64 32, i1 false)
 ; CHECK-NEXT:    [[TMP12:%.*]] = getelementptr inbounds nuw <{ i32, i32, [6 x i8], i16, i32, i32, [4 x i8], float }>, ptr [[TMP0]], i32 0, i32 3

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -160,6 +160,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value_size": true,
       "value_size.description": "The size of the loaded value.",
       "alignment": true,
@@ -184,6 +186,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -225,6 +229,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.replace": true,
       "value.description": "The loaded value.",
@@ -251,6 +257,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -265,6 +273,20 @@
       "sync_scope_id.description": "The sync scope id of the store.",
       "is_volatile": true,
       "is_volatile.description": "Flag indicating a volatile store.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
+    }
+  },
+  "special_value": {
+    "base_pointer_info": {
+      "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
+      "base_pointer": true,
+      "base_pointer.replace": true,
+      "base_pointer.description": "The base pointer in question.",
+      "base_pointer_kind": true,
+      "base_pointer_kind.description": "The base pointer kind (argument, global, instruction, unknown).",
       "id": true,
       "id.description": "A unique ID associated with the given instrumentor call"
     }

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -18,6 +18,8 @@
   "module_pre": {
     "module": {
       "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
       "module_name": true,
       "module_name.description": "The module/translation unit name.",
       "target_triple": true,
@@ -29,6 +31,8 @@
   "module_post": {
     "module": {
       "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
       "module_name": true,
       "module_name.description": "The module/translation unit name.",
       "target_triple": true,
@@ -40,6 +44,8 @@
   "global_pre": {
     "global": {
       "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
       "address": true,
       "address.replace": true,
       "address.description": "The address of the global (replaceable for definitions).",
@@ -64,6 +70,8 @@
   "global_post": {
     "global": {
       "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
       "address": true,
       "address.description": "The address of the global (replaceable for definitions).",
       "address_space": true,
@@ -140,6 +148,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value_size": true,
       "value_size.description": "The size of the loaded value.",
       "alignment": true,
@@ -176,6 +186,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -203,6 +215,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.replace": true,
       "value.description": "The loaded value.",
@@ -243,6 +257,8 @@
       "pointer.description": "The accessed pointer.",
       "pointer_as": true,
       "pointer_as.description": "The address space of the accessed pointer.",
+      "base_pointer_info": true,
+      "base_pointer_info.description": "The runtime provided base pointer info.",
       "value": true,
       "value.description": "The stored value.",
       "value_size": true,
@@ -257,6 +273,20 @@
       "sync_scope_id.description": "The sync scope id of the store.",
       "is_volatile": true,
       "is_volatile.description": "Flag indicating a volatile store.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
+    }
+  },
+  "special_value": {
+    "base_pointer_info": {
+      "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
+      "base_pointer": true,
+      "base_pointer.replace": true,
+      "base_pointer.description": "The base pointer in question.",
+      "base_pointer_kind": true,
+      "base_pointer_kind.description": "The base pointer kind (argument, global, instruction, unknown).",
       "id": true,
       "id.description": "A unique ID associated with the given instrumentor call"
     }

--- a/llvm/test/Instrumentation/Instrumentor/module_and_globals.ll
+++ b/llvm/test/Instrumentation/Instrumentor/module_and_globals.ll
@@ -34,25 +34,28 @@ entry:
 ; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    call void @__instrumentor_pre_function(ptr @foo, ptr @__instrumentor_.str.5, i32 0, ptr null, i8 0, i32 12) #[[ATTR0:[0-9]+]]
 ; CHECK-NEXT:    [[Z_SHADOW_LOAD:%.*]] = load ptr, ptr @__instrumentor_shadow.Z, align 8
+; CHECK-NEXT:    [[TMP0:%.*]] = call ptr @__instrumentor_post_base_pointer_info(ptr [[Z_SHADOW_LOAD]], i32 2, i32 -11) #[[ATTR0]]
 ; CHECK-NEXT:    [[Y_SHADOW_LOAD:%.*]] = load ptr, ptr @__instrumentor_shadow.Y, align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @__instrumentor_post_base_pointer_info(ptr [[Y_SHADOW_LOAD]], i32 2, i32 -10) #[[ATTR0]]
 ; CHECK-NEXT:    [[X_SHADOW_LOAD:%.*]] = load ptr, ptr @__instrumentor_shadow.X, align 8
-; CHECK-NEXT:    [[TMP0:%.*]] = call ptr @__instrumentor_pre_load(ptr [[X_SHADOW_LOAD]], i32 0, i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 9) #[[ATTR0]]
-; CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[TMP0]], align 4
-; CHECK-NEXT:    [[TMP2:%.*]] = zext i32 [[TMP1]] to i64
-; CHECK-NEXT:    [[TMP3:%.*]] = call i64 @__instrumentor_post_load(ptr [[X_SHADOW_LOAD]], i32 0, i64 [[TMP2]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 -9) #[[ATTR0]]
-; CHECK-NEXT:    [[TMP4:%.*]] = trunc i64 [[TMP3]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = call ptr @__instrumentor_pre_load(ptr [[Y_SHADOW_LOAD]], i32 0, i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 10) #[[ATTR0]]
-; CHECK-NEXT:    [[TMP6:%.*]] = load i32, ptr [[TMP5]], align 4
-; CHECK-NEXT:    [[TMP7:%.*]] = zext i32 [[TMP6]] to i64
-; CHECK-NEXT:    [[TMP8:%.*]] = call i64 @__instrumentor_post_load(ptr [[Y_SHADOW_LOAD]], i32 0, i64 [[TMP7]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 -10) #[[ATTR0]]
-; CHECK-NEXT:    [[TMP9:%.*]] = trunc i64 [[TMP8]] to i32
-; CHECK-NEXT:    [[TMP10:%.*]] = call ptr @__instrumentor_pre_load(ptr [[Z_SHADOW_LOAD]], i32 0, i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 11) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @__instrumentor_post_base_pointer_info(ptr [[X_SHADOW_LOAD]], i32 2, i32 -9) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP10:%.*]] = call ptr @__instrumentor_pre_load(ptr [[X_SHADOW_LOAD]], i32 0, ptr [[TMP2]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 9) #[[ATTR0]]
 ; CHECK-NEXT:    [[TMP11:%.*]] = load i32, ptr [[TMP10]], align 4
 ; CHECK-NEXT:    [[TMP12:%.*]] = zext i32 [[TMP11]] to i64
-; CHECK-NEXT:    [[TMP13:%.*]] = call i64 @__instrumentor_post_load(ptr [[Z_SHADOW_LOAD]], i32 0, i64 [[TMP12]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 -11) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP13:%.*]] = call i64 @__instrumentor_post_load(ptr [[X_SHADOW_LOAD]], i32 0, ptr [[TMP2]], i64 [[TMP12]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 -9) #[[ATTR0]]
 ; CHECK-NEXT:    [[TMP14:%.*]] = trunc i64 [[TMP13]] to i32
-; CHECK-NEXT:    [[ADD:%.*]] = add nsw i32 [[TMP4]], [[TMP9]]
-; CHECK-NEXT:    [[ADD2:%.*]] = add nsw i32 [[ADD]], [[TMP14]]
+; CHECK-NEXT:    [[TMP8:%.*]] = call ptr @__instrumentor_pre_load(ptr [[Y_SHADOW_LOAD]], i32 0, ptr [[TMP1]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 10) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP9:%.*]] = load i32, ptr [[TMP8]], align 4
+; CHECK-NEXT:    [[TMP18:%.*]] = zext i32 [[TMP9]] to i64
+; CHECK-NEXT:    [[TMP19:%.*]] = call i64 @__instrumentor_post_load(ptr [[Y_SHADOW_LOAD]], i32 0, ptr [[TMP1]], i64 [[TMP18]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 -10) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP20:%.*]] = trunc i64 [[TMP19]] to i32
+; CHECK-NEXT:    [[TMP21:%.*]] = call ptr @__instrumentor_pre_load(ptr [[Z_SHADOW_LOAD]], i32 0, ptr [[TMP0]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 11) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP22:%.*]] = load i32, ptr [[TMP21]], align 4
+; CHECK-NEXT:    [[TMP15:%.*]] = zext i32 [[TMP22]] to i64
+; CHECK-NEXT:    [[TMP16:%.*]] = call i64 @__instrumentor_post_load(ptr [[Z_SHADOW_LOAD]], i32 0, ptr [[TMP0]], i64 [[TMP15]], i64 4, i64 4, i32 12, i32 0, i8 1, i8 0, i32 -11) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP17:%.*]] = trunc i64 [[TMP16]] to i32
+; CHECK-NEXT:    [[ADD1:%.*]] = add nsw i32 [[TMP14]], [[TMP20]]
+; CHECK-NEXT:    [[ADD2:%.*]] = add nsw i32 [[ADD1]], [[TMP17]]
 ; CHECK-NEXT:    call void @__instrumentor_post_function(ptr @foo, ptr @__instrumentor_.str.5, i32 0, ptr null, i8 0, i32 -13) #[[ATTR0]]
 ; CHECK-NEXT:    ret i32 [[ADD2]]
 ;


### PR DESCRIPTION
Loads, stores, and later probably calls, can request a base pointer info
object from the user runtime. This object is queried right after the
base pointer of the operation is defined, and then passed to the
pre/post runtime calls of the loads and stores. This allows users to
inspect pointers early and once, but provide the analysis results to all
operations that might be executed in loops. A potential use case is to
lookup the size and start of the underlying object and then provide
those to the access runtime calls for in-bounds checking.