### PR TITLE
[clang][deps] Consolidate types into new `DependencyActionController.h`

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyActionController.h
+++ b/clang/include/clang/DependencyScanning/DependencyActionController.h
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYACTIONCONTROLLER_H
+#define LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYACTIONCONTROLLER_H
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace clang {
+
+class CompilerInstance;
+class CompilerInvocation;
+class CowCompilerInvocation;
+
+namespace dependencies {
+struct ModuleDeps;
+
+/// An output from a module compilation, such as the path of the module file.
+enum class ModuleOutputKind {
+  /// The module file (.pcm). Required.
+  ModuleFile,
+  /// The path of the dependency file (.d), if any.
+  DependencyFile,
+  /// The null-separated list of names to use as the targets in the dependency
+  /// file, if any. Defaults to the value of \c ModuleFile, as in the driver.
+  DependencyTargets,
+  /// The path of the serialized diagnostic file (.dia), if any.
+  DiagnosticSerializationFile,
+};
+
+/// Dependency scanner callbacks that are used during scanning to influence the
+/// behaviour of the scan - for example, to customize the scanned invocations.
+class DependencyActionController {
+public:
+  virtual ~DependencyActionController() = default;
+
+  /// Creates a copy of the controller. The result must be both thread-safe.
+  virtual std::unique_ptr<DependencyActionController> clone() const = 0;
+
+  /// Provides output path for a given module dependency. Must be thread-safe.
+  virtual std::string lookupModuleOutput(const ModuleDeps &MD,
+                                         ModuleOutputKind Kind) = 0;
+
+  /// Initializes the scan invocation.
+  virtual void initializeScanInvocation(CompilerInvocation &ScanInvocation) {}
+
+  /// Initializes the scan instance and modifies the resulting TU invocation.
+  /// Returns true on success, false on failure.
+  virtual bool initialize(CompilerInstance &ScanInstance,
+                          CompilerInvocation &NewInvocation) {
+    return true;
+  }
+
+  /// Finalizes the scan instance and modifies the resulting TU invocation.
+  /// Returns true on success, false on failure.
+  virtual bool finalize(CompilerInstance &ScanInstance,
+                        CompilerInvocation &NewInvocation) {
+    return true;
+  }
+
+  /// Returns the cache key for the resulting invocation, or nullopt.
+  virtual std::optional<std::string>
+  getCacheKey(const CompilerInvocation &NewInvocation) {
+    return std::nullopt;
+  }
+
+  /// Initializes the module scan instance.
+  /// Returns true on success, false on failure.
+  virtual bool initializeModuleBuild(CompilerInstance &ModuleScanInstance) {
+    return true;
+  }
+
+  /// Finalizes the module scan instance.
+  /// Returns true on success, false on failure.
+  virtual bool finalizeModuleBuild(CompilerInstance &ModuleScanInstance) {
+    return true;
+  }
+
+  /// Modifies the resulting module invocation and the associated structure.
+  /// Returns true on success, false on failure.
+  virtual bool finalizeModuleInvocation(CompilerInstance &ScanInstance,
+                                        CowCompilerInvocation &CI,
+                                        const ModuleDeps &MD) {
+    return true;
+  }
+};
+} // namespace dependencies
+} // namespace clang
+
+#endif // LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYACTIONCONTROLLER_H

--- a/clang/include/clang/DependencyScanning/DependencyScanningUtils.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningUtils.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYSCANNINGUTILS_H
 #define LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYSCANNINGUTILS_H
 
+#include "clang/DependencyScanning/DependencyActionController.h"
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/DependencyScanning/ModuleDepCollector.h"

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -61,63 +61,6 @@ public:
   virtual void handleContextHash(std::string Hash) = 0;
 };
 
