### PR TITLE
[2/3][RegAlloc][LiveRegMatrix] Fix inconsistency when fold creates a CopyMI

### DIFF
--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1105,9 +1105,29 @@ foldMemoryOperand(ArrayRef<std::pair<MachineInstr *, unsigned>> Ops,
   if (CopyMI) {
     SlotIndex CopyIdx = LIS.InsertMachineInstrInMaps(*CopyMI).getRegSlot();
     if (!MRI.isSSA()) {
-      LiveInterval &LI = LIS.getInterval(CopyMI->getOperand(0).getReg());
+      Register CopyDstReg = CopyMI->getOperand(0).getReg();
+      LiveInterval &LI = LIS.getInterval(CopyDstReg);
+
+      // The addSegment below extends CopyDstReg's LiveInterval with a new
+      // segment for the copy. If CopyDstReg is already assigned in the
+      // LiveRegMatrix, we must unassign before the modification and reassign
+      // after, so the matrix stays consistent with the updated interval.
+      // This can happen when the fold target creates a copy
+      // to preserve a source operand, defining a vreg that was already
+      // allocated to a physreg.
+      bool NeedMatrixReassign =
+          Matrix && CopyDstReg.isVirtual() && VRM.hasPhys(CopyDstReg);
+      MCRegister PhysReg;
+      if (NeedMatrixReassign) {
+        PhysReg = VRM.getPhys(CopyDstReg);
+        Matrix->unassign(LI);
+      }
+
       VNInfo *VNI = LI.getNextValue(CopyIdx, LIS.getVNInfoAllocator());
       LI.addSegment(LiveRange::Segment(CopyIdx, FoldIdx.getRegSlot(), VNI));
+
+      if (NeedMatrixReassign)
+        Matrix->assign(LI, PhysReg);
     }
   }
   // Update the call info.

--- a/llvm/lib/CodeGen/InlineSpiller.cpp
+++ b/llvm/lib/CodeGen/InlineSpiller.cpp
@@ -1099,9 +1099,29 @@ foldMemoryOperand(ArrayRef<std::pair<MachineInstr *, unsigned>> Ops,
   if (CopyMI) {
     SlotIndex CopyIdx = LIS.InsertMachineInstrInMaps(*CopyMI).getRegSlot();
     if (!MRI.isSSA()) {
-      LiveInterval &LI = LIS.getInterval(CopyMI->getOperand(0).getReg());
+      Register CopyDstReg = CopyMI->getOperand(0).getReg();
+      LiveInterval &LI = LIS.getInterval(CopyDstReg);
+
+      // The addSegment below extends CopyDstReg's LiveInterval with a new
+      // segment for the copy. If CopyDstReg is already assigned in the
+      // LiveRegMatrix, we must unassign before the modification and reassign
+      // after, so the matrix stays consistent with the updated interval.
+      // This can happen when the fold target creates a copy
+      // to preserve a source operand, defining a vreg that was already
+      // allocated to a physreg.
+      bool NeedMatrixReassign =
+          Matrix && CopyDstReg.isVirtual() && VRM.hasPhys(CopyDstReg);
+      MCRegister PhysReg;
+      if (NeedMatrixReassign) {
+        PhysReg = VRM.getPhys(CopyDstReg);
+        Matrix->unassign(LI);
+      }
+
       VNInfo *VNI = LI.getNextValue(CopyIdx, LIS.getVNInfoAllocator());
       LI.addSegment(LiveRange::Segment(CopyIdx, FoldIdx.getRegSlot(), VNI));
+
+      if (NeedMatrixReassign)
+        Matrix->assign(LI, PhysReg);
     }
   }
   // Update the call info.

--- a/llvm/lib/CodeGen/LiveRangeEdit.cpp
+++ b/llvm/lib/CodeGen/LiveRangeEdit.cpp
@@ -167,9 +167,20 @@ bool LiveRangeEdit::foldAsLoad(LiveInterval *LI,
   ++NumDCEFoldedLoads;
   if (CopyMI) {
     SlotIndex CopyIdx = LIS.InsertMachineInstrInMaps(*CopyMI).getRegSlot();
-    LiveInterval &LI = LIS.getInterval(CopyMI->getOperand(0).getReg());
-    VNInfo *VNI = LI.getNextValue(CopyIdx, LIS.getVNInfoAllocator());
-    LI.addSegment(LiveRange::Segment(CopyIdx, FoldIdx.getRegSlot(), VNI));
+    Register CopyDstReg = CopyMI->getOperand(0).getReg();
+    LiveInterval &CopyDstLI = LIS.getInterval(CopyDstReg);
+
+    // The addSegment below extends CopyDstLI. If this vreg is already
+    // assigned in the LiveRegMatrix, the matrix becomes inconsistent.
+    // Notify the delegate so it can unassign and re-enqueue the vreg.
+    if (TheDelegate && CopyDstReg.isVirtual() && VRM &&
+        VRM->hasPhys(CopyDstReg))
+      TheDelegate->LRE_WillShrinkVirtReg(CopyDstReg);
+
+    VNInfo *VNI = CopyDstLI.getNextValue(CopyIdx, LIS.getVNInfoAllocator());
+    CopyDstLI.addSegment(
+        LiveRange::Segment(CopyIdx, FoldIdx.getRegSlot(), VNI));
+
     Register R = CopyMI->getOperand(1).getReg();
     if (R.isVirtual()) {
       LiveInterval &SrcLI = LIS.getInterval(R);


### PR DESCRIPTION
When TargetInstrInfo::foldMemoryOperand produces a side-effect CopyMI, the copy destination vreg's LiveInterval is extended via addSegment. If that vreg is already assigned in LiveRegMatrix, the matrix becomes inconsistent because it still holds the old (smaller) interval.

Fix this in two places:

- InlineSpiller::foldMemoryOperand: unassign the vreg from the matrix before addSegment, reassign after, so the matrix reflects the updated interval.

- LiveRangeEdit::foldAsLoad: notify the delegate via LRE_WillShrinkVirtReg before addSegment.

LIT test exercised by this patch (i.e. if I introduce consistency verification as in https://github.com/llvm/llvm-project/pull/197778 but not this patch, the following test fails):
CodeGen/X86/apx/pr191368.ll

Assisted-by: Cursor/Claude Opus