### PR TITLE
[lldb][windows] Keep int3 breakpoints inside the debugger on lldb-server

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -564,17 +564,19 @@ NativeProcessWindows::OnDebugException(bool first_chance,
       return ExceptionResult::BreakInDebugger;
     }
 
-    // Any remaining STATUS_BREAKPOINT is a breakpoint instruction in the
-    // program's own code (e.g. `__debugbreak()` or `__builtin_debugtrap()`).
-    // Stop the debugger and let the user decide what to do.
-    std::string desc =
-        formatv("Exception {0} encountered at address {1}",
-                llvm::format_hex(record.GetExceptionCode(), 8),
-                llvm::format_hex(record.GetExceptionAddress(), 8))
-            .str();
-    StopThread(record.GetThreadID(), StopReason::eStopReasonException,
-               std::move(desc));
-    SetState(eStateStopped, true);
+    {
+      // Any remaining STATUS_BREAKPOINT is a breakpoint instruction in the
+      // program's own code (e.g. `__debugbreak()` or `__builtin_debugtrap()`).
+      // Stop the debugger and let the user decide what to do.
+      std::string desc =
+          formatv("Exception {0:x8} encountered at address {1:x8}",
+                  record.GetExceptionCode(), record.GetExceptionAddress())
+              .str();
+      StopThread(record.GetThreadID(), StopReason::eStopReasonException,
+                 std::move(desc));
+      SetState(eStateStopped, true);
+    }
+
     return ExceptionResult::MaskException;
   default:
     LLDB_LOG(log,

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -564,7 +564,18 @@ NativeProcessWindows::OnDebugException(bool first_chance,
       return ExceptionResult::BreakInDebugger;
     }
 
-    [[fallthrough]];
+    // Any remaining STATUS_BREAKPOINT is a breakpoint instruction in the
+    // program's own code (e.g. `__debugbreak()` or `__builtin_debugtrap()`).
+    // Stop the debugger and let the user decide what to do.
+    std::string desc =
+        formatv("Exception {0} encountered at address {1}",
+                llvm::format_hex(record.GetExceptionCode(), 8),
+                llvm::format_hex(record.GetExceptionAddress(), 8))
+            .str();
+    StopThread(record.GetThreadID(), StopReason::eStopReasonException,
+               std::move(desc));
+    SetState(eStateStopped, true);
+    return ExceptionResult::MaskException;
   default:
     LLDB_LOG(log,
              "Debugger thread reported exception {0:x} at address {1:x} "


### PR DESCRIPTION
`NativeProcessWindows::OnDebugException` forwarded `STATUS_BREAKPOINT` exceptions, which returned `ExceptionResult::SendToApplication` on first chance.

On Windows an unhandled `STATUS_BREAKPOINT` is fatal to the process. Programs containing explicit `int3`, `__debugbreak()`, or `__builtin_debugtrap()` were killed when hitting the instruction and the subsequent user `continue` had nothing to resume.

This patch mirrors the `ProcessWindows` plugin handling of `EXCEPTION_BREAKPOINT`. It fixes all shell `Register/*-read.test` / `*-write.test` cases and several expression side-effect tests in `check-lldb` with `LLDB_USE_LLDB_SERVER=1`.

rdar://177072682