### PR TITLE
[LLVM] Add a function to reset the opt bisector

### DIFF
--- a/llvm/include/llvm/IR/OptBisect.h
+++ b/llvm/include/llvm/IR/OptBisect.h
@@ -36,6 +36,10 @@ public:
 
   /// isEnabled() should return true before calling shouldRunPass().
   virtual bool isEnabled() const { return false; }
+
+  /// Reset the pass gate to its initial configuration, before any command line
+  /// options were parsed.
+  virtual void reset() {}
 };
 
 /// This class implements a mechanism to disable passes and individual
@@ -70,6 +74,11 @@ public:
   /// isEnabled() should return true before calling shouldRunPass().
   bool isEnabled() const override {
     return !BisectIntervals.empty() || !DisabledPasses.empty();
+  }
+
+  void reset() override {
+    clearIntervals();
+    DisabledPasses.clear();
   }
 
   /// Set intervals directly from an IntervalList.


### PR DESCRIPTION
For daemonized testing, we need to be able to reset the global opt bisector between test runs. This PR just adds a small function to the OptPassGate class to reset its state.