### PR TITLE
[lldb] Fix data race on Process::FindPlugin's unique-id counter

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -410,7 +410,7 @@ ProcessSP Process::FindPlugin(lldb::TargetSP target_sp,
                               ListenerSP listener_sp,
                               const FileSpec *crash_file_path,
                               bool can_connect) {
-  static uint32_t g_process_unique_id = 0;
+  static std::atomic<uint32_t> g_process_unique_id{0};
 
   ProcessSP process_sp;
   ProcessCreateInstance create_callback = nullptr;


### PR DESCRIPTION
g_process_unique_id is a function-local static used to hand out unique IDs to each Process. It was a plain uint32_t, so concurrent SBTarget::LoadCore / Target::CreateProcess calls raced on the increment.

Make it std::atomic<uint32_t>. Prefix operator++ on std::atomic is already an atomic fetch_add that returns the new value, so the call sites are unchanged.

Found by ThreadSanitizer as part of #197792.