### PR TITLE
[objcopy] Fix uninitialized ShndxType value in ELF symbol

### DIFF
--- a/llvm/lib/ObjCopy/ELF/ELFObject.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObject.cpp
@@ -720,9 +720,11 @@ void SymbolTableSection::addSymbol(Twine Name, uint8_t Bind, uint8_t Type,
   Sym.Binding = Bind;
   Sym.Type = Type;
   Sym.DefinedIn = DefinedIn;
-  if (DefinedIn != nullptr)
+  if (DefinedIn != nullptr) {
     DefinedIn->HasSymbol = true;
-  if (DefinedIn == nullptr) {
+    Sym.ShndxType = SYMBOL_SIMPLE_INDEX;
+  }
+  else {
     if (Shndx >= SHN_LORESERVE)
       Sym.ShndxType = static_cast<SymbolShndxType>(Shndx);
     else


### PR DESCRIPTION
While playing around with the ObjCopy library, I noticed strange values, due to uninitialized ShndxType member of the llvm::objcopy::elf::Symbol structure.

When a symbol is defined in a section, the ShndxType member is never initialized.

This patch initialize it to the "SYMBOL_SIMPLE_INDEX" value, which seems to be the most reasonable choice, as this symbol effectively have a valid section index (regular or extended).