### PR TITLE
[lldb] fix single-character token not underlined correctly in diagnostics

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -280,11 +280,9 @@ public:
           // Find the range of the primary location.
           for (const auto &range : Info.getRanges()) {
             if (range.getBegin() != sloc)
-              continue
-            SourceLocation end = range.getEnd();
+              continue SourceLocation end = range.getEnd();
             if (range.isTokenRange())
-              end =
-                  clang::Lexer::getLocForEndOfToken(end, 0, sm, m_lang_opts);
+              end = clang::Lexer::getLocForEndOfToken(end, 0, sm, m_lang_opts);
             // FIXME: This is probably not handling wide characters correctly.
             unsigned end_col = sm.getSpellingColumnNumber(end);
             // Ignore ranges that span multiple lines.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -30,6 +30,7 @@
 #include "clang/Frontend/TextDiagnostic.h"
 #include "clang/Frontend/TextDiagnosticBuffer.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "clang/Lex/Lexer.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Parse/ParseAST.h"
 #include "clang/Rewrite/Core/Rewriter.h"
@@ -279,8 +280,16 @@ public:
           // Find the range of the primary location.
           for (const auto &range : Info.getRanges()) {
             if (range.getBegin() == sloc) {
+              SourceLocation end = range.getEnd();
+              if (range.isTokenRange())
+                end =
+                    clang::Lexer::getLocForEndOfToken(end, 0, sm, m_lang_opts);
+              // Ignore ranges that span multiple lines.
+              if (sm.getSpellingLineNumber(end) !=
+                  sm.getSpellingLineNumber(sloc))
+                break;
               // FIXME: This is probably not handling wide characters correctly.
-              unsigned end_col = sm.getSpellingColumnNumber(range.getEnd());
+              unsigned end_col = sm.getSpellingColumnNumber(end);
               if (end_col > loc.column)
                 loc.length = end_col - loc.column;
               break;
@@ -307,6 +316,7 @@ public:
   }
 
   void BeginSourceFile(const LangOptions &LO, const Preprocessor *PP) override {
+    m_lang_opts = LO;
     m_passthrough->BeginSourceFile(LO, PP);
   }
 
@@ -315,6 +325,7 @@ public:
 private:
   DiagnosticManager *m_manager = nullptr;
   DiagnosticOptions m_options;
+  LangOptions m_lang_opts;
   /// Output string filled by m_os.
   std::string m_output;
   /// Output stream of m_passthrough.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -279,21 +279,20 @@ public:
 
           // Find the range of the primary location.
           for (const auto &range : Info.getRanges()) {
-            if (range.getBegin() == sloc) {
-              SourceLocation end = range.getEnd();
-              if (range.isTokenRange())
-                end =
-                    clang::Lexer::getLocForEndOfToken(end, 0, sm, m_lang_opts);
-              // Ignore ranges that span multiple lines.
-              if (sm.getSpellingLineNumber(end) !=
-                  sm.getSpellingLineNumber(sloc))
-                break;
-              // FIXME: This is probably not handling wide characters correctly.
-              unsigned end_col = sm.getSpellingColumnNumber(end);
-              if (end_col > loc.column)
-                loc.length = end_col - loc.column;
+            if (range.getBegin() != sloc)
+              continue
+            SourceLocation end = range.getEnd();
+            if (range.isTokenRange())
+              end =
+                  clang::Lexer::getLocForEndOfToken(end, 0, sm, m_lang_opts);
+            // FIXME: This is probably not handling wide characters correctly.
+            unsigned end_col = sm.getSpellingColumnNumber(end);
+            // Ignore ranges that span multiple lines.
+            if (end_col != sm.getSpellingLineNumber(sloc))
               break;
-            }
+            if (end_col > loc.column)
+              loc.length = end_col - loc.column;
+            break;
           }
           detail.source_location = loc;
         }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -280,7 +280,8 @@ public:
           // Find the range of the primary location.
           for (const auto &range : Info.getRanges()) {
             if (range.getBegin() != sloc)
-              continue SourceLocation end = range.getEnd();
+              continue;
+            SourceLocation end = range.getEnd();
             if (range.isTokenRange())
               end = clang::Lexer::getLocForEndOfToken(end, 0, sm, m_lang_opts);
             // FIXME: This is probably not handling wide characters correctly.

--- a/lldb/unittests/Host/common/DiagnosticsRenderingTest.cpp
+++ b/lldb/unittests/Host/common/DiagnosticsRenderingTest.cpp
@@ -27,6 +27,18 @@ TEST_F(ErrorDisplayTest, RenderStatus) {
   }
 
   {
+    // Test that a single-character token (length=1) renders as just a caret
+    // with no underlines.
+    SourceLocation loc1 = {FileSpec{"a.c"}, 1, 6, 1, false, true};
+    std::string result =
+        Render({DiagnosticDetail{loc1, eSeverityError, "X", "X"}});
+    llvm::SmallVector<StringRef> lines;
+    StringRef(result).split(lines, '\n');
+    //                123456
+    ASSERT_EQ(lines[0], "     ^");
+    ASSERT_EQ(lines[1], "     error: X");
+  }
+  {
     // Test that diagnostics on the same column can be handled and all
     // three errors are diagnosed.
     SourceLocation loc1 = {FileSpec{"a.c"}, 13, 5, 0, false, true};


### PR DESCRIPTION
A single-character token at the end of a user expression was rendered with trailing underlines:

# Result 
```
(lldb) p foo!
          ^~~~~~
          error: ...
```

# Expected:

```
(lldb) p foo!
          ^
          error: ...
```

There were 2 issues:

1. Token ranges store their end as the start of the last token: a single token range produces `end_col == loc.column`, giving a length of 0.

2. A token at the very end of the user expression can cause Clang's range to end inside the wrapper suffix. `getSpellingColumnNumber` on a location on a different line returns that line's column. It can be larger than `loc.column`, producing an incorret range. The fix here is to discard any range whose end is on a different line than the diagnostic's location.

rdar://176913198