### PR TITLE
[lldb][windows] Add --lldb-use-lldb-server to lit

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -92,6 +92,7 @@ set(LLDB_TEST_EXECUTABLE "${LLDB_DEFAULT_TEST_EXECUTABLE}" CACHE PATH "lldb exec
 set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
 set(LLDB_TEST_DSYMUTIL "${LLDB_DEFAULT_TEST_DSYMUTIL}" CACHE PATH "dsymutil used for generating dSYM bundles")
 set(LLDB_TEST_MAKE "${LLDB_DEFAULT_TEST_MAKE}" CACHE PATH "make tool used for building test executables")
+set(LLDB_TEST_USE_LLDB_SERVER "" CACHE STRING "If ON/1, run the API test suite against the lldb-server backend on Windows")
 
 if ("${LLDB_TEST_COMPILER}" STREQUAL "")
   message(FATAL_ERROR "LLDB test compiler not specified. Tests will not run.")

--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -92,7 +92,6 @@ set(LLDB_TEST_EXECUTABLE "${LLDB_DEFAULT_TEST_EXECUTABLE}" CACHE PATH "lldb exec
 set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
 set(LLDB_TEST_DSYMUTIL "${LLDB_DEFAULT_TEST_DSYMUTIL}" CACHE PATH "dsymutil used for generating dSYM bundles")
 set(LLDB_TEST_MAKE "${LLDB_DEFAULT_TEST_MAKE}" CACHE PATH "make tool used for building test executables")
-set(LLDB_TEST_USE_LLDB_SERVER "" CACHE STRING "If ON/1, run the API test suite against the lldb-server backend on Windows")
 
 if ("${LLDB_TEST_COMPILER}" STREQUAL "")
   message(FATAL_ERROR "LLDB test compiler not specified. Tests will not run.")

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -361,9 +361,7 @@ if platform.system() == "Windows":
     use_server = lit_config.params.get("lldb-use-lldb-server", None)
     if use_server is None:
         use_server = getattr(config, "lldb_use_lldb_server", None)
-    if use_server is not None and str(use_server).lower() in (
-        "1", "on", "yes", "true"
-    ):
+    if use_server is not None and str(use_server).lower() in ("1", "on", "yes", "true"):
         lit_config.note("Running API tests with LLDB_USE_LLDB_SERVER=1")
         config.environment["LLDB_USE_LLDB_SERVER"] = "1"
 

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -354,9 +354,19 @@ if "XDG_CACHE_HOME" in os.environ:
 
 # Transfer some environment variables into the tests on Windows build host.
 if platform.system() == "Windows":
-    for v in ["SystemDrive", "LLDB_USE_LLDB_SERVER"]:
+    for v in ["SystemDrive"]:
         if v in os.environ:
             config.environment[v] = os.environ[v]
+
+    use_server = lit_config.params.get("lldb-use-lldb-server", None)
+    if use_server is None:
+        use_server = getattr(config, "lldb_use_lldb_server", None)
+    if use_server is not None and str(use_server).lower() in (
+        "1", "on", "yes", "true"
+    ):
+        lit_config.note("Running API tests with LLDB_USE_LLDB_SERVER=1")
+        config.environment["LLDB_USE_LLDB_SERVER"] = "1"
+
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT
     # escape sequences into the output stream, which breaks tests that check
     # for specific stdout/stderr content.

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -358,11 +358,7 @@ if platform.system() == "Windows":
         if v in os.environ:
             config.environment[v] = os.environ[v]
 
-    use_server = lit_config.params.get("lldb-use-lldb-server", None)
-    if use_server is None:
-        use_server = getattr(config, "lldb_use_lldb_server", None)
-    if use_server is not None and str(use_server).lower() in ("1", "on", "yes", "true"):
-        lit_config.note("Running API tests with LLDB_USE_LLDB_SERVER=1")
+    if getattr(config, "lldb_use_lldb_server", False):
         config.environment["LLDB_USE_LLDB_SERVER"] = "1"
 
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -354,7 +354,7 @@ if "XDG_CACHE_HOME" in os.environ:
 
 # Transfer some environment variables into the tests on Windows build host.
 if platform.system() == "Windows":
-    for v in ["SystemDrive"]:
+    for v in ["SystemDrive", "LLDB_USE_LLDB_SERVER"]:
         if v in os.environ:
             config.environment[v] = os.environ[v]
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -45,7 +45,7 @@ config.libcxx_include_target_dir = "@LIBCXX_GENERATED_INCLUDE_TARGET_DIR@"
 config.lldb_launcher = "@LLDB_LAUNCHER@"
 config.lldb_enable_mte = @LLDB_ENABLE_MTE@
 config.lldb_enable_arm64e_debugserver = @LLDB_USE_ARM64E_DEBUGSERVER@
-config.lldb_use_lldb_server = "@LLDB_TEST_USE_LLDB_SERVER@"
+config.lldb_use_lldb_server = @LLDB_TEST_USE_LLDB_SERVER@
 # The API tests use their own module caches.
 config.lldb_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_LLDB@", "lldb-api")
 config.clang_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_CLANG@", "lldb-api")

--- a/lldb/test/API/lit.site.cfg.py.in
+++ b/lldb/test/API/lit.site.cfg.py.in
@@ -45,6 +45,7 @@ config.libcxx_include_target_dir = "@LIBCXX_GENERATED_INCLUDE_TARGET_DIR@"
 config.lldb_launcher = "@LLDB_LAUNCHER@"
 config.lldb_enable_mte = @LLDB_ENABLE_MTE@
 config.lldb_enable_arm64e_debugserver = @LLDB_USE_ARM64E_DEBUGSERVER@
+config.lldb_use_lldb_server = "@LLDB_TEST_USE_LLDB_SERVER@"
 # The API tests use their own module caches.
 config.lldb_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_LLDB@", "lldb-api")
 config.clang_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_CLANG@", "lldb-api")

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -255,6 +255,7 @@ if (LLDB_ENABLE_ARM64E_DEBUGSERVER OR LLDB_USE_SYSTEM_DEBUGSERVER)
 endif()
 
 set(LLDB_TEST_SHELL_DISABLE_REMOTE OFF CACHE BOOL "Disable remote Shell tests execution")
+set(LLDB_TEST_USE_LLDB_SERVER OFF CACHE BOOL "If ON, run the test suites against the lldb-server backend on Windows")
 
 # These values are not canonicalized within LLVM.
 llvm_canonicalize_cmake_booleans(
@@ -268,6 +269,7 @@ llvm_canonicalize_cmake_booleans(
   LLVM_ENABLE_DIA_SDK
   LLDB_HAS_LIBCXX
   LLDB_TEST_SHELL_DISABLE_REMOTE
+  LLDB_TEST_USE_LLDB_SERVER
   LLDB_TOOL_LLDB_SERVER_BUILD
   LLDB_USE_SYSTEM_DEBUGSERVER
   LLDB_IS_64_BITS

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -54,7 +54,6 @@ llvm_config.with_system_environment(
         "TEMP",
         "TMP",
         "XDG_CACHE_HOME",
-        "LLDB_USE_LLDB_SERVER",
     ]
 )
 
@@ -178,6 +177,8 @@ if config.have_dia_sdk:
     config.available_features.add("diasdk")
 
 if platform.system() == "Windows":
+    if getattr(config, "lldb_use_lldb_server", False):
+        config.environment["LLDB_USE_LLDB_SERVER"] = "1"
     # Use anonymous pipes instead of ConPTY for all tests. ConPTY injects VT
     # escape sequences into the output stream, which breaks tests that check
     # for specific stdout/stderr content.

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -54,6 +54,7 @@ llvm_config.with_system_environment(
         "TEMP",
         "TMP",
         "XDG_CACHE_HOME",
+        "LLDB_USE_LLDB_SERVER",
     ]
 )
 

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -37,6 +37,7 @@ config.lldb_has_lldbrpc = @LLDB_BUILD_LLDBRPC@
 config.have_dia_sdk = @LLVM_ENABLE_DIA_SDK@
 config.lldb_launcher = "@LLDB_LAUNCHER@"
 config.lldb_enable_mte = @LLDB_ENABLE_MTE@
+config.lldb_use_lldb_server = @LLDB_TEST_USE_LLDB_SERVER@
 # The shell tests use their own module caches.
 config.lldb_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_LLDB@", "lldb-shell")
 config.clang_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_CLANG@", "lldb-shell")


### PR DESCRIPTION
Currently, the Windows builds of lit only allow `SystemDrive` when copying env vars into the test environment. `LLDB_USE_LLDB_SERVER=1` in the developer shell never reached the `lldb.exe` subprocess under `check-lldb`. Baseline and lldb-server runs therefore looked identical even when the user expected lldb-server to be used.

`--lldb-use-lldb-server` in lit invocations sets `LLDB_USE_LLDB_SERVER=1` to test lldb on Windows with `lldb-server` instead of the in process plugin.

Depends on:
- https://github.com/llvm/llvm-zorg/pull/848

rdar://177442264