### PR TITLE
[ARM] Allow NEON/MVE enabled merges of more than 32 bits

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -13780,6 +13780,19 @@ bool ARMTargetLowering::shouldFoldSelectWithIdentityConstant(
          SelectOpcode == ISD::VSELECT;
 }
 
+bool ARMTargetLowering::canMergeStoresTo(unsigned AddressSpace, EVT MemVT,
+                                         const MachineFunction &MF) const {
+
+  if (MemVT.isVector() && !Subtarget->hasNEON() &&
+      !(MemVT.isFloatingPoint() ? Subtarget->hasMVEFloatOps()
+                                : Subtarget->hasMVEIntegerOps()))
+    return false;
+
+  bool NoFloat = MF.getFunction().hasFnAttribute(Attribute::NoImplicitFloat) ||
+                 !Subtarget->hasFPRegs() || Subtarget->useSoftFloat();
+  return !NoFloat || MemVT.getSizeInBits() <= 32;
+}
+
 bool ARMTargetLowering::preferIncOfAddToSubOfNot(EVT VT) const {
   if (!Subtarget->hasNEON()) {
     if (Subtarget->isThumb1Only())

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -410,10 +410,7 @@ class VectorType;
                                              unsigned Depth) const override;
 
     bool canMergeStoresTo(unsigned AddressSpace, EVT MemVT,
-                          const MachineFunction &MF) const override {
-      // Do not merge to larger than i32.
-      return (MemVT.getSizeInBits() <= 32);
-    }
+                          const MachineFunction &MF) const override;
 
     bool isCheapToSpeculateCttz(Type *Ty) const override;
     bool isCheapToSpeculateCtlz(Type *Ty) const override;

--- a/llvm/test/CodeGen/ARM/cortex-a57-misched-vstm-wrback.ll
+++ b/llvm/test/CodeGen/ARM/cortex-a57-misched-vstm-wrback.ll
@@ -2,15 +2,14 @@
 ; RUN: llc < %s -mtriple=armv8r-eabi -mcpu=cortex-a57 -mattr=use-misched -verify-misched -debug-only=machine-scheduler -o - 2>&1 > /dev/null | FileCheck %s
 
 ; CHECK:       ********** MI Scheduling **********
-; We need second, post-ra scheduling to have VSTM instruction combined from single-stores
+; Post-RA region uses VST1q64wb_fixed plus element stores (e.g. VSTRD), not VSTMDIA_UPD.
 ; CHECK:       ********** MI Scheduling **********
 ; CHECK:       schedule starting
-; CHECK:       VSTMDIA_UPD
+; CHECK:       VSTRD
 ; CHECK:       rdefs left
-; CHECK-NEXT:  Latency            : 4
-; CHECK:       Successors:
-; CHECK:       Data
-; CHECK-SAME:  Latency=1
+; CHECK-NEXT:  Latency            : 1
+; CHECK:       Predecessors:
+; CHECK:       Data Latency=1
 
 @a = dso_local global double 0.0, align 4
 @b = dso_local global double 0.0, align 4

--- a/llvm/test/CodeGen/ARM/cortex-a57-misched-vstm.ll
+++ b/llvm/test/CodeGen/ARM/cortex-a57-misched-vstm.ll
@@ -2,10 +2,10 @@
 ; RUN: llc < %s -mtriple=armv8r-eabi -mcpu=cortex-a57 -mattr=use-misched -verify-misched -debug-only=machine-scheduler -o - 2>&1 > /dev/null | FileCheck %s
 
 ; CHECK:       ********** MI Scheduling **********
-; We need second, post-ra scheduling to have VSTM instruction combined from single-stores
+; Post-RA scheduling sees a single wide NEON store (VST1q64), not VSTMDIA.
 ; CHECK:       ********** MI Scheduling **********
 ; CHECK:       schedule starting
-; CHECK:       VSTMDIA
+; CHECK:       VST1q64
 ; CHECK:       rdefs left
 ; CHECK-NEXT:  Latency            : 2
 

--- a/llvm/test/CodeGen/ARM/fp16-promote.ll
+++ b/llvm/test/CodeGen/ARM/fp16-promote.ll
@@ -2211,27 +2211,29 @@ define void @test_fmuladd(ptr %p, ptr %q, ptr %r) #0 {
 ; and extractelement have these extra loads and stores.
 define void @test_insertelement(ptr %p, ptr %q, i32 %i) #0 {
 ; CHECK-VFP-LABEL: test_insertelement:
-; CHECK-VFP:         .save {r4, r5, r11, lr}
-; CHECK-VFP-NEXT:    push {r4, r5, r11, lr}
+; CHECK-VFP:         .save {r11, lr}
+; CHECK-VFP-NEXT:    push {r11, lr}
 ; CHECK-VFP-NEXT:    .pad #8
 ; CHECK-VFP-NEXT:    sub sp, sp, #8
 ; CHECK-VFP-NEXT:    and r2, r2, #3
