### PR TITLE
[dsymutil] Collect .cas-config files in dSYM bundles

### DIFF
--- a/llvm/test/tools/dsymutil/AArch64/cas-config.test
+++ b/llvm/test/tools/dsymutil/AArch64/cas-config.test
@@ -1,0 +1,36 @@
+# Verify that dsymutil collects .cas-config files in parent paths of
+# each debug map object and aggregates their contents into
+# Contents/Resources/CASConfigs.json inside the output dSYM bundle.
+
+# RUN: rm -rf %t.dir && mkdir -p %t.dir/sub
+# RUN: cp %p/../Inputs/DWARF5/1.o %t.dir/sub/1.o
+# RUN: echo '{"CASPath": "test-cas1"}' > %t.dir/sub/.cas-config
+# RUN: echo '{"CASPath": "test-cas2"}' > %t.dir/.cas-config
+
+# RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.dir/sub -o %t.dir/classic.dSYM
+# RUN: cat %t.dir/classic.dSYM/Contents/Resources/CASConfigs.json | FileCheck %s
+
+# RUN: rm -rf %t.dir/parallel.dSYM
+# RUN: dsymutil --linker parallel -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.dir/sub -o %t.dir/parallel.dSYM
+# RUN: cat %t.dir/parallel.dSYM/Contents/Resources/CASConfigs.json | FileCheck %s
+
+# CHECK: [
+# CHECK:   {"CASPath": "test-cas1"}
+# CHECK:   {"CASPath": "test-cas2"}
+# CHECK: ]
+
+# Without a .cas-config file present, no CASConfigs.json should be produced.
+
+# RUN: rm -rf %t.empty_classic && mkdir -p %t.empty_classic
+# RUN: cp %p/../Inputs/DWARF5/1.o %t.empty_classic/1.o
+# RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.empty_classic -o %t.empty_classic/out.dSYM
+# RUN: not ls %t.empty_classic/out.dSYM/Contents/Resources/CASConfigs.json
+
+# RUN: rm -rf %t.empty.parallel && mkdir -p %t.empty.parallel
+# RUN: cp %p/../Inputs/DWARF5/1.o %t.empty.parallel/1.o
+# RUN: dsymutil --linker classic -y %p/dummy-debug-map-arm64.map \
+# RUN:   -oso-prepend-path=%t.empty.parallel -o %t.empty.parallel/out.dSYM
+# RUN: not ls %t.empty.parallel/out.dSYM/Contents/Resources/CASConfigs.json

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -829,6 +829,54 @@ bool DwarfLinkerForBinary::linkImpl(
         MaxDWARFVersion = std::max(Unit.getVersion(), MaxDWARFVersion);
       };
 
+  if (Options.ResourceDir) {
+    // Collect .cas-config files. The build system might put these
+    // anywhere in the build directory, so dsymutil scans all parent
+    // paths of each object file. Their contents is a JSON dictionary,
+    // so this loop aggregates them in a JSON array.
+    llvm::StringSet<> VisitedPaths;
+    std::string CASConfigs = "[\n";
+    raw_string_ostream CASConfigStream(CASConfigs);
+    bool Found = false;
+    for (const auto &Obj : Map.objects()) {
+      StringRef ObjPath = Obj->getObjectFilename();
+      for (StringRef Dir = sys::path::parent_path(ObjPath); !Dir.empty();
+           Dir = sys::path::parent_path(Dir)) {
+        if (!VisitedPaths.insert(Dir).second)
+          break;
+
+        SmallString<256> CASConfigPath(Dir);
+        sys::path::append(CASConfigPath, ".cas-config");
+        auto BufferOrErr = MemoryBuffer::getFile(CASConfigPath);
+        if (!BufferOrErr)
+          continue;
+
+        CASConfigStream << (*BufferOrErr)->getBuffer() << ",\n";
+        Found = true;
+      }
+    }
+    CASConfigStream << "]\n";
+    if (Found) {
+      std::error_code EC;
+      SmallString<128> CASConfigsPath;
+      sys::path::append(CASConfigsPath, *Options.ResourceDir);
+      EC = sys::fs::create_directories(CASConfigsPath.str(), true,
+                                       sys::fs::perms::all_all);
+      if (EC) {
+        reportWarning("could not create directory '" + CASConfigsPath +
+                      "': " + EC.message());
+      } else {
+        sys::path::append(CASConfigsPath, "CASConfigs.json");
+        raw_fd_ostream OS(CASConfigsPath.str(), EC, sys::fs::OF_Text);
+        if (EC)
+          reportWarning("could not open '" + CASConfigsPath +
+                        "': " + EC.message());
+        else
+          OS << CASConfigs;
+      }
+    }
+  }
+
   llvm::StringSet<> SwiftModules;
   for (const auto &Obj : Map.objects()) {
     // N_AST objects (swiftmodule files) should get dumped directly into the
@@ -843,13 +891,13 @@ bool DwarfLinkerForBinary::linkImpl(
 
       auto ErrorOrMem = MemoryBuffer::getFile(File);
       if (!ErrorOrMem) {
-        reportWarning("Could not open '" + File + "'");
+        reportWarning("could not open '" + File + "'");
         continue;
       }
       auto FromInterfaceOrErr =
           IsBuiltFromSwiftInterface((*ErrorOrMem)->getBuffer());
       if (!FromInterfaceOrErr) {
-        reportWarning("Could not parse binary Swift module: " +
+        reportWarning("could not parse binary Swift module: " +
                           toString(FromInterfaceOrErr.takeError()),
                       Obj->getObjectFilename());
         // Only skip swiftmodules that could be parsed and are positively


### PR DESCRIPTION
When caching is enabled the Swift compiler might substitute CAS identifiers for on-disk paths. In order to resolve them the build system puts a .cas-config file in the build directory. Dsymutil needs to collect the contents of these files so tools consuming the dSYM (which do not have access to the original build directory) can resolve these CAS identifiers, too.

Assisted-by: claude

rdar://169986664