### PR TITLE
[llvm-ar] add N modifier to extract operation documentation

### DIFF
--- a/llvm/docs/CommandGuide/llvm-ar.rst
+++ b/llvm/docs/CommandGuide/llvm-ar.rst
@@ -144,12 +144,12 @@ t[v]
 
  A synonym for the :option:`--version` option.
 
-.. option:: x [oP]
+.. option:: x [oPN]
 
- Extract ``archive`` members back to files. The :option:`o` modifier applies
- to this operation. This operation retrieves the indicated *files* from the
- archive and writes them back to the operating system's file system. If no
- *files* are specified, the entire archive is extracted.
+ Extract ``archive`` members back to files. The :option:`o` and :option:`N`
+ modifiers apply to this operation. This operation retrieves the indicated
+ *files* from the archive and writes them back to the operating system's file
+ system. If no *files* are specified, the entire archive is extracted.
 
 Modifiers (operation specific)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A follow up to: https://github.com/llvm/llvm-project/pull/196541#issuecomment-4442635635

Add modifier `N` to list of modifiers allowed with `X` option documentation.
Relevant source location: [llvm-ar.cpp](https://github.com/llvm/llvm-project/blob/ecc8a95/llvm/tools/llvm-ar/llvm-ar.cpp#L462)


CC: @MaskRay @jh7370