### PR TITLE
[LLD] [MinGW] Implement --{push,pop}-state

### DIFF
--- a/lld/MinGW/Driver.cpp
+++ b/lld/MinGW/Driver.cpp
@@ -44,6 +44,7 @@
 #include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
+#include <stack>
 
 using namespace lld;
 using namespace llvm::opt;
@@ -576,6 +577,11 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
 
   StringRef prefix = "";
   bool isStatic = false;
+  struct PushPopState {
+    StringRef prefix;
+    bool isStatic;
+  };
+  std::stack<PushPopState, std::vector<PushPopState>> pushPopStates;
   for (auto *a : args) {
     switch (a->getOption().getID()) {
     case OPT_INPUT:
@@ -603,6 +609,18 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       break;
     case OPT_Bdynamic:
       isStatic = false;
+      break;
+    case OPT_push_state:
+      pushPopStates.push({prefix, isStatic});
+      break;
+    case OPT_pop_state:
+      if (pushPopStates.empty()) {
+        error("unbalanced --push-state/--pop-state");
+        break;
+      }
+      prefix = pushPopStates.top().prefix;
+      isStatic = pushPopStates.top().isStatic;
+      pushPopStates.pop();
       break;
     }
   }

--- a/lld/MinGW/Options.td
+++ b/lld/MinGW/Options.td
@@ -125,6 +125,10 @@ def o: JoinedOrSeparate<["-"], "o">, MetaVarName<"<path>">,
   HelpText<"Path to file to write output">;
 defm out_implib: Eq<"out-implib", "Import library name">;
 defm output_def: Eq<"output-def", "Output def file">;
+def pop_state: F<"pop-state">,
+  HelpText<"Restore the states saved by --push-state">;
+def push_state: F<"push-state">,
+  HelpText<"Save the current state of --Bstatic/--Bdynamic and --whole-archive">;
 defm reloc_section: B_enable_disable<"reloc-section",
      "Enable base relocations", "Disable base relocations">;
 defm section_alignment: Eq<"section-alignment", "Set section alignment">;

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -49,6 +49,10 @@ COFF Improvements
 MinGW Improvements
 ------------------
 
+* Added ``--push-state`` and ``--pop-state``, offering the same semantics as
+  when used with the ELF linker: The state of ``--Bstatic``/``--Bdynamic`` and
+  ``--whole-archive`` are pushed onto a stack and popped from it.
+
 MachO Improvements
 ------------------
 

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -501,3 +501,11 @@ NO-FAT-LTO: -fat-lto-objects:no
 
 RUN: ld.lld -### -m i386pep foo.o --no-fat-lto-objects --fat-lto-objects 2>&1 | FileCheck -check-prefix FAT-LTO %s
 FAT-LTO: -fat-lto-objects{{ }}
+
+RUN: ld.lld -### -m i386pep foo.o --push-state --whole-archive bar.a --pop-state baz.a 2>&1 | FileCheck -check-prefix PUSH-POP-STATE %s
+RUN: ld.lld -### -m i386pep foo.o -push-state -whole-archive bar.a -pop-state baz.a 2>&1 | FileCheck -check-prefix PUSH-POP-STATE %s
+PUSH-POP-STATE: foo.o -wholearchive:bar.a baz.a
+
+RUN: not ld.lld -m i386pep foo.o --pop-state 2>&1 | FileCheck -check-prefix PUSH-POP-STATE-UNBALANCED %s
+RUN: not ld.lld -m i386pep foo.o --push-state --pop-state --pop-state 2>&1 | FileCheck -check-prefix PUSH-POP-STATE-UNBALANCED %s
+PUSH-POP-STATE-UNBALANCED: error: unbalanced --push-state/--pop-state


### PR DESCRIPTION
Implement `--push-state` and `--pop-state` for the MinGW lld driver. Those options were already implemented by GNU ld for MinGW:
```
  --push-state                Push state of flags governing input file handling
  --pop-state                 Pop state of flags governing input file handling
```

This will align the MinGW frontend's options closer with those of the ELF frontend and fix issues due to e.g. CMake misdetecting `--push-state`/`--pop-state` support by accidentally querying the ELF driver.

Fixes #131007.