### PR TITLE
[BOLT] Define hugify option in CommandLineOpts.cpp

### DIFF
--- a/bolt/lib/RuntimeLibs/HugifyRuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/HugifyRuntimeLibrary.cpp
@@ -25,13 +25,6 @@ extern cl::OptionCategory BoltOptCategory;
 
 extern cl::opt<bool> HotText;
 
-cl::opt<bool>
-    Hugify("hugify",
-           cl::desc("Automatically put hot code on 2MB page(s) (hugify) at "
-                    "runtime. No manual call to hugify is needed in the binary "
-                    "(which is what --hot-text relies on)."),
-           cl::cat(BoltOptCategory));
-
 static cl::opt<std::string>
     RuntimeHugifyLib("runtime-hugify-lib",
                      cl::desc("specify path of the runtime hugify library"),

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -216,6 +216,13 @@ cl::opt<bool> HotText(
         "will put hot code into 2M pages. This requires relocation."),
     cl::ZeroOrMore, cl::cat(BoltCategory));
 
+cl::opt<bool> Hugify(
+    "hugify",
+    cl::desc("Automatically put hot code on 2MB page(s) (hugify) at runtime. "
+             "No manual call to hugify is needed in the binary (which is what "
+             "--hot-text relies on)."),
+    cl::cat(BoltOptCategory));
+
 cl::opt<bool>
     Instrument("instrument",
                cl::desc("instrument code to generate accurate profile data"),


### PR DESCRIPTION
#195272 added a reference to opts::Hugify from LongJmp.cpp. This
broke shared-library builds because LLVMBOLTPasses does not link
against LLVMBOLTRuntimeLibs, where the option was previously defined.

Move the opts::Hugify definition to CommandLineOpts.cpp, alongside
the other global BOLT command-line options. This keeps the option
available to LLVMBOLTPasses through its existing LLVMBOLTUtils
dependency without adding a dependency on the runtime library layer.