### PR TITLE
[libc] Annex K: strcpy_s

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -75,6 +75,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strcmp
     libc.src.string.strcoll
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strdup
     libc.src.string.strerror

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -75,6 +75,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strcmp
     libc.src.string.strcoll
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strdup
     libc.src.string.strerror

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -38,6 +38,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strchrnul
     libc.src.string.strcmp
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strlcat
     libc.src.string.strlcpy

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -37,6 +37,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strchrnul
     libc.src.string.strcmp
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strlcat
     libc.src.string.strlcpy

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -68,6 +68,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strcmp
     libc.src.string.strcoll
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strdup
     libc.src.string.strerror

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -41,6 +41,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strchrnul
     libc.src.string.strcmp
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strlcat
     libc.src.string.strlcpy

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -70,6 +70,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.string.strcmp
     libc.src.string.strcoll
     libc.src.string.strcpy
+    libc.src.string.strcpy_s
     libc.src.string.strcspn
     libc.src.string.strdup
     libc.src.string.strerror

--- a/libc/include/llvm-libc-macros/annex-k-macros.h
+++ b/libc/include/llvm-libc-macros/annex-k-macros.h
@@ -1,9 +1,14 @@
-//===-- Definition of macros to be used with Annex K functions ------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines macros used with Annex K functions.
+///
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_LIBC_INCLUDE_LLVM_LIBC_MACROS_ANNEX_K_MACROS_H
@@ -19,6 +24,8 @@
 #if defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
 
 #define LIBC_HAS_ANNEX_K
+
+#define LIBC_ERRNO_T_ERROR_VALUE 1
 
 #endif // defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ == 1
 

--- a/libc/include/string.yaml
+++ b/libc/include/string.yaml
@@ -169,6 +169,15 @@ functions:
     arguments:
       - type: char *__restrict
       - type: const char *__restrict
+  - name: strcpy_s
+    standards:
+      - stdc
+    return_type: errno_t
+    arguments:
+      - type: char *__restrict
+      - type: rsize_t
+      - type: const char *__restrict
+    guard: LIBC_HAS_ANNEX_K
   - name: strcspn
     standards:
       - stdc

