### PR TITLE
[clang][NFC] Mark CWG717 as implemented and add a test

### DIFF
--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -104,10 +104,33 @@ namespace cwg717 { // cwg717: 3.3
 void f() {
   thread_local extern int i;
   thread_local extern int& j;
+
+  [] {
+    thread_local extern int k;
+    thread_local extern int& l;
+  }();
+}
+
+template <typename T>
+void g() {
+  thread_local extern T i;
+  thread_local extern T& j;
+
+  [] {
+    thread_local extern T k;
+    thread_local extern T& l;
+  }();
 }
 
 struct S {
   thread_local static int i;
+  thread_local static int& j;
+};
+
+template <typename T>
+struct C {
+  thread_local static T i;
+  thread_local static T& j;
 };
 #endif
 } // namespace cwg717

--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -99,6 +99,19 @@ static_assert(!is_volatile<void()volatile&>::value, "");
 #endif
 } // namespace cwg713
 
+namespace cwg717 { // cwg717: 3.3
+#if __cplusplus >= 201103L
+void f() {
+  thread_local extern int i;
+  thread_local extern int& j;
+}
+
+struct S {
+  thread_local static int i;
+};
+#endif
+} // namespace cwg717
+
 // cwg722 is in cwg722.cpp
 
 namespace cwg727 { // cwg727: partial

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -5069,7 +5069,7 @@
     <td>[<a href="https://wg21.link/dcl.stc">dcl.stc</a>]</td>
     <td>CD2</td>
     <td>Unintentional restrictions on the use of <TT>thread_local</TT></td>
-    <td class="unknown" align="center">Unknown</td>
+    <td class="full" align="center">Clang 3.3</td>
   </tr>
   <tr id="718">
     <td><a href="https://cplusplus.github.io/CWG/issues/718.html">718</a></td>


### PR DESCRIPTION
[CWG717](https://wg21.link/cwg717) allows applying `thread_local` to `extern` block-scope variables and static data members. Clang implements this since 3.3: https://godbolt.org/z/sx4nc3qqe