### PR TITLE
[AMDGPU] Less-constrained scheduling for ASYNCMARK

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -3562,7 +3562,7 @@ bool AMDGPUInstructionSelector::selectG_INSERT_VECTOR_ELT(
   return true;
 }
 
-static bool isAsyncLDSDMA(Intrinsic::ID Intr) {
+static bool isPreGFX12Async(Intrinsic::ID Intr) {
   switch (Intr) {
   case Intrinsic::amdgcn_raw_buffer_load_async_lds:
   case Intrinsic::amdgcn_raw_ptr_buffer_load_async_lds:
@@ -3637,6 +3637,12 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
     break;
   }
 
+  if (isPreGFX12Async(IntrinsicID)) {
+    int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+    assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+    Opc = AsyncOpc;
+  }
+
   MachineBasicBlock *MBB = MI.getParent();
   const DebugLoc &DL = MI.getDebugLoc();
   BuildMI(*MBB, &MI, DL, TII.get(AMDGPU::COPY), AMDGPU::M0)
@@ -3670,7 +3676,6 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
       Aux & (IsGFX12Plus ? AMDGPU::CPol::SWZ : AMDGPU::CPol::SWZ_pregfx12)
           ? 1
           : 0); // swz
-  MIB.addImm(isAsyncLDSDMA(IntrinsicID));
 
   MachineMemOperand *LoadMMO = *MI.memoperands_begin();
   // Don't set the offset value here because the pointer points to the base of
@@ -3854,6 +3859,12 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
     }
   }
 
+  if (isPreGFX12Async(IntrinsicID)) {
+    int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+    assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+    Opc = AsyncOpc;
+  }
+
   auto MIB = BuildMI(*MBB, &MI, DL, TII.get(Opc))
     .addReg(Addr);
 
@@ -3864,7 +3875,6 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
 
   unsigned Aux = MI.getOperand(5).getImm();
   MIB.addImm(Aux & ~AMDGPU::CPol::VIRTUAL_BITS); // cpol
-  MIB.addImm(isAsyncLDSDMA(IntrinsicID));
 
   MachineMemOperand *LoadMMO = *MI.memoperands_begin();
   MachinePointerInfo LoadPtrI = LoadMMO->getPointerInfo();

--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructionSelector.cpp
@@ -3496,7 +3496,7 @@ bool AMDGPUInstructionSelector::selectG_INSERT_VECTOR_ELT(
   return true;
 }
 
-static bool isAsyncLDSDMA(Intrinsic::ID Intr) {
+static bool isPreGFX12Async(Intrinsic::ID Intr) {
   switch (Intr) {
   case Intrinsic::amdgcn_raw_buffer_load_async_lds:
   case Intrinsic::amdgcn_raw_ptr_buffer_load_async_lds:
@@ -3571,6 +3571,12 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
     break;
   }
 
+  if (isPreGFX12Async(IntrinsicID)) {
+    int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+    assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+    Opc = AsyncOpc;
+  }
+
   MachineBasicBlock *MBB = MI.getParent();
   const DebugLoc &DL = MI.getDebugLoc();
   BuildMI(*MBB, &MI, DL, TII.get(AMDGPU::COPY), AMDGPU::M0)
@@ -3604,7 +3610,6 @@ bool AMDGPUInstructionSelector::selectBufferLoadLds(MachineInstr &MI) const {
       Aux & (IsGFX12Plus ? AMDGPU::CPol::SWZ : AMDGPU::CPol::SWZ_pregfx12)
           ? 1
           : 0); // swz
-  MIB.addImm(isAsyncLDSDMA(IntrinsicID));
 
   MachineMemOperand *LoadMMO = *MI.memoperands_begin();
   // Don't set the offset value here because the pointer points to the base of
@@ -3789,6 +3794,12 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
     }
   }
 
+  if (isPreGFX12Async(IntrinsicID)) {
+    int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+    assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+    Opc = AsyncOpc;
+  }
+
   auto MIB = BuildMI(*MBB, &MI, DL, TII.get(Opc))
     .addReg(Addr);
 
