### PR TITLE
[BOLT][DebugInfo] Make parallel DWARF debug names generation deterministic(1/2)

### DIFF
--- a/bolt/include/bolt/Core/DIEBuilder.h
+++ b/bolt/include/bolt/Core/DIEBuilder.h
@@ -132,9 +132,6 @@ private:
   uint64_t DebugNamesUnitSize{0};
   llvm::DenseSet<uint64_t> AllProcessed;
   DWARF5AcceleratorTable &DebugNamesTable;
-  // Unordered map to handle name collision if output DWO directory is
-  // specified.
-  std::unordered_map<std::string, uint32_t> NameToIndexMap;
 
   /// Returns current state of the DIEBuilder
   State &getState() { return *BuilderState; }
@@ -392,12 +389,12 @@ public:
   std::string updateDWONameCompDir(DebugStrOffsetsWriter &StrOffstsWriter,
                                    DebugStrWriter &StrWriter,
                                    DWARFUnit &SkeletonCU,
-                                   std::optional<StringRef> DwarfOutputPath,
-                                   std::optional<StringRef> DWONameToUse);
+                                   StringRef DwarfOutputPath,
+                                   const StringRef DWOName);
   /// Updates DWO Name and Compilation directory for Type Units.
   void updateDWONameCompDirForTypes(DebugStrOffsetsWriter &StrOffstsWriter,
                                     DebugStrWriter &StrWriter, DWARFUnit &Unit,
-                                    std::optional<StringRef> DwarfOutputPath,
+                                    StringRef DwarfOutputPath,
                                     const StringRef DWOName);
 };
 } // namespace bolt

--- a/bolt/include/bolt/Core/DebugNames.h
+++ b/bolt/include/bolt/Core/DebugNames.h
@@ -104,7 +104,7 @@ private:
   /// Track whether AcceleratorTable have been preallocated.
   bool Preallocated = false;
   /// Map from DWO ID to preallocated CU index.
