### PR TITLE
[BOLT][DebugInfo] Speed up DIEBuilder with DenseMap

### DIFF
--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -61,7 +61,7 @@ public:
     bool IsConstructed = false;
     // A map of DIE offsets in original DWARF section to DIE ID.
     // Which is used to access DieInfoVector.
-    std::unordered_map<uint64_t, uint32_t> DIEIDMap;
+    DenseMap<uint64_t, uint32_t> DIEIDMap;
 
     // Some STL implementations don't have a noexcept move constructor for
     // unordered_map (e.g. https://github.com/microsoft/STL/issues/165 explains
@@ -105,9 +105,9 @@ private:
 
   struct State {
     /// A map of Units to Unit Index.
-    std::unordered_map<uint64_t, uint32_t> UnitIDMap;
+    DenseMap<uint64_t, uint32_t> UnitIDMap;
     /// A map of Type Units to Type DIEs.
-    std::unordered_map<DWARFUnit *, DIE *> TypeDIEMap;
+    DenseMap<DWARFUnit *, DIE *> TypeDIEMap;
     std::list<DWARFUnit *> DUList;
     std::vector<DWARFUnitInfo> CloneUnitCtxMap;
     std::vector<std::pair<DIEInfo *, AddrReferenceInfo>> AddrReferences;


### PR DESCRIPTION
We replaced `std::unordered_map` with LLVM's `DenseMap` for the DIE maps in DIEBuilder. Since this map is accessed frequently during DWARF rewriting, the improved data layout translates directly into reduced cache misses. As shown in the benchmark results, this change yields 1.22x–1.27x speedup.

**Program from Bytedance**
| BatchSize | Baseline (s) | Optimized (s) | Speedup |
|---|---|---|---|
| 2 | 120.01 | 98.32 | 1.22x |
| 4 | 104.12 | 85.37 | 1.22x |
| 16 | 82.31 | 66.41 | 1.24x |
| 32 | 77.45 | 61.01 | 1.27x |
| 64 | 71.69 | 56.35 | 1.27x |
