### PR TITLE
[lldb] Make PTY initialization idempotent

### DIFF
--- a/lldb/include/lldb/Host/PseudoTerminal.h
+++ b/lldb/include/lldb/Host/PseudoTerminal.h
@@ -44,6 +44,11 @@ public:
   /// Close the secondary file descriptor if it is valid.
   void CloseSecondaryFileDescriptor();
 
+  /// Close both file descriptors and clear cached state. Used to recycle a
+  /// PseudoTerminal across multiple launches without invalidating any
+  /// outstanding shared_ptr references.
+  void Reset();
+
   /// Fork a child process that uses pseudo terminals for its stdio.
   ///
   /// In the parent process, a call to this function results in a pid being

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -69,6 +69,13 @@ public:
   /// CreateProcessW to avoid keeping the pipes alive indefinitely.
   void CloseAnonymousPipes();
 
+  /// Closes any open ConPTY/pipe handles and resets internal state to a
+  /// freshly-constructed PseudoConsole. Useful when a ProcessLaunchInfo gets
+  /// reused for a second launch — the previous PseudoConsole would otherwise
+  /// trip the `m_mode == Mode::None` assert in OpenPseudoConsole /
+  /// OpenAnonymousPipes.
+  void Reset();
+
   /// Returns whether the ConPTY and its pipes are currently open and valid.
   bool IsConnected() const;
 

--- a/lldb/include/lldb/Host/windows/PseudoConsole.h
+++ b/lldb/include/lldb/Host/windows/PseudoConsole.h
@@ -70,10 +70,7 @@ public:
   void CloseAnonymousPipes();
 
   /// Closes any open ConPTY/pipe handles and resets internal state to a
-  /// freshly-constructed PseudoConsole. Useful when a ProcessLaunchInfo gets
-  /// reused for a second launch — the previous PseudoConsole would otherwise
-  /// trip the `m_mode == Mode::None` assert in OpenPseudoConsole /
-  /// OpenAnonymousPipes.
+  /// freshly-constructed PseudoConsole.
   void Reset();
 
   /// Returns whether the ConPTY and its pipes are currently open and valid.

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -233,8 +233,6 @@ llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
 
   if (!m_pty)
     m_pty = std::make_shared<PTY>();
-  else
-    m_pty->Reset();
 
   bool stdin_free = GetFileActionForFD(STDIN_FILENO) == nullptr;
   bool stdout_free = GetFileActionForFD(STDOUT_FILENO) == nullptr;