-  DenseMap<uint64_t, uint32_t> DWOIdToCUIndex;
+  std::unordered_map<uint64_t, uint32_t> DWOIdToCUIndex;
   /// Represents a group of entries with identical name (and hence, hash value).
   struct HashData {
     uint64_t StrOffset;

--- a/bolt/include/bolt/Core/DebugNames.h
+++ b/bolt/include/bolt/Core/DebugNames.h
@@ -103,8 +103,6 @@ private:
   DenseMap<uint64_t, uint32_t> TUHashToIndexMap;
   /// Track whether AcceleratorTable have been preallocated.
   bool Preallocated = false;
-  /// Map from DWO ID to preallocated CU index.
-  std::unordered_map<uint64_t, uint32_t> DWOIdToCUIndex;
   /// Represents a group of entries with identical name (and hence, hash value).
   struct HashData {
     uint64_t StrOffset;
@@ -138,7 +136,7 @@ private:
   uint32_t AugmentationStringSize = 0;
   dwarf::Form CUIndexForm = dwarf::DW_FORM_data4;
   dwarf::Form TUIndexForm = dwarf::DW_FORM_data4;
-  constexpr static uint32_t BADCUOFFSET = 0xBADBA;
+  constexpr static uint32_t BADCUOFFSET = 0xBADBAD;
 
   BucketList Buckets;
 
@@ -152,7 +150,7 @@ private:
   std::unique_ptr<raw_svector_ostream> AugStringtream;
   llvm::DenseMap<llvm::hash_code, uint64_t> StrCacheToOffsetMap;
   // Contains DWO ID to CUList Index.
-  llvm::DenseMap<uint64_t, uint32_t> CUOffsetsToPatch;
+  std::unordered_map<uint64_t, uint32_t> CUOffsetsToPatch;
   // Contains a map of Entry ID to Entry relative offset.
   llvm::DenseMap<uint64_t, uint32_t> EntryRelativeOffsets;
   llvm::DenseMap<uint64_t, std::pair<DWARFUnit *, const DIE *>> CrossCUDies;

--- a/bolt/include/bolt/Core/DebugNames.h
+++ b/bolt/include/bolt/Core/DebugNames.h
@@ -17,6 +17,7 @@
 #include "bolt/Core/DebugData.h"
 #include "llvm/CodeGen/AccelTable.h"
 
+#include <mutex>
 namespace llvm {
 namespace bolt {
 class BOLTDWARF5AccelTableData : public DWARF5AccelTableData {
@@ -71,16 +72,20 @@ public:
   std::unique_ptr<DebugBufferVector> releaseBuffer() {
     return std::move(FullTableBuffer);
   }
-  /// Adds a DIE that is referenced across CUs.
-  void addCrossCUDie(DWARFUnit *Unit, const DIE *Die) {
-    CrossCUDies.insert({Die->getOffset(), {Unit, Die}});
-  }
+  void addCrossCUDie(DWARFUnit *Unit, const DIE *Die);
+  /// Looks up a DIE that is referenced across CUs.
+  std::optional<std::pair<DWARFUnit *, const DIE *>>
+  getCrossCUDie(uint64_t Offset);
   /// Returns true if the DIE can generate an entry for a cross cu reference.
   /// This only checks TAGs of a DIE because when this is invoked DIE might not
   /// be fully constructed.
   bool canGenerateEntryWithCrossCUReference(
       const DWARFUnit &Unit, const DIE &Die,
       const DWARFAbbreviationDeclaration::AttributeSpec &AttrSpec);
+
+  /// Pre-allocate CU and Foreign TU slots in deterministic order.
+  /// Must be called before any concurrent addAccelTableEntry() calls.
+  void preAllocateUnits(DWARFContext &DwCtx);
 
 private:
   BinaryContext &BC;
@@ -90,12 +95,16 @@ private:
   StringRef StrSection;
   uint64_t CurrentUnitOffset = 0;
   const DWARFUnit *CurrentUnit = nullptr;
+  std::mutex CrossCUDiesMutex;
   std::unordered_map<uint32_t, uint32_t> AbbrevTagToIndexMap;
   /// Contains a map of TU hashes to a Foreign TU indices.
   /// This is used to reduce the size of Foreign TU list since there could be
   /// multiple TUs with the same hash.
   DenseMap<uint64_t, uint32_t> TUHashToIndexMap;
-
+  /// Track whether AcceleratorTable have been preallocated.
+  bool Preallocated = false;
+  /// Map from DWO ID to preallocated CU index.
+  DenseMap<uint64_t, uint32_t> DWOIdToCUIndex;
   /// Represents a group of entries with identical name (and hence, hash value).
   struct HashData {
     uint64_t StrOffset;
@@ -129,6 +138,7 @@ private:
   uint32_t AugmentationStringSize = 0;
   dwarf::Form CUIndexForm = dwarf::DW_FORM_data4;
   dwarf::Form TUIndexForm = dwarf::DW_FORM_data4;
+  constexpr static uint32_t BADCUOFFSET = 0xBADBA;
 
   BucketList Buckets;
 

--- a/bolt/lib/Core/DIEBuilder.cpp
+++ b/bolt/lib/Core/DIEBuilder.cpp
@@ -42,29 +42,6 @@ extern cl::opt<unsigned> Verbosity;
 namespace llvm {
 namespace bolt {
 
-/// Returns DWO Name to be used to update DW_AT_dwo_name/DW_AT_GNU_dwo_name
-/// either in CU or TU unit die. Handles case where user specifies output DWO
-/// directory, and there are duplicate names. Assumes DWO ID is unique.
-static std::string
-getDWOName(llvm::DWARFUnit &CU,
-           std::unordered_map<std::string, uint32_t> &NameToIndexMap,
-           std::optional<StringRef> &DwarfOutputPath) {
-  assert(CU.getDWOId() && "DWO ID not found.");
-  std::string DWOName = dwarf::toString(
-      CU.getUnitDIE().find({dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}),
-      "");
-  assert(!DWOName.empty() &&
-         "DW_AT_dwo_name/DW_AT_GNU_dwo_name does not exist.");
-  if (DwarfOutputPath) {
-    DWOName = std::string(sys::path::filename(DWOName));
-    uint32_t &Index = NameToIndexMap[DWOName];
-    DWOName.append(std::to_string(Index));
-    ++Index;
-  }
-  DWOName.append(".dwo");
-  return DWOName;
-}
-
 /// Adds a \p Str to .debug_str section.
 /// Uses \p AttrInfoVal to either update entry in a DIE for legacy DWARF using
 /// \p DebugInfoPatcher, or for DWARF5 update an index in .debug_str_offsets
@@ -85,38 +62,31 @@ static void addStringHelper(DebugStrOffsetsWriter &StrOffstsWriter,
 
 std::string DIEBuilder::updateDWONameCompDir(
     DebugStrOffsetsWriter &StrOffstsWriter, DebugStrWriter &StrWriter,
-    DWARFUnit &SkeletonCU, std::optional<StringRef> DwarfOutputPath,
-    std::optional<StringRef> DWONameToUse) {
+    DWARFUnit &SkeletonCU, StringRef DwarfOutputPath,
+    const StringRef DWONameToUse) {
   DIE &UnitDIE = *getUnitDIEbyUnit(SkeletonCU);
   DIEValue DWONameAttrInfo = UnitDIE.findAttribute(dwarf::DW_AT_dwo_name);
   if (!DWONameAttrInfo)
     DWONameAttrInfo = UnitDIE.findAttribute(dwarf::DW_AT_GNU_dwo_name);
   if (!DWONameAttrInfo)
     return "";
-  std::string ObjectName;
-  if (DWONameToUse)
-    ObjectName = *DWONameToUse;
-  else
-    ObjectName = getDWOName(SkeletonCU, NameToIndexMap, DwarfOutputPath);
+  std::string ObjectName(DWONameToUse);
   addStringHelper(StrOffstsWriter, StrWriter, *this, UnitDIE, SkeletonCU,
                   DWONameAttrInfo, ObjectName);
 
   DIEValue CompDirAttrInfo = UnitDIE.findAttribute(dwarf::DW_AT_comp_dir);
   assert(CompDirAttrInfo && "DW_AT_comp_dir is not in Skeleton CU.");
 
-  if (DwarfOutputPath) {
-    if (!sys::fs::exists(*DwarfOutputPath))
-      sys::fs::create_directory(*DwarfOutputPath);
+  if (!DwarfOutputPath.empty()) {
     addStringHelper(StrOffstsWriter, StrWriter, *this, UnitDIE, SkeletonCU,
-                    CompDirAttrInfo, *DwarfOutputPath);
+                    CompDirAttrInfo, DwarfOutputPath);
   }
   return ObjectName;
 }
 
 void DIEBuilder::updateDWONameCompDirForTypes(
     DebugStrOffsetsWriter &StrOffstsWriter, DebugStrWriter &StrWriter,
-    DWARFUnit &Unit, std::optional<StringRef> DwarfOutputPath,
-    const StringRef DWOName) {
+    DWARFUnit &Unit, StringRef DwarfOutputPath, const StringRef DWOName) {
   for (DWARFUnit *DU : getState().DWARF5TUVector)
     updateDWONameCompDir(StrOffstsWriter, StrWriter, *DU, DwarfOutputPath,
                          DWOName);

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -74,13 +74,13 @@ void DWARF5AcceleratorTable::preAllocateUnits(DWARFContext &DwCtx) {
     if (!DWOId)
       continue;
 
-    const DWARFDie UnitDIE = CU->getUnitDIE();
-    if (!UnitDIE.find({dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}))
-      continue;
-
     uint32_t Idx = CUList.size();
     CUList.push_back(BADCUOFFSET);
     CUOffsetsToPatch[*DWOId] = Idx;
+
+    const DWARFDie UnitDIE = CU->getUnitDIE();
+    if (!UnitDIE.find({dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}))
+      continue;
 
     std::optional<DWARFUnit *> DWOCU = BC.getDWOCU(*DWOId);
     if (!DWOCU || !*DWOCU)

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -86,7 +86,7 @@ void DWARF5AcceleratorTable::preAllocateUnits(DWARFContext &DwCtx) {
     if (!DWOCU || !*DWOCU)
       continue;
 
-    // check dwo_types_section_units for DWARF4 type units in DWO.
+    // Iterate DWO info section units for type units (Foreign TU list).
     DWARFContext &DWOCtx = (*DWOCU)->getContext();
     for (const auto &TU : DWOCtx.dwo_units()) {
       if (!TU->isTypeUnit())

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -88,7 +88,7 @@ void DWARF5AcceleratorTable::preAllocateUnits(DWARFContext &DwCtx) {
 
     // Iterate DWO info section units for type units (Foreign TU list).
     DWARFContext &DWOCtx = (*DWOCU)->getContext();
-    for (const auto &TU : DWOCtx.dwo_units()) {
+    for (const auto &TU : DWOCtx.dwo_info_section_units()) {
       if (!TU->isTypeUnit())
         continue;
       const uint64_t TUHash = cast<DWARFTypeUnit>(TU.get())->getTypeHash();

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -67,25 +67,27 @@ DWARF5AcceleratorTable::DWARF5AcceleratorTable(
 }
 
 void DWARF5AcceleratorTable::preAllocateUnits(DWARFContext &DwCtx) {
-  // Collect all DWO IDs in deterministic order (by CU offset in .debug_info).
-  // This is single-threaded, called before parallel process.
-  for (const auto &CU : DwCtx.compile_units()) {
-    if (std::optional<uint64_t> DWOId = CU->getDWOId()) {
-      uint32_t Idx = CUList.size();
-      CUList.push_back(BADCUOFFSET);
-      CUOffsetsToPatch[*DWOId] = Idx;
-      DWOIdToCUIndex[*DWOId] = Idx;
-    }
-  }
+  // Single pass: allocate CU slots and collect Foreign TU hashes
+  // in deterministic order (by CU offset in .debug_info).
   for (const auto &CU : DwCtx.compile_units()) {
     std::optional<uint64_t> DWOId = CU->getDWOId();
     if (!DWOId)
       continue;
+
+    const DWARFDie UnitDIE = CU->getUnitDIE();
+    if (!UnitDIE.find({dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name}))
+      continue;
+
+    uint32_t Idx = CUList.size();
+    CUList.push_back(BADCUOFFSET);
+    CUOffsetsToPatch[*DWOId] = Idx;
+
     std::optional<DWARFUnit *> DWOCU = BC.getDWOCU(*DWOId);
     if (!DWOCU || !*DWOCU)
       continue;
-    DWARFContext &DWOCtx = (*DWOCU)->getContext();
+
     // check dwo_types_section_units for DWARF4 type units in DWO.
+    DWARFContext &DWOCtx = (*DWOCU)->getContext();
     for (const auto &TU : DWOCtx.dwo_units()) {
       if (!TU->isTypeUnit())
         continue;
@@ -293,8 +295,8 @@ uint32_t DWARF5AcceleratorTable::getUnitID(const DWARFUnit &Unit,
     return LocalTUList.size() - 1;
   }
   if (Preallocated && DWOID) {
-    auto Iter = DWOIdToCUIndex.find(*DWOID);
-    assert(Iter != DWOIdToCUIndex.end() && "DWO ID not preallocated");
+    auto Iter = CUOffsetsToPatch.find(*DWOID);
+    assert(Iter != CUOffsetsToPatch.end() && "DWO ID not preallocated");
     return Iter->second;
   }
   return CUList.size() - 1;
@@ -513,6 +515,20 @@ void DWARF5AcceleratorTable::computeBucketCount() {
     BucketCount = std::max<uint32_t>(UniqueHashCount, 1);
 }
 
+/// Returns a stable compile-unit sort key for a debug_names entry.
+static unsigned getCompileUnitKey(const BOLTDWARF5AccelTableData *Entry) {
+  if (Entry->getSecondUnitID())
+    return *Entry->getSecondUnitID();
+  if (!Entry->isTU())
+    return Entry->getUnitID();
+  return std::numeric_limits<unsigned>::max();
+}
+
+static unsigned getTypeUnitKey(const BOLTDWARF5AccelTableData *Entry) {
+  return Entry->isTU() ? Entry->getUnitID()
+                       : std::numeric_limits<unsigned>::max();
+}
+
 /// Bucket code as in: AccelTableBase::finalize()
 void DWARF5AcceleratorTable::finalize() {
   if (!NeedToCreate)
@@ -540,23 +556,10 @@ void DWARF5AcceleratorTable::finalize() {
                                       const BOLTDWARF5AccelTableData *RHS) {
         // Sort entries by (DieOffset, CompileUnitID, TypeUnitID) to ensure
         // deterministic output order across multi-threaded processing runs.
-        const auto GetCompileUnitKey =
-            [](const BOLTDWARF5AccelTableData *Entry) -> unsigned {
-          if (Entry->getSecondUnitID())
-            return *Entry->getSecondUnitID();
-          if (!Entry->isTU())
-            return Entry->getUnitID();
-          return std::numeric_limits<unsigned>::max();
-        };
-        const auto GetTypeUnitKey =
-            [](const BOLTDWARF5AccelTableData *Entry) -> unsigned {
-          return Entry->isTU() ? Entry->getUnitID()
-                               : std::numeric_limits<unsigned>::max();
-        };
-        return std::make_tuple(LHS->getDieOffset(), GetCompileUnitKey(LHS),
-                               GetTypeUnitKey(LHS)) <
-               std::make_tuple(RHS->getDieOffset(), GetCompileUnitKey(RHS),
-                               GetTypeUnitKey(RHS));
+        return std::make_tuple(LHS->getDieOffset(), getCompileUnitKey(LHS),
+                               getTypeUnitKey(LHS)) <
+               std::make_tuple(RHS->getDieOffset(), getCompileUnitKey(RHS),
+                               getTypeUnitKey(RHS));
       });
   }
 

--- a/bolt/lib/Core/DebugNames.cpp
+++ b/bolt/lib/Core/DebugNames.cpp
@@ -13,7 +13,9 @@
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/LEB128.h"
 #include <cstdint>
+#include <limits>
 #include <optional>
+#include <tuple>
 
 namespace llvm {
 namespace bolt {
@@ -64,6 +66,39 @@ DWARF5AcceleratorTable::DWARF5AcceleratorTable(
   }
 }
 
+void DWARF5AcceleratorTable::preAllocateUnits(DWARFContext &DwCtx) {
+  // Collect all DWO IDs in deterministic order (by CU offset in .debug_info).
+  // This is single-threaded, called before parallel process.
+  for (const auto &CU : DwCtx.compile_units()) {
+    if (std::optional<uint64_t> DWOId = CU->getDWOId()) {
+      uint32_t Idx = CUList.size();
+      CUList.push_back(BADCUOFFSET);
+      CUOffsetsToPatch[*DWOId] = Idx;
+      DWOIdToCUIndex[*DWOId] = Idx;
+    }
+  }
+  for (const auto &CU : DwCtx.compile_units()) {
+    std::optional<uint64_t> DWOId = CU->getDWOId();
+    if (!DWOId)
+      continue;
+    std::optional<DWARFUnit *> DWOCU = BC.getDWOCU(*DWOId);
+    if (!DWOCU || !*DWOCU)
+      continue;
+    DWARFContext &DWOCtx = (*DWOCU)->getContext();
+    // check dwo_types_section_units for DWARF4 type units in DWO.
+    for (const auto &TU : DWOCtx.dwo_units()) {
+      if (!TU->isTypeUnit())
+        continue;
+      const uint64_t TUHash = cast<DWARFTypeUnit>(TU.get())->getTypeHash();
+      if (!TUHashToIndexMap.count(TUHash)) {
+        TUHashToIndexMap.insert({TUHash, ForeignTUList.size()});
+        ForeignTUList.push_back(TUHash);
+      }
+    }
+  }
+  Preallocated = true;
+}
+
 void DWARF5AcceleratorTable::setCurrentUnit(DWARFUnit &Unit,
                                             const uint64_t UnitStartOffset) {
   CurrentUnit = nullptr;
@@ -79,10 +114,33 @@ void DWARF5AcceleratorTable::setCurrentUnit(DWARFUnit &Unit,
   }
 }
 
+void DWARF5AcceleratorTable::addCrossCUDie(DWARFUnit *Unit, const DIE *Die) {
+  std::lock_guard<std::mutex> Lock(CrossCUDiesMutex);
+  CrossCUDies.insert({Die->getOffset(), {Unit, Die}});
+}
+std::optional<std::pair<DWARFUnit *, const DIE *>>
+DWARF5AcceleratorTable::getCrossCUDie(uint64_t Offset) {
+  std::lock_guard<std::mutex> Lock(CrossCUDiesMutex);
+  auto Iter = CrossCUDies.find(Offset);
+  if (Iter == CrossCUDies.end())
+    return std::nullopt;
+  return Iter->second;
+}
+
 void DWARF5AcceleratorTable::addUnit(DWARFUnit &Unit,
                                      const std::optional<uint64_t> &DWOID) {
-  constexpr uint32_t BADCUOFFSET = 0xBADBAD;
   StrSection = Unit.getStringSection();
+  if (Preallocated) {
+    if (!Unit.isTypeUnit() && !DWOID) {
+      CUList.push_back(CurrentUnitOffset);
+    }
+    if (Unit.isTypeUnit() && !DWOID) {
+      LocalTUList.push_back(CurrentUnitOffset);
+    }
+    // For DWO CUs and TUs, slots are already preallocated.
+    return;
+  }
+
   if (Unit.isTypeUnit()) {
     if (DWOID) {
       // We adding an entry for a DWO TU. The DWO CU might not have any entries,
@@ -234,6 +292,11 @@ uint32_t DWARF5AcceleratorTable::getUnitID(const DWARFUnit &Unit,
     }
     return LocalTUList.size() - 1;
   }
+  if (Preallocated && DWOID) {
+    auto Iter = DWOIdToCUIndex.find(*DWOID);
+    assert(Iter != DWOIdToCUIndex.end() && "DWO ID not preallocated");
+    return Iter->second;
+  }
   return CUList.size() - 1;
 }
 
@@ -329,15 +392,15 @@ DWARF5AcceleratorTable::processReferencedDie(
     if (!Value)
       return std::nullopt;
     if (Value.getForm() == dwarf::DW_FORM_ref_addr) {
-      auto Iter = CrossCUDies.find(Value.getDIEInteger().getValue());
-      if (Iter == CrossCUDies.end()) {
+      auto CrossCUEntry = getCrossCUDie(Value.getDIEInteger().getValue());
+      if (!CrossCUEntry) {
         BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
                      "referenced DIE in CrossCUDies for "
                   << Twine::utohexstr(Value.getDIEInteger().getValue())
                   << ".\n";
         return std::nullopt;
       }
-      return Iter->second;
+      return CrossCUEntry;
     }
     const DIEEntry &DIEENtry = Value.getDIEEntry();
     return {{&Unit, &DIEENtry.getEntry()}};
@@ -475,7 +538,25 @@ void DWARF5AcceleratorTable::finalize() {
     for (HashData *H : Bucket)
       llvm::stable_sort(H->Values, [](const BOLTDWARF5AccelTableData *LHS,
                                       const BOLTDWARF5AccelTableData *RHS) {
-        return LHS->getDieOffset() < RHS->getDieOffset();
+        // Sort entries by (DieOffset, CompileUnitID, TypeUnitID) to ensure
+        // deterministic output order across multi-threaded processing runs.
+        const auto GetCompileUnitKey =
+            [](const BOLTDWARF5AccelTableData *Entry) -> unsigned {
+          if (Entry->getSecondUnitID())
+            return *Entry->getSecondUnitID();
+          if (!Entry->isTU())
+            return Entry->getUnitID();
+          return std::numeric_limits<unsigned>::max();
+        };
+        const auto GetTypeUnitKey =
+            [](const BOLTDWARF5AccelTableData *Entry) -> unsigned {
+          return Entry->isTU() ? Entry->getUnitID()
+                               : std::numeric_limits<unsigned>::max();
+        };
+        return std::make_tuple(LHS->getDieOffset(), GetCompileUnitKey(LHS),
+                               GetTypeUnitKey(LHS)) <
+               std::make_tuple(RHS->getDieOffset(), GetCompileUnitKey(RHS),
+                               GetTypeUnitKey(RHS));
       });
   }
 

--- a/bolt/lib/Rewrite/DWARFRewriter.cpp
+++ b/bolt/lib/Rewrite/DWARFRewriter.cpp
@@ -579,6 +579,41 @@ static CUPartitionVector partitionCUs(DWARFContext &DwCtx) {
   return Vec;
 }
 
+static std::unordered_map<uint64_t, std::string>
+getDWONameMap(DWARFContext &DwCtx) {
+  const size_t Size =
+      std::distance(DwCtx.compile_units().begin(), DwCtx.compile_units().end());
+  std::unordered_map<uint64_t, std::string> DWOIDToNameMap(Size);
+  std::unordered_map<std::string, uint32_t> NameToIndexMap(Size);
+  for (const std::unique_ptr<DWARFUnit> &CU : DwCtx.compile_units()) {
+    std::optional<uint64_t> DWOID = CU->getDWOId();
+    if (!DWOID)
+      continue;
+
+    const DWARFDie UnitDIE = CU->getUnitDIE();
+    auto DWONameAttr =
+        UnitDIE.find({dwarf::DW_AT_dwo_name, dwarf::DW_AT_GNU_dwo_name});
+
+    // Skip invalid (broken) skeleton units that have a DWOId but lack
+    // DW_AT_dwo_name / DW_AT_GNU_dwo_name.
+    if (!CU->isDWOUnit() && !DWONameAttr)
+      continue;
+
+    std::string DWOName = dwarf::toString(DWONameAttr, "");
+    if (DWOName.empty())
+      continue;
+
+    if (!opts::DwarfOutputPath.empty()) {
+      DWOName = std::string(sys::path::filename(DWOName));
+      uint32_t &Index = NameToIndexMap[DWOName];
+      DWOName.append(std::to_string(Index));
+      ++Index;
+    }
+    DWOName.append(".dwo");
+    DWOIDToNameMap.emplace(*DWOID, std::move(DWOName));
+  }
+  return DWOIDToNameMap;
+}
 void DWARFRewriter::updateDebugInfo() {
   ErrorOr<BinarySection &> DebugInfo = BC.getUniqueSectionByName(".debug_info");
   if (!DebugInfo)
@@ -648,18 +683,30 @@ void DWARFRewriter::updateDebugInfo() {
 
   DWARF5AcceleratorTable DebugNamesTable(opts::CreateDebugNames, BC,
                                          *StrWriter);
+  if (DebugNamesTable.isCreated())
+    DebugNamesTable.preAllocateUnits(*BC.DwCtx);
+  std::unordered_map<uint64_t, std::string> DWOToNameMap =
+      getDWONameMap(*BC.DwCtx);
   GDBIndex GDBIndexSection(BC);
+  if (!opts::DwarfOutputPath.empty()) {
+    if (std::error_code EC =
+            sys::fs::create_directories(opts::DwarfOutputPath)) {
+      BC.errs() << "BOLT-ERROR: could not create directory '"
+                << opts::DwarfOutputPath << "': " << EC.message() << '\n';
+      return;
+    }
+  }
   auto processSplitCU = [&](DWARFUnit &Unit, DWARFUnit &SplitCU,
                             DebugRangesSectionWriter &TempRangesSectionWriter,
                             DebugAddrWriter &AddressWriter,
-                            const std::string &DWOName,
-                            const std::optional<std::string> &DwarfOutputPath,
+                            const std::string DWOName,
                             DIEBuilder &DWODIEBuilder) {
     DWODIEBuilder.buildDWOUnit(SplitCU);
     DebugStrOffsetsWriter DWOStrOffstsWriter(BC);
     DebugStrWriter DWOStrWriter((SplitCU).getContext(), true);
-    DWODIEBuilder.updateDWONameCompDirForTypes(
-        DWOStrOffstsWriter, DWOStrWriter, SplitCU, DwarfOutputPath, DWOName);
+    DWODIEBuilder.updateDWONameCompDirForTypes(DWOStrOffstsWriter, DWOStrWriter,
+                                               SplitCU, opts::DwarfOutputPath,
+                                               DWOName);
     DebugLoclistWriter DebugLocDWoWriter(Unit, Unit.getVersion(), true,
                                          AddressWriter);
 
@@ -744,12 +791,16 @@ void DWARFRewriter::updateDebugInfo() {
       DebugRangesSectionWriter &TempRangesSectionWriter =
           CU->getVersion() >= 5 ? *RangeListsWritersByCU[*DWOId].get()
                                 : *LegacyRangesWritersByCU[*DWOId].get();
-      std::optional<std::string> DwarfOutputPath =
-          opts::DwarfOutputPath.empty()
-              ? std::nullopt
-              : std::optional<std::string>(opts::DwarfOutputPath.c_str());
-      std::string DWOName = DIEBlder.updateDWONameCompDir(
-          *StrOffstsWriter, *StrWriter, *CU, DwarfOutputPath, std::nullopt);
+      auto NameIt = DWOToNameMap.find(*DWOId);
+      if (NameIt == DWOToNameMap.end()) {
+        BC.errs() << "BOLT-WARNING: [internal-dwarf-warning]: Could not find "
+                     "DWO name for DWO ID "
+                  << Twine::utohexstr(*DWOId) << ".\n";
+        continue;
+      }
+      auto DWOName = NameIt->second;
+      DIEBlder.updateDWONameCompDir(*StrOffstsWriter, *StrWriter, *CU,
+                                    opts::DwarfOutputPath, DWOName);
       auto DWODIEBuilderPtr = std::make_unique<DIEBuilder>(
           BC, &(**SplitCU).getContext(), DebugNamesTable, CU);
       DIEBuilder &DWODIEBuilder =
@@ -761,9 +812,9 @@ void DWARFRewriter::updateDebugInfo() {
       // loop, dereferencing CU/SplitCU in the call to processSplitCU means it
       // will dereference a different variable than the one intended, causing a
       // seg fault.
-      ThreadPool.async([&, DwarfOutputPath, DWOName, CU, SplitCU] {
+      ThreadPool.async([&, DWOName, CU, SplitCU] {
         processSplitCU(*CU, **SplitCU, TempRangesSectionWriter, AddressWriter,
-                       DWOName, DwarfOutputPath, DWODIEBuilder);
+                       DWOName, DWODIEBuilder);
       });
     }
     ThreadPool.wait();


### PR DESCRIPTION
This change makes BOLT's split DWARF rewriting path produce deterministic debug names output when processing CUs in parallel. 

Previously, several pieces of state used while building `.debug_names` and updating DWO names were populated during parallel CU processing. This could make CU/TU index assignment, cross- 
  CU DIE lookup, and duplicate DWO name disambiguation depend on thread scheduling order, which in turn could lead to non-reproducible output across runs.                                     
                                                                                                                                                                                               
The patch moves DWO name collection into a deterministic pre-processing step, pre-allocates debug names CU / foreign TU slots before concurrent processing, protects cross-CU DIE tracking 
  with a mutex, and adds a stable tie-breaker when sorting accelerator table entries. It also centralizes creation of the DWO output directory before parallel work starts.                    
                                                                                                                                                                                               
This improves reproducibility of BOLT output, makes debug info rewriting less sensitive to parallel execution order, and avoids subtle nondeterminism in generated `.debug_names` / split  DWARF artifacts. 

RFC - [[RFC][BOLT] A New Parallel DWARF Processing Approach in BOLT](https://discourse.llvm.org/t/rfc-bolt-a-new-parallel-dwarf-processing-approach-in-bolt/90736) (The overall changes will be split into two separate PRs for easier review.)
Draft PR - [[BOLT][DebugInfo] Add a new parallel DWARF processing(2/2)](https://github.com/llvm/llvm-project/pull/197859) (including all changes)