### PR TITLE
[CIR][NFC] Remove unused functions in MissingFeatures.h

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -34,7 +34,6 @@ struct MissingFeatures {
   static bool opGlobalVisibility() { return false; }
   static bool opGlobalDLLImportExport() { return false; }
   static bool opGlobalPartition() { return false; }
-  static bool opGlobalUsedOrCompilerUsed() { return false; }
   static bool opGlobalPragmaClangSection() { return false; }
   static bool opGlobalAnnotations() { return false; }
   static bool opGlobalCtorPriority() { return false; }
@@ -42,13 +41,11 @@ struct MissingFeatures {
   static bool setDSOLocal() { return false; }
 
   static bool supportIFuncAttr() { return false; }
-  static bool supportVisibility() { return false; }
   static bool hiddenVisibility() { return false; }
   static bool protectedVisibility() { return false; }
   static bool defaultVisibility() { return false; }
 
   // Load/store attributes
-  static bool opLoadStoreThreadLocal() { return false; }
   static bool opLoadEmitScalarRangeCheck() { return false; }
   static bool opLoadStoreNontemporal() { return false; }
   static bool opLoadStoreTbaa() { return false; }
@@ -63,7 +60,6 @@ struct MissingFeatures {
   static bool opAllocaTLS() { return false; }
   static bool opAllocaOpenMPThreadPrivate() { return false; }
   static bool opAllocaEscapeByReference() { return false; }
-  static bool opAllocaReference() { return false; }
   static bool opAllocaAnnotations() { return false; }
   static bool opAllocaCaptureByInit() { return false; }
 
@@ -81,7 +77,6 @@ struct MissingFeatures {
   static bool opFuncMultiVersioning() { return false; }
   static bool opFuncNakedAttr() { return false; }
   static bool opFuncNoDuplicateAttr() { return false; }
-  static bool opFuncOpenCLKernelMetadata() { return false; }
   static bool opFuncOperandBundles() { return false; }
   static bool opFuncOptNoneAttr() { return false; }
   static bool opFuncParameterAttributes() { return false; }
@@ -93,27 +88,20 @@ struct MissingFeatures {
   static bool setLLVMFunctionFEnvAttributes() { return false; }
 
   // CallOp handling
-  static bool opCallAggregateArgs() { return false; }
   static bool opCallPaddingArgs() { return false; }
-  static bool opCallABIExtendArg() { return false; }
-  static bool opCallABIIndirectArg() { return false; }
-  static bool opCallWidenArg() { return false; }
   static bool opCallBitcastArg() { return false; }
   static bool opCallReturn() { return false; }
   static bool opCallArgEvaluationOrder() { return false; }
   static bool opCallCallConv() { return false; }
-  static bool opCallSideEffect() { return false; }
   static bool opCallMustTail() { return false; }
   static bool opCallInAlloca() { return false; }
   static bool opCallAttrs() { return false; }
   static bool opCallSurroundingTry() { return false; }
-  static bool opCallASTAttr() { return false; }
   static bool opCallObjCMethod() { return false; }
   static bool opCallExtParameterInfo() { return false; }
   static bool opCallCIRGenFuncInfoParamInfo() { return false; }
   static bool opCallCIRGenFuncInfoExtParamInfo() { return false; }
   static bool opCallChain() { return false; }
-  static bool opCallExceptionAttr() { return false; }
 
   // FnInfoOpts -- This is used to track whether calls are chain calls or
   // instance methods. Classic codegen uses chain call to track and extra free
@@ -124,9 +112,6 @@ struct MissingFeatures {
 
   // ScopeOp handling
   static bool opScopeCleanupRegion() { return false; }
-
-  // Unary operator handling
-  static bool opUnaryPromotionType() { return false; }
 
   // SwitchOp handling
   static bool foldRangeCase() { return false; }
@@ -147,7 +132,6 @@ struct MissingFeatures {
   static bool cgmRelease() { return false; }
   static bool checkAliases() { return false; }
   static bool shouldSkipAliasEmission() { return false; }
-  static bool deferredFuncDecls() { return false; }
 
   // CXXABI
   static bool cxxABI() { return false; }
@@ -166,14 +150,11 @@ struct MissingFeatures {
   static bool atomicInfo() { return false; }
   static bool atomicInfoGetAtomicPointer() { return false; }
   static bool atomicInfoGetAtomicAddress() { return false; }
-  static bool atomicScope() { return false; }
   static bool atomicSyncScopeID() { return false; }
-  static bool atomicMapTargetSyncScope() { return false; }
   static bool atomicTypes() { return false; }
   static bool atomicUseLibCall() { return false; }
   static bool atomicMicrosoftVolatile() { return false; }
   static bool atomicOpenMP() { return false; }
-  static bool atomicInitTailPadding() { return false; }
 
   // Global ctor handling
   static bool globalCtorLexOrder() { return false; }
@@ -207,7 +188,6 @@ struct MissingFeatures {
   static bool allocToken() { return false; }
   static bool appleArm64CXXABI() { return false; }
   static bool appleKext() { return false; }
-  static bool armComputeVolatileBitfields() { return false; }
   static bool asmGoto() { return false; }
   static bool asmLabelAttr() { return false; }
   static bool asmLLVMAssume() { return false; }
@@ -217,10 +197,8 @@ struct MissingFeatures {
   static bool assignMemcpyizer() { return false; }
   static bool astVarDeclInterface() { return false; }
   static bool attributeNoBuiltin() { return false; }
-  static bool bitfields() { return false; }
   static bool builtinCall() { return false; }
   static bool builtinCallF128() { return false; }
-  static bool builtinCallMathErrno() { return false; }
   static bool builtinBitCountExpr() { return false; }
   static bool builtinCheckKind() { return false; }
   static bool cgCapturedStmtInfo() { return false; }
@@ -229,9 +207,7 @@ struct MissingFeatures {
   static bool cirgenABIInfo() { return false; }
   static bool cleanupAfterErrorDiags() { return false; }
   static bool cleanupDeactivationScope() { return false; }
-  static bool cleanupWithPreservedValues() { return false; }
   static bool cleanupsToDeactivate() { return false; }
-  static bool constEmitterAggILE() { return false; }
   static bool constEmitterArrayILE() { return false; }
   static bool constEmitterVectorILE() { return false; }
   static bool constantFoldSwitchStatement() { return false; }
@@ -244,16 +220,13 @@ struct MissingFeatures {
   static bool cudaSupport() { return false; }
   static bool hipModuleCtor() { return false; }
   static bool globalRegistration() { return false; }
-  static bool dataLayoutTypeIsSized() { return false; }
   static bool dataLayoutTypeAllocSize() { return false; }
-  static bool dataLayoutTypeStoreSize() { return false; }
   static bool dataLayoutPtrHandlingBasedOnLangAS() { return false; }
   static bool deferredCXXGlobalInit() { return false; }
   static bool deleteArray() { return false; }
   static bool devirtualizeDestructor() { return false; }
   static bool dtorCleanups() { return false; }
   static bool ehCleanupScope() { return false; }
-  static bool ehScopeFilter() { return false; }
   static bool emitCheckedInBoundsGEP() { return false; }
   static bool emitCondLikelihoodViaExpectIntrinsic() { return false; }
   static bool emitConstrainedFPCall() { return false; }
@@ -276,7 +249,6 @@ struct MissingFeatures {
   static bool fpConstraints() { return false; }
   static bool generateDebugInfo() { return false; }
   static bool getRuntimeFunctionDecl() { return false; }
-  static bool globalViewIndices() { return false; }
   static bool globalViewIntLowering() { return false; }
   static bool guardAbortOnException() { return false; }
   static bool handleBuiltinICEArguments() { return false; }
@@ -285,13 +257,10 @@ struct MissingFeatures {
   static bool insertBuiltinUnpredictable() { return false; }
   static bool instrumentation() { return false; }
   static bool intrinsicElementTypeSupport() { return false; }
-  static bool intrinsics() { return false; }
   static bool isTrivialCtorOrDtor() { return false; }
   static bool loopInfoStack() { return false; }
   static bool lowerAggregateLoadStore() { return false; }
   static bool lowerModeOptLevel() { return false; }
-  static bool loweringPrepareX86CXXABI() { return false; }
-  static bool loweringPrepareAArch64XXABI() { return false; }
   static bool makeTripleAlwaysPresent() { return false; }
   static bool maybeHandleStaticInExternC() { return false; }
   static bool mergeAllConstants() { return false; }
@@ -300,7 +269,6 @@ struct MissingFeatures {
   static bool metaDataNode() { return false; }
   static bool moduleNameHash() { return false; }
   static bool msabi() { return false; }
-  static bool nrvo() { return false; }
   static bool objCBlocks() { return false; }
   static bool objCGC() { return false; }
   static bool objCLifetime() { return false; }
@@ -312,7 +280,6 @@ struct MissingFeatures {
   static bool peepholeProtection() { return false; }
   static bool pgoUse() { return false; }
   static bool pointerAuthentication() { return false; }
-  static bool pointerOverflowSanitizer() { return false; }
   static bool preservedAccessIndexRegion() { return false; }
   static bool loopSpecificCleanupHandling() { return false; }
   static bool returnValueSlotFeatures() { return false; }
@@ -361,14 +328,12 @@ struct MissingFeatures {
   // Future CIR operations
   static bool callOp() { return false; }
   static bool llvmLoweringPtrDiffConsidersPointee() { return false; }
-  static bool switchOp() { return false; }
   static bool tryOp() { return false; }
   static bool vecTernaryOp() { return false; }
   static bool zextOp() { return false; }
 
   // Future CIR attributes
   static bool optInfoAttr() { return false; }
-  static bool functionArgumentAttrs() { return false; }
 
   // Maybe only needed for Windows exception handling
   static bool currentFuncletPad() { return false; }


### PR DESCRIPTION
### Summary

This NFC change removes 33  entries from MissingFeatures.h that have no callers in tree as of <b4f7c93e7d1325f1c1f00b47c10d2923e8259369>

- `switchOp`
- `opUnaryPromotionType`
- `supportVisibility`
- `atomicInitTailPadding`
- `atomicMapTargetSyncScope`
- `atomicScope`
- `bitfields`
- `builtinCallMathErrno`
- `cleanupWithPreservedValues`
- `constEmitterAggILE`
- `dataLayoutTypeIsSized`
- `dataLayoutTypeStoreSize`
- `deferredFuncDecls`
- `ehScopeFilter`
- `functionArgumentAttrs`
- `globalViewIndices`
- `intrinsics`
- `loweringPrepareAArch64XXABI`
- `loweringPrepareX86CXXABI`
- `nrvo`
- `opAllocaReference`
- `opCallABIExtendArg`
- `opCallABIIndirectArg`
- `opCallAggregateArgs`
- `opCallASTAttr`
- `opCallExceptionAttr`
- `opCallSideEffect`
- `opCallWidenArg`
- `opFuncOpenCLKernelMetadata`
- `opGlobalUsedOrCompilerUsed`
- `opLoadStoreThreadLocal`
- `opUnaryPromotionType`
- `pointerOverflowSanitizer`