### PR TITLE
[libc] Restore sysconf to default entrypoints

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -390,6 +390,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.setsid
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
+    libc.src.unistd.sysconf
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat
@@ -1267,11 +1268,6 @@ if(LLVM_LIBC_FULL_BUILD)
   )
 endif()
 
-if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    libc.src.unistd.sysconf
-  )
-endif()
 
 set(TARGET_LIBMVEC_ENTRYPOINTS)
 

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -393,6 +393,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.setsid
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
+    libc.src.unistd.sysconf
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat
@@ -1401,11 +1402,6 @@ if(LLVM_LIBC_FULL_BUILD)
   )
 endif()
 
-if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    libc.src.unistd.sysconf
-  )
-endif()
 
 set(TARGET_LLVMLIBC_ENTRYPOINTS
   ${TARGET_LIBC_ENTRYPOINTS}

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -411,6 +411,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.unistd.setsid
     libc.src.unistd.symlink
     libc.src.unistd.symlinkat
+    libc.src.unistd.sysconf
     libc.src.unistd.truncate
     libc.src.unistd.unlink
     libc.src.unistd.unlinkat
@@ -1491,11 +1492,6 @@ if(LLVM_LIBC_FULL_BUILD)
   )
 endif()
 
-if(LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS)
-  list(APPEND TARGET_LIBC_ENTRYPOINTS
-    libc.src.unistd.sysconf
-  )
-endif()
 
 set(TARGET_LIBMVEC_ENTRYPOINTS)
 

--- a/libc/test/integration/scudo/CMakeLists.txt
+++ b/libc/test/integration/scudo/CMakeLists.txt
@@ -28,6 +28,7 @@ add_entrypoint_library(
     libc.src.unistd.__llvm_libc_syscall
     libc.src.unistd.close
     libc.src.unistd.read
+    libc.src.unistd.sysconf
     libc.src.unistd.write
 )
 


### PR DESCRIPTION
Reverts the experimental gating of sysconf introduced in 1d93fc4f74fe and restores it to the Scudo integration test entrypoints (undoing 8257855f77d5).

sysconf works correctly for the constants it handles. Moving it behind the experimental flag broke the Scudo build since Scudo calls sysconf(_SC_PAGESIZE).

Changes:
* libc/config/linux/{x86_64,aarch64,riscv}/entrypoints.txt: moved sysconf back into TARGET_LIBC_ENTRYPOINTS, removed the LLVM_LIBC_ENABLE_EXPERIMENTAL_ENTRYPOINTS guard.
* libc/test/integration/scudo/CMakeLists.txt: restored libc.src.unistd.sysconf to the Scudo entrypoint library.

Assisted-by: Automated tooling, human reviewed.