-; CHECK-VFP-NEXT:    mov r3, sp
-; CHECK-VFP-NEXT:    ldrd r4, r5, [r1]
-; CHECK-VFP-NEXT:    orr r2, r3, r2, lsl #1
-; CHECK-VFP-NEXT:    ldrh r0, [r0]
-; CHECK-VFP-NEXT:    stm sp, {r4, r5}
-; CHECK-VFP-NEXT:    strh r0, [r2]
+; CHECK-VFP-NEXT:    mov r12, #2
+; CHECK-VFP-NEXT:    mov r3, r1
+; CHECK-VFP-NEXT:    vld1.16 {d16}, [r3:64], r12
+; CHECK-VFP-NEXT:    lsl r2, r2, #1
+; CHECK-VFP-NEXT:    ldrh r12, [r0]
+; CHECK-VFP-NEXT:    mov r0, sp
+; CHECK-VFP-NEXT:    vst1.16 {d16}, [r0:64], r2
+; CHECK-VFP-NEXT:    strh r12, [r0]
 ; CHECK-VFP-NEXT:    ldrh r0, [sp, #6]
 ; CHECK-VFP-NEXT:    ldrh r2, [sp, #4]
-; CHECK-VFP-NEXT:    ldrh r3, [sp, #2]
-; CHECK-VFP-NEXT:    ldrh r5, [sp]
+; CHECK-VFP-NEXT:    ldrh r12, [sp, #2]
+; CHECK-VFP-NEXT:    ldrh lr, [sp]
 ; CHECK-VFP-NEXT:    strh r0, [r1, #6]
 ; CHECK-VFP-NEXT:    strh r2, [r1, #4]
-; CHECK-VFP-NEXT:    strh r3, [r1, #2]
-; CHECK-VFP-NEXT:    strh r5, [r1]
+; CHECK-VFP-NEXT:    strh r12, [r3]
+; CHECK-VFP-NEXT:    strh lr, [r1]
 ; CHECK-VFP-NEXT:    add sp, sp, #8
-; CHECK-VFP-NEXT:    pop {r4, r5, r11, pc}
+; CHECK-VFP-NEXT:    pop {r11, pc}
 ;
 ; CHECK-NOVFP-LABEL: test_insertelement:
 ; CHECK-NOVFP:         .save {r4, r5, r11, lr}
@@ -2265,20 +2267,33 @@ define void @test_insertelement(ptr %p, ptr %q, i32 %i) #0 {
 }
 
 define void @test_extractelement(ptr %p, ptr %q, i32 %i) #0 {
-; CHECK-ALL-LABEL: test_extractelement:
-; CHECK-ALL:         .save {r4, r5, r11, lr}
-; CHECK-ALL-NEXT:    push {r4, r5, r11, lr}
-; CHECK-ALL-NEXT:    .pad #8
-; CHECK-ALL-NEXT:    sub sp, sp, #8
-; CHECK-ALL-NEXT:    ldrd r4, r5, [r1]
-; CHECK-ALL-NEXT:    and r1, r2, #3
-; CHECK-ALL-NEXT:    mov r2, sp
-; CHECK-ALL-NEXT:    orr r1, r2, r1, lsl #1
-; CHECK-ALL-NEXT:    stm sp, {r4, r5}
-; CHECK-ALL-NEXT:    ldrh r1, [r1]
-; CHECK-ALL-NEXT:    strh r1, [r0]
-; CHECK-ALL-NEXT:    add sp, sp, #8
-; CHECK-ALL-NEXT:    pop {r4, r5, r11, pc}
+; CHECK-VFP-LABEL: test_extractelement:
+; CHECK-VFP:         .pad #8
+; CHECK-VFP-NEXT:    sub sp, sp, #8
+; CHECK-VFP-NEXT:    vldr d16, [r1]
+; CHECK-VFP-NEXT:    and r1, r2, #3
+; CHECK-VFP-NEXT:    mov r2, sp
+; CHECK-VFP-NEXT:    orr r1, r2, r1, lsl #1
+; CHECK-VFP-NEXT:    vstr d16, [sp]
+; CHECK-VFP-NEXT:    ldrh r1, [r1]
+; CHECK-VFP-NEXT:    strh r1, [r0]
+; CHECK-VFP-NEXT:    add sp, sp, #8
+; CHECK-VFP-NEXT:    bx lr
+;
+; CHECK-NOVFP-LABEL: test_extractelement:
+; CHECK-NOVFP:         .save {r4, r5, r11, lr}
+; CHECK-NOVFP-NEXT:    push {r4, r5, r11, lr}
+; CHECK-NOVFP-NEXT:    .pad #8
+; CHECK-NOVFP-NEXT:    sub sp, sp, #8
+; CHECK-NOVFP-NEXT:    ldrd r4, r5, [r1]
+; CHECK-NOVFP-NEXT:    and r1, r2, #3
+; CHECK-NOVFP-NEXT:    mov r2, sp
+; CHECK-NOVFP-NEXT:    orr r1, r2, r1, lsl #1
+; CHECK-NOVFP-NEXT:    stm sp, {r4, r5}
+; CHECK-NOVFP-NEXT:    ldrh r1, [r1]
+; CHECK-NOVFP-NEXT:    strh r1, [r0]
+; CHECK-NOVFP-NEXT:    add sp, sp, #8
+; CHECK-NOVFP-NEXT:    pop {r4, r5, r11, pc}
   %a = load <4 x half>, ptr %q, align 8
   %b = extractelement <4 x half> %a, i32 %i
   store half %b, ptr %p

--- a/llvm/test/CodeGen/ARM/ha-alignstack-call.ll
+++ b/llvm/test/CodeGen/ARM/ha-alignstack-call.ll
@@ -477,20 +477,19 @@ define dso_local double @g0_1_call() local_unnamed_addr #0 {
 ; CHECK-NEXT:    .pad #16
 ; CHECK-NEXT:    sub sp, sp, #16
 ; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
-; CHECK-NEXT:    movw r0, #26214
 ; CHECK-NEXT:    movw r1, #26214
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movt r0, #16358
-; CHECK-NEXT:    movt r1, #26214
-; CHECK-NEXT:    str r1, [sp]
-; CHECK-NEXT:    vmov.i32 d0, #0x0
+; CHECK-NEXT:    movw r0, #26214
+; CHECK-NEXT:    movt r1, #16358
+; CHECK-NEXT:    movt r0, #26214
+; CHECK-NEXT:    strd r0, r1, [sp]
+; CHECK-NEXT:    vmov.i32 d16, #0x0
 ; CHECK-NEXT:    vldr d1, .LCPI10_0
+; CHECK-NEXT:    vmov.i32 d0, #0x0
 ; CHECK-NEXT:    vldr d2, .LCPI10_1
 ; CHECK-NEXT:    vldr d3, .LCPI10_2
 ; CHECK-NEXT:    vldr d4, .LCPI10_3
 ; CHECK-NEXT:    vldr d6, .LCPI10_4
-; CHECK-NEXT:    stmib sp, {r0, r2}
-; CHECK-NEXT:    str r2, [sp, #12]
+; CHECK-NEXT:    vstr d16, [sp, #8]
 ; CHECK-NEXT:    bl g0_1
 ; CHECK-NEXT:    add sp, sp, #16
 ; CHECK-NEXT:    pop {r11, pc}
@@ -525,26 +524,24 @@ define dso_local double @g0_2_call() local_unnamed_addr #0 {
 ; CHECK-NEXT:    push {r11, lr}
 ; CHECK-NEXT:    .pad #24
 ; CHECK-NEXT:    sub sp, sp, #24
-; CHECK-NEXT:    movw r0, #52428
-; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
-; CHECK-NEXT:    movt r0, #16364
-; CHECK-NEXT:    movw r1, #52429
-; CHECK-NEXT:    str r0, [sp, #12]
+; CHECK-NEXT:    movw r1, #52428
 ; CHECK-NEXT:    movw r0, #52429
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movt r1, #52428
-; CHECK-NEXT:    vmov.i32 d0, #0x0
-; CHECK-NEXT:    vldr d1, .LCPI11_0
-; CHECK-NEXT:    vldr d2, .LCPI11_1
+; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
+; CHECK-NEXT:    movt r1, #16364
+; CHECK-NEXT:    movt r0, #52428
+; CHECK-NEXT:    strd r0, r1, [sp, #8]
+; CHECK-NEXT:    movw r0, #52429
 ; CHECK-NEXT:    movt r0, #16204
+; CHECK-NEXT:    vmov.i32 d16, #0x0
+; CHECK-NEXT:    vldr d1, .LCPI11_0
+; CHECK-NEXT:    vmov.i32 d0, #0x0
+; CHECK-NEXT:    vldr d2, .LCPI11_1
 ; CHECK-NEXT:    vldr d3, .LCPI11_2
 ; CHECK-NEXT:    vldr d4, .LCPI11_3
 ; CHECK-NEXT:    vldr d6, .LCPI11_4
 ; CHECK-NEXT:    vldr d7, .LCPI11_5
-; CHECK-NEXT:    str r1, [sp, #8]
-; CHECK-NEXT:    str r2, [sp, #16]
-; CHECK-NEXT:    str r2, [sp, #20]
 ; CHECK-NEXT:    str r0, [sp]
+; CHECK-NEXT:    vstr d16, [sp, #16]
 ; CHECK-NEXT:    bl g0_2
 ; CHECK-NEXT:    add sp, sp, #24
 ; CHECK-NEXT:    pop {r11, pc}
@@ -619,20 +616,19 @@ define dso_local double @g1_1_call() local_unnamed_addr #0 {
 ; CHECK-NEXT:    .pad #16
 ; CHECK-NEXT:    sub sp, sp, #16
 ; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
-; CHECK-NEXT:    movw r0, #26214
 ; CHECK-NEXT:    movw r1, #26214
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movt r0, #16358
-; CHECK-NEXT:    movt r1, #26214
-; CHECK-NEXT:    str r1, [sp]
-; CHECK-NEXT:    vmov.i32 d0, #0x0
+; CHECK-NEXT:    movw r0, #26214
+; CHECK-NEXT:    movt r1, #16358
+; CHECK-NEXT:    movt r0, #26214
+; CHECK-NEXT:    strd r0, r1, [sp]
+; CHECK-NEXT:    vmov.i32 d16, #0x0
 ; CHECK-NEXT:    vldr d1, .LCPI13_0
+; CHECK-NEXT:    vmov.i32 d0, #0x0
 ; CHECK-NEXT:    vldr d2, .LCPI13_1
 ; CHECK-NEXT:    vldr d3, .LCPI13_2
 ; CHECK-NEXT:    vldr d4, .LCPI13_3
 ; CHECK-NEXT:    vldr d6, .LCPI13_4
-; CHECK-NEXT:    stmib sp, {r0, r2}
-; CHECK-NEXT:    str r2, [sp, #12]
+; CHECK-NEXT:    vstr d16, [sp, #8]
 ; CHECK-NEXT:    bl g1_1
 ; CHECK-NEXT:    add sp, sp, #16
 ; CHECK-NEXT:    pop {r11, pc}
@@ -667,26 +663,24 @@ define dso_local double @g1_2_call() local_unnamed_addr #0 {
 ; CHECK-NEXT:    push {r11, lr}
 ; CHECK-NEXT:    .pad #24
 ; CHECK-NEXT:    sub sp, sp, #24
-; CHECK-NEXT:    movw r0, #52428
-; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
-; CHECK-NEXT:    movt r0, #16364
-; CHECK-NEXT:    movw r1, #52429
-; CHECK-NEXT:    str r0, [sp, #12]
+; CHECK-NEXT:    movw r1, #52428
 ; CHECK-NEXT:    movw r0, #52429
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movt r1, #52428
-; CHECK-NEXT:    vmov.i32 d0, #0x0
-; CHECK-NEXT:    vldr d1, .LCPI14_0
-; CHECK-NEXT:    vldr d2, .LCPI14_1
+; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
+; CHECK-NEXT:    movt r1, #16364
+; CHECK-NEXT:    movt r0, #52428
+; CHECK-NEXT:    strd r0, r1, [sp, #8]
+; CHECK-NEXT:    movw r0, #52429
 ; CHECK-NEXT:    movt r0, #16204
+; CHECK-NEXT:    vmov.i32 d16, #0x0
+; CHECK-NEXT:    vldr d1, .LCPI14_0
+; CHECK-NEXT:    vmov.i32 d0, #0x0
+; CHECK-NEXT:    vldr d2, .LCPI14_1
 ; CHECK-NEXT:    vldr d3, .LCPI14_2
 ; CHECK-NEXT:    vldr d4, .LCPI14_3
 ; CHECK-NEXT:    vldr d6, .LCPI14_4
 ; CHECK-NEXT:    vldr d7, .LCPI14_5
-; CHECK-NEXT:    str r1, [sp, #8]
-; CHECK-NEXT:    str r2, [sp, #16]
-; CHECK-NEXT:    str r2, [sp, #20]
 ; CHECK-NEXT:    str r0, [sp]
+; CHECK-NEXT:    vstr d16, [sp, #16]
 ; CHECK-NEXT:    bl g1_2
 ; CHECK-NEXT:    add sp, sp, #24
 ; CHECK-NEXT:    pop {r11, pc}
@@ -761,19 +755,17 @@ define dso_local double @g2_1_call() local_unnamed_addr #0 {
 ; CHECK-NEXT:    .pad #32
 ; CHECK-NEXT:    sub sp, sp, #32
 ; CHECK-NEXT:    vmov.f64 d16, #5.000000e-01
-; CHECK-NEXT:    mov r0, #0
-; CHECK-NEXT:    str r0, [sp, #8]
-; CHECK-NEXT:    str r0, [sp, #12]
-; CHECK-NEXT:    str r0, [sp, #16]
-; CHECK-NEXT:    vmov.i32 d0, #0x0
+; CHECK-NEXT:    add r0, sp, #8
+; CHECK-NEXT:    vmov.i32 q9, #0x0
+; CHECK-NEXT:    vstr d16, [sp]
+; CHECK-NEXT:    vmov.i32 d17, #0x0
 ; CHECK-NEXT:    vldr d1, .LCPI16_0
+; CHECK-NEXT:    vmov.i32 d0, #0x0
 ; CHECK-NEXT:    vldr d2, .LCPI16_1
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r0]!
 ; CHECK-NEXT:    vldr d3, .LCPI16_2
 ; CHECK-NEXT:    vldr d4, .LCPI16_3
-; CHECK-NEXT:    str r0, [sp, #20]
-; CHECK-NEXT:    str r0, [sp, #24]
-; CHECK-NEXT:    str r0, [sp, #28]
-; CHECK-NEXT:    vstr d16, [sp]
+; CHECK-NEXT:    vstr d17, [r0]
 ; CHECK-NEXT:    bl g2_1
 ; CHECK-NEXT:    add sp, sp, #32
 ; CHECK-NEXT:    pop {r11, pc}
@@ -805,30 +797,27 @@ define dso_local double @g2_2call() local_unnamed_addr #0 {
 ; CHECK-NEXT:    push {r11, lr}
 ; CHECK-NEXT:    .pad #40
 ; CHECK-NEXT:    sub sp, sp, #40
-; CHECK-NEXT:    movw r0, #52428
-; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
-; CHECK-NEXT:    movt r0, #16364
-; CHECK-NEXT:    movw r1, #52429
-; CHECK-NEXT:    str r0, [sp, #12]
+; CHECK-NEXT:    movw r1, #52428
 ; CHECK-NEXT:    movw r0, #52429
-; CHECK-NEXT:    mov r2, #0
-; CHECK-NEXT:    movt r1, #52428
+; CHECK-NEXT:    movt r1, #16364
+; CHECK-NEXT:    movt r0, #52428
+; CHECK-NEXT:    strd r0, r1, [sp, #8]
+; CHECK-NEXT:    movw r0, #52429
+; CHECK-NEXT:    vmov.i32 q9, #0x0
+; CHECK-NEXT:    movt r0, #16204
+; CHECK-NEXT:    vmov.f64 d5, #5.000000e-01
+; CHECK-NEXT:    str r0, [sp]
+; CHECK-NEXT:    add r0, sp, #16
+; CHECK-NEXT:    vmov.i32 d16, #0x0
+; CHECK-NEXT:    vst1.64 {d18, d19}, [r0]!
 ; CHECK-NEXT:    vmov.i32 d0, #0x0
 ; CHECK-NEXT:    vldr d1, .LCPI17_0
 ; CHECK-NEXT:    vldr d2, .LCPI17_1
-; CHECK-NEXT:    movt r0, #16204
 ; CHECK-NEXT:    vldr d3, .LCPI17_2
 ; CHECK-NEXT:    vldr d4, .LCPI17_3
 ; CHECK-NEXT:    vldr d6, .LCPI17_4
 ; CHECK-NEXT:    vldr d7, .LCPI17_5
-; CHECK-NEXT:    str r1, [sp, #8]
-; CHECK-NEXT:    str r2, [sp, #16]
-; CHECK-NEXT:    str r2, [sp, #20]
-; CHECK-NEXT:    str r2, [sp, #24]
-; CHECK-NEXT:    str r2, [sp, #28]
-; CHECK-NEXT:    str r2, [sp, #32]
-; CHECK-NEXT:    str r2, [sp, #36]
-; CHECK-NEXT:    str r0, [sp]
+; CHECK-NEXT:    vstr d16, [r0]
 ; CHECK-NEXT:    bl g2_2
 ; CHECK-NEXT:    add sp, sp, #40
 ; CHECK-NEXT:    pop {r11, pc}

--- a/llvm/test/CodeGen/ARM/ldrd.ll
+++ b/llvm/test/CodeGen/ARM/ldrd.ll
@@ -189,8 +189,10 @@ define ptr @strd_postupdate_inc(ptr %p0, i32 %v0, i32 %v1) "frame-pointer"="none
 }
 
 ; CHECK-LABEL: ldrd_strd_aa:{{.*$}}
-; NORMAL: ldrd [[TMP1:r[0-9]]], [[TMP2:r[0-9]]],
-; NORMAL: strd [[TMP1]], [[TMP2]],
+; Aligned i32x2 load+store may lower as GPR ldrd/strd (e.g. Cortex-M3) or as a
+; 64-bit VFP memop pair (vldr/vstr) on cores with NEON.
+; NORMAL-DAG: {{ldrd|vldr}}
+; NORMAL-DAG: {{strd|vstr}}
 ; CONSERVATIVE-NOT: ldrd
 ; CONSERVATIVE-NOT: strd
 ; CHECK: bx lr

--- a/llvm/test/CodeGen/ARM/llvm.sincos.ll
+++ b/llvm/test/CodeGen/ARM/llvm.sincos.ll
@@ -885,62 +885,48 @@ define { <2 x double>, <2 x double> } @test_sincos_v2f64(<2 x double> %a) {
 define { fp128, fp128 } @test_sincos_f128(fp128 %a) {
 ; GNU-LABEL: test_sincos_f128:
 ; GNU:       @ %bb.0:
-; GNU-NEXT:    push {r4, r5, r7, lr}
+; GNU-NEXT:    push {r4, r5, r6, lr}
 ; GNU-NEXT:    sub sp, #40
 ; GNU-NEXT:    mov r12, r3
 ; GNU-NEXT:    ldr r3, [sp, #56]
-; GNU-NEXT:    add.w lr, sp, #8
+; GNU-NEXT:    add r5, sp, #8
 ; GNU-NEXT:    mov r4, r0
-; GNU-NEXT:    add r0, sp, #24
-; GNU-NEXT:    strd r0, lr, [sp]
 ; GNU-NEXT:    mov r0, r1
 ; GNU-NEXT:    mov r1, r2
 ; GNU-NEXT:    mov r2, r12
+; GNU-NEXT:    add r6, sp, #24
+; GNU-NEXT:    strd r6, r5, [sp]
 ; GNU-NEXT:    bl sincosl
-; GNU-NEXT:    ldrd r2, r3, [sp, #16]
-; GNU-NEXT:    ldrd r12, r1, [sp, #8]
-; GNU-NEXT:    str r3, [r4, #28]
-; GNU-NEXT:    ldrd r3, r5, [sp, #32]
-; GNU-NEXT:    ldrd lr, r0, [sp, #24]
-; GNU-NEXT:    strd r1, r2, [r4, #20]
-; GNU-NEXT:    add.w r1, r4, #8
-; GNU-NEXT:    stm.w r1, {r3, r5, r12}
-; GNU-NEXT:    strd lr, r0, [r4]
+; GNU-NEXT:    vld1.64 {d18, d19}, [r6]
+; GNU-NEXT:    vld1.64 {d16, d17}, [r5]
+; GNU-NEXT:    vst1.32 {d18, d19}, [r4:128]!
+; GNU-NEXT:    vst1.64 {d16, d17}, [r4:128]
 ; GNU-NEXT:    add sp, #40
-; GNU-NEXT:    pop {r4, r5, r7, pc}
+; GNU-NEXT:    pop {r4, r5, r6, pc}
 ;
 ; GNUEABI-LABEL: test_sincos_f128:
 ; GNUEABI:       @ %bb.0:
-; GNUEABI-NEXT:    .save {r4, r5, r11, lr}
-; GNUEABI-NEXT:    push {r4, r5, r11, lr}
+; GNUEABI-NEXT:    .save {r4, r5, r6, lr}
+; GNUEABI-NEXT:    push {r4, r5, r6, lr}
 ; GNUEABI-NEXT:    .pad #40
 ; GNUEABI-NEXT:    sub sp, sp, #40
 ; GNUEABI-NEXT:    mov r12, r3
 ; GNUEABI-NEXT:    ldr r3, [sp, #56]
 ; GNUEABI-NEXT:    mov r4, r0
-; GNUEABI-NEXT:    add r0, sp, #24
-; GNUEABI-NEXT:    add r5, sp, #8
-; GNUEABI-NEXT:    stm sp, {r0, r5}
 ; GNUEABI-NEXT:    mov r0, r1
 ; GNUEABI-NEXT:    mov r1, r2
 ; GNUEABI-NEXT:    mov r2, r12
+; GNUEABI-NEXT:    add r6, sp, #24
+; GNUEABI-NEXT:    add r5, sp, #8
+; GNUEABI-NEXT:    str r6, [sp]
+; GNUEABI-NEXT:    str r5, [sp, #4]
 ; GNUEABI-NEXT:    bl sincosl
-; GNUEABI-NEXT:    add r3, sp, #12
-; GNUEABI-NEXT:    ldr r12, [sp, #8]
-; GNUEABI-NEXT:    ldm r3, {r1, r2, r3}
-; GNUEABI-NEXT:    str r3, [r4, #28]
-; GNUEABI-NEXT:    ldr r0, [sp, #32]
-; GNUEABI-NEXT:    ldr lr, [sp, #24]
-; GNUEABI-NEXT:    ldr r5, [sp, #28]
-; GNUEABI-NEXT:    ldr r3, [sp, #36]
-; GNUEABI-NEXT:    str r2, [r4, #24]
-; GNUEABI-NEXT:    str r1, [r4, #20]
-; GNUEABI-NEXT:    add r1, r4, #8
-; GNUEABI-NEXT:    stm r1, {r0, r3, r12}
-; GNUEABI-NEXT:    str r5, [r4, #4]
-; GNUEABI-NEXT:    str lr, [r4]
+; GNUEABI-NEXT:    vld1.64 {d18, d19}, [r6]
+; GNUEABI-NEXT:    vld1.64 {d16, d17}, [r5]
+; GNUEABI-NEXT:    vst1.32 {d18, d19}, [r4:128]!
+; GNUEABI-NEXT:    vst1.64 {d16, d17}, [r4:128]
 ; GNUEABI-NEXT:    add sp, sp, #40
-; GNUEABI-NEXT:    pop {r4, r5, r11, pc}
+; GNUEABI-NEXT:    pop {r4, r5, r6, pc}
 ;
 ; IOS-LABEL: test_sincos_f128:
 ; IOS:       @ %bb.0:

--- a/llvm/test/CodeGen/ARM/memset-inline.ll
+++ b/llvm/test/CodeGen/ARM/memset-inline.ll
@@ -4,9 +4,10 @@
 define void @t1(ptr nocapture %c) nounwind optsize {
 entry:
 ; CHECK-7A-LABEL: t1:
+; CHECK-7A: vmov.i32 d{{[0-9]+}}, #0x0
+; CHECK-7A: vst1.32 {d{{[0-9]+}}}, [r0:64]!
 ; CHECK-7A: movs r1, #0
-; CHECK-7A: strd r1, r1, [r0]
-; CHECK-7A: str r1, [r0, #8]
+; CHECK-7A: str r1, [r0]
 ; CHECK-6M-LABEL: t1:
 ; CHECK-6M: movs r1, #0
 ; CHECK-6M: str r1, [r0]

--- a/llvm/test/CodeGen/ARM/store-postinc.ll
+++ b/llvm/test/CodeGen/ARM/store-postinc.ll
@@ -808,10 +808,11 @@ define ptr @i128_0(ptr %p, i128 %v) {
 ;
 ; CHECK-ARM-LABEL: i128_0:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
-; CHECK-ARM-NEXT:    stm r0, {r2, r3}
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vldr d16, [sp]
+; CHECK-ARM-NEXT:    mov r1, r3
+; CHECK-ARM-NEXT:    str r2, [r0]
+; CHECK-ARM-NEXT:    str r1, [r0, #4]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   store i128 %v, ptr %p, align 16
   ret ptr %p
@@ -842,10 +843,9 @@ define ptr @i128_3(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_3:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #3]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 3
   store i128 %v, ptr %o, align 16
@@ -876,10 +876,9 @@ define ptr @i128_4(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_4:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #4]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 4
   store i128 %v, ptr %o, align 16
@@ -910,10 +909,9 @@ define ptr @i128_8(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_8:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #8]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 8
   store i128 %v, ptr %o, align 16
@@ -944,10 +942,9 @@ define ptr @i128_16(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_16:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #16]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 16
   store i128 %v, ptr %o, align 16
@@ -977,11 +974,12 @@ define ptr @i128_m1(ptr %p, i128 %v) {
 ;
 ; CHECK-ARM-LABEL: i128_m1:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    str r2, [r0, #-1]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
-; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vldr d16, [sp]
+; CHECK-ARM-NEXT:    mvn r1, #7
+; CHECK-ARM-NEXT:    str r3, [r0, #3]
+; CHECK-ARM-NEXT:    add r0, r0, #7
+; CHECK-ARM-NEXT:    vst1.32 {d16}, [r0:64], r1
+; CHECK-ARM-NEXT:    str r2, [r0]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 -1
   store i128 %v, ptr %o, align 16
@@ -1011,10 +1009,11 @@ define ptr @i128_m4(ptr %p, i128 %v) {
 ;
 ; CHECK-ARM-LABEL: i128_m4:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
-; CHECK-ARM-NEXT:    str r3, [r0]
-; CHECK-ARM-NEXT:    stmib r0, {r1, r12}
-; CHECK-ARM-NEXT:    str r2, [r0, #-4]!
+; CHECK-ARM-NEXT:    vldr d16, [sp]
+; CHECK-ARM-NEXT:    mvn r1, #7
+; CHECK-ARM-NEXT:    str r3, [r0], #4
+; CHECK-ARM-NEXT:    vst1.32 {d16}, [r0:64], r1
+; CHECK-ARM-NEXT:    str r2, [r0]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 -4
   store i128 %v, ptr %o, align 16

--- a/llvm/test/CodeGen/ARM/store-preinc.ll
+++ b/llvm/test/CodeGen/ARM/store-preinc.ll
@@ -808,10 +808,11 @@ define ptr @i128_0(ptr %p, i128 %v) {
 ;
 ; CHECK-ARM-LABEL: i128_0:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
-; CHECK-ARM-NEXT:    stm r0, {r2, r3}
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vldr d16, [sp]
+; CHECK-ARM-NEXT:    mov r1, r3
+; CHECK-ARM-NEXT:    str r2, [r0]
+; CHECK-ARM-NEXT:    str r1, [r0, #4]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   store i128 %v, ptr %p, align 16
   ret ptr %p
@@ -842,10 +843,9 @@ define ptr @i128_3(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_3:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #3]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 3
   store i128 %v, ptr %o, align 16
@@ -876,10 +876,9 @@ define ptr @i128_4(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_4:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #4]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 4
   store i128 %v, ptr %o, align 16
@@ -910,10 +909,9 @@ define ptr @i128_8(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_8:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #8]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 8
   store i128 %v, ptr %o, align 16
@@ -944,10 +942,9 @@ define ptr @i128_16(ptr %p, i128 %v) {
 ; CHECK-ARM-LABEL: i128_16:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    str r2, [r0, #16]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
+; CHECK-ARM-NEXT:    vldr d16, [sp]
 ; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vstr d16, [r0, #8]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 16
   store i128 %v, ptr %o, align 16
@@ -977,11 +974,12 @@ define ptr @i128_m1(ptr %p, i128 %v) {
 ;
 ; CHECK-ARM-LABEL: i128_m1:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    str r2, [r0, #-1]!
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
-; CHECK-ARM-NEXT:    str r3, [r0, #4]
-; CHECK-ARM-NEXT:    str r1, [r0, #8]
-; CHECK-ARM-NEXT:    str r12, [r0, #12]
+; CHECK-ARM-NEXT:    vldr d16, [sp]
+; CHECK-ARM-NEXT:    mvn r1, #7
+; CHECK-ARM-NEXT:    str r3, [r0, #3]
+; CHECK-ARM-NEXT:    add r0, r0, #7
+; CHECK-ARM-NEXT:    vst1.32 {d16}, [r0:64], r1
+; CHECK-ARM-NEXT:    str r2, [r0]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 -1
   store i128 %v, ptr %o, align 16
@@ -1011,10 +1009,11 @@ define ptr @i128_m4(ptr %p, i128 %v) {
 ;
 ; CHECK-ARM-LABEL: i128_m4:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    ldm sp, {r1, r12}
-; CHECK-ARM-NEXT:    str r3, [r0]
-; CHECK-ARM-NEXT:    stmib r0, {r1, r12}
-; CHECK-ARM-NEXT:    str r2, [r0, #-4]!
+; CHECK-ARM-NEXT:    vldr d16, [sp]
+; CHECK-ARM-NEXT:    mvn r1, #7
+; CHECK-ARM-NEXT:    str r3, [r0], #4
+; CHECK-ARM-NEXT:    vst1.32 {d16}, [r0:64], r1
+; CHECK-ARM-NEXT:    str r2, [r0]
 ; CHECK-ARM-NEXT:    bx lr
   %o = getelementptr inbounds i8, ptr %p, i32 -4
   store i128 %v, ptr %o, align 16

--- a/llvm/test/CodeGen/ARM/strictfp_f16_abi_promote.ll
+++ b/llvm/test/CodeGen/ARM/strictfp_f16_abi_promote.ll
@@ -218,17 +218,20 @@ define void @outgoing_v4f16_return(ptr %ptr) #0 {
 define void @outgoing_v8f16_return(ptr %ptr) #0 {
 ; NOFP16-LABEL: outgoing_v8f16_return:
 ; NOFP16:       @ %bb.0:
-; NOFP16-NEXT:    push {r4, r10, r11, lr}
+; NOFP16-NEXT:    push {r4, r5, r11, lr}
 ; NOFP16-NEXT:    add r11, sp, #8
 ; NOFP16-NEXT:    sub sp, sp, #16
 ; NOFP16-NEXT:    bfc sp, #0, #4
+; NOFP16-NEXT:    mov r5, sp
 ; NOFP16-NEXT:    mov r4, r0
-; NOFP16-NEXT:    mov r0, sp
+; NOFP16-NEXT:    mov r0, r5
 ; NOFP16-NEXT:    bl v8f16_result
-; NOFP16-NEXT:    ldm sp, {r0, r1, r2, r3}
-; NOFP16-NEXT:    stm r4, {r0, r1, r2, r3}
+; NOFP16-NEXT:    vld1.32 {d16}, [r5:64]!
+; NOFP16-NEXT:    vldr d17, [r5]
+; NOFP16-NEXT:    vst1.32 {d16}, [r4:64]!
+; NOFP16-NEXT:    vstr d17, [r4]
 ; NOFP16-NEXT:    sub sp, r11, #8
-; NOFP16-NEXT:    pop {r4, r10, r11, pc}
+; NOFP16-NEXT:    pop {r4, r5, r11, pc}
   %val = call <8 x half> @v8f16_result() #0
   store <8 x half> %val, ptr %ptr
   ret void

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/memcall.ll
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/memcall.ll
@@ -156,24 +156,20 @@ for.body:                                         ; preds = %entry, %for.body
 define void @test_memcpy16(ptr nocapture %x, ptr nocapture readonly %y, i32 %n) {
 ; CHECK-LABEL: test_memcpy16:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, lr}
-; CHECK-NEXT:    push {r4, lr}
+; CHECK-NEXT:    .save {r7, lr}
+; CHECK-NEXT:    push {r7, lr}
 ; CHECK-NEXT:    cmp r2, #1
 ; CHECK-NEXT:    it lt
-; CHECK-NEXT:    poplt {r4, pc}
+; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB3_1: @ %for.body.preheader
 ; CHECK-NEXT:    dls lr, r2
 ; CHECK-NEXT:  .LBB3_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    ldm.w r1, {r2, r3, r12}
-; CHECK-NEXT:    ldr r4, [r1, #12]
-; CHECK-NEXT:    adds r1, #64
-; CHECK-NEXT:    stm.w r0, {r2, r3, r12}
-; CHECK-NEXT:    str r4, [r0, #12]
-; CHECK-NEXT:    adds r0, #64
+; CHECK-NEXT:    vldrw.u32 q0, [r1], #64
+; CHECK-NEXT:    vstrb.8 q0, [r0], #64
 ; CHECK-NEXT:    le lr, .LBB3_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
-; CHECK-NEXT:    pop {r4, pc}
+; CHECK-NEXT:    pop {r7, pc}
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.cond.cleanup
@@ -203,12 +199,10 @@ define void @test_memset16(ptr nocapture %x, i32 %n) {
 ; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB4_1: @ %for.body.preheader
 ; CHECK-NEXT:    dls lr, r1
-; CHECK-NEXT:    movs r1, #0
+; CHECK-NEXT:    vmov.i32 q0, #0x0
 ; CHECK-NEXT:  .LBB4_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    strd r1, r1, [r0]
-; CHECK-NEXT:    strd r1, r1, [r0, #8]
-; CHECK-NEXT:    adds r0, #64
+; CHECK-NEXT:    vstrb.8 q0, [r0], #64
 ; CHECK-NEXT:    le lr, .LBB4_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
 ; CHECK-NEXT:    pop {r7, pc}
@@ -232,24 +226,20 @@ for.body:                                         ; preds = %entry, %for.body
 define void @test_memmove16(ptr nocapture %x, ptr nocapture readonly %y, i32 %n) {
 ; CHECK-LABEL: test_memmove16:
 ; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    .save {r4, lr}
-; CHECK-NEXT:    push {r4, lr}
+; CHECK-NEXT:    .save {r7, lr}
+; CHECK-NEXT:    push {r7, lr}
 ; CHECK-NEXT:    cmp r2, #1
 ; CHECK-NEXT:    it lt
-; CHECK-NEXT:    poplt {r4, pc}
+; CHECK-NEXT:    poplt {r7, pc}
 ; CHECK-NEXT:  .LBB5_1: @ %for.body.preheader
 ; CHECK-NEXT:    dls lr, r2
 ; CHECK-NEXT:  .LBB5_2: @ %for.body
 ; CHECK-NEXT:    @ =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    ldm.w r1, {r2, r3, r12}
-; CHECK-NEXT:    ldr r4, [r1, #12]
-; CHECK-NEXT:    adds r1, #64
-; CHECK-NEXT:    stm.w r0, {r2, r3, r12}
-; CHECK-NEXT:    str r4, [r0, #12]
-; CHECK-NEXT:    adds r0, #64
+; CHECK-NEXT:    vldrw.u32 q0, [r1], #64
+; CHECK-NEXT:    vstrb.8 q0, [r0], #64
 ; CHECK-NEXT:    le lr, .LBB5_2
 ; CHECK-NEXT:  @ %bb.3: @ %for.cond.cleanup
-; CHECK-NEXT:    pop {r4, pc}
+; CHECK-NEXT:    pop {r7, pc}
 entry:
   %cmp6 = icmp sgt i32 %n, 0
   br i1 %cmp6, label %for.body, label %for.cond.cleanup

--- a/llvm/test/CodeGen/Thumb2/shift_parts.ll
+++ b/llvm/test/CodeGen/Thumb2/shift_parts.ll
@@ -240,16 +240,27 @@ entry:
 %struct.b = type { i184 }
 
 define void @lsll_256bit_shift(ptr nocapture %x) local_unnamed_addr #0 {
-; CHECK-LABEL: lsll_256bit_shift:
-; CHECK:       @ %bb.0: @ %entry
-; CHECK-NEXT:    movs r1, #0
-; CHECK-NEXT:    str r1, [r0, #16]
-; CHECK-NEXT:    strd r1, r1, [r0, #8]
-; CHECK-NEXT:    strd r1, r1, [r0]
-; CHECK-NEXT:    ldrb r1, [r0, #23]
-; CHECK-NEXT:    lsls r1, r1, #24
-; CHECK-NEXT:    str r1, [r0, #20]
-; CHECK-NEXT:    bx lr
+; CHECK-MVE-LABEL: lsll_256bit_shift:
+; CHECK-MVE:       @ %bb.0: @ %entry
+; CHECK-MVE-NEXT:    movs r1, #0
+; CHECK-MVE-NEXT:    vmov.i32 q0, #0x0
+; CHECK-MVE-NEXT:    str r1, [r0, #16]
+; CHECK-MVE-NEXT:    vstrw.32 q0, [r0]
+; CHECK-MVE-NEXT:    ldrb r1, [r0, #23]
+; CHECK-MVE-NEXT:    lsls r1, r1, #24
+; CHECK-MVE-NEXT:    str r1, [r0, #20]
+; CHECK-MVE-NEXT:    bx lr
+;
+; CHECK-NON-MVE-LABEL: lsll_256bit_shift:
+; CHECK-NON-MVE:       @ %bb.0: @ %entry
+; CHECK-NON-MVE-NEXT:    movs r1, #0
+; CHECK-NON-MVE-NEXT:    str r1, [r0, #16]
+; CHECK-NON-MVE-NEXT:    strd r1, r1, [r0, #8]
+; CHECK-NON-MVE-NEXT:    strd r1, r1, [r0]
+; CHECK-NON-MVE-NEXT:    ldrb r1, [r0, #23]
+; CHECK-NON-MVE-NEXT:    lsls r1, r1, #24
+; CHECK-NON-MVE-NEXT:    str r1, [r0, #20]
+; CHECK-NON-MVE-NEXT:    bx lr
 entry:
   %bf.load = load i192, ptr %x, align 8
   %bf.clear4 = and i192 %bf.load, -24519928653854221733733552434404946937899825954937634816


### PR DESCRIPTION
Needs more refinement for some regressions but in other cases, there seems to be a strong benefit.