### PR TITLE
[lldb] Move GetSelectedTarget from Debugger to CommandInterpreter (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -196,10 +196,6 @@ public:
   // GetSourceManager on the target instead.
   SourceManager &GetSourceManager();
 
-  lldb::TargetSP GetSelectedTarget() {
-    return m_target_list.GetSelectedTarget();
-  }
-
   /// Get the execution context representing the selected entities in the
   /// selected target. If no target is selected, the execution context will
   /// contain the dummy target if adopt_dummy_target is true.

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -470,6 +470,14 @@ public:
 
   Debugger &GetDebugger() { return m_debugger; }
 
+  /// Get the target selected by the user at the command line. All commands
+  /// should prefer this over any other notion of a "current" target, so that
+  /// the user's explicit `target select` stays authoritative within the
+  /// command layer. Non-command code should use the execution context instead.
+  lldb::TargetSP GetSelectedTarget() {
+    return m_debugger.GetTargetList().GetSelectedTarget();
+  }
+
   ExecutionContext GetExecutionContext() const;
 
   lldb::PlatformSP GetPlatform(bool prefer_target_platform);

--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -383,7 +383,7 @@ SBProcess SBCommandInterpreter::GetProcess() {
   SBProcess sb_process;
   ProcessSP process_sp;
   if (IsValid()) {
-    TargetSP target_sp(m_opaque_ptr->GetDebugger().GetSelectedTarget());
+    TargetSP target_sp(m_opaque_ptr->GetSelectedTarget());
     if (target_sp) {
       std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
       process_sp = target_sp->GetProcessSP();
@@ -471,7 +471,7 @@ void SBCommandInterpreter::SourceInitFileInGlobalDirectory(
 
   result.Clear();
   if (IsValid()) {
-    TargetSP target_sp(m_opaque_ptr->GetDebugger().GetSelectedTarget());
+    TargetSP target_sp(m_opaque_ptr->GetSelectedTarget());
     std::unique_lock<std::recursive_mutex> lock;
     if (target_sp)
       lock = std::unique_lock<std::recursive_mutex>(target_sp->GetAPIMutex());
@@ -494,7 +494,7 @@ void SBCommandInterpreter::SourceInitFileInHomeDirectory(
 
   result.Clear();
   if (IsValid()) {
-    TargetSP target_sp(m_opaque_ptr->GetDebugger().GetSelectedTarget());
+    TargetSP target_sp(m_opaque_ptr->GetSelectedTarget());
     std::unique_lock<std::recursive_mutex> lock;
     if (target_sp)
       lock = std::unique_lock<std::recursive_mutex>(target_sp->GetAPIMutex());
@@ -510,7 +510,7 @@ void SBCommandInterpreter::SourceInitFileInCurrentWorkingDirectory(
 
   result.Clear();
   if (IsValid()) {
-    TargetSP target_sp(m_opaque_ptr->GetDebugger().GetSelectedTarget());
+    TargetSP target_sp(m_opaque_ptr->GetSelectedTarget());
     std::unique_lock<std::recursive_mutex> lock;
     if (target_sp)
       lock = std::unique_lock<std::recursive_mutex>(target_sp->GetAPIMutex());

--- a/lldb/source/API/SBDebugger.cpp
+++ b/lldb/source/API/SBDebugger.cpp
@@ -526,7 +526,8 @@ void SBDebugger::HandleCommand(const char *command) {
   LLDB_INSTRUMENT_VA(this, command);
 
   if (m_opaque_sp) {
-    TargetSP target_sp(m_opaque_sp->GetSelectedTarget());
+    TargetSP target_sp(
+        m_opaque_sp->GetCommandInterpreter().GetSelectedTarget());
     std::unique_lock<std::recursive_mutex> lock;
     if (target_sp)
       lock = std::unique_lock<std::recursive_mutex>(target_sp->GetAPIMutex());

--- a/lldb/source/Commands/CommandCompletions.cpp
+++ b/lldb/source/Commands/CommandCompletions.cpp
@@ -335,7 +335,7 @@ void CommandCompletions::SourceFiles(CommandInterpreter &interpreter,
   SourceFileCompleter completer(interpreter, request);
 
   if (searcher == nullptr) {
-    lldb::TargetSP target_sp = interpreter.GetDebugger().GetSelectedTarget();
+    lldb::TargetSP target_sp = interpreter.GetSelectedTarget();
     SearchFilterForUnconstrainedSearches null_searcher(target_sp);
     completer.DoCompletion(&null_searcher);
   } else {
@@ -549,7 +549,7 @@ void CommandCompletions::Modules(CommandInterpreter &interpreter,
   ModuleCompleter completer(interpreter, request);
 
   if (searcher == nullptr) {
-    lldb::TargetSP target_sp = interpreter.GetDebugger().GetSelectedTarget();
+    lldb::TargetSP target_sp = interpreter.GetSelectedTarget();
     SearchFilterForUnconstrainedSearches null_searcher(target_sp);
     completer.DoCompletion(&null_searcher);
   } else {
@@ -581,7 +581,7 @@ void CommandCompletions::Symbols(CommandInterpreter &interpreter,
   SymbolCompleter completer(interpreter, request);
 
   if (searcher == nullptr) {
-    lldb::TargetSP target_sp = interpreter.GetDebugger().GetSelectedTarget();
+    lldb::TargetSP target_sp = interpreter.GetSelectedTarget();
     SearchFilterForUnconstrainedSearches null_searcher(target_sp);
     completer.DoCompletion(&null_searcher);
   } else {
@@ -652,7 +652,7 @@ void CommandCompletions::Registers(CommandInterpreter &interpreter,
 void CommandCompletions::Breakpoints(CommandInterpreter &interpreter,
                                      CompletionRequest &request,
                                      SearchFilter *searcher) {
-  lldb::TargetSP target = interpreter.GetDebugger().GetSelectedTarget();
+  lldb::TargetSP target = interpreter.GetSelectedTarget();
   if (!target)
     return;
 
@@ -683,7 +683,7 @@ void CommandCompletions::Breakpoints(CommandInterpreter &interpreter,
 void CommandCompletions::BreakpointNames(CommandInterpreter &interpreter,
                                          CompletionRequest &request,
                                          SearchFilter *searcher) {
-  lldb::TargetSP target = interpreter.GetDebugger().GetSelectedTarget();
+  lldb::TargetSP target = interpreter.GetSelectedTarget();
   if (!target)
     return;
 

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -494,7 +494,7 @@ may even involve JITing and running code in the target program.)");
       // Access the default max-depth from the target. This is because
       // GetRepeatCommand is called before ParseOptions, which is when
       // m_varobj_options.max_depth becomes assigned.
-      if (auto target_sp = GetDebugger().GetSelectedTarget()) {
+      if (auto target_sp = GetCommandInterpreter().GetSelectedTarget()) {
         auto [default_depth, _] =
             target_sp->GetMaximumDepthOfChildrenToDisplay();
         // Insert the depth after `frame variable`, before positional args.

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -250,14 +250,14 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
 
-    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
+    Target *target = &GetTarget();
+    if (target->IsDummyTarget())
+      target = nullptr;
     PlatformSP platform_sp;
-    if (target) {
+    if (target)
       platform_sp = target->GetPlatform();
-    }
-    if (!platform_sp) {
+    if (!platform_sp)
       platform_sp = GetDebugger().GetPlatformList().GetSelectedPlatform();
-    }
     if (platform_sp) {
       platform_sp->GetStatus(ostrm);
       result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -1071,11 +1071,8 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
-    PlatformSP platform_sp;
-    if (target) {
-      platform_sp = target->GetPlatform();
-    }
+    Target *target = &GetTarget();
+    PlatformSP platform_sp = target->GetPlatform();
     if (!platform_sp) {
       platform_sp = GetDebugger().GetPlatformList().GetSelectedPlatform();
     }
@@ -1083,7 +1080,6 @@ protected:
     if (platform_sp) {
       Status error;
       const size_t argc = args.GetArgumentCount();
-      Target *target = m_exe_ctx.GetTargetPtr();
       Module *exe_module = target->GetExecutableModulePointer();
       if (exe_module) {
         m_options.launch_info.GetExecutableFile() = exe_module->GetFileSpec();
@@ -1223,7 +1219,9 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
+    Target *target = &GetTarget();
+    if (target->IsDummyTarget())
+      target = nullptr;
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();
@@ -1470,7 +1468,9 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
+    Target *target = &GetTarget();
+    if (target->IsDummyTarget())
+      target = nullptr;
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -250,7 +250,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
 
-    Target *target = GetDebugger().GetSelectedTarget().get();
+    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();
@@ -1071,7 +1071,7 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = GetDebugger().GetSelectedTarget().get();
+    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();
@@ -1223,7 +1223,7 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = GetDebugger().GetSelectedTarget().get();
+    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();
@@ -1470,7 +1470,7 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = GetDebugger().GetSelectedTarget().get();
+    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -143,7 +143,7 @@ public:
 
 protected:
   void DoExecute(Args &launch_args, CommandReturnObject &result) override {
-    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
+    Target *target = &GetTarget();
     // If our listener is nullptr, users aren't allows to launch
     ModuleSP exe_module_sp = target->GetExecutableModule();
 
@@ -313,7 +313,9 @@ protected:
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
 
-    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
+    Target *target = &GetTarget();
+    if (target->IsDummyTarget())
+      target = nullptr;
     // N.B. The attach should be synchronous.  It doesn't help much to get the
     // prompt back between initiating the attach and the target actually
     // stopping.  So even if the interpreter is set to be asynchronous, we wait
@@ -915,15 +917,16 @@ protected:
     Status error;
     Debugger &debugger = GetDebugger();
     PlatformSP platform_sp = m_interpreter.GetPlatform(true);
-    Target *selected_target = GetCommandInterpreter().GetSelectedTarget().get();
+    Target *target = &GetTarget();
+    if (target->IsDummyTarget())
+      target = nullptr;
     ProcessSP process_sp =
         debugger.GetAsyncExecution()
             ? platform_sp->ConnectProcess(command.GetArgumentAtIndex(0),
-                                          plugin_name, debugger,
-                                          selected_target, error)
+                                          plugin_name, debugger, target, error)
             : platform_sp->ConnectProcessSynchronous(
                   command.GetArgumentAtIndex(0), plugin_name, debugger,
-                  result.GetOutputStream(), selected_target, error);
+                  result.GetOutputStream(), target, error);
     if (error.Fail() || process_sp == nullptr) {
       result.AppendError(error.AsCString("Error connecting to the process"));
     }

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -143,8 +143,7 @@ public:
 
 protected:
   void DoExecute(Args &launch_args, CommandReturnObject &result) override {
-    Debugger &debugger = GetDebugger();
-    Target *target = debugger.GetSelectedTarget().get();
+    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
     // If our listener is nullptr, users aren't allows to launch
     ModuleSP exe_module_sp = target->GetExecutableModule();
 
@@ -314,7 +313,7 @@ protected:
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
 
-    Target *target = GetDebugger().GetSelectedTarget().get();
+    Target *target = GetCommandInterpreter().GetSelectedTarget().get();
     // N.B. The attach should be synchronous.  It doesn't help much to get the
     // prompt back between initiating the attach and the target actually
     // stopping.  So even if the interpreter is set to be asynchronous, we wait
@@ -916,15 +915,15 @@ protected:
     Status error;
     Debugger &debugger = GetDebugger();
     PlatformSP platform_sp = m_interpreter.GetPlatform(true);
+    Target *selected_target = GetCommandInterpreter().GetSelectedTarget().get();
     ProcessSP process_sp =
         debugger.GetAsyncExecution()
-            ? platform_sp->ConnectProcess(
-                  command.GetArgumentAtIndex(0), plugin_name, debugger,
-                  debugger.GetSelectedTarget().get(), error)
+            ? platform_sp->ConnectProcess(command.GetArgumentAtIndex(0),
+                                          plugin_name, debugger,
+                                          selected_target, error)
             : platform_sp->ConnectProcessSynchronous(
                   command.GetArgumentAtIndex(0), plugin_name, debugger,
-                  result.GetOutputStream(), debugger.GetSelectedTarget().get(),
-                  error);
+                  result.GetOutputStream(), selected_target, error);
     if (error.Fail() || process_sp == nullptr) {
       result.AppendError(error.AsCString("Error connecting to the process"));
     }

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4973,8 +4973,8 @@ protected:
     //  First step, make the specifier.
     std::unique_ptr<SymbolContextSpecifier> specifier_up;
     if (m_options.m_sym_ctx_specified) {
-      specifier_up = std::make_unique<SymbolContextSpecifier>(
-          GetCommandInterpreter().GetSelectedTarget());
+      specifier_up =
+          std::make_unique<SymbolContextSpecifier>(target.shared_from_this());
 
       if (!m_options.m_module_name.empty()) {
         specifier_up->AddSpecification(
@@ -5616,8 +5616,8 @@ protected:
 
     // Set up symbol context specifier if filter options were provided.
     if (m_options.m_sym_ctx_specified) {
-      auto specifier_up = std::make_unique<SymbolContextSpecifier>(
-          GetCommandInterpreter().GetSelectedTarget());
+      auto specifier_up =
+          std::make_unique<SymbolContextSpecifier>(target.shared_from_this());
 
       if (!m_options.m_module_name.empty())
         specifier_up->AddSpecification(

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -4974,7 +4974,7 @@ protected:
     std::unique_ptr<SymbolContextSpecifier> specifier_up;
     if (m_options.m_sym_ctx_specified) {
       specifier_up = std::make_unique<SymbolContextSpecifier>(
-          GetDebugger().GetSelectedTarget());
+          GetCommandInterpreter().GetSelectedTarget());
 
       if (!m_options.m_module_name.empty()) {
         specifier_up->AddSpecification(
@@ -5617,7 +5617,7 @@ protected:
     // Set up symbol context specifier if filter options were provided.
     if (m_options.m_sym_ctx_specified) {
       auto specifier_up = std::make_unique<SymbolContextSpecifier>(
-          GetDebugger().GetSelectedTarget());
+          GetCommandInterpreter().GetSelectedTarget());
 
       if (!m_options.m_module_name.empty())
         specifier_up->AddSpecification(

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2764,7 +2764,7 @@ public:
 protected:
   void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
-    TargetSP target_sp = GetCommandInterpreter().GetSelectedTarget();
+    Target *target = &GetTarget();
     Thread *thread = GetDefaultThread();
     if (!thread) {
       result.AppendError("no default thread");
@@ -2775,13 +2775,13 @@ protected:
         thread->GetSelectedFrame(DoNoSelectMostRelevantFrame);
     ValueObjectSP result_valobj_sp;
     EvaluateExpressionOptions options;
-    lldb::ExpressionResults expr_result = target_sp->EvaluateExpression(
+    lldb::ExpressionResults expr_result = target->EvaluateExpression(
         command, frame_sp.get(), result_valobj_sp, options);
     if (expr_result == eExpressionCompleted && result_valobj_sp) {
       result_valobj_sp =
           result_valobj_sp->GetQualifiedRepresentationIfAvailable(
-              target_sp->GetPreferDynamicValue(),
-              target_sp->GetEnableSyntheticValue());
+              target->GetPreferDynamicValue(),
+              target->GetEnableSyntheticValue());
       typename FormatterType::SharedPointer formatter_sp =
           m_discovery_function(*result_valobj_sp);
       if (formatter_sp) {

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2764,7 +2764,7 @@ public:
 protected:
   void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
-    TargetSP target_sp = GetDebugger().GetSelectedTarget();
+    TargetSP target_sp = GetCommandInterpreter().GetSelectedTarget();
     Thread *thread = GetDefaultThread();
     if (!thread) {
       result.AppendError("no default thread");

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1308,7 +1308,7 @@ Debugger::GetSelectedExecutionContext(bool adopt_dummy_target) {
 
 ExecutionContextRef
 Debugger::GetSelectedExecutionContextRef(bool adopt_dummy_target) {
-  if (TargetSP selected_target_sp = GetSelectedTarget())
+  if (TargetSP selected_target_sp = m_target_list.GetSelectedTarget())
     return ExecutionContextRef(selected_target_sp.get(),
                                /*adopt_selected=*/true);
 

--- a/lldb/source/Core/IOHandlerCursesGUI.cpp
+++ b/lldb/source/Core/IOHandlerCursesGUI.cpp
@@ -2962,7 +2962,10 @@ public:
   // Get the basename of the target's main executable if available, empty string
   // otherwise.
   std::string GetDefaultProcessName() {
-    Target *target = m_debugger.GetSelectedTarget().get();
+    Target *target = m_debugger
+                         .GetSelectedExecutionContext(
+                             /*adopt_dummy_target=*/false)
+                         .GetTargetPtr();
     if (target == nullptr)
       return "";
 
@@ -2997,7 +3000,10 @@ public:
   }
 
   Target *GetTarget() {
-    Target *target = m_debugger.GetSelectedTarget().get();
+    Target *target = m_debugger
+                         .GetSelectedExecutionContext(
+                             /*adopt_dummy_target=*/false)
+                         .GetTargetPtr();
 
     if (target != nullptr)
       return target;
@@ -3355,7 +3361,10 @@ public:
   // Methods for setting the default value of the fields.
 
   void SetArgumentsFieldDefaultValue() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return;
 
@@ -3365,7 +3374,10 @@ public:
   }
 
   void SetTargetEnvironmentFieldDefaultValue() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return;
 
@@ -3374,7 +3386,10 @@ public:
   }
 
   void SetInheritedEnvironmentFieldDefaultValue() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return;
 
@@ -3385,7 +3400,10 @@ public:
   }
 
   std::string GetDefaultWorkingDirectory() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return "";
 
@@ -3394,7 +3412,10 @@ public:
   }
 
   bool GetDefaultDisableASLR() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return false;
 
@@ -3402,7 +3423,10 @@ public:
   }
 
   bool GetDefaultDisableStandardIO() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return true;
 
@@ -3410,7 +3434,10 @@ public:
   }
 
   bool GetDefaultDetachOnError() {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (target == nullptr)
       return true;
 
@@ -3421,7 +3448,10 @@ public:
   // ProcessLaunchInfo.
 
   void GetExecutableSettings(ProcessLaunchInfo &launch_info) {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     ModuleSP executable_module = target->GetExecutableModule();
     llvm::StringRef target_settings_argv0 = target->GetArg0();
 
@@ -3437,7 +3467,10 @@ public:
   }
 
   void GetArguments(ProcessLaunchInfo &launch_info) {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     Args arguments = m_arguments_field->GetArguments();
     launch_info.GetArguments().AppendArguments(arguments);
   }
@@ -3488,7 +3521,10 @@ public:
     if (!m_arch_field->IsSpecified())
       return;
 
-    TargetSP target_sp = m_debugger.GetSelectedTarget();
+    TargetSP target_sp = m_debugger
+                             .GetSelectedExecutionContext(
+                                 /*adopt_dummy_target=*/false)
+                             .GetTargetSP();
     PlatformSP platform_sp =
         target_sp ? target_sp->GetPlatform() : PlatformSP();
     launch_info.GetArchitecture() = Platform::GetAugmentedArchSpec(
@@ -3529,7 +3565,11 @@ public:
   }
 
   void GetInheritTCC(ProcessLaunchInfo &launch_info) {
-    if (m_debugger.GetSelectedTarget()->GetInheritTCC())
+    if (Target *target = m_debugger
+                             .GetSelectedExecutionContext(
+                                 /*adopt_dummy_target=*/false)
+                             .GetTargetPtr();
+        target && target->GetInheritTCC())
       launch_info.GetFlags().Set(eLaunchFlagInheritTCCFromParent);
   }
 
@@ -3576,7 +3616,10 @@ public:
   }
 
   Target *GetTarget() {
-    Target *target = m_debugger.GetSelectedTarget().get();
+    Target *target = m_debugger
+                         .GetSelectedExecutionContext(
+                             /*adopt_dummy_target=*/false)
+                         .GetTargetPtr();
 
     if (target == nullptr) {
       SetError("No target exists!");
@@ -5469,7 +5512,10 @@ public:
   ~BreakpointTreeDelegate() override = default;
 
   BreakpointSP GetBreakpoint(const TreeItem &item) {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     BreakpointList &breakpoints = target->GetBreakpointList(false);
     return breakpoints.GetBreakpointAtIndex(item.GetIdentifier());
   }
@@ -5514,7 +5560,10 @@ public:
   ~BreakpointsTreeDelegate() override = default;
 
   bool TreeDelegateShouldDraw() override {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
     if (!target)
       return false;
 
@@ -5526,7 +5575,10 @@ public:
   }
 
   void TreeDelegateGenerateChildren(TreeItem &item) override {
-    TargetSP target = m_debugger.GetSelectedTarget();
+    TargetSP target = m_debugger
+                          .GetSelectedExecutionContext(
+                              /*adopt_dummy_target=*/false)
+                          .GetTargetSP();
 
     BreakpointList &breakpoints = target->GetBreakpointList(false);
     std::unique_lock<std::recursive_mutex> lock;

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -779,7 +779,7 @@ Thread *CommandObject::GetDefaultThread() {
   if (!process) {
     Target *target = m_exe_ctx.GetTargetPtr();
     if (!target) {
-      target = m_interpreter.GetDebugger().GetSelectedTarget().get();
+      target = m_interpreter.GetSelectedTarget().get();
     }
     if (target)
       process = target->GetProcessSP().get();

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -741,8 +741,7 @@ void Options::HandleOptionArgumentCompletion(
             request.GetParsedLine().GetArgumentAtIndex(cur_arg_pos);
         if (module_name) {
           FileSpec module_spec(module_name);
-          lldb::TargetSP target_sp =
-              interpreter.GetDebugger().GetSelectedTarget();
+          lldb::TargetSP target_sp = interpreter.GetSelectedTarget();
           // Search filters require a target...
           if (target_sp)
             filter_up =

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -196,7 +196,7 @@ DebuggerResourceProvider::ReadTargetResource(llvm::StringRef uri,
   target_resource.target_idx = target_idx;
   target_resource.arch = target_sp->GetArchitecture().GetTriple().str();
   target_resource.dummy = target_sp->IsDummyTarget();
-  target_resource.selected = target_sp == debugger_sp->GetSelectedTarget();
+  target_resource.selected = target_sp == target_list.GetSelectedTarget();
 
   if (Module *exe_module = target_sp->GetExecutableModulePointer())
     target_resource.path = exe_module->GetFileSpec().GetPath();

--- a/lldb/unittests/Core/DebuggerTest.cpp
+++ b/lldb/unittests/Core/DebuggerTest.cpp
@@ -57,7 +57,7 @@ TEST_F(DebuggerTest,
   DebuggerSP debugger_sp = Debugger::CreateInstance();
 
   // No targets have been added, so no target is selected.
-  ASSERT_EQ(debugger_sp->GetSelectedTarget().get(), nullptr);
+  ASSERT_EQ(debugger_sp->GetTargetList().GetSelectedTarget().get(), nullptr);
 
   Target &dummy_target = debugger_sp->GetDummyTarget();
 


### PR DESCRIPTION
The notion of a "selected target" is something that belongs at the command layer rather than the debugger layer. Jim and I were discussing how this is a foot-gun and I suggested moving it into the CommandInterpreter. Everyone else that needs to get their hands on the current target should do so through the execution context. The latter is trivial to swap out if the "selected one" isn't what you should be operating on.