### PR TITLE
[lldb] Fix data race on ThreadPlan::GetNextID's plan-ID counter

### DIFF
--- a/lldb/source/Target/ThreadPlan.cpp
+++ b/lldb/source/Target/ThreadPlan.cpp
@@ -16,6 +16,8 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/State.h"
 
+#include <atomic>
+
 using namespace lldb;
 using namespace lldb_private;
 
@@ -144,7 +146,7 @@ bool ThreadPlan::WillResume(StateType resume_state, bool current_plan) {
 }
 
 lldb::user_id_t ThreadPlan::GetNextID() {
-  static uint32_t g_nextPlanID = 0;
+  static std::atomic<uint32_t> g_nextPlanID{0};
   return ++g_nextPlanID;
 }
 


### PR DESCRIPTION
`g_nextPlanID` is a function-local static used to hand out unique ThreadPlan IDs. It was a plain uint32_t, so concurrent ThreadPlan constructors (e.g. each Process's private state thread queueing its base plan) raced on the increment.

Make it std::atomic<uint32_t>. Prefix operator++ on std::atomic is already an atomic fetch_add that returns the new value, so the call sites are unchanged.

Found by ThreadSanitizer as part of #197792.