### PR TITLE
[flang-rt] Move template parameters to runtime to improve compile times

### DIFF
--- a/flang-rt/lib/runtime/extrema.cpp
+++ b/flang-rt/lib/runtime/extrema.cpp
@@ -24,31 +24,35 @@ namespace Fortran::runtime {
 
 // MAXLOC & MINLOC
 
-template <typename T, bool IS_MAX, bool BACK> struct NumericCompare {
+template <typename T, bool IS_MAX> struct NumericCompare {
   using Type = T;
-  explicit RT_API_ATTRS NumericCompare(std::size_t /*elemLen; ignored*/) {}
+  explicit RT_API_ATTRS NumericCompare(std::size_t /*elemLen*/, bool back)
+      : back_{back} {}
   RT_API_ATTRS bool operator()(const T &value, const T &previous) const {
     if (std::is_floating_point_v<T> && previous != previous) {
-      return BACK || value == value; // replace NaN
+      return back_ || value == value; // replace NaN
     } else if (value == previous) {
-      return BACK;
+      return back_;
     } else if constexpr (IS_MAX) {
       return value > previous;
     } else {
       return value < previous;
     }
   }
+
+private:
+  bool back_;
 };
 
-template <typename T, bool IS_MAX, bool BACK> class CharacterCompare {
+template <typename T, bool IS_MAX> class CharacterCompare {
 public:
   using Type = T;
-  explicit RT_API_ATTRS CharacterCompare(std::size_t elemLen)
-      : chars_{elemLen / sizeof(T)} {}
+  explicit RT_API_ATTRS CharacterCompare(std::size_t elemLen, bool back)
+      : chars_{elemLen / sizeof(T)}, back_{back} {}
   RT_API_ATTRS bool operator()(const T &value, const T &previous) const {
     int cmp{CharacterScalarCompare<T>(&value, &previous, chars_, chars_)};
     if (cmp == 0) {
-      return BACK;
+      return back_;
     } else if constexpr (IS_MAX) {
       return cmp > 0;
     } else {
@@ -58,13 +62,15 @@ public:
 
 private:
   std::size_t chars_;
+  bool back_;
 };
 
 template <typename COMPARE> class ExtremumLocAccumulator {
 public:
   using Type = typename COMPARE::Type;
-  RT_API_ATTRS ExtremumLocAccumulator(const Descriptor &array)
-      : array_{array}, argRank_{array.rank()}, compare_{array.ElementBytes()} {
+  RT_API_ATTRS ExtremumLocAccumulator(const Descriptor &array, bool back)
+      : array_{array}, argRank_{array.rank()},
+        compare_{array.ElementBytes(), back} {
     Reinitialize();
   }
   RT_API_ATTRS void Reinitialize() {
@@ -108,27 +114,22 @@ private:
 template <typename ACCUMULATOR, typename CPPTYPE>
 static RT_API_ATTRS void LocationHelper(const char *intrinsic,
     Descriptor &result, const Descriptor &x, int kind, const Descriptor *mask,
-    Terminator &terminator) {
-  ACCUMULATOR accumulator{x};
+    Terminator &terminator, bool back) {
+  ACCUMULATOR accumulator{x, back};
   DoTotalReduction<CPPTYPE>(x, 0, mask, accumulator, intrinsic, terminator);
   ApplyIntegerKind<LocationResultHelper<ACCUMULATOR>::template Functor, void>(
       kind, terminator, accumulator, result);
 }
 
 template <TypeCategory CAT, int KIND, bool IS_MAX,
-    template <typename, bool, bool> class COMPARE>
+    template <typename, bool> class COMPARE>
 inline RT_API_ATTRS void DoMaxOrMinLoc(const char *intrinsic,
     Descriptor &result, const Descriptor &x, int kind, const char *source,
     int line, const Descriptor *mask, bool back) {
   using CppType = CppTypeFor<CAT, KIND>;
   Terminator terminator{source, line};
-  if (back) {
-    LocationHelper<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, true>>,
-        CppType>(intrinsic, result, x, kind, mask, terminator);
-  } else {
-    LocationHelper<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, false>>,
-        CppType>(intrinsic, result, x, kind, mask, terminator);
-  }
+  LocationHelper<ExtremumLocAccumulator<COMPARE<CppType, IS_MAX>>, CppType>(
+      intrinsic, result, x, kind, mask, terminator, back);
 }
 
 template <bool IS_MAX> struct CharacterMaxOrMinLocHelper {
@@ -367,34 +368,20 @@ RT_EXT_API_GROUP_END
 // MAXLOC/MINLOC with DIM=
 
 template <TypeCategory CAT, int KIND, bool IS_MAX,
-    template <typename, bool, bool> class COMPARE, bool BACK>
-static RT_API_ATTRS void DoPartialMaxOrMinLocDirection(const char *intrinsic,
+    template <typename, bool> class COMPARE>
+static RT_API_ATTRS void DoPartialMaxOrMinLoc(const char *intrinsic,
     Descriptor &result, const Descriptor &x, int kind, int dim,
-    const Descriptor *mask, Terminator &terminator) {
+    const Descriptor *mask, Terminator &terminator, bool back) {
   using CppType = CppTypeFor<CAT, KIND>;
-  using Accumulator = ExtremumLocAccumulator<COMPARE<CppType, IS_MAX, BACK>>;
-  Accumulator accumulator{x};
+  using Accumulator = ExtremumLocAccumulator<COMPARE<CppType, IS_MAX>>;
+  Accumulator accumulator{x, back};
   ApplyIntegerKind<PartialLocationHelper<Accumulator>::template Functor, void>(
       kind, terminator, result, x, dim, mask, terminator, intrinsic,
       accumulator);
 }
 
-template <TypeCategory CAT, int KIND, bool IS_MAX,
-    template <typename, bool, bool> class COMPARE>
-inline RT_API_ATTRS void DoPartialMaxOrMinLoc(const char *intrinsic,
-    Descriptor &result, const Descriptor &x, int kind, int dim,
-    const Descriptor *mask, bool back, Terminator &terminator) {
-  if (back) {
-    DoPartialMaxOrMinLocDirection<CAT, KIND, IS_MAX, COMPARE, true>(
-        intrinsic, result, x, kind, dim, mask, terminator);
-  } else {
-    DoPartialMaxOrMinLocDirection<CAT, KIND, IS_MAX, COMPARE, false>(
-        intrinsic, result, x, kind, dim, mask, terminator);
-  }
-}
-
 template <TypeCategory CAT, bool IS_MAX,
-    template <typename, bool, bool> class COMPARE>
+    template <typename, bool> class COMPARE>
 struct DoPartialMaxOrMinLocHelper {
   template <int KIND> struct Functor {
     // NVCC inlines more aggressively which causes too many specializations of
@@ -404,7 +391,7 @@ struct DoPartialMaxOrMinLocHelper {
         Descriptor &result, const Descriptor &x, int kind, int dim,
         const Descriptor *mask, bool back, Terminator &terminator) const {
       DoPartialMaxOrMinLoc<CAT, KIND, IS_MAX, COMPARE>(
-          intrinsic, result, x, kind, dim, mask, back, terminator);
+          intrinsic, result, x, kind, dim, mask, terminator, back);
     }
   };
 };

--- a/flang-rt/lib/runtime/matmul-transpose.cpp
+++ b/flang-rt/lib/runtime/matmul-transpose.cpp
@@ -163,11 +163,10 @@ inline static RT_API_ATTRS void MatrixTransposedTimesVectorHelper(
 }
 
 // Implements an instance of MATMUL for given argument types.
-template <bool IS_ALLOCATING, TypeCategory RCAT, int RKIND, typename XT,
-    typename YT>
-inline static RT_API_ATTRS void DoMatmulTranspose(
-    std::conditional_t<IS_ALLOCATING, Descriptor, const Descriptor> &result,
-    const Descriptor &x, const Descriptor &y, Terminator &terminator) {
+template <TypeCategory RCAT, int RKIND, typename XT, typename YT>
+inline static RT_API_ATTRS void DoMatmulTranspose(Descriptor &result,
+    const Descriptor &x, const Descriptor &y, Terminator &terminator,
+    bool isAllocating) {
   int xRank{x.rank()};
   int yRank{y.rank()};
   int resRank{xRank + yRank - 2};
@@ -177,7 +176,7 @@ inline static RT_API_ATTRS void DoMatmulTranspose(
   }
   SubscriptValue extent[2]{x.GetDimension(1).Extent(),
       resRank == 2 ? y.GetDimension(1).Extent() : 0};
-  if constexpr (IS_ALLOCATING) {
+  if (isAllocating) {
     result.Establish(
         RCAT, RKIND, nullptr, resRank, extent, CFI_attribute_allocatable);
     for (int j{0}; j < resRank; ++j) {
@@ -212,7 +211,7 @@ inline static RT_API_ATTRS void DoMatmulTranspose(
   const SubscriptValue cols{extent[1]};
   if constexpr (RCAT != TypeCategory::Logical) {
     if (x.IsContiguous(1) && y.IsContiguous(1) &&
-        (IS_ALLOCATING || result.IsContiguous())) {
+        (isAllocating || result.IsContiguous())) {
       // Contiguous numeric matrices (maybe with columns
       // separated by a stride).
       Fortran::common::optional<std::size_t> xColumnByteStride;
@@ -326,14 +325,12 @@ inline static RT_API_ATTRS void DoMatmulTranspose(
   }
 }
 
-template <bool IS_ALLOCATING, TypeCategory XCAT, int XKIND, TypeCategory YCAT,
-    int YKIND>
+template <TypeCategory XCAT, int XKIND, TypeCategory YCAT, int YKIND>
 struct MatmulTransposeHelper {
-  using ResultDescriptor =
-      std::conditional_t<IS_ALLOCATING, Descriptor, const Descriptor>;
   using ResultTy = Fortran::common::optional<std::pair<TypeCategory, int>>;
-  RT_API_ATTRS void operator()(ResultDescriptor &result, const Descriptor &x,
-      const Descriptor &y, const char *sourceFile, int line) const {
+  RT_API_ATTRS void operator()(Descriptor &result, const Descriptor &x,
+      const Descriptor &y, const char *sourceFile, int line,
+      bool isAllocating) const {
     Terminator terminator{sourceFile, line};
     auto xCatKind{x.type().GetCategoryAndKind()};
     auto yCatKind{y.type().GetCategoryAndKind()};
@@ -342,9 +339,9 @@ struct MatmulTransposeHelper {
     RUNTIME_CHECK(terminator, yCatKind->first == YCAT);
     if constexpr (constexpr ResultTy resultType{
                       GetResultType(XCAT, XKIND, YCAT, YKIND)}) {
-      return DoMatmulTranspose<IS_ALLOCATING, resultType->first,
-          resultType->second, CppTypeFor<XCAT, XKIND>, CppTypeFor<YCAT, YKIND>>(
-          result, x, y, terminator);
+      return DoMatmulTranspose<resultType->first, resultType->second,
+          CppTypeFor<XCAT, XKIND>, CppTypeFor<YCAT, YKIND>>(
+          result, x, y, terminator, isAllocating);
     }
     terminator.Crash("MATMUL-TRANSPOSE: bad operand types (%d(%d), %d(%d))",
         static_cast<int>(XCAT), XKIND, static_cast<int>(YCAT), YKIND);
@@ -360,16 +357,16 @@ RT_EXT_API_GROUP_BEGIN
   void RTDEF(MatmulTranspose##XCAT##XKIND##YCAT##YKIND)(Descriptor & result, \
       const Descriptor &x, const Descriptor &y, const char *sourceFile, \
       int line) { \
-    MatmulTransposeHelper<true, TypeCategory::XCAT, XKIND, TypeCategory::YCAT, \
-        YKIND>{}(result, x, y, sourceFile, line); \
+    MatmulTransposeHelper<TypeCategory::XCAT, XKIND, TypeCategory::YCAT, \
+        YKIND>{}(result, x, y, sourceFile, line, true); \
   }
 
 #define MATMUL_DIRECT_INSTANCE(XCAT, XKIND, YCAT, YKIND) \
   void RTDEF(MatmulTransposeDirect##XCAT##XKIND##YCAT##YKIND)( \
       Descriptor & result, const Descriptor &x, const Descriptor &y, \
       const char *sourceFile, int line) { \
-    MatmulTransposeHelper<false, TypeCategory::XCAT, XKIND, \
-        TypeCategory::YCAT, YKIND>{}(result, x, y, sourceFile, line); \
+    MatmulTransposeHelper<TypeCategory::XCAT, XKIND, TypeCategory::YCAT, \
+        YKIND>{}(result, x, y, sourceFile, line, false); \
   }
 
 #define MATMUL_FORCE_ALL_TYPES 0

--- a/flang-rt/lib/runtime/matmul.cpp
+++ b/flang-rt/lib/runtime/matmul.cpp
@@ -235,11 +235,10 @@ inline RT_API_ATTRS void VectorTimesMatrixHelper(
 }
 
 // Implements an instance of MATMUL for given argument types.
-template <bool IS_ALLOCATING, TypeCategory RCAT, int RKIND, typename XT,
-    typename YT>
-static inline RT_API_ATTRS void DoMatmul(
-    std::conditional_t<IS_ALLOCATING, Descriptor, const Descriptor> &result,
-    const Descriptor &x, const Descriptor &y, Terminator &terminator) {
+template <TypeCategory RCAT, int RKIND, typename XT, typename YT>
+static inline RT_API_ATTRS void DoMatmul(Descriptor &result,
+    const Descriptor &x, const Descriptor &y, Terminator &terminator,
+    bool isAllocating) {
   int xRank{x.rank()};
   int yRank{y.rank()};
   int resRank{xRank + yRank - 2};
@@ -249,7 +248,7 @@ static inline RT_API_ATTRS void DoMatmul(
   SubscriptValue extent[2]{
       xRank == 2 ? x.GetDimension(0).Extent() : y.GetDimension(1).Extent(),
       resRank == 2 ? y.GetDimension(1).Extent() : 0};
-  if constexpr (IS_ALLOCATING) {
+  if (isAllocating) {
     result.Establish(
         RCAT, RKIND, nullptr, resRank, extent, CFI_attribute_allocatable);
     for (int j{0}; j < resRank; ++j) {
@@ -294,7 +293,7 @@ static inline RT_API_ATTRS void DoMatmul(
           RKIND>;
   if constexpr (RCAT != TypeCategory::Logical) {
     if (x.IsContiguous(1) && y.IsContiguous(1) &&
-        (IS_ALLOCATING || result.IsContiguous())) {
+        (isAllocating || result.IsContiguous())) {
       // Contiguous numeric matrices (maybe with columns
       // separated by a stride).
       Fortran::common::optional<std::size_t> xColumnByteStride;
@@ -421,14 +420,12 @@ static inline RT_API_ATTRS void DoMatmul(
   }
 }
 
-template <bool IS_ALLOCATING, TypeCategory XCAT, int XKIND, TypeCategory YCAT,
-    int YKIND>
+template <TypeCategory XCAT, int XKIND, TypeCategory YCAT, int YKIND>
 struct MatmulHelper {
   using ResultTy = Fortran::common::optional<std::pair<TypeCategory, int>>;
-  using ResultDescriptor =
-      std::conditional_t<IS_ALLOCATING, Descriptor, const Descriptor>;
-  RT_API_ATTRS void operator()(ResultDescriptor &result, const Descriptor &x,
-      const Descriptor &y, const char *sourceFile, int line) const {
+  RT_API_ATTRS void operator()(Descriptor &result, const Descriptor &x,
+      const Descriptor &y, const char *sourceFile, int line,
+      bool isAllocating) const {
     Terminator terminator{sourceFile, line};
     auto xCatKind{x.type().GetCategoryAndKind()};
     auto yCatKind{y.type().GetCategoryAndKind()};
@@ -442,9 +439,9 @@ struct MatmulHelper {
                         yCatKind->first == TypeCategory::Unsigned))));
     if constexpr (constexpr ResultTy resultType{
                       GetResultType(XCAT, XKIND, YCAT, YKIND)}) {
-      return DoMatmul<IS_ALLOCATING, resultType->first, resultType->second,
+      return DoMatmul<resultType->first, resultType->second,
           CppTypeFor<XCAT, XKIND>, CppTypeFor<YCAT, YKIND>>(
-          result, x, y, terminator);
+          result, x, y, terminator, isAllocating);
     }
     terminator.Crash("MATMUL: bad operand types (%d(%d), %d(%d))",
         static_cast<int>(XCAT), XKIND, static_cast<int>(YCAT), YKIND);
@@ -460,16 +457,16 @@ RT_EXT_API_GROUP_BEGIN
   void RTDEF(Matmul##XCAT##XKIND##YCAT##YKIND)(Descriptor & result, \
       const Descriptor &x, const Descriptor &y, const char *sourceFile, \
       int line) { \
-    MatmulHelper<true, TypeCategory::XCAT, XKIND, TypeCategory::YCAT, \
-        YKIND>{}(result, x, y, sourceFile, line); \
+    MatmulHelper<TypeCategory::XCAT, XKIND, TypeCategory::YCAT, YKIND>{}( \
+        result, x, y, sourceFile, line, true); \
   }
 
 #define MATMUL_DIRECT_INSTANCE(XCAT, XKIND, YCAT, YKIND) \
   void RTDEF(MatmulDirect##XCAT##XKIND##YCAT##YKIND)(Descriptor & result, \
       const Descriptor &x, const Descriptor &y, const char *sourceFile, \
       int line) { \
-    MatmulHelper<false, TypeCategory::XCAT, XKIND, TypeCategory::YCAT, \
-        YKIND>{}(result, x, y, sourceFile, line); \
+    MatmulHelper<TypeCategory::XCAT, XKIND, TypeCategory::YCAT, YKIND>{}( \
+        result, x, y, sourceFile, line, false); \
   }
 
 #define MATMUL_FORCE_ALL_TYPES 0


### PR DESCRIPTION
Summary:
These files take an extraordinarily long amount of time to compile. This
is due to the combinatorial explosino of template parameters. This PR
takes a few choice factors and puts them as runtime components instead.
This should have no real impact on runtime with optimizations, but
brings the compilation for these from 60s each to 30s on my machine. A
future PR will split these up by component so we get more build-system
parallelism.
