### PR TITLE
[lldb] Use identity hashing for HashToISAMap in ObjCLanguageRuntime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -15,6 +15,8 @@
 #include <optional>
 #include <unordered_set>
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
 #include "lldb/Breakpoint/BreakpointPrecondition.h"
@@ -420,7 +422,17 @@ private:
   typedef std::map<ClassAndSel, lldb::addr_t> MsgImplMap;
   typedef std::map<ClassAndSelStr, lldb::addr_t> MsgImplStrMap;
   typedef llvm::DenseMap<ObjCISA, ClassDescriptorSP> ISAToDescriptorMap;
-  typedef llvm::DenseMap<uint32_t, llvm::SmallVector<ObjCISA, 2>> HashToISAMap;
+
+  // Keys are already djbHash values, so use identity as the hash function.
+  struct IdentityHashKeyInfo {
+    static constexpr uint32_t getEmptyKey() { return ~0U; }
+    static constexpr uint32_t getTombstoneKey() { return ~0U - 1; }
+    static unsigned getHashValue(uint32_t Val) { return Val; }
+    static bool isEqual(uint32_t LHS, uint32_t RHS) { return LHS == RHS; }
+  };
+
+  typedef llvm::SmallVector<ObjCISA, 2> ISAVector;
+  typedef llvm::DenseMap<uint32_t, ISAVector, IdentityHashKeyInfo> HashToISAMap;
   typedef ISAToDescriptorMap::iterator ISAToDescriptorIterator;
   typedef ThreadSafeDenseMap<void *, uint64_t> TypeSizeCache;
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -423,7 +423,7 @@ private:
   typedef std::map<ClassAndSelStr, lldb::addr_t> MsgImplStrMap;
   typedef llvm::DenseMap<ObjCISA, ClassDescriptorSP> ISAToDescriptorMap;
 
-  // Keys are already djbHash values, so use identity as the hash function.
+  /// Keys are already djbHash values, so use identity as the hash function.
   struct IdentityHashKeyInfo {
     static constexpr uint32_t getEmptyKey() { return ~0U; }
     static constexpr uint32_t getTombstoneKey() { return ~0U - 1; }


### PR DESCRIPTION
The keys of HashToISAMap are already hashes, and can be used as-is.
