### PR TITLE
[CIR] Emit cir.bool constant for non-odr-use of bool member

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -2454,7 +2454,16 @@ mlir::Value ScalarExprEmitter::VisitMemberExpr(MemberExpr *e) {
   if (e->EvaluateAsInt(result, cgf.getContext(), Expr::SE_AllowSideEffects)) {
     llvm::APSInt value = result.Val.getInt();
     cgf.emitIgnoredExpr(e->getBase());
-    return builder.getConstInt(cgf.getLoc(e->getExprLoc()), value);
+    mlir::Location loc = cgf.getLoc(e->getExprLoc());
+    // The constant is folded from an APSInt with the source-type's bit width
+    // (1 for bool), but the AST's expression type is what later consumers of
+    // this value see. For a bool member we have to emit a !cir.bool constant
+    // -- otherwise downstream ops (cir.call into a bool parameter, cir.if /
+    // cir.ternary on the value, ...) would all reject the !cir.int<u, 1> the
+    // raw APSInt would produce.
+    if (e->getType()->isBooleanType())
+      return builder.getBool(value.getBoolValue(), loc);
+    return builder.getConstInt(loc, value);
   }
   return emitLoadOfLValue(e);
 }

--- a/clang/test/CIR/CodeGen/non-odr-use-const-bool.cpp
+++ b/clang/test/CIR/CodeGen/non-odr-use-const-bool.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct Foo { static const bool flag = true; };
+
+void take_bool(bool);
+extern int side();
+
+void pass_to_call(Foo x) {
+  take_bool(x.flag);
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z12pass_to_call3Foo
+// CIR:         %[[B_CALL:.+]] = cir.const #true
+// CIR:         cir.call @_Z9take_boolb(%[[B_CALL]]) : (!cir.bool{{.*}}) -> ()
+
+// LLVM-LABEL: define {{.*}} void @_Z12pass_to_call3Foo
+// LLVM:         call void @_Z9take_boolb(i1 {{.*}}true)
+
+// OGCG-LABEL: define {{.*}} void @_Z12pass_to_call3Foo
+// OGCG:         call void @_Z9take_boolb(i1 {{.*}}true)
+
+int use_in_if(Foo x) {
+  if (x.flag) return 1;
+  return 0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z9use_in_if3Foo
+// CIR:         %[[B_IF:.+]] = cir.const #true
+// CIR:         cir.if %[[B_IF]]
+
+// LLVM-LABEL: define {{.*}}i32 @_Z9use_in_if3Foo
+// LLVM:         br i1 true,
+
+// OGCG-LABEL: define {{.*}}i32 @_Z9use_in_if3Foo
+
+int short_circuit(Foo x) {
+  return (x.flag && side()) ? 1 : 0;
+}
+
+// CIR-LABEL: cir.func{{.*}} @_Z13short_circuit3Foo
+// CIR:         %[[B_TERN:.+]] = cir.const #true
+// CIR:         cir.ternary(%[[B_TERN]],
+
+// LLVM-LABEL: define {{.*}}i32 @_Z13short_circuit3Foo
+
+// OGCG-LABEL: define {{.*}}i32 @_Z13short_circuit3Foo


### PR DESCRIPTION
`ScalarExprEmitter::VisitMemberExpr` has a constant-folding shortcut: when an expression evaluates as a compile-time integer, it bypasses the LValue load and emits the constant directly via `builder.getConstInt(loc, APSInt)`. That builder helper derives the CIR result type from the APSInt's bit width — for a `bool` member that is `!cir.int<u, 1>`, while the AST expression type is `bool` which CIR maps to `!cir.bool`.

Downstream ops that consume the value all reject the mismatch: `cir.if` and `cir.ternary` need `!cir.bool` operands, and `cir.call` rejects `!cir.int<u, 1>` against a `!cir.bool` parameter (which surfaces as the `emitCall: widening integer call argument` NYI in `CIRGenCall.cpp`). The fix dispatches on `e->getType()->isBooleanType()` and emits through `builder.getBool()` so the constant is typed `!cir.bool` from the start. Non-bool integral members keep the prior code path. The dispatch mirrors what `tryEmitPrivate`'s `APValue::Int` branch already does at `CIRGenExprConstant.cpp:1816-1817`.

In SPEC CPU 2026 this fires from `gcc/wide-int.h`'s `is_sign_extended` template-static-bool plumbing. Before the fix, four 721.gcc_r / 821.gcc_s TUs (`alias.cc`, `c-ada-spec.cc`, `c-pretty-print.cc`, `c-warn.cc`) hit a chain of widening NYIs and downstream `cir.if` / `cir.ternary` verifier errors; with the fix all four compile cleanly.

The new `clang/test/CIR/CodeGen/non-odr-use-const-bool.cpp` covers three downstream consumers — call argument, `if` condition, `&&` short-circuit — with CIR + LLVM + OGCG checks. The pre-existing `// TODO(cir): The classic codegen calls tryEmitAsConstant() here.` at the same site stays in place; this is the targeted fix in the meantime, and the broader refactor (extending `tryEmitAsConstant` to handle constant `VarDecl`s so the constant emitter takes over entirely) is the right follow-up.
