### PR TITLE
[lldb][NFC] Socket::Send should return a signed type

### DIFF
--- a/lldb/include/lldb/Host/Socket.h
+++ b/lldb/include/lldb/Host/Socket.h
@@ -173,7 +173,7 @@ public:
 protected:
   Socket(SocketProtocol protocol, bool should_close);
 
-  virtual size_t Send(const void *buf, const size_t num_bytes);
+  virtual ssize_t Send(const void *buf, const size_t num_bytes);
 
   static int CloseSocket(NativeSocket sockfd);
   static Status GetLastError();

--- a/lldb/include/lldb/Host/common/UDPSocket.h
+++ b/lldb/include/lldb/Host/common/UDPSocket.h
@@ -24,7 +24,7 @@ public:
 private:
   UDPSocket(NativeSocket socket);
 
-  size_t Send(const void *buf, const size_t num_bytes) override;
+  ssize_t Send(const void *buf, const size_t num_bytes) override;
   Status Connect(llvm::StringRef name) override;
   Status Listen(llvm::StringRef name, int backlog) override;
 

--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -403,7 +403,7 @@ int Socket::SetOption(NativeSocket sockfd, int level, int option_name,
                       sizeof(option_value));
 }
 
-size_t Socket::Send(const void *buf, const size_t num_bytes) {
+ssize_t Socket::Send(const void *buf, const size_t num_bytes) {
   return ::send(m_socket, static_cast<const char *>(buf), num_bytes, 0);
 }
 

--- a/lldb/source/Host/common/UDPSocket.cpp
+++ b/lldb/source/Host/common/UDPSocket.cpp
@@ -34,7 +34,7 @@ UDPSocket::UDPSocket(NativeSocket socket)
 
 UDPSocket::UDPSocket(bool should_close) : Socket(ProtocolUdp, should_close) {}
 
-size_t UDPSocket::Send(const void *buf, const size_t num_bytes) {
+ssize_t UDPSocket::Send(const void *buf, const size_t num_bytes) {
   return ::sendto(m_socket, static_cast<const char *>(buf), num_bytes, 0,
                   m_sockaddr, m_sockaddr.GetLength());
 }


### PR DESCRIPTION
The underlying `::send` and `::sendto` returns `ssize_t` on macOS/Linux and `int` on Windows. These functions also commmunicate an error through returning -1 (which is not expressible in a size_t).