### PR TITLE
[lldb] Fix data race in ObjectFile::GetSectionList

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -779,6 +779,12 @@ protected:
   /// need to use a std::unique_ptr to a llvm::once_flag so if we clear the
   /// symbol table, we can have a new once flag to use when it is created again.
   std::unique_ptr<llvm::once_flag> m_symtab_once_up;
+  /// Same rationale as m_symtab_once_up: taking the module mutex in
+  /// GetSectionList would deadlock against DWARF indexing workers. Use a
+  /// per-ObjectFile recursive mutex instead, since CreateSections in some
+  /// plugins (e.g. ELF's .gnu_debugdata path) re-enters GetSectionList on
+  /// the same ObjectFile.
+  std::recursive_mutex m_sections_mutex;
   std::optional<uint32_t> m_cache_hash;
 
   /// Sets the architecture for a module.  At present the architecture can

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -771,7 +771,10 @@ protected:
   lldb::ProcessWP m_process_wp;
   /// Set if the object file only exists in memory.
   const lldb::addr_t m_memory_addr;
+
   std::unique_ptr<lldb_private::SectionList> m_sections_up;
+  std::recursive_mutex m_sections_mutex;
+
   std::unique_ptr<lldb_private::Symtab> m_symtab_up;
   /// We need a llvm::once_flag that we can use to avoid locking the module
   /// lock and deadlocking LLDB. See comments in ObjectFile::GetSymtab() for
@@ -779,12 +782,6 @@ protected:
   /// need to use a std::unique_ptr to a llvm::once_flag so if we clear the
   /// symbol table, we can have a new once flag to use when it is created again.
   std::unique_ptr<llvm::once_flag> m_symtab_once_up;
-  /// Same rationale as m_symtab_once_up: taking the module mutex in
-  /// GetSectionList would deadlock against DWARF indexing workers. Use a
-  /// per-ObjectFile recursive mutex instead, since CreateSections in some
-  /// plugins (e.g. ELF's .gnu_debugdata path) re-enters GetSectionList on
-  /// the same ObjectFile.
-  std::recursive_mutex m_sections_mutex;
   std::optional<uint32_t> m_cache_hash;
 
   /// Sets the architecture for a module.  At present the architecture can

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -603,20 +603,19 @@ void ObjectFile::ClearSymtab() {
 }
 
 SectionList *ObjectFile::GetSectionList(bool update_module_section_list) {
-  if (update_module_section_list) {
-    ModuleSP module_sp(GetModule());
-    if (module_sp) {
-      // The module mutex guards m_sections_up: check and populate under the
-      // lock so concurrent first-time initialization from multiple threads
-      // that share this Module doesn't race.
-      std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
-      if (m_sections_up == nullptr)
-        CreateSections(*module_sp->GetUnifiedSectionList());
-      return m_sections_up.get();
-    }
+  // Don't take the module lock here: DWARF indexing workers call into this
+  // path while the main thread holds the module lock during PreloadSymbols,
+  // which would deadlock. See ObjectFile::GetSymtab() for the analogous
+  // pattern. Use a per-ObjectFile recursive mutex instead, since some plugin
+  // implementations of CreateSections re-enter GetSectionList on the same
+  // ObjectFile (e.g. ObjectFileELF's .gnu_debugdata path).
+  std::lock_guard<std::recursive_mutex> guard(m_sections_mutex);
+  if (m_sections_up)
     return m_sections_up.get();
-  }
-  if (m_sections_up == nullptr) {
+  if (update_module_section_list) {
+    if (ModuleSP module_sp = GetModule())
+      CreateSections(*module_sp->GetUnifiedSectionList());
+  } else {
     SectionList unified_section_list;
     CreateSections(unified_section_list);
   }

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -603,17 +603,22 @@ void ObjectFile::ClearSymtab() {
 }
 
 SectionList *ObjectFile::GetSectionList(bool update_module_section_list) {
-  if (m_sections_up == nullptr) {
-    if (update_module_section_list) {
-      ModuleSP module_sp(GetModule());
-      if (module_sp) {
-        std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
+  if (update_module_section_list) {
+    ModuleSP module_sp(GetModule());
+    if (module_sp) {
+      // The module mutex guards m_sections_up: check and populate under the
+      // lock so concurrent first-time initialization from multiple threads
+      // that share this Module doesn't race.
+      std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
+      if (m_sections_up == nullptr)
         CreateSections(*module_sp->GetUnifiedSectionList());
-      }
-    } else {
-      SectionList unified_section_list;
-      CreateSections(unified_section_list);
+      return m_sections_up.get();
     }
+    return m_sections_up.get();
+  }
+  if (m_sections_up == nullptr) {
+    SectionList unified_section_list;
+    CreateSections(unified_section_list);
   }
   return m_sections_up.get();
 }

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -603,18 +603,14 @@ void ObjectFile::ClearSymtab() {
 }
 
 SectionList *ObjectFile::GetSectionList(bool update_module_section_list) {
-  // Don't take the module lock here: DWARF indexing workers call into this
-  // path while the main thread holds the module lock during PreloadSymbols,
-  // which would deadlock. See ObjectFile::GetSymtab() for the analogous
-  // pattern. Use a per-ObjectFile recursive mutex instead, since some plugin
-  // implementations of CreateSections re-enter GetSectionList on the same
-  // ObjectFile (e.g. ObjectFileELF's .gnu_debugdata path).
   std::lock_guard<std::recursive_mutex> guard(m_sections_mutex);
   if (m_sections_up)
     return m_sections_up.get();
   if (update_module_section_list) {
-    if (ModuleSP module_sp = GetModule())
+    if (ModuleSP module_sp = GetModule()) {
+      std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
       CreateSections(*module_sp->GetUnifiedSectionList());
+    }
   } else {
     SectionList unified_section_list;
     CreateSections(unified_section_list);


### PR DESCRIPTION
The early `m_sections_up == nullptr` check was performed outside the module mutex, so two threads sharing the same Module could both enter the branch and race on the write in CreateSections. Restructure so the check and populate both happen under the module mutex; this is a standard double-checked locking fix.

Found by ThreadSanitizer as part of #197792.