### PR TITLE
[lldb] Fix data race in UnwindTable::Initialize

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindTable.h
+++ b/lldb/include/lldb/Symbol/UnwindTable.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_SYMBOL_UNWINDTABLE_H
 #define LLDB_SYMBOL_UNWINDTABLE_H
 
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -75,11 +76,10 @@ private:
   Module &m_module;
   collection m_unwinds;
 
-  bool m_scanned_all_unwind_sources; // true when we have looked at the
-                                     // ObjectFile and SymbolFile for all
-                                     // sources of unwind information; false if
-                                     // we haven't done that yet, or one of the
-                                     // files has been updated in the Module.
+  /// This is true when we have looked at the ObjectFile and SymbolFile for all
+  /// sources of unwind information; false if we haven't done that yet, or one
+  /// of the files has been updated in the Module.
+  std::atomic<bool> m_scanned_all_unwind_sources;
   std::mutex m_mutex;
 
   std::unique_ptr<CallFrameInfo> m_object_file_unwind_up;


### PR DESCRIPTION
UnwindTable::Initialize uses double-checked locking (DCL) against m_scanned_all_unwind_sources, but the flag was a plain bool. The fast-path read outside the mutex is unsynchronized with the write inside the mutex, so concurrent first-time callers can observe partially initialized state.

Make m_scanned_all_unwind_sources std::atomic<bool>. The default memory ordering (seq_cst) is sufficient for the DCL pattern used here.

Found by ThreadSanitizer as part of #197792.