### PR TITLE
[Bazel] Port ca6e386cbf5b3e75a2a62e6c4d29b24109727a52

### DIFF
--- a/llvm/lib/MC/DXContainerInfo.cpp
+++ b/llvm/lib/MC/DXContainerInfo.cpp
@@ -8,7 +8,6 @@
 
 #include "llvm/MC/DXContainerInfo.h"
 #include "llvm/BinaryFormat/DXContainer.h"
-#include "llvm/Object/DXContainer.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include <type_traits>
 

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -6932,6 +6932,7 @@ cc_binary(
         ":BinaryFormat",
         ":DebugInfoCodeView",
         ":DebugInfoDWARF",
+        ":MC",
         ":Object",
         ":ObjectYAML",
         ":Support",


### PR DESCRIPTION
obj2yaml now depends on MC (although probably not for much), and remove an unnecessary header creating a layering violation.