### PR TITLE
[AArch64][GlobalISel] Add static regbank mapping for pointer G_LOAD/G_STORE

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -989,6 +989,17 @@ AArch64RegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
              nullptr}),
         /*NumOperands=*/2);
   }
+  case TargetOpcode::G_LOAD:
+  case TargetOpcode::G_STORE: {
+    LLT ValTy = MRI.getType(MI.getOperand(0).getReg());
+    // Pointer loads/stores are always mapped to GPRs.
+    if (ValTy.isPointer())
+      return getInstructionMapping(
+          DefaultMappingID, /*Cost=*/1,
+          getValueMapping(PMI_FirstGPR, TypeSize::getFixed(64)),
+          /*NumOperands=*/2);
+    break;
+  }
   default:
     break;
   }


### PR DESCRIPTION
Pointer loads/stores are always mapped to GPRs. Returning the default
register-bank mapping directly is a -0.25% geomean compile-time improvement on
CTMark aarch64-O0-g. sqlite -0.61%.

https://llvm-compile-time-tracker.com/compare.php?from=35f5d7ea802eae78b26a5fb2a46f072acd15f49d&to=fbdd065d4292c6f7c145f663e6de0d34df3bc489&stat=instructions%3Au

Assisted-by: codex