### PR TITLE
[clang][driver][darwin] Hold onto full triples in Darwin SDKPlatformInfo

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -36,32 +36,16 @@ public:
   /// definitions, in the SDK.
   struct SDKPlatformInfo {
   public:
-    SDKPlatformInfo(llvm::Triple::VendorType Vendor, llvm::Triple::OSType OS,
-                    llvm::Triple::EnvironmentType Environment,
-                    llvm::Triple::ObjectFormatType ObjectFormat,
-                    StringRef PlatformPrefix)
-        : Vendor(Vendor), OS(OS), Environment(Environment),
-          ObjectFormat(ObjectFormat), PlatformPrefix(PlatformPrefix) {}
+    using TripleStorageType = SmallVector<llvm::Triple, 5>;
 
-    llvm::Triple::VendorType getVendor() const { return Vendor; }
-    llvm::Triple::OSType getOS() const { return OS; }
-    llvm::Triple::EnvironmentType getEnvironment() const { return Environment; }
-    llvm::Triple::ObjectFormatType getObjectFormat() const {
-      return ObjectFormat;
-    }
+    SDKPlatformInfo(TripleStorageType Triples, StringRef PlatformPrefix)
+        : Triples(std::move(Triples)), PlatformPrefix(PlatformPrefix) {}
+
+    const TripleStorageType &getTriples() const { return Triples; }
     StringRef getPlatformPrefix() const { return PlatformPrefix; }
 
-    bool operator==(const llvm::Triple &RHS) const {
-      return (Vendor == RHS.getVendor()) && (OS == RHS.getOS()) &&
-             (Environment == RHS.getEnvironment()) &&
-             (ObjectFormat == RHS.getObjectFormat());
-    }
-
   private:
-    llvm::Triple::VendorType Vendor;
-    llvm::Triple::OSType OS;
-    llvm::Triple::EnvironmentType Environment;
-    llvm::Triple::ObjectFormatType ObjectFormat;
+    TripleStorageType Triples;
     std::string PlatformPrefix;
   };
 
@@ -190,11 +174,21 @@ public:
           VersionMappings =
               llvm::DenseMap<OSEnvPair::StorageType,
                              std::optional<RelatedTargetVersionMapping>>())
-      : FilePath(FilePath), OS(OS), Environment(Environment), Version(Version),
-        DisplayName(DisplayName),
+      : FilePath(std::move(FilePath)), OS(OS), Environment(Environment),
+        Version(Version), DisplayName(DisplayName),
         MaximumDeploymentTarget(MaximumDeploymentTarget),
         PlatformInfos(std::move(PlatformInfos)),
         VersionMappings(std::move(VersionMappings)) {}
+
+  /// Construct SDK Info inferred from the parameters rather than read from
+  /// SDKSettings.json.
+  ///
+  /// This will infer \c PlatformInfos from an SDK for the OS/Environment that
+  /// predates the introduction of SDKSettings.json, and will not infer version
+  /// mappings.
+  DarwinSDKInfo(llvm::Triple::OSType OS,
+                llvm::Triple::EnvironmentType Environment, VersionTuple Version,
+                StringRef DisplayName, VersionTuple MaximumDeploymentTarget);
 
   StringRef getFilePath() const { return FilePath; }
 
@@ -206,19 +200,18 @@ public:
 
   const StringRef getDisplayName() const { return DisplayName; }
 
