### PR TITLE
[llvm] Re-format aarch64-apple-tuning-features.td. NFC

### DIFF
--- a/llvm/test/TableGen/aarch64-apple-tuning-features.td
+++ b/llvm/test/TableGen/aarch64-apple-tuning-features.td
@@ -1,28 +1,279 @@
-// RUN: llvm-tblgen -print-records %p/../../lib/Target/AArch64/AArch64.td -I %p/../../lib/Target/AArch64 -I %p/../../include | FileCheck %s
+// RUN: llvm-tblgen -print-records %p/../../lib/Target/AArch64/AArch64.td -I %p/../../lib/Target/AArch64 -I %p/../../include \
+// RUN:    | sed -e "s/, /, \n/g" -e "s/\[/\[\n/g" \
+// RUN:    | FileCheck %s --implicit-check-not="def TuneApple"
 
 // Verify the resolved tuning feature lists for Apple CPUs.
 // Each generation inherits from the previous and applies add/remove deltas.
 // When adding a tuning feature to an Apple core, update the expected list below.
 
-// CHECK-LABEL: def TuneAppleA10 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFuseAES, FeatureFuseCryptoEOR, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128];
-// CHECK-LABEL: def TuneAppleA11 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFuseAES, FeatureFuseCryptoEOR, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128];
-// CHECK-LABEL: def TuneAppleA12 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFuseAES, FeatureFuseCryptoEOR, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128];
-// CHECK-LABEL: def TuneAppleA13 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFuseAES, FeatureFuseCryptoEOR, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128];
-// CHECK-LABEL: def TuneAppleA14 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAggressiveFMA, FeatureAlignCmpCSelPairs, FeatureAlternateSExtLoadCVTF32Pattern, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFastLD1Single, FeatureFuseAddress, FeatureFuseAES, FeatureFuseArithmeticLogic, FeatureFuseCmpCSel, FeatureFuseCryptoEOR, FeatureFuseLiterals, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureMaxInterleaveFactor4];
-// CHECK-LABEL: def TuneAppleA15 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureAlignCmpCSelPairs, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFastLD1Single, FeatureFuseAddress, FeatureFuseAdrpAdd, FeatureFuseAES, FeatureFuseArithmeticLogic, FeatureFuseCmpCSel, FeatureFuseCryptoEOR, FeatureFuseLiterals, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureMaxInterleaveFactor4];
-// CHECK-LABEL: def TuneAppleA16 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureAlignCmpCSelPairs, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFastLD1Single, FeatureFuseAddress, FeatureFuseAdrpAdd, FeatureFuseAES, FeatureFuseArithmeticLogic, FeatureFuseCmpCSel, FeatureFuseFCmpFCSel, FeatureFuseCryptoEOR, FeatureFuseLiterals, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureMaxInterleaveFactor4];
-// CHECK-LABEL: def TuneAppleA17 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureAlignCmpCSelPairs, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFastLD1Single, FeatureFuseAddress, FeatureFuseAdrpAdd, FeatureFuseAES, FeatureFuseArithmeticLogic, FeatureFuseCmpCSel, FeatureFuseFCmpFCSel, FeatureFuseCryptoEOR, FeatureFuseLiterals, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureMaxInterleaveFactor4];
-// CHECK-LABEL: def TuneAppleA7 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFuseAES, FeatureFuseCryptoEOR, FeatureStorePairSuppress, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureZCZeroingFPWorkaround];
-// CHECK-LABEL: def TuneAppleM4 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureAlignCmpCSelPairs, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFastLD1Single, FeatureFuseAddress, FeatureFuseAdrpAdd, FeatureFuseAES, FeatureFuseArithmeticLogic, FeatureFuseCmpCSel, FeatureFuseFCmpFCSel, FeatureFuseCryptoEOR, FeatureFuseLiterals, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureMaxInterleaveFactor4];
-// CHECK-LABEL: def TuneAppleM5 {
-// CHECK: list<SubtargetFeature> Implies = [FeatureAlternateSExtLoadCVTF32Pattern, FeatureAlignCmpCSelPairs, FeatureArithmeticBccFusion, FeatureArithmeticCbzFusion, FeatureDisableLatencySchedHeuristic, FeatureFastLD1Single, FeatureFuseAddress, FeatureFuseAdrpAdd, FeatureFuseAES, FeatureFuseArithmeticLogic, FeatureFuseCmpCSel, FeatureFuseFCmpFCSel, FeatureFuseCryptoEOR, FeatureFuseLiterals, FeatureZCRegMoveGPR64, FeatureZCRegMoveFPR128, FeatureZCZeroingGPR32, FeatureZCZeroingGPR64, FeatureNoZCZeroingFPR64, FeatureZCZeroingFPR128, FeatureMaxInterleaveFactor4];
+// CHECK-LABEL: def TuneAppleA10 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a10";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA10";
+// CHECK-NEXT:    string Desc = "Apple A10";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA11 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a11";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA11";
+// CHECK-NEXT:    string Desc = "Apple A11";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA12 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a12";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA12";
+// CHECK-NEXT:    string Desc = "Apple A12";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA13 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a13";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA13";
+// CHECK-NEXT:    string Desc = "Apple A13";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA14 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a14";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA14";
+// CHECK-NEXT:    string Desc = "Apple A14";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAggressiveFMA,
+// CHECK-NEXT:    FeatureAlignCmpCSelPairs,
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFastLD1Single,
+// CHECK-NEXT:    FeatureFuseAddress,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseArithmeticLogic,
+// CHECK-NEXT:    FeatureFuseCmpCSel,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureFuseLiterals,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureMaxInterleaveFactor4];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA15 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a15";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA15";
+// CHECK-NEXT:    string Desc = "Apple A15";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureAlignCmpCSelPairs,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFastLD1Single,
+// CHECK-NEXT:    FeatureFuseAddress,
+// CHECK-NEXT:    FeatureFuseAdrpAdd,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseArithmeticLogic,
+// CHECK-NEXT:    FeatureFuseCmpCSel,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureFuseLiterals,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureMaxInterleaveFactor4];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA16 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a16";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA16";
+// CHECK-NEXT:    string Desc = "Apple A16";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureAlignCmpCSelPairs,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFastLD1Single,
+// CHECK-NEXT:    FeatureFuseAddress,
+// CHECK-NEXT:    FeatureFuseAdrpAdd,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseArithmeticLogic,
+// CHECK-NEXT:    FeatureFuseCmpCSel,
+// CHECK-NEXT:    FeatureFuseFCmpFCSel,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureFuseLiterals,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureMaxInterleaveFactor4];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA17 {      // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a17";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA17";
+// CHECK-NEXT:    string Desc = "Apple A17";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureAlignCmpCSelPairs,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFastLD1Single,
+// CHECK-NEXT:    FeatureFuseAddress,
+// CHECK-NEXT:    FeatureFuseAdrpAdd,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseArithmeticLogic,
+// CHECK-NEXT:    FeatureFuseCmpCSel,
+// CHECK-NEXT:    FeatureFuseFCmpFCSel,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureFuseLiterals,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureMaxInterleaveFactor4];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleA7 {       // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-a7";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleA7";
+// CHECK-NEXT:    string Desc = "Apple A7 (the CPU formerly known as Cyclone)";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureStorePairSuppress,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureZCZeroingFPWorkaround];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleM4 {       // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-m4";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleM4";
+// CHECK-NEXT:    string Desc = "Apple M4";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureAlignCmpCSelPairs,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFastLD1Single,
+// CHECK-NEXT:    FeatureFuseAddress,
+// CHECK-NEXT:    FeatureFuseAdrpAdd,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseArithmeticLogic,
+// CHECK-NEXT:    FeatureFuseCmpCSel,
+// CHECK-NEXT:    FeatureFuseFCmpFCSel,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureFuseLiterals,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureMaxInterleaveFactor4];
+// CHECK-NEXT: }
+// CHECK-LABEL: def TuneAppleM5 {       // SubtargetFeature
+// CHECK-NEXT:    string Name = "apple-m5";
+// CHECK-NEXT:    string FieldName = "ARMProcFamily";
+// CHECK-NEXT:    string Value = "AppleM5";
+// CHECK-NEXT:    string Desc = "Apple M5";
+// CHECK-NEXT:    list<SubtargetFeature> Implies = [
+// CHECK-NEXT:    FeatureAlternateSExtLoadCVTF32Pattern,
+// CHECK-NEXT:    FeatureAlignCmpCSelPairs,
+// CHECK-NEXT:    FeatureArithmeticBccFusion,
+// CHECK-NEXT:    FeatureArithmeticCbzFusion,
+// CHECK-NEXT:    FeatureDisableLatencySchedHeuristic,
+// CHECK-NEXT:    FeatureFastLD1Single,
+// CHECK-NEXT:    FeatureFuseAddress,
+// CHECK-NEXT:    FeatureFuseAdrpAdd,
+// CHECK-NEXT:    FeatureFuseAES,
+// CHECK-NEXT:    FeatureFuseArithmeticLogic,
+// CHECK-NEXT:    FeatureFuseCmpCSel,
+// CHECK-NEXT:    FeatureFuseFCmpFCSel,
+// CHECK-NEXT:    FeatureFuseCryptoEOR,
+// CHECK-NEXT:    FeatureFuseLiterals,
+// CHECK-NEXT:    FeatureZCRegMoveGPR64,
+// CHECK-NEXT:    FeatureZCRegMoveFPR128,
+// CHECK-NEXT:    FeatureZCZeroingGPR32,
+// CHECK-NEXT:    FeatureZCZeroingGPR64,
+// CHECK-NEXT:    FeatureNoZCZeroingFPR64,
+// CHECK-NEXT:    FeatureZCZeroingFPR128,
+// CHECK-NEXT:    FeatureMaxInterleaveFactor4];
+// CHECK-NEXT: }


### PR DESCRIPTION
It's much easier to review diffs with each feature on its own line. Also add an -implicit-check-not so we don't miss any CPUs going forward.