### PR TITLE
[CIR] Correct 'body' of range-for scope.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -936,6 +936,7 @@ CIRGenFunction::emitCXXForRangeStmt(const CXXForRangeStmt &s,
           bool useCurrentScope = true;
           if (emitStmt(s.getLoopVarStmt(), useCurrentScope).failed())
             loopRes = mlir::failure();
+          LexicalScope lexScope{*this, loc, builder.getInsertionBlock()};
           if (emitStmt(s.getBody(), useCurrentScope).failed())
             loopRes = mlir::failure();
           emitStopPoint(&s);

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -919,8 +919,9 @@ CIRGenFunction::emitCXXForRangeStmt(const CXXForRangeStmt &s,
     // sure we handle all cases.
     assert(!cir::MissingFeatures::loopSpecificCleanupHandling());
     // https://en.cppreference.com/w/cpp/language/for
-    // Given: 
-    // for ( init-statement condition ﻿(optional) ; expression ﻿(optional) ) statement
+    // Given:
+    // for ( init-statement condition ﻿(optional) ; expression ﻿(optional) )
+    // statement
     forOp = builder.createFor(
         getLoc(s.getSourceRange()),
         /*condBuilder=*/

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -920,8 +920,8 @@ CIRGenFunction::emitCXXForRangeStmt(const CXXForRangeStmt &s,
     assert(!cir::MissingFeatures::loopSpecificCleanupHandling());
     // https://en.cppreference.com/w/cpp/language/for
     // Given:
-    // for ( init-statement condition ﻿(optional) ; expression ﻿(optional) )
-    // statement
+    // for ( init-statement condition ﻿(optional) ; expression ﻿(optional)
+    // ) statement
     forOp = builder.createFor(
         getLoc(s.getSourceRange()),
         /*condBuilder=*/

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -918,7 +918,9 @@ CIRGenFunction::emitCXXForRangeStmt(const CXXForRangeStmt &s,
     // We probably already do the right thing because of ScopeOp, but make
     // sure we handle all cases.
     assert(!cir::MissingFeatures::loopSpecificCleanupHandling());
-
+    // https://en.cppreference.com/w/cpp/language/for
+    // Given: 
+    // for ( init-statement condition ﻿(optional) ; expression ﻿(optional) ) statement
     forOp = builder.createFor(
         getLoc(s.getSourceRange()),
         /*condBuilder=*/
@@ -930,14 +932,13 @@ CIRGenFunction::emitCXXForRangeStmt(const CXXForRangeStmt &s,
         },
         /*bodyBuilder=*/
         [&](mlir::OpBuilder &b, mlir::Location loc) {
-          // https://en.cppreference.com/w/cpp/language/for
-          // In C++ the scope of the init-statement and the scope of
-          // statement are one and the same.
+          // https://en.cppreference.com/cpp/language/range-for
+          // The scope of statement and the scope of expression are disjoint
+          // and nested within the scope of init-statement and condition.
           bool useCurrentScope = true;
           if (emitStmt(s.getLoopVarStmt(), useCurrentScope).failed())
             loopRes = mlir::failure();
-          LexicalScope lexScope{*this, loc, builder.getInsertionBlock()};
-          if (emitStmt(s.getBody(), useCurrentScope).failed())
+          if (emitStmt(s.getBody(), /*useCurrentScope=*/false).failed())
             loopRes = mlir::failure();
           emitStopPoint(&s);
         },

--- a/clang/test/CIR/CodeGen/forrange.cpp
+++ b/clang/test/CIR/CodeGen/forrange.cpp
@@ -131,3 +131,38 @@ void for_range3() {
 // CIR:        cir.yield
 // CIR:      }
 // CIR:    }
+
+struct HasDtor { ~HasDtor(); };
+
+void for_range4() {
+  C3 c;
+  for (Element &e : c) {
+    HasDtor hd;
+  }
+}
+// CIR: cir.func{{.*}} @_Z10for_range4v()
+// CIR:    cir.scope {
+// CIR:      %[[RANGE_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C3>{{.*}} ["__range1", init, const]
+// CIR:      %[[BEGIN_ADDR:.*]] = cir.alloca !rec_Iterator, !cir.ptr<!rec_Iterator>{{.*}} ["__begin1", init]
+// CIR:      %[[END_ADDR:.*]] = cir.alloca !rec_Iterator, !cir.ptr<!rec_Iterator>{{.*}} ["__end1", init]
+// CIR:      %[[E_ADDR:.*]] = cir.alloca !cir.ptr<!rec_Element>{{.*}} ["e", init, const]
+// CIR:      cir.store{{.*}} %[[C_ADDR]], %[[RANGE_ADDR]]
+// CIR:      cir.for : cond {
+// CIR:        %[[ITER_NE:.*]] = cir.call @_ZNK8IteratorneERKS_(%[[BEGIN_ADDR]], %[[END_ADDR]])
+// CIR:        cir.condition(%[[ITER_NE]])
+// CIR:      } body {
+// CIR:        %[[HD:.*]] = cir.alloca !rec_HasDtor, !cir.ptr<!rec_HasDtor>, ["hd"]
+// CIR:        %[[E:.*]] = cir.call @_ZN8IteratordeEv(%[[BEGIN_ADDR]])
+// CIR:        cir.store{{.*}} %[[E]], %[[E_ADDR]]
+// CIR:        cir.cleanup.scope {
+// CIR:          cir.yield
+// CIR:        } cleanup normal {
+// CIR:          cir.call @_ZN7HasDtorD1Ev(%[[HD]]) nothrow 
+// CIR:          cir.yield
+// CIR:        }
+// CIR:        cir.yield
+// CIR:      } step {
+// CIR:        %[[ITER_NEXT:.*]] = cir.call @_ZN8IteratorppEv(%[[BEGIN_ADDR]])
+// CIR:        cir.yield
+// CIR:      }
+// CIR:    }

--- a/clang/test/CIR/CodeGen/forrange.cpp
+++ b/clang/test/CIR/CodeGen/forrange.cpp
@@ -151,14 +151,16 @@ void for_range4() {
 // CIR:        %[[ITER_NE:.*]] = cir.call @_ZNK8IteratorneERKS_(%[[BEGIN_ADDR]], %[[END_ADDR]])
 // CIR:        cir.condition(%[[ITER_NE]])
 // CIR:      } body {
-// CIR:        %[[HD:.*]] = cir.alloca !rec_HasDtor, !cir.ptr<!rec_HasDtor>, ["hd"]
 // CIR:        %[[E:.*]] = cir.call @_ZN8IteratordeEv(%[[BEGIN_ADDR]])
 // CIR:        cir.store{{.*}} %[[E]], %[[E_ADDR]]
-// CIR:        cir.cleanup.scope {
-// CIR:          cir.yield
-// CIR:        } cleanup normal {
-// CIR:          cir.call @_ZN7HasDtorD1Ev(%[[HD]]) nothrow 
-// CIR:          cir.yield
+// CIR:        cir.scope {
+// CIR:          %[[HD:.*]] = cir.alloca !rec_HasDtor, !cir.ptr<!rec_HasDtor>, ["hd"]
+// CIR:          cir.cleanup.scope {
+// CIR:            cir.yield
+// CIR:          } cleanup normal {
+// CIR:            cir.call @_ZN7HasDtorD1Ev(%[[HD]]) nothrow 
+// CIR:            cir.yield
+// CIR:          }
 // CIR:        }
 // CIR:        cir.yield
 // CIR:      } step {


### PR DESCRIPTION
Without this, we fail the verifier due to lack of a terminator on the scope if there is a destructed type in the 'body', as the cleanup scope on the cir.scope object will insert the yield in the body (since that is the last place we needed a cleanup), rather than actually putting one at the end of the scope itself.

This patch just makes sure that "statement" (aka body) of the range-for happens in its own scope.  This is necessary because, as cpp reference says:

```
The scope of init-statement and the scope of condition are the same.
The scope of statement and the scope of expression are disjoint and nested within the scope of init-statement and condition.
```

We were not making them distinct, so we were doing cleanups incorrectly. 