### PR TITLE
Exclude documentation files from 80 columns rule in Coding Standard

### DIFF
--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -461,7 +461,7 @@ standardized on 80 columns, so some people have already configured their editors
 for it (vs something else, like 90 columns).
 
 However, documentation files are not source code files, and instead of fitting into 80 columns, they must be formatted to one sentence per line.
-This way a change in the middle of a paragraph doesn't cause unnecessary changes in subsequent lines.
+This way a change in the middle of a paragraph doesn't cause unnecessary changes in subsequent lines, making it easier for reviewers to see what has changed when documentation is updated.
 
 Whitespace
 ^^^^^^^^^^

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -460,6 +460,9 @@ and would be detrimental to printing out code.  Also many other projects have
 standardized on 80 columns, so some people have already configured their editors
 for it (vs something else, like 90 columns).
 
+However, documentation files are not source code files, and instead of fitting into 80 columns, they must be formatted to one sentence per line.
+This way a change in the middle of a paragraph doesn't cause unnecessary changes in subsequent lines.
+
 Whitespace
 ^^^^^^^^^^
 


### PR DESCRIPTION
This implements the accepted [RFC](https://discourse.llvm.org/t/rfc-remove-80-column-limit-in-documentation-files/89678) "Remove 80 column limit in documentation files."