-/// Dependency scanner callbacks that are used during scanning to influence the
-/// behaviour of the scan - for example, to customize the scanned invocations.
-class DependencyActionController {
-public:
-  virtual ~DependencyActionController();
-
-  /// Creates a copy of the controller. The result must be both thread-safe.
-  virtual std::unique_ptr<DependencyActionController> clone() const = 0;
-
-  /// Provides output path for a given module dependency. Must be thread-safe.
-  virtual std::string lookupModuleOutput(const ModuleDeps &MD,
-                                         ModuleOutputKind Kind) = 0;
-
-  /// Initializes the scan invocation.
-  virtual void initializeScanInvocation(CompilerInvocation &ScanInvocation) {}
-
-  /// Initializes the scan instance and modifies the resulting TU invocation.
-  /// Returns true on success, false on failure.
-  virtual bool initialize(CompilerInstance &ScanInstance,
-                          CompilerInvocation &NewInvocation) {
-    return true;
-  }
-
-  /// Finalizes the scan instance and modifies the resulting TU invocation.
-  /// Returns true on success, false on failure.
-  virtual bool finalize(CompilerInstance &ScanInstance,
-                        CompilerInvocation &NewInvocation) {
-    return true;
-  }
-
-  /// Returns the cache key for the resulting invocation, or nullopt.
-  virtual std::optional<std::string>
-  getCacheKey(const CompilerInvocation &NewInvocation) {
-    return std::nullopt;
-  }
-
-  /// Initializes the module scan instance.
-  /// Returns true on success, false on failure.
-  virtual bool initializeModuleBuild(CompilerInstance &ModuleScanInstance) {
-    return true;
-  }
-
-  /// Finalizes the module scan instance.
-  /// Returns true on success, false on failure.
-  virtual bool finalizeModuleBuild(CompilerInstance &ModuleScanInstance) {
-    return true;
-  }
-
-  /// Modifies the resulting module invocation and the associated structure.
-  /// Returns true on success, false on failure.
-  virtual bool finalizeModuleInvocation(CompilerInstance &ScanInstance,
-                                        CowCompilerInvocation &CI,
-                                        const ModuleDeps &MD) {
-    return true;
-  }
-};
-
 /// An individual dependency scanning worker that is able to run on its own
 /// thread.
 ///

--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -76,19 +76,6 @@ private:
   std::set<StringRef> ModuleFileDependents;
 };
 
-/// An output from a module compilation, such as the path of the module file.
-enum class ModuleOutputKind {
-  /// The module file (.pcm). Required.
-  ModuleFile,
-  /// The path of the dependency file (.d), if any.
-  DependencyFile,
-  /// The null-separated list of names to use as the targets in the dependency
-  /// file, if any. Defaults to the value of \c ModuleFile, as in the driver.
-  DependencyTargets,
-  /// The path of the serialized diagnostic file (.dia), if any.
-  DiagnosticSerializationFile,
-};
-
 class ModuleDepCollector;
 
 /// Callback that records textual includes and direct modular includes/imports

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/DependencyScanning/DependencyActionController.h"
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/DiagnosticSerialization.h"

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/DependencyScanning/DependencyActionController.h"
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/DiagnosticSerialization.h"
+#include "clang/DependencyScanning/DependencyActionController.h"
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
 #include "clang/DependencyScanning/DependencyScanningService.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -38,7 +38,6 @@ DependencyScanningWorker::DependencyScanningWorker(
 }
 
 DependencyScanningWorker::~DependencyScanningWorker() = default;
-DependencyActionController::~DependencyActionController() = default;
 
 static bool createAndRunToolInvocation(
     ArrayRef<std::string> CommandLine, DependencyScanningAction &Action,

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -9,6 +9,7 @@
 #include "clang/DependencyScanning/ModuleDepCollector.h"
 
 #include "clang/Basic/MakeSupport.h"
+#include "clang/DependencyScanning/DependencyActionController.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"


### PR DESCRIPTION
This PR pulls types from multiple headers into new `DependencyActionController.h`. This is just a cleanup, NFC.