--- a/libc/src/string/CMakeLists.txt
+++ b/libc/src/string/CMakeLists.txt
@@ -173,6 +173,25 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  strcpy_s
+  SRCS
+    strcpy_s.cpp
+  HDRS
+    strcpy_s.h
+  DEPENDS
+    .memory_utils.inline_memcpy
+    .string_utils
+    .strnlen_s
+    libc.src.__support.common
+    libc.src.__support.constraint_handler
+    libc.src.__support.macros.config
+    libc.hdr.types.constraint_handler_t
+    libc.hdr.types.errno_t
+    libc.hdr.types.rsize_t
+    libc.hdr.stdint_proxy
+)
+
+add_entrypoint_object(
   strcspn
   SRCS
     strcspn.cpp

--- a/libc/src/string/CMakeLists.txt
+++ b/libc/src/string/CMakeLists.txt
@@ -181,9 +181,9 @@ add_entrypoint_object(
   DEPENDS
     .memory_utils.inline_memcpy
     .string_utils
-    .strnlen_s
     libc.src.__support.common
     libc.src.__support.constraint_handler
+    libc.src.__support.CPP.expected
     libc.src.__support.macros.config
     libc.hdr.types.constraint_handler_t
     libc.hdr.types.errno_t

--- a/libc/src/string/strcpy_s.cpp
+++ b/libc/src/string/strcpy_s.cpp
@@ -11,11 +11,9 @@
 ///
 //===----------------------------------------------------------------------===//
 
-// For RSIZE_MAX
 #define __STDC_WANT_LIB_EXT1__ 1
 #include "hdr/stdint_proxy.h"
 #undef __STDC_WANT_LIB_EXT1__
-
 #include "hdr/types/constraint_handler_t.h"
 #include "hdr/types/errno_t.h"
 #include "hdr/types/rsize_t.h"
@@ -55,7 +53,10 @@ LLVM_LIBC_FUNCTION(errno_t, strcpy_s,
   // Use s1max for the destination's length, not count + 1, because the
   // standard allows for overwriting the entire destination region, even if
   // s2's length is smaller than s1max.
-  else if (s2 < (s1 + s1max) && s1 < (s2 + count + 1)) {
+  else if (const uintptr_t s1_addr = reinterpret_cast<uintptr_t>(s1),
+           s2_addr = reinterpret_cast<uintptr_t>(s2);
+           s1_addr < s2_addr ? s2_addr - s1_addr < s1max
+                             : s1_addr - s2_addr < count + 1) {
     constraint_violation_msg = "strcpy_s: s1 and s2 cannot overlap";
   }
 

--- a/libc/src/string/strcpy_s.cpp
+++ b/libc/src/string/strcpy_s.cpp
@@ -1,0 +1,71 @@
+//===-- Implementation of strcpy_s ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// For RSIZE_MAX
+#define __STDC_WANT_LIB_EXT1__ 1
+#include "hdr/stdint_proxy.h"
+#undef __STDC_WANT_LIB_EXT1__
+
+#include "hdr/types/constraint_handler_t.h"
+#include "hdr/types/errno_t.h"
+#include "hdr/types/rsize_t.h"
+#include "src/__support/common.h"
+#include "src/__support/constraint_handler.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/strcpy_s.h"
+#include "src/string/string_utils.h"
+#include "src/string/strnlen_s.h"
+
+#define ERRNO_T_FAIL 1
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(errno_t, strcpy_s,
+                   (char *__restrict s1, rsize_t s1max,
+                    const char *__restrict s2)) {
+  const char *constraint_violation_msg = 0;
+  size_t count;
+
+  if (s1 == 0) {
+    constraint_violation_msg = "strcpy_s: s1 is null";
+  } else if (s2 == 0) {
+    constraint_violation_msg = "strcpy_s: s2 is null";
+  } else if (s1max > RSIZE_MAX) {
+    constraint_violation_msg = "strcpy_s: s1max exceeds RSIZE_MAX";
+  } else if (s1max == 0) {
+    constraint_violation_msg = "strcpy_s: s1max is 0";
+  } else if (count = strnlen_s(s2, s1max);
+             s1max == count) { // count can't be greater than s1max by
+                               // definition, so no need to check for this case
+    constraint_violation_msg = "strcpy_s: s1max is too small for s2";
+  }
+  // Check overlap using the full regions defined by the standard, including the
+  // terminating null byte:
+  //   destination: [s1, s1 + s1max)
+  //   source:      [s2, s2 + count + 1)
+  // Use s1max for the destination's length, not count + 1, because the
+  // standard allows for overwriting the entire destination region, even if
+  // s2's length is smaller than s1max.
+  else if (s2 < (s1 + s1max) && s1 < (s2 + count + 1)) {
+    constraint_violation_msg = "strcpy_s: s1 and s2 overlap";
+  }
+
+  if (constraint_violation_msg) {
+    if (s1 != 0 && s1max > 0 && s1max <= RSIZE_MAX) {
+      s1[0] = '\0';
+    }
+    libc_global_constraint_handler(constraint_violation_msg, 0, ERRNO_T_FAIL);
+    return ERRNO_T_FAIL;
+  }
+
+  inline_memcpy(s1, s2, count + 1);
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/string/strcpy_s.cpp
+++ b/libc/src/string/strcpy_s.cpp
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of strcpy_s.
+///
+//===----------------------------------------------------------------------===//
+
+// For RSIZE_MAX
+#define __STDC_WANT_LIB_EXT1__ 1
+#include "hdr/stdint_proxy.h"
+#undef __STDC_WANT_LIB_EXT1__
+
+#include "hdr/types/constraint_handler_t.h"
+#include "hdr/types/errno_t.h"
+#include "hdr/types/rsize_t.h"
+#include "src/__support/common.h"
+#include "src/__support/constraint_handler.h"
+#include "src/__support/macros/config.h"
+#include "src/string/memory_utils/inline_memcpy.h"
+#include "src/string/strcpy_s.h"
+#include "src/string/string_utils.h"
+#include "src/string/strnlen_s.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(errno_t, strcpy_s,
+                   (char *__restrict s1, rsize_t s1max,
+                    const char *__restrict s2)) {
+  const char *constraint_violation_msg = 0;
+  size_t count;
+
+  if (s1 == 0) {
+    constraint_violation_msg = "strcpy_s: s1 cannot be null";
+  } else if (s2 == 0) {
+    constraint_violation_msg = "strcpy_s: s2 cannot be null";
+  } else if (s1max > RSIZE_MAX) {
+    constraint_violation_msg = "strcpy_s: s1max cannot exceed RSIZE_MAX";
+  } else if (s1max == 0) {
+    constraint_violation_msg = "strcpy_s: s1max cannot be 0";
+  } else if (count = strnlen_s(s2, s1max);
+             s1max == count) { // count can't be greater than s1max by
+                               // definition, so no need to check for this case
+    constraint_violation_msg = "strcpy_s: s1max is too small for s2";
+  }
+  // Check overlap using the full regions defined by the standard, including the
+  // terminating null byte:
+  //   destination: [s1, s1 + s1max)
+  //   source:      [s2, s2 + count + 1)
+  // Use s1max for the destination's length, not count + 1, because the
+  // standard allows for overwriting the entire destination region, even if
+  // s2's length is smaller than s1max.
+  else if (s2 < (s1 + s1max) && s1 < (s2 + count + 1)) {
+    constraint_violation_msg = "strcpy_s: s1 and s2 cannot overlap";
+  }
+
+  if (constraint_violation_msg) {
+    if (s1 != 0 && s1max > 0 && s1max <= RSIZE_MAX) {
+      s1[0] = '\0';
+    }
+    libc_global_constraint_handler(constraint_violation_msg, 0, 1);
+    return 1;
+  }
+
+  inline_memcpy(s1, s2, count + 1);
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/string/strcpy_s.cpp
+++ b/libc/src/string/strcpy_s.cpp
@@ -11,41 +11,39 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "src/string/strcpy_s.h"
 #define __STDC_WANT_LIB_EXT1__ 1
 #include "hdr/stdint_proxy.h"
 #undef __STDC_WANT_LIB_EXT1__
 #include "hdr/types/constraint_handler_t.h"
 #include "hdr/types/errno_t.h"
 #include "hdr/types/rsize_t.h"
+#include "src/__support/CPP/expected.h"
 #include "src/__support/common.h"
 #include "src/__support/constraint_handler.h"
 #include "src/__support/macros/config.h"
 #include "src/string/memory_utils/inline_memcpy.h"
-#include "src/string/strcpy_s.h"
 #include "src/string/string_utils.h"
-#include "src/string/strnlen_s.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(errno_t, strcpy_s,
-                   (char *__restrict s1, rsize_t s1max,
-                    const char *__restrict s2)) {
-  const char *constraint_violation_msg = 0;
-  size_t count;
+LIBC_INLINE static cpp::expected<size_t, const char *>
+validate(char *__restrict s1, rsize_t s1max, const char *__restrict s2) {
+  if (s1 == nullptr)
+    return cpp::unexpected("strcpy_s: s1 cannot be null");
+  if (s2 == nullptr)
+    return cpp::unexpected("strcpy_s: s2 cannot be null");
+  if (s1max > RSIZE_MAX)
+    return cpp::unexpected("strcpy_s: s1max cannot exceed RSIZE_MAX");
+  if (s1max == 0)
+    return cpp::unexpected("strcpy_s: s1max cannot be 0");
 
-  if (s1 == 0) {
-    constraint_violation_msg = "strcpy_s: s1 cannot be null";
-  } else if (s2 == 0) {
-    constraint_violation_msg = "strcpy_s: s2 cannot be null";
-  } else if (s1max > RSIZE_MAX) {
-    constraint_violation_msg = "strcpy_s: s1max cannot exceed RSIZE_MAX";
-  } else if (s1max == 0) {
-    constraint_violation_msg = "strcpy_s: s1max cannot be 0";
-  } else if (count = strnlen_s(s2, s1max);
-             s1max == count) { // count can't be greater than s1max by
-                               // definition, so no need to check for this case
-    constraint_violation_msg = "strcpy_s: s1max is too small for s2";
-  }
+  // count can't be greater than s1max by definition, so no need to check for
+  // this case.
+  size_t count = internal::strnlen_s(s2, s1max);
+  if (s1max == count)
+    return cpp::unexpected("strcpy_s: s1max is too small for s2");
+
   // Check overlap using the full regions defined by the standard, including the
   // terminating null byte:
   //   destination: [s1, s1 + s1max)
@@ -53,22 +51,30 @@ LLVM_LIBC_FUNCTION(errno_t, strcpy_s,
   // Use s1max for the destination's length, not count + 1, because the
   // standard allows for overwriting the entire destination region, even if
   // s2's length is smaller than s1max.
-  else if (const uintptr_t s1_addr = reinterpret_cast<uintptr_t>(s1),
-           s2_addr = reinterpret_cast<uintptr_t>(s2);
-           s1_addr < s2_addr ? s2_addr - s1_addr < s1max
-                             : s1_addr - s2_addr < count + 1) {
-    constraint_violation_msg = "strcpy_s: s1 and s2 cannot overlap";
-  }
+  const uintptr_t s1_addr = reinterpret_cast<uintptr_t>(s1);
+  const uintptr_t s2_addr = reinterpret_cast<uintptr_t>(s2);
+  if (s1_addr < s2_addr ? s2_addr - s1_addr < s1max
+                        : s1_addr - s2_addr < count + 1)
+    return cpp::unexpected("strcpy_s: s1 and s2 cannot overlap");
 
-  if (constraint_violation_msg) {
-    if (s1 != 0 && s1max > 0 && s1max <= RSIZE_MAX) {
+  return count;
+}
+
+LLVM_LIBC_FUNCTION(errno_t, strcpy_s,
+                   (char *__restrict s1, rsize_t s1max,
+                    const char *__restrict s2)) {
+  const auto count_expected = validate(s1, s1max, s2);
+
+  if (!count_expected.has_value()) {
+    if (s1 != nullptr && s1max > 0 && s1max <= RSIZE_MAX) {
       s1[0] = '\0';
     }
-    libc_global_constraint_handler(constraint_violation_msg, 0, 1);
-    return 1;
+    libc_global_constraint_handler(count_expected.error(), 0,
+                                   LIBC_ERRNO_T_ERROR_VALUE);
+    return LIBC_ERRNO_T_ERROR_VALUE;
   }
 
-  inline_memcpy(s1, s2, count + 1);
+  inline_memcpy(s1, s2, count_expected.value() + 1);
   return 0;
 }
 

--- a/libc/src/string/strcpy_s.h
+++ b/libc/src/string/strcpy_s.h
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation header for strcpy_s.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCPY_S_H
+#define LLVM_LIBC_SRC_STRING_STRCPY_S_H
+
+#include "hdr/types/errno_t.h"
+#include "hdr/types/rsize_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+errno_t strcpy_s(char *__restrict s1, rsize_t s1max, const char *__restrict s2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCPY_S_H

--- a/libc/src/string/strcpy_s.h
+++ b/libc/src/string/strcpy_s.h
@@ -1,0 +1,22 @@
+//===-- Implementation header for strcpy_s ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_STRING_STRCPY_S_H
+#define LLVM_LIBC_SRC_STRING_STRCPY_S_H
+
+#include "hdr/types/errno_t.h"
+#include "hdr/types/rsize_t.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+errno_t strcpy_s(char *__restrict s1, rsize_t s1max, const char *__restrict s2);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_STRING_STRCPY_S_H

--- a/libc/src/string/string_utils.h
+++ b/libc/src/string/string_utils.h
@@ -130,6 +130,10 @@ LIBC_INLINE size_t strnlen(const char *s, size_t max_len) {
   return temp ? reinterpret_cast<const char *>(temp) - s : max_len;
 }
 
+LIBC_INLINE size_t strnlen_s(const char *s, size_t n) {
+  return (s != nullptr) ? internal::strnlen(s, n) : 0;
+}
+
 } // namespace internal
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/string/strnlen_s.cpp
+++ b/libc/src/string/strnlen_s.cpp
@@ -15,7 +15,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(size_t, strnlen_s, (const char *s, size_t n)) {
-  return (s != 0) ? internal::strnlen(s, n) : 0;
+  return internal::strnlen_s(s, n);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -221,3 +221,14 @@ add_header_library(
     libc.src.__support.macros.properties.architectures
     libc.src.errno.errno
 )
+
+add_header_library(
+  ConstraintHandlerCheckingTest
+  HDRS
+    ConstraintHandlerCheckingTest.h
+  DEPENDS
+    libc.hdr.types.constraint_handler_t
+    libc.hdr.types.errno_t
+    libc.src.stdlib.set_constraint_handler_s
+    libc.src.string.string_utils
+)

--- a/libc/test/UnitTest/ConstraintHandlerCheckingTest.h
+++ b/libc/test/UnitTest/ConstraintHandlerCheckingTest.h
@@ -1,0 +1,44 @@
+//===-- ConstraintHandlerCheckingTest.h ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_TEST_UNITTEST_CONSTRAINTHANDLERCHECKINGTEST_H
+#define LLVM_LIBC_TEST_UNITTEST_CONSTRAINTHANDLERCHECKINGTEST_H
+
+#include "hdr/types/constraint_handler_t.h"
+#include "hdr/types/errno_t.h"
+#include "src/stdlib/set_constraint_handler_s.h"
+#include "src/string/string_utils.h"
+#include "test/UnitTest/Test.h"
+
+namespace {
+
+char buffer[300];
+
+void local_constraint_handler(const char *__restrict msg,
+                              void *__restrict /*ptr*/, errno_t /*error*/) {
+  LIBC_NAMESPACE::internal::strlcpy(buffer, msg, sizeof(buffer));
+}
+
+} // anonymous namespace
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace testing {
+
+class ConstraintHandlerCheckingTest : public Test {
+public:
+  void SetUp() override {
+    Test::SetUp();
+    LIBC_NAMESPACE::set_constraint_handler_s(local_constraint_handler);
+  }
+};
+
+} // namespace testing
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_TEST_UNITTEST_CONSTRAINTHANDLERCHECKINGTEST_H

--- a/libc/test/src/string/CMakeLists.txt
+++ b/libc/test/src/string/CMakeLists.txt
@@ -150,6 +150,19 @@ add_libc_test(
 )
 
 add_libc_test(
+  strcpy_s_test
+  SUITE
+    libc-string-tests
+  SRCS
+    strcpy_s_test.cpp
+  DEPENDS
+    libc.src.string.strcpy_s
+    libc.hdr.stdint_proxy
+    libc.hdr.types.errno_t
+    libc.test.UnitTest.ConstraintHandlerCheckingTest
+)
+
+add_libc_test(
   strcspn_test
   SUITE
     libc-string-tests

--- a/libc/test/src/string/strcpy_s_test.cpp
+++ b/libc/test/src/string/strcpy_s_test.cpp
@@ -1,0 +1,138 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains unit tests for strcpy_s.
+///
+//===----------------------------------------------------------------------===//
+
+#define __STDC_WANT_LIB_EXT1__ 1
+#include "hdr/stdint_proxy.h"
+#undef __STDC_WANT_LIB_EXT1__
+
+#include "hdr/types/errno_t.h"
+#include "src/string/strcpy_s.h"
+#include "test/UnitTest/ConstraintHandlerCheckingTest.h"
+
+using LlvmLibcStrCpySTest =
+    LIBC_NAMESPACE::testing::ConstraintHandlerCheckingTest;
+
+// Success cases
+TEST_F(LlvmLibcStrCpySTest, SuccessfulCopy) {
+  char s1[8];
+  const char *s2 = "abc";
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, sizeof(s1), s2);
+  ASSERT_EQ(result, 0);
+  ASSERT_STREQ(s1, s2);
+  ASSERT_FALSE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, ExactFitSuccessfulCopy) {
+  char s1[4];
+  const char *s2 = "abc";
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, sizeof(s1), s2);
+  ASSERT_EQ(result, 0);
+  ASSERT_STREQ(s1, s2);
+  ASSERT_FALSE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, AdjacentObjectsDoNotOverlap) {
+  char s[8] = {'a', 'b', 'c', '\0', '?', '?', '?', '?'};
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s + 4, 4, s);
+  ASSERT_EQ(result, 0);
+  ASSERT_STREQ(s + 4, "abc");
+  ASSERT_FALSE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, EmptySourceString) {
+  char s1[4];
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, sizeof(s1), "");
+  ASSERT_EQ(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_FALSE(error_flag);
+}
+
+// Failure cases
+TEST_F(LlvmLibcStrCpySTest, NullS1) {
+  const char *s2 = "abc";
+  char *s1 = 0;
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 4, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_TRUE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, NullS2) {
+  char s1[4];
+  const char *s2 = 0;
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 4, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_TRUE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, S1MaxGreaterThanRSizeMax) {
+  char s1[4];
+  const char *s2 = "abc";
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, RSIZE_MAX + 1, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_TRUE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, S1MaxIsZero) {
+  char s1[4];
+  const char *s2 = "abc";
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 0, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_TRUE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, S1MaxTooSmallForS2) {
+  char s1[3];
+  const char *s2 = "abc";
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 3, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_TRUE(error_flag);
+
+  s2 = "abcd";
+  s1[0] = '?';
+  error_flag = false;
+  ASSERT_FALSE(error_flag);
+  result = LIBC_NAMESPACE::strcpy_s(s1, 3, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_TRUE(error_flag);
+}
+
+TEST_F(LlvmLibcStrCpySTest, OverlappingObjects) {
+  char s[10] = "123456789";
+
+  ASSERT_FALSE(error_flag);
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s, 6, s + 4);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s[0], '\0');
+  ASSERT_TRUE(error_flag);
+}

--- a/libc/test/src/string/strcpy_s_test.cpp
+++ b/libc/test/src/string/strcpy_s_test.cpp
@@ -1,0 +1,122 @@
+//===-- Unittests for strcpy_s --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define __STDC_WANT_LIB_EXT1__ 1
+#include "hdr/stdint_proxy.h"
+#undef __STDC_WANT_LIB_EXT1__
+
+#include "hdr/types/errno_t.h"
+#include "src/string/strcpy_s.h"
+#include "test/UnitTest/ConstraintHandlerCheckingTest.h"
+
+using LlvmLibcStrCpySTest =
+    LIBC_NAMESPACE::testing::ConstraintHandlerCheckingTest;
+
+// Success cases
+TEST_F(LlvmLibcStrCpySTest, SuccessfulCopy) {
+  char s1[8];
+  const char *s2 = "abc";
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, sizeof(s1), s2);
+  ASSERT_EQ(result, 0);
+  ASSERT_STREQ(s1, s2);
+  ASSERT_STREQ(buffer, "");
+}
+
+TEST_F(LlvmLibcStrCpySTest, ExactFitSuccessfulCopy) {
+  char s1[4];
+  const char *s2 = "abc";
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, sizeof(s1), s2);
+  ASSERT_EQ(result, 0);
+  ASSERT_STREQ(s1, s2);
+  ASSERT_STREQ(buffer, "");
+}
+
+TEST_F(LlvmLibcStrCpySTest, AdjacentObjectsDoNotOverlap) {
+  char s[8] = {'a', 'b', 'c', '\0', '?', '?', '?', '?'};
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s + 4, 4, s);
+  ASSERT_EQ(result, 0);
+  ASSERT_STREQ(s + 4, "abc");
+  ASSERT_STREQ(buffer, "");
+}
+
+TEST_F(LlvmLibcStrCpySTest, EmptySourceString) {
+  char s1[4];
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, sizeof(s1), "");
+  ASSERT_EQ(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_STREQ(buffer, "");
+}
+
+// Failure cases
+TEST_F(LlvmLibcStrCpySTest, NullS1) {
+  const char *s2 = "abc";
+  char *s1 = 0;
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 4, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_STREQ(buffer, "strcpy_s: s1 is null");
+}
+
+TEST_F(LlvmLibcStrCpySTest, NullS2) {
+  char s1[4];
+  const char *s2 = 0;
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 4, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_STREQ(buffer, "strcpy_s: s2 is null");
+}
+
+TEST_F(LlvmLibcStrCpySTest, S1MaxGreaterThanRSizeMax) {
+  char s1[4];
+  const char *s2 = "abc";
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, RSIZE_MAX + 1, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_STREQ(buffer, "strcpy_s: s1max exceeds RSIZE_MAX");
+}
+
+TEST_F(LlvmLibcStrCpySTest, S1MaxIsZero) {
+  char s1[4];
+  const char *s2 = "abc";
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 0, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_STREQ(buffer, "strcpy_s: s1max is 0");
+}
+
+TEST_F(LlvmLibcStrCpySTest, S1MaxTooSmallForS2) {
+  char s1[3];
+  const char *s2 = "abc";
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s1, 3, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_STREQ(buffer, "strcpy_s: s1max is too small for s2");
+
+  s2 = "abcd";
+  s1[0] = '?';
+  buffer[0] = '\0';
+  result = LIBC_NAMESPACE::strcpy_s(s1, 3, s2);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s1[0], '\0');
+  ASSERT_STREQ(buffer, "strcpy_s: s1max is too small for s2");
+}
+
+TEST_F(LlvmLibcStrCpySTest, OverlappingObjects) {
+  char s[10] = "123456789";
+
+  errno_t result = LIBC_NAMESPACE::strcpy_s(s, 6, s + 4);
+  ASSERT_NE(result, 0);
+  ASSERT_EQ(s[0], '\0');
+  ASSERT_STREQ(buffer, "strcpy_s: s1 and s2 overlap");
+}


### PR DESCRIPTION
This patch adds Annex K's `strcpy_s`.