### PR TITLE
[LifetimeSafety] Warn when lifetimebound attribute is present on the definition but not on declaration

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -42,6 +42,11 @@ bool isNormalAssignmentOperator(const FunctionDecl *FD);
 bool isAssignmentOperatorLifetimeBound(const CXXMethodDecl *CMD);
 
 /// Returns the lifetimebound attribute for the implicit this parameter, if it
+/// exists on the current type.
+const LifetimeBoundAttr *
+getDirectImplicitObjectLifetimeBoundAttr(const FunctionDecl *FD);
+
+/// Returns the lifetimebound attribute for the implicit this parameter, if it
 /// exists on any redeclaration.
 const LifetimeBoundAttr *
 getImplicitObjectParamLifetimeBoundAttr(const FunctionDecl *FD);

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -15,8 +15,6 @@
 
 namespace clang ::lifetimes {
 
-enum class WarningScope;
-
 // This function is needed because Decl::isInStdNamespace will return false for
 // iterators in some STL implementations due to them being defined in a
 // namespace outside of the std namespace.
@@ -48,9 +46,6 @@ bool isAssignmentOperatorLifetimeBound(const CXXMethodDecl *CMD);
 const LifetimeBoundAttr *
 getDirectImplicitObjectLifetimeBoundAttr(const FunctionDecl *FD);
 
-const std::pair<const Decl *, WarningScope>
-getUnannotatedDeclBestMatch(const FunctionDecl *FD,
-                            const ParmVarDecl *PVD = nullptr);
 /// Returns the lifetimebound attribute for the implicit this parameter, if it
 /// exists on any redeclaration.
 const LifetimeBoundAttr *

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -12,9 +12,10 @@
 
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
-#include "clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h"
 
 namespace clang ::lifetimes {
+
+enum class WarningScope;
 
 // This function is needed because Decl::isInStdNamespace will return false for
 // iterators in some STL implementations due to them being defined in a

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeAnnotations.h
@@ -12,6 +12,7 @@
 
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h"
 
 namespace clang ::lifetimes {
 
@@ -46,6 +47,9 @@ bool isAssignmentOperatorLifetimeBound(const CXXMethodDecl *CMD);
 const LifetimeBoundAttr *
 getDirectImplicitObjectLifetimeBoundAttr(const FunctionDecl *FD);
 
+const std::pair<const Decl *, WarningScope>
+getUnannotatedDeclBestMatch(const FunctionDecl *FD,
+                            const ParmVarDecl *PVD = nullptr);
 /// Returns the lifetimebound attribute for the implicit this parameter, if it
 /// exists on any redeclaration.
 const LifetimeBoundAttr *

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -131,13 +131,13 @@ public:
   reportLifetimeboundViolation(const CXXMethodDecl *MDWithLifetimebound) {}
 
   // Reports a member function definition that has [[clang::lifetimebound]] on
-  // the implicit this parameter when the previous declaration does not.
+  // the implicit this parameter when the canonical declaration does not.
   virtual void reportMisplacedLifetimebound(WarningScope Scope,
                                             const CXXMethodDecl *FDef,
                                             const CXXMethodDecl *FDecl) {}
 
   // Reports a function definition parameter that has [[clang::lifetimebound]]
-  // when the corresponding parameter in the previous declaration does not.
+  // when the corresponding parameter in the canonical declaration.
   virtual void reportMisplacedLifetimebound(WarningScope Scope,
                                             const ParmVarDecl *PVDDef,
                                             const ParmVarDecl *PVDDecl) {}

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -41,9 +41,9 @@ struct LifetimeSafetyOpts {
 };
 
 /// Enum to track functions visible across or within TU.
-enum class SuggestionScope {
-  CrossTU, // For suggestions on declarations visible across Translation Units.
-  IntraTU  // For suggestions on definitions local to a Translation Unit.
+enum class WarningScope {
+  CrossTU, // For warnings on declarations visible across Translation Units.
+  IntraTU  // For warnings on functions local to a Translation Unit.
 };
 
 /// Abstract interface for operations requiring Sema access.
@@ -105,7 +105,7 @@ public:
       llvm::PointerUnion<const Expr *, const FieldDecl *, const VarDecl *>;
 
   // Suggests lifetime bound annotations for function parameters.
-  virtual void suggestLifetimeboundToParmVar(SuggestionScope Scope,
+  virtual void suggestLifetimeboundToParmVar(WarningScope Scope,
                                              const ParmVarDecl *ParmToAnnotate,
                                              EscapingTarget Target) {}
 
@@ -132,16 +132,18 @@ public:
 
   // Reports a member function definition that has [[clang::lifetimebound]] on
   // the implicit this parameter when the previous declaration does not.
-  virtual void reportMisplacedLifetimebound(const FunctionDecl *FDef,
-                                            const FunctionDecl *FDecl) {}
+  virtual void reportMisplacedLifetimebound(WarningScope Scope,
+                                            const CXXMethodDecl *FDef,
+                                            const CXXMethodDecl *FDecl) {}
 
   // Reports a function definition parameter that has [[clang::lifetimebound]]
   // when the corresponding parameter in the previous declaration does not.
-  virtual void reportMisplacedLifetimebound(const ParmVarDecl *PVDDef,
+  virtual void reportMisplacedLifetimebound(WarningScope Scope,
+                                            const ParmVarDecl *PVDDef,
                                             const ParmVarDecl *PVDDecl) {}
 
   // Suggests lifetime bound annotations for implicit this.
-  virtual void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,
+  virtual void suggestLifetimeboundToImplicitThis(WarningScope Scope,
                                                   const CXXMethodDecl *MD,
                                                   const Expr *EscapeExpr) {}
 

--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h
@@ -130,6 +130,16 @@ public:
   virtual void
   reportLifetimeboundViolation(const CXXMethodDecl *MDWithLifetimebound) {}
 
+  // Reports a member function definition that has [[clang::lifetimebound]] on
+  // the implicit this parameter when the previous declaration does not.
+  virtual void reportMisplacedLifetimebound(const FunctionDecl *FDef,
+                                            const FunctionDecl *FDecl) {}
+
+  // Reports a function definition parameter that has [[clang::lifetimebound]]
+  // when the corresponding parameter in the previous declaration does not.
+  virtual void reportMisplacedLifetimebound(const ParmVarDecl *PVDDef,
+                                            const ParmVarDecl *PVDDecl) {}
+
   // Suggests lifetime bound annotations for implicit this.
   virtual void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,
                                                   const CXXMethodDecl *MD,

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -640,7 +640,7 @@ def LifetimeSafetyMisplacedLifetimebound
                 [LifetimeSafetyCrossTUMisplacedLifetimebound,
                  LifetimeSafetyIntraTUMisplacedLifetimebound]> {
     code Documentation = [{
-Detects function definitions whose parameters or implicit this argument are marked as [[clang::lifetimebound]] when the corresponding declaration is not.
+Detects function definitions whose parameters or implicit this argument are marked as [[clang::lifetimebound]] when the canonical declaration is not.
 }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -640,7 +640,7 @@ def LifetimeSafetyMisplacedLifetimebound
                 [LifetimeSafetyCrossTUMisplacedLifetimebound,
                  LifetimeSafetyIntraTUMisplacedLifetimebound]> {
     code Documentation = [{
-Detects function definitions whose parameters or implicit this argument are marked as [[clang::lifetimebound]] when the canonical declaration is not.
+Detects function definitions whose parameters or implicit this argument are marked as [[clang::lifetimebound]] when the first declaration is not.
 }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -631,7 +631,14 @@ This warning may produce false-positives diagnostics when it cannot fully model 
   }];
 }
 
-def LifetimeSafetyMisplacedLifetimebound : DiagGroup<"lifetime-safety-misplaced-lifetimebound"> {
+def LifetimeSafetyCrossTUMisplacedLifetimebound
+    : DiagGroup<"lifetime-safety-cross-tu-misplaced-lifetimebound">;
+def LifetimeSafetyIntraTUMisplacedLifetimebound
+    : DiagGroup<"lifetime-safety-intra-tu-misplaced-lifetimebound">;
+def LifetimeSafetyMisplacedLifetimebound
+    : DiagGroup<"lifetime-safety-misplaced-lifetimebound",
+                [LifetimeSafetyCrossTUMisplacedLifetimebound,
+                 LifetimeSafetyIntraTUMisplacedLifetimebound]> {
     code Documentation = [{
 Detects function definitions whose parameters or implicit this argument are marked as [[clang::lifetimebound]] when the corresponding declaration is not.
 }];

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -631,6 +631,12 @@ This warning may produce false-positives diagnostics when it cannot fully model 
   }];
 }
 
+def LifetimeSafetyMisplacedLifetimebound : DiagGroup<"lifetime-safety-misplaced-lifetimebound"> {
+    code Documentation = [{
+Detects function definitions whose parameters or implicit this argument are marked as [[clang::lifetimebound]] when the corresponding declaration is not.
+}];
+}
+
 def LifetimeSafetyPermissive : DiagGroup<"lifetime-safety-permissive",
                                          [LifetimeSafetyUseAfterScope,
                                          LifetimeSafetyReturnStackAddr,
@@ -674,7 +680,8 @@ Detects misuse of [[clang::noescape]] annotation where the parameter escapes (fo
 
 def LifetimeSafetyValidations : DiagGroup<"lifetime-safety-validations",
                                           [LifetimeSafetyNoescape,
-                                           LifetimeSafetyLifetimeboundViolation]> {
+                                           LifetimeSafetyLifetimeboundViolation,
+                                           LifetimeSafetyMisplacedLifetimebound]> {
   code Documentation = [{
 Verify function implementations adhere to the annotated lifetime contracts through lifetime safety
 like verifying [[clang::noescape]] and [[clang::lifetimebound]].

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11019,12 +11019,12 @@ def warn_lifetime_safety_lifetimebound_violation
       DefaultIgnore;
 
 def warn_lifetime_safety_intra_tu_misplaced_lifetimebound
-    : Warning<"'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead">,
+    : Warning<"'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead">,
       InGroup<LifetimeSafetyIntraTUMisplacedLifetimebound>,
       DefaultIgnore;
 
 def warn_lifetime_safety_cross_tu_misplaced_lifetimebound
-    : Warning<"'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead">,
+    : Warning<"'lifetimebound' attribute on this definition is not visible to callers in other translation units; add it to the declaration instead">,
       InGroup<LifetimeSafetyCrossTUMisplacedLifetimebound>,
       DefaultIgnore;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11018,9 +11018,14 @@ def warn_lifetime_safety_lifetimebound_violation
       InGroup<LifetimeSafetyLifetimeboundViolation>,
       DefaultIgnore;
 
-def warn_lifetime_safety_misplaced_lifetimebound
-    : Warning<"'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead">,
-      InGroup<LifetimeSafetyMisplacedLifetimebound>,
+def warn_lifetime_safety_intra_tu_misplaced_lifetimebound
+    : Warning<"'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead">,
+      InGroup<LifetimeSafetyIntraTUMisplacedLifetimebound>,
+      DefaultIgnore;
+
+def warn_lifetime_safety_cross_tu_misplaced_lifetimebound
+    : Warning<"'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead">,
+      InGroup<LifetimeSafetyCrossTUMisplacedLifetimebound>,
       DefaultIgnore;
 
 def note_lifetime_safety_used_here : Note<"later used here">;
@@ -11035,7 +11040,7 @@ def note_lifetime_safety_dangling_static_here: Note<"this static storage dangles
 def note_lifetime_safety_escapes_to_field_here: Note<"escapes to this field">;
 def note_lifetime_safety_escapes_to_global_here: Note<"escapes to this global storage">;
 def note_lifetime_safety_escapes_to_static_storage_here: Note<"escapes to this static storage">;
-def note_lifetime_safety_definition_lifetimebound_attribute_here: Note<"'lifetimebound' attribute written on the definition is here">;
+def note_lifetime_safety_lifetimebound_here: Note<"'lifetimebound' attribute appears here on the definition">;
 
 def warn_lifetime_safety_intra_tu_param_suggestion
     : Warning<"parameter in intra-TU function should be marked "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11019,7 +11019,7 @@ def warn_lifetime_safety_lifetimebound_violation
       DefaultIgnore;
 
 def warn_lifetime_safety_misplaced_lifetimebound
-    : Warning<"'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead">,
+    : Warning<"'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead">,
       InGroup<LifetimeSafetyMisplacedLifetimebound>,
       DefaultIgnore;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11018,6 +11018,11 @@ def warn_lifetime_safety_lifetimebound_violation
       InGroup<LifetimeSafetyLifetimeboundViolation>,
       DefaultIgnore;
 
+def warn_lifetime_safety_misplaced_lifetimebound
+    : Warning<"'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead">,
+      InGroup<LifetimeSafetyMisplacedLifetimebound>,
+      DefaultIgnore;
+
 def note_lifetime_safety_used_here : Note<"later used here">;
 def note_lifetime_safety_invalidated_here : Note<"invalidated here">;
 def note_lifetime_safety_destroyed_here : Note<"destroyed here">;
@@ -11030,6 +11035,7 @@ def note_lifetime_safety_dangling_static_here: Note<"this static storage dangles
 def note_lifetime_safety_escapes_to_field_here: Note<"escapes to this field">;
 def note_lifetime_safety_escapes_to_global_here: Note<"escapes to this global storage">;
 def note_lifetime_safety_escapes_to_static_storage_here: Note<"escapes to this static storage">;
+def note_lifetime_safety_definition_lifetimebound_attribute_here: Note<"'lifetimebound' attribute written on the definition is here">;
 
 def warn_lifetime_safety_intra_tu_param_suggestion
     : Warning<"parameter in intra-TU function should be marked "

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -334,13 +334,13 @@ public:
     return {CanonicalDecl, Scope};
   }
 
-  const std::pair<const CXXMethodDecl *, WarningScope>
+  std::pair<const CXXMethodDecl *, WarningScope>
   getCanonicalDeclForAttr(const CXXMethodDecl *MD) {
     auto [CanonicalFD, Scope] = getCanonicalFunctionDeclForAttr(MD);
     return {cast_or_null<CXXMethodDecl>(CanonicalFD), Scope};
   }
 
-  const std::pair<const ParmVarDecl *, WarningScope>
+  std::pair<const ParmVarDecl *, WarningScope>
   getCanonicalDeclForAttr(const FunctionDecl *FD, const ParmVarDecl *PVD) {
     auto [CanonicalFD, Scope] = getCanonicalFunctionDeclForAttr(FD);
     if (!CanonicalFD)

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -61,7 +61,6 @@ private:
   llvm::DenseMap<AnnotationTarget, EscapingTarget> AnnotationWarningsMap;
   llvm::DenseMap<const ParmVarDecl *, EscapingTarget> NoescapeWarningsMap;
   llvm::DenseSet<const Decl *> VerifiedLiftimeboundEscapes;
-  llvm::DenseMap<const Decl *, WarningScope> DeclarationsToAnnotate;
   const LoanPropagationAnalysis &LoanPropagation;
   const MovedLoansAnalysis &MovedLoans;
   const LiveOriginsAnalysis &LiveOrigins;
@@ -136,10 +135,6 @@ public:
       if (PVD->hasAttr<LifetimeBoundAttr>()) {
         // Track that this lifetimebound parameter correctly escapes.
         VerifiedLiftimeboundEscapes.insert(PVD);
-        if (auto [UnannotatedFDecl, Scope] =
-                getUnannotatedDeclBestMatch(cast<FunctionDecl>(FD), PVD);
-            UnannotatedFDecl)
-          DeclarationsToAnnotate.try_emplace(UnannotatedFDecl, Scope);
       } else {
         // Otherwise, suggest lifetimebound for parameter escaping through
         // return or a field in constructor.
@@ -157,10 +152,6 @@ public:
         VerifiedLiftimeboundEscapes.insert(MD);
       else if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
         AnnotationWarningsMap.try_emplace(MD, ReturnEsc->getReturnExpr());
-      if (getDirectImplicitObjectLifetimeBoundAttr(MD))
-        if (auto [UnannotatedFDecl, Scope] = getUnannotatedDeclBestMatch(MD);
-            UnannotatedFDecl)
-          DeclarationsToAnnotate.try_emplace(UnannotatedFDecl, Scope);
     };
     auto MovedAtEscape = MovedLoans.getMovedLoans(OEF);
     for (LoanID LID : EscapedLoans) {
@@ -325,6 +316,42 @@ public:
     }
   }
 
+  const std::pair<const FunctionDecl *, WarningScope>
+  getCanonicalFunctionDeclForAttr(const FunctionDecl *FD) {
+    if (!FD || !FD->isExternallyVisible())
+      return {nullptr, WarningScope::IntraTU};
+
+    const auto &SM = FD->getASTContext().getSourceManager();
+    const FileID DefFile = SM.getFileID(SM.getExpansionLoc(FD->getLocation()));
+    const FunctionDecl *FirstDecl = nullptr;
+    WarningScope Scope = WarningScope::IntraTU;
+
+    for (const FunctionDecl *D = FD->getPreviousDecl(); D;
+         D = D->getPreviousDecl()) {
+      if (D->isThisDeclarationADefinition())
+        continue;
+      FirstDecl = D;
+      Scope = SM.getFileID(SM.getExpansionLoc(D->getLocation())) != DefFile
+                  ? WarningScope::CrossTU
+                  : WarningScope::IntraTU;
+    }
+    return {FirstDecl, Scope};
+  }
+
+  const std::pair<const CXXMethodDecl *, WarningScope>
+  getCanonicalDeclForAttr(const CXXMethodDecl *MD) {
+    auto [CanonicalFD, Scope] = getCanonicalFunctionDeclForAttr(MD);
+    return {cast_or_null<CXXMethodDecl>(CanonicalFD), Scope};
+  }
+
+  const std::pair<const ParmVarDecl *, WarningScope>
+  getCanonicalDeclForAttr(const FunctionDecl *FD, const ParmVarDecl *PVD) {
+    auto [CanonicalFD, Scope] = getCanonicalFunctionDeclForAttr(FD);
+    if (!CanonicalFD)
+      return {nullptr, Scope};
+    return {CanonicalFD->getParamDecl(PVD->getFunctionScopeIndex()), Scope};
+  }
+
   /// Returns the declaration of a function that is visible across translation
   /// units, if such a declaration exists and is different from the definition.
   static const FunctionDecl *getCrossTUDecl(const FunctionDecl &FD,
@@ -428,13 +455,18 @@ public:
     const FunctionDecl *FDef = dyn_cast<FunctionDecl>(FD);
     if (!FDef)
       return;
-    for (auto [Decl, Scope] : DeclarationsToAnnotate) {
-      if (const auto *MD = dyn_cast<CXXMethodDecl>(Decl))
-        SemaHelper->reportMisplacedLifetimebound(Scope,
-                                                 cast<CXXMethodDecl>(FDef), MD);
-      else if (const auto *PVD = dyn_cast<ParmVarDecl>(Decl))
-        SemaHelper->reportMisplacedLifetimebound(
-            Scope, FDef->getParamDecl(PVD->getFunctionScopeIndex()), PVD);
+    if (const auto *MDef = dyn_cast<CXXMethodDecl>(FDef);
+        MDef && getDirectImplicitObjectLifetimeBoundAttr(MDef))
+      if (auto [MDecl, Scope] = getCanonicalDeclForAttr(MDef);
+          MDecl && !getDirectImplicitObjectLifetimeBoundAttr(MDecl))
+        SemaHelper->reportMisplacedLifetimebound(Scope, MDef, MDecl);
+    for (const auto *PDef : FDef->parameters()) {
+      const auto *Attr = PDef->getAttr<LifetimeBoundAttr>();
+      if (!Attr || Attr->isImplicit())
+        continue;
+      if (auto [PDecl, Scope] = getCanonicalDeclForAttr(FDef, PDef);
+          PDecl && !PDecl->hasAttr<LifetimeBoundAttr>())
+        SemaHelper->reportMisplacedLifetimebound(Scope, PDef, PDecl);
     }
   }
 

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -317,13 +317,17 @@ public:
   }
 
   std::pair<const FunctionDecl *, WarningScope>
-  getCanonicalFunctionDeclForAttr(const FunctionDecl *FD) {
-    if (!FD)
+  getCanonicalFunctionDeclForAttr(const FunctionDecl *FDef) {
+    if (!FDef)
       return {nullptr, WarningScope::IntraTU};
 
-    const auto &SM = FD->getASTContext().getSourceManager();
-    const FileID DefFile = SM.getFileID(SM.getExpansionLoc(FD->getLocation()));
-    const FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();
+    assert(FDef->isThisDeclarationADefinition() &&
+           "Expected FunctionDecl to be a definition");
+
+    const auto &SM = FDef->getASTContext().getSourceManager();
+    const FileID DefFile =
+        SM.getFileID(SM.getExpansionLoc(FDef->getLocation()));
+    const FunctionDecl *CanonicalDecl = FDef->getCanonicalDecl();
     WarningScope Scope = WarningScope::IntraTU;
 
     Scope = SM.getFileID(SM.getExpansionLoc(CanonicalDecl->getLocation())) !=
@@ -335,17 +339,18 @@ public:
   }
 
   std::pair<const CXXMethodDecl *, WarningScope>
-  getCanonicalDeclForAttr(const CXXMethodDecl *MD) {
-    auto [CanonicalFD, Scope] = getCanonicalFunctionDeclForAttr(MD);
-    return {cast_or_null<CXXMethodDecl>(CanonicalFD), Scope};
+  getCanonicalDeclForAttr(const CXXMethodDecl *MDef) {
+    auto [CanonicalFDecl, Scope] = getCanonicalFunctionDeclForAttr(MDef);
+    return {cast_or_null<CXXMethodDecl>(CanonicalFDecl), Scope};
   }
 
   std::pair<const ParmVarDecl *, WarningScope>
-  getCanonicalDeclForAttr(const FunctionDecl *FD, const ParmVarDecl *PVD) {
-    auto [CanonicalFD, Scope] = getCanonicalFunctionDeclForAttr(FD);
-    if (!CanonicalFD)
+  getCanonicalDeclForAttr(const FunctionDecl *FDef, const ParmVarDecl *PVDDef) {
+    auto [CanonicalFDecl, Scope] = getCanonicalFunctionDeclForAttr(FDef);
+    if (!CanonicalFDecl)
       return {nullptr, Scope};
-    return {CanonicalFD->getParamDecl(PVD->getFunctionScopeIndex()), Scope};
+    return {CanonicalFDecl->getParamDecl(PVDDef->getFunctionScopeIndex()),
+            Scope};
   }
 
   /// Returns the declaration of a function that is visible across translation

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -323,19 +323,15 @@ public:
 
     const auto &SM = FD->getASTContext().getSourceManager();
     const FileID DefFile = SM.getFileID(SM.getExpansionLoc(FD->getLocation()));
-    const FunctionDecl *FirstDecl = nullptr;
+    const FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();
     WarningScope Scope = WarningScope::IntraTU;
 
-    for (const FunctionDecl *D = FD->getPreviousDecl(); D;
-         D = D->getPreviousDecl()) {
-      if (D->isThisDeclarationADefinition())
-        continue;
-      FirstDecl = D;
-      Scope = SM.getFileID(SM.getExpansionLoc(D->getLocation())) != DefFile
-                  ? WarningScope::CrossTU
-                  : WarningScope::IntraTU;
-    }
-    return {FirstDecl, Scope};
+    Scope = SM.getFileID(SM.getExpansionLoc(CanonicalDecl->getLocation())) !=
+                    DefFile
+                ? WarningScope::CrossTU
+                : WarningScope::IntraTU;
+
+    return {CanonicalDecl, Scope};
   }
 
   const std::pair<const CXXMethodDecl *, WarningScope>

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -318,7 +318,7 @@ public:
 
   const std::pair<const FunctionDecl *, WarningScope>
   getCanonicalFunctionDeclForAttr(const FunctionDecl *FD) {
-    if (!FD || !FD->isExternallyVisible())
+    if (!FD)
       return {nullptr, WarningScope::IntraTU};
 
     const auto &SM = FD->getASTContext().getSourceManager();

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -316,7 +316,7 @@ public:
     }
   }
 
-  const std::pair<const FunctionDecl *, WarningScope>
+  std::pair<const FunctionDecl *, WarningScope>
   getCanonicalFunctionDeclForAttr(const FunctionDecl *FD) {
     if (!FD)
       return {nullptr, WarningScope::IntraTU};
@@ -447,15 +447,22 @@ public:
     }
   }
 
+  // Reports lifetimebound attributes that are placed on a function definition
+  // but not on the corresponding declaration.
   void reportMisplacedLifetimebound() {
     const FunctionDecl *FDef = dyn_cast<FunctionDecl>(FD);
     if (!FDef)
       return;
+    // Check if implicit 'this' has lifetimebound on definition but not on
+    // declaration.
     if (const auto *MDef = dyn_cast<CXXMethodDecl>(FDef);
         MDef && getDirectImplicitObjectLifetimeBoundAttr(MDef))
       if (auto [MDecl, Scope] = getCanonicalDeclForAttr(MDef);
           MDecl && !getDirectImplicitObjectLifetimeBoundAttr(MDecl))
         SemaHelper->reportMisplacedLifetimebound(Scope, MDef, MDecl);
+
+    // Check each parameter for explicit lifetimebound on definition but not on
+    // declaration.
     for (const auto *PDef : FDef->parameters()) {
       const auto *Attr = PDef->getAttr<LifetimeBoundAttr>();
       if (!Attr || Attr->isImplicit())

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -103,6 +103,7 @@ public:
     suggestAnnotations();
     reportNoescapeViolations();
     reportLifetimeboundViolations();
+    reportMisplacedLifetimebound();
     //  Annotation inference is currently guarded by a frontend flag. In the
     //  future, this might be replaced by a design that differentiates between
     //  explicit and inferred findings with separate warning groups.
@@ -412,6 +413,28 @@ public:
              "should escape through return");
       if (!isImplicit && !Escapes)
         SemaHelper->reportLifetimeboundViolation(PVD);
+    }
+  }
+
+  void reportMisplacedLifetimebound() {
+    const FunctionDecl *FDef = dyn_cast<FunctionDecl>(FD);
+    if (!FDef)
+      return;
+
+    const FunctionDecl *FDecl = FDef->getPreviousDecl();
+    if (!FDecl)
+      return;
+
+    if (isa<CXXMethodDecl>(FDef) &&
+        getDirectImplicitObjectLifetimeBoundAttr(FDef) &&
+        !getDirectImplicitObjectLifetimeBoundAttr(FDecl))
+      SemaHelper->reportMisplacedLifetimebound(FDef, FDecl);
+
+    for (auto [PVDDef, PVDDecl] :
+         llvm::zip_equal(FDef->parameters(), FDecl->parameters())) {
+      if (PVDDef->hasAttr<LifetimeBoundAttr>() &&
+          !PVDDecl->hasAttr<LifetimeBoundAttr>())
+        SemaHelper->reportMisplacedLifetimebound(PVDDef, PVDDecl);
     }
   }
 

--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -61,6 +61,7 @@ private:
   llvm::DenseMap<AnnotationTarget, EscapingTarget> AnnotationWarningsMap;
   llvm::DenseMap<const ParmVarDecl *, EscapingTarget> NoescapeWarningsMap;
   llvm::DenseSet<const Decl *> VerifiedLiftimeboundEscapes;
+  llvm::DenseMap<const Decl *, WarningScope> DeclarationsToAnnotate;
   const LoanPropagationAnalysis &LoanPropagation;
   const MovedLoansAnalysis &MovedLoans;
   const LiveOriginsAnalysis &LiveOrigins;
@@ -135,6 +136,10 @@ public:
       if (PVD->hasAttr<LifetimeBoundAttr>()) {
         // Track that this lifetimebound parameter correctly escapes.
         VerifiedLiftimeboundEscapes.insert(PVD);
+        if (auto [UnannotatedFDecl, Scope] =
+                getUnannotatedDeclBestMatch(cast<FunctionDecl>(FD), PVD);
+            UnannotatedFDecl)
+          DeclarationsToAnnotate.try_emplace(UnannotatedFDecl, Scope);
       } else {
         // Otherwise, suggest lifetimebound for parameter escaping through
         // return or a field in constructor.
@@ -152,6 +157,10 @@ public:
         VerifiedLiftimeboundEscapes.insert(MD);
       else if (auto *ReturnEsc = dyn_cast<ReturnEscapeFact>(OEF))
         AnnotationWarningsMap.try_emplace(MD, ReturnEsc->getReturnExpr());
+      if (getDirectImplicitObjectLifetimeBoundAttr(MD))
+        if (auto [UnannotatedFDecl, Scope] = getUnannotatedDeclBestMatch(MD);
+            UnannotatedFDecl)
+          DeclarationsToAnnotate.try_emplace(UnannotatedFDecl, Scope);
     };
     auto MovedAtEscape = MovedLoans.getMovedLoans(OEF);
     for (LoanID LID : EscapedLoans) {
@@ -346,11 +355,11 @@ public:
 
     if (const FunctionDecl *CrossTUDecl = getCrossTUDecl(*PVD, SM))
       SemaHelper->suggestLifetimeboundToParmVar(
-          SuggestionScope::CrossTU,
+          WarningScope::CrossTU,
           CrossTUDecl->getParamDecl(PVD->getFunctionScopeIndex()),
           EscapeTarget);
     else
-      SemaHelper->suggestLifetimeboundToParmVar(SuggestionScope::IntraTU, PVD,
+      SemaHelper->suggestLifetimeboundToParmVar(WarningScope::IntraTU, PVD,
                                                 EscapeTarget);
   }
 
@@ -360,11 +369,10 @@ public:
                                   const Expr *EscapeExpr) {
     if (const FunctionDecl *CrossTUDecl = getCrossTUDecl(*MD, SM))
       SemaHelper->suggestLifetimeboundToImplicitThis(
-          SuggestionScope::CrossTU, cast<CXXMethodDecl>(CrossTUDecl),
-          EscapeExpr);
+          WarningScope::CrossTU, cast<CXXMethodDecl>(CrossTUDecl), EscapeExpr);
     else
-      SemaHelper->suggestLifetimeboundToImplicitThis(SuggestionScope::IntraTU,
-                                                     MD, EscapeExpr);
+      SemaHelper->suggestLifetimeboundToImplicitThis(WarningScope::IntraTU, MD,
+                                                     EscapeExpr);
   }
 
   void suggestAnnotations() {
@@ -420,21 +428,13 @@ public:
     const FunctionDecl *FDef = dyn_cast<FunctionDecl>(FD);
     if (!FDef)
       return;
-
-    const FunctionDecl *FDecl = FDef->getPreviousDecl();
-    if (!FDecl)
-      return;
-
-    if (isa<CXXMethodDecl>(FDef) &&
-        getDirectImplicitObjectLifetimeBoundAttr(FDef) &&
-        !getDirectImplicitObjectLifetimeBoundAttr(FDecl))
-      SemaHelper->reportMisplacedLifetimebound(FDef, FDecl);
-
-    for (auto [PVDDef, PVDDecl] :
-         llvm::zip_equal(FDef->parameters(), FDecl->parameters())) {
-      if (PVDDef->hasAttr<LifetimeBoundAttr>() &&
-          !PVDDecl->hasAttr<LifetimeBoundAttr>())
-        SemaHelper->reportMisplacedLifetimebound(PVDDef, PVDDecl);
+    for (auto [Decl, Scope] : DeclarationsToAnnotate) {
+      if (const auto *MD = dyn_cast<CXXMethodDecl>(Decl))
+        SemaHelper->reportMisplacedLifetimebound(Scope,
+                                                 cast<CXXMethodDecl>(FDef), MD);
+      else if (const auto *PVD = dyn_cast<ParmVarDecl>(Decl))
+        SemaHelper->reportMisplacedLifetimebound(
+            Scope, FDef->getParamDecl(PVD->getFunctionScopeIndex()), PVD);
     }
   }
 

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -73,15 +73,22 @@ getLifetimeBoundAttrFromFunctionType(const TypeSourceInfo &TSI) {
 }
 
 const LifetimeBoundAttr *
+getDirectImplicitObjectLifetimeBoundAttr(const FunctionDecl *FD) {
+  if (const TypeSourceInfo *TSI = FD->getTypeSourceInfo())
+    if (const auto *Attr = getLifetimeBoundAttrFromFunctionType(*TSI))
+      return Attr;
+  return nullptr;
+}
+
+const LifetimeBoundAttr *
 getImplicitObjectParamLifetimeBoundAttr(const FunctionDecl *FD) {
   FD = getDeclWithMergedLifetimeBoundAttrs(FD);
   // Attribute merging doesn't work well with attributes on function types (like
   // 'this' param). We need to check all redeclarations.
   auto CheckRedecls = [](const FunctionDecl *F) -> const LifetimeBoundAttr * {
     for (const FunctionDecl *Redecl : F->redecls())
-      if (const TypeSourceInfo *TSI = Redecl->getTypeSourceInfo())
-        if (const auto *Attr = getLifetimeBoundAttrFromFunctionType(*TSI))
-          return Attr;
+      if (const auto *Attr = getDirectImplicitObjectLifetimeBoundAttr(Redecl))
+        return Attr;
     return nullptr;
   };
 

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -13,9 +13,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
-#include "clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h"
 #include "clang/Basic/OperatorKinds.h"
-#include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/StringSet.h"
 
 namespace clang::lifetimes {
@@ -105,42 +103,6 @@ bool implicitObjectParamIsLifetimeBound(const FunctionDecl *FD) {
   if (getImplicitObjectParamLifetimeBoundAttr(FD))
     return true;
   return isNormalAssignmentOperator(FD);
-}
-
-const std::pair<const Decl *, WarningScope>
-getUnannotatedDeclBestMatch(const FunctionDecl *FD, const ParmVarDecl *PVD) {
-  if (!FD || !FD->isExternallyVisible())
-    return {nullptr, WarningScope::IntraTU};
-
-  auto HasAttr = [PVD](const FunctionDecl *D) -> bool {
-    if (PVD)
-      return D->getParamDecl(PVD->getFunctionScopeIndex())
-          ->hasAttr<LifetimeBoundAttr>();
-    return getDirectImplicitObjectLifetimeBoundAttr(D);
-  };
-
-  auto GetAnnotatedDecl = [PVD](const FunctionDecl *D) -> const Decl * {
-    if (!D)
-      return nullptr;
-    if (PVD)
-      return D->getParamDecl(PVD->getFunctionScopeIndex());
-    return D;
-  };
-
-  const auto &SM = FD->getASTContext().getSourceManager();
-  const FileID DefFile = SM.getFileID(SM.getExpansionLoc(FD->getLocation()));
-  const FunctionDecl *Fallback = nullptr;
-
-  for (const FunctionDecl *D = FD->getPreviousDecl(); D;
-       D = D->getPreviousDecl()) {
-    if (D->isThisDeclarationADefinition() || HasAttr(D))
-      continue;
-    if (!Fallback)
-      Fallback = D;
-    if (SM.getFileID(SM.getExpansionLoc(D->getLocation())) != DefFile)
-      return {GetAnnotatedDecl(D), WarningScope::CrossTU};
-  }
-  return {GetAnnotatedDecl(Fallback), WarningScope::IntraTU};
 }
 
 bool isInStlNamespace(const Decl *D) {

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -14,6 +14,7 @@
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/OperatorKinds.h"
+#include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/StringSet.h"
 
 namespace clang::lifetimes {
@@ -103,6 +104,42 @@ bool implicitObjectParamIsLifetimeBound(const FunctionDecl *FD) {
   if (getImplicitObjectParamLifetimeBoundAttr(FD))
     return true;
   return isNormalAssignmentOperator(FD);
+}
+
+const std::pair<const Decl *, WarningScope>
+getUnannotatedDeclBestMatch(const FunctionDecl *FD, const ParmVarDecl *PVD) {
+  if (!FD || !FD->isExternallyVisible())
+    return {nullptr, WarningScope::IntraTU};
+
+  auto HasAttr = [PVD](const FunctionDecl *D) -> bool {
+    if (PVD)
+      return D->getParamDecl(PVD->getFunctionScopeIndex())
+          ->hasAttr<LifetimeBoundAttr>();
+    return getDirectImplicitObjectLifetimeBoundAttr(D);
+  };
+
+  auto GetAnnotatedDecl = [PVD](const FunctionDecl *D) -> const Decl * {
+    if (!D)
+      return nullptr;
+    if (PVD)
+      return D->getParamDecl(PVD->getFunctionScopeIndex());
+    return D;
+  };
+
+  const auto &SM = FD->getASTContext().getSourceManager();
+  const FileID DefFile = SM.getFileID(SM.getExpansionLoc(FD->getLocation()));
+  const FunctionDecl *Fallback = nullptr;
+
+  for (const FunctionDecl *D = FD->getPreviousDecl(); D;
+       D = D->getPreviousDecl()) {
+    if (D->isThisDeclarationADefinition() || HasAttr(D))
+      continue;
+    if (!Fallback)
+      Fallback = D;
+    if (SM.getFileID(SM.getExpansionLoc(D->getLocation())) != DefFile)
+      return {GetAnnotatedDecl(D), WarningScope::CrossTU};
+  }
+  return {GetAnnotatedDecl(Fallback), WarningScope::IntraTU};
 }
 
 bool isInStlNamespace(const Decl *D) {

--- a/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/LifetimeAnnotations.cpp
@@ -13,6 +13,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeLoc.h"
+#include "clang/Analysis/Analyses/LifetimeSafety/LifetimeSafety.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/StringSet.h"

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -279,7 +279,7 @@ public:
   void reportMisplacedLifetimebound(WarningScope Scope,
                                     const CXXMethodDecl *FDef,
                                     const CXXMethodDecl *FDecl) override {
-    const auto *Attr = getImplicitObjectParamLifetimeBoundAttr(FDef);
+    const auto *Attr = getDirectImplicitObjectLifetimeBoundAttr(FDef);
     assert(Attr && "Expected lifetimebound attribute");
     unsigned DiagID =
         Scope == WarningScope::CrossTU

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -275,6 +275,33 @@ public:
         << 2 << "" << Attr->getRange();
   }
 
+  void reportMisplacedLifetimebound(const FunctionDecl *FDef,
+                                    const FunctionDecl *FDecl) override {
+    const auto *Attr = getImplicitObjectParamLifetimeBoundAttr(FDef);
+    assert(Attr && "Expected lifetimebound attribute");
+    S.Diag(Lexer::getLocForEndOfToken(FDecl->getEndLoc(), 0,
+                                      S.getSourceManager(), S.getLangOpts()),
+           diag::warn_lifetime_safety_misplaced_lifetimebound);
+
+    S.Diag(Attr->getLocation(),
+           diag::note_lifetime_safety_definition_lifetimebound_attribute_here)
+        << Attr->getRange();
+  }
+
+  void reportMisplacedLifetimebound(const ParmVarDecl *PVDDef,
+                                    const ParmVarDecl *PVDDecl) override {
+
+    const auto *Attr = PVDDef->getAttr<LifetimeBoundAttr>();
+    assert(Attr && "Expected lifetimebound attribute");
+    S.Diag(PVDDecl->getBeginLoc(),
+           diag::warn_lifetime_safety_misplaced_lifetimebound)
+        << PVDDecl->getSourceRange();
+
+    S.Diag(Attr->getLocation(),
+           diag::note_lifetime_safety_definition_lifetimebound_attribute_here)
+        << Attr->getRange();
+  }
+
   void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,
                                           const CXXMethodDecl *MD,
                                           const Expr *EscapeExpr) override {

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -40,7 +40,8 @@ inline bool IsLifetimeSafetyEnabled(Sema &S, const Decl *D) {
       diag::warn_lifetime_safety_dangling_global_moved,
       diag::warn_lifetime_safety_noescape_escapes,
       diag::warn_lifetime_safety_lifetimebound_violation,
-  };
+      diag::warn_lifetime_safety_cross_tu_misplaced_lifetimebound,
+      diag::warn_lifetime_safety_intra_tu_misplaced_lifetimebound};
   for (unsigned DiagID : DiagIDs)
     if (!Diags.isIgnored(DiagID, D->getBeginLoc()))
       return true;
@@ -225,11 +226,11 @@ public:
           << DanglingGlobal->getEndLoc();
   }
 
-  void suggestLifetimeboundToParmVar(SuggestionScope Scope,
+  void suggestLifetimeboundToParmVar(WarningScope Scope,
                                      const ParmVarDecl *ParmToAnnotate,
                                      EscapingTarget Target) override {
     unsigned DiagID =
-        (Scope == SuggestionScope::CrossTU)
+        (Scope == WarningScope::CrossTU)
             ? diag::warn_lifetime_safety_cross_tu_param_suggestion
             : diag::warn_lifetime_safety_intra_tu_param_suggestion;
     SourceLocation InsertionPoint = Lexer::getLocForEndOfToken(
@@ -275,37 +276,43 @@ public:
         << 2 << "" << Attr->getRange();
   }
 
-  void reportMisplacedLifetimebound(const FunctionDecl *FDef,
-                                    const FunctionDecl *FDecl) override {
+  void reportMisplacedLifetimebound(WarningScope Scope,
+                                    const CXXMethodDecl *FDef,
+                                    const CXXMethodDecl *FDecl) override {
     const auto *Attr = getImplicitObjectParamLifetimeBoundAttr(FDef);
     assert(Attr && "Expected lifetimebound attribute");
+    unsigned DiagID =
+        Scope == WarningScope::CrossTU
+            ? diag::warn_lifetime_safety_cross_tu_misplaced_lifetimebound
+            : diag::warn_lifetime_safety_intra_tu_misplaced_lifetimebound;
     S.Diag(Lexer::getLocForEndOfToken(FDecl->getEndLoc(), 0,
                                       S.getSourceManager(), S.getLangOpts()),
-           diag::warn_lifetime_safety_misplaced_lifetimebound);
+           DiagID);
 
-    S.Diag(Attr->getLocation(),
-           diag::note_lifetime_safety_definition_lifetimebound_attribute_here)
+    S.Diag(Attr->getLocation(), diag::note_lifetime_safety_lifetimebound_here)
         << Attr->getRange();
   }
 
-  void reportMisplacedLifetimebound(const ParmVarDecl *PVDDef,
+  void reportMisplacedLifetimebound(WarningScope Scope,
+                                    const ParmVarDecl *PVDDef,
                                     const ParmVarDecl *PVDDecl) override {
 
     const auto *Attr = PVDDef->getAttr<LifetimeBoundAttr>();
     assert(Attr && "Expected lifetimebound attribute");
-    S.Diag(PVDDecl->getBeginLoc(),
-           diag::warn_lifetime_safety_misplaced_lifetimebound)
-        << PVDDecl->getSourceRange();
+    unsigned DiagID =
+        Scope == WarningScope::CrossTU
+            ? diag::warn_lifetime_safety_cross_tu_misplaced_lifetimebound
+            : diag::warn_lifetime_safety_intra_tu_misplaced_lifetimebound;
+    S.Diag(PVDDecl->getBeginLoc(), DiagID) << PVDDecl->getSourceRange();
 
-    S.Diag(Attr->getLocation(),
-           diag::note_lifetime_safety_definition_lifetimebound_attribute_here)
+    S.Diag(Attr->getLocation(), diag::note_lifetime_safety_lifetimebound_here)
         << Attr->getRange();
   }
 
-  void suggestLifetimeboundToImplicitThis(SuggestionScope Scope,
+  void suggestLifetimeboundToImplicitThis(WarningScope Scope,
                                           const CXXMethodDecl *MD,
                                           const Expr *EscapeExpr) override {
-    unsigned DiagID = (Scope == SuggestionScope::CrossTU)
+    unsigned DiagID = (Scope == WarningScope::CrossTU)
                           ? diag::warn_lifetime_safety_cross_tu_this_suggestion
                           : diag::warn_lifetime_safety_intra_tu_this_suggestion;
     const auto MDL = MD->getTypeSourceInfo()->getTypeLoc();

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-cross-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-cross-tu.cpp
@@ -7,11 +7,11 @@ struct HeaderObj {
   ~HeaderObj() {}
 };
 
-HeaderObj &header_param(HeaderObj &obj); // expected-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+HeaderObj &header_param(HeaderObj &obj); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers in other translation units; add it to the declaration instead}}
 
 struct HeaderS {
   HeaderObj data;
-  HeaderObj &header_this(); // expected-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+  HeaderObj &header_this(); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers in other translation units; add it to the declaration instead}}
 };
 
 //--- cross.cpp

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-cross-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-cross-tu.cpp
@@ -1,26 +1,26 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-cross-tu-misplaced-lifetimebound -Wno-dangling -I%t -verify=cross %t/cross.cpp
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-cross-tu-misplaced-lifetimebound -Wno-dangling -I%t -verify %t/cross.cpp
 
 //--- cross.h
 struct HeaderObj {
   ~HeaderObj() {}
 };
 
-HeaderObj &header_param(HeaderObj &obj); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+HeaderObj &header_param(HeaderObj &obj); // expected-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
 
 struct HeaderS {
   HeaderObj data;
-  HeaderObj &header_this(); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+  HeaderObj &header_this(); // expected-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
 //--- cross.cpp
 #include "cross.h"
 
-HeaderObj &header_param(HeaderObj &obj [[clang::lifetimebound]]) { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+HeaderObj &header_param(HeaderObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
-HeaderObj &HeaderS::header_this() [[clang::lifetimebound]] { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+HeaderObj &HeaderS::header_this() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return data;
 }

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-cross-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-cross-tu.cpp
@@ -1,0 +1,26 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-cross-tu-misplaced-lifetimebound -Wno-dangling -I%t -verify=cross %t/cross.cpp
+
+//--- cross.h
+struct HeaderObj {
+  ~HeaderObj() {}
+};
+
+HeaderObj &header_param(HeaderObj &obj); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+
+struct HeaderS {
+  HeaderObj data;
+  HeaderObj &header_this(); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+};
+
+//--- cross.cpp
+#include "cross.h"
+
+HeaderObj &header_param(HeaderObj &obj [[clang::lifetimebound]]) { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+  return obj;
+}
+
+HeaderObj &HeaderS::header_this() [[clang::lifetimebound]] { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+  return data;
+}

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
@@ -4,16 +4,16 @@ struct MyObj {
   ~MyObj() {}
 };
 
-MyObj &free_param(MyObj &obj);                           // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+MyObj &free_param(MyObj &obj);                           // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 MyObj &free_param(MyObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 struct S {
   MyObj data;
-  const MyObj &implicit_this_only();         // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
-  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
-  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  const MyObj &implicit_this_only();         // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
+  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
+  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 };
 
 const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute appears here on the definition}}
@@ -34,7 +34,7 @@ const MyObj &S::both(
 template <class T>
 struct MixedSpecializations {
   T data;
-  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 };
 
 template <>
@@ -49,14 +49,14 @@ struct InternalObj {
 };
 
 namespace {
-InternalObj &anon_param(InternalObj &obj);                           // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+InternalObj &anon_param(InternalObj &obj);                           // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 InternalObj &anon_param(InternalObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 struct AnonS {
   InternalObj data;
-  InternalObj &anon_this(); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  InternalObj &anon_this(); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 };
 
 InternalObj &AnonS::anon_this() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute appears here on the definition}}
@@ -64,7 +64,7 @@ InternalObj &AnonS::anon_this() [[clang::lifetimebound]] { // expected-note {{'l
 }
 } // namespace
 
-static InternalObj &static_param(InternalObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+static InternalObj &static_param(InternalObj &obj); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 static InternalObj &static_param(InternalObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
@@ -73,14 +73,14 @@ struct IntraSuppressedObj {
   ~IntraSuppressedObj() {}
 };
 
-IntraSuppressedObj &intra_suppressed(IntraSuppressedObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+IntraSuppressedObj &intra_suppressed(IntraSuppressedObj &obj); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 IntraSuppressedObj &intra_suppressed(
     IntraSuppressedObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 struct View {
-  friend View friend_redecl(MyObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  friend View friend_redecl(MyObj &obj); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
 };
 
 // FIXME: This diagnoses an attribute inherited from another redeclaration, not one written on the definition. Once we enforce that redeclarations agree on lifetimebound, handle this with a dedicated warning and note.

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
@@ -83,7 +83,7 @@ struct View {
   friend View friend_redecl(MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
-// FIXME: Fix warning location, add a note pointing to this declaration saying "attribute inherited from this declaration"
+// FIXME: This diagnoses an attribute inherited from another redeclaration, not one written on the definition. Once we enforce that redeclarations agree on lifetimebound, handle this with a dedicated warning and note.
 View friend_redecl(MyObj &obj [[clang::lifetimebound]]); // intra-note {{'lifetimebound' attribute appears here on the definition}}
 
 View friend_redecl(MyObj &obj) {

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
@@ -1,9 +1,5 @@
-// RUN: rm -rf %t
-// RUN: split-file %s %t
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-intra-tu-misplaced-lifetimebound -Wno-dangling -verify=intra %t/test.cpp
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-cross-tu-misplaced-lifetimebound -Wno-dangling -I%t -verify=cross %t/cross.cpp
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-intra-tu-misplaced-lifetimebound -Wno-dangling -verify=intra %s
 
-//--- test.cpp
 struct MyObj {
   ~MyObj() {}
 };
@@ -81,34 +77,4 @@ IntraSuppressedObj &intra_suppressed(IntraSuppressedObj &obj); // intra-warning 
 IntraSuppressedObj &intra_suppressed(
     IntraSuppressedObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
-}
-
-//--- cross.h
-struct HeaderObj {
-  ~HeaderObj() {}
-};
-
-HeaderObj &header_param(HeaderObj &obj); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
-
-HeaderObj &header_then_source_redecl(HeaderObj &obj); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
-
-struct HeaderS {
-  HeaderObj data;
-  HeaderObj &header_this(); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
-};
-
-//--- cross.cpp
-#include "cross.h"
-
-HeaderObj &header_param(HeaderObj &obj [[clang::lifetimebound]]) { // cross-note {{'lifetimebound' attribute appears here on the definition}}
-  return obj;
-}
-
-HeaderObj &header_then_source_redecl(HeaderObj &obj);
-HeaderObj &header_then_source_redecl(HeaderObj &obj [[clang::lifetimebound]]) { // cross-note {{'lifetimebound' attribute appears here on the definition}}
-  return obj;
-}
-
-HeaderObj &HeaderS::header_this() [[clang::lifetimebound]] { // cross-note {{'lifetimebound' attribute appears here on the definition}}
-  return data;
 }

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
@@ -1,46 +1,46 @@
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-intra-tu-misplaced-lifetimebound -Wno-dangling -verify=intra %s
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-intra-tu-misplaced-lifetimebound -Wno-dangling -verify %s
 
 struct MyObj {
   ~MyObj() {}
 };
 
-MyObj &free_param(MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
-MyObj &free_param(MyObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+MyObj &free_param(MyObj &obj);                           // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+MyObj &free_param(MyObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 struct S {
   MyObj data;
-  const MyObj &implicit_this_only(); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
-  const MyObj &param_only(const MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
-  const MyObj &both(const MyObj &obj, bool); // intra-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  const MyObj &implicit_this_only();         // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
-const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return data;
 }
 
 const MyObj &S::param_only(
-    const MyObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 const MyObj &S::both(
-    const MyObj &obj [[clang::lifetimebound]], bool use_obj) // intra-note {{'lifetimebound' attribute appears here on the definition}}
-    [[clang::lifetimebound]] { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+    const MyObj &obj [[clang::lifetimebound]], bool use_obj) // expected-note {{'lifetimebound' attribute appears here on the definition}}
+    [[clang::lifetimebound]] {                               // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return use_obj ? obj : data;
 }
 
 template <class T>
 struct MixedSpecializations {
   T data;
-  T &both(T &arg, bool); // intra-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
 template <>
 MyObj &MixedSpecializations<MyObj>::both(
-    MyObj &arg [[clang::lifetimebound]], bool use_arg) // intra-note {{'lifetimebound' attribute appears here on the definition}}
-    [[clang::lifetimebound]] { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+    MyObj &arg [[clang::lifetimebound]], bool use_arg) // expected-note {{'lifetimebound' attribute appears here on the definition}}
+    [[clang::lifetimebound]] {                         // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return use_arg ? arg : data;
 }
 
@@ -49,23 +49,23 @@ struct InternalObj {
 };
 
 namespace {
-InternalObj &anon_param(InternalObj &obj);
-InternalObj &anon_param(InternalObj &obj [[clang::lifetimebound]]) {
+InternalObj &anon_param(InternalObj &obj);                           // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+InternalObj &anon_param(InternalObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 struct AnonS {
   InternalObj data;
-  InternalObj &anon_this();
+  InternalObj &anon_this(); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
-InternalObj &AnonS::anon_this() [[clang::lifetimebound]] {
+InternalObj &AnonS::anon_this() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return data;
 }
 } // namespace
 
-static InternalObj &static_param(InternalObj &obj);
-static InternalObj &static_param(InternalObj &obj [[clang::lifetimebound]]) {
+static InternalObj &static_param(InternalObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+static InternalObj &static_param(InternalObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
@@ -73,18 +73,18 @@ struct IntraSuppressedObj {
   ~IntraSuppressedObj() {}
 };
 
-IntraSuppressedObj &intra_suppressed(IntraSuppressedObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+IntraSuppressedObj &intra_suppressed(IntraSuppressedObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 IntraSuppressedObj &intra_suppressed(
-    IntraSuppressedObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+    IntraSuppressedObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 struct View {
-  friend View friend_redecl(MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  friend View friend_redecl(MyObj &obj); // expected-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
 // FIXME: This diagnoses an attribute inherited from another redeclaration, not one written on the definition. Once we enforce that redeclarations agree on lifetimebound, handle this with a dedicated warning and note.
-View friend_redecl(MyObj &obj [[clang::lifetimebound]]); // intra-note {{'lifetimebound' attribute appears here on the definition}}
+View friend_redecl(MyObj &obj [[clang::lifetimebound]]); // expected-note {{'lifetimebound' attribute appears here on the definition}}
 
 View friend_redecl(MyObj &obj) {
   return View{};

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
@@ -89,3 +89,14 @@ View friend_redecl(MyObj &obj [[clang::lifetimebound]]); // expected-note {{'lif
 View friend_redecl(MyObj &obj) {
   return View{};
 }
+
+template <typename T>
+// FIXME: Current analysis suggests adding to the primary template declaration, which is not ideal, as it will affect all specializations.
+MyObj &spec_func(T &obj); // expected-warning {{'lifetimebound' attribute on this definition is not visible to callers before the definition; add it to the declaration instead}}
+
+template <>
+// FIXME: Attribute is inhetired, diagnostic's wording is not correct.
+MyObj &spec_func<MyObj>(MyObj &obj [[clang::lifetimebound]]); // expected-note {{'lifetimebound' attribute appears here on the definition}}
+
+template <>
+MyObj &spec_func<MyObj>(MyObj &obj) { return obj; }

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound-intra-tu.cpp
@@ -78,3 +78,14 @@ IntraSuppressedObj &intra_suppressed(
     IntraSuppressedObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
+
+struct View {
+  friend View friend_redecl(MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+};
+
+// FIXME: Fix warning location, add a note pointing to this declaration saying "attribute inherited from this declaration"
+View friend_redecl(MyObj &obj [[clang::lifetimebound]]); // intra-note {{'lifetimebound' attribute appears here on the definition}}
+
+View friend_redecl(MyObj &obj) {
+  return View{};
+}

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound.cpp
@@ -1,0 +1,40 @@
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-validations -Wno-dangling -verify %s
+
+struct MyObj {
+  ~MyObj() {}
+};
+
+struct S {
+  MyObj data;
+  const MyObj &implicit_this_only(); // expected-warning {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
+  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
+  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
+};
+
+const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+  return data;
+}
+
+const MyObj &S::param_only(
+    const MyObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+  return obj;
+}
+
+const MyObj &S::both(
+    const MyObj &obj [[clang::lifetimebound]], bool use_obj) // expected-note {{'lifetimebound' attribute written on the definition is here}}
+    [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+  return use_obj ? obj : data;
+}
+
+template <class T>
+struct MixedSpecializations {
+  T data;
+  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
+};
+
+template <>
+MyObj &MixedSpecializations<MyObj>::both(
+    MyObj &arg [[clang::lifetimebound]], bool use_arg) // expected-note {{'lifetimebound' attribute written on the definition is here}}
+    [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+  return use_arg ? arg : data;
+}

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound.cpp
@@ -6,9 +6,9 @@ struct MyObj {
 
 struct S {
   MyObj data;
-  const MyObj &implicit_this_only(); // expected-warning {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
-  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
-  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
+  const MyObj &implicit_this_only(); // expected-warning {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
+  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
+  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
 };
 
 const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
@@ -29,7 +29,7 @@ const MyObj &S::both(
 template <class T>
 struct MixedSpecializations {
   T data;
-  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible from this declaration; add it to the declaration instead}}
+  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
 };
 
 template <>

--- a/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-misplaced-lifetimebound.cpp
@@ -1,40 +1,114 @@
-// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-validations -Wno-dangling -verify %s
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-intra-tu-misplaced-lifetimebound -Wno-dangling -verify=intra %t/test.cpp
+// RUN: %clang_cc1 -fsyntax-only -Wlifetime-safety-cross-tu-misplaced-lifetimebound -Wno-dangling -I%t -verify=cross %t/cross.cpp
 
+//--- test.cpp
 struct MyObj {
   ~MyObj() {}
 };
 
+MyObj &free_param(MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+MyObj &free_param(MyObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+  return obj;
+}
+
 struct S {
   MyObj data;
-  const MyObj &implicit_this_only(); // expected-warning {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
-  const MyObj &param_only(const MyObj &obj); // expected-warning {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
-  const MyObj &both(const MyObj &obj, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
+  const MyObj &implicit_this_only(); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  const MyObj &param_only(const MyObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+  const MyObj &both(const MyObj &obj, bool); // intra-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
-const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+const MyObj &S::implicit_this_only() [[clang::lifetimebound]] { // intra-note {{'lifetimebound' attribute appears here on the definition}}
   return data;
 }
 
 const MyObj &S::param_only(
-    const MyObj &obj [[clang::lifetimebound]]) { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+    const MyObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
   return obj;
 }
 
 const MyObj &S::both(
-    const MyObj &obj [[clang::lifetimebound]], bool use_obj) // expected-note {{'lifetimebound' attribute written on the definition is here}}
-    [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+    const MyObj &obj [[clang::lifetimebound]], bool use_obj) // intra-note {{'lifetimebound' attribute appears here on the definition}}
+    [[clang::lifetimebound]] { // intra-note {{'lifetimebound' attribute appears here on the definition}}
   return use_obj ? obj : data;
 }
 
 template <class T>
 struct MixedSpecializations {
   T data;
-  T &both(T &arg, bool); // expected-warning 2 {{'lifetimebound' attribute on the definition is not visible to callers; add it to this declaration instead}}
+  T &both(T &arg, bool); // intra-warning 2 {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
 };
 
 template <>
 MyObj &MixedSpecializations<MyObj>::both(
-    MyObj &arg [[clang::lifetimebound]], bool use_arg) // expected-note {{'lifetimebound' attribute written on the definition is here}}
-    [[clang::lifetimebound]] { // expected-note {{'lifetimebound' attribute written on the definition is here}}
+    MyObj &arg [[clang::lifetimebound]], bool use_arg) // intra-note {{'lifetimebound' attribute appears here on the definition}}
+    [[clang::lifetimebound]] { // intra-note {{'lifetimebound' attribute appears here on the definition}}
   return use_arg ? arg : data;
+}
+
+struct InternalObj {
+  ~InternalObj() {}
+};
+
+namespace {
+InternalObj &anon_param(InternalObj &obj);
+InternalObj &anon_param(InternalObj &obj [[clang::lifetimebound]]) {
+  return obj;
+}
+
+struct AnonS {
+  InternalObj data;
+  InternalObj &anon_this();
+};
+
+InternalObj &AnonS::anon_this() [[clang::lifetimebound]] {
+  return data;
+}
+} // namespace
+
+static InternalObj &static_param(InternalObj &obj);
+static InternalObj &static_param(InternalObj &obj [[clang::lifetimebound]]) {
+  return obj;
+}
+
+struct IntraSuppressedObj {
+  ~IntraSuppressedObj() {}
+};
+
+IntraSuppressedObj &intra_suppressed(IntraSuppressedObj &obj); // intra-warning {{'lifetimebound' attribute on an intra-TU definition is not visible to callers; add it to the declaration instead}}
+IntraSuppressedObj &intra_suppressed(
+    IntraSuppressedObj &obj [[clang::lifetimebound]]) { // intra-note {{'lifetimebound' attribute appears here on the definition}}
+  return obj;
+}
+
+//--- cross.h
+struct HeaderObj {
+  ~HeaderObj() {}
+};
+
+HeaderObj &header_param(HeaderObj &obj); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+
+HeaderObj &header_then_source_redecl(HeaderObj &obj); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+
+struct HeaderS {
+  HeaderObj data;
+  HeaderObj &header_this(); // cross-warning {{'lifetimebound' attribute on a cross-TU definition is not visible to callers; add it to the declaration instead}}
+};
+
+//--- cross.cpp
+#include "cross.h"
+
+HeaderObj &header_param(HeaderObj &obj [[clang::lifetimebound]]) { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+  return obj;
+}
+
+HeaderObj &header_then_source_redecl(HeaderObj &obj);
+HeaderObj &header_then_source_redecl(HeaderObj &obj [[clang::lifetimebound]]) { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+  return obj;
+}
+
+HeaderObj &HeaderS::header_this() [[clang::lifetimebound]] { // cross-note {{'lifetimebound' attribute appears here on the definition}}
+  return data;
 }


### PR DESCRIPTION
Warn when the `[[clang::lifetimebound]]` attribute is present on a definition but not on the corresponding declaration, with a note pointing to where the attribute appears.

Closes #183016