### PR TITLE
[clang-tidy] Remove 80 char limit checking in CI. NFC.

### DIFF
--- a/clang-tools-extra/clang-tidy/doc8.ini
+++ b/clang-tools-extra/clang-tidy/doc8.ini
@@ -1,2 +1,3 @@
 [doc8]
 ignore-path = clang-tools-extra/docs/clang-tidy/Integrations.rst
+ignore = D001


### PR DESCRIPTION
The [RFC](https://discourse.llvm.org/t/rfc-remove-80-column-limit-in-documentation-files/89678/41) on removing 80 columns limit got accepted. So we should no longer enforce that rule in clang-tidy's code-linter workflow.