-  const SDKPlatformInfo &getCanonicalPlatformInfo() const {
-    return PlatformInfos[0];
+  const llvm::Triple &getCanonicalPlatformTriple() const {
+    return PlatformInfos[0].getTriples()[0];
   }
 
-  bool supportsTriple(llvm::Triple Triple) const {
-    return llvm::find(PlatformInfos, Triple) != PlatformInfos.end();
+  bool supportsTriple(const llvm::Triple &Triple) const {
+    return getPlatformInfo(Triple) != nullptr;
   }
 
-  const StringRef getPlatformPrefix(llvm::Triple Triple) const {
-    auto PlatformInfoIt = llvm::find(PlatformInfos, Triple);
-    if (PlatformInfoIt == PlatformInfos.end())
-      return StringRef();
-    return PlatformInfoIt->getPlatformPrefix();
+  StringRef getPlatformPrefix(const llvm::Triple &Triple) const {
+    if (const SDKPlatformInfo *PlatformInfo = getPlatformInfo(Triple))
+      return PlatformInfo->getPlatformPrefix();
+    return StringRef();
   }
 
   // Returns the optional, target-specific version mapping that maps from one
@@ -244,6 +237,15 @@ public:
                              const llvm::json::Object *Obj);
 
 private:
+  const SDKPlatformInfo *getPlatformInfo(const llvm::Triple &Triple) const {
+    for (const SDKPlatformInfo &PlatformInfo : PlatformInfos) {
+      const auto &Triples = PlatformInfo.getTriples();
+      if (llvm::find(Triples, Triple) != Triples.end())
+        return &PlatformInfo;
+    }
+    return nullptr;
+  }
+
   std::string FilePath;
   llvm::Triple::OSType OS;
   llvm::Triple::EnvironmentType Environment;

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -100,39 +100,117 @@ parseOSAndEnvironment(std::optional<StringRef> XcodePlatform) {
   return {OS, Environment};
 }
 
+static DarwinSDKInfo::PlatformInfoStorageType
+legacyPlatformInfos(llvm::Triple::OSType SDKOS,
+                    llvm::Triple::EnvironmentType SDKEnvironment) {
+  DarwinSDKInfo::PlatformInfoStorageType PlatformInfos;
+  // Synthesize platform infos for older SDKs from the first SDKs with
+  // SupportedTargets: macOS 10.15 (DriverKit 19.0), iOS 13.0, tvOS 13.0,
+  // watchOS 6.0. Older SDKs (especially iOS) most likely supported armv6 and
+  // armv7 architectures that aren't listed here and are difficult to identify
+  // from the SDK.
+  switch (SDKOS) {
+  case llvm::Triple::MacOSX:
+    PlatformInfos.push_back({{llvm::Triple("x86_64-apple-macosx")}, ""});
+    // macOS 10.15 also has a Mac Catalyst supported target, but Mac Catalyst
+    // was new in that version so omit it for older versions.
+    break;
+  case llvm::Triple::DriverKit:
+    // DriverKit 19.0 only had SDKSettings.plist, which isn't used. So this code
+    // path is used in 19.x as well, not just earlier versions.
+    PlatformInfos.push_back(
+        {{llvm::Triple("x86_64-apple-driverkit")}, "/System/DriverKit"});
+    break;
+  case llvm::Triple::IOS:
+    switch (SDKEnvironment) {
+    case llvm::Triple::UnknownEnvironment:
+      PlatformInfos.push_back(
+          {{llvm::Triple("armv7-apple-ios"), llvm::Triple("armv7s-apple-ios"),
+            llvm::Triple("arm64-apple-ios")},
+           ""});
+      break;
+    case llvm::Triple::Simulator:
+      PlatformInfos.push_back(
+          {{llvm::Triple("x86_64-apple-ios-simulator")}, ""});
+      break;
+    default:
+      break;
+    }
+    break;
+  case llvm::Triple::TvOS:
+    switch (SDKEnvironment) {
+    case llvm::Triple::UnknownEnvironment:
+      PlatformInfos.push_back({{llvm::Triple("arm64-apple-tvos")}, ""});
+      break;
+    case llvm::Triple::Simulator:
+      PlatformInfos.push_back(
+          {{llvm::Triple("x86_64-apple-tvos-simulator")}, ""});
+      break;
+    default:
+      break;
+    }
+    break;
+  case llvm::Triple::WatchOS:
+    switch (SDKEnvironment) {
+    case llvm::Triple::UnknownEnvironment:
+      PlatformInfos.push_back({{llvm::Triple("armv7k-apple-watchos"),
+                                llvm::Triple("arm64_32-apple-watchos")},
+                               ""});
+      break;
+    case llvm::Triple::Simulator:
+      PlatformInfos.push_back(
+          {{llvm::Triple("x86_64-apple-watchos-simulator")}, ""});
+      break;
+    default:
+      break;
+    }
+    break;
+  case llvm::Triple::BridgeOS:
+    PlatformInfos.push_back({{llvm::Triple("armv7-apple-bridgeos"),
+                              llvm::Triple("armv7s-apple-bridgeos"),
+                              llvm::Triple("arm64-apple-bridgeos")},
+                             ""});
+    break;
+  default:
+    break;
+  }
+  return PlatformInfos;
+}
+
 static DarwinSDKInfo::PlatformInfoStorageType parsePlatformInfos(
     const llvm::json::Object &Obj, std::optional<StringRef> XcodePlatform,
     llvm::Triple::OSType SDKOS, llvm::Triple::EnvironmentType SDKEnvironment,
     VersionTuple Version) {
   DarwinSDKInfo::PlatformInfoStorageType PlatformInfos;
   auto SupportedTargets = Obj.getObject("SupportedTargets");
-  if (!SupportedTargets) {
-    // For older SDKs that don't have SupportedTargets, infer one from the SDK's
-    // OS/Environment.
-    StringRef PlatformPrefix;
-    if (SDKOS == llvm::Triple::DriverKit)
-      PlatformPrefix = "/System/DriverKit";
-    PlatformInfos.push_back({llvm::Triple::Apple, SDKOS, SDKEnvironment,
-                             llvm::Triple::MachO, PlatformPrefix});
-    return PlatformInfos;
-  }
+  if (!SupportedTargets)
+    return legacyPlatformInfos(SDKOS, SDKEnvironment);
 
-  for (auto SupportedTargetPair : *SupportedTargets) {
-    llvm::json::Object *SupportedTarget =
+  for (const auto &SupportedTargetPair : *SupportedTargets) {
+    const llvm::json::Object *SupportedTarget =
         SupportedTargetPair.getSecond().getAsObject();
-    auto Vendor = SupportedTarget->getString("LLVMTargetTripleVendor");
-    auto OS = SupportedTarget->getString("LLVMTargetTripleSys");
-    if (!Vendor || !OS)
+    if (!SupportedTarget)
       continue;
 
-    StringRef Arch = llvm::Triple::getArchName(llvm::Triple::UnknownArch);
+    auto Archs = SupportedTarget->getArray("Archs");
+    auto Vendor = SupportedTarget->getString("LLVMTargetTripleVendor");
+    auto OS = SupportedTarget->getString("LLVMTargetTripleSys");
+    if (!Archs || !Vendor || !OS)
+      continue;
+
+    DarwinSDKInfo::SDKPlatformInfo::TripleStorageType Triples;
     auto Environment =
         SupportedTarget->getString("LLVMTargetTripleEnvironment");
-    llvm::Triple Triple;
-    if (Environment)
-      Triple = llvm::Triple(Arch, *Vendor, *OS, *Environment);
-    else
-      Triple = llvm::Triple(Arch, *Vendor, *OS);
+    for (const auto &ArchValue : *Archs) {
+      if (auto Arch = ArchValue.getAsString()) {
+        if (Environment)
+          Triples.emplace_back(*Arch, *Vendor, *OS, *Environment);
+        else
+          Triples.emplace_back(*Arch, *Vendor, *OS);
+      }
+    }
+    if (Triples.empty())
+      continue;
 
     // The key is either the Xcode platform, or a variant. The platform must be
     // the first entry in the returned PlatformInfoStorageType.
@@ -147,19 +225,17 @@ static DarwinSDKInfo::PlatformInfoStorageType parsePlatformInfos(
       } else {
         // Older SDKs don't have SystemPrefix in SupportedTargets, manually add
         // their prefixes.
-        if ((Triple.getOS() == llvm::Triple::DriverKit) &&
+        if ((Triples[0].getOS() == llvm::Triple::DriverKit) &&
             (Version < VersionTuple(22, 1)))
           EffectivePlatformPrefix = "/System/DriverKit";
       }
     }
 
-    DarwinSDKInfo::SDKPlatformInfo PlatformInfo(
-        Triple.getVendor(), Triple.getOS(), Triple.getEnvironment(),
-        Triple.getObjectFormat(), EffectivePlatformPrefix);
     if (PlatformOrVariant == XcodePlatform)
-      PlatformInfos.insert(PlatformInfos.begin(), PlatformInfo);
+      PlatformInfos.insert(PlatformInfos.begin(),
+                           {std::move(Triples), EffectivePlatformPrefix});
     else
-      PlatformInfos.push_back(PlatformInfo);
+      PlatformInfos.emplace_back(std::move(Triples), EffectivePlatformPrefix);
   }
   return PlatformInfos;
 }
@@ -265,3 +341,11 @@ clang::parseDarwinSDKInfo(llvm::vfs::FileSystem &VFS, StringRef SDKRootPath) {
   return llvm::make_error<llvm::StringError>("invalid SDKSettings.json",
                                              llvm::inconvertibleErrorCode());
 }
+
+DarwinSDKInfo::DarwinSDKInfo(llvm::Triple::OSType OS,
+                             llvm::Triple::EnvironmentType Environment,
+                             VersionTuple Version, StringRef DisplayName,
+                             VersionTuple MaximumDeploymentTarget)
+    : DarwinSDKInfo("", OS, Environment, Version, DisplayName,
+                    MaximumDeploymentTarget,
+                    legacyPlatformInfos(OS, Environment)) {}

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1214,7 +1214,7 @@ AppleMachO::~AppleMachO() {}
 MachO::~MachO() {}
 
 void Darwin::VerifyTripleForSDK(const llvm::opt::ArgList &Args,
-                                const llvm::Triple Triple) const {
+                                const llvm::Triple &Triple) const {
   if (SDKInfo) {
     if (!SDKInfo->supportsTriple(Triple))
       getDriver().Diag(diag::warn_incompatible_sysroot)
@@ -2035,15 +2035,14 @@ struct DarwinPlatform {
   }
   static DarwinPlatform createFromSDKInfo(StringRef SDKRoot,
                                           const DarwinSDKInfo &SDKInfo) {
-    const DarwinSDKInfo::SDKPlatformInfo PlatformInfo =
-        SDKInfo.getCanonicalPlatformInfo();
-    const llvm::Triple::OSType OS = PlatformInfo.getOS();
+    const llvm::Triple &PlatformTriple = SDKInfo.getCanonicalPlatformTriple();
+    const llvm::Triple::OSType OS = PlatformTriple.getOS();
     VersionTuple Version = SDKInfo.getVersion();
     if (OS == llvm::Triple::MacOSX)
       Version = getVersionFromString(
           getSystemOrSDKMacOSVersion(Version.getAsString()));
     DarwinPlatform Result(InferredFromSDK, getPlatformFromOS(OS), Version);
-    Result.Environment = getEnvKindFromEnvType(PlatformInfo.getEnvironment());
+    Result.Environment = getEnvKindFromEnvType(PlatformTriple.getEnvironment());
     Result.InferSimulatorFromArch = false;
     Result.InferredSource = SDKRoot;
     return Result;
@@ -2076,15 +2075,10 @@ struct DarwinPlatform {
     llvm::Triple::OSType OS = getOSFromPlatform(Platform);
     llvm::Triple::EnvironmentType EnvironmentType =
         getEnvTypeFromEnvKind(Environment);
-    StringRef PlatformPrefix =
-        (Platform == DarwinPlatformKind::DriverKit) ? "/System/DriverKit" : "";
-    return DarwinSDKInfo("", OS, EnvironmentType, getOSVersion(),
+    return DarwinSDKInfo(OS, EnvironmentType, getOSVersion(),
                          getDisplayName(Platform, Environment, getOSVersion()),
                          /*MaximumDeploymentTarget=*/
-                         VersionTuple(getOSVersion().getMajor(), 0, 99),
-                         {DarwinSDKInfo::SDKPlatformInfo(
-                             llvm::Triple::Apple, OS, EnvironmentType,
-                             llvm::Triple::MachO, PlatformPrefix)});
+                         VersionTuple(getOSVersion().getMajor(), 0, 99));
   }
 
 private:

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -389,7 +389,7 @@ private:
   void AddDeploymentTarget(llvm::opt::DerivedArgList &Args) const;
 
   void VerifyTripleForSDK(const llvm::opt::ArgList &Args,
-                          const llvm::Triple Triple) const;
+                          const llvm::Triple &Triple) const;
 
 protected:
   /// Lazily initialize the target platform from the triple when

--- a/clang/unittests/Basic/DarwinSDKInfoTest.cpp
+++ b/clang/unittests/Basic/DarwinSDKInfoTest.cpp
@@ -107,8 +107,8 @@ TEST(DarwinSDKInfo, PlatformPrefix) {
   ASSERT_TRUE(SDKInfo);
   EXPECT_EQ(SDKInfo->getPlatformPrefix(Triple("arm64-apple-macos26.0")),
             "/System/macOSSupport");
-  // The triple's architecture doesn't matter.
-  EXPECT_EQ(SDKInfo->getPlatformPrefix(Triple("ppc-apple-macos26.0")),
+  // The triple's architecture matters.
+  EXPECT_NE(SDKInfo->getPlatformPrefix(Triple("ppc-apple-macos26.0")),
             "/System/macOSSupport");
   // OSes that aren't specified in the SDK never get a system prefix.
   EXPECT_EQ(SDKInfo->getPlatformPrefix(Triple("arm64-apple-ios26.0")), "");


### PR DESCRIPTION
The architecture can be relevant when determining if an SDK supports a particular triple. Record the full triples in SDKPlatformInfo instead of all of the non-architecture triple components.

Assisted-by: Claude Code

rdar://172876443