### PR TITLE
[libc] Add all the toolchains needed for libc-shared-tests to the docker container.

### DIFF
--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -8,6 +8,24 @@ RUN apt-get update && \
     libgmp-dev \
     libmpc-dev \
     ninja-build \
+    build-essential \
+    gcc-9 \
+    g++-9 \
+    gcc-11 \
+    g++-11 \
+    qemu-user-static \
+    libc6-dev-arm64-cross \
+    libstdc++6-arm64-cross \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    libc6-dev-riscv64-cross \
+    libstdc++6-riscv64-cross \
+    gcc-riscv64-linux-gnu \
+    g++-riscv64-linux-gnu \
+    libc6-dev-ppc64el-cross \
+    libstdc++6-ppc64el-cross \
+    gcc-powerpc64le-linux-gnu \
+    g++-powerpc64le-linux-gnu \
     sudo \
     sccache \
     wget \
@@ -23,6 +41,69 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     chmod +x llvm.sh && \
     sudo ./llvm.sh 23 && \
     rm llvm.sh
+
+# Install gmp and mpfr for cross compilation
+RUN wget https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz && \
+    tar -xf gmp-6.3.0.tar.xz && \
+    cd gmp-6.3.0 && \
+    ./configure --host=riscv64-linux-gnu --prefix=/usr/riscv64-linux-gnu && \
+    make -j8 && \
+    sudo make install && \
+    cd .. && \
+    rm -rf gmp-6.3.0 && \
+    rm gmp-6.3.0.tar.xz
+
+RUN wget https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz && \
+    tar -xf mpfr-4.2.2.tar.xz && \
+    cd mpfr-4.2.2 && \
+    ./configure --host=riscv64-linux-gnu --prefix=/usr/riscv64-linux-gnu \
+    --with-gmp=/usr/riscv64-linux-gnu && \
+    make -j8 && \
+    sudo make install && \
+    cd .. && \
+    rm -rf mpfr-4.2.2 && \
+    rm mpfr-4.2.2.tar.xz
+
+RUN wget https://ftp.gnu.org/gnu/mpc/mpc-1.4.1.tar.xz && \
+    tar -xf mpc-1.4.1 && \
+    cd mpc-1.4.1 && \
+    ./configure --host=riscv64-linux-gnu --prefix=/usr/riscv64-linux-gnu \
+    --with-gmp=/usr/riscv64-linux-gnu \
+    --with-mpfr=/usr/riscv64-linux-gnu && \
+    make -j8 && \
+    sudo make install && \
+    cd .. && \
+    rm -rf mpc-1.4.1 && \
+    rm mpc-1.4.1.tar.xz
+
+# Install gcc-7 and g++-7.
+RUN wget https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz && \
+    tar -xf gcc-7.5.0.tar.xz && \
+    mkdir gcc-7 && \
+    cd gcc-7 && \
+    ../gcc-7.5.0/configure --prefix=/usr/local/gcc7 --enable-languages=c,c++ \
+    --disable-multilib && \
+    make -j8 && \
+    sudo make install && \
+    cd .. && \
+    rm -rf gcc-7 && \
+    rm -rf gcc-7.5.0 && \
+    rm gcc-7.5.0.tar.xz
+
+# Install gcc-8 and g++-8.
+RUN wget https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz && \
+    tar -xf gcc-8.5.0.tar.xz && \
+    mkdir gcc-8 && \
+    cd gcc-8 && \
+    ../gcc-8.5.0/configure --prefix=/usr/local/gcc8 --enable-languages=c,c++ \
+    --disable-multilib && \
+    make -j8 && \
+    sudo make install && \
+    cd .. && \
+    rm -rf gcc-8 && \
+    rm -rf gcc-8.5.0 && \
+    rm gcc-8.5.0.tar.xz
+
     
 # Debian has a multilib setup, so we need to symlink the asm directory.
 # For more information, see https://wiki.debian.org/Multiarch/LibraryPathOverview

--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -80,11 +80,14 @@ RUN wget https://ftp.gnu.org/gnu/mpc/mpc-1.4.1.tar.xz && \
 # Install gcc-7 and g++-7.
 RUN wget https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz && \
     tar -xf gcc-7.5.0.tar.xz && \
+    cd gcc-7.5.0 && \
+    ./contrib/download_prerequisites && \
+    cd .. && \
     mkdir gcc-7 && \
     cd gcc-7 && \
     ../gcc-7.5.0/configure --prefix=/usr/local/gcc7 --enable-languages=c,c++ \
     --disable-multilib && \
-    make -j8 && \
+    make && \
     sudo make install && \
     cd .. && \
     rm -rf gcc-7 && \
@@ -94,11 +97,14 @@ RUN wget https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz && \
 # Install gcc-8 and g++-8.
 RUN wget https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz && \
     tar -xf gcc-8.5.0.tar.xz && \
+    cd gcc-8.5.0 && \
+    ./contrib/download_prerequisites && \
+    cd .. && \
     mkdir gcc-8 && \
     cd gcc-8 && \
     ../gcc-8.5.0/configure --prefix=/usr/local/gcc8 --enable-languages=c,c++ \
     --disable-multilib && \
-    make -j8 && \
+    make && \
     sudo make install && \
     cd .. && \
     rm -rf gcc-8 && \

--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -86,8 +86,8 @@ RUN wget https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz && \
     mkdir gcc-7 && \
     cd gcc-7 && \
     ../gcc-7.5.0/configure --prefix=/usr/local/gcc7 --enable-languages=c,c++ \
-    --disable-multilib && \
-    make && \
+    --disable-multilib --disable-libsanitizer && \
+    make -j8 && \
     sudo make install && \
     cd .. && \
     rm -rf gcc-7 && \
@@ -103,8 +103,8 @@ RUN wget https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz && \
     mkdir gcc-8 && \
     cd gcc-8 && \
     ../gcc-8.5.0/configure --prefix=/usr/local/gcc8 --enable-languages=c,c++ \
-    --disable-multilib && \
-    make && \
+    --disable-multilib --disable-libsanitizer && \
+    make -j8 && \
     sudo make install && \
     cd .. && \
     rm -rf gcc-8 && \

--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     software-properties-common \
     gnupg \
     cmake \
+    m4 \
     linux-libc-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/containers/libc/Dockerfile
+++ b/.github/workflows/containers/libc/Dockerfile
@@ -66,7 +66,7 @@ RUN wget https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz && \
     rm mpfr-4.2.2.tar.xz
 
 RUN wget https://ftp.gnu.org/gnu/mpc/mpc-1.4.1.tar.xz && \
-    tar -xf mpc-1.4.1 && \
+    tar -xf mpc-1.4.1.tar.xz && \
     cd mpc-1.4.1 && \
     ./configure --host=riscv64-linux-gnu --prefix=/usr/riscv64-linux-gnu \
     --with-gmp=/usr/riscv64-linux-gnu \


### PR DESCRIPTION
Toolchains include:
- gcc-7, 8, 9, 11
- qemu-static-user
- cross-build toolchain for aarch64, riscv64, ppc64le, including gcc, g++, gmp, mpfr, mpc.

Container size before the change: ~ 500 MB
Container size after the change: ~ 1.3 - 1.4 GB