### PR TITLE
[clang][deps] Consolidate types into new `DependencyConsumer.h`

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyConsumer.h
+++ b/clang/include/clang/DependencyScanning/DependencyConsumer.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYCONSUMER_H
+#define LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYCONSUMER_H
+
+#include "clang/Basic/LLVM.h"
+#include "clang/DependencyScanning/DependencyGraph.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace clang::dependencies {
+class DependencyConsumer {
+public:
+  virtual ~DependencyConsumer() {}
+
+  virtual void handleProvidedAndRequiredStdCXXModules(
+      std::optional<P1689ModuleInfo> Provided,
+      std::vector<P1689ModuleInfo> Requires) {}
+
+  virtual void handleBuildCommand(Command Cmd) {}
+
+  virtual void
+  handleDependencyOutputOpts(const DependencyOutputOptions &Opts) = 0;
+
+  virtual void handleFileDependency(StringRef Filename) = 0;
+
+  virtual void handlePrebuiltModuleDependency(PrebuiltModuleDep PMD) = 0;
+
+  virtual void handleModuleDependency(ModuleDeps MD) = 0;
+
+  virtual void handleDirectModuleDependency(ModuleID MD) = 0;
+
+  virtual void handleVisibleModule(std::string ModuleName) = 0;
+
+  virtual void handleContextHash(std::string Hash) = 0;
+};
+} // namespace clang::dependencies
+
+#endif // LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYCONSUMER_H

--- a/clang/include/clang/DependencyScanning/DependencyScanningUtils.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningUtils.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_DEPENDENCYSCANNING_DEPENDENCYSCANNINGUTILS_H
 
 #include "clang/DependencyScanning/DependencyActionController.h"
+#include "clang/DependencyScanning/DependencyConsumer.h"
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/DependencyScanning/ModuleDepCollector.h"

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -33,33 +33,8 @@ class CompilerInstanceWithContext;
 
 namespace dependencies {
 
+class DependencyConsumer;
 class DependencyScanningWorkerFilesystem;
-
-class DependencyConsumer {
-public:
-  virtual ~DependencyConsumer() {}
-
-  virtual void handleProvidedAndRequiredStdCXXModules(
-      std::optional<P1689ModuleInfo> Provided,
-      std::vector<P1689ModuleInfo> Requires) {}
-
-  virtual void handleBuildCommand(Command Cmd) {}
-
-  virtual void
-  handleDependencyOutputOpts(const DependencyOutputOptions &Opts) = 0;
-
-  virtual void handleFileDependency(StringRef Filename) = 0;
-
-  virtual void handlePrebuiltModuleDependency(PrebuiltModuleDep PMD) = 0;
-
-  virtual void handleModuleDependency(ModuleDeps MD) = 0;
-
-  virtual void handleDirectModuleDependency(ModuleID MD) = 0;
-
-  virtual void handleVisibleModule(std::string ModuleName) = 0;
-
-  virtual void handleContextHash(std::string Hash) = 0;
-};
 
 /// An individual dependency scanning worker that is able to run on its own
 /// thread.

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -10,6 +10,7 @@
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/DiagnosticSerialization.h"
 #include "clang/DependencyScanning/DependencyActionController.h"
+#include "clang/DependencyScanning/DependencyConsumer.h"
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
 #include "clang/DependencyScanning/DependencyScanningService.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -9,6 +9,7 @@
 #include "clang/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/DependencyScanning/DependencyConsumer.h"
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
 #include "clang/Serialization/ObjectFilePCHContainerReader.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -10,6 +10,7 @@
 
 #include "clang/Basic/MakeSupport.h"
 #include "clang/DependencyScanning/DependencyActionController.h"
+#include "clang/DependencyScanning/DependencyConsumer.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"


### PR DESCRIPTION
This PR pulls the `DependencyConsumer` type out of `DependencyScanningWorker.h` into its own header. Just a cleanup, NFC.