### PR TITLE
[clang][deps] Expose the tracing VFS directly

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -94,13 +94,20 @@ public:
 
   llvm::vfs::FileSystem &getVFS() const { return *DepFS; }
 
+  /// Returns the worker tracing VFS, if it was requested via the service.
+  llvm::vfs::TracingFileSystem *getTracingVFS() const {
+    return TracingFS.get();
+  }
+
 private:
   /// The parent dependency scanning service.
   DependencyScanningService &Service;
   std::shared_ptr<PCHContainerOperations> PCHContainerOps;
   /// This is the caching (and optionally dependency-directives-providing) VFS
-  /// overlaid on top of the base VFS passed in the constructor.
+  /// overlaid on top of the base VFS.
   IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
+  /// The tracing VFS overlaid on top of the base VFS.
+  IntrusiveRefCntPtr<llvm::vfs::TracingFileSystem> TracingFS;
 
   friend tooling::CompilerInstanceWithContext;
 };

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -112,7 +112,10 @@ public:
       const llvm::DenseSet<dependencies::ModuleID> &AlreadySeen,
       dependencies::DependencyActionController &Controller);
 
-  llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
+  /// Returns the worker tracing VFS, if it was requested via the service.
+  llvm::vfs::TracingFileSystem *getWorkerTracingVFS() const {
+    return Worker.getTracingVFS();
+  }
 
 private:
   dependencies::DependencyScanningWorker Worker;

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -29,9 +29,11 @@ DependencyScanningWorker::DependencyScanningWorker(
 
   auto BaseFS = Service.getOpts().MakeVFS();
 
-  if (Service.getOpts().TraceVFS)
-    BaseFS = llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(
+  if (Service.getOpts().TraceVFS) {
+    TracingFS = llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(
         std::move(BaseFS));
+    BaseFS = TracingFS;
+  }
 
   DepFS = llvm::makeIntrusiveRefCnt<DependencyScanningWorkerFilesystem>(
       Service.getSharedCache(), std::move(BaseFS));

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1159,16 +1159,14 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
       }
     }
 
-    WorkerTool.getWorkerVFS().visit([&](llvm::vfs::FileSystem &VFS) {
-      if (auto *T = dyn_cast_or_null<llvm::vfs::TracingFileSystem>(&VFS)) {
-        NumStatusCalls += T->NumStatusCalls;
-        NumOpenFileForReadCalls += T->NumOpenFileForReadCalls;
-        NumDirBeginCalls += T->NumDirBeginCalls;
-        NumGetRealPathCalls += T->NumGetRealPathCalls;
-        NumExistsCalls += T->NumExistsCalls;
-        NumIsLocalCalls += T->NumIsLocalCalls;
-      }
-    });
+    if (auto *T = WorkerTool.getWorkerTracingVFS()) {
+      NumStatusCalls += T->NumStatusCalls;
+      NumOpenFileForReadCalls += T->NumOpenFileForReadCalls;
+      NumDirBeginCalls += T->NumDirBeginCalls;
+      NumGetRealPathCalls += T->NumGetRealPathCalls;
+      NumExistsCalls += T->NumExistsCalls;
+      NumIsLocalCalls += T->NumIsLocalCalls;
+    }
   };
 
   DependencyScanningServiceOptions Opts;


### PR DESCRIPTION
This adds new `DependencyScanningWorker::getTracingVFS()` API that allows direct access to the tracing VFS, if present. This replaces the call to `vfs::FileSystem::visit()` in clang-scan-deps. This will allow removing `DependencyScanningWorker::getVFS()` and simplifying VFS overlay handling in a follow-up PR.