### PR TITLE
[Clang][Modules] Restore embedded transient headers to VFS when physi…

### DIFF
--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -329,6 +329,11 @@ private:
   StringRef getCanonicalName(const void *Entry, StringRef Name);
 
 public:
+  /// Programmatically invalidates and clears all cached SeenFileEntries
+  /// matching the given Filename (normalized and checked as absolute path) to
+  /// force VFS re-lookups.
+  void invalidateFileCache(StringRef Filename);
+
   void PrintStats() const;
 
   /// Import statistics from a child FileManager and add them to this current

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -686,6 +686,30 @@ void FileManager::AddStats(const FileManager &Other) {
   NumFileCacheMisses += Other.NumFileCacheMisses;
 }
 
+// Invalidates and clears all cached results in SeenFileEntries that match
+// the given Filename. Key comparison is performed robustly by converting
+// both the target path and cached keys to their canonical absolute paths.
+void FileManager::invalidateFileCache(StringRef Filename) {
+  SmallString<128> AbsPath(Filename);
+  makeAbsolutePath(AbsPath, /*Canonicalize=*/true);
+  StringRef TargetPath = AbsPath.str();
+
+  // Collect keys to remove in a separate pass to avoid iterator invalidation
+  // during StringMap iteration.
+  SmallVector<StringRef, 4> KeysToRemove;
+  for (const auto &Entry : SeenFileEntries) {
+    SmallString<128> EntryAbsPath(Entry.getKey());
+    makeAbsolutePath(EntryAbsPath, /*Canonicalize=*/true);
+    if (EntryAbsPath.str() == TargetPath) {
+      KeysToRemove.push_back(Entry.getKey());
+    }
+  }
+
+  for (StringRef Key : KeysToRemove) {
+    SeenFileEntries.erase(Key);
+  }
+}
+
 void FileManager::PrintStats() const {
   llvm::errs() << "\n*** File Manager Stats:\n";
   llvm::errs() << UniqueRealFiles.size() << " real files found, "

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5468,8 +5468,15 @@ IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 clang::createVFSFromCompilerInvocation(
     const CompilerInvocation &CI, DiagnosticsEngine &Diags,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS) {
-  return createVFSFromOverlayFiles(CI.getHeaderSearchOpts().VFSOverlayFiles,
-                                   Diags, std::move(BaseFS));
+  auto VFS = createVFSFromOverlayFiles(CI.getHeaderSearchOpts().VFSOverlayFiles,
+                                       Diags, std::move(BaseFS));
+  // Always wrap the returned VFS in an OverlayFileSystem to ensure that
+  // initialization paths not using CompilerInstance (such as ASTUnit/libclang)
+  // maintain a consistent VFS stack capable of dynamic overlay injections.
+  if (llvm::isa<llvm::vfs::OverlayFileSystem>(VFS.get()))
+    return VFS;
+  return llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(
+      std::move(VFS));
 }
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem> clang::createVFSFromOverlayFiles(

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -123,6 +123,7 @@
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/VersionTuple.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 #include <algorithm>
@@ -1885,6 +1886,48 @@ int ASTReader::getSLocEntryID(SourceLocation::UIntTy SLocOffset) {
   return F->SLocEntryBaseID + *std::prev(It);
 }
 
+/// Retrieves the existing InMemoryFileSystem from the active VFS stack,
+/// or dynamically wraps the FileManager's VFS inside a new OverlayFileSystem
+/// with InMemoryFileSystem pushed on top if not found.
+/// It also synchronizes the current working directory from the parent VFS.
+static llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem>
+getOrCreateInMemoryFileSystem(Preprocessor &PP) {
+  FileManager &FileMgr = PP.getFileManager();
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
+      FileMgr.getVirtualFileSystemPtr();
+
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> InMemoryFS;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS;
+  VFS->visit([&](llvm::vfs::FileSystem &SubFS) {
+    if (!InMemoryFS) {
+      if (auto *FS = llvm::dyn_cast<llvm::vfs::InMemoryFileSystem>(&SubFS)) {
+        InMemoryFS = FS;
+      }
+    }
+    if (!OverlayFS) {
+      if (auto *OFS = llvm::dyn_cast<llvm::vfs::OverlayFileSystem>(&SubFS)) {
+        OverlayFS = OFS;
+      }
+    }
+  });
+
+  if (InMemoryFS)
+    return InMemoryFS;
+
+  InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  if (auto CWD = VFS->getCurrentWorkingDirectory()) {
+    InMemoryFS->setCurrentWorkingDirectory(*CWD);
+  }
+
+  if (OverlayFS) {
+    OverlayFS->pushOverlay(InMemoryFS);
+  } else {
+    llvm_unreachable(
+        "OverlayFileSystem must always be present in the active VFS stack!");
+  }
+  return InMemoryFS;
+}
+
 bool ASTReader::ReadSLocEntry(int ID) {
   if (ID == 0)
     return false;
@@ -2025,6 +2068,19 @@ bool ASTReader::ReadSLocEntry(int ID) {
       auto Buffer = ReadBuffer(SLocEntryCursor, File->getName());
       if (!Buffer)
         return true;
+
+      auto MemFS = getOrCreateInMemoryFileSystem(PP);
+      // Only inject into VFS and invalidate cache if a dummy file was
+      // pre-registered in MemFS, preserving FileEntry identity and VFS
+      // cleanliness for physical files.
+      if (MemFS->status(File->getName())) {
+        auto VFSBuffer = llvm::MemoryBuffer::getMemBufferCopy(
+            Buffer->getBuffer(), File->getName());
+        MemFS->addFile(File->getName(), File->getModificationTime(),
+                       std::move(VFSBuffer));
+        PP.getFileManager().invalidateFileCache(File->getName());
+      }
+
       SourceMgr.overrideFileContents(*File, std::move(Buffer));
     }
 
@@ -5199,6 +5255,61 @@ ASTReader::ASTReadResult ASTReader::ReadAST(ModuleFileName FileName,
           M.Mod->InputFilesValidationTimestamp < HSOpts.BuildSessionTimestamp)
         getModuleManager().getModuleCache().updateModuleTimestamp(
             M.Mod->FileName);
+    }
+  }
+
+  // Pre-register empty dummy files in VFS for embedded transient headers to
+  // allow HeaderSearch to pass, while keeping their actual AST content loading
+  // completely lazy (on-demand).
+  for (ImportedModule &M : Loaded) {
+    ModuleFile &F = *M.Mod;
+
+    // Only pre-register if the module is actually defined in the current
+    // compilation's module maps, to avoid polluting VFS with headers from
+    // unrelated loaded PCM files.
+    if (!PP.getHeaderSearchInfo().getModuleMap().findModule(F.ModuleName))
+      continue;
+
+    // If the module map file used to build this module no longer exists
+    // physically, do not pre-register dummy files as we won't be able to
+    // resolve includes to module imports anyway.
+    if (!F.ModuleMapPath.empty() &&
+        !PP.getFileManager().getOptionalFileRef(F.ModuleMapPath).has_value())
+      continue;
+
+    for (unsigned I = 1; I <= F.InputFileInfosLoaded.size(); ++I) {
+      InputFileInfo IFI = getInputFileInfo(F, I);
+      if (IFI.Transient && IFI.isValid()) {
+        // Resolve the unresolved filename to an absolute path using the module
+        // file's BaseDirectory.
+        SmallString<256> ResolvedPath(IFI.UnresolvedImportedFilename);
+        if (llvm::sys::path::is_relative(ResolvedPath)) {
+          ResolvedPath.clear();
+          SmallString<256> AbsBaseDir(F.BaseDirectory);
+          PP.getFileManager().makeAbsolutePath(AbsBaseDir,
+                                               /*Canonicalize=*/true);
+          llvm::sys::path::append(ResolvedPath, AbsBaseDir,
+                                  IFI.UnresolvedImportedFilename);
+        }
+        llvm::sys::path::remove_dots(ResolvedPath, /*remove_dot_dot=*/true);
+
+        // Now we can check physical file existence robustly using the resolved
+        // absolute path.
+        bool PhysicalExists =
+            PP.getFileManager().getOptionalFileRef(ResolvedPath).has_value();
+
+        // Only pre-register if the file is transient, valid, and does NOT exist
+        // on the physical disk.
+        if (!PhysicalExists) {
+          auto MemFS = getOrCreateInMemoryFileSystem(PP);
+          // Create a lightweight empty memory buffer to satisfy VFS existence
+          // checks without memory overhead. Content and actual size will be
+          // overwritten with real content on-demand when the SLocID is loaded.
+          auto DummyBuffer = llvm::MemoryBuffer::getMemBuffer("", ResolvedPath);
+          MemFS->addFile(ResolvedPath, IFI.StoredTime, std::move(DummyBuffer));
+          PP.getFileManager().invalidateFileCache(ResolvedPath);
+        }
+      }
     }
   }
 

--- a/clang/test/Modules/reproduce-issue-169768.cpp
+++ b/clang/test/Modules/reproduce-issue-169768.cpp
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: echo 'module A { header "A.h" export * }' > %t/module.modulemap
+// RUN: echo '#define MY_MACRO 42' > %t/A.h
+// RUN: echo '#include "A.h"' > %t/A.cpp
+
+// Compile the module with embedded source files in C++ mode
+// RUN: %clang_cc1 -fmodules -I%t -fmodules-cache-path=%t -fmodules-embed-all-files %t/module.modulemap -fmodule-name=A -x c++ -emit-module -o %t/A.pcm
+
+// Remove the physical transient header file completely
+// RUN: rm %t/A.h
+
+// Verify that compilation compiles successfully without "file not found" errors in C++ mode
+// by dynamically restoring the transient header into VFS from the embedded PCM.
+// RUN: %clang_cc1 -fmodules -I%t -fmodules-cache-path=%t -fmodule-map-file=%t/module.modulemap -fmodule-file=%t/A.pcm %t/A.cpp -emit-obj -o %t/A.o
+
+// Test home-is-cwd mode with embedded files
+// RUN: mkdir %t/cwd_test
+// RUN: echo 'module B { header "B.h" export * }' > %t/cwd_test/module.modulemap
+// RUN: echo '#define MY_MACRO_B 42' > %t/cwd_test/B.h
+// RUN: echo '#include "B.h"' > %t/cwd_test/B.cpp
+// RUN: cd %t/cwd_test && %clang_cc1 -fmodules -I. -fmodules-cache-path=. -fmodules-embed-all-files -fmodule-map-file-home-is-cwd module.modulemap -fmodule-name=B -x c++ -emit-module -o B.pcm
+// RUN: rm %t/cwd_test/B.h
+// RUN: cd %t/cwd_test && %clang_cc1 -fmodules -I. -fmodules-cache-path=. -fmodule-map-file-home-is-cwd -fmodule-map-file=module.modulemap -fmodule-file=B.pcm B.cpp -emit-obj -o B.o


### PR DESCRIPTION
…cal files are missing

When modules are built with embedded headers (e.g., `-fmodules-embed-all-files`), transient input headers might be missing from the physical disk on the importer side. This patch implements a mechanism to dynamically restore these embedded headers into an in-memory virtual file system (VFS) so that HeaderSearch and FileManager can resolve them properly during module loading and AST parsing.

To ensure robustness and prevent VFS pollution or cache corruption, several safety measures and memory optimizations are introduced:
1. VFS Stack Consistency: Ensures `createVFSFromCompilerInvocation` always wraps the VFS inside an `OverlayFileSystem`, preventing assertion failures during AST loading paths (like in `c-index-test`).
2. Module Definition Filtering: Skips VFS pre-registration if the module is not defined in the active compilation's module maps, avoiding path conflicts from unrelated loaded PCM files. This robustly protects compilation environments even under relative base directories (e.g., `-fmodule-map-file-home-is-cwd`).
3. Physical File Protection: In `ASTReader::ReadSLocEntry`, VFS buffer injection and cache invalidation are strictly restricted to pre-registered dummy files (`MemFS->status(...)`). This prevents disrupting `FileEntry` identity and cache validation for physical files that actually exist on disk.
4. Zero Memory Overhead: Pre-registers lightweight empty buffers (`getMemBuffer("")`) during `ReadAST` to satisfy VFS existence checks without allocating memory for file size, and overrides them with real content on-demand when the `SLocID` is actually loaded.

Fixes: [#169768](https://github.com/llvm/llvm-project/issues/169768)
Assisted-by: Gemini