### PR TITLE
[flang][docs][nfc] Wordsmith -frelaxed-c-loc-checks flag description

### DIFF
--- a/clang/include/clang/Options/FlangOptions.td
+++ b/clang/include/clang/Options/FlangOptions.td
@@ -279,16 +279,14 @@ defm unsafe_cray_pointers : BoolOptionWithoutMarshalling<"f", "unsafe-cray-point
   PosFlag<SetTrue, [], [FlangOption, FC1Option], "Optimizations allow for unsafe Cray pointer usages">,
   NegFlag<SetFalse, [], [FlangOption, FC1Option], "Optimizations don't allow for unsafe Cray pointer usages (default)">>;
 
-def relaxed_c_loc : Flag<["-"], "frelaxed-c-loc">, Group<f_Group>,
+def relaxed_c_loc : Flag<["-"], "frelaxed-c-loc-checks">, Group<f_Group>,
   Visibility<[FlangOption, FC1Option]>,
-  HelpText<"Unsafe relaxation of C_LOC() argument restrictions for compatibility">,
+  HelpText<"Allow a data object or function pointer as the C_LOC() argument">,
   DocBrief<[{
-    Unsafe relaxation of C_LOC() argument restrictions for compatibility.
-    All C_LOC values should be passed directly to C calls.
-
-    This is unsafe, because it can be used to create aliases the compiler
-    is unaware of, please fix your applications instead of using this flag.
-    This may be removed in the future.}]>;
+    Allow a data object or function pointer as the C_LOC() argument
+    (not just pointers/targets). The compiler cannot reason about aliases
+    created through non-target non-pointer arguments and may generate
+    incorrect code if such aliases are used in Fortran code.}]>;
 
 def fhermetic_module_files : Flag<["-"], "fhermetic-module-files">, Group<f_Group>,
   HelpText<"Emit hermetic module files (no nested USE association)">;

--- a/clang/include/clang/Options/FlangOptions.td
+++ b/clang/include/clang/Options/FlangOptions.td
@@ -284,9 +284,9 @@ def relaxed_c_loc : Flag<["-"], "frelaxed-c-loc-checks">, Group<f_Group>,
   HelpText<"Allow a data object or function pointer as the C_LOC() argument">,
   DocBrief<[{
     Allow a data object or function pointer as the C_LOC() argument
-    (not just pointers/targets). The compiler cannot reason about aliases
-    created through non-target non-pointer arguments and may generate
-    incorrect code if such aliases are used in Fortran code.}]>;
+    (not just pointers/targets). The compiler will not reason about aliases
+    created through non-target non-pointer arguments and code generated
+    using such aliases may exhibit unexpected behavior.}]>;
 
 def fhermetic_module_files : Flag<["-"], "fhermetic-module-files">, Group<f_Group>,
   HelpText<"Emit hermetic module files (no nested USE association)">;

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -528,10 +528,10 @@ end program
   fixed-width input field.  Includes the case with only an
   exponent letter for compatibility with other compilers.
 * Allow a data object or function pointer as the `C_LOC()`
-  argument (not just pointers/targets). The compiler cannot
+  argument (not just pointers/targets). The compiler will not
   reason about aliases created through non-target non-pointer
-  arguments and may generate incorrect code if such aliases
-  are used in Fortran code. This is for compatibility with
+  arguments and code generated using such aliases may exhibit
+  unexpected behavior. This is for compatibility with
   legacy code; legacy code should be updated to be correct.
   This could be removed at any time.
   [-frelaxed-c-loc-checks]

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -527,12 +527,14 @@ end program
 * Default exponent of zero, e.g. `3.14159E`, on a READ from a
   fixed-width input field.  Includes the case with only an
   exponent letter for compatibility with other compilers.
-* Relax some restrictions to make `C_LOC` more like `LOC` for
-  compatibility with legacy code that should be fixed. This is
-  unsafe and can be used to create aliases that the compiler
-  does not know about. Locations obtained this way should be
-  passed directly to C code. This could be removed at any time.
-  [-frelaxed-c-loc]
+* Allow a data object or function pointer as the `C_LOC()`
+  argument (not just pointers/targets). The compiler cannot
+  reason about aliases created through non-target non-pointer
+  arguments and may generate incorrect code if such aliases
+  are used in Fortran code. This is for compatibility with
+  legacy code; legacy code should be updated to be correct.
+  This could be removed at any time.
+  [-frelaxed-c-loc-checks]
 
 ### Extensions and legacy features deliberately not supported
 

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -868,7 +868,7 @@ static bool parseFrontendArgs(FrontendOptions &opts, llvm::opt::ArgList &args,
                        args.hasFlag(clang::options::OPT_funsigned,
                                     clang::options::OPT_fno_unsigned, false));
 
-  // -frelaxed-c-loc
+  // -frelaxed-c-loc-checks
   if (args.hasArg(clang::options::OPT_relaxed_c_loc)) {
     opts.features.Enable(Fortran::common::LanguageFeature::RelaxedCLoc);
   }

--- a/flang/test/Semantics/c_loc01-relaxed.f90
+++ b/flang/test/Semantics/c_loc01-relaxed.f90
@@ -1,4 +1,4 @@
-! RUN: %python %S/test_errors.py %s %flang_fc1 -frelaxed-c-loc
+! RUN: %python %S/test_errors.py %s %flang_fc1 -frelaxed-c-loc-checks
 module m
   use iso_c_binding
   type haslen(L)


### PR DESCRIPTION
Clarify that unexpected behavior reflects the compiler's design choice
not to track aliases from non-target non-pointer C_LOC() arguments,
rather than implying a compiler defect. Align phrasing across
FlangOptions.td and Extensions.md.

Also add the `-checks` suffix to the flag per @sscalpone's suggestion.