### PR TITLE
[CIR][NFC] Mark Complex visitExpr as unsupported

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -360,7 +360,8 @@ void ComplexExprEmitter::emitStoreOfComplex(mlir::Location loc, mlir::Value val,
 mlir::Value ComplexExprEmitter::VisitExpr(Expr *e) {
   cgf.cgm.errorUnsupported(e, "complex expression");
   mlir::Type complexTy = cgf.convertType(e->getType());
-  return builder.getNullValue(complexTy, cgf.getLoc(e->getExprLoc()));
+  mlir::Location loc = cgf.getLoc(e->getExprLoc());
+  return builder.getConstant(loc, cir::PoisonAttr::get(complexTy));
 }
 
 mlir::Value

--- a/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprComplex.cpp
@@ -358,8 +358,9 @@ void ComplexExprEmitter::emitStoreOfComplex(mlir::Location loc, mlir::Value val,
 //===----------------------------------------------------------------------===//
 
 mlir::Value ComplexExprEmitter::VisitExpr(Expr *e) {
-  cgf.cgm.errorNYI(e->getExprLoc(), "ComplexExprEmitter VisitExpr");
-  return {};
+  cgf.cgm.errorUnsupported(e, "complex expression");
+  mlir::Type complexTy = cgf.convertType(e->getType());
+  return builder.getNullValue(complexTy, cgf.getLoc(e->getExprLoc()));
 }
 
 mlir::Value


### PR DESCRIPTION
Mark Complex visitExpr as unsupported, similar to Clang ORCG, not as NYI