### PR TITLE
[lldb] Expose the process arguments in SBProcessInfo

### DIFF
--- a/lldb/bindings/interface/SBProcessInfoExtensions.i
+++ b/lldb/bindings/interface/SBProcessInfoExtensions.i
@@ -1,0 +1,18 @@
+
+%extend lldb::SBProcessInfo {
+
+#ifdef SWIGPYTHON
+    %pythoncode %{ 
+    @property
+    def arguments(self):
+        """A read only property that returns a list of lldb.SBProcessInfo arguments."""
+        if not hasattr(self, "_arguments"):
+            self._arguments = [
+                self.GetArgumentAtIndex(idx)
+                for idx in range(self.GetNumArguments())
+            ]
+            
+        return self._arguments
+    %}
+#endif
+}

--- a/lldb/bindings/interfaces.swig
+++ b/lldb/bindings/interfaces.swig
@@ -56,6 +56,7 @@
 %include "./interface/SBPlatformExtensions.i"
 %include "./interface/SBProcessDocstrings.i"
 %include "./interface/SBProcessInfoDocstrings.i"
+%include "./interface/SBProcessInfoExtensions.i"
 %include "./interface/SBProgressDocstrings.i"
 %include "./interface/SBQueueDocstrings.i"
 %include "./interface/SBQueueItemDocstrings.i"

--- a/lldb/include/lldb/API/SBProcessInfo.h
+++ b/lldb/include/lldb/API/SBProcessInfo.h
@@ -53,6 +53,13 @@ public:
   /// Return the target triple (arch-vendor-os) for the described process.
   const char *GetTriple();
 
+  /// Returns the number of command line arguments for the described process.
+  uint32_t GetNumArguments() const;
+
+  /// Returns the command line argument at the given index, or `nullptr` if
+  /// the index is out of range or if the process info is invalid..
+  const char *GetArgumentAtIndex(uint32_t idx) const;
+
 private:
   friend class SBProcess;
   friend class SBProcessInfoList;

--- a/lldb/source/API/SBProcessInfo.cpp
+++ b/lldb/source/API/SBProcessInfo.cpp
@@ -203,5 +203,5 @@ const char *SBProcessInfo::GetArgumentAtIndex(uint32_t idx) const {
     return nullptr;
 
   const Args &args = m_opaque_up->GetArguments();
-  return args.GetArgumentAtIndex(idx);
+  return ConstString(args.GetArgumentAtIndex(idx)).GetCString();
 }

--- a/lldb/source/API/SBProcessInfo.cpp
+++ b/lldb/source/API/SBProcessInfo.cpp
@@ -185,3 +185,23 @@ const char *SBProcessInfo::GetTriple() {
 
   return ConstString(arch.GetTriple().getTriple().c_str()).GetCString();
 }
+
+uint32_t SBProcessInfo::GetNumArguments() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  if (!m_opaque_up)
+    return 0;
+
+  const Args &args = m_opaque_up->GetArguments();
+  return args.GetArgumentCount();
+}
+
+const char *SBProcessInfo::GetArgumentAtIndex(uint32_t idx) const {
+  LLDB_INSTRUMENT_VA(this, idx);
+
+  if (!m_opaque_up)
+    return nullptr;
+
+  const Args &args = m_opaque_up->GetArguments();
+  return args.GetArgumentAtIndex(idx);
+}

--- a/lldb/test/API/python_api/default-constructor/sb_process_info.py
+++ b/lldb/test/API/python_api/default-constructor/sb_process_info.py
@@ -19,3 +19,5 @@ def fuzz_obj(obj):
     obj.EffectiveUserIDIsValid()
     obj.EffectiveGroupIDIsValid()
     obj.GetParentProcessID()
+    obj.GetNumArguments()
+    obj.GetArgumentAtIndex(100)

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -372,6 +372,8 @@ class ProcessAPITestCase(TestBase):
         launch_flags = launch_info.GetLaunchFlags()
         launch_flags |= lldb.eLaunchFlagStopAtEntry
         launch_info.SetLaunchFlags(launch_flags)
+        expected_arguments = ["10", "qu'o'tes\"", "hello", "מזל טוב"]
+        launch_info.SetArguments(expected_arguments, False)
         error = lldb.SBError()
         process = target.Launch(launch_info, error)
 
@@ -444,6 +446,14 @@ class ProcessAPITestCase(TestBase):
             )
 
         process_info.GetParentProcessID()
+
+        self.assertListEqual(process_info.arguments, expected_arguments)
+        self.assertEqual(process_info.GetNumArguments(), 4)
+        self.assertEqual(process_info.GetArgumentAtIndex(0), "10")
+        self.assertEqual(process_info.GetArgumentAtIndex(1), "qu'o'tes\"")
+        self.assertEqual(process_info.GetArgumentAtIndex(2), "hello")
+        self.assertEqual(process_info.GetArgumentAtIndex(3), "מזל טוב")
+        self.assertEqual(process_info.GetArgumentAtIndex(4), None)
 
     def test_allocate_deallocate_memory(self):
         """Test Python SBProcess.AllocateMemory() and SBProcess.DeallocateMemory() APIs."""


### PR DESCRIPTION
Add GetNumArguments() and GetArgumentAtIndex() to SBProcessInfo. Add a convienence property `arguments` in the python api.

lldb-dap uses this to show more information to the user when picking a process.

Fixes: #197509