### PR TITLE
[mlir] Cleanup Operation.cpp (NFC)

### DIFF
--- a/mlir/include/mlir/IR/Operation.h
+++ b/mlir/include/mlir/IR/Operation.h
@@ -18,7 +18,6 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Region.h"
-#include "llvm/ADT/Twine.h"
 #include <optional>
 
 namespace mlir {

--- a/mlir/lib/IR/Operation.cpp
+++ b/mlir/lib/IR/Operation.cpp
@@ -21,7 +21,6 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
-#include <numeric>
 #include <optional>
 
 using namespace mlir;
@@ -40,7 +39,7 @@ Operation *Operation::create(const OperationState &state) {
     assert(!state.properties);
     LogicalResult result =
         op->setPropertiesFromAttribute(state.propertiesAttr,
-                                       /*diagnostic=*/nullptr);
+                                       /*emitError=*/nullptr);
     assert(result.succeeded() && "invalid properties in op creation");
     (void)result;
   }
@@ -678,7 +677,7 @@ Operation::CloneOptions::CloneOptions(
     bool cloneRegions, bool cloneOperands,
     std::optional<SmallVector<Type>> resultTypes)
     : cloneRegionsFlag(cloneRegions), cloneOperandsFlag(cloneOperands),
-      resultTypes(resultTypes) {}
+      resultTypes(std::move(resultTypes)) {}
 
 Operation::CloneOptions Operation::CloneOptions::all() {
   return CloneOptions().cloneRegions().cloneOperands().withResultTypes(


### PR DESCRIPTION
This PR cleans up the Operation.cpp based on clangd suggestions. It removes unused headers, fixes incorrect comments, and improves performance by applying std::move where appropriate.