### PR TITLE
[flang] Add diagnostics for conflicting EXTERNAL/INTRINSIC and TARGET attributes

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -1466,6 +1466,10 @@ void CheckHelper::CheckArraySpec(
 void CheckHelper::CheckProcEntity(
     const Symbol &symbol, const ProcEntityDetails &details) {
   CheckSymbolType(symbol);
+  // F2018 8.5.17: an entity with the TARGET attribute shall be a variable;
+  // a procedure (EXTERNAL or INTRINSIC) is not a variable.
+  CheckConflicting(symbol, Attr::EXTERNAL, Attr::TARGET);
+  CheckConflicting(symbol, Attr::INTRINSIC, Attr::TARGET);
   const Symbol *interface{details.procInterface()};
   if (details.isDummy()) {
     if (!symbol.attrs().test(Attr::POINTER) && // C843

--- a/flang/test/Semantics/declarations09.f90
+++ b/flang/test/Semantics/declarations09.f90
@@ -1,0 +1,17 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Check that EXTERNAL/INTRINSIC and TARGET attributes conflict
+
+subroutine test1()
+  !ERROR: 'f1' may not have both the EXTERNAL and TARGET attributes
+  real, target, external :: f1
+  !ERROR: 'f2' may not have both the EXTERNAL and TARGET attributes
+  real, external, target :: f2
+  ! These are fine individually
+  real, external :: f3
+  real, target :: x1
+end subroutine
+
+subroutine test2()
+  !ERROR: 'abs' may not have both the INTRINSIC and TARGET attributes
+  integer, target, intrinsic :: abs
+end subroutine


### PR DESCRIPTION
Flang silently accepted declarations with both EXTERNAL and TARGET (or
INTRINSIC and TARGET) attributes on the same entity. This violates the
Fortran standard since TARGET requires a variable, but EXTERNAL/INTRINSIC
makes the entity a procedure.

Add CheckConflicting calls in CheckProcEntity to diagnose both cases.
All other major Fortran compilers already reject these combinations.

Fixes #197830

Assisted-by: Claude Opus 4.6.