### PR TITLE
[1/3][RegAlloc][LiveRegMatrix] Fix inconsistency in HoistSpillHelper delegates

### DIFF
--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1874,33 +1874,35 @@ bool HoistSpillHelper::LRE_CanEraseVirtReg(Register VirtReg) {
 /// For VirtReg clone, the \p New register should have the same physreg or
 /// stackslot as the \p old register.
 void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
-  auto AssignToPhys = [&](Register VReg, MCRegister PhysReg) {
-    if (Matrix && LIS.hasInterval(VReg))
-      Matrix->assign(LIS.getInterval(VReg), PhysReg);
-    else
-      VRM.assignVirt2Phys(VReg, PhysReg);
-  };
+  // New is freshly created by LiveRangeEdit::eliminateDeadDefs and its interval
+  // is guaranteed to exist on every path below.
+  assert(LIS.hasInterval(New) && "Cloned vreg without live interval");
 
   auto PendingIt = PendingReassignments.find(Old);
   if (PendingIt != PendingReassignments.end()) {
-    // Old was already unassigned in LRE_WillShrinkVirtReg.
-    assert(LIS.hasInterval(Old) &&
-           "Pending reassignment for vreg without live interval");
+    // Old was already unassigned in LRE_WillShrinkVirtReg, which only
+    // enrolls vregs when Matrix is non-null and the interval exists.
+    assert(Matrix && LIS.hasInterval(Old) &&
+           "Pending reassignment without matrix or live interval");
     MCRegister PhysReg = PendingIt->second;
     PendingReassignments.erase(PendingIt);
 
     // Reassign both Old (with its shrunk interval) and New to the matrix.
-    AssignToPhys(Old, PhysReg);
-    AssignToPhys(New, PhysReg);
+    Matrix->assign(LIS.getInterval(Old), PhysReg);
+    Matrix->assign(LIS.getInterval(New), PhysReg);
   } else if (VRM.hasPhys(Old)) {
     MCRegister PhysReg = VRM.getPhys(Old);
     if (Matrix && LIS.hasInterval(Old)) {
+      const LiveInterval &LI = LIS.getInterval(Old);
       // Drop the stale pre-clone segments before reassigning Old's current LI.
-      Matrix->unassign(LIS.getInterval(Old),
+      Matrix->unassign(LI,
                        /*ClearAllReferencingSegments=*/true);
-      AssignToPhys(Old, PhysReg);
+      Matrix->assign(LI, PhysReg);
     }
-    AssignToPhys(New, PhysReg);
+    if (Matrix)
+      Matrix->assign(LIS.getInterval(New), PhysReg);
+    else
+      VRM.assignVirt2Phys(New, PhysReg);
   } else if (VRM.getStackSlot(Old) != VirtRegMap::NO_STACK_SLOT) {
     VRM.assignVirt2StackSlot(New, VRM.getStackSlot(Old));
   } else {

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1837,15 +1837,9 @@ void HoistSpillHelper::hoistAllSpills() {
 
   // Flush vregs that were unassigned from the matrix during shrinking but
   // were not split (so LRE_DidCloneVirtReg never re-assigned them).
-  for (auto &[VReg, PhysReg] : PendingReassignments) {
-    if (LIS.hasInterval(VReg)) {
-      LiveInterval &LI = LIS.getInterval(VReg);
-      if (!LI.empty())
-        Matrix->assign(LI, PhysReg);
-      else
-        VRM.assignVirt2Phys(VReg, PhysReg);
-    }
-  }
+  for (auto &[VReg, PhysReg] : PendingReassignments)
+    if (LIS.hasInterval(VReg))
+      Matrix->assign(LIS.getInterval(VReg), PhysReg);
   PendingReassignments.clear();
 }
 
@@ -1873,35 +1867,29 @@ bool HoistSpillHelper::LRE_CanEraseVirtReg(Register VirtReg) {
 /// For VirtReg clone, the \p New register should have the same physreg or
 /// stackslot as the \p old register.
 void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
-  // Place VReg at PhysReg. Goes through LiveRegMatrix when VReg has a
-  // non-empty live interval and the matrix is available; otherwise records
-  // the assignment directly in VirtRegMap.
   auto AssignToPhys = [&](Register VReg, MCRegister PhysReg) {
-    if (Matrix && LIS.hasInterval(VReg)) {
-      LiveInterval &LI = LIS.getInterval(VReg);
-      if (!LI.empty()) {
-        Matrix->assign(LI, PhysReg);
-        return;
-      }
-    }
-    VRM.assignVirt2Phys(VReg, PhysReg);
+    if (Matrix && LIS.hasInterval(VReg))
+      Matrix->assign(LIS.getInterval(VReg), PhysReg);
+    else
+      VRM.assignVirt2Phys(VReg, PhysReg);
   };
 
   auto PendingIt = PendingReassignments.find(Old);
   if (PendingIt != PendingReassignments.end()) {
-    // Old was already unassigned from the matrix by LRE_WillShrinkVirtReg.
-    // Reassign both Old (with its shrunk interval) and New to the matrix.
+    // LRE_WillShrinkVirtReg only enrolls regs that had a live interval.
+    assert(LIS.hasInterval(Old) &&
+           "Pending reassignment for vreg without live interval");
     MCRegister PhysReg = PendingIt->second;
     PendingReassignments.erase(PendingIt);
 
-    if (LIS.hasInterval(Old))
-      AssignToPhys(Old, PhysReg);
+    // Reassign both Old (with its shrunk interval) and New to the matrix.
+    AssignToPhys(Old, PhysReg);
     AssignToPhys(New, PhysReg);
   } else if (VRM.hasPhys(Old)) {
     MCRegister PhysReg = VRM.getPhys(Old);
     if (Matrix && LIS.hasInterval(Old)) {
-      LiveInterval &OldLI = LIS.getInterval(Old);
-      Matrix->unassign(OldLI, /*ClearAllReferencingSegments=*/true);
+      Matrix->unassign(LIS.getInterval(Old),
+                       /*ClearAllReferencingSegments=*/true);
       AssignToPhys(Old, PhysReg);
     }
     AssignToPhys(New, PhysReg);

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1837,15 +1837,22 @@ void HoistSpillHelper::hoistAllSpills() {
 
   // Flush vregs that were unassigned from the matrix during shrinking but
   // were not split (so LRE_DidCloneVirtReg never re-assigned them).
-  for (auto &[VReg, PhysReg] : PendingReassignments)
-    if (LIS.hasInterval(VReg))
-      Matrix->assign(LIS.getInterval(VReg), PhysReg);
+  for (auto &[VReg, PhysReg] : PendingReassignments) {
+    assert(Matrix && LIS.hasInterval(VReg) &&
+           "Pending reassignment without matrix or live interval");
+    Matrix->assign(LIS.getInterval(VReg), PhysReg);
+  }
   PendingReassignments.clear();
 }
 
+/// Called when a virtual register's live interval is about to be shrunk.
+/// Unassign from the matrix so the shrunk interval can be re-assigned by a
+/// later LRE_DidCloneVirtReg or by hoistAllSpills' flush, and stash the
+/// physreg in PendingReassignments since the unassign clears VRM.
 void HoistSpillHelper::LRE_WillShrinkVirtReg(Register VirtReg) {
   if (!Matrix || !VRM.hasPhys(VirtReg) || !LIS.hasInterval(VirtReg))
     return;
+
   MCRegister PhysReg = VRM.getPhys(VirtReg);
   LiveInterval &LI = LIS.getInterval(VirtReg);
   Matrix->unassign(LI, /*ClearAllReferencingSegments=*/true);
@@ -1876,7 +1883,7 @@ void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
 
   auto PendingIt = PendingReassignments.find(Old);
   if (PendingIt != PendingReassignments.end()) {
-    // LRE_WillShrinkVirtReg only enrolls regs that had a live interval.
+    // Old was already unassigned in LRE_WillShrinkVirtReg.
     assert(LIS.hasInterval(Old) &&
            "Pending reassignment for vreg without live interval");
     MCRegister PhysReg = PendingIt->second;
@@ -1888,6 +1895,7 @@ void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
   } else if (VRM.hasPhys(Old)) {
     MCRegister PhysReg = VRM.getPhys(Old);
     if (Matrix && LIS.hasInterval(Old)) {
+      // Drop the stale pre-clone segments before reassigning Old's current LI.
       Matrix->unassign(LIS.getInterval(Old),
                        /*ClearAllReferencingSegments=*/true);
       AssignToPhys(Old, PhysReg);

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1892,17 +1892,17 @@ void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
     Matrix->assign(LIS.getInterval(New), PhysReg);
   } else if (VRM.hasPhys(Old)) {
     MCRegister PhysReg = VRM.getPhys(Old);
-    if (Matrix && LIS.hasInterval(Old)) {
-      const LiveInterval &LI = LIS.getInterval(Old);
-      // Drop the stale pre-clone segments before reassigning Old's current LI.
-      Matrix->unassign(LI,
-                       /*ClearAllReferencingSegments=*/true);
-      Matrix->assign(LI, PhysReg);
-    }
-    if (Matrix)
+    if (Matrix) {
+      if (LIS.hasInterval(Old)) {
+        const LiveInterval &LI = LIS.getInterval(Old);
+        // Drop stale pre-clone segments before reassigning Old's current LI.
+        Matrix->unassign(LI, /*ClearAllReferencingSegments=*/true);
+        Matrix->assign(LI, PhysReg);
+      }
       Matrix->assign(LIS.getInterval(New), PhysReg);
-    else
+    } else {
       VRM.assignVirt2Phys(New, PhysReg);
+    }
   } else if (VRM.getStackSlot(Old) != VirtRegMap::NO_STACK_SLOT) {
     VRM.assignVirt2StackSlot(New, VRM.getStackSlot(Old));
   } else {

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1873,6 +1873,20 @@ bool HoistSpillHelper::LRE_CanEraseVirtReg(Register VirtReg) {
 /// For VirtReg clone, the \p New register should have the same physreg or
 /// stackslot as the \p old register.
 void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
+  // Place VReg at PhysReg. Goes through LiveRegMatrix when VReg has a
+  // non-empty live interval and the matrix is available; otherwise records
+  // the assignment directly in VirtRegMap.
+  auto AssignToPhys = [&](Register VReg, MCRegister PhysReg) {
+    if (Matrix && LIS.hasInterval(VReg)) {
+      LiveInterval &LI = LIS.getInterval(VReg);
+      if (!LI.empty()) {
+        Matrix->assign(LI, PhysReg);
+        return;
+      }
+    }
+    VRM.assignVirt2Phys(VReg, PhysReg);
+  };
+
   auto PendingIt = PendingReassignments.find(Old);
   if (PendingIt != PendingReassignments.end()) {
     // Old was already unassigned from the matrix by LRE_WillShrinkVirtReg.
@@ -1880,41 +1894,17 @@ void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
     MCRegister PhysReg = PendingIt->second;
     PendingReassignments.erase(PendingIt);
 
-    if (LIS.hasInterval(Old)) {
-      LiveInterval &OldLI = LIS.getInterval(Old);
-      if (!OldLI.empty())
-        Matrix->assign(OldLI, PhysReg);
-      else
-        VRM.assignVirt2Phys(Old, PhysReg);
-    }
-    if (LIS.hasInterval(New)) {
-      LiveInterval &NewLI = LIS.getInterval(New);
-      if (!NewLI.empty())
-        Matrix->assign(NewLI, PhysReg);
-      else
-        VRM.assignVirt2Phys(New, PhysReg);
-    } else {
-      VRM.assignVirt2Phys(New, PhysReg);
-    }
+    if (LIS.hasInterval(Old))
+      AssignToPhys(Old, PhysReg);
+    AssignToPhys(New, PhysReg);
   } else if (VRM.hasPhys(Old)) {
     MCRegister PhysReg = VRM.getPhys(Old);
     if (Matrix && LIS.hasInterval(Old)) {
       LiveInterval &OldLI = LIS.getInterval(Old);
       Matrix->unassign(OldLI, /*ClearAllReferencingSegments=*/true);
-      if (!OldLI.empty())
-        Matrix->assign(OldLI, PhysReg);
-      else
-        VRM.assignVirt2Phys(Old, PhysReg);
+      AssignToPhys(Old, PhysReg);
     }
-    if (Matrix && LIS.hasInterval(New)) {
-      LiveInterval &NewLI = LIS.getInterval(New);
-      if (!NewLI.empty())
-        Matrix->assign(NewLI, PhysReg);
-      else
-        VRM.assignVirt2Phys(New, PhysReg);
-    } else {
-      VRM.assignVirt2Phys(New, PhysReg);
-    }
+    AssignToPhys(New, PhysReg);
   } else if (VRM.getStackSlot(Old) != VirtRegMap::NO_STACK_SLOT) {
     VRM.assignVirt2StackSlot(New, VRM.getStackSlot(Old));
   } else {

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -140,8 +140,14 @@ public:
                             Register Original);
   bool rmFromMergeableSpills(MachineInstr &Spill, int StackSlot);
   void hoistAllSpills();
+  void LRE_WillShrinkVirtReg(Register) override;
   bool LRE_CanEraseVirtReg(Register) override;
   void LRE_DidCloneVirtReg(Register, Register) override;
+
+private:
+  // Vregs unassigned from the matrix during LRE_WillShrinkVirtReg, pending
+  // re-assignment after the interval is shrunk/split.
+  DenseMap<Register, MCRegister> PendingReassignments;
 };
 
 class InlineSpiller : public Spiller {
@@ -1828,12 +1834,35 @@ void HoistSpillHelper::hoistAllSpills() {
     }
     Edit.eliminateDeadDefs(SpillsToRm, {});
   }
+
+  // Flush vregs that were unassigned from the matrix during shrinking but
+  // were not split (so LRE_DidCloneVirtReg never re-assigned them).
+  for (auto &[VReg, PhysReg] : PendingReassignments) {
+    if (LIS.hasInterval(VReg)) {
+      LiveInterval &LI = LIS.getInterval(VReg);
+      if (!LI.empty())
+        Matrix->assign(LI, PhysReg);
+      else
+        VRM.assignVirt2Phys(VReg, PhysReg);
+    }
+  }
+  PendingReassignments.clear();
+}
+
+void HoistSpillHelper::LRE_WillShrinkVirtReg(Register VirtReg) {
+  if (!Matrix || !VRM.hasPhys(VirtReg) || !LIS.hasInterval(VirtReg))
+    return;
+  MCRegister PhysReg = VRM.getPhys(VirtReg);
+  LiveInterval &LI = LIS.getInterval(VirtReg);
+  Matrix->unassign(LI, /*ClearAllReferencingSegments=*/true);
+  PendingReassignments[VirtReg] = PhysReg;
 }
 
 /// Called before a virtual register is erased from LiveIntervals.
 /// Forcibly remove the register from LiveRegMatrix before it's deleted,
 /// preventing dangling pointers.
 bool HoistSpillHelper::LRE_CanEraseVirtReg(Register VirtReg) {
+  PendingReassignments.erase(VirtReg);
   if (Matrix && VRM.hasPhys(VirtReg)) {
     const LiveInterval &LI = LIS.getInterval(VirtReg);
     Matrix->unassign(LI, /*ClearAllReferencingSegments=*/true);
@@ -1844,12 +1873,53 @@ bool HoistSpillHelper::LRE_CanEraseVirtReg(Register VirtReg) {
 /// For VirtReg clone, the \p New register should have the same physreg or
 /// stackslot as the \p old register.
 void HoistSpillHelper::LRE_DidCloneVirtReg(Register New, Register Old) {
-  if (VRM.hasPhys(Old))
-    VRM.assignVirt2Phys(New, VRM.getPhys(Old));
-  else if (VRM.getStackSlot(Old) != VirtRegMap::NO_STACK_SLOT)
+  auto PendingIt = PendingReassignments.find(Old);
+  if (PendingIt != PendingReassignments.end()) {
+    // Old was already unassigned from the matrix by LRE_WillShrinkVirtReg.
+    // Reassign both Old (with its shrunk interval) and New to the matrix.
+    MCRegister PhysReg = PendingIt->second;
+    PendingReassignments.erase(PendingIt);
+
+    if (LIS.hasInterval(Old)) {
+      LiveInterval &OldLI = LIS.getInterval(Old);
+      if (!OldLI.empty())
+        Matrix->assign(OldLI, PhysReg);
+      else
+        VRM.assignVirt2Phys(Old, PhysReg);
+    }
+    if (LIS.hasInterval(New)) {
+      LiveInterval &NewLI = LIS.getInterval(New);
+      if (!NewLI.empty())
+        Matrix->assign(NewLI, PhysReg);
+      else
+        VRM.assignVirt2Phys(New, PhysReg);
+    } else {
+      VRM.assignVirt2Phys(New, PhysReg);
+    }
+  } else if (VRM.hasPhys(Old)) {
+    MCRegister PhysReg = VRM.getPhys(Old);
+    if (Matrix && LIS.hasInterval(Old)) {
+      LiveInterval &OldLI = LIS.getInterval(Old);
+      Matrix->unassign(OldLI, /*ClearAllReferencingSegments=*/true);
+      if (!OldLI.empty())
+        Matrix->assign(OldLI, PhysReg);
+      else
+        VRM.assignVirt2Phys(Old, PhysReg);
+    }
+    if (Matrix && LIS.hasInterval(New)) {
+      LiveInterval &NewLI = LIS.getInterval(New);
+      if (!NewLI.empty())
+        Matrix->assign(NewLI, PhysReg);
+      else
+        VRM.assignVirt2Phys(New, PhysReg);
+    } else {
+      VRM.assignVirt2Phys(New, PhysReg);
+    }
+  } else if (VRM.getStackSlot(Old) != VirtRegMap::NO_STACK_SLOT) {
     VRM.assignVirt2StackSlot(New, VRM.getStackSlot(Old));
-  else
+  } else {
     llvm_unreachable("VReg should be assigned either physreg or stackslot");
+  }
   if (VRM.hasShape(Old))
     VRM.assignVirt2Shape(New, VRM.getShape(Old));
 }


### PR DESCRIPTION
HoistSpillHelper's LiveRangeEdit delegate callbacks did not keep the LiveRegMatrix consistent when eliminateDeadDefs triggered interval shrinking and splitting during spill hoisting.

Three issues:

1. No LRE_WillShrinkVirtReg override: when eliminateDeadDefs shrinks a vreg's interval via shrinkToUses, the matrix was not updated. Add an override that unassigns the vreg from the matrix and records it in PendingReassignments for later re-assignment.

2. LRE_DidCloneVirtReg called VRM.assignVirt2Phys without Matrix->assign: when splitSeparateComponents creates new vregs, the clones got VRM entries but were never inserted into the matrix. Fix by consuming PendingReassignments and properly assigning both Old (shrunk) and New (split) intervals to the matrix.

3. No flush for shrink-without-split: if a vreg was shrunk but not split, LRE_DidCloneVirtReg was never called to re-assign it. Add a flush loop at the end of hoistAllSpills to re-assign any remaining pending vregs.

Also update LRE_CanEraseVirtReg to clear pending entries for erased vregs.

LIT tests exercised by this patch (i.e. if I introduce consistency verification as in https://github.com/llvm/llvm-project/pull/197778 but not this patch, the following tests fail): 
CodeGen/X86/AMX/amx-gemm.ll
CodeGen/X86/apx/push2-pop2.ll
CodeGen/X86/udivmodei5.ll

Assisted-by: Cursor/Claude Opus