@@ -272,8 +270,6 @@ llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
 llvm::Error ProcessLaunchInfo::SetUpPipeRedirection() {
   if (!m_pty)
     m_pty = std::make_shared<PTY>();
-  else
-    m_pty->Reset();
   return m_pty->OpenAnonymousPipes();
 }
 #endif

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -231,9 +231,10 @@ void ProcessLaunchInfo::SetDetachOnError(bool enable) {
 llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
   Log *log = GetLog(LLDBLog::Process);
 
-  // Always start with a fresh PTY. `ProcessLaunchInfo` is reused across
-  // multiple launches and the underlying PTY is single-shot.
-  m_pty = std::make_shared<PTY>();
+  if (!m_pty)
+    m_pty = std::make_shared<PTY>();
+  else
+    m_pty->Reset();
 
   bool stdin_free = GetFileActionForFD(STDIN_FILENO) == nullptr;
   bool stdout_free = GetFileActionForFD(STDOUT_FILENO) == nullptr;
@@ -269,7 +270,10 @@ llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
 
 #ifdef _WIN32
 llvm::Error ProcessLaunchInfo::SetUpPipeRedirection() {
-  m_pty = std::make_shared<PTY>();
+  if (!m_pty)
+    m_pty = std::make_shared<PTY>();
+  else
+    m_pty->Reset();
   return m_pty->OpenAnonymousPipes();
 }
 #endif

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -231,12 +231,9 @@ void ProcessLaunchInfo::SetDetachOnError(bool enable) {
 llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
   Log *log = GetLog(LLDBLog::Process);
 
-#ifdef _WIN32
+  // Always start with a fresh PTY. `ProcessLaunchInfo` is reused across
+  // multiple launches and the underlying PTY is single-shot.
   m_pty = std::make_shared<PTY>();
-#else
-  if (!m_pty)
-    m_pty = std::make_shared<PTY>();
-#endif
 
   bool stdin_free = GetFileActionForFD(STDIN_FILENO) == nullptr;
   bool stdout_free = GetFileActionForFD(STDOUT_FILENO) == nullptr;

--- a/lldb/source/Host/common/ProcessLaunchInfo.cpp
+++ b/lldb/source/Host/common/ProcessLaunchInfo.cpp
@@ -231,8 +231,12 @@ void ProcessLaunchInfo::SetDetachOnError(bool enable) {
 llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
   Log *log = GetLog(LLDBLog::Process);
 
+#ifdef _WIN32
+  m_pty = std::make_shared<PTY>();
+#else
   if (!m_pty)
     m_pty = std::make_shared<PTY>();
+#endif
 
   bool stdin_free = GetFileActionForFD(STDIN_FILENO) == nullptr;
   bool stdout_free = GetFileActionForFD(STDOUT_FILENO) == nullptr;
@@ -268,8 +272,7 @@ llvm::Error ProcessLaunchInfo::SetUpPtyRedirection() {
 
 #ifdef _WIN32
 llvm::Error ProcessLaunchInfo::SetUpPipeRedirection() {
-  if (!m_pty)
-    m_pty = std::make_shared<PTY>();
+  m_pty = std::make_shared<PTY>();
   return m_pty->OpenAnonymousPipes();
 }
 #endif

--- a/lldb/source/Host/common/PseudoTerminal.cpp
+++ b/lldb/source/Host/common/PseudoTerminal.cpp
@@ -38,10 +38,7 @@ PseudoTerminal::PseudoTerminal() = default;
 // are valid and ownership has not been released using the
 // ReleasePrimaryFileDescriptor() or the ReleaseSaveFileDescriptor() member
 // functions.
-PseudoTerminal::~PseudoTerminal() {
-  ClosePrimaryFileDescriptor();
-  CloseSecondaryFileDescriptor();
-}
+PseudoTerminal::~PseudoTerminal() { Reset(); }
 
 // Close the primary file descriptor if it is valid.
 void PseudoTerminal::ClosePrimaryFileDescriptor() {

--- a/lldb/source/Host/common/PseudoTerminal.cpp
+++ b/lldb/source/Host/common/PseudoTerminal.cpp
@@ -65,6 +65,7 @@ void PseudoTerminal::Reset() {
 }
 
 llvm::Error PseudoTerminal::OpenFirstAvailablePrimary(int oflag) {
+  Reset();
 #if LLDB_ENABLE_POSIX
   // Open the primary side of a pseudo terminal
   m_primary_fd = ::posix_openpt(oflag);

--- a/lldb/source/Host/common/PseudoTerminal.cpp
+++ b/lldb/source/Host/common/PseudoTerminal.cpp
@@ -59,6 +59,11 @@ void PseudoTerminal::CloseSecondaryFileDescriptor() {
   }
 }
 
+void PseudoTerminal::Reset() {
+  ClosePrimaryFileDescriptor();
+  CloseSecondaryFileDescriptor();
+}
+
 llvm::Error PseudoTerminal::OpenFirstAvailablePrimary(int oflag) {
 #if LLDB_ENABLE_POSIX
   // Open the primary side of a pseudo terminal

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -91,11 +91,7 @@ llvm::Error PseudoConsole::CreateOverlappedPipePair(HANDLE &out_read,
   return llvm::Error::success();
 }
 
-PseudoConsole::~PseudoConsole() {
-  Close();
-  ClosePseudoConsolePipes();
-  CloseAnonymousPipes();
-}
+PseudoConsole::~PseudoConsole() { Reset(); }
 
 llvm::Error PseudoConsole::OpenPseudoConsole() {
   Reset();

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -98,16 +98,11 @@ PseudoConsole::~PseudoConsole() {
 }
 
 llvm::Error PseudoConsole::OpenPseudoConsole() {
-  assert(m_mode == Mode::None &&
-         "Attempted to open a PseudoConsole in a different mode than None");
+  Reset();
 
   if (!kernel32.IsConPTYAvailable())
     return llvm::make_error<llvm::StringError>("ConPTY is not available",
                                                llvm::errc::io_error);
-
-  assert(m_conpty_handle == INVALID_HANDLE_VALUE &&
-         "ConPTY has already been opened");
-
   // A 4096 bytes buffer should be large enough for the majority of console
   // burst outputs.
   wchar_t pipe_name[MAX_PATH];
@@ -223,8 +218,7 @@ void PseudoConsole::Reset() {
 }
 
 llvm::Error PseudoConsole::OpenAnonymousPipes() {
-  assert(m_mode == Mode::None &&
-         "Attempted to open a AnonymousPipes in a different mode than None");
+  Reset();
 
   SECURITY_ATTRIBUTES sa = {sizeof(SECURITY_ATTRIBUTES), NULL, TRUE};
   HANDLE hStdinRead = INVALID_HANDLE_VALUE;

--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -215,6 +215,13 @@ void PseudoConsole::CloseAnonymousPipes() {
   m_pipe_child_stdout = INVALID_HANDLE_VALUE;
 }
 
+void PseudoConsole::Reset() {
+  Close();
+  ClosePseudoConsolePipes();
+  CloseAnonymousPipes();
+  m_mode = Mode::None;
+}
+
 llvm::Error PseudoConsole::OpenAnonymousPipes() {
   assert(m_mode == Mode::None &&
          "Attempted to open a AnonymousPipes in a different mode than None");


### PR DESCRIPTION
This patch ensures that the PTY initialization is idempotent by always resetting the PTY before creating it.

# Details

A `ProcessLaunchInfo` is reused across multiple launches and the underlying PTY is single-shot:
- On POSIX, `posix_openpt` would silently leak `m_primary_fd` if the same PTY were reused.
- On Windows, `PseudoConsole::OpenPseudoConsole` asserts when `m_mode != Mode::None`.

Reset the existing PTY (closing any previously-opened FDs/handles) so the next `Open*()` runs against a clean slate. Deliberately do NOT replace `m_pty` itself: callers (e.g. `ProcessWindows`, `ProcessLauncherWindows`, `PlatformQemuUser`) hold copies of the `shared_ptr` and may read it after the launch returns, so the object's identity has to survive `SetUpPtyRedirection`.

# Fixed tests

This patch fixes all the `types/*` tests when running  `check-lldb` with `LLDB_USE_LLDB_SERVER=1` on Windows.

rdar://177073941