### PR TITLE
[flang][PPC] Improve vector type names in expression diagnostics (NFC)

### DIFF
--- a/flang/lib/Evaluate/formatting.cpp
+++ b/flang/lib/Evaluate/formatting.cpp
@@ -676,6 +676,9 @@ llvm::raw_ostream &StructureConstructor::AsFortran(llvm::raw_ostream &o) const {
 std::string DynamicType::AsFortran() const {
   if (derived_) {
     CHECK(category_ == TypeCategory::Derived);
+    if (derived_->IsVectorType()) {
+      return derived_->VectorTypeAsFortran();
+    }
     std::string result{DerivedTypeSpecAsFortran(*derived_)};
     if (IsPolymorphic()) {
       result = "CLASS("s + result + ')';

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -5538,7 +5538,9 @@ std::string ArgumentAnalyzer::TypeAsFortran(std::size_t i) {
         : type->IsUnlimitedPolymorphic() ? "CLASS(*)"s
         : type->IsPolymorphic()          ? type->AsFortran()
         : type->category() == TypeCategory::Derived
-        ? "TYPE("s + type->AsFortran() + ')'
+        ? (type->GetDerivedTypeSpec().IsVectorType()
+                  ? type->AsFortran()
+                  : "TYPE("s + type->AsFortran() + ')')
         : type->category() == TypeCategory::Character
         ? "CHARACTER(KIND="s + std::to_string(type->kind()) + ')'
         : ToUpperCase(type->AsFortran());

--- a/flang/test/Semantics/PowerPC/ppc-vector-diagnostics.f90
+++ b/flang/test/Semantics/PowerPC/ppc-vector-diagnostics.f90
@@ -1,0 +1,15 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1
+! REQUIRES: target=powerpc{{.*}}
+
+subroutine test_vector_add()
+  vector(integer(4)) :: v1, v2
+  !ERROR: Operands of + must be numeric; have vector(integer(4)) and vector(integer(4))
+  v1 = v1 + v2
+end subroutine
+
+subroutine test_vector_assignment()
+  vector(integer(4)) :: v1
+  vector(real(4)) :: v2
+  !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types vector(integer(4)) and vector(real(4))
+  v1 = v2
+end subroutine


### PR DESCRIPTION
## Summary

Improve Flang semantic diagnostics for vector types by printing vector type spellings in Fortran syntax instead of internal builtin-derived type names.

## Problem

Diagnostics for invalid operations on vector types currently display internal type names such as:

- `TYPE(_(element_category=0_4,element_kind=4_4))`
- `__builtin_ppc_intrinsic_vector(element_category=0_4,element_kind=4_4)`

This makes errors harder to read.

## Change

Use `DerivedTypeSpec::VectorTypeAsFortran()` when producing vector operand type names in `ArgumentAnalyzer::TypeAsFortran()`, instead of relying on the generic type formatting path.

This updates diagnostics to print vector types as Fortran source-like spellings, such as:
- `vector(integer(4))`
- `vector(real(4))`

while preserving the existing formatting for non-vector derived types.

## Examples

```text
vector(integer(4)) :: v1, v2
v1 = v1 + v2
end
```

Before:

```text
error: Operands of + must be numeric; have __builtin_ppc_intrinsic_vector(element_category=0_4,element_kind=4_4) and __builtin_ppc_intrinsic_vector(element_category=0_4,element_kind=4_4)
```

After:

```text
error: Operands of + must be numeric; have vector(integer(4)) and vector(integer(4))
```
---

```text
vector(integer(4)) :: v1
vector(real(4)) :: v2
v1 = v2
end
```

Before:

```text
error: No intrinsic or user-defined ASSIGNMENT(=) matches operand types __builtin_ppc_intrinsic_vector(element_category=0_4,element_kind=4_4) and __builtin_ppc_intrinsic_vector(element_category=2_4,element_kind=4_4)
```

After:

```text
error: No intrinsic or user-defined ASSIGNMENT(=) matches operand types vector(integer(4)) and vector(real(4))
```

## Testing

Tested invalid vector diagnostics for:
- numeric operators
- relational operators
- assignment mismatch

to confirm that vector operand types are now printed with the expected Fortran-style formatting.
