### PR TITLE
[InferAttrs] Annotate math and basic string libcalls with `nosync`

### DIFF
--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -1423,7 +1423,6 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotCallback(F);
     Changed |= setDoesNotFreeMemory(F);
     Changed |= setWillReturn(F);
-    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_sincos:
   case LibFunc_sincosf:

--- a/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/BuildLibCalls.cpp
@@ -61,6 +61,7 @@ STATISTIC(NumReturnedArg, "Number of arguments inferred as returned");
 STATISTIC(NumWillReturn, "Number of functions inferred as willreturn");
 STATISTIC(NumCold, "Number of functions inferred as cold");
 STATISTIC(NumNoReturn, "Number of functions inferred as no return");
+STATISTIC(NumNoSync, "Number of functions inferred as nosync");
 
 static bool setDoesNotAccessMemory(Function &F) {
   if (F.doesNotAccessMemory())
@@ -192,6 +193,14 @@ static bool setDoesNotAlias(Function &F, unsigned ArgNo) {
     return false;
   F.addParamAttr(ArgNo, Attribute::NoAlias);
   ++NumNoAlias;
+  return true;
+}
+
+static bool setDoesNotSync(Function &F) {
+  if (F.hasFnAttribute(Attribute::NoSync))
+    return false;
+  F.addFnAttr(Attribute::NoSync);
+  ++NumNoSync;
   return true;
 }
 
@@ -348,6 +357,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyAccessesArgMemory(F);
     Changed |= setWillReturn(F);
     Changed |= setDoesNotCapture(F, 0);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_strchr:
   case LibFunc_strrchr:
@@ -356,6 +366,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotThrow(F);
     Changed |= setDoesNotCallback(F);
     Changed |= setWillReturn(F);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_strtol:
   case LibFunc_strtod:
@@ -381,6 +392,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyReadsMemory(F, 1);
     Changed |= setDoesNotAlias(F, 0);
     Changed |= setDoesNotAlias(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_strcpy:
   case LibFunc_strncpy:
@@ -397,6 +409,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyReadsMemory(F, 1);
     Changed |= setDoesNotAlias(F, 0);
     Changed |= setDoesNotAlias(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_strxfrm:
     Changed |= setDoesNotThrow(F);
@@ -417,6 +430,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyReadsMemory(F);
     Changed |= setDoesNotCapture(F, 0);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_strcoll:
   case LibFunc_strcasecmp:  // 0,1
@@ -438,6 +452,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotCallback(F);
     Changed |= setWillReturn(F);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_strtok:
   case LibFunc_strtok_r:
@@ -547,6 +562,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setWillReturn(F);
     Changed |= setDoesNotCapture(F, 0);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_memchr:
   case LibFunc_memrchr:
@@ -555,6 +571,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyAccessesArgMemory(F);
     Changed |= setOnlyReadsMemory(F);
     Changed |= setWillReturn(F);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_modf:
   case LibFunc_modff:
@@ -565,6 +582,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyAccessesArgMemory(F);
     Changed |= setOnlyWritesMemory(F);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_memcpy:
     Changed |= setDoesNotThrow(F);
@@ -577,6 +595,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotAlias(F, 1);
     Changed |= setDoesNotCapture(F, 1);
     Changed |= setOnlyReadsMemory(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_memmove:
     Changed |= setDoesNotThrow(F);
@@ -587,6 +606,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyWritesMemory(F, 0);
     Changed |= setDoesNotCapture(F, 1);
     Changed |= setOnlyReadsMemory(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_mempcpy:
   case LibFunc_memccpy:
@@ -601,6 +621,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotAlias(F, 1);
     Changed |= setDoesNotCapture(F, 1);
     Changed |= setOnlyReadsMemory(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_memalign:
     Changed |= setAllocFamily(F, "malloc");
@@ -704,6 +725,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyReadsMemory(F, 0);
     Changed |= setOnlyWritesMemory(F, 1);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_bcmp:
     Changed |= setDoesNotThrow(F);
@@ -713,6 +735,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setWillReturn(F);
     Changed |= setDoesNotCapture(F, 0);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_bzero:
     Changed |= setDoesNotThrow(F);
@@ -721,6 +744,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setWillReturn(F);
     Changed |= setDoesNotCapture(F, 0);
     Changed |= setOnlyWritesMemory(F, 0);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_calloc:
   case LibFunc_vec_calloc:
@@ -757,6 +781,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyReadsMemory(F);
     Changed |= setWillReturn(F);
     Changed |= setDoesNotCapture(F, 0);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_access:
     Changed |= setRetAndArgsNoUndef(F);
@@ -836,6 +861,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyAccessesArgMemory(F);
     Changed |= setOnlyWritesMemory(F);
     Changed |= setDoesNotCapture(F, 1);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_fstatvfs:
     Changed |= setRetAndArgsNoUndef(F);
@@ -1197,6 +1223,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setOnlyWritesMemory(F, 0);
     Changed |= setDoesNotThrow(F);
     Changed |= setDoesNotCallback(F);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_abort:
     Changed |= setIsCold(F);
@@ -1337,6 +1364,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotFreeMemory(F);
     Changed |= setWillReturn(F);
     Changed |= setOnlyWritesErrnoMemory(F);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_abs:
   case LibFunc_cbrt:
@@ -1395,6 +1423,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotCallback(F);
     Changed |= setDoesNotFreeMemory(F);
     Changed |= setWillReturn(F);
+    Changed |= setDoesNotSync(F);
     break;
   case LibFunc_sincos:
   case LibFunc_sincosf:
@@ -1412,6 +1441,7 @@ bool llvm::inferNonMandatoryLibFuncAttrs(Function &F,
     Changed |= setDoesNotCapture(F, 2);
     Changed |= setWillReturn(F);
     Changed |= setOnlyWritesArgMemOrErrnoMem(F);
+    Changed |= setDoesNotSync(F);
     break;
   default:
     // FIXME: It'd be really nice to cover all the library functions we're

--- a/llvm/test/Transforms/InferFunctionAttrs/annotate.ll
+++ b/llvm/test/Transforms/InferFunctionAttrs/annotate.ll
@@ -201,70 +201,70 @@ declare i32 @abs(i32)
 ; CHECK: declare noundef i32 @access(ptr noundef readonly captures(none), i32 noundef) [[NOFREE_NOUNWIND:#[0-9]+]]
 declare i32 @access(ptr, i32)
 
-; CHECK: declare double @acos(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
+; CHECK: declare double @acos(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare double @acos(double)
 
-; CHECK: declare float @acosf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @acosf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @acosf(float)
 
-; CHECK: declare double @acosh(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @acosh(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @acosh(double)
 
-; CHECK: declare float @acoshf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @acoshf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @acoshf(float)
 
-; CHECK: declare x86_fp80 @acoshl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @acoshl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @acoshl(x86_fp80)
 
-; CHECK: declare x86_fp80 @acosl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @acosl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @acosl(x86_fp80)
 
 ; CHECK: declare noalias noundef ptr @aligned_alloc(i64 allocalign noundef, i64 noundef) [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCKIND_ALLOCUNINIT_ALLOCSIZE1_FAMILY_MALLOC:#[0-9]+]]
 declare ptr @aligned_alloc(i64, i64)
 
-; CHECK: declare double @asin(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @asin(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @asin(double)
 
-; CHECK: declare float @asinf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @asinf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @asinf(float)
 
-; CHECK: declare double @asinh(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @asinh(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @asinh(double)
 
-; CHECK: declare float @asinhf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @asinhf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @asinhf(float)
 
-; CHECK: declare x86_fp80 @asinhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @asinhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @asinhl(x86_fp80)
 
-; CHECK: declare x86_fp80 @asinl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @asinl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @asinl(x86_fp80)
 
-; CHECK: declare double @atan(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @atan(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @atan(double)
 
-; CHECK: declare double @atan2(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @atan2(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @atan2(double, double)
 
-; CHECK: declare float @atan2f(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @atan2f(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @atan2f(float, float)
 
-; CHECK: declare x86_fp80 @atan2l(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @atan2l(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @atan2l(x86_fp80, x86_fp80)
 
-; CHECK: declare float @atanf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @atanf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @atanf(float)
 
-; CHECK: declare double @atanh(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @atanh(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @atanh(double)
 
-; CHECK: declare float @atanhf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @atanhf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @atanhf(float)
 
-; CHECK: declare x86_fp80 @atanhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @atanhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @atanhl(x86_fp80)
 
-; CHECK: declare x86_fp80 @atanl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @atanl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @atanl(x86_fp80)
 
 ; CHECK: declare double @atof(ptr captures(none)) [[NOFREE_NOUNWIND_READONLY_WILLRETURN:#[0-9]+]]
@@ -283,10 +283,10 @@ declare i64 @atoll(ptr)
 ; CHECK-NOLINUX: declare i32 @bcmp(ptr, ptr, i64){{$}}
 declare i32 @bcmp(ptr, ptr, i64)
 
-; CHECK: declare void @bcopy(ptr readonly captures(none), ptr writeonly captures(none), i64)  [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
+; CHECK: declare void @bcopy(ptr readonly captures(none), ptr writeonly captures(none), i64)  [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare void @bcopy(ptr, ptr, i64)
 
-; CHECK: declare void @bzero(ptr writeonly captures(none), i64)  [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare void @bzero(ptr writeonly captures(none), i64)  [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @bzero(ptr, i64)
 
 ; CHECK: declare noalias noundef ptr @calloc(i64 noundef, i64 noundef) [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCKIND_ALLOCZEROED_ALLOCSIZE01_FAMILY_MALLOC:#[0-9]+]]
@@ -339,52 +339,52 @@ declare float @copysignf(float, float)
 ; CHECK: declare x86_fp80 @copysignl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @copysignl(x86_fp80, x86_fp80)
 
-; CHECK: declare double @cos(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @cos(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @cos(double)
 
-; CHECK: declare float @cosf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @cosf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @cosf(float)
 
-; CHECK: declare double @cosh(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @cosh(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @cosh(double)
 
-; CHECK: declare float @coshf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @coshf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @coshf(float)
 
-; CHECK: declare x86_fp80 @coshl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @coshl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @coshl(x86_fp80)
 
-; CHECK: declare x86_fp80 @cosl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @cosl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @cosl(x86_fp80)
 
 ; CHECK: declare noundef ptr @ctermid(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare ptr @ctermid(ptr)
 
-; CHECK: declare double @exp(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @exp(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @exp(double)
 
-; CHECK: declare double @exp2(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @exp2(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @exp2(double)
 
-; CHECK: declare float @exp2f(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @exp2f(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @exp2f(float)
 
-; CHECK: declare x86_fp80 @exp2l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @exp2l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @exp2l(x86_fp80)
 
-; CHECK: declare float @expf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @expf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @expf(float)
 
-; CHECK: declare x86_fp80 @expl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @expl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @expl(x86_fp80)
 
-; CHECK: declare double @expm1(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @expm1(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @expm1(double)
 
-; CHECK: declare float @expm1f(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @expm1f(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @expm1f(float)
 
-; CHECK: declare x86_fp80 @expm1l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @expm1l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @expm1l(x86_fp80)
 
 ; CHECK: declare double @fabs(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
@@ -491,13 +491,13 @@ declare float @fminimum_numf(float, float)
 ; CHECK: declare x86_fp80 @fminimum_numl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fminimum_numl(x86_fp80, x86_fp80)
 
-; CHECK: declare double @fmod(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fmod(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fmod(double, double)
 
-; CHECK: declare float @fmodf(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fmodf(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fmodf(float, float)
 
-; CHECK: declare x86_fp80 @fmodl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fmodl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fmodl(x86_fp80, x86_fp80)
 
 ; CHECK: declare noalias noundef ptr @fopen(ptr noundef readonly captures(none), ptr noundef readonly captures(none)) [[NOFREE_NOUNWIND]]
@@ -521,13 +521,13 @@ declare void @free(ptr)
 ; CHECK-AIX: declare void @vec_free(ptr allocptr noundef captures(none)) [[INACCESSIBLEMEMORARGMEMONLY_NOUNWIND_WILLRETURN_FAMILY_VEC_MALLOC:#[0-9]+]]
 declare void @vec_free(ptr)
 
-; CHECK: declare double @frexp(double, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY:#[0-9]+]]
+; CHECK: declare double @frexp(double, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY:#[0-9]+]]
 declare double @frexp(double, ptr)
 
-; CHECK: declare float @frexpf(float, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY]]
+; CHECK: declare float @frexpf(float, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]]
 declare float @frexpf(float, ptr)
 
-; CHECK: declare x86_fp80 @frexpl(x86_fp80, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY]]
+; CHECK: declare x86_fp80 @frexpl(x86_fp80, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]]
 declare x86_fp80 @frexpl(x86_fp80, ptr)
 
 ; CHECK: declare noundef i32 @fscanf(ptr noundef captures(none), ptr noundef readonly captures(none), ...) [[NOFREE_NOUNWIND]]
@@ -607,13 +607,13 @@ declare ptr @gets(ptr)
 ; CHECK: declare noundef i32 @gettimeofday(ptr noundef captures(none), ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare i32 @gettimeofday(ptr, ptr)
 
-; CHECK: declare double @hypot(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @hypot(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @hypot(double, double)
 
-; CHECK: declare float @hypotf(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @hypotf(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @hypotf(float, float)
 
-; CHECK: declare x86_fp80 @hypotl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @hypotl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @hypotl(x86_fp80, x86_fp80)
 
 ; CHECK: declare i32 @isascii(i32) [[NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
@@ -628,79 +628,79 @@ declare i64 @labs(i64)
 ; CHECK: declare noundef i32 @lchown(ptr noundef readonly captures(none), i32 noundef, i32 noundef) [[NOFREE_NOUNWIND]]
 declare i32 @lchown(ptr, i32, i32)
 
-; CHECK: declare double @ldexp(double, i32) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @ldexp(double, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @ldexp(double, i32)
 
-; CHECK: declare float @ldexpf(float, i32) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @ldexpf(float, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @ldexpf(float, i32)
 
-; CHECK: declare x86_fp80 @ldexpl(x86_fp80, i32) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @ldexpl(x86_fp80, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @ldexpl(x86_fp80, i32)
 
 ; CHECK: declare i64 @llabs(i64) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare i64 @llabs(i64)
 
-; CHECK: declare double @log(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @log(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @log(double)
 
-; CHECK: declare double @log10(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @log10(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @log10(double)
 
-; CHECK: declare float @log10f(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @log10f(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @log10f(float)
 
-; CHECK: declare x86_fp80 @log10l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @log10l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @log10l(x86_fp80)
 
-; CHECK: declare double @log1p(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @log1p(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @log1p(double)
 
-; CHECK: declare float @log1pf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @log1pf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @log1pf(float)
 
-; CHECK: declare x86_fp80 @log1pl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @log1pl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @log1pl(x86_fp80)
 
-; CHECK: declare double @log2(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @log2(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @log2(double)
 
-; CHECK: declare float @log2f(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @log2f(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @log2f(float)
 
-; CHECK: declare x86_fp80 @log2l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @log2l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @log2l(x86_fp80)
 
-; CHECK: declare i32 @ilogb(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i32 @ilogb(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i32 @ilogb(double)
 
-; CHECK: declare i32 @ilogbf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i32 @ilogbf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i32 @ilogbf(float)
 
-; CHECK: declare i32 @ilogbl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i32 @ilogbl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i32 @ilogbl(x86_fp80)
 
-; CHECK: declare double @logb(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @logb(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @logb(double)
 
-; CHECK: declare float @logbf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @logbf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @logbf(float)
 
-; CHECK: declare x86_fp80 @logbl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @logbl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @logbl(x86_fp80)
 
-; CHECK: declare float @logf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @logf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @logf(float)
 
-; CHECK: declare x86_fp80 @logl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @logl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @logl(x86_fp80)
 
-; CHECK: declare double @tgamma(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @tgamma(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @tgamma(double)
 
-; CHECK: declare float @tgammaf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @tgammaf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @tgammaf(float)
 
-; CHECK: declare x86_fp80 @tgammal(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @tgammal(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @tgammal(x86_fp80)
 
 ; CHECK: declare noundef i32 @lstat(ptr noundef readonly captures(none), ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
@@ -718,7 +718,7 @@ declare ptr @vec_malloc(i64)
 ; CHECK-LINUX: declare noalias noundef ptr @memalign(i64 allocalign, i64) [[INACCESSIBLEMEMONLY_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare ptr @memalign(i64, i64)
 
-; CHECK: declare ptr @memccpy(ptr noalias writeonly, ptr noalias readonly captures(none), i32, i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @memccpy(ptr noalias writeonly, ptr noalias readonly captures(none), i32, i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @memccpy(ptr, ptr, i32, i64)
 
 ; CHECK-LINUX:   declare ptr @memchr(ptr, i32, i64) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
@@ -729,22 +729,22 @@ declare ptr @memchr(ptr, i32, i64)
 ; CHECK: declare i32 @memcmp(ptr captures(none), ptr captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
 declare i32 @memcmp(ptr, ptr, i64)
 
-; CHECK: declare ptr @memcpy(ptr noalias returned writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @memcpy(ptr noalias returned writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @memcpy(ptr, ptr, i64)
 
-; CHECK: declare ptr @__memcpy_chk(ptr noalias writeonly, ptr noalias readonly captures(none), i64, i64) [[ARGMEMONLY_NOFREE_NOUNWIND:#[0-9]+]]
+; CHECK: declare ptr @__memcpy_chk(ptr noalias writeonly, ptr noalias readonly captures(none), i64, i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND:#[0-9]+]]
 declare ptr @__memcpy_chk(ptr, ptr, i64, i64)
 
-; CHECK: declare ptr @mempcpy(ptr noalias writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @mempcpy(ptr noalias writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @mempcpy(ptr, ptr, i64)
 
-; CHECK: declare ptr @memmove(ptr returned writeonly, ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @memmove(ptr returned writeonly, ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @memmove(ptr, ptr, i64)
 
-; CHECK: declare ptr @memset(ptr writeonly, i32, i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
+; CHECK: declare ptr @memset(ptr writeonly, i32, i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare ptr @memset(ptr, i32, i64)
 
-; CHECK: declare ptr @__memset_chk(ptr writeonly, i32, i64, i64) [[ARGMEMONLY_NOFREE_NOUNWIND]]
+; CHECK: declare ptr @__memset_chk(ptr writeonly, i32, i64, i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND]]
 declare ptr @__memset_chk(ptr, i32, i64, i64)
 
 ; CHECK: declare noundef i32 @mkdir(ptr noundef readonly captures(none), i16 noundef zeroext) [[NOFREE_NOUNWIND]]
@@ -753,22 +753,22 @@ declare i32 @mkdir(ptr, i16 zeroext)
 ; CHECK: declare noundef i64 @mktime(ptr noundef captures(none)) [[NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare i64 @mktime(ptr)
 
-; CHECK: declare double @modf(double, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY]]
+; CHECK: declare double @modf(double, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]]
 declare double @modf(double, ptr)
 
-; CHECK: declare float @modff(float, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY]]
+; CHECK: declare float @modff(float, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]]
 declare float @modff(float, ptr)
 
-; CHECK: declare x86_fp80 @modfl(x86_fp80, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY]]
+; CHECK: declare x86_fp80 @modfl(x86_fp80, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]]
 declare x86_fp80 @modfl(x86_fp80, ptr)
 
-; CHECK: declare double @nan(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN:#[0-9]+]]
+; CHECK: declare double @nan(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN:#[0-9]+]]
 declare double @nan(ptr)
 
-; CHECK: declare float @nanf(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN]]
+; CHECK: declare float @nanf(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]]
 declare float @nanf(ptr)
 
-; CHECK: declare x86_fp80 @nanl(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN]]
+; CHECK: declare x86_fp80 @nanl(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]]
 declare x86_fp80 @nanl(ptr)
 
 ; CHECK: declare double @nearbyint(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
@@ -780,22 +780,22 @@ declare float @nearbyintf(float)
 ; CHECK: declare x86_fp80 @nearbyintl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @nearbyintl(x86_fp80)
 
-; CHECK: declare double @nextafter(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @nextafter(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @nextafter(double, double)
 
-; CHECK: declare float @nextafterf(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @nextafterf(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @nextafterf(float, float)
 
-; CHECK: declare x86_fp80 @nextafterl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @nextafterl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @nextafterl(x86_fp80, x86_fp80)
 
-; CHECK: declare double @nexttoward(double, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @nexttoward(double, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @nexttoward(double, x86_fp80)
 
-; CHECK: declare float @nexttowardf(float, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @nexttowardf(float, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @nexttowardf(float, x86_fp80)
 
-; CHECK: declare x86_fp80 @nexttowardl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @nexttowardl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @nexttowardl(x86_fp80, x86_fp80)
 
 ; CHECK-LINUX: declare noundef i32 @open(ptr noundef readonly captures(none), i32 noundef, ...) [[NOFREE]]
@@ -820,13 +820,13 @@ declare ptr @popen(ptr, ptr)
 ; CHECK: declare i32 @posix_memalign(ptr, i64, i64) [[NOFREE]]
 declare i32 @posix_memalign(ptr, i64, i64)
 
-; CHECK: declare double @pow(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @pow(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @pow(double, double)
 
-; CHECK: declare float @powf(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @powf(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @powf(float, float)
 
-; CHECK: declare x86_fp80 @powl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @powl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @powl(x86_fp80, x86_fp80)
 
 ; CHECK: declare noundef i64 @pread(i32 noundef, ptr noundef captures(none), i64 noundef, i64 noundef) [[NOFREE]]
@@ -878,35 +878,35 @@ declare ptr @vec_realloc(ptr, i64)
 ; CHECK: declare noundef ptr @realpath(ptr noundef readonly captures(none), ptr noundef) [[NOFREE_NOUNWIND]]
 declare ptr @realpath(ptr, ptr)
 
-; CHECK: declare double @remainder(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @remainder(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @remainder(double, double)
 
-; CHECK: declare float @remainderf(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @remainderf(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @remainderf(float, float)
 
-; CHECK: declare x86_fp80 @remainderl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @remainderl(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @remainderl(x86_fp80, x86_fp80)
 
 ; CHECK: declare noundef i32 @remove(ptr noundef readonly captures(none)) [[NOFREE_NOUNWIND]]
 declare i32 @remove(ptr)
 
-; CHECK: declare double @remquo(double, double, ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
+; CHECK: declare double @remquo(double, double, ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare double @remquo(double, double, ptr)
 
-; CHECK: declare float @remquof(float, float, ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @remquof(float, float, ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @remquof(float, float, ptr)
 
-; CHECK: declare x86_fp80 @remquol(x86_fp80, x86_fp80, ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @remquol(x86_fp80, x86_fp80, ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @remquol(x86_fp80, x86_fp80, ptr)
 
 
-; CHECK: declare double @fdim(double, double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fdim(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fdim(double, double)
 
-; CHECK: declare float @fdimf(float, float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fdimf(float, float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fdimf(float, float)
 
-; CHECK: declare x86_fp80 @fdiml(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fdiml(x86_fp80, x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fdiml(x86_fp80, x86_fp80)
 
 ; CHECK: declare noundef i32 @rename(ptr noundef readonly captures(none), ptr noundef readonly captures(none)) [[NOFREE_NOUNWIND]]
@@ -915,13 +915,13 @@ declare i32 @rename(ptr, ptr)
 ; CHECK: declare void @rewind(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare void @rewind(ptr)
 
-; CHECK: declare double @rint(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @rint(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @rint(double)
 
-; CHECK: declare float @rintf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @rintf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @rintf(float)
 
-; CHECK: declare x86_fp80 @rintl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @rintl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @rintl(x86_fp80)
 
 ; CHECK: declare noundef i32 @rmdir(ptr noundef readonly captures(none)) [[NOFREE_NOUNWIND]]
@@ -945,22 +945,22 @@ declare float @roundevenf(float)
 ; CHECK: declare x86_fp80 @roundevenl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @roundevenl(x86_fp80)
 
-; CHECK: declare double @scalbln(double, i64) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @scalbln(double, i64) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @scalbln(double, i64)
 
-; CHECK: declare float @scalblnf(float, i64) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @scalblnf(float, i64) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @scalblnf(float, i64)
 
-; CHECK: declare x86_fp80 @scalblnl(x86_fp80, i64) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @scalblnl(x86_fp80, i64) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @scalblnl(x86_fp80, i64)
 
-; CHECK: declare double @scalbn(double, i32) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @scalbn(double, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @scalbn(double, i32)
 
-; CHECK: declare float @scalbnf(float, i32) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @scalbnf(float, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @scalbnf(float, i32)
 
-; CHECK: declare x86_fp80 @scalbnl(x86_fp80, i32) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @scalbnl(x86_fp80, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @scalbnl(x86_fp80, i32)
 
 ; CHECK: declare noundef i32 @scanf(ptr noundef readonly captures(none), ...) [[NOFREE_NOUNWIND]]
@@ -975,22 +975,22 @@ declare i32 @setitimer(i32, ptr, ptr)
 ; CHECK: declare noundef i32 @setvbuf(ptr noundef captures(none), ptr noundef, i32 noundef, i64 noundef) [[NOFREE_NOUNWIND]]
 declare i32 @setvbuf(ptr, ptr, i32, i64)
 
-; CHECK: declare double @sin(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @sin(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @sin(double)
 
-; CHECK: declare float @sinf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @sinf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @sinf(float)
 
-; CHECK: declare double @sinh(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @sinh(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @sinh(double)
 
-; CHECK: declare float @sinhf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @sinhf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @sinhf(float)
 
-; CHECK: declare x86_fp80 @sinhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @sinhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @sinhl(x86_fp80)
 
-; CHECK: declare x86_fp80 @sinl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @sinl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @sinl(x86_fp80)
 
 ; CHECK: declare noundef i32 @snprintf(ptr noalias noundef writeonly captures(none), i64 noundef, ptr noundef readonly captures(none), ...) [[NOFREE_NOUNWIND]]
@@ -999,13 +999,13 @@ declare i32 @snprintf(ptr, i64, ptr, ...)
 ; CHECK: declare noundef i32 @sprintf(ptr noalias noundef writeonly captures(none), ptr noundef readonly captures(none), ...) [[NOFREE_NOUNWIND]]
 declare i32 @sprintf(ptr, ptr, ...)
 
-; CHECK: declare double @sqrt(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @sqrt(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @sqrt(double)
 
-; CHECK: declare float @sqrtf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @sqrtf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @sqrtf(float)
 
-; CHECK: declare x86_fp80 @sqrtl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @sqrtl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @sqrtl(x86_fp80)
 
 ; CHECK: declare noundef i32 @sscanf(ptr noundef readonly captures(none), ptr noundef readonly captures(none), ...) [[NOFREE_NOUNWIND]]
@@ -1023,16 +1023,16 @@ declare i32 @statvfs(ptr, ptr)
 ; CHECK-LINUX: declare noundef i32 @statvfs64(ptr noundef readonly captures(none), ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare i32 @statvfs64(ptr, ptr)
 
-; CHECK: declare ptr @stpcpy(ptr noalias writeonly, ptr noalias readonly captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @stpcpy(ptr noalias writeonly, ptr noalias readonly captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @stpcpy(ptr, ptr)
 
-; CHECK: declare ptr @stpncpy(ptr noalias writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @stpncpy(ptr noalias writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @stpncpy(ptr, ptr, i64)
 
 ; CHECK: declare i32 @strcasecmp(ptr captures(none), ptr captures(none)) [[NOFREE_NOUNWIND_READONLY_WILLRETURN:#[0-9]+]]
 declare i32 @strcasecmp(ptr, ptr)
 
-; CHECK: declare ptr @strcat(ptr noalias returned, ptr noalias readonly captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @strcat(ptr noalias returned, ptr noalias readonly captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @strcat(ptr, ptr)
 
 ; CHECK: declare ptr @strchr(ptr, i32) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
@@ -1044,7 +1044,7 @@ declare i32 @strcmp(ptr, ptr)
 ; CHECK: declare i32 @strcoll(ptr captures(none), ptr captures(none)) [[NOFREE_NOUNWIND_READONLY_WILLRETURN]]
 declare i32 @strcoll(ptr, ptr)
 
-; CHECK: declare ptr @strcpy(ptr noalias returned writeonly, ptr noalias readonly captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @strcpy(ptr noalias returned writeonly, ptr noalias readonly captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @strcpy(ptr, ptr)
 
 ; CHECK: declare i64 @strcspn(ptr captures(none), ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
@@ -1059,22 +1059,22 @@ declare i64 @strlen(ptr)
 ; CHECK: declare i32 @strncasecmp(ptr captures(none), ptr captures(none), i64) [[NOFREE_NOUNWIND_READONLY_WILLRETURN]]
 declare i32 @strncasecmp(ptr, ptr, i64)
 
-; CHECK: declare ptr @strncat(ptr noalias returned, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @strncat(ptr noalias returned, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @strncat(ptr, ptr, i64)
 
 ; CHECK: declare i32 @strncmp(ptr captures(none), ptr captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
 declare i32 @strncmp(ptr, ptr, i64)
 
-; CHECK: declare ptr @strncpy(ptr noalias returned writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare ptr @strncpy(ptr noalias returned writeonly, ptr noalias readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare ptr @strncpy(ptr, ptr, i64)
 
 ; CHECK: declare noalias ptr @strndup(ptr readonly captures(none), i64 noundef) [[INACCESSIBLEMEMORARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_FAMILY_MALLOC]]
 declare ptr @strndup(ptr, i64)
 
-; CHECK: declare i64 @strnlen(ptr captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN]]
+; CHECK: declare i64 @strnlen(ptr captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]]
 declare i64 @strnlen(ptr, i64)
 
-; CHECK: declare ptr @strpbrk(ptr, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN]]
+; CHECK: declare ptr @strpbrk(ptr, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]]
 declare ptr @strpbrk(ptr, ptr)
 
 ; CHECK: declare ptr @strrchr(ptr, i32) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
@@ -1083,7 +1083,7 @@ declare ptr @strrchr(ptr, i32)
 ; CHECK: declare i64 @strspn(ptr captures(none), ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY]]
 declare i64 @strspn(ptr, ptr)
 
-; CHECK: declare ptr @strstr(ptr, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN]]
+; CHECK: declare ptr @strstr(ptr, ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]]
 declare ptr @strstr(ptr, ptr)
 
 ; CHECK: declare double @strtod(ptr readonly, ptr captures(none)) [[NOCALLBACK_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
@@ -1119,22 +1119,22 @@ declare i64 @strxfrm(ptr, ptr, i64)
 ; CHECK: declare noundef i32 @system(ptr noundef readonly captures(none)) [[NOFREE]]
 declare i32 @system(ptr)
 
-; CHECK: declare double @tan(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @tan(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @tan(double)
 
-; CHECK: declare float @tanf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @tanf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @tanf(float)
 
-; CHECK: declare double @tanh(double) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @tanh(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @tanh(double)
 
-; CHECK: declare float @tanhf(float) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @tanhf(float) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @tanhf(float)
 
-; CHECK: declare x86_fp80 @tanhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @tanhl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @tanhl(x86_fp80)
 
-; CHECK: declare x86_fp80 @tanl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @tanl(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @tanl(x86_fp80)
 
 ; CHECK: declare noundef i64 @times(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
@@ -1212,41 +1212,41 @@ declare void @__cxa_throw(ptr, ptr, ptr)
 ; CHECK: declare void @_ZSt9terminatev() [[NOFREE_COLD_NORETURN:#[0-9]+]]
 declare void @_ZSt9terminatev()
 
-; CHECK: declare void @sincos(double, ptr writeonly captures(none), ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare void @sincos(double, ptr writeonly captures(none), ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @sincos(double, ptr, ptr)
 
-; CHECK: declare void @sincosf(float, ptr writeonly captures(none), ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare void @sincosf(float, ptr writeonly captures(none), ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @sincosf(float, ptr, ptr)
 
-; CHECK: declare void @sincosl(x86_fp80, ptr writeonly captures(none), ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare void @sincosl(x86_fp80, ptr writeonly captures(none), ptr writeonly captures(none)) [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @sincosl(x86_fp80, ptr, ptr)
 
 ; memset_pattern{4,8,16} aren't available everywhere.
-; CHECK-DARWIN: declare void @memset_pattern4(ptr writeonly captures(none), ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-DARWIN: declare void @memset_pattern4(ptr writeonly captures(none), ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @memset_pattern4(ptr, ptr, i64)
-; CHECK-DARWIN: declare void @memset_pattern8(ptr writeonly captures(none), ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-DARWIN: declare void @memset_pattern8(ptr writeonly captures(none), ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @memset_pattern8(ptr, ptr, i64)
-; CHECK-DARWIN: declare void @memset_pattern16(ptr writeonly captures(none), ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-DARWIN: declare void @memset_pattern16(ptr writeonly captures(none), ptr readonly captures(none), i64) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare void @memset_pattern16(ptr, ptr, i64)
 
 ; CHECK-DAG: attributes [[NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nofree nounwind willreturn }
 ; CHECK-DAG: attributes [[NOCALLBACK_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn }
 ; CHECK-DAG: attributes [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(none) }
-; CHECK-DAG: attributes [[ARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn memory(argmem: write, errnomem: write) }
-; CHECK-DAG: attributes [[ERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn memory(errnomem: write) }
-; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN_WRITEONLY]] = { mustprogress nocallback nofree nounwind willreturn memory(argmem: write) }
+; CHECK-DAG: attributes [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write, errnomem: write) }
+; CHECK-DAG: attributes [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(errnomem: write) }
+; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write) }
 ; CHECK-DAG: attributes [[NOFREE_NOUNWIND]] = { nofree nounwind }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCKIND_ALLOCUNINIT_ALLOCSIZE1_FAMILY_MALLOC]] = { mustprogress nofree nounwind willreturn allockind("alloc,uninitialized,aligned") allocsize(1) memory(inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCKIND_ALLOCZEROED_ALLOCSIZE01_FAMILY_MALLOC]] = { mustprogress nofree nounwind willreturn allockind("alloc,zeroed") allocsize(0,1) memory(inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }
 ; CHECK-DAG: attributes [[NOFREE_NOUNWIND_READONLY_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn memory(read) }
-; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 ; CHECK-DAG: attributes [[NOFREE_NOUNWIND_READONLY]] = { nofree nounwind memory(read) }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORARGMEMONLY_NOUNWIND_WILLRETURN_ALLOCKIND_FREE_FAMILY_MALLOC]] = { mustprogress nounwind willreturn allockind("free") memory(argmem: readwrite, inaccessiblemem: readwrite) "alloc-family"="malloc" }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCKIND_ALLOCUNINIT_ALLOCSIZE0_FAMILY_MALLOC]] = { mustprogress nofree nounwind willreturn allockind("alloc,uninitialized") allocsize(0) memory(inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCKIND_ALLOCUNINIT_FAMILY_MALLOC]] = { mustprogress nofree nounwind willreturn allockind("alloc,uninitialized") memory(inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }
-; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOUNWIND_READONLY_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn memory(argmem: read) }
+; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: read) }
 ; CHECK-DAG: attributes [[NOFREE]] = { nofree }
-; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOUNWIND]] = { nocallback nofree nounwind memory(argmem: readwrite) }
+; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND]] = { nocallback nofree nosync nounwind memory(argmem: readwrite) }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORARGMEMORERRNOMEMONLY_NOUNWIND_WILLRETURN_ALLOCKIND_REALLOC_ALLOCSIZE1_FAMILY_MALLOC]] = { mustprogress nounwind willreturn allockind("realloc") allocsize(1) memory(argmem: readwrite, inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORARGMEMORERRNOMEMONLY_NOUNWIND_WILLRETURN_ALLOCKIND_REALLOC_ALLOCSIZE12_FAMILY_MALLOC]] = { mustprogress nounwind willreturn allockind("realloc") allocsize(1,2) memory(argmem: readwrite, inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }
 ; CHECK-DAG: attributes [[INACCESSIBLEMEMORARGMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_FAMILY_MALLOC]] = { mustprogress nofree nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite, errnomem: write) "alloc-family"="malloc" }

--- a/llvm/test/Transforms/InferFunctionAttrs/annotate.ll
+++ b/llvm/test/Transforms/InferFunctionAttrs/annotate.ll
@@ -195,7 +195,7 @@ declare double @__sinpi(double)
 ; CHECK: declare float @__sinpif(float)
 declare float @__sinpif(float)
 
-; CHECK: declare i32 @abs(i32) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
+; CHECK: declare i32 @abs(i32) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare i32 @abs(i32)
 
 ; CHECK: declare noundef i32 @access(ptr noundef readonly captures(none), i32 noundef) [[NOFREE_NOUNWIND:#[0-9]+]]
@@ -295,22 +295,22 @@ declare ptr @calloc(i64, i64)
 ; CHECK-AIX: declare noalias noundef ptr @vec_calloc(i64 noundef, i64 noundef) [[INACCESSIBLEMEMORERRNOMEMONLY_NOFREE_NOUNWIND_WILLRETURN_ALLOCSIZE01_FAMILY_VEC_MALLOC:#[0-9]+]]
 declare ptr @vec_calloc(i64, i64)
 
-; CHECK: declare double @cbrt(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @cbrt(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @cbrt(double)
 
-; CHECK: declare float @cbrtf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @cbrtf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @cbrtf(float)
 
-; CHECK: declare x86_fp80 @cbrtl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @cbrtl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @cbrtl(x86_fp80)
 
-; CHECK: declare double @ceil(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @ceil(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @ceil(double)
 
-; CHECK: declare float @ceilf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @ceilf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @ceilf(float)
 
-; CHECK: declare x86_fp80 @ceill(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @ceill(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @ceill(x86_fp80)
 
 ; The second argument of int chmod(FILE*, mode_t) is a 32-bit int on most
@@ -330,13 +330,13 @@ declare void @clearerr(ptr)
 ; CHECK: declare noundef i32 @closedir(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare i32 @closedir(ptr)
 
-; CHECK: declare double @copysign(double, double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @copysign(double, double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @copysign(double, double)
 
-; CHECK: declare float @copysignf(float, float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @copysignf(float, float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @copysignf(float, float)
 
-; CHECK: declare x86_fp80 @copysignl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @copysignl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @copysignl(x86_fp80, x86_fp80)
 
 ; CHECK: declare double @cos(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
@@ -387,13 +387,13 @@ declare float @expm1f(float)
 ; CHECK: declare x86_fp80 @expm1l(x86_fp80) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @expm1l(x86_fp80)
 
-; CHECK: declare double @fabs(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fabs(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fabs(double)
 
-; CHECK: declare float @fabsf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fabsf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fabsf(float)
 
-; CHECK: declare x86_fp80 @fabsl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fabsl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fabsl(x86_fp80)
 
 ; CHECK: declare noundef i32 @fclose(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
@@ -411,14 +411,14 @@ declare i32 @ferror(ptr)
 ; CHECK: declare noundef i32 @fflush(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare i32 @fflush(ptr)
 
-; CHECK: declare i32 @ffs(i32) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i32 @ffs(i32) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i32 @ffs(i32)
 
-; CHECK-KNOWN: declare i32 @ffsl(i64) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-KNOWN: declare i32 @ffsl(i64) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 ; CHECK-UNKNOWN: declare i32 @ffsl(i64){{$}}
 declare i32 @ffsl(i64)
 
-; CHECK-KNOWN: declare i32 @ffsll(i64) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK-KNOWN: declare i32 @ffsll(i64) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 ; CHECK-UNKNOWN: declare i32 @ffsll(i64){{$}}
 declare i32 @ffsll(i64)
 
@@ -437,13 +437,13 @@ declare i32 @fileno(ptr)
 ; CHECK: declare void @flockfile(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
 declare void @flockfile(ptr)
 
-; CHECK: declare double @floor(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @floor(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @floor(double)
 
-; CHECK: declare float @floorf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @floorf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @floorf(float)
 
-; CHECK: declare x86_fp80 @floorl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @floorl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @floorl(x86_fp80)
 
 ; CHECK: declare i32 @fls(i32)
@@ -455,40 +455,40 @@ declare i32 @flsl(i64)
 ; CHECK: declare i32 @flsll(i64)
 declare i32 @flsll(i64)
 
-; CHECK: declare double @fmax(double, double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fmax(double, double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fmax(double, double)
 
-; CHECK: declare float @fmaxf(float, float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fmaxf(float, float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fmaxf(float, float)
 
-; CHECK: declare x86_fp80 @fmaxl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fmaxl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fmaxl(x86_fp80, x86_fp80)
 
-; CHECK: declare double @fmin(double, double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fmin(double, double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fmin(double, double)
 
-; CHECK: declare float @fminf(float, float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fminf(float, float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fminf(float, float)
 
-; CHECK: declare x86_fp80 @fminl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fminl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fminl(x86_fp80, x86_fp80)
 
-; CHECK: declare double @fmaximum_num(double, double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fmaximum_num(double, double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fmaximum_num(double, double)
 
-; CHECK: declare float @fmaximum_numf(float, float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fmaximum_numf(float, float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fmaximum_numf(float, float)
 
-; CHECK: declare x86_fp80 @fmaximum_numl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fmaximum_numl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fmaximum_numl(x86_fp80, x86_fp80)
 
-; CHECK: declare double @fminimum_num(double, double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @fminimum_num(double, double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @fminimum_num(double, double)
 
-; CHECK: declare float @fminimum_numf(float, float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @fminimum_numf(float, float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @fminimum_numf(float, float)
 
-; CHECK: declare x86_fp80 @fminimum_numl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @fminimum_numl(x86_fp80, x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @fminimum_numl(x86_fp80, x86_fp80)
 
 ; CHECK: declare double @fmod(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
@@ -622,7 +622,7 @@ declare i32 @isascii(i32)
 ; CHECK: declare i32 @isdigit(i32) [[NOFREE_NOUNWIND_WILLRETURN:#[0-9]+]]
 declare i32 @isdigit(i32)
 
-; CHECK: declare i64 @labs(i64) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i64 @labs(i64) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i64 @labs(i64)
 
 ; CHECK: declare noundef i32 @lchown(ptr noundef readonly captures(none), i32 noundef, i32 noundef) [[NOFREE_NOUNWIND]]
@@ -637,7 +637,7 @@ declare float @ldexpf(float, i32)
 ; CHECK: declare x86_fp80 @ldexpl(x86_fp80, i32) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @ldexpl(x86_fp80, i32)
 
-; CHECK: declare i64 @llabs(i64) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i64 @llabs(i64) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i64 @llabs(i64)
 
 ; CHECK: declare double @log(double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
@@ -771,13 +771,13 @@ declare float @nanf(ptr)
 ; CHECK: declare x86_fp80 @nanl(ptr captures(none)) [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_READONLY_WILLRETURN]]
 declare x86_fp80 @nanl(ptr)
 
-; CHECK: declare double @nearbyint(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @nearbyint(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @nearbyint(double)
 
-; CHECK: declare float @nearbyintf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @nearbyintf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @nearbyintf(float)
 
-; CHECK: declare x86_fp80 @nearbyintl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @nearbyintl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @nearbyintl(x86_fp80)
 
 ; CHECK: declare double @nextafter(double, double) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
@@ -927,22 +927,22 @@ declare x86_fp80 @rintl(x86_fp80)
 ; CHECK: declare noundef i32 @rmdir(ptr noundef readonly captures(none)) [[NOFREE_NOUNWIND]]
 declare i32 @rmdir(ptr)
 
-; CHECK: declare double @round(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @round(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @round(double)
 
-; CHECK: declare float @roundf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @roundf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @roundf(float)
 
-; CHECK: declare x86_fp80 @roundl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @roundl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @roundl(x86_fp80)
 
-; CHECK: declare double @roundeven(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @roundeven(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @roundeven(double)
 
-; CHECK: declare float @roundevenf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @roundevenf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @roundevenf(float)
 
-; CHECK: declare x86_fp80 @roundevenl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @roundevenl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @roundevenl(x86_fp80)
 
 ; CHECK: declare double @scalbln(double, i64) [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
@@ -1146,16 +1146,16 @@ declare ptr @tmpfile()
 ; CHECK-LINUX: declare noalias noundef ptr @tmpfile64() [[NOFREE_NOUNWIND]]
 declare ptr @tmpfile64()
 
-; CHECK: declare i32 @toascii(i32) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare i32 @toascii(i32) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare i32 @toascii(i32)
 
-; CHECK: declare double @trunc(double) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare double @trunc(double) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare double @trunc(double)
 
-; CHECK: declare float @truncf(float) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare float @truncf(float) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare float @truncf(float)
 
-; CHECK: declare x86_fp80 @truncl(x86_fp80) [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]]
+; CHECK: declare x86_fp80 @truncl(x86_fp80) [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]]
 declare x86_fp80 @truncl(x86_fp80)
 
 ; CHECK: declare noundef i32 @uname(ptr noundef captures(none)) [[NOFREE_NOUNWIND]]
@@ -1231,7 +1231,7 @@ declare void @memset_pattern16(ptr, ptr, i64)
 
 ; CHECK-DAG: attributes [[NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nofree nounwind willreturn }
 ; CHECK-DAG: attributes [[NOCALLBACK_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nounwind willreturn }
-; CHECK-DAG: attributes [[MEMNONE_NOFREE_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(none) }
+; CHECK-DAG: attributes [[MEMNONE_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(none) }
 ; CHECK-DAG: attributes [[ARGMEMORERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write, errnomem: write) }
 ; CHECK-DAG: attributes [[ERRNOMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(errnomem: write) }
 ; CHECK-DAG: attributes [[ARGMEMONLY_NOFREE_NOSYNC_NOUNWIND_WILLRETURN_WRITEONLY]] = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: write) }

--- a/llvm/test/Transforms/LICM/strlen.ll
+++ b/llvm/test/Transforms/LICM/strlen.ll
@@ -13,7 +13,7 @@ loop:
 }
 
 ; CHECK: declare i64 @strlen(ptr captures(none)) #0
-; CHECK: attributes #0 = { mustprogress nocallback nofree nounwind willreturn memory(argmem: read) }
+; CHECK: attributes #0 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: read) }
 declare i64 @strlen(ptr)
 
 

--- a/llvm/test/Transforms/MergeICmps/X86/alias-merge-blocks.ll
+++ b/llvm/test/Transforms/MergeICmps/X86/alias-merge-blocks.ll
@@ -119,7 +119,7 @@ exit:
 !5 = !{!"branch_weights", i32 11, i32 13}
 ;.
 ; X86: attributes #[[ATTR0:[0-9]+]] = { nofree nosync }
-; X86: attributes #[[ATTR1:[0-9]+]] = { nocallback nofree nounwind willreturn memory(argmem: read) }
+; X86: attributes #[[ATTR1:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: read) }
 ;.
 ; X86: [[META0:![0-9]+]] = !{!"function_entry_count", i32 100}
 ; X86: [[RNG1]] = !{i32 0, i32 2}

--- a/llvm/test/Transforms/MergeICmps/X86/entry-block-shuffled.ll
+++ b/llvm/test/Transforms/MergeICmps/X86/entry-block-shuffled.ll
@@ -74,7 +74,7 @@ opeq1.exit:
 !3 = !{!"branch_weights", i32 11, i32 13}
 ;.
 ; CHECK: attributes #[[ATTR0:[0-9]+]] = { nofree nosync }
-; CHECK: attributes #[[ATTR1:[0-9]+]] = { nocallback nofree nounwind willreturn memory(argmem: read) }
+; CHECK: attributes #[[ATTR1:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: read) }
 ;.
 ; CHECK: [[META0:![0-9]+]] = !{!"function_entry_count", i32 10}
 ; CHECK: [[PROF1]] = !{!"branch_weights", i32 2, i32 3}

--- a/llvm/test/Transforms/PreISelIntrinsicLowering/X86/memset-pattern.ll
+++ b/llvm/test/Transforms/PreISelIntrinsicLowering/X86/memset-pattern.ll
@@ -214,7 +214,7 @@ define void @memset_pattern_i64_x_fromnonconstptr(ptr %a, i64 %x, ptr %p) nounwi
 ;.
 ; CHECK: attributes #[[ATTR0]] = { nounwind }
 ; CHECK: attributes #[[ATTR1:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: write) }
-; CHECK: attributes #[[ATTR2:[0-9]+]] = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+; CHECK: attributes #[[ATTR2:[0-9]+]] = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 ;.
 ; CHECK: [[DOUBLE_TBAA0]] = !{[[META1:![0-9]+]], [[META1]], i64 0}
 ; CHECK: [[META1]] = !{!"double", [[META2:![0-9]+]], i64 0}


### PR DESCRIPTION
Math libcalls as well as some simple string ones do not create synchronizes-with edges, thus `nosync` may be derived.

(Excluded strings setting locale)

Partial revive of: https://reviews.llvm.org/D98605.

Co-authored-by: Johannes Doerfert <jdoerfert.llvm@gmail.com>