### PR TITLE
[libc][math] Fix UBSan errors from left-shifting negative values

### DIFF
--- a/libc/src/__support/math/exp.h
+++ b/libc/src/__support/math/exp.h
@@ -394,7 +394,7 @@ LIBC_INLINE double exp(double x) {
   } else {
     // to multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r =
         cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(exp_mid.hi + lo));
     return r;
@@ -411,7 +411,7 @@ LIBC_INLINE double exp(double x) {
     if (LIBC_LIKELY(upper == lower)) {
       // to multiply by 2^hi, a fast way is to simply add hi to the exponent
       // field.
-      int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+      int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
       double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
       return r;
     }
@@ -429,7 +429,7 @@ LIBC_INLINE double exp(double x) {
     double lower_dd = r_dd.hi + (r_dd.lo - EXP_ERR_DD);
 
     if (LIBC_LIKELY(upper_dd == lower_dd)) {
-      int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+      int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
       double r =
           cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
       return r;

--- a/libc/src/__support/math/exp10.h
+++ b/libc/src/__support/math/exp10.h
@@ -406,7 +406,7 @@ LIBC_INLINE LIBC_CONSTEXPR double exp10(double x) {
   double lo = fputil::multiply_add(p, mid_lo, exp_mid.lo);
 
 #ifdef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
-  int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+  int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
   double r =
       cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(exp_mid.hi + lo));
   return r;
@@ -417,7 +417,7 @@ LIBC_INLINE LIBC_CONSTEXPR double exp10(double x) {
   if (LIBC_LIKELY(upper == lower)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -484,7 +484,7 @@ LIBC_INLINE LIBC_CONSTEXPR double exp10(double x) {
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/__support/math/exp2.h
+++ b/libc/src/__support/math/exp2.h
@@ -380,7 +380,7 @@ LIBC_INLINE LIBC_CONSTEXPR double exp2(double x) {
 #ifdef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
   // To multiply by 2^hi, a fast way is to simply add hi to the exponent
   // field.
-  int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+  int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
   double r =
       cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(exp_mid.hi + lo));
   return r;
@@ -391,7 +391,7 @@ LIBC_INLINE LIBC_CONSTEXPR double exp2(double x) {
   if (LIBC_LIKELY(upper == lower)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -405,7 +405,7 @@ LIBC_INLINE LIBC_CONSTEXPR double exp2(double x) {
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
     // To multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }

--- a/libc/src/__support/math/exp_utils.h
+++ b/libc/src/__support/math/exp_utils.h
@@ -27,7 +27,8 @@ ziv_test_denorm(int hi, double mid, double lo, double err) {
   using FPBits = typename fputil::FPBits<double>;
 
   // Scaling factor = 1/(min normal number) = 2^1022
-  int64_t exp_hi = static_cast<int64_t>(hi + 1022) * (1LL << FPBits::FRACTION_LEN);
+  int64_t exp_hi =
+      static_cast<int64_t>(hi + 1022) * (1LL << FPBits::FRACTION_LEN);
   double mid_hi = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(mid));
   double lo_scaled =
       (lo != 0.0) ? cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(lo))

--- a/libc/src/__support/math/exp_utils.h
+++ b/libc/src/__support/math/exp_utils.h
@@ -27,7 +27,7 @@ ziv_test_denorm(int hi, double mid, double lo, double err) {
   using FPBits = typename fputil::FPBits<double>;
 
   // Scaling factor = 1/(min normal number) = 2^1022
-  int64_t exp_hi = static_cast<int64_t>(hi + 1022) << FPBits::FRACTION_LEN;
+  int64_t exp_hi = static_cast<int64_t>(hi + 1022) * (1LL << FPBits::FRACTION_LEN);
   double mid_hi = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(mid));
   double lo_scaled =
       (lo != 0.0) ? cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(lo))

--- a/libc/src/__support/math/expm1.h
+++ b/libc/src/__support/math/expm1.h
@@ -478,7 +478,7 @@ LIBC_INLINE LIBC_CONSTEXPR double expm1(double x) {
   if (LIBC_LIKELY(upper == lower)) {
     // to multiply by 2^hi, a fast way is to simply add hi to the exponent
     // field.
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper));
     return r;
   }
@@ -498,7 +498,7 @@ LIBC_INLINE LIBC_CONSTEXPR double expm1(double x) {
   double lower_dd = r_dd.hi + (r_dd.lo - err_dd);
 
   if (LIBC_LIKELY(upper_dd == lower_dd)) {
-    int64_t exp_hi = static_cast<int64_t>(hi) << FPBits::FRACTION_LEN;
+    int64_t exp_hi = static_cast<int64_t>(hi) * (1LL << FPBits::FRACTION_LEN);
     double r = cpp::bit_cast<double>(exp_hi + cpp::bit_cast<int64_t>(upper_dd));
     return r;
   }


### PR DESCRIPTION
Replace left-shift operations on potentially negative exponent values
with mathematically equivalent multiplication to avoid undefined
behavior. When computing exponential functions for inputs that produce
results less than 1, the exponent 'hi' can be negative (e.g., -2 for
exp(-1.0) ≈ 0.368). Left-shifting negative values is undefined behavior
in C++.

Fixed in:
- exp.h: 3 instances
- exp2.h: 3 instances
- exp10.h: 3 instances
- expm1.h: 2 instances
- exp_utils.h: 1 instance (hi + 1022 can be negative)

Exposed by 2b2a63819f9f.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
