### PR TITLE
[libc] Remove sysconf from Scudo integration test entrypoints

### DIFF
--- a/libc/test/integration/scudo/CMakeLists.txt
+++ b/libc/test/integration/scudo/CMakeLists.txt
@@ -28,7 +28,6 @@ add_entrypoint_library(
     libc.src.unistd.__llvm_libc_syscall
     libc.src.unistd.close
     libc.src.unistd.read
-    libc.src.unistd.sysconf
     libc.src.unistd.write
 )
 


### PR DESCRIPTION
sysconf moved behind LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS in commit 8146920541c4. When that flag is OFF (the default), the target is not built as an OBJECT library, so referencing it via add_entrypoint_library causes a CMake generation error on the libc-x86_64-debian-fullbuild bot.

Scudo does not use sysconf, so this is a safe removal.

Assisted-by: Automated tooling, human reviewed.