### PR TITLE
[lldb] Fix data race on ValueObject's unique-id counter

### DIFF
--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Support/Compiler.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
@@ -75,7 +76,7 @@ class SymbolContextScope;
 using namespace lldb;
 using namespace lldb_private;
 
-static user_id_t g_value_obj_uid = 0;
+static std::atomic<user_id_t> g_value_obj_uid{0};
 
 // FIXME: this will return true for vector types whose elements
 // are floats. Audit all usages of this function and call


### PR DESCRIPTION
g_value_obj_uid is a file-scope static that hands out unique IDs to every ValueObject. It was a plain user_id_t, so concurrent SBTarget::FindGlobalVariables / EvaluateExpression calls raced on the increment.

Make it std::atomic<user_id_t>. Prefix operator++ on std::atomic is already an atomic fetch_add that returns the new value, so the call sites are unchanged.

Found by ThreadSanitizer as part of #197792.