### PR TITLE
[CIR] Cast global var address to declared type at dtor call site

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -163,9 +163,22 @@ static void emitDeclDestroy(CIRGenFunction &cgf, const VarDecl *vd,
     // call right here.
     auto gd = GlobalDecl(dtor, Dtor_Complete);
     fnOp = cgm.getAddrAndTypeOfCXXStructor(gd).second;
+    // When a global has a constant initializer that fixes the active member
+    // of a union (e.g. an SSO short variant), CIR creates the global with
+    // the initializer's narrowed record type, so `getAddrOfGlobalVar` returns
+    // a pointer to the narrowed type rather than the variable's declared
+    // type.  Mirror the cast pattern from `emitGlobalVarDeclLValue` so the
+    // destructor receives a `this` pointer typed as the declared class.
+    mlir::Value thisAddr = cgm.getAddrOfGlobalVar(vd);
+    mlir::Type realVarTy = cgm.getTypes().convertTypeForMem(type);
+    cir::PointerType realPtrTy = cir::PointerType::get(
+        realVarTy,
+        mlir::cast<cir::PointerType>(thisAddr.getType()).getAddrSpace());
+    if (realPtrTy != thisAddr.getType())
+      thisAddr = builder.createBitcast(thisAddr.getLoc(), thisAddr, realPtrTy);
     builder.createCallOp(cgf.getLoc(vd->getSourceRange()),
                          mlir::FlatSymbolRefAttr::get(fnOp.getSymNameAttr()),
-                         mlir::ValueRange{cgm.getAddrOfGlobalVar(vd)});
+                         mlir::ValueRange{thisAddr});
     assert(fnOp && "expected cir.func");
     // TODO(cir): This doesn't do anything but check for unhandled conditions.
     // What it is meant to do should really be happening in LoweringPrepare.

--- a/clang/test/CIR/CodeGen/global-dtor-union-narrowed.cpp
+++ b/clang/test/CIR/CodeGen/global-dtor-union-narrowed.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s -o %t.cir 2> %t-before.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t-before.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -mconstructor-aliases -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct S {
+  struct Rep {
+    union {
+      char shortbuf[16];
+      struct { long sz; char *p; } longrep;
+    };
+    constexpr Rep() : shortbuf{} {}
+  } r;
+
+  constexpr S() : r() {}
+  ~S() {}
+};
+
+S g;
+
+// The dtor region must bitcast `@g`'s narrowed pointer back to `!rec_S`
+// before the dtor call.
+
+// CIR: !rec_S = !cir.record<struct "S"
+// CIR: cir.global external @g = #cir.zero : ![[NARROW_TY:rec_anon_struct[0-9]*]] dtor {
+// CIR:   %[[ADDR:.+]] = cir.get_global @g : !cir.ptr<![[NARROW_TY]]>
+// CIR:   %[[CAST:.+]] = cir.cast bitcast %[[ADDR]] : !cir.ptr<![[NARROW_TY]]> -> !cir.ptr<!rec_S>
+// CIR:   cir.call @_ZN1SD2Ev(%[[CAST]]) : (!cir.ptr<!rec_S>) -> ()
+// CIR: }
+
+// LLVM: @g = global { { { [16 x i8] } } } zeroinitializer
+// LLVM: define internal void @__cxx_global_array_dtor(ptr noundef %[[A0:.*]])
+// LLVM:   call void @_ZN1SD2Ev(ptr %[[A0]])
+// LLVM: define internal void @__cxx_global_var_init()
+// LLVM:   call void @__cxa_atexit(ptr @__cxx_global_array_dtor, ptr @g, ptr @__dso_handle)
+
+// OGCG: @g = global { { { [16 x i8] } } } zeroinitializer
+// OGCG: define internal void @__cxx_global_var_init()
+// OGCG:   call i32 @__cxa_atexit(ptr @_ZN1SD2Ev, ptr @g, ptr @__dso_handle)


### PR DESCRIPTION
A C++ global with a constexpr default constructor that fixes the active member of a union — `std::basic_string`'s SSO `__short` variant is a common example — has a `cir.global` whose stored record type is the narrowed shape of that active variant.  Classic CodeGen does the same (`@g = global { { { [16 x i8] } } } zeroinitializer`) and accepts the resulting `__cxa_atexit(@D1, @g, ...)` because LLVM IR uses opaque pointers.  CIR has typed pointers, so the `cir.call` registering the destructor for `__cxa_atexit` carries an operand type that doesn't match the dtor's `this` parameter.  This trips 16 libcxx tests and 71 cases total across libcxx, MultiSource, SingleSource, and SPEC in our build.

`verifyPointerTypeArgs(oldF, newF, userMap)` in `CIRGenModule::applyReplacements` (`clang/lib/CIR/CodeGen/CIRGenModule.cpp:1700`) catches this when ctor-dtor aliases are enabled and D1 is RAUW'd by D2.  Without aliases, the `cir.call` op verifier rejects the same operand-type mismatch directly.

The fix mirrors the cast pattern `emitGlobalVarDeclLValue` (`clang/lib/CIR/CodeGen/CIRGenExpr.cpp:441-445`) already uses for every AST-level reference to a global: bitcast the result of `getAddrOfGlobalVar` to `convertTypeForMem(type)` before any typed-pointer op consumes it.  `getAddrOfGlobalVar` itself stays raw so callers that walk to the underlying `GetGlobalOp` via `getDefiningOp()` keep working.

`global-dtor-union-narrowed.cpp` pins the CIR bitcast, the lowered LLVM helper-wrapped `__cxa_atexit`, and the equivalent OGCG direct `__cxa_atexit`.
