### PR TITLE
[compiler-rt] Fix StackDepot benchmark thread barrier

### DIFF
--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_stackdepot_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_stackdepot_test.cpp
@@ -174,11 +174,11 @@ class StackDepotBenchmark
 //   '--gtest_filter=*Benchmark*'
 TEST_P(StackDepotBenchmark, DISABLED_Benchmark) {
   auto Param = GetParam();
-  std::atomic<unsigned int> here = {};
+  std::atomic<int> here = {};
 
   auto thread = [&](int idx) {
     here++;
-    while (here < Param.UniqueThreads) std::this_thread::yield();
+    while (here < Param.Threads) std::this_thread::yield();
 
     std::vector<uptr> frames(64);
     for (int r = 0; r < Param.RepeatPerThread; ++r) {


### PR DESCRIPTION
Use Param.Threads (number of worker threads) as barrier threshold instead of Param.UniqueThreads (boolean that controls input generation).

This also silences [-Wbool-integral-comparison](https://github.com/llvm/llvm-project/pull/194180) warning I'm working on.
