### PR TITLE
[ARM] Do not pass debug insn to liveness analysis

### DIFF
--- a/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/ARM/ARMLoadStoreOptimizer.cpp
@@ -613,7 +613,8 @@ void ARMLoadStoreOpt::moveLiveRegsBefore(const MachineBasicBlock &MBB,
   // Move backward just before the "Before" position.
   while (LiveRegPos != Before) {
     --LiveRegPos;
-    LiveRegs.stepBackward(*LiveRegPos);
+    if (!LiveRegPos->isDebugInstr())
+      LiveRegs.stepBackward(*LiveRegPos);
   }
 }
 


### PR DESCRIPTION
Debug instructions must not affect liveness analysis.   stepBackward has an assertion failure on debug instructions after https://github.com/llvm/llvm-project/pull/193104.