@@ -3799,7 +3810,6 @@ bool AMDGPUInstructionSelector::selectGlobalLoadLds(MachineInstr &MI) const{
 
   unsigned Aux = MI.getOperand(5).getImm();
   MIB.addImm(Aux & ~AMDGPU::CPol::VIRTUAL_BITS); // cpol
-  MIB.addImm(isAsyncLDSDMA(IntrinsicID));
 
   MachineMemOperand *LoadMMO = *MI.memoperands_begin();
   MachinePointerInfo LoadPtrI = LoadMMO->getPointerInfo();

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -9419,10 +9419,6 @@ void AMDGPUAsmParser::cvtMubufImpl(MCInst &Inst, const OperandVector &Operands,
   // Parse a dummy operand as a placeholder for the SWZ operand. This enforces
   // agreement between MCInstrDesc.getNumOperands and MCInst.getNumOperands.
   Inst.addOperand(MCOperand::createImm(0));
-  // The LDS variants carry a trailing IsAsync operand. Parse a dummy the same
-  // way as the SWZ operand.
-  if (AMDGPU::hasNamedOperand(Inst.getOpcode(), AMDGPU::OpName::IsAsync))
-    Inst.addOperand(MCOperand::createImm(0));
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -418,14 +418,13 @@ class getBUFVDataRegisterOperandForOp<RegisterOperand Op, bit isTFE> {
 
 class getMUBUFInsDA<list<RegisterOperand> vdataList,
                     list<RegisterOperand> vaddrList, bit isTFE, bit hasRestrictedSOffset,
-                    bit isTrue16, bit isLds> {
+                    bit isTrue16> {
   RegisterOperand vdataClass = !if(!empty(vdataList), ?, !head(vdataList));
   RegisterOperand vaddr_op = !if(!empty(vaddrList), ?, !head(vaddrList));
   RegisterOperand vdata_op = getBUFVDataRegisterOperand<!cast<SIRegisterClassLike>(vdataClass.RegClass).Size, isTFE, isTrue16>.ret;
 
   dag SOffset = !if(hasRestrictedSOffset, (ins SReg_32:$soffset), (ins SCSrc_b32:$soffset));
-  dag IsAsyncOpnd = !if(isLds, (ins i1imm_0:$IsAsync), (ins));
-  dag NonVaddrInputs = !con((ins SReg_128_XNULL:$srsrc), SOffset, (ins Offset:$offset, CPol_0:$cpol, i1imm_0:$swz), IsAsyncOpnd);
+  dag NonVaddrInputs = !con((ins SReg_128_XNULL:$srsrc), SOffset, (ins Offset:$offset, CPol_0:$cpol, i1imm_0:$swz));
 
   dag Inputs = !if(!empty(vaddrList), NonVaddrInputs, !con((ins vaddr_op:$vaddr), NonVaddrInputs));
   dag ret = !if(!empty(vdataList), Inputs, !con((ins vdata_op:$vdata), Inputs));
@@ -451,13 +450,13 @@ class getMUBUFElements<ValueType vt> {
 }
 
 class getMUBUFIns<int addrKind, list<RegisterOperand> vdataList, bit isTFE,
-                  bit hasRestrictedSOffset, bit isTrue16, bit isLds> {
+                  bit hasRestrictedSOffset, bit isTrue16> {
   dag ret =
-    !if(!eq(addrKind, BUFAddrKind.Offset), getMUBUFInsDA<vdataList, [], isTFE, hasRestrictedSOffset, isTrue16, isLds>.ret,
-    !if(!eq(addrKind, BUFAddrKind.OffEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16, isLds>.ret,
-    !if(!eq(addrKind, BUFAddrKind.IdxEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16, isLds>.ret,
-    !if(!eq(addrKind, BUFAddrKind.BothEn), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16, isLds>.ret,
-    !if(!eq(addrKind, BUFAddrKind.Addr64), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16, isLds>.ret,
+    !if(!eq(addrKind, BUFAddrKind.Offset), getMUBUFInsDA<vdataList, [], isTFE, hasRestrictedSOffset, isTrue16>.ret,
+    !if(!eq(addrKind, BUFAddrKind.OffEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16>.ret,
+    !if(!eq(addrKind, BUFAddrKind.IdxEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16>.ret,
+    !if(!eq(addrKind, BUFAddrKind.BothEn), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16>.ret,
+    !if(!eq(addrKind, BUFAddrKind.Addr64), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16>.ret,
     (ins))))));
 }
 
@@ -490,25 +489,26 @@ class MUBUF_SetupAddr<int addrKind> {
   bits<1> has_vaddr = !ne(addrKind, BUFAddrKind.Offset);
 }
 
-class MUBUF_Load_Pseudo <string opName,
-                         int addrKind,
-                         ValueType vdata_vt,
-                         bit HasTiedDest = 0,
-                         bit isLds = 0,
-                         bit isLdsOpc = 0,
-                         bit isTFE = 0,
-                         bit hasRestrictedSOffset = 0,
-                         list<dag> pattern=[],
-                         RegisterOperand vdata_op = getBUFVDataRegisterOperand<vdata_vt.Size, isTFE>.ret>
+class MUBUF_Load_PseudoImpl <string opName,
+                             int addrKind,
+                             ValueType vdata_vt,
+                             bit HasTiedDest = 0,
+                             bit isLds = 0,
+                             bit isLdsOpc = 0,
+                             bit isTFE = 0,
+                             bit hasRestrictedSOffset = 0,
+                             list<dag> pattern=[],
+                             RegisterOperand vdata_op = getBUFVDataRegisterOperand<vdata_vt.Size, isTFE>.ret,
+                             bit isPreGFX12Async = 0>
   : MUBUF_Pseudo<opName,
                  !if(!or(isLds, isLdsOpc), (outs), (outs vdata_op:$vdata)),
-                 !con(getMUBUFIns<addrKind, [], isTFE, hasRestrictedSOffset, 0, isLds>.ret,
+                 !con(getMUBUFIns<addrKind, [], isTFE, hasRestrictedSOffset, 0>.ret,
                       !if(HasTiedDest, (ins vdata_op:$vdata_in), (ins))),
                  getMUBUFAsmOps<addrKind, !or(isLds, isLdsOpc), isLds, isTFE>.ret,
                  pattern>,
     MUBUF_SetupAddr<addrKind> {
-  let PseudoInstr = opName # !if(isLds, "_lds", "") # !if(isTFE, "_tfe", "") #
-                    "_" # getAddrName<addrKind>.ret;
+  let PseudoInstr = opName # !if(isPreGFX12Async, "_lds_async", !if(isLds, "_lds", "")) #
+                    !if(isTFE, "_tfe", "") # "_" # getAddrName<addrKind>.ret;
   let AsmMatchConverter = "cvtMubuf";
 
   let Constraints = !if(HasTiedDest, "$vdata = $vdata_in", "");
@@ -516,11 +516,40 @@ class MUBUF_Load_Pseudo <string opName,
   let has_vdata = !not(!or(isLds, isLdsOpc));
   let mayLoad = 1;
   let mayStore = isLds;
-  let Uses = !if(!or(isLds, isLdsOpc) , [EXEC, M0], [EXEC]);
+  let Uses = !if(isPreGFX12Async, [EXEC, M0, AsyncMarker],
+                 !if(!or(isLds, isLdsOpc), [EXEC, M0], [EXEC]));
   let tfe = isTFE;
   let lds = isLds;
   let elements = getMUBUFElements<vdata_vt>.ret;
   let VALU = isLds;
+}
+
+// Emits the non-async pseudo and, when isLds, its PreGFX12Async sibling.
+multiclass MUBUF_Load_Pseudo <string opName,
+                              int addrKind,
+                              ValueType vdata_vt,
+                              bit HasTiedDest = 0,
+                              bit isLds = 0,
+                              bit isLdsOpc = 0,
+                              bit isTFE = 0,
+                              bit hasRestrictedSOffset = 0,
+                              list<dag> pattern=[],
+                              RegisterOperand vdata_op = getBUFVDataRegisterOperand<vdata_vt.Size, isTFE>.ret,
+                              bit isAddr64 = 0,
+                              string addr64Key = ""> {
+  // Fall back to NAME for unpaired forms; the row lookup is then a harmless -1.
+  defvar nonAsyncKey = !if(!eq(addr64Key, ""), NAME, addr64Key);
+  if isLds then {
+    def ""     : MUBUF_Load_PseudoImpl<opName, addrKind, vdata_vt, HasTiedDest, isLds, isLdsOpc, isTFE, hasRestrictedSOffset, pattern, vdata_op>,
+                 MUBUFAddr64Table<isAddr64, nonAsyncKey>,
+                 PreGFX12AsyncTable<NAME, 0>;
+    def _ASYNC : MUBUF_Load_PseudoImpl<opName, addrKind, vdata_vt, HasTiedDest, isLds, isLdsOpc, isTFE, hasRestrictedSOffset, pattern, vdata_op, /*isPreGFX12Async=*/1>,
+                 MUBUFAddr64Table<isAddr64, nonAsyncKey # "_ASYNC">,
+                 PreGFX12AsyncTable<NAME, 1>;
+  } else {
+    def "" : MUBUF_Load_PseudoImpl<opName, addrKind, vdata_vt, HasTiedDest, isLds, isLdsOpc, isTFE, hasRestrictedSOffset, pattern, vdata_op>,
+             MUBUFAddr64Table<isAddr64, nonAsyncKey>;
+  }
 }
 
 class MUBUF_Offset_Load_Pat <Instruction inst, ValueType load_vt = i32, SDPatternOperator ld = null_frag> : GCNPat <
@@ -550,48 +579,55 @@ multiclass MUBUF_Pseudo_Load_Pats<string BaseInst, ValueType load_vt = i32, SDPa
 multiclass MUBUF_Pseudo_Loads_Helper<string opName, ValueType load_vt,
                                      bit TiedDest, bit isLds, bit isTFE, bit hasRestrictedSOffset> {
   defvar legal_load_vt = !if(!eq(load_vt, v3f16), v4f16, load_vt);
+  defvar addr64Key = NAME # !if(isLds, "_LDS", "");
 
-  def _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>,
-    MUBUFAddr64Table<0, NAME # !if(isLds, "_LDS", "")>;
+  defm _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [],
+                                    getBUFVDataRegisterOperand<legal_load_vt.Size, isTFE>.ret,
+                                    /*isAddr64=*/0, addr64Key>;
 
-  def _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>,
-    MUBUFAddr64Table<1, NAME # !if(isLds, "_LDS", "")>;
+  defm _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [],
+                                    getBUFVDataRegisterOperand<legal_load_vt.Size, isTFE>.ret,
+                                    /*isAddr64=*/1, addr64Key>;
 
-  def _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
-  def _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
-  def _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+  defm _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+  defm _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+  defm _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
 
   let DisableWQM = 1 in {
-    def _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
-    def _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
-    def _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
-    def _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+    defm _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+    defm _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+    defm _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
+    defm _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset>;
   }
 }
 
 multiclass MUBUF_Pseudo_Loads_Helper_t16<string opName, string Hi16Name, string Lo16Name, ValueType load_vt,
                                      bit TiedDest, bit isLds, bit isTFE, bit hasRestrictedSOffset> {
-  def _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
-    MUBUFAddr64Table<0, NAME # !if(isLds, "_LDS", "")>, True16D16Table<Hi16Name#"_OFFSET", Lo16Name#"_OFFSET">;
+  defvar addr64Key = NAME # !if(isLds, "_LDS", "");
 
-  def _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
-    MUBUFAddr64Table<1, NAME # !if(isLds, "_LDS", "")>, True16D16Table<Hi16Name#"_ADDR64", Lo16Name#"_ADDR64">;
+  defm _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16,
+                                    /*isAddr64=*/0, addr64Key>,
+    True16D16Table<Hi16Name#"_OFFSET", Lo16Name#"_OFFSET">;
 
-  def _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+  defm _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16,
+                                    /*isAddr64=*/1, addr64Key>,
+    True16D16Table<Hi16Name#"_ADDR64", Lo16Name#"_ADDR64">;
+
+  defm _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
     True16D16Table<Hi16Name#"_OFFEN", Lo16Name#"_OFFEN">;
-  def _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+  defm _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
     True16D16Table<Hi16Name#"_IDXEN", Lo16Name#"_IDXEN">;
-  def _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+  defm _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
     True16D16Table<Hi16Name#"_BOTHEN", Lo16Name#"_BOTHEN">;
 
   let DisableWQM = 1 in {
-    def _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+    defm _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_OFFSET_exact", Lo16Name#"_OFFSET_exact">;
-    def _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+    defm _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_OFFEN_exact", Lo16Name#"_OFFEN_exact">;
-    def _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+    defm _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_IDXEN_exact", Lo16Name#"_IDXEN_exact">;
-    def _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
+    defm _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_BOTHEN_exact", Lo16Name#"_BOTHEN_exact">;
   }
 }
@@ -634,7 +670,6 @@ multiclass MUBUF_Pseudo_Loads_Lds<string opName, ValueType load_vt = i32, Predic
   } else {
     defm _LDS : MUBUF_Pseudo_Loads<opName, load_vt, 0, 1>;
   }
-
 }
 
 class MUBUF_Store_Pseudo <string opName,
@@ -646,7 +681,7 @@ class MUBUF_Store_Pseudo <string opName,
                           bit isTrue16 = false>
   : MUBUF_Pseudo<opName,
                  (outs),
-                 getMUBUFIns<addrKind, [getVregSrcForVT<store_vt, isTrue16, 0>.ret], isTFE, hasRestrictedSOffset, isTrue16, 0>.ret,
+                 getMUBUFIns<addrKind, [getVregSrcForVT<store_vt, isTrue16, 0>.ret], isTFE, hasRestrictedSOffset, isTrue16>.ret,
                  getMUBUFAsmOps<addrKind, 0, 0, isTFE>.ret,
                  pattern>,
     MUBUF_SetupAddr<addrKind> {

--- a/llvm/lib/Target/AMDGPU/BUFInstructions.td
+++ b/llvm/lib/Target/AMDGPU/BUFInstructions.td
@@ -428,14 +428,13 @@ class getBUFVDataRegisterOperandForOp<RegisterOperand Op, bit isTFE> {
 
 class getMUBUFInsDA<list<RegisterOperand> vdataList,
                     list<RegisterOperand> vaddrList, bit isTFE, bit hasRestrictedSOffset,
-                    bit isTrue16, bit isLds, DAGOperand RsrcRC = SReg_128_XNULL> {
+                    bit isTrue16, DAGOperand RsrcRC = SReg_128_XNULL> {
   RegisterOperand vdataClass = !if(!empty(vdataList), ?, !head(vdataList));
   RegisterOperand vaddr_op = !if(!empty(vaddrList), ?, !head(vaddrList));
   RegisterOperand vdata_op = getBUFVDataRegisterOperand<!cast<SIRegisterClassLike>(vdataClass.RegClass).Size, isTFE, isTrue16>.ret;
 
   dag SOffset = !if(hasRestrictedSOffset, (ins SReg_32:$soffset), (ins SCSrc_b32:$soffset));
-  dag IsAsyncOpnd = !if(isLds, (ins i1imm_0:$IsAsync), (ins));
-  dag NonVaddrInputs = !con((ins RsrcRC:$srsrc), SOffset, (ins Offset:$offset, CPol_0:$cpol, i1imm_0:$swz), IsAsyncOpnd);
+  dag NonVaddrInputs = !con((ins RsrcRC:$srsrc), SOffset, (ins Offset:$offset, CPol_0:$cpol, i1imm_0:$swz));
 
   dag Inputs = !if(!empty(vaddrList), NonVaddrInputs, !con((ins vaddr_op:$vaddr), NonVaddrInputs));
   dag ret = !if(!empty(vdataList), Inputs, !con((ins vdata_op:$vdata), Inputs));
@@ -461,13 +460,13 @@ class getMUBUFElements<ValueType vt> {
 }
 
 class getMUBUFIns<int addrKind, list<RegisterOperand> vdataList, bit isTFE,
-                  bit hasRestrictedSOffset, bit isTrue16, bit isLds, DAGOperand RsrcRC = SReg_128_XNULL> {
+                  bit hasRestrictedSOffset, bit isTrue16, DAGOperand RsrcRC = SReg_128_XNULL> {
   dag ret =
-    !if(!eq(addrKind, BUFAddrKind.Offset), getMUBUFInsDA<vdataList, [], isTFE, hasRestrictedSOffset, isTrue16, isLds, RsrcRC>.ret,
-    !if(!eq(addrKind, BUFAddrKind.OffEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16, isLds, RsrcRC>.ret,
-    !if(!eq(addrKind, BUFAddrKind.IdxEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16, isLds, RsrcRC>.ret,
-    !if(!eq(addrKind, BUFAddrKind.BothEn), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16, isLds, RsrcRC>.ret,
-    !if(!eq(addrKind, BUFAddrKind.Addr64), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16, isLds, RsrcRC>.ret,
+    !if(!eq(addrKind, BUFAddrKind.Offset), getMUBUFInsDA<vdataList, [], isTFE, hasRestrictedSOffset, isTrue16, RsrcRC>.ret,
+    !if(!eq(addrKind, BUFAddrKind.OffEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16, RsrcRC>.ret,
+    !if(!eq(addrKind, BUFAddrKind.IdxEn),  getMUBUFInsDA<vdataList, [VGPROp_32], isTFE, hasRestrictedSOffset, isTrue16, RsrcRC>.ret,
+    !if(!eq(addrKind, BUFAddrKind.BothEn), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16, RsrcRC>.ret,
+    !if(!eq(addrKind, BUFAddrKind.Addr64), getMUBUFInsDA<vdataList, [VGPROp_64], isTFE, hasRestrictedSOffset, isTrue16, RsrcRC>.ret,
     (ins))))));
 }
 
@@ -500,27 +499,30 @@ class MUBUF_SetupAddr<int addrKind> {
   bits<1> has_vaddr = !ne(addrKind, BUFAddrKind.Offset);
 }
 
-class MUBUF_Load_Pseudo <string opName,
-                         int addrKind,
-                         ValueType vdata_vt,
-                         bit HasTiedDest = 0,
-                         bit isLds = 0,
-                         bit isLdsOpc = 0,
-                         bit isTFE = 0,
-                         bit hasRestrictedSOffset = 0,
-                         DAGOperand RsrcRC = SReg_128_XNULL,
-                         list<dag> pattern=[],
-                         RegisterOperand vdata_op = getBUFVDataRegisterOperand<vdata_vt.Size, isTFE>.ret>
+class MUBUF_Load_PseudoImpl <string opName,
+                             int addrKind,
+                             ValueType vdata_vt,
+                             bit HasTiedDest = 0,
+                             bit isLds = 0,
+                             bit isLdsOpc = 0,
+                             bit isTFE = 0,
+                             bit hasRestrictedSOffset = 0,
+                             DAGOperand RsrcRC = SReg_128_XNULL,
+                             list<dag> pattern=[],
+                             RegisterOperand vdata_op = getBUFVDataRegisterOperand<vdata_vt.Size, isTFE>.ret,
+                             bit isPreGFX12Async = 0>
   : MUBUF_Pseudo<opName,
                  !if(!or(isLds, isLdsOpc), (outs), (outs vdata_op:$vdata)),
-                 !con(getMUBUFIns<addrKind, [], isTFE, hasRestrictedSOffset, 0, isLds, RsrcRC>.ret,
+                 !con(getMUBUFIns<addrKind, [], isTFE, hasRestrictedSOffset, 0, RsrcRC>.ret,
                       !if(HasTiedDest, (ins vdata_op:$vdata_in), (ins))),
                  getMUBUFAsmOps<addrKind, !or(isLds, isLdsOpc), isLds, isTFE>.ret,
                  pattern>,
     MUBUF_SetupAddr<addrKind> {
   let isIndexed = !ne(RsrcRC, SReg_128_XNULL);
   defvar suffix = !if(isIndexed, "_indexed", "");
-  let PseudoInstr = opName # suffix # !if(isLds, "_lds", "") # !if(isTFE, "_tfe", "") #
+  let PseudoInstr = opName # suffix #
+                    !if(isPreGFX12Async, "_lds_async", !if(isLds, "_lds", "")) #
+                    !if(isTFE, "_tfe", "") #
                     "_" # getAddrName<addrKind>.ret;
   let AsmMatchConverter = "cvtMubuf";
 
@@ -529,11 +531,41 @@ class MUBUF_Load_Pseudo <string opName,
   let has_vdata = !not(!or(isLds, isLdsOpc));
   let mayLoad = 1;
   let mayStore = isLds;
-  let Uses = !if(!or(isLds, isLdsOpc) , [EXEC, M0], [EXEC]);
+  let Uses = !if(isPreGFX12Async, [EXEC, M0, AsyncMarker],
+                 !if(!or(isLds, isLdsOpc), [EXEC, M0], [EXEC]));
   let tfe = isTFE;
   let lds = isLds;
   let elements = getMUBUFElements<vdata_vt>.ret;
   let VALU = isLds;
+}
+
+// Emits the non-async pseudo and, when isLds, its PreGFX12Async sibling.
+multiclass MUBUF_Load_Pseudo <string opName,
+                              int addrKind,
+                              ValueType vdata_vt,
+                              bit HasTiedDest = 0,
+                              bit isLds = 0,
+                              bit isLdsOpc = 0,
+                              bit isTFE = 0,
+                              bit hasRestrictedSOffset = 0,
+                              DAGOperand RsrcRC = SReg_128_XNULL,
+                              list<dag> pattern=[],
+                              RegisterOperand vdata_op = getBUFVDataRegisterOperand<vdata_vt.Size, isTFE>.ret,
+                              bit isAddr64 = 0,
+                              string addr64Key = ""> {
+  // Fall back to NAME for unpaired forms; the row lookup is then a harmless -1.
+  defvar nonAsyncKey = !if(!eq(addr64Key, ""), NAME, addr64Key);
+  if isLds then {
+    def ""     : MUBUF_Load_PseudoImpl<opName, addrKind, vdata_vt, HasTiedDest, isLds, isLdsOpc, isTFE, hasRestrictedSOffset, RsrcRC, pattern, vdata_op>,
+                 MUBUFAddr64Table<isAddr64, nonAsyncKey>,
+                 PreGFX12AsyncTable<NAME, 0>;
+    def _ASYNC : MUBUF_Load_PseudoImpl<opName, addrKind, vdata_vt, HasTiedDest, isLds, isLdsOpc, isTFE, hasRestrictedSOffset, RsrcRC, pattern, vdata_op, /*isPreGFX12Async=*/1>,
+                 MUBUFAddr64Table<isAddr64, nonAsyncKey # "_ASYNC">,
+                 PreGFX12AsyncTable<NAME, 1>;
+  } else {
+    def "" : MUBUF_Load_PseudoImpl<opName, addrKind, vdata_vt, HasTiedDest, isLds, isLdsOpc, isTFE, hasRestrictedSOffset, RsrcRC, pattern, vdata_op>,
+             MUBUFAddr64Table<isAddr64, nonAsyncKey>;
+  }
 }
 
 class MUBUF_Offset_Load_Pat <Instruction inst, ValueType load_vt = i32, SDPatternOperator ld = null_frag> : GCNPat <
@@ -563,48 +595,55 @@ multiclass MUBUF_Pseudo_Load_Pats<string BaseInst, ValueType load_vt = i32, SDPa
 multiclass MUBUF_Pseudo_Loads_Helper<string opName, ValueType load_vt,
                                      bit TiedDest, bit isLds, bit isTFE, bit hasRestrictedSOffset, DAGOperand RsrcRC = SReg_128_XNULL> {
   defvar legal_load_vt = !if(!eq(load_vt, v3f16), v4f16, load_vt);
+  defvar addr64Key = NAME # !if(isLds, "_LDS", "");
 
-  def _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>,
-    MUBUFAddr64Table<0, NAME # !if(isLds, "_LDS", "")>;
+  defm _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [],
+                                    getBUFVDataRegisterOperand<legal_load_vt.Size, isTFE>.ret,
+                                    /*isAddr64=*/0, addr64Key>;
 
-  def _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>,
-    MUBUFAddr64Table<1, NAME # !if(isLds, "_LDS", "")>;
+  defm _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [],
+                                    getBUFVDataRegisterOperand<legal_load_vt.Size, isTFE>.ret,
+                                    /*isAddr64=*/1, addr64Key>;
 
-  def _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
-  def _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
-  def _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+  defm _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+  defm _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+  defm _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
 
   let DisableWQM = 1 in {
-    def _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
-    def _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
-    def _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
-    def _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+    defm _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+    defm _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+    defm _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
+    defm _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, legal_load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC>;
   }
 }
 
 multiclass MUBUF_Pseudo_Loads_Helper_t16<string opName, string Hi16Name, string Lo16Name, ValueType load_vt,
                                      bit TiedDest, bit isLds, bit isTFE, bit hasRestrictedSOffset, DAGOperand RsrcRC = SReg_128_XNULL> {
-  def _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
-    MUBUFAddr64Table<0, NAME # !if(isLds, "_LDS", "")>, True16D16Table<Hi16Name#"_OFFSET", Lo16Name#"_OFFSET">;
+  defvar addr64Key = NAME # !if(isLds, "_LDS", "");
 
-  def _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
-    MUBUFAddr64Table<1, NAME # !if(isLds, "_LDS", "")>, True16D16Table<Hi16Name#"_ADDR64", Lo16Name#"_ADDR64">;
+  defm _OFFSET : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16,
+                                    /*isAddr64=*/0, addr64Key>,
+    True16D16Table<Hi16Name#"_OFFSET", Lo16Name#"_OFFSET">;
 
-  def _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+  defm _ADDR64 : MUBUF_Load_Pseudo <opName, BUFAddrKind.Addr64, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16,
+                                    /*isAddr64=*/1, addr64Key>,
+    True16D16Table<Hi16Name#"_ADDR64", Lo16Name#"_ADDR64">;
+
+  defm _OFFEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
     True16D16Table<Hi16Name#"_OFFEN", Lo16Name#"_OFFEN">;
-  def _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+  defm _IDXEN  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
     True16D16Table<Hi16Name#"_IDXEN", Lo16Name#"_IDXEN">;
-  def _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+  defm _BOTHEN : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
     True16D16Table<Hi16Name#"_BOTHEN", Lo16Name#"_BOTHEN">;
 
   let DisableWQM = 1 in {
-    def _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+    defm _OFFSET_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.Offset, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_OFFSET_exact", Lo16Name#"_OFFSET_exact">;
-    def _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+    defm _OFFEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.OffEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_OFFEN_exact", Lo16Name#"_OFFEN_exact">;
-    def _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+    defm _IDXEN_exact  : MUBUF_Load_Pseudo <opName, BUFAddrKind.IdxEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_IDXEN_exact", Lo16Name#"_IDXEN_exact">;
-    def _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
+    defm _BOTHEN_exact : MUBUF_Load_Pseudo <opName, BUFAddrKind.BothEn, load_vt, TiedDest, isLds, 0, isTFE, hasRestrictedSOffset, RsrcRC, [], VGPROp_16>,
       True16D16Table<Hi16Name#"_BOTHEN_exact", Lo16Name#"_BOTHEN_exact">;
   }
 }
@@ -665,7 +704,7 @@ class MUBUF_Store_Pseudo <string opName,
                           bit isTrue16 = false>
   : MUBUF_Pseudo<opName,
                  (outs),
-                 getMUBUFIns<addrKind, [getVregSrcForVT<store_vt, isTrue16, 0>.ret], isTFE, hasRestrictedSOffset, isTrue16, 0, RsrcRC>.ret,
+                 getMUBUFIns<addrKind, [getVregSrcForVT<store_vt, isTrue16, 0>.ret], isTFE, hasRestrictedSOffset, isTrue16, RsrcRC>.ret,
                  getMUBUFAsmOps<addrKind, 0, 0, isTFE>.ret,
                  pattern>,
     MUBUF_SetupAddr<addrKind> {

--- a/llvm/lib/Target/AMDGPU/FLATInstructions.td
+++ b/llvm/lib/Target/AMDGPU/FLATInstructions.td
@@ -390,16 +390,19 @@ multiclass FLAT_Global_Store_Pseudo_t16<string opName> {
 
 // Async loads, introduced in gfx1250, will store directly
 // to a DS address in vdst (they will not use M0 for DS addess).
-class FLAT_Global_Load_LDS_Pseudo <string opName, bit EnableSaddr = 0, bit IsAsync = 0, bit IsLegacyLDSDMA = 0> : FLAT_Pseudo<
+class FLAT_Global_Load_LDS_PseudoImpl <string opName, bit EnableSaddr = 0, bit IsAsync = 0, bit IsPreGFX12Async = 0> : FLAT_Pseudo<
   opName,
   (outs ),
   !con(
        !if(IsAsync, (ins VGPROp_32:$vdst), (ins)),
        !if(EnableSaddr, (ins SReg_64:$saddr, VGPROp_32:$vaddr), (ins VGPROp_64:$vaddr)),
-       (ins flat_offset:$offset, CPol_0:$cpol),
-       !if(IsLegacyLDSDMA, (ins i1imm_0:$IsAsync), (ins))),
+       (ins flat_offset:$offset, CPol_0:$cpol)),
   !if(IsAsync, " $vdst,", "")#" $vaddr"#!if(EnableSaddr, ", $saddr", ", off")#"$offset$cpol"> {
   let LGKM_CNT = 0;
+  // IsPreGFX12Async is a pure modeling fiction: keep VM_CNT/ASYNC_CNT TSFlags
+  // unchanged so SIInsertWaitcnts treats the pseudo like a normal gfx9/gfx10
+  // load-to-LDS instruction (and never tries to emit S_WAIT_ASYNCCNT,
+  // gfx12+ only).
   let VM_CNT = !not(IsAsync);
   let ASYNC_CNT = IsAsync;
   let is_flat_global = 1;
@@ -412,16 +415,30 @@ class FLAT_Global_Load_LDS_Pseudo <string opName, bit EnableSaddr = 0, bit IsAsy
   let enabled_saddr = EnableSaddr;
   let VALU = 1;
   let PseudoInstr = opName#!if(EnableSaddr, "_SADDR", "");
-  let Uses = !if(IsAsync, [EXEC, ASYNCcnt], [M0, EXEC]);
+  let Uses = !if(IsPreGFX12Async, [M0, EXEC, AsyncMarker],
+                  !if(IsAsync, [EXEC, ASYNCcnt], [M0, EXEC]));
   let Defs = !if(IsAsync, [ASYNCcnt], []);
   let SchedRW = [WriteVMEM, WriteLDS];
 }
 
-multiclass FLAT_Global_Load_LDS_Pseudo<string opName, bit IsAsync = 0, bit IsLegacyLDSDMA = 0> {
-  def ""     : FLAT_Global_Load_LDS_Pseudo<opName, 0, IsAsync, IsLegacyLDSDMA>,
-    GlobalSaddrTable<0, opName>;
-  def _SADDR : FLAT_Global_Load_LDS_Pseudo<opName, 1, IsAsync, IsLegacyLDSDMA>,
-    GlobalSaddrTable<1, opName>;
+// Emits the non-async pseudo pair and, when IsPreGFX12Async, its async pair.
+multiclass FLAT_Global_Load_LDS_Pseudo<string opName, bit IsAsync = 0, bit IsPreGFX12Async = 0> {
+  def ""     : FLAT_Global_Load_LDS_PseudoImpl<opName, 0, IsAsync, 0>,
+    GlobalSaddrTable<0, opName>,
+    PreGFX12AsyncTable<opName, 0>;
+  def _SADDR : FLAT_Global_Load_LDS_PseudoImpl<opName, 1, IsAsync, 0>,
+    GlobalSaddrTable<1, opName>,
+    PreGFX12AsyncTable<opName # "_SADDR", 0>;
+
+  if IsPreGFX12Async then {
+    // Fake-async siblings don't participate in getGlobalSaddrOp pairing
+    // (no codegen path queries them by SADDR/non-SADDR), so skip
+    // GlobalSaddrTable attachment to avoid OpName-row collisions.
+    def _ASYNC       : FLAT_Global_Load_LDS_PseudoImpl<opName, 0, IsAsync, /*IsPreGFX12Async=*/1>,
+      PreGFX12AsyncTable<opName, 1>;
+    def _ASYNC_SADDR : FLAT_Global_Load_LDS_PseudoImpl<opName, 1, IsAsync, /*IsPreGFX12Async=*/1>,
+      PreGFX12AsyncTable<opName # "_SADDR", 1>;
+  }
 }
 
 class FLAT_Global_STORE_LDS_Pseudo <string opName, bit EnableSaddr = 0> : FLAT_Pseudo<
@@ -1214,15 +1231,15 @@ let SubtargetPredicate = HasGFX10_BEncoding in {
                                 VGPROp_32, i32>;
 }
 
-defm GLOBAL_LOAD_LDS_UBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ubyte", 0, 1>;
-defm GLOBAL_LOAD_LDS_SBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sbyte", 0, 1>;
-defm GLOBAL_LOAD_LDS_USHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ushort", 0, 1>;
-defm GLOBAL_LOAD_LDS_SSHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sshort", 0, 1>;
-defm GLOBAL_LOAD_LDS_DWORD  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dword", 0, 1>;
+defm GLOBAL_LOAD_LDS_UBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ubyte",  0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_SBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sbyte",  0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_USHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ushort", 0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_SSHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sshort", 0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_DWORD  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dword",  0, /*IsPreGFX12Async=*/1>;
 
 let SubtargetPredicate = HasGFX950Insts in {
-defm GLOBAL_LOAD_LDS_DWORDX3 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx3", 0, 1>;
-defm GLOBAL_LOAD_LDS_DWORDX4 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx4", 0, 1>;
+defm GLOBAL_LOAD_LDS_DWORDX3 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx3", 0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_DWORDX4 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx4", 0, /*IsPreGFX12Async=*/1>;
 }
 
 let SubtargetPredicate = isGFX12PlusNot12_50 in

--- a/llvm/lib/Target/AMDGPU/FLATInstructions.td
+++ b/llvm/lib/Target/AMDGPU/FLATInstructions.td
@@ -390,16 +390,18 @@ multiclass FLAT_Global_Store_Pseudo_t16<string opName> {
 
 // Async loads, introduced in gfx1250, will store directly
 // to a DS address in vdst (they will not use M0 for DS addess).
-class FLAT_Global_Load_LDS_Pseudo <string opName, bit EnableSaddr = 0, bit IsAsync = 0, bit IsLegacyLDSDMA = 0> : FLAT_Pseudo<
+class FLAT_Global_Load_LDS_PseudoImpl <string opName, bit EnableSaddr = 0, bit IsAsync = 0, bit IsPreGFX12Async = 0> : FLAT_Pseudo<
   opName,
   (outs ),
   !con(
        !if(IsAsync, (ins VGPROp_32:$vdst), (ins)),
        !if(EnableSaddr, (ins SReg_64:$saddr, VGPROp_32:$vaddr), (ins VGPROp_64:$vaddr)),
-       (ins flat_offset:$offset, CPol_0:$cpol),
-       !if(IsLegacyLDSDMA, (ins i1imm_0:$IsAsync), (ins))),
+       (ins flat_offset:$offset, CPol_0:$cpol)),
   !if(IsAsync, " $vdst,", "")#" $vaddr"#!if(EnableSaddr, ", $saddr", ", off")#"$offset$cpol"> {
   let LGKM_CNT = 0;
+  // Pre-gfx12 async operations use a distinct pseudo to carry AsyncMarker
+  // dependencies while retaining their VM_CNT behavior. Keep VM_CNT/ASYNC_CNT
+  // unchanged so SIInsertWaitcnts never emits S_WAIT_ASYNCCNT (gfx12+ only).
   let VM_CNT = !not(IsAsync);
   let ASYNC_CNT = IsAsync;
   let is_flat_global = 1;
@@ -412,16 +414,30 @@ class FLAT_Global_Load_LDS_Pseudo <string opName, bit EnableSaddr = 0, bit IsAsy
   let enabled_saddr = EnableSaddr;
   let VALU = 1;
   let PseudoInstr = opName#!if(EnableSaddr, "_SADDR", "");
-  let Uses = !if(IsAsync, [EXEC, ASYNCcnt], [M0, EXEC]);
+  let Uses = !if(IsPreGFX12Async, [M0, EXEC, AsyncMarker],
+                  !if(IsAsync, [EXEC, ASYNCcnt], [M0, EXEC]));
   let Defs = !if(IsAsync, [ASYNCcnt], []);
   let SchedRW = [WriteVMEM, WriteLDS];
 }
 
-multiclass FLAT_Global_Load_LDS_Pseudo<string opName, bit IsAsync = 0, bit IsLegacyLDSDMA = 0> {
-  def ""     : FLAT_Global_Load_LDS_Pseudo<opName, 0, IsAsync, IsLegacyLDSDMA>,
-    GlobalSaddrTable<0, opName>;
-  def _SADDR : FLAT_Global_Load_LDS_Pseudo<opName, 1, IsAsync, IsLegacyLDSDMA>,
-    GlobalSaddrTable<1, opName>;
+// Emits the non-async pseudo pair and, when IsPreGFX12Async, its async pair.
+multiclass FLAT_Global_Load_LDS_Pseudo<string opName, bit IsAsync = 0, bit IsPreGFX12Async = 0> {
+  def ""     : FLAT_Global_Load_LDS_PseudoImpl<opName, 0, IsAsync, 0>,
+    GlobalSaddrTable<0, opName>,
+    PreGFX12AsyncTable<opName, 0>;
+  def _SADDR : FLAT_Global_Load_LDS_PseudoImpl<opName, 1, IsAsync, 0>,
+    GlobalSaddrTable<1, opName>,
+    PreGFX12AsyncTable<opName # "_SADDR", 0>;
+
+  if IsPreGFX12Async then {
+    // Fake-async siblings don't participate in getGlobalSaddrOp pairing
+    // (no codegen path queries them by SADDR/non-SADDR), so skip
+    // GlobalSaddrTable attachment to avoid OpName-row collisions.
+    def _ASYNC       : FLAT_Global_Load_LDS_PseudoImpl<opName, 0, IsAsync, /*IsPreGFX12Async=*/1>,
+      PreGFX12AsyncTable<opName, 1>;
+    def _ASYNC_SADDR : FLAT_Global_Load_LDS_PseudoImpl<opName, 1, IsAsync, /*IsPreGFX12Async=*/1>,
+      PreGFX12AsyncTable<opName # "_SADDR", 1>;
+  }
 }
 
 class FLAT_Global_STORE_LDS_Pseudo <string opName, bit EnableSaddr = 0> : FLAT_Pseudo<
@@ -1214,15 +1230,15 @@ let SubtargetPredicate = HasGFX10_BEncoding in {
                                 VGPROp_32, i32>;
 }
 
-defm GLOBAL_LOAD_LDS_UBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ubyte", 0, 1>;
-defm GLOBAL_LOAD_LDS_SBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sbyte", 0, 1>;
-defm GLOBAL_LOAD_LDS_USHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ushort", 0, 1>;
-defm GLOBAL_LOAD_LDS_SSHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sshort", 0, 1>;
-defm GLOBAL_LOAD_LDS_DWORD  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dword", 0, 1>;
+defm GLOBAL_LOAD_LDS_UBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ubyte",  0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_SBYTE  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sbyte",  0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_USHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_ushort", 0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_SSHORT : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_sshort", 0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_DWORD  : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dword",  0, /*IsPreGFX12Async=*/1>;
 
 let SubtargetPredicate = HasGFX950Insts in {
-defm GLOBAL_LOAD_LDS_DWORDX3 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx3", 0, 1>;
-defm GLOBAL_LOAD_LDS_DWORDX4 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx4", 0, 1>;
+defm GLOBAL_LOAD_LDS_DWORDX3 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx3", 0, /*IsPreGFX12Async=*/1>;
+defm GLOBAL_LOAD_LDS_DWORDX4 : FLAT_Global_Load_LDS_Pseudo <"global_load_lds_dwordx4", 0, /*IsPreGFX12Async=*/1>;
 }
 
 let SubtargetPredicate = isGFX12PlusNot12_50 in

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -679,8 +679,13 @@ static void addRegsToSet(const SIRegisterInfo &TRI,
                          iterator_range<MachineInstr::const_mop_iterator> Ops,
                          BitVector &DefSet, BitVector &UseSet) {
   for (const MachineOperand &Op : Ops) {
-    if (Op.isReg())
-      addRegUnits(TRI, Op.isDef() ? DefSet : UseSet, Op.getReg().asMCReg());
+    if (!Op.isReg())
+      continue;
+    // AsyncMarker is a class-less fake register used for dependency modeling;
+    // it has no soft-clause def/use semantics.
+    if (Op.getReg() == AMDGPU::AsyncMarker)
+      continue;
+    addRegUnits(TRI, Op.isDef() ? DefSet : UseSet, Op.getReg().asMCReg());
   }
 }
 
@@ -806,6 +811,10 @@ int GCNHazardRecognizer::checkVMEMHazards(MachineInstr *VMEM) const {
   };
   for (const MachineOperand &Use : VMEM->uses()) {
     if (!Use.isReg() || TRI.isVectorRegister(MF.getRegInfo(), Use.getReg()))
+      continue;
+    // AsyncMarker is a class-less fake register used for dependency modeling;
+    // it isn't a real SGPR and has no VALU-write hazard.
+    if (Use.getReg() == AMDGPU::AsyncMarker)
       continue;
 
     int WaitStatesNeededForUse =
@@ -1456,7 +1465,12 @@ bool GCNHazardRecognizer::fixSMEMtoVectorWriteHazards(MachineInstr *MI) {
   const MachineOperand *SDST = TII->getNamedOperand(*MI, SDSTName);
   if (!SDST) {
     for (const auto &MO : MI->implicit_operands()) {
-      if (MO.isDef() && TRI->isSGPRClass(TRI->getPhysRegBaseClass(MO.getReg()))) {
+      // AsyncMarker is a class-less fake register used for dependency modeling;
+      // getPhysRegBaseClass returns null for it.
+      if (MO.getReg() == AMDGPU::AsyncMarker)
+        continue;
+      if (MO.isDef() &&
+          TRI->isSGPRClass(TRI->getPhysRegBaseClass(MO.getReg()))) {
         SDST = &MO;
         break;
       }

--- a/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNHazardRecognizer.cpp
@@ -1120,8 +1120,13 @@ static void addRegsToSet(const SIRegisterInfo &TRI,
                          iterator_range<MachineInstr::const_mop_iterator> Ops,
                          BitVector &DefSet, BitVector &UseSet) {
   for (const MachineOperand &Op : Ops) {
-    if (Op.isReg())
-      addRegUnits(TRI, Op.isDef() ? DefSet : UseSet, Op.getReg().asMCReg());
+    if (!Op.isReg())
+      continue;
+    // AsyncMarker is a class-less fake register used for dependency modeling;
+    // it has no soft-clause def/use semantics.
+    if (Op.getReg() == AMDGPU::AsyncMarker)
+      continue;
+    addRegUnits(TRI, Op.isDef() ? DefSet : UseSet, Op.getReg().asMCReg());
   }
 }
 
@@ -1247,6 +1252,10 @@ int GCNHazardRecognizer::checkVMEMHazards(MachineInstr *VMEM) const {
   };
   for (const MachineOperand &Use : VMEM->uses()) {
     if (!Use.isReg() || TRI.isVectorRegister(MF.getRegInfo(), Use.getReg()))
+      continue;
+    // AsyncMarker is a class-less fake register used for dependency modeling;
+    // it isn't a real SGPR and has no VALU-write hazard.
+    if (Use.getReg() == AMDGPU::AsyncMarker)
       continue;
 
     int WaitStatesNeededForUse =
@@ -1912,7 +1921,12 @@ bool GCNHazardRecognizer::fixSMEMtoVectorWriteHazards(MachineInstr *MI) {
   const MachineOperand *SDST = TII->getNamedOperand(*MI, SDSTName);
   if (!SDST) {
     for (const auto &MO : MI->implicit_operands()) {
-      if (MO.isDef() && TRI->isSGPRClass(TRI->getPhysRegBaseClass(MO.getReg()))) {
+      // AsyncMarker is a class-less fake register used for dependency modeling;
+      // getPhysRegBaseClass returns null for it.
+      if (MO.getReg() == AMDGPU::AsyncMarker)
+        continue;
+      if (MO.isDef() &&
+          TRI->isSGPRClass(TRI->getPhysRegBaseClass(MO.getReg()))) {
         SDST = &MO;
         break;
       }

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -12081,7 +12081,7 @@ SDValue SITargetLowering::handleD16VData(SDValue VData, SelectionDAG &DAG,
   return VData;
 }
 
-static bool isAsyncLDSDMA(Intrinsic::ID Intr) {
+static bool isPreGFX12Async(Intrinsic::ID Intr) {
   switch (Intr) {
   case Intrinsic::amdgcn_raw_buffer_load_async_lds:
   case Intrinsic::amdgcn_raw_ptr_buffer_load_async_lds:
@@ -12348,6 +12348,12 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
       break;
     }
 
+    if (isPreGFX12Async(IntrinsicID)) {
+      int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+      assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+      Opc = AsyncOpc;
+    }
+
     SDValue M0Val = copyToM0(DAG, Chain, DL, Op.getOperand(3));
 
     SmallVector<SDValue, 8> Ops;
@@ -12375,8 +12381,6 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
             ? 1
             : 0,
         DL, MVT::i8));                                           // swz
-    Ops.push_back(
-        DAG.getTargetConstant(isAsyncLDSDMA(IntrinsicID), DL, MVT::i8));
     Ops.push_back(M0Val.getValue(0));                            // Chain
     Ops.push_back(M0Val.getValue(1));                            // Glue
 
@@ -12456,13 +12460,17 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
       Ops.push_back(VOffset);
     }
 
+    if (isPreGFX12Async(IntrinsicID)) {
+      int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+      assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+      Opc = AsyncOpc;
+    }
+
     Ops.push_back(Op.getOperand(5));  // Offset
 
     unsigned Aux = Op.getConstantOperandVal(6);
     Ops.push_back(DAG.getTargetConstant(Aux & ~AMDGPU::CPol::VIRTUAL_BITS, DL,
                                         MVT::i32)); // CPol
-    Ops.push_back(
-        DAG.getTargetConstant(isAsyncLDSDMA(IntrinsicID), DL, MVT::i8));
 
     Ops.push_back(M0Val.getValue(0)); // Chain
     Ops.push_back(M0Val.getValue(1)); // Glue

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -12552,7 +12552,7 @@ SDValue SITargetLowering::handleD16VData(SDValue VData, SelectionDAG &DAG,
   return VData;
 }
 
-static bool isAsyncLDSDMA(Intrinsic::ID Intr) {
+static bool isPreGFX12Async(Intrinsic::ID Intr) {
   switch (Intr) {
   case Intrinsic::amdgcn_raw_buffer_load_async_lds:
   case Intrinsic::amdgcn_raw_ptr_buffer_load_async_lds:
@@ -12835,6 +12835,12 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
       break;
     }
 
+    if (isPreGFX12Async(IntrinsicID)) {
+      int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+      assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+      Opc = AsyncOpc;
+    }
+
     SDValue M0Val = copyToM0(DAG, Chain, DL, Op.getOperand(3));
 
     SmallVector<SDValue, 8> Ops;
@@ -12862,8 +12868,6 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
             ? 1
             : 0,
         DL, MVT::i8));                                           // swz
-    Ops.push_back(
-        DAG.getTargetConstant(isAsyncLDSDMA(IntrinsicID), DL, MVT::i8));
     Ops.push_back(M0Val.getValue(0));                            // Chain
     Ops.push_back(M0Val.getValue(1));                            // Glue
 
@@ -12943,13 +12947,17 @@ SDValue SITargetLowering::LowerINTRINSIC_VOID(SDValue Op,
       Ops.push_back(VOffset);
     }
 
+    if (isPreGFX12Async(IntrinsicID)) {
+      int AsyncOpc = AMDGPU::getPreGFX12AsyncOp(Opc);
+      assert(AsyncOpc != -1 && "PreGFX12Async sibling missing");
+      Opc = AsyncOpc;
+    }
+
     Ops.push_back(Op.getOperand(5));  // Offset
 
     unsigned Aux = Op.getConstantOperandVal(6);
     Ops.push_back(DAG.getTargetConstant(Aux & ~AMDGPU::CPol::VIRTUAL_BITS, DL,
                                         MVT::i32)); // CPol
-    Ops.push_back(
-        DAG.getTargetConstant(isAsyncLDSDMA(IntrinsicID), DL, MVT::i8));
 
     Ops.push_back(M0Val.getValue(0)); // Chain
     Ops.push_back(M0Val.getValue(1)); // Glue

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -660,9 +660,8 @@ public:
       return false;
     if (SIInstrInfo::usesASYNC_CNT(MI))
       return true;
-    const MachineOperand *Async =
-        TII.getNamedOperand(MI, AMDGPU::OpName::IsAsync);
-    return Async && (Async->getImm());
+    // Having a non-async sibling means MI is itself a PreGFX12 _ASYNC pseudo.
+    return AMDGPU::getPreGFX12NonAsyncOp(MI.getOpcode()) != -1;
   }
 
   bool isNonAsyncLdsDmaWrite(const MachineInstr &MI) const {

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -414,9 +414,8 @@ public:
       return false;
     if (SIInstrInfo::usesASYNC_CNT(MI))
       return true;
-    const MachineOperand *Async =
-        TII.getNamedOperand(MI, AMDGPU::OpName::IsAsync);
-    return Async && (Async->getImm());
+    // Having a non-async sibling means MI is itself a PreGFX12 _ASYNC pseudo.
+    return AMDGPU::getPreGFX12NonAsyncOp(MI.getOpcode()) != -1;
   }
 
   bool isNonAsyncLdsDmaWrite(const MachineInstr &MI) const {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10597,6 +10597,10 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
       Opcode = MFMAOp;
   }
 
+  // preGFX12Async pseudos share the encoding of their non-async sibling.
+  if (int NonAsync = AMDGPU::getPreGFX12NonAsyncOp(Opcode); NonAsync != -1)
+    Opcode = NonAsync;
+
   int32_t MCOp = AMDGPU::getMCOpcode(Opcode, Gen);
 
   if (MCOp == AMDGPU::INSTRUCTION_LIST_END && ST.hasGFX11_7Insts())

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -10868,6 +10868,10 @@ int SIInstrInfo::pseudoToMCOpcode(int Opcode) const {
     int MFMAOp = AMDGPU::getMFMAEarlyClobberOp(Opcode);
     if (MFMAOp != -1)
       Opcode = MFMAOp;
+  } else if (int NonAsync = AMDGPU::getPreGFX12NonAsyncOp(Opcode);
+             NonAsync != -1) {
+    // PreGFX12Async pseudos share the encoding of their non-async sibling.
+    Opcode = NonAsync;
   }
 
   int32_t MCOp = AMDGPU::getMCOpcode(Opcode, Gen);

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1852,6 +1852,15 @@ namespace AMDGPU {
   LLVM_READONLY
   int32_t getIfAddr64Inst(uint32_t Opcode);
 
+  /// Returns the PreGFX12Async sibling of a load-to-LDS opcode (MUBUF or FLAT),
+  /// or -1 if \p Opcode has no such sibling.
+  LLVM_READONLY
+  int32_t getPreGFX12AsyncOp(uint32_t Opcode);
+
+  /// Inverse of getPreGFX12AsyncOp.
+  LLVM_READONLY
+  int32_t getPreGFX12NonAsyncOp(uint32_t Opcode);
+
   LLVM_READONLY
   int32_t getSOPKOp(uint32_t Opcode);
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1870,6 +1870,15 @@ namespace AMDGPU {
   LLVM_READONLY
   int32_t getIfAddr64Inst(uint32_t Opcode);
 
+  /// Returns the PreGFX12Async sibling of a load-to-LDS opcode (MUBUF or FLAT),
+  /// or -1 if \p Opcode has no such sibling.
+  LLVM_READONLY
+  int32_t getPreGFX12AsyncOp(uint32_t Opcode);
+
+  /// Inverse of getPreGFX12AsyncOp.
+  LLVM_READONLY
+  int32_t getPreGFX12NonAsyncOp(uint32_t Opcode);
+
   LLVM_READONLY
   int32_t getSOPKOp(uint32_t Opcode);
 

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1274,8 +1274,6 @@ def CPol_NonGLC : ValuePredicatedOperand<CPol, "!(Op.getImm() & CPol::GLC)", 1>;
 def CPol_GLC_WithDefault : DefaultOperand<CPol_GLC, !shl(1, CPolBit.GLC)>;
 def CPol_NonGLC_WithDefault : DefaultOperand<CPol_NonGLC, 0>;
 
-def IsAsync : NamedBitOperand<"isasync">;
-
 def TFE : NamedBitOperand<"tfe">;
 def UNorm : NamedBitOperand<"unorm">;
 def DA : NamedBitOperand<"da">;
@@ -3415,6 +3413,30 @@ def getIfAddr64Inst : InstrMapping {
   let ColFields = ["IsAddr64"];
   let KeyCol = ["1"];
   let ValueCols = [["1"]];
+}
+
+// Pairs each MUBUF/FLAT load-to-LDS pseudo with its PreGFX12Async sibling.
+class PreGFX12AsyncTable<string opName, bit is_async = 0> {
+  string PreGFX12AsyncOpName = opName;
+  bit IsPreGFX12Async = is_async;
+}
+
+// Maps a load-to-LDS pseudo to its PreGFX12Async _ASYNC sibling.
+def getPreGFX12AsyncOp : InstrMapping {
+  let FilterClass = "PreGFX12AsyncTable";
+  let RowFields = ["PreGFX12AsyncOpName"];
+  let ColFields = ["IsPreGFX12Async"];
+  let KeyCol = ["0"];
+  let ValueCols = [["1"]];
+}
+
+// Inverse of getPreGFX12AsyncOp.
+def getPreGFX12NonAsyncOp : InstrMapping {
+  let FilterClass = "PreGFX12AsyncTable";
+  let RowFields = ["PreGFX12AsyncOpName"];
+  let ColFields = ["IsPreGFX12Async"];
+  let KeyCol = ["1"];
+  let ValueCols = [["0"]];
 }
 
 // Maps a GLOBAL to its SADDR form.

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -1332,8 +1332,6 @@ def CPol_NonGLC : ValuePredicatedOperand<CPol, "!(Op.getImm() & CPol::GLC)", 1>;
 def CPol_GLC_WithDefault : DefaultOperand<CPol_GLC, !shl(1, CPolBit.GLC)>;
 def CPol_NonGLC_WithDefault : DefaultOperand<CPol_NonGLC, 0>;
 
-def IsAsync : NamedBitOperand<"isasync">;
-
 def TFE : NamedBitOperand<"tfe">;
 def UNorm : NamedBitOperand<"unorm">;
 def DA : NamedBitOperand<"da">;
@@ -3488,6 +3486,30 @@ def getIfAddr64Inst : InstrMapping {
   let ColFields = ["IsAddr64"];
   let KeyCol = ["1"];
   let ValueCols = [["1"]];
+}
+
+// Pairs each MUBUF/FLAT load-to-LDS pseudo with its PreGFX12Async sibling.
+class PreGFX12AsyncTable<string opName, bit is_async = 0> {
+  string PreGFX12AsyncOpName = opName;
+  bit IsPreGFX12Async = is_async;
+}
+
+// Maps a load-to-LDS pseudo to its PreGFX12Async _ASYNC sibling.
+def getPreGFX12AsyncOp : InstrMapping {
+  let FilterClass = "PreGFX12AsyncTable";
+  let RowFields = ["PreGFX12AsyncOpName"];
+  let ColFields = ["IsPreGFX12Async"];
+  let KeyCol = ["0"];
+  let ValueCols = [["1"]];
+}
+
+// Inverse of getPreGFX12AsyncOp.
+def getPreGFX12NonAsyncOp : InstrMapping {
+  let FilterClass = "PreGFX12AsyncTable";
+  let RowFields = ["PreGFX12AsyncOpName"];
+  let ColFields = ["IsPreGFX12Async"];
+  let KeyCol = ["1"];
+  let ValueCols = [["0"]];
 }
 
 // Maps a GLOBAL to its SADDR form.

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -616,6 +616,7 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   // Reserve async counters pseudo registers
   reserveRegisterTuples(Reserved, AMDGPU::ASYNCcnt);
   reserveRegisterTuples(Reserved, AMDGPU::TENSORcnt);
+  reserveRegisterTuples(Reserved, AMDGPU::AsyncMarker);
 
   // Reserve src_pops_exiting_wave_id - support is not implemented in Codegen.
   reserveRegisterTuples(Reserved, AMDGPU::SRC_POPS_EXITING_WAVE_ID);

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -625,6 +625,7 @@ BitVector SIRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
   // Reserve async counters pseudo registers
   reserveRegisterTuples(Reserved, AMDGPU::ASYNCcnt);
   reserveRegisterTuples(Reserved, AMDGPU::TENSORcnt);
+  reserveRegisterTuples(Reserved, AMDGPU::AsyncMarker);
 
   // Reserve src_pops_exiting_wave_id - support is not implemented in Codegen.
   reserveRegisterTuples(Reserved, AMDGPU::SRC_POPS_EXITING_WAVE_ID);

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
@@ -276,6 +276,9 @@ def MODE : SIReg <"mode", 0>;
 def ASYNCcnt : SIReg <"ASYNCcnt", 0>;
 def TENSORcnt : SIReg <"TENSORcnt", 0>;
 
+// Not addressable. Models asyncmark/wait_asyncmark ordering (not a HW counter).
+def AsyncMarker : SIReg <"AsyncMarker", 0>;
+
 def LDS_DIRECT : SIReg <"src_lds_direct", 254> {
   // There is no physical register corresponding to this. This is an
   // encoding value in a source field, which will ultimately trigger a

--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.td
@@ -278,6 +278,9 @@ def MODE : SIReg <"mode", 0>;
 def ASYNCcnt : SIReg <"ASYNCcnt", 0>;
 def TENSORcnt : SIReg <"TENSORcnt", 0>;
 
+// Not addressable. Models asyncmark/wait_asyncmark ordering (not a HW counter).
+def AsyncMarker : SIReg <"AsyncMarker", 0>;
+
 def LDS_DIRECT : SIReg <"src_lds_direct", 254> {
   // There is no physical register corresponding to this. This is an
   // encoding value in a source field, which will ultimately trigger a

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-merge-rebase-pregfx12.mir
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-merge-rebase-pregfx12.mir
@@ -27,10 +27,10 @@ body:             |
   ; CHECK-NEXT:   liveins: $vgpr0_vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $m0 = S_MOV_B32 0
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
@@ -38,7 +38,7 @@ body:             |
   ; CHECK-NEXT:   liveins: $vgpr0_vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $m0 = S_MOV_B32 0
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
   ; CHECK-NEXT:   ASYNCMARK
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
@@ -62,10 +62,10 @@ body:             |
     liveins: $vgpr0_vgpr1, $vgpr2
 
     $m0 = S_MOV_B32 0
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
     S_BRANCH %bb.3
 
   ; branch target: async-mark predecessor, merged first (seeds incoming state)
@@ -74,7 +74,7 @@ body:             |
     liveins: $vgpr0_vgpr1, $vgpr2
 
     $m0 = S_MOV_B32 0
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
     ASYNCMARK
     S_BRANCH %bb.3
 
@@ -106,7 +106,7 @@ body:             |
   ; CHECK-NEXT:   liveins: $vgpr0_vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $m0 = S_MOV_B32 0
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
   ; CHECK-NEXT:   ASYNCMARK
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
@@ -115,10 +115,10 @@ body:             |
   ; CHECK-NEXT:   liveins: $vgpr0_vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $m0 = S_MOV_B32 0
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+  ; CHECK-NEXT:   GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3:
@@ -141,7 +141,7 @@ body:             |
     liveins: $vgpr0_vgpr1, $vgpr2
 
     $m0 = S_MOV_B32 0
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
     ASYNCMARK
     S_BRANCH %bb.3
 
@@ -151,10 +151,10 @@ body:             |
     liveins: $vgpr0_vgpr1, $vgpr2
 
     $m0 = S_MOV_B32 0
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 0, 0, 1, implicit $m0, implicit $exec :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
+    GLOBAL_LOAD_LDS_DWORD_ASYNC $vgpr0_vgpr1, 0, 0, implicit $m0, implicit $exec, implicit $asyncmarker :: (load (s32), addrspace 1), (store (s32), addrspace 3)
     S_BRANCH %bb.3
 
   bb.3:

--- a/llvm/test/CodeGen/AMDGPU/hazard-flat-instruction-valu-check.mir
+++ b/llvm/test/CodeGen/AMDGPU/hazard-flat-instruction-valu-check.mir
@@ -12,10 +12,10 @@ body:             |
     ; GCN-LABEL: name: test_flat_valu_hazard
     ; GCN: liveins: $vgpr0, $vgpr1
     ; GCN-NEXT: {{  $}}
-    ; GCN-NEXT: GLOBAL_LOAD_LDS_DWORD_SADDR killed $sgpr0_sgpr1, killed $vgpr0, 32, 2, 0, implicit $m0, implicit $exec
+    ; GCN-NEXT: GLOBAL_LOAD_LDS_DWORD_SADDR killed $sgpr0_sgpr1, killed $vgpr0, 32, 2, implicit $m0, implicit $exec
     ; GCN-NEXT: $vgpr0 = V_MOV_B32_e32 killed $vgpr1, implicit $exec, implicit $exec
     ; GCN-NEXT: FLAT_STORE_DWORDX2 killed renamable $vgpr2_vgpr3, killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
-    GLOBAL_LOAD_LDS_DWORD_SADDR killed $sgpr0_sgpr1, killed $vgpr0, 32, 2, 0, implicit $m0, implicit $exec
+    GLOBAL_LOAD_LDS_DWORD_SADDR killed $sgpr0_sgpr1, killed $vgpr0, 32, 2, implicit $m0, implicit $exec
     $vgpr0 = V_MOV_B32_e32 killed $vgpr1, implicit $exec, implicit $exec
     FLAT_STORE_DWORDX2 killed renamable $vgpr2_vgpr3, killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr
 ...

--- a/llvm/test/CodeGen/AMDGPU/insert-waitcnts-fence-soft.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-waitcnts-fence-soft.mir
@@ -10,12 +10,12 @@ body:             |
     ; GCN-LABEL: name: dma_then_fence
     ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
-    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
+    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     S_WAITCNT_lds_direct
     $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     S_ENDPGM 0
@@ -31,13 +31,13 @@ body:             |
     ; GCN-LABEL: name: dma_then_global_load
     ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
-    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
+    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: S_WAITCNT .Vmcnt_1
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     S_WAITCNT_lds_direct
     $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
@@ -71,12 +71,12 @@ body:             |
   bb.0:
     ; GCN-LABEL: name: dma_then_system_fence
     ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
-    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
+    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: S_WAITCNT .Vmcnt_1
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     S_WAITCNT_lds_direct
     $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
@@ -93,13 +93,13 @@ body:             |
     ; GCN-LABEL: name: merge_with_prev_wait
     ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
-    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
+    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     S_WAITCNT 3952
     S_WAITCNT_lds_direct
@@ -117,13 +117,13 @@ body:             |
     ; GCN-LABEL: name: merge_with_next_wait
     ; GCN: S_WAITCNT .Vmcnt_0_Expcnt_0_Lgkmcnt_0
     ; GCN-NEXT: $m0 = S_MOV_B32 0
-    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
+    ; GCN-NEXT: BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1), (store (s32) into `ptr addrspace(3) poison` + 4, addrspace 3)
     ; GCN-NEXT: $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     ; GCN-NEXT: S_WAITCNT .Vmcnt_0
     ; GCN-NEXT: $vgpr1 = V_ADD_F32_e32 $vgpr1, $vgpr1, implicit $mode, implicit $exec
     ; GCN-NEXT: S_ENDPGM 0
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr2 = GLOBAL_LOAD_DWORD $vgpr4_vgpr5, 0, 0, implicit $exec
     S_WAITCNT_lds_direct
     S_WAITCNT 3952

--- a/llvm/test/CodeGen/AMDGPU/lds-dma-hazards.mir
+++ b/llvm/test/CodeGen/AMDGPU/lds-dma-hazards.mir
@@ -9,7 +9,7 @@ name: buffer_load_dword_lds
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_ADDR64 $vgpr0_vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, 0, 4, 0, 0, 0, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORD_LDS_ADDR64 $vgpr0_vgpr1, $sgpr0_sgpr1_sgpr2_sgpr3, 0, 4, 0, 0, implicit $exec, implicit $m0
 ...
 
 # GCN-LABEL: name: buffer_store_lds_dword
@@ -33,7 +33,7 @@ name: global_load_lds_dword
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    GLOBAL_LOAD_LDS_DWORD $vgpr2_vgpr3, 0, 0, 0, implicit $exec, implicit $m0
+    GLOBAL_LOAD_LDS_DWORD $vgpr2_vgpr3, 0, 0, implicit $exec, implicit $m0
 ...
 
 # GCN-LABEL: name: scratch_load_lds_dword

--- a/llvm/test/CodeGen/AMDGPU/lds-dma-waitcnt.mir
+++ b/llvm/test/CodeGen/AMDGPU/lds-dma-waitcnt.mir
@@ -10,7 +10,7 @@ name: buffer_load_dword_lds_ds_read
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr0 = DS_READ_B32_gfx9 $vgpr1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) poison`)
     S_ENDPGM 0
 
@@ -27,7 +27,7 @@ name: buffer_load_dword_lds_vmcnt_1
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
     $vgpr10 = BUFFER_LOAD_DWORD_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`)
     $vgpr0 = DS_READ_B32_gfx9 $vgpr1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) poison`)
     S_ENDPGM 0
@@ -44,7 +44,7 @@ name: buffer_load_dword_lds_flat_read
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
     $vgpr0 = FLAT_LOAD_DWORD $vgpr0_vgpr1, 0, 0, implicit $exec, implicit $flat_scr :: (load (s32) from `ptr poison`)
 
     S_ENDPGM 0
@@ -61,7 +61,7 @@ name: global_load_lds_dword_ds_read
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    GLOBAL_LOAD_LDS_DWORD $vgpr0_vgpr1, 4, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr0 = DS_READ_B32_gfx9 $vgpr1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) poison`)
     S_ENDPGM 0
 
@@ -80,7 +80,7 @@ body:             |
   bb.0:
     $m0 = S_MOV_B32 0
     $vgpr0 = DS_READ_B32_gfx9 $vgpr1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) poison`)
-    GLOBAL_LOAD_LDS_DWORD $vgpr2_vgpr3, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    GLOBAL_LOAD_LDS_DWORD $vgpr2_vgpr3, 4, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
     $vgpr4 = V_ADD_U32_e32 $vgpr0, $vgpr0, implicit $exec
     S_ENDPGM 0
 
@@ -100,7 +100,7 @@ body:             |
   bb.0:
     $m0 = S_MOV_B32 0
     $vgpr0 = DS_READ_B32_gfx9 $vgpr1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) poison`)
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr2, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
     $vgpr4 = V_ADD_U32_e32 $vgpr0, $vgpr0, implicit $exec
     S_ENDPGM 0
 
@@ -149,9 +149,9 @@ name: series_of_buffer_load_dword_lds_ds_read
 body:             |
   bb.0:
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
-    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 8, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 8), (store (s32) into `ptr addrspace(3) poison` + 8)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 0, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison`), (store (s32) into `ptr addrspace(3) poison`)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 4, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 4), (store (s32) into `ptr addrspace(3) poison` + 4)
+    BUFFER_LOAD_DWORD_LDS_IDXEN $vgpr0, $sgpr0_sgpr1_sgpr2_sgpr3, $sgpr4, 8, 0, 0, implicit $exec, implicit $m0 :: (load (s32) from `ptr addrspace(1) poison` + 8), (store (s32) into `ptr addrspace(3) poison` + 8)
     $vgpr0 = DS_READ_B32_gfx9 $vgpr1, 0, 0, implicit $m0, implicit $exec :: (load (s32) from `ptr addrspace(3) poison`)
     S_ENDPGM 0
 

--- a/llvm/test/CodeGen/AMDGPU/ldsdma-not-coexec-valu.mir
+++ b/llvm/test/CodeGen/AMDGPU/ldsdma-not-coexec-valu.mir
@@ -17,11 +17,11 @@ body: |
     ; CHECK-NEXT: $exec = IMPLICIT_DEF
     ; CHECK-NEXT: $m0 = IMPLICIT_DEF
     ; CHECK-NEXT: early-clobber $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = V_WMMA_F32_16X16X32_BF16_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 8, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, 0, 0, 0, 0, implicit $exec
-    ; CHECK-NEXT: GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr0_sgpr1, $vgpr16, 0, 0, 0, implicit $m0, implicit $exec
+    ; CHECK-NEXT: GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr0_sgpr1, $vgpr16, 0, 0, implicit $m0, implicit $exec
     ; CHECK-NEXT: S_ENDPGM 0
     $exec = IMPLICIT_DEF
     $m0 = IMPLICIT_DEF
     $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23 = V_WMMA_F32_16X16X32_BF16_w32_twoaddr $vgpr0_vgpr1_vgpr2_vgpr3_vgpr4_vgpr5_vgpr6_vgpr7, $vgpr8_vgpr9_vgpr10_vgpr11_vgpr12_vgpr13_vgpr14_vgpr15, 8, $vgpr16_vgpr17_vgpr18_vgpr19_vgpr20_vgpr21_vgpr22_vgpr23, 0, 0, 0, 0, implicit $exec
-    GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr0_sgpr1, $vgpr16, 0, 0, 0, implicit $m0, implicit $exec
+    GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr0_sgpr1, $vgpr16, 0, 0, implicit $m0, implicit $exec
     S_ENDPGM 0
 ...

--- a/llvm/test/CodeGen/AMDGPU/ldsdma-not-valu-wait-sgpr.mir
+++ b/llvm/test/CodeGen/AMDGPU/ldsdma-not-valu-wait-sgpr.mir
@@ -21,7 +21,7 @@ body: |
     ; CHECK-NEXT: $m0 = IMPLICIT_DEF
     ; CHECK-NEXT: $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr4, implicit $exec
     ; CHECK-NEXT: $sgpr5 = V_READFIRSTLANE_B32 $vgpr3, implicit $exec
-    ; CHECK-NEXT: GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr4_sgpr5, $vgpr0, 0, 0, 0, implicit $m0, implicit $exec
+    ; CHECK-NEXT: GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr4_sgpr5, $vgpr0, 0, 0, implicit $m0, implicit $exec
     ; CHECK-NEXT: S_ENDPGM 0
     $exec_lo = IMPLICIT_DEF
     $vgpr0 = IMPLICIT_DEF
@@ -32,6 +32,6 @@ body: |
     $m0 = IMPLICIT_DEF
     $vgpr1 = V_CNDMASK_B32_e64 0, $vgpr1, 0, $vgpr2, $sgpr4, implicit $exec
     $sgpr5 = V_READFIRSTLANE_B32 $vgpr3, implicit $exec
-    GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr4_sgpr5, $vgpr0, 0, 0, 0, implicit $m0, implicit $exec
+    GLOBAL_LOAD_LDS_DWORD_SADDR $sgpr4_sgpr5, $vgpr0, 0, 0, implicit $m0, implicit $exec
     S_ENDPGM 0
 ...

--- a/llvm/test/CodeGen/AMDGPU/sched-handleMoveUp-dead-def-join.mir
+++ b/llvm/test/CodeGen/AMDGPU/sched-handleMoveUp-dead-def-join.mir
@@ -178,9 +178,9 @@ body:             |
     %8.sub2:sgpr_128 = COPY %9.sub2
     %8.sub3:sgpr_128 = COPY %9.sub3
     $m0 = S_MOV_B32 45408
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %106, %8, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %106, %8, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     $m0 = S_MOV_B32 46432
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %107, %8, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %107, %8, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %108:vgpr_32 = nuw nsw V_LSHLREV_B32_e32 3, %22, implicit $exec
     %109:vgpr_32 = disjoint V_OR_B32_e32 512, %108, implicit $exec
     %110:vgpr_32 = disjoint V_OR_B32_e32 1024, %108, implicit $exec
@@ -194,41 +194,41 @@ body:             |
     %7.sub3:sgpr_128 = COPY %9.sub3
     %116:vgpr_32 = V_LSHLREV_B32_e32 1, %112, implicit $exec
     $m0 = S_MOV_B32 32768
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %116, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %116, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %117:vgpr_32 = V_LSHLREV_B32_e32 1, %113, implicit $exec
     $m0 = S_MOV_B32 33824
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %117, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %117, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %118:vgpr_32 = V_LSHLREV_B32_e32 1, %114, implicit $exec
     $m0 = S_MOV_B32 34880
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %118, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %118, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %119:vgpr_32 = V_LSHLREV_B32_e32 1, %115, implicit $exec
     $m0 = S_MOV_B32 35936
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %119, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %119, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %120:sreg_32 = disjoint S_OR_B32 %105, 2048, implicit-def dead $scc
     %121:vgpr_32 = disjoint V_OR_B32_e32 %120, %29, implicit $exec
     %122:vgpr_32 = disjoint V_OR_B32_e32 %120, %30, implicit $exec
     S_WAITCNT 49279
     WAVE_BARRIER
     $m0 = S_MOV_B32 47456
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %121, %8, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %121, %8, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     $m0 = S_MOV_B32 48480
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %122, %8, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %122, %8, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %123:vgpr_32 = disjoint V_OR_B32_e32 %120, %108, implicit $exec
     %124:vgpr_32 = disjoint V_OR_B32_e32 %120, %109, implicit $exec
     %125:vgpr_32 = disjoint V_OR_B32_e32 %120, %110, implicit $exec
     %126:vgpr_32 = V_OR_B32_e32 %120, %111, implicit $exec
     %127:vgpr_32 = V_LSHLREV_B32_e32 1, %123, implicit $exec
     $m0 = S_MOV_B32 36992
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %127, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %127, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %128:vgpr_32 = V_LSHLREV_B32_e32 1, %124, implicit $exec
     $m0 = S_MOV_B32 38048
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %128, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %128, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %129:vgpr_32 = V_LSHLREV_B32_e32 1, %125, implicit $exec
     $m0 = S_MOV_B32 39104
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %129, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %129, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %130:vgpr_32 = V_LSHLREV_B32_e32 1, %126, implicit $exec
     $m0 = S_MOV_B32 40160
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %130, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %130, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     S_WAITCNT 49279
     WAVE_BARRIER
     %131:sreg_32 = disjoint S_OR_B32 %105, 4096, implicit-def dead $scc
@@ -719,9 +719,9 @@ body:             |
     %389:sreg_32 = S_LSHL_B32 %17, 11, implicit-def dead $scc
     %14:sreg_32 = S_ADD_I32 %389, 45408, implicit-def dead $scc
     $m0 = COPY %14
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %387, %8, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %387, %8, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     $m0 = S_ADD_I32 %389, 46432, implicit-def dead $scc
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %388, %8, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %388, %8, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %390:vgpr_32 = nuw V_ADD_U32_e32 %316, %133, implicit $exec
     %391:vreg_128_align2 = DS_READ_B128_gfx9 %390, 0, 0, implicit $exec
     %392:vreg_128_align2 = DS_READ_B128_gfx9 %390, 16, 0, implicit $exec
@@ -2666,16 +2666,16 @@ body:             |
     %15:sreg_32 = S_ADD_I32 %1162, 32768, implicit-def dead $scc
     %1163:vgpr_32 = V_LSHLREV_B32_e32 1, %1156, implicit $exec
     $m0 = COPY %15
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %1163, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %1163, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     $m0 = S_ADD_I32 %1162, 33824, implicit-def dead $scc
     %1164:vgpr_32 = V_LSHLREV_B32_e32 1, %1157, implicit $exec
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %1164, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %1164, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     $m0 = S_ADD_I32 %1162, 34880, implicit-def dead $scc
     %1165:vgpr_32 = V_LSHLREV_B32_e32 1, %1158, implicit $exec
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %1165, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %1165, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     $m0 = S_ADD_I32 %1162, 35936, implicit-def dead $scc
     %1166:vgpr_32 = V_LSHLREV_B32_e32 1, %1159, implicit $exec
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %1166, %7, 0, 0, 0, 0, 1, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN_ASYNC %1166, %7, 0, 0, 0, 0, implicit $exec, implicit $m0, implicit $asyncmarker
     %1167:vgpr_32 = nuw V_ADD_U32_e32 %319, %108, implicit $exec
     undef %1168.sub0_sub1:av_128_align2 = DS_READ_B64_TR_B16 %1167, 0, 0, implicit $exec
     %1168.sub2_sub3:av_128_align2 = DS_READ_B64_TR_B16 %1167, 512, 0, implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/sched.group.classification.mir
+++ b/llvm/test/CodeGen/AMDGPU/sched.group.classification.mir
@@ -18,11 +18,11 @@ body: |
     ; CHECK-NEXT: [[V_ADD_U32_e32_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[DEF2]], [[DEF3]], implicit $exec
     ; CHECK-NEXT: [[V_ADD_U32_e32_1:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[DEF3]], [[V_ADD_U32_e32_]], implicit $exec
     ; CHECK-NEXT: $m0 = S_MOV_B32 0
-    ; CHECK-NEXT: BUFFER_LOAD_DWORDX4_LDS_OFFEN [[DEF]], [[DEF1]], 0, 0, 0, 0, 0, implicit $exec, implicit $m0
+    ; CHECK-NEXT: BUFFER_LOAD_DWORDX4_LDS_OFFEN [[DEF]], [[DEF1]], 0, 0, 0, 0, implicit $exec, implicit $m0
     ; CHECK-NEXT: [[V_ADD_U32_e32_2:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[V_ADD_U32_e32_]], [[V_ADD_U32_e32_1]], implicit $exec
     ; CHECK-NEXT: [[V_ADD_U32_e32_3:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[V_ADD_U32_e32_1]], [[V_ADD_U32_e32_2]], implicit $exec
     ; CHECK-NEXT: $m0 = S_MOV_B32 1
-    ; CHECK-NEXT: BUFFER_LOAD_DWORDX4_LDS_OFFEN [[DEF]], [[DEF1]], 0, 0, 0, 0, 0, implicit $exec, implicit $m0
+    ; CHECK-NEXT: BUFFER_LOAD_DWORDX4_LDS_OFFEN [[DEF]], [[DEF1]], 0, 0, 0, 0, implicit $exec, implicit $m0
     ; CHECK-NEXT: [[V_ADD_U32_e32_4:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[V_ADD_U32_e32_2]], [[V_ADD_U32_e32_3]], implicit $exec
     ; CHECK-NEXT: [[V_ADD_U32_e32_5:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[V_ADD_U32_e32_3]], [[V_ADD_U32_e32_4]], implicit $exec
     ; CHECK-NEXT: [[V_ADD_U32_e32_6:%[0-9]+]]:vgpr_32 = V_ADD_U32_e32 [[V_ADD_U32_e32_4]], [[V_ADD_U32_e32_5]], implicit $exec
@@ -41,9 +41,9 @@ body: |
     %4:vgpr_32 = V_ADD_U32_e32 %2, %3, implicit $exec
     %5:vgpr_32 = V_ADD_U32_e32 %3, %4, implicit $exec
     $m0 = S_MOV_B32 0
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %0, %1, 0, 0, 0, 0, 0, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN %0, %1, 0, 0, 0, 0, implicit $exec, implicit $m0
     $m0 = S_MOV_B32 1
-    BUFFER_LOAD_DWORDX4_LDS_OFFEN %0, %1, 0, 0, 0, 0, 0, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORDX4_LDS_OFFEN %0, %1, 0, 0, 0, 0, implicit $exec, implicit $m0
     %6:vgpr_32 = V_ADD_U32_e32 %4, %5, implicit $exec
     %7:vgpr_32 = V_ADD_U32_e32 %5, %6, implicit $exec
     %8:vgpr_32 = V_ADD_U32_e32 %6, %7, implicit $exec

--- a/llvm/test/MC/AMDGPU/buffer-op-lds-operand.s
+++ b/llvm/test/MC/AMDGPU/buffer-op-lds-operand.s
@@ -7,7 +7,6 @@ buffer_load_dword off, s[8:11], 0 lds
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
-// CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>>
 buffer_load_dword v18, s[8:11], 0 offen lds
 // CHECK: buffer_load_dword v18, s[8:11], 0 offen lds ; <MCInst #{{[0-9]+}} BUFFER_LOAD_DWORD_LDS_OFFEN
@@ -16,13 +15,11 @@ buffer_load_dword v18, s[8:11], 0 offen lds
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
-// CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>>
 buffer_load_dword v18, s[8:11], 0 idxen lds
 // CHECK: buffer_load_dword v18, s[8:11], 0 idxen lds ; <MCInst #{{[0-9]+}} BUFFER_LOAD_DWORD_LDS_IDXEN
 // CHECK-NEXT: ;  <MCOperand Reg:VGPR18>
 // CHECK-NEXT: ;  <MCOperand Reg:SGPR8_SGPR9_SGPR10_SGPR11>
-// CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>
 // CHECK-NEXT: ;  <MCOperand Imm:0>

--- a/llvm/unittests/Target/AMDGPU/InstSizes.cpp
+++ b/llvm/unittests/Target/AMDGPU/InstSizes.cpp
@@ -22,8 +22,8 @@ public:
 };
 
 // getInstSizeInBytes appends a 4-byte literal word for a VALU/SALU instruction
-// whose source operand is a non-inline immediate. The offset/cpol/swz/IsAsync
-// fields of an LDS-DMA buffer load are packed into the instruction word and are
+// whose source operand is a non-inline immediate. The offset/cpol/swz fields of
+// an LDS-DMA buffer load are packed into the instruction word and are
 // not source operands, so they must not be counted as a literal: the load is
 // 8 bytes, not 12.
 TEST_F(InstSizesTest, BufferLoadLdsIsNotOverSized) {
@@ -31,8 +31,8 @@ TEST_F(InstSizesTest, BufferLoadLdsIsNotOverSized) {
 name: buffer_load_lds
 body: |
   bb.0:
-    BUFFER_LOAD_DWORD_LDS_OFFEN $vgpr1, $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, 0, implicit $exec, implicit $m0
-    BUFFER_LOAD_DWORD_LDS_OFFSET $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, 0, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORD_LDS_OFFEN $vgpr1, $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, implicit $exec, implicit $m0
+    BUFFER_LOAD_DWORD_LDS_OFFSET $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, implicit $exec, implicit $m0
     $vgpr0 = V_MOV_B32_e32 12345, implicit $exec
     $vgpr0 = V_MOV_B32_e32 1, implicit $exec
     S_ENDPGM 0


### PR DESCRIPTION
ASYNCMARK previously acted as a global memory barrier in the scheduler because of its hasSideEffects bit, pinning all surrounding memory access (read/write, sync/async, vmem/lds, etc) in place.

This commit improves scheduling freedom for ASYNCMARK by

1. Stop reporting ASYNCMARK as a global memory object. WAIT_ASYNCMARK is still a global memory object so ordinary loads/stores remain anchored across waits.

2. Instead, express the strictly necessary ordering with an artificial-edge DAG mutation:

   2.1. Relative order of ASYNCMARKs and WAIT_ASYNCMARKs is kept. 2.2. Each async load/store gets an edge to the next ASYNCMARK and an edge from the previous ASYNCMARK.

   ASYNCMARKs are otherwise exempt from dependencies with non-async load/store. WAIT_ASYNCMARK anchoring is left to the natural memory dep that WAIT_ASYNCMARK provides as a global memory object.

The mutation is registered in every pre-RA scheduler stage and in the post-RA scheduler, and handles BUNDLEs created by SIPostRABundler / SIInsertHardClauses.

The new mutation is a must-have for correctness: once ASYNCMARK is no longer a global memory object, the scheduler is free to reorder it across async loads/stores and WAIT_ASYNCMARK in ways that break program semantics. Later scheduler stages must remember to register this mutation.