### PR TITLE
[CIR] Honor explicit-object parameter in CXX method arrangement

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCall.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCall.cpp
@@ -1028,7 +1028,15 @@ CIRGenTypes::arrangeCXXMethodDeclaration(const CXXMethodDecl *md) {
       md->getType()->getCanonicalTypeUnqualified().getAs<FunctionProtoType>();
   assert(!cir::MissingFeatures::cudaSupport());
 
-  if (md->isInstance()) {
+  // Mirrors classic CodeGen's check at CGCall.cpp.  C++23 explicit-object
+  // member functions (P0847R7, `void f(this Self&&)`) do not receive an
+  // implicit `this`; the explicit object parameter takes its place at the
+  // AST level and appears as the first parameter of the FunctionProtoType.
+  // Arrange them as free functions so we don't prepend a stale implicit
+  // `this` to the parameter list, which would produce a CIRGenFunctionInfo
+  // with one more argument than the matching cir.func type and trip the
+  // assertion in setArgAttrs.
+  if (md->isImplicitObjectMemberFunction()) {
     // The abstract case is perfectly fine.
     auto *thisType = theCXXABI.getThisArgumentTypeForMethod(md);
     return arrangeCXXMethodType(thisType, prototype.getTypePtr(), md);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -531,8 +531,12 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
     }
   }
 
+  // Only implicit-object member functions (without an explicit `this`
+  // parameter) receive an implicit `this` argument that the CXXABI prolog has
+  // to set up. C++23 explicit-object members (P0847R7) carry their object via a
+  // regular parameter and use the standard parameter prolog instead.
   if (isa_and_nonnull<CXXMethodDecl>(d) &&
-      cast<CXXMethodDecl>(d)->isInstance()) {
+      cast<CXXMethodDecl>(d)->isImplicitObjectMemberFunction()) {
     cgm.getCXXABI().emitInstanceFunctionProlog(loc, *this);
 
     const auto *md = cast<CXXMethodDecl>(d);
@@ -1017,8 +1021,11 @@ clang::QualType CIRGenFunction::buildFunctionArgList(clang::GlobalDecl gd,
   const auto *fd = cast<FunctionDecl>(gd.getDecl());
   QualType retTy = fd->getReturnType();
 
+  // Only implicit-object member functions need the CXXABI-supplied `this`
+  // parameter prepended to the arg list.  Explicit-object members carry the
+  // object as a regular parameter that fd->parameters() already enumerates.
   const auto *md = dyn_cast<CXXMethodDecl>(fd);
-  if (md && md->isInstance()) {
+  if (md && md->isImplicitObjectMemberFunction()) {
     if (cgm.getCXXABI().hasThisReturn(gd))
       cgm.errorNYI(fd->getSourceRange(), "this return");
     else if (cgm.getCXXABI().hasMostDerivedReturn(gd))

--- a/clang/test/CIR/CodeGen/cxx23-explicit-object-member.cpp
+++ b/clang/test/CIR/CodeGen/cxx23-explicit-object-member.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++23 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=LLVM
+
+// Explicit-object member function with no use of `self` in the body.
+// The function has two AST parameters (self, x) and no implicit `this`.
+struct Functor {
+  int operator()(this Functor const& self, int x) { return x + 1; }
+};
+
+int call_simple(Functor f) {
+  return f(3);
+}
+
+// CIR-LABEL: cir.func{{.*}} @_ZNH7FunctorclERKS_i(%arg0: !cir.ptr<!rec_Functor>
+// CIR-SAME:                                       %arg1: !s32i
+
+// LLVM-LABEL: define {{.*}}i32 @_ZNH7FunctorclERKS_i(ptr {{.*}}%{{.+}}, i32 {{.*}}%{{.+}})
+
+// Explicit-object member function that uses `self` to access a member.
+// Confirms the explicit-object parameter is properly entered into the local
+// decl map so `self.base` resolves correctly.
+struct Adder {
+  int base;
+  int operator()(this Adder const& self, int x) { return self.base + x; }
+};
+
+int call_with_member(Adder a) {
+  return a(7);
+}
+
+// CIR-LABEL: cir.func{{.*}} @_ZNH5AdderclERKS_i(%arg0: !cir.ptr<!rec_Adder>
+// CIR-SAME:                                     %arg1: !s32i
+// CIR:         %[[SELF_SLOT:.+]] = cir.alloca !cir.ptr<!rec_Adder>, {{.*}}["self"
+// CIR:         %[[SELF_PTR:.+]] = cir.load{{.*}} %[[SELF_SLOT]] : !cir.ptr<!cir.ptr<!rec_Adder>>, !cir.ptr<!rec_Adder>
+// CIR:         %[[BASE_PTR:.+]] = cir.get_member %[[SELF_PTR]][0] {name = "base"} : !cir.ptr<!rec_Adder> -> !cir.ptr<!s32i>
+// CIR:         %[[BASE:.+]] = cir.load{{.*}} %[[BASE_PTR]] : !cir.ptr<!s32i>, !s32i
+
+// LLVM-LABEL: define {{.*}}i32 @_ZNH5AdderclERKS_i(ptr {{.*}}%{{.+}}, i32 {{.*}}%{{.+}})
+// LLVM:         %[[SELF_PTR:.+]] = load ptr, ptr %{{.+}}
+// LLVM:         %[[BASE:.+]] = load i32, ptr %{{.+}}
+// LLVM:         %[[X:.+]] = load i32, ptr %{{.+}}
+// LLVM:         add nsw i32 %[[BASE]], %[[X]]
+
+// Lambda with deducing-this explicit object parameter.
+int call_lambda() {
+  auto add5 = [](this auto const&, int x) { return x + 5; };
+  return add5(10);
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z11call_lambdav
+
+// LLVM-LABEL: define {{.*}}i32 @_Z11call_lambdav
+
+// Control: ordinary (implicit-`this`) instance member function still gets
+// the `this` parameter prepended.
+struct WithThis {
+  int v;
+  int regular(int x) { return v + x; }
+};
+
+int call_regular(WithThis w) {
+  return w.regular(2);
+}
+
+// CIR-LABEL: cir.func{{.*}} @_ZN8WithThis7regularEi(%arg0: !cir.ptr<!rec_WithThis>
+// CIR-SAME:                                          %arg1: !s32i
+
+// LLVM-LABEL: define {{.*}}i32 @_ZN8WithThis7regularEi(ptr {{.*}}%{{.+}}, i32 {{.*}}%{{.+}})


### PR DESCRIPTION
CIRGen's CXX method-arrangement and prolog paths use `md->isInstance()` to decide whether to prepend a CXXABI-supplied `this` to the parameter list.  `isInstance()` is positive for *any* non-static member, including C++23 explicit-object member functions (P0847R7, `void f(this Self&&)`), where the explicit object parameter takes the place of the implicit `this` at the AST level and appears as the first parameter of the `FunctionProtoType`.

For these methods the existing path produces a `CIRGenFunctionInfo` with one more argument than `convertType(fd->getType())` gives the matching `cir.func` type, so `setCIRFunctionAttributes` runs `setArgAttrs` off the end of the cir.func arg list and crashes with `"invalid argument number"`.  The same off-by-one shows up on the prolog side, where `buildFunctionArgList` prepends a `this` `ParmVarDecl` that doesn't actually exist and `emitInstanceFunctionProlog` sets up `CXXThisValue` from a cir.func argument that is really the explicit-object parameter.  The crash hits 29 tests in the libcxx `std/utilities/format/**` and `std/containers/**/format/**` subtrees on the current four-fix integration baseline, plus `std/utilities/function.objects/func.bind.partial/bind_front.nttp.pass.cpp`.

Switch three sites in `CIRGenCall.cpp` and `CIRGenFunction.cpp` to the positive predicate `isImplicitObjectMemberFunction()`, matching how classic CodeGen distinguishes the two cases in `CGCall.cpp`.  Explicit-object members now flow through `arrangeFreeFunctionType`, are entered into `localDeclMap` as regular parameters, and lower to the same LLVM IR that classic CodeGen produces for the same source.

New `cxx23-explicit-object-member.cpp` test (CIR + a shared `LLVM` prefix that covers both the CIR-to-LLVM and OGCG runs) covers `operator()(this Self const& self, int)` with and without `self`-side member access, a `[](this auto const&, int){...}` lambda invocation, and a control implicit-`this` instance method whose CIR signature still begins with `!cir.ptr<!rec_*>`.
