### PR TITLE
[clang][deps] Simplify VFS overlays

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -78,7 +78,7 @@ public:
 
   /// Run the dependency scanning tool for all given frontend command-lines,
   /// and report the discovered dependencies to the provided consumer. The
-  /// \C OverlayFS will be used to call \c makeEffectiveVFS().
+  /// \c OverlayFS will be used to call \c makeEffectiveVFS().
   ///
   /// \returns false if any errors occurred (with diagnostics reported to
   /// \c DiagConsumer), true otherwise.

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -77,12 +77,8 @@ public:
   ~DependencyScanningWorker();
 
   /// Run the dependency scanning tool for all given frontend command-lines,
-  /// and report the discovered dependencies to the provided consumer.
-  ///
-  /// OverlayFS should be based on the Worker's dependency scanning file-system
-  /// and can be used to provide any input specified on the command-line as
-  /// in-memory file. If no overlay file-system is provided, the Worker's
-  /// dependency scanning file-system is used instead.
+  /// and report the discovered dependencies to the provided consumer. The
+  /// \C OverlayFS will be used to call \c makeEffectiveVFS().
   ///
   /// \returns false if any errors occurred (with diagnostics reported to
   /// \c DiagConsumer), true otherwise.
@@ -90,9 +86,17 @@ public:
       StringRef WorkingDirectory, ArrayRef<ArrayRef<std::string>> CommandLines,
       DependencyConsumer &DepConsumer, DependencyActionController &Controller,
       DiagnosticConsumer &DiagConsumer,
-      IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS = nullptr);
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS = nullptr);
 
-  llvm::vfs::FileSystem &getVFS() const { return *DepFS; }
+  /// Creates the effective VFS that will be used for the scan.
+  ///
+  /// If provided, OverlayFS will be overlaid on top of the Worker's dependency
+  /// scanning file-system and can be used to provide any input specified on the
+  /// command-line as in-memory file. If no overlay file-system is provided, the
+  /// Worker's dependency scanning file-system is used directly.
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> makeEffectiveVFS(
+      StringRef WorkingDirectory,
+      IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS = nullptr) const;
 
   /// Returns the worker tracing VFS, if it was requested via the service.
   llvm::vfs::TracingFileSystem *getTracingVFS() const {

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -140,7 +140,7 @@ bool computeDependencies(
     dependencies::DependencyConsumer &Consumer,
     dependencies::DependencyActionController &Controller,
     DiagnosticConsumer &DiagConsumer,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS = nullptr);
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS = nullptr);
 
 class CompilerInstanceWithContext {
   // Context
@@ -179,7 +179,7 @@ class CompilerInstanceWithContext {
   bool initialize(dependencies::DependencyActionController &Controller,
                   std::unique_ptr<dependencies::DiagnosticsEngineWithDiagOpts>
                       DiagEngineWithDiagOpts,
-                  IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS);
+                  IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS);
 
 public:
   /// @brief Initialize the tool's compiler instance from the commandline.

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -55,24 +55,27 @@ static bool createAndRunToolInvocation(
                               Diags.getClient());
 }
 
+IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+DependencyScanningWorker::makeEffectiveVFS(
+    StringRef WorkingDirectory,
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) const {
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS = DepFS;
+  if (OverlayFS) {
+    auto NewFS =
+        llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(std::move(FS));
+    NewFS->pushOverlay(std::move(OverlayFS));
+    FS = std::move(NewFS);
+  }
+  FS->setCurrentWorkingDirectory(WorkingDirectory);
+  return FS;
+}
+
 bool DependencyScanningWorker::computeDependencies(
     StringRef WorkingDirectory, ArrayRef<ArrayRef<std::string>> CommandLines,
     DependencyConsumer &DepConsumer, DependencyActionController &Controller,
     DiagnosticConsumer &DiagConsumer,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
-  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS = nullptr;
-  if (OverlayFS) {
-#ifndef NDEBUG
-    bool SawDepFS = false;
-    OverlayFS->visit(
-        [&](llvm::vfs::FileSystem &VFS) { SawDepFS |= &VFS == DepFS.get(); });
-    assert(SawDepFS && "OverlayFS not based on DepFS");
-#endif
-    FS = std::move(OverlayFS);
-  } else {
-    FS = DepFS;
-    FS->setCurrentWorkingDirectory(WorkingDirectory);
-  }
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
+  auto FS = makeEffectiveVFS(WorkingDirectory, std::move(OverlayFS));
 
   DependencyScanningAction Action(Service, WorkingDirectory, DepConsumer,
                                   Controller, DepFS);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -146,14 +146,8 @@ static bool computeDependenciesForDriverCommandLine(
     DependencyScanningWorker &Worker, StringRef WorkingDirectory,
     ArrayRef<std::string> CommandLine, DependencyConsumer &Consumer,
     DependencyActionController &Controller, DiagnosticConsumer &DiagConsumer,
-    IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
-  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS = nullptr;
-  if (OverlayFS) {
-    FS = OverlayFS;
-  } else {
-    FS = &Worker.getVFS();
-    FS->setCurrentWorkingDirectory(WorkingDirectory);
-  }
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
+  auto FS = Worker.makeEffectiveVFS(WorkingDirectory, OverlayFS);
 
   // Compilation holds a non-owning a reference to the Driver, hence we need to
   // keep the Driver alive when we use Compilation. Arguments to commands may be
@@ -174,7 +168,7 @@ static bool computeDependenciesForDriverCommandLine(
 
   return Worker.computeDependencies(WorkingDirectory, FrontendCommandLinesView,
                                     Consumer, Controller, DiagConsumer,
-                                    OverlayFS);
+                                    std::move(OverlayFS));
 }
 
 static llvm::Error makeErrorFromDiagnosticsOS(
@@ -187,7 +181,7 @@ bool tooling::computeDependencies(
     DependencyScanningWorker &Worker, StringRef WorkingDirectory,
     ArrayRef<std::string> CommandLine, DependencyConsumer &Consumer,
     DependencyActionController &Controller, DiagnosticConsumer &DiagConsumer,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
   const auto IsCC1Input = (CommandLine.size() >= 2 && CommandLine[1] == "-cc1");
   return IsCC1Input ? Worker.computeDependencies(WorkingDirectory, CommandLine,
                                                  Consumer, Controller,
@@ -269,61 +263,41 @@ std::optional<P1689Rule> DependencyScanningTool::getP1689ModuleDependencyFile(
   return Rule;
 }
 
-static std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
+static std::pair<IntrusiveRefCntPtr<llvm::vfs::FileSystem>,
                  std::vector<std::string>>
-initVFSForTUBufferScanning(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
-                           ArrayRef<std::string> CommandLine,
-                           StringRef WorkingDirectory,
+initVFSForTUBufferScanning(ArrayRef<std::string> CommandLine,
                            llvm::MemoryBufferRef TUBuffer) {
-  // Reset what might have been modified in the previous worker invocation.
-  BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
+  StringRef InputPath = TUBuffer.getBufferIdentifier();
+  auto InputBuf = llvm::MemoryBuffer::getMemBufferCopy(TUBuffer.getBuffer());
 
-  auto OverlayFS =
-      llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(BaseFS);
-  auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
-  InMemoryFS->setCurrentWorkingDirectory(WorkingDirectory);
-  auto InputPath = TUBuffer.getBufferIdentifier();
-  InMemoryFS->addFile(
-      InputPath, 0, llvm::MemoryBuffer::getMemBufferCopy(TUBuffer.getBuffer()));
-  IntrusiveRefCntPtr<llvm::vfs::FileSystem> InMemoryOverlay = InMemoryFS;
+  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  FS->addFile(InputPath, 0, std::move(InputBuf));
 
-  OverlayFS->pushOverlay(InMemoryOverlay);
   std::vector<std::string> ModifiedCommandLine(CommandLine);
   ModifiedCommandLine.emplace_back(InputPath);
 
-  return std::make_pair(OverlayFS, ModifiedCommandLine);
+  return std::make_pair(std::move(FS), ModifiedCommandLine);
 }
 
-static std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
+static std::pair<IntrusiveRefCntPtr<llvm::vfs::FileSystem>,
                  std::vector<std::string>>
-initVFSForByNameScanning(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
-                         ArrayRef<std::string> CommandLine,
-                         StringRef WorkingDirectory) {
-  // Reset what might have been modified in the previous worker invocation.
-  BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
-
-  // If we're scanning based on a module name alone, we don't expect the client
-  // to provide us with an input file. However, the driver really wants to have
-  // one. Let's just make it up to make the driver happy.
-  auto OverlayFS =
-      llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(BaseFS);
-  auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
-  InMemoryFS->setCurrentWorkingDirectory(WorkingDirectory);
-  StringRef FakeInputPath("module-include.input");
-  // The fake input buffer is read-only, and it is used to produce
-  // unique source locations for the diagnostics. Therefore sharing
-  // this global buffer across threads is ok.
+initVFSForByNameScanning(ArrayRef<std::string> CommandLine) {
+  // The fake input buffer is read-only, and it is used to produce unique source
+  // locations for the diagnostics. Therefore, sharing this global buffer across
+  // threads is ok.
   static const std::string FakeInput(
-      clang::tooling::CompilerInstanceWithContext::MaxNumOfQueries, ' ');
-  InMemoryFS->addFile(FakeInputPath, 0,
-                      llvm::MemoryBuffer::getMemBuffer(FakeInput));
-  IntrusiveRefCntPtr<llvm::vfs::FileSystem> InMemoryOverlay = InMemoryFS;
-  OverlayFS->pushOverlay(InMemoryOverlay);
+      CompilerInstanceWithContext::MaxNumOfQueries, ' ');
+
+  StringRef InputPath = "/module-include.input";
+  auto InputBuf = llvm::MemoryBuffer::getMemBuffer(FakeInput, InputPath);
+
+  auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  FS->addFile(InputPath, 0, std::move(InputBuf));
 
   std::vector<std::string> ModifiedCommandLine(CommandLine);
-  ModifiedCommandLine.emplace_back(FakeInputPath);
+  ModifiedCommandLine.emplace_back(InputPath);
 
-  return std::make_pair(OverlayFS, ModifiedCommandLine);
+  return std::make_pair(std::move(FS), ModifiedCommandLine);
 }
 
 std::optional<TranslationUnitDeps>
@@ -338,17 +312,16 @@ DependencyScanningTool::getTranslationUnitDependencies(
 
   // If we are scanning from a TUBuffer, create an overlay filesystem with the
   // input as an in-memory file and add it to the command line.
-  IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS = nullptr;
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS = nullptr;
   std::vector<std::string> CommandLineWithTUBufferInput;
   if (TUBuffer) {
     std::tie(OverlayFS, CommandLineWithTUBufferInput) =
-        initVFSForTUBufferScanning(&Worker.getVFS(), CommandLine, CWD,
-                                   *TUBuffer);
+        initVFSForTUBufferScanning(CommandLine, *TUBuffer);
     CommandLine = CommandLineWithTUBufferInput;
   }
 
   if (!computeDependencies(Worker, CWD, CommandLine, Consumer, Controller,
-                           DiagConsumer, OverlayFS))
+                           DiagConsumer, std::move(OverlayFS)))
     return std::nullopt;
   return Consumer.takeTranslationUnitDeps();
 }
@@ -369,13 +342,13 @@ DependencyScanningTool::getModuleDependencies(
 
 static std::optional<SmallVector<std::string, 0>> getFirstCC1CommandLine(
     ArrayRef<std::string> CommandLine, DiagnosticsEngine &Diags,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
   // Compilation holds a non-owning a reference to the Driver, hence we need to
   // keep the Driver alive when we use Compilation. Arguments to commands may be
   // owned by Alloc when expanded from response files.
   llvm::BumpPtrAllocator Alloc;
   const auto [Driver, Compilation] =
-      buildCompilation(CommandLine, Diags, OverlayFS, Alloc);
+      buildCompilation(CommandLine, Diags, std::move(FS), Alloc);
   if (!Compilation)
     return std::nullopt;
 
@@ -394,18 +367,20 @@ CompilerInstanceWithContext::initializeFromCommandline(
     DependencyScanningTool &Tool, StringRef CWD,
     ArrayRef<std::string> CommandLine, DependencyActionController &Controller,
     DiagnosticConsumer &DC) {
-  auto [OverlayFS, ModifiedCommandLine] =
-      initVFSForByNameScanning(&Tool.Worker.getVFS(), CommandLine, CWD);
+  auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(CommandLine);
+  auto FS = Tool.Worker.makeEffectiveVFS(CWD, OverlayFS);
+
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
-                                                      OverlayFS, DC);
+                                                      FS, DC);
 
   if (CommandLine.size() >= 2 && CommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the
     // compiler instance directly from it.
     CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD, CommandLine);
-    if (!CIWithContext.initialize(
-            Controller, std::move(DiagEngineWithCmdAndOpts), OverlayFS))
+    if (!CIWithContext.initialize(Controller,
+                                  std::move(DiagEngineWithCmdAndOpts),
+                                  std::move(OverlayFS)))
       return std::nullopt;
     return std::move(CIWithContext);
   }
@@ -414,7 +389,7 @@ CompilerInstanceWithContext::initializeFromCommandline(
   // ill-formed. In this case, we will first call the Driver to build a -cc1
   // command line for this compilation or diagnose any ill-formed input.
   const auto MaybeFirstCC1 = getFirstCC1CommandLine(
-      ModifiedCommandLine, *DiagEngineWithCmdAndOpts->DiagEngine, OverlayFS);
+      ModifiedCommandLine, *DiagEngineWithCmdAndOpts->DiagEngine, FS);
   if (!MaybeFirstCC1)
     return std::nullopt;
 
@@ -423,7 +398,7 @@ CompilerInstanceWithContext::initializeFromCommandline(
   CompilerInstanceWithContext CIWithContext(Tool.Worker, CWD,
                                             std::move(CC1CommandLine));
   if (!CIWithContext.initialize(Controller, std::move(DiagEngineWithCmdAndOpts),
-                                OverlayFS))
+                                std::move(OverlayFS)))
     return std::nullopt;
   return std::move(CIWithContext);
 }
@@ -460,19 +435,13 @@ CompilerInstanceWithContext::computeDependenciesByNameOrError(
 bool CompilerInstanceWithContext::initialize(
     DependencyActionController &Controller,
     std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
-    IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
+    IntrusiveRefCntPtr<llvm::vfs::FileSystem> OverlayFS) {
   assert(DiagEngineWithDiagOpts && "Valid diagnostics engine required!");
   DiagEngineWithCmdAndOpts = std::move(DiagEngineWithDiagOpts);
   DiagConsumer = DiagEngineWithCmdAndOpts->DiagEngine->getClient();
 
-#ifndef NDEBUG
   assert(OverlayFS && "OverlayFS required!");
-  bool SawDepFS = false;
-  OverlayFS->visit([&](llvm::vfs::FileSystem &VFS) {
-    SawDepFS |= &VFS == Worker.DepFS.get();
-  });
-  assert(SawDepFS && "OverlayFS not based on DepFS");
-#endif
+  auto FS = Worker.makeEffectiveVFS(CWD, std::move(OverlayFS));
 
   OriginalInvocation = createCompilerInvocation(
       CommandLine, *DiagEngineWithCmdAndOpts->DiagEngine);
@@ -497,7 +466,7 @@ bool CompilerInstanceWithContext::initialize(
   auto &CI = *CIPtr;
 
   initializeScanCompilerInstance(
-      CI, OverlayFS, DiagEngineWithCmdAndOpts->DiagEngine->getClient(),
+      CI, std::move(FS), DiagEngineWithCmdAndOpts->DiagEngine->getClient(),
       Worker.Service, Worker.DepFS);
 
   StableDirs = getInitialStableDirs(CI);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -288,7 +288,10 @@ initVFSForByNameScanning(ArrayRef<std::string> CommandLine) {
   static const std::string FakeInput(
       CompilerInstanceWithContext::MaxNumOfQueries, ' ');
 
-  StringRef InputPath = "/module-include.input";
+  StringRef InputPath =
+      llvm::sys::path::is_style_windows(llvm::sys::path::Style::native)
+          ? "Z:\\module-include.input"
+          : "/module-include.input";
   auto InputBuf = llvm::MemoryBuffer::getMemBuffer(FakeInput, InputPath);
 
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -340,9 +340,10 @@ DependencyScanningTool::getModuleDependencies(
       ModuleName, AlreadySeen, Controller);
 }
 
-static std::optional<SmallVector<std::string, 0>> getFirstCC1CommandLine(
-    ArrayRef<std::string> CommandLine, DiagnosticsEngine &Diags,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
+static std::optional<SmallVector<std::string, 0>>
+getFirstCC1CommandLine(ArrayRef<std::string> CommandLine,
+                       DiagnosticsEngine &Diags,
+                       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
   // Compilation holds a non-owning a reference to the Driver, hence we need to
   // keep the Driver alive when we use Compilation. Arguments to commands may be
   // owned by Alloc when expanded from response files.
@@ -371,8 +372,8 @@ CompilerInstanceWithContext::initializeFromCommandline(
   auto FS = Tool.Worker.makeEffectiveVFS(CWD, OverlayFS);
 
   auto DiagEngineWithCmdAndOpts =
-      std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
-                                                      FS, DC);
+      std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine, FS,
+                                                      DC);
 
   if (CommandLine.size() >= 2 && CommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the


### PR DESCRIPTION
Instead of operating on on-disk files, the scanner can be made to operate on in-memory buffers and module names. This is facilitated by changes to the command line and the VFS, where an imaginary file is injected (mainly to make the driver happy). Currently, this is implemented by functions external to the worker that take its base VFS, wrap it with an overlay VFS, and pass it back to the worker. Since the worker _needs_ to operate on top of the base VFS, it performs a sanity check like so:

```c++
#ifndef NDEBUG
    bool SawDepFS = false;
    OverlayFS->visit(
        [&](llvm::vfs::FileSystem &VFS) { SawDepFS |= &VFS == DepFS.get(); });
    assert(SawDepFS && "OverlayFS not based on DepFS");
#endif
```

This PR simplifies the situation by passing the custom VFS to the new `DependencyScanningWorker::makeEffectiveVFS()`. This is used by external tools that need to operate in the same context as the worker, but it's also called by the worker itself, guaranteeing that it operates on the expected VFS, which in turn allows removing the complicated visitation and assert pattern.