### PR TITLE
[lldb-dap] Don't emit memory reference for constants

### DIFF
--- a/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
+++ b/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py
@@ -155,6 +155,7 @@ class TestDAP_evaluate(lldbdap_testcase.DAPTestCaseBase):
         self.assertEvaluate("non_static_int", "43", want_type="int")
         self.assertEvaluate("struct1.foo", "15", want_type="int")
         self.assertEvaluate("struct2->foo", "16", want_type="int")
+        self.assertEvaluate("10", "10", want_type="int", want_memref=False)
 
         if self.isResultExpandedDescription():
             self.assertEvaluate(

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -118,11 +118,11 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
   if (value.GetError().Fail())
     return ToError(value.GetError(), /*show_user=*/false);
 
-  // Check original value type before calling `Persist`, because it change value
-  // type to const result
+  // Check the original value type before calling `Persist`, because it changes
+  // the type to const result
   if (lldb::addr_t addr = value.GetLoadAddress();
-      value.GetValueType() != lldb::eValueTypeConstResult &&
-      addr != LLDB_INVALID_ADDRESS)
+      addr != LLDB_INVALID_ADDRESS &&
+      value.GetValueType() != lldb::eValueTypeConstResult)
     body.memoryReference = EncodeMemoryReference(addr);
 
   if (is_repl_context) {

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -118,6 +118,13 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
   if (value.GetError().Fail())
     return ToError(value.GetError(), /*show_user=*/false);
 
+  // Check original value type before calling `Persist`, because it change value
+  // type to const result
+  if (lldb::addr_t addr = value.GetLoadAddress();
+      value.GetValueType() != lldb::eValueTypeConstResult &&
+      addr != LLDB_INVALID_ADDRESS)
+    body.memoryReference = EncodeMemoryReference(addr);
+
   if (is_repl_context) {
     // save the new variable expression
     dap.last_valid_variable_expression = std::move(expression);
@@ -136,9 +143,6 @@ EvaluateRequestHandler::Run(const EvaluateArguments &arguments) const {
   if (value.MightHaveChildren() || ValuePointsToCode(value))
     body.variablesReference = dap.reference_storage.Insert(
         value, /*is_permanent=*/is_repl_context, /*is_internal=*/false);
-
-  if (lldb::addr_t addr = value.GetLoadAddress(); addr != LLDB_INVALID_ADDRESS)
-    body.memoryReference = EncodeMemoryReference(addr);
 
   if (ValuePointsToCode(value) &&
       body.variablesReference.Kind() != eReferenceKindInvalid)


### PR DESCRIPTION
Some time ago I noticed that constants in Watch Window have meaningless memory references (their values were interpreted as load addresses). I am not an expert in LLDB internals, but hope it is correct fix.