### PR TITLE
[HLSL][SPIRV] Correct reversebit 64 split

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -3685,19 +3685,21 @@ bool SPIRVInstructionSelector::selectBitreverse64(Register ResVReg,
   if (!selectBitreverseNative(Reverse32, VecI32Type, I, Vec32))
     return false;
 
-  // Splits result into highbit lane and lowbit lane
-  auto MaybeParts = splitEvenOddLanes(Reverse32, ComponentCount, I, I32Type);
-  if (!MaybeParts)
-    return false;
-  SplitParts &Parts = *MaybeParts;
-
   // Reversing a 64-bit value = reverse each 32-bit half AND swap them,
   // so the old High word becomes lane 0 (low) and old Low becomes lane 1
   // (high).
   Register SwappedVec = MRI->createVirtualRegister(GR.getRegClass(VecI32Type));
-  if (!selectOpWithSrcs(SwappedVec, VecI32Type, I, {Parts.High, Parts.Low},
-                        SPIRV::OpCompositeConstruct))
-    return false;
+  auto MIB = BuildMI(*I.getParent(), I, I.getDebugLoc(),
+                     TII.get(SPIRV::OpVectorShuffle))
+                 .addDef(SwappedVec)
+                 .addUse(GR.getSPIRVTypeID(VecI32Type))
+                 .addUse(Reverse32)
+                 .addUse(Reverse32);
+  for (unsigned J = 0; J < ComponentCount; ++J) {
+    MIB.addImm(2 * J + 1);
+    MIB.addImm(2 * J);
+  }
+  MIB.constrainAllUses(TII, TRI, RBI);
 
   // Groups 32 bit vector back to 64 bit scalar.
   return selectOpWithSrcs(ResVReg, ResType, I, {SwappedVec}, SPIRV::OpBitcast);

--- a/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/reversebits.ll
+++ b/llvm/test/CodeGen/SPIRV/hlsl-intrinsics/reversebits.ll
@@ -15,8 +15,6 @@
 ;CHECK-DAG: %[[#vec_int_16:]] = OpTypeVector %[[#int_16]] 2
 
 ;CHECK-DAG: %[[#const_16:]] = OpConstant %[[#int_32]] 16
-;CHECK-DAG: %[[#const_zero:]] = OpConstant %[[#int_32]] 0
-;CHECK-DAG: %[[#const_one:]] = OpConstant %[[#int_32]] 1
 ;CHECK-DAG: %[[#const_two:]] = OpConstant %[[#int_64]] 2
 ;CHECK-DAG: %[[#composite:]] = OpConstantComposite %[[#vec_int_32]] %[[#const_16]] %[[#const_16]] 
 
@@ -69,9 +67,7 @@ entry:
 ; CHECK: %[[#param:]] = OpFunctionParameter %[[#int_64]]
 ; CHECK: %[[#vec_cast:]] = OpBitcast %[[#vec_int_32]] %[[#param]]
 ; CHECK: %[[#reverse:]] = OpBitReverse %[[#vec_int_32]] %[[#vec_cast]]
-; CHECK: %[[#low:]] = OpVectorExtractDynamic %[[#int_32]] %[[#reverse]] %[[#const_one]]
-; CHECK: %[[#high:]] = OpVectorExtractDynamic %[[#int_32]] %[[#reverse]] %[[#const_zero]]
-; CHECK: %[[#vec_rebuild:]] = OpCompositeConstruct %[[#vec_int_32]] %[[#low]] %[[#high]]
+; CHECK: %[[#vec_rebuild:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 1 0
 ; CHECK: %[[#]] = OpBitcast %[[#int_64]] %[[#vec_rebuild]]
   %elt.bitreverse = call i64 @llvm.bitreverse.i64(i64 %a)
   ret i64 %elt.bitreverse
@@ -82,9 +78,7 @@ entry:
 ; CHECK: %[[#param:]] = OpFunctionParameter %[[#vec_int_64]]
 ; CHECK: %[[#vec_cast:]] = OpBitcast %[[#vec_int_32x4]] %[[#param]]
 ; CHECK: %[[#reverse:]] = OpBitReverse %[[#vec_int_32x4]] %[[#vec_cast]]
-; CHECK: %[[#low:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 1 3
-; CHECK: %[[#high:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 0 2
-; CHECK: %[[#vec_rebuild:]] = OpCompositeConstruct %[[#vec_int_32x4]] %[[#low]] %[[#high]]
+; CHECK: %[[#vec_rebuild:]] = OpVectorShuffle %[[#vec_int_32x4]] %[[#reverse]] %[[#reverse]] 1 0 3 2
 ; CHECK: %[[#]] = OpBitcast %[[#vec_int_64]] %[[#vec_rebuild]]
   %elt.bitreverse = call <2 x i64> @llvm.bitreverse.v2i64(<2 x i64> %a)
   ret <2 x i64> %elt.bitreverse
@@ -96,17 +90,13 @@ entry:
 ; CHECK: %[[#first_part:]] = OpVectorShuffle %[[#vec_int_64]] %[[#param]] %[[#param]] 0 1
 ; CHECK: %[[#vec_cast:]] = OpBitcast %[[#vec_int_32x4]] %[[#first_part]]
 ; CHECK: %[[#reverse:]] = OpBitReverse %[[#vec_int_32x4]] %[[#vec_cast]]
-; CHECK: %[[#low:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 1 3
-; CHECK: %[[#high:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 0 2
-; CHECK: %[[#vec_rebuild:]] = OpCompositeConstruct %[[#vec_int_32x4]] %[[#low]] %[[#high]]
+; CHECK: %[[#vec_rebuild:]] = OpVectorShuffle %[[#vec_int_32x4]] %[[#reverse]] %[[#reverse]] 1 0 3 2
 ; CHECK: %[[#first_result:]] = OpBitcast %[[#vec_int_64]] %[[#vec_rebuild]]
 
 ; CHECK: %[[#third_element:]] = OpVectorExtractDynamic %[[#int_64]] %[[#param]] %[[#const_two]]
 ; CHECK: %[[#bitcast:]] = OpBitcast %[[#vec_int_32]] %[[#third_element]]
 ; CHECK: %[[#bitreverse:]] = OpBitReverse %[[#vec_int_32]] %[[#bitcast]]
-; CHECK: %[[#extract_one:]] = OpVectorExtractDynamic %[[#int_32]] %[[#bitreverse]] %[[#const_one]]
-; CHECK: %[[#extract_zero:]] = OpVectorExtractDynamic %[[#int_32]] %[[#bitreverse]] %[[#const_zero]]
-; CHECK: %[[#composite:]] = OpCompositeConstruct %[[#vec_int_32]] %[[#extract_one]] %[[#extract_zero]]
+; CHECK: %[[#composite:]] = OpVectorShuffle %[[#vec_int_32]] %[[#bitreverse]] %[[#bitreverse]] 1 0
 
 ; CHECK: %[[#second_result:]] = OpBitcast %[[#int_64]] %[[#composite]]
 ; CHECK: %[[#]] = OpCompositeConstruct %[[#vec_int_64x3]] %[[#first_result]] %[[#second_result]]
@@ -120,17 +110,13 @@ entry:
 ; CHECK: %[[#first_part:]] = OpVectorShuffle %[[#vec_int_64]] %[[#param]] %[[#param]] 0 1
 ; CHECK: %[[#vec_cast:]] = OpBitcast %[[#vec_int_32x4]] %[[#first_part]]
 ; CHECK: %[[#reverse:]] = OpBitReverse %[[#vec_int_32x4]] %[[#vec_cast]]
-; CHECK: %[[#low:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 1 3
-; CHECK: %[[#high:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 0 2
-; CHECK: %[[#vec_rebuild:]] = OpCompositeConstruct %[[#vec_int_32x4]] %[[#low]] %[[#high]]
+; CHECK: %[[#vec_rebuild:]] = OpVectorShuffle %[[#vec_int_32x4]] %[[#reverse]] %[[#reverse]] 1 0 3 2
 ; CHECK: %[[#first_result:]] = OpBitcast %[[#vec_int_64]] %[[#vec_rebuild]]
 
 ; CHECK: %[[#second_part:]] = OpVectorShuffle %[[#vec_int_64]] %[[#param]] %[[#param]] 2 3
 ; CHECK: %[[#vec_cast:]] = OpBitcast %[[#vec_int_32x4]] %[[#second_part]]
 ; CHECK: %[[#reverse:]] = OpBitReverse %[[#vec_int_32x4]] %[[#vec_cast]]
-; CHECK: %[[#low:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 1 3
-; CHECK: %[[#high:]] = OpVectorShuffle %[[#vec_int_32]] %[[#reverse]] %[[#reverse]] 0 2
-; CHECK: %[[#vec_rebuild:]] = OpCompositeConstruct %[[#vec_int_32x4]] %[[#low]] %[[#high]]
+; CHECK: %[[#vec_rebuild:]] = OpVectorShuffle %[[#vec_int_32x4]] %[[#reverse]] %[[#reverse]] 1 0 3 2
 ; CHECK: %[[#second_result:]] = OpBitcast %[[#vec_int_64]] %[[#vec_rebuild]]
 
 ; CHECK: %[[#]] = OpCompositeConstruct %[[#vec_int_64x4]] %[[#first_result]] %[[#second_result]]


### PR DESCRIPTION
Replace the split-lanes + OpCompositeConstruct sequence in selectBitreverse64 with a single OpVectorShuffle to swap the high/low 32-bit halves, simplifying both the selector logic, the emitted SPIR-V and fixing the bug.

fix: #197810 
Assisted by: Claude Opus 4.6