### PR TITLE
[Clang][AST] Fix ExplicitInstantiationDecl accessors for variable templates with tag types

### DIFF
--- a/clang/include/clang/AST/ASTNodeTraverser.h
+++ b/clang/include/clang/AST/ASTNodeTraverser.h
@@ -686,9 +686,11 @@ public:
   void VisitExplicitInstantiationDecl(const ExplicitInstantiationDecl *D) {
     if (TypeSourceInfo *TSI = D->getTypeAsWritten())
       Visit(TSI->getTypeLoc());
-    for (unsigned I = 0, E = D->getNumTemplateArgs(); I != E; ++I) {
-      TemplateArgumentLoc Loc = D->getTemplateArg(I);
-      Visit(Loc.getArgument(), Loc.getSourceRange());
+    if (D->hasTemplateArgs()) {
+      for (unsigned I = 0, E = D->getNumTemplateArgs(); I != E; ++I) {
+        TemplateArgumentLoc Loc = D->getTemplateArg(I);
+        Visit(Loc.getArgument(), Loc.getSourceRange());
+      }
     }
   }
 

--- a/clang/include/clang/AST/ASTNodeTraverser.h
+++ b/clang/include/clang/AST/ASTNodeTraverser.h
@@ -686,8 +686,8 @@ public:
   void VisitExplicitInstantiationDecl(const ExplicitInstantiationDecl *D) {
     if (TypeSourceInfo *TSI = D->getTypeAsWritten())
       Visit(TSI->getTypeLoc());
-    if (D->hasTemplateArgs()) {
-      for (unsigned I = 0, E = D->getNumTemplateArgs(); I != E; ++I) {
+    if (auto NumArgs = D->getNumTemplateArgs()) {
+      for (unsigned I = 0; I != *NumArgs; ++I) {
         TemplateArgumentLoc Loc = D->getTemplateArg(I);
         Visit(Loc.getArgument(), Loc.getSourceRange());
       }

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -3519,11 +3519,9 @@ public:
   /// for function / variable templates, from a trailing object.
   NestedNameSpecifierLoc getQualifierLoc() const;
 
-  /// Whether this explicit instantiation has a template argument list.
-  /// Must be checked before calling getNumTemplateArgs() and friends.
-  bool hasTemplateArgs() const;
-
-  unsigned getNumTemplateArgs() const;
+  /// Returns the number of explicit template arguments, or std::nullopt if
+  /// this entity has no template argument list (e.g., nested classes).
+  std::optional<unsigned> getNumTemplateArgs() const;
   TemplateArgumentLoc getTemplateArg(unsigned I) const;
   SourceLocation getTemplateArgsLAngleLoc() const;
   SourceLocation getTemplateArgsRAngleLoc() const;

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -3519,6 +3519,10 @@ public:
   /// for function / variable templates, from a trailing object.
   NestedNameSpecifierLoc getQualifierLoc() const;
 
+  /// Whether this explicit instantiation has a template argument list.
+  /// Must be checked before calling getNumTemplateArgs() and friends.
+  bool hasTemplateArgs() const;
+
   unsigned getNumTemplateArgs() const;
   TemplateArgumentLoc getTemplateArg(unsigned I) const;
   SourceLocation getTemplateArgsLAngleLoc() const;

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -3449,9 +3449,19 @@ class ExplicitInstantiationDecl final
     return hasTrailingQualifier() ? 1 : 0;
   }
 
-  /// Raw access to the internal TypeSourceInfo.  For class templates this is
-  /// a TemplateSpecializationTypeLoc; for nested classes a TagTypeLoc.
-  /// Public getTypeAsWritten() returns null for those cases.
+  /// For class templates / nested classes, returns the TypeLoc encoding the
+  /// entity (TemplateSpecializationTypeLoc or TagTypeLoc).  For function /
+  /// variable templates -- where TypeSourceInfo holds the declared type
+  /// rather than the entity -- returns std::nullopt.
+  std::optional<TypeLoc> getClassTypeLoc() const {
+    if (!isa<RecordDecl>(getSpecialization()))
+      return std::nullopt;
+    if (auto *TSI = TypeAndFlags.getPointer())
+      return TSI->getTypeLoc();
+    return std::nullopt;
+  }
+
+  /// Raw TypeSourceInfo pointer, needed by the serializer.
   TypeSourceInfo *getRawTypeSourceInfo() const {
     return TypeAndFlags.getPointer();
   }
@@ -3493,13 +3503,10 @@ public:
   SourceLocation getTemplateLoc() const { return getLocation(); }
   SourceLocation getNameLoc() const { return NameLoc; }
 
-  /// For class templates / nested classes, the tag keyword location is
-  /// stored inside TypeSourceInfo; otherwise returns an invalid location.
+  /// The tag keyword (struct/class/union) location for class templates /
+  /// nested classes; invalid for function / variable templates.
   SourceLocation getTagKWLoc() const;
 
-  /// Whether the qualifier is stored as a trailing object (function / variable
-  /// templates) rather than inside TypeSourceInfo (class templates / nested
-  /// classes).
   bool hasTrailingQualifier() const {
     return TypeAndFlags.getInt() & HasQualifierFlag;
   }
@@ -3508,24 +3515,17 @@ public:
   }
 
   /// Returns the qualifier regardless of where it is stored.
-  /// For class templates / nested classes, it is extracted from TypeSourceInfo
-  /// (TemplateSpecializationTypeLoc or TagTypeLoc).
-  /// For function / variable templates, it comes from a trailing object.
+  /// For class templates / nested classes, extracted from the class TypeLoc;
+  /// for function / variable templates, from a trailing object.
   NestedNameSpecifierLoc getQualifierLoc() const;
 
-  /// Number of explicit template arguments, regardless of storage.
-  /// For class templates they come from TemplateSpecializationTypeLoc;
-  /// for function / variable templates from trailing
-  /// ASTTemplateArgumentListInfo.
   unsigned getNumTemplateArgs() const;
   TemplateArgumentLoc getTemplateArg(unsigned I) const;
   SourceLocation getTemplateArgsLAngleLoc() const;
   SourceLocation getTemplateArgsRAngleLoc() const;
 
-  /// For function / variable templates, returns the declared type (return type
-  /// or variable type).  For class templates and nested classes returns null —
-  /// the qualifier, tag keyword, and template arguments are accessible via
-  /// getQualifierLoc(), getTagKWLoc(), and getTemplateArg().
+  /// The declared type (return type or variable type) for function / variable
+  /// templates.  Null for class templates and nested classes.
   TypeSourceInfo *getTypeAsWritten() const;
 
   TemplateSpecializationKind getTemplateSpecializationKind() const {

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1765,8 +1765,9 @@ DEF_TRAVERSE_DECL(ExplicitInstantiationDecl, {
     TRY_TO(TraverseNestedNameSpecifierLoc(D->getQualifierLoc()));
   if (TypeSourceInfo *TSI = D->getTypeAsWritten())
     TRY_TO(TraverseTypeLoc(TSI->getTypeLoc()));
-  for (unsigned I = 0, E = D->getNumTemplateArgs(); I != E; ++I)
-    TRY_TO(TraverseTemplateArgumentLoc(D->getTemplateArg(I)));
+  if (D->hasTemplateArgs())
+    for (unsigned I = 0, E = D->getNumTemplateArgs(); I != E; ++I)
+      TRY_TO(TraverseTemplateArgumentLoc(D->getTemplateArg(I)));
 })
 
 DEF_TRAVERSE_DECL(TranslationUnitDecl, {

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1765,8 +1765,8 @@ DEF_TRAVERSE_DECL(ExplicitInstantiationDecl, {
     TRY_TO(TraverseNestedNameSpecifierLoc(D->getQualifierLoc()));
   if (TypeSourceInfo *TSI = D->getTypeAsWritten())
     TRY_TO(TraverseTypeLoc(TSI->getTypeLoc()));
-  if (D->hasTemplateArgs())
-    for (unsigned I = 0, E = D->getNumTemplateArgs(); I != E; ++I)
+  if (auto NumArgs = D->getNumTemplateArgs())
+    for (unsigned I = 0; I != *NumArgs; ++I)
       TRY_TO(TraverseTemplateArgumentLoc(D->getTemplateArg(I)));
 })
 

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1346,7 +1346,8 @@ void DeclPrinter::VisitExplicitInstantiationDecl(ExplicitInstantiationDecl *D) {
   if (D->getQualifierLoc())
     D->getQualifierLoc().getNestedNameSpecifier().print(NameOS, Policy);
   Spec->printName(NameOS, Policy);
-  if (unsigned NumArgs = D->getNumTemplateArgs()) {
+  if (D->hasTemplateArgs()) {
+    unsigned NumArgs = D->getNumTemplateArgs();
     SmallVector<TemplateArgumentLoc, 4> Args;
     for (unsigned I = 0; I < NumArgs; ++I)
       Args.push_back(D->getTemplateArg(I));

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1346,13 +1346,11 @@ void DeclPrinter::VisitExplicitInstantiationDecl(ExplicitInstantiationDecl *D) {
   if (D->getQualifierLoc())
     D->getQualifierLoc().getNestedNameSpecifier().print(NameOS, Policy);
   Spec->printName(NameOS, Policy);
-  if (D->hasTemplateArgs()) {
-    if (unsigned NumArgs = D->getNumTemplateArgs()) {
-      SmallVector<TemplateArgumentLoc, 4> Args;
-      for (unsigned I = 0; I < NumArgs; ++I)
-        Args.push_back(D->getTemplateArg(I));
-      printTemplateArgumentList(NameOS, Args, Policy);
-    }
+  if (auto NumArgs = D->getNumTemplateArgs(); NumArgs && *NumArgs > 0) {
+    SmallVector<TemplateArgumentLoc, 4> Args;
+    for (unsigned I = 0; I < *NumArgs; ++I)
+      Args.push_back(D->getTemplateArg(I));
+    printTemplateArgumentList(NameOS, Args, Policy);
   }
 
   if (auto *RD = dyn_cast<RecordDecl>(Spec)) {

--- a/clang/lib/AST/DeclPrinter.cpp
+++ b/clang/lib/AST/DeclPrinter.cpp
@@ -1347,11 +1347,12 @@ void DeclPrinter::VisitExplicitInstantiationDecl(ExplicitInstantiationDecl *D) {
     D->getQualifierLoc().getNestedNameSpecifier().print(NameOS, Policy);
   Spec->printName(NameOS, Policy);
   if (D->hasTemplateArgs()) {
-    unsigned NumArgs = D->getNumTemplateArgs();
-    SmallVector<TemplateArgumentLoc, 4> Args;
-    for (unsigned I = 0; I < NumArgs; ++I)
-      Args.push_back(D->getTemplateArg(I));
-    printTemplateArgumentList(NameOS, Args, Policy);
+    if (unsigned NumArgs = D->getNumTemplateArgs()) {
+      SmallVector<TemplateArgumentLoc, 4> Args;
+      for (unsigned I = 0; I < NumArgs; ++I)
+        Args.push_back(D->getTemplateArg(I));
+      printTemplateArgumentList(NameOS, Args, Policy);
+    }
   }
 
   if (auto *RD = dyn_cast<RecordDecl>(Spec)) {

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1867,22 +1867,13 @@ TypeSourceInfo *ExplicitInstantiationDecl::getTypeAsWritten() const {
   return getRawTypeSourceInfo();
 }
 
-bool ExplicitInstantiationDecl::hasTemplateArgs() const {
-  if (getTrailingArgsInfo())
-    return true;
-  if (auto TL = getClassTypeLoc())
-    if (TL->getAs<TemplateSpecializationTypeLoc>())
-      return true;
-  return false;
-}
-
-unsigned ExplicitInstantiationDecl::getNumTemplateArgs() const {
+std::optional<unsigned> ExplicitInstantiationDecl::getNumTemplateArgs() const {
   if (const auto *Args = getTrailingArgsInfo())
     return Args->NumTemplateArgs;
   if (auto TL = getClassTypeLoc())
     if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
       return TST.getNumArgs();
-  llvm_unreachable("template arguments not found in trailing args or TypeLoc");
+  return std::nullopt;
 }
 
 TemplateArgumentLoc
@@ -1920,7 +1911,7 @@ SourceLocation ExplicitInstantiationDecl::getEndLoc() const {
     if (TSI->getType().hasPostfixDeclaratorSyntax())
       return TSI->getTypeLoc().getEndLoc();
   // Otherwise, template args RAngleLoc or NameLoc.
-  if (hasTemplateArgs()) {
+  if (getNumTemplateArgs()) {
     SourceLocation RAngle = getTemplateArgsRAngleLoc();
     if (RAngle.isValid())
       return RAngle;

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1867,13 +1867,22 @@ TypeSourceInfo *ExplicitInstantiationDecl::getTypeAsWritten() const {
   return getRawTypeSourceInfo();
 }
 
+bool ExplicitInstantiationDecl::hasTemplateArgs() const {
+  if (getTrailingArgsInfo())
+    return true;
+  if (auto TL = getClassTypeLoc())
+    if (TL->getAs<TemplateSpecializationTypeLoc>())
+      return true;
+  return false;
+}
+
 unsigned ExplicitInstantiationDecl::getNumTemplateArgs() const {
   if (const auto *Args = getTrailingArgsInfo())
     return Args->NumTemplateArgs;
   if (auto TL = getClassTypeLoc())
     if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
       return TST.getNumArgs();
-  return 0;
+  llvm_unreachable("template arguments not found in trailing args or TypeLoc");
 }
 
 TemplateArgumentLoc
@@ -1892,7 +1901,7 @@ SourceLocation ExplicitInstantiationDecl::getTemplateArgsLAngleLoc() const {
   if (auto TL = getClassTypeLoc())
     if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
       return TST.getLAngleLoc();
-  return SourceLocation();
+  llvm_unreachable("template arguments not found in trailing args or TypeLoc");
 }
 
 SourceLocation ExplicitInstantiationDecl::getTemplateArgsRAngleLoc() const {
@@ -1901,7 +1910,7 @@ SourceLocation ExplicitInstantiationDecl::getTemplateArgsRAngleLoc() const {
   if (auto TL = getClassTypeLoc())
     if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
       return TST.getRAngleLoc();
-  return SourceLocation();
+  llvm_unreachable("template arguments not found in trailing args or TypeLoc");
 }
 
 SourceLocation ExplicitInstantiationDecl::getEndLoc() const {
@@ -1911,8 +1920,12 @@ SourceLocation ExplicitInstantiationDecl::getEndLoc() const {
     if (TSI->getType().hasPostfixDeclaratorSyntax())
       return TSI->getTypeLoc().getEndLoc();
   // Otherwise, template args RAngleLoc or NameLoc.
-  SourceLocation RAngle = getTemplateArgsRAngleLoc();
-  return RAngle.isValid() ? RAngle : NameLoc;
+  if (hasTemplateArgs()) {
+    SourceLocation RAngle = getTemplateArgsRAngleLoc();
+    if (RAngle.isValid())
+      return RAngle;
+  }
+  return NameLoc;
 }
 
 SourceRange ExplicitInstantiationDecl::getSourceRange() const {

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1843,11 +1843,11 @@ ExplicitInstantiationDecl::CreateDeserialized(ASTContext &C, GlobalDeclID ID,
 }
 
 SourceLocation ExplicitInstantiationDecl::getTagKWLoc() const {
-  if (auto *TSI = getRawTypeSourceInfo()) {
-    if (auto TL = TSI->getTypeLoc().getAs<TemplateSpecializationTypeLoc>())
-      return TL.getElaboratedKeywordLoc();
-    if (auto TL = TSI->getTypeLoc().getAs<TagTypeLoc>())
-      return TL.getElaboratedKeywordLoc();
+  if (auto TL = getClassTypeLoc()) {
+    if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
+      return TST.getElaboratedKeywordLoc();
+    if (auto Tag = TL->getAs<TagTypeLoc>())
+      return Tag.getElaboratedKeywordLoc();
   }
   return SourceLocation();
 }
@@ -1855,29 +1855,24 @@ SourceLocation ExplicitInstantiationDecl::getTagKWLoc() const {
 NestedNameSpecifierLoc ExplicitInstantiationDecl::getQualifierLoc() const {
   if (hasTrailingQualifier())
     return *getTrailingObjects<NestedNameSpecifierLoc>();
-  if (auto *TSI = getRawTypeSourceInfo())
-    return TSI->getTypeLoc().getPrefix();
+  if (auto TL = getClassTypeLoc())
+    return TL->getPrefix();
   return NestedNameSpecifierLoc();
 }
 
 TypeSourceInfo *ExplicitInstantiationDecl::getTypeAsWritten() const {
-  auto *TSI = getRawTypeSourceInfo();
-  if (!TSI)
+  // For class-like entities, TSI encodes the class itself, not a declared type.
+  if (getClassTypeLoc())
     return nullptr;
-  TypeLoc TL = TSI->getTypeLoc();
-  // For class templates and nested classes, the "type" is fully described by
-  // the unified accessors (getQualifierLoc, getTemplateArg, getTagKWLoc).
-  if (TL.getAs<TemplateSpecializationTypeLoc>() || TL.getAs<TagTypeLoc>())
-    return nullptr;
-  return TSI;
+  return getRawTypeSourceInfo();
 }
 
 unsigned ExplicitInstantiationDecl::getNumTemplateArgs() const {
   if (const auto *Args = getTrailingArgsInfo())
     return Args->NumTemplateArgs;
-  if (auto *TSI = getRawTypeSourceInfo())
-    if (auto TL = TSI->getTypeLoc().getAs<TemplateSpecializationTypeLoc>())
-      return TL.getNumArgs();
+  if (auto TL = getClassTypeLoc())
+    if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
+      return TST.getNumArgs();
   return 0;
 }
 
@@ -1885,25 +1880,28 @@ TemplateArgumentLoc
 ExplicitInstantiationDecl::getTemplateArg(unsigned I) const {
   if (const auto *Args = getTrailingArgsInfo())
     return (*Args)[I];
-  auto *TSI = getRawTypeSourceInfo();
-  return TSI->getTypeLoc().castAs<TemplateSpecializationTypeLoc>().getArgLoc(I);
+  // Must be a class template -- args live in the TemplateSpecializationTypeLoc.
+  return getRawTypeSourceInfo()
+      ->getTypeLoc()
+      .castAs<TemplateSpecializationTypeLoc>()
+      .getArgLoc(I);
 }
 
 SourceLocation ExplicitInstantiationDecl::getTemplateArgsLAngleLoc() const {
   if (const auto *Args = getTrailingArgsInfo())
     return Args->getLAngleLoc();
-  if (auto *TSI = getRawTypeSourceInfo())
-    if (auto TL = TSI->getTypeLoc().getAs<TemplateSpecializationTypeLoc>())
-      return TL.getLAngleLoc();
+  if (auto TL = getClassTypeLoc())
+    if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
+      return TST.getLAngleLoc();
   return SourceLocation();
 }
 
 SourceLocation ExplicitInstantiationDecl::getTemplateArgsRAngleLoc() const {
   if (const auto *Args = getTrailingArgsInfo())
     return Args->getRAngleLoc();
-  if (auto *TSI = getRawTypeSourceInfo())
-    if (auto TL = TSI->getTypeLoc().getAs<TemplateSpecializationTypeLoc>())
-      return TL.getRAngleLoc();
+  if (auto TL = getClassTypeLoc())
+    if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
+      return TST.getRAngleLoc();
   return SourceLocation();
 }
 

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1880,11 +1880,10 @@ TemplateArgumentLoc
 ExplicitInstantiationDecl::getTemplateArg(unsigned I) const {
   if (const auto *Args = getTrailingArgsInfo())
     return (*Args)[I];
-  // Must be a class template -- args live in the TemplateSpecializationTypeLoc.
-  return getRawTypeSourceInfo()
-      ->getTypeLoc()
-      .castAs<TemplateSpecializationTypeLoc>()
-      .getArgLoc(I);
+  if (auto TL = getClassTypeLoc())
+    if (auto TST = TL->getAs<TemplateSpecializationTypeLoc>())
+      return TST.getArgLoc(I);
+  llvm_unreachable("template arguments not found in trailing args or TypeLoc");
 }
 
 SourceLocation ExplicitInstantiationDecl::getTemplateArgsLAngleLoc() const {

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -10790,6 +10790,7 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
 
     VarDecl *Prev = Previous.getAsSingle<VarDecl>();
     VarTemplateDecl *PrevTemplate = Previous.getAsSingle<VarTemplateDecl>();
+    const ASTTemplateArgumentListInfo *ArgsAsWritten = nullptr;
 
     if (!PrevTemplate) {
       if (!Prev || !Prev->isStaticDataMember()) {
@@ -10858,6 +10859,8 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
       // Ignore access control bits, we don't need them for redeclaration
       // checking.
       Prev = cast<VarDecl>(Res.get());
+      ArgsAsWritten =
+          ASTTemplateArgumentListInfo::Create(Context, TemplateArgs);
     }
 
     // C++0x [temp.explicit]p2:
@@ -10912,9 +10915,6 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
       return true;
     }
 
-    const ASTTemplateArgumentListInfo *ArgsAsWritten = nullptr;
-    if (auto *VTSD = dyn_cast<VarTemplateSpecializationDecl>(Prev))
-      ArgsAsWritten = VTSD->getTemplateArgsAsWritten();
     addExplicitInstantiationDecl(
         Context, CurContext, Prev, ExternLoc, TemplateLoc,
         D.getCXXScopeSpec().getWithLocInContext(Context), ArgsAsWritten,

--- a/clang/test/AST/ast-print-explicit-instantiation.cpp
+++ b/clang/test/AST/ast-print-explicit-instantiation.cpp
@@ -20,6 +20,10 @@ template <typename T> void bar(T) {}
 // CHECK: template void bar(int);
 template void bar(int);
 
+// empty <> (args deduced)
+// CHECK: template void ns::foo(double);
+template void ns::foo<>(double);
+
 // CHECK: template int ns::var<int>;
 template int ns::var<int>;
 // CHECK: extern template float ns::var<float>;
@@ -110,3 +114,12 @@ extern template ns::S<int> var2<ns::S<int>>;
 // CHECK: extern template ns::S<float> var2<ns::S<float>>;
 extern template ns::S<float> var2<ns::S<float>>;
 } // namespace GH197797
+
+// empty <> (default template arguments)
+template <typename T = int> struct Defaulted {};
+// CHECK: template struct Defaulted;
+template struct Defaulted<>;
+
+template <typename T = int> T defaulted_var = T{};
+// CHECK: template int defaulted_var;
+template int defaulted_var<>;

--- a/clang/test/AST/ast-print-explicit-instantiation.cpp
+++ b/clang/test/AST/ast-print-explicit-instantiation.cpp
@@ -25,19 +25,34 @@ template int ns::var<int>;
 // CHECK: extern template float ns::var<float>;
 extern template float ns::var<float>;
 
+namespace ns {
+// CHECK: template struct S<short>;
+template struct S<short>;
+// CHECK: template void foo<short>(short);
+template void foo<short>(short);
+// CHECK: template short var<short>;
+template short var<short>;
+}
+
 template <typename T> struct X { struct Inner {}; };
 // CHECK: template struct X<int>::Inner;
 template struct X<int>::Inner;
+// CHECK: extern template struct X<float>::Inner;
+extern template struct X<float>::Inner;
 
 template <typename T> struct Outer {
   void method();
   template <typename U> void f(U);
   template <typename U> static U var;
   template <typename U> struct Inner {};
+  static T sval;
+  static T arr[1];
 };
 template <typename T> void Outer<T>::method() {}
 template <typename T> template <typename U> void Outer<T>::f(U) {}
 template <typename T> template <typename U> U Outer<T>::var = U{};
+template <typename T> T Outer<T>::sval = T{};
+template <typename T> T Outer<T>::arr[1] = {};
 
 // CHECK: template void Outer<int>::method();
 template void Outer<int>::method();
@@ -47,6 +62,21 @@ template void Outer<int>::f<double>(double);
 template double Outer<int>::var<double>;
 // CHECK: template struct Outer<int>::Inner<double>;
 template struct Outer<int>::Inner<double>;
+// CHECK: template int Outer<int>::sval;
+template int Outer<int>::sval;
+// CHECK: template int Outer<int>::arr[1];
+template int Outer<int>::arr[1];
+
+// CHECK: extern template void Outer<float>::method();
+extern template void Outer<float>::method();
+// CHECK: extern template void Outer<float>::f<double>(double);
+extern template void Outer<float>::f<double>(double);
+// CHECK: extern template double Outer<float>::var<double>;
+extern template double Outer<float>::var<double>;
+// CHECK: extern template struct Outer<float>::Inner<double>;
+extern template struct Outer<float>::Inner<double>;
+// CHECK: extern template int Outer<float>::sval;
+extern template int Outer<float>::sval;
 
 template <typename T> struct A {
   template <typename U> struct B {
@@ -58,3 +88,25 @@ void A<T>::B<U>::g(V) {}
 
 // CHECK: template void A<int>::B<double>::g<float>(float);
 template void A<int>::B<double>::g<float>(float);
+// CHECK: extern template void A<float>::B<double>::g<int>(int);
+extern template void A<float>::B<double>::g<int>(int);
+
+namespace GH197797 {
+struct S {};
+enum E { X };
+template <typename T> struct Wrap {};
+
+template <typename T> T var = T{};
+// CHECK: extern template S var<S>;
+extern template S var<S>;
+// CHECK: extern template E var<E>;
+extern template E var<E>;
+// CHECK: extern template Wrap<int> var<Wrap<int>>;
+extern template Wrap<int> var<Wrap<int>>;
+
+template <typename T> T var2 = T{};
+// CHECK: extern template ns::S<int> var2<ns::S<int>>;
+extern template ns::S<int> var2<ns::S<int>>;
+// CHECK: extern template ns::S<float> var2<ns::S<float>>;
+extern template ns::S<float> var2<ns::S<float>>;
+} // namespace GH197797

--- a/clang/test/AST/explicit-instantiation-source-info.cpp
+++ b/clang/test/AST/explicit-instantiation-source-info.cpp
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -ast-dump %s | FileCheck %s
 
+struct Plain {};
+enum Color { Red };
+template <typename T> struct Wrap {};
+
 namespace ns {
   template <typename T> void foo(T x) {}
   template <typename T> T bar = T{};
@@ -158,6 +162,43 @@ extern template struct ns::S<double>::Inner;
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'ns::S<double>'
 // CHECK-NEXT: CXXRecord {{.*}} 'Inner'
 
+// extern template: member variable template
+extern template double ns::S<double>::mvar<double>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:50> col:8 explicit_instantiation_declaration extern 'mvar'
+// CHECK-NEXT: NestedNameSpecifier TypeSpec 'ns::S<double>'
+// CHECK-NEXT: VarTemplateSpecialization {{.*}} 'mvar' 'double'
+// CHECK-NEXT: BuiltinTypeLoc <col:17> 'double'
+// CHECK-NEXT: TemplateArgument <col:44> type 'double'
+// CHECK-NEXT:   BuiltinType {{.*}} 'double'
+
+// extern template: member class template
+extern template struct ns::S<double>::Nested<double>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:52> col:8 explicit_instantiation_declaration extern 'Nested'
+// CHECK-NEXT: NestedNameSpecifier TypeSpec 'ns::S<double>'
+// CHECK-NEXT: ClassTemplateSpecialization {{.*}} 'Nested'
+// CHECK-NEXT: TemplateArgument <col:46> type 'double'
+// CHECK-NEXT:   BuiltinType {{.*}} 'double'
+
+// extern template: static data member (array)
+extern template double ns::S<double>::arr[1];
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:44> col:8 explicit_instantiation_declaration extern 'arr'
+// CHECK-NEXT: NestedNameSpecifier TypeSpec 'ns::S<double>'
+// CHECK-NEXT: Var {{.*}} 'arr' 'double[1]'
+// CHECK-NEXT: ConstantArrayTypeLoc <col:17, col:44> 'double[1]' 1
+// CHECK-NEXT:   BuiltinTypeLoc <col:17> 'double'
+
+// extern template: deeply nested
+extern template void ns::A<int>::B<float>::deep<double>(double);
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:63> col:8 explicit_instantiation_declaration extern 'deep'
+// CHECK-NEXT: NestedNameSpecifier TypeSpec 'ns::A<int>::B<float>'
+// CHECK-NEXT: CXXMethod {{.*}} 'deep' 'void (double)'
+// CHECK-NEXT: FunctionProtoTypeLoc <col:17, col:63> 'void (double)' cdecl
+// CHECK-NEXT:   ParmVarDecl {{.*}} <col:57> col:63 'double'
+// CHECK-NEXT:     BuiltinTypeLoc <col:57> 'double'
+// CHECK-NEXT:   BuiltinTypeLoc <col:17> 'void'
+// CHECK-NEXT: TemplateArgument <col:49> type 'double'
+// CHECK-NEXT:   BuiltinType {{.*}} 'double'
+
 // member variable template
 template double ns::S<long>::mvar<double>;
 // CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:41> col:1 explicit_instantiation_definition 'mvar'
@@ -211,4 +252,39 @@ namespace ns {
   // CHECK-NEXT: ClassTemplateSpecialization {{.*}} 'S'
   // CHECK-NEXT: TemplateArgument <col:21> type 'short'
   // CHECK-NEXT:   BuiltinType {{.*}} 'short'
+}
+
+extern template Plain ns::bar<Plain>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:36> col:8 explicit_instantiation_declaration extern 'bar'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'ns'
+// CHECK-NEXT: VarTemplateSpecialization {{.*}} 'bar' 'Plain'
+// CHECK-NEXT: RecordTypeLoc <col:17> 'Plain'
+// CHECK:      TemplateArgument <col:31> type 'Plain'
+
+template Plain ns::bar<Plain>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:29> col:1 explicit_instantiation_definition 'bar'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'ns'
+// CHECK-NEXT: VarTemplateSpecialization {{.*}} 'bar' 'Plain'
+// CHECK-NEXT: RecordTypeLoc <col:10> 'Plain'
+// CHECK:      TemplateArgument <col:24> type 'Plain'
+
+extern template Color ns::bar<Color>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:36> col:8 explicit_instantiation_declaration extern 'bar'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'ns'
+// CHECK-NEXT: VarTemplateSpecialization {{.*}} 'bar' 'Color'
+// CHECK-NEXT: EnumTypeLoc <col:17> 'Color'
+// CHECK:      TemplateArgument <col:31> type 'Color'
+
+extern template Wrap<int> ns::bar<Wrap<int>>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:44> col:8 explicit_instantiation_declaration extern 'bar'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'ns'
+// CHECK-NEXT: VarTemplateSpecialization {{.*}} 'bar' 'Wrap<int>'
+// CHECK-NEXT: TemplateSpecializationTypeLoc <col:17, col:25> 'Wrap<int>'
+
+namespace ns {
+  extern template Wrap<int> bar<Wrap<int>>;
+  // CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:3, col:42> col:10 explicit_instantiation_declaration extern 'bar'
+  // CHECK-NOT: NestedNameSpecifier
+  // CHECK-NEXT: VarTemplateSpecialization {{.*}} 'bar' 'Wrap<int>'
+  // CHECK-NEXT: TemplateSpecializationTypeLoc <col:19, col:27> 'Wrap<int>'
 }

--- a/clang/test/AST/explicit-instantiation-source-info.cpp
+++ b/clang/test/AST/explicit-instantiation-source-info.cpp
@@ -3,6 +3,8 @@
 struct Plain {};
 enum Color { Red };
 template <typename T> struct Wrap {};
+template <typename T = int> struct Defaulted {};
+template <typename T = int> T defaulted_var = T{};
 
 namespace ns {
   template <typename T> void foo(T x) {}
@@ -253,6 +255,35 @@ namespace ns {
   // CHECK-NEXT: TemplateArgument <col:21> type 'short'
   // CHECK-NEXT:   BuiltinType {{.*}} 'short'
 }
+
+// empty <> (args deduced)
+template void ns::foo<>(double);
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:31> col:1 explicit_instantiation_definition 'foo'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'ns'
+// CHECK-NEXT: Function {{.*}} 'foo' 'void (double)'
+// CHECK-NEXT: FunctionProtoTypeLoc <col:10, col:31> 'void (double)' cdecl
+// CHECK-NEXT:   ParmVarDecl {{.*}} <col:25> col:31 'double'
+// CHECK-NEXT:     BuiltinTypeLoc <col:25> 'double'
+// CHECK-NEXT:   BuiltinTypeLoc <col:10> 'void'
+
+template void ns::S<long>::tmpl<>(float);
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:40> col:1 explicit_instantiation_definition 'tmpl'
+// CHECK-NEXT: NestedNameSpecifier TypeSpec 'ns::S<long>'
+// CHECK-NEXT: CXXMethod {{.*}} 'tmpl' 'void (float)'
+// CHECK-NEXT: FunctionProtoTypeLoc <col:10, col:40> 'void (float)' cdecl
+// CHECK-NEXT:   ParmVarDecl {{.*}} <col:35> col:40 'float'
+// CHECK-NEXT:     BuiltinTypeLoc <col:35> 'float'
+// CHECK-NEXT:   BuiltinTypeLoc <col:10> 'void'
+
+// empty <> (default template arguments)
+template struct Defaulted<>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:27> col:1 explicit_instantiation_definition 'Defaulted'
+// CHECK-NEXT: ClassTemplateSpecialization {{.*}} 'Defaulted'
+
+template int defaulted_var<>;
+// CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:28> col:1 explicit_instantiation_definition 'defaulted_var'
+// CHECK-NEXT: VarTemplateSpecialization {{.*}} 'defaulted_var' 'int'
+// CHECK-NEXT: BuiltinTypeLoc <col:10> 'int'
 
 extern template Plain ns::bar<Plain>;
 // CHECK: ExplicitInstantiationDecl {{.*}} <line:[[@LINE-1]]:1, col:36> col:8 explicit_instantiation_declaration extern 'bar'


### PR DESCRIPTION
Several `ExplicitInstantiationDecl` accessors assumed that `TypeSourceInfo` always encodes a class entity, but for variable templates the `TypeSourceInfo` holds the *declared type* (e.g. `Plain`, `Color`, `Wrap<int>`). When that declared type happened to be a `TagType` or `TemplateSpecializationType`, the accessors would misinterpret it:

- `getTypeAsWritten()` returned `nullptr` → crash in `DeclPrinter`
- `getQualifierLoc()` leaked the type's qualifier into the variable name
- `getTagKWLoc()` returned the type's elaborated keyword
- `getNumTemplateArgs` / angle-loc getters extracted from the type instead of the variable's template arguments

Add a private `getClassTypeLoc()` helper that returns the entity `TypeLoc` only for class-like instantiations (`isa<RecordDecl>(getSpecialization())`), and guard all `TypeSourceInfo` fallback paths with it. For non-class entities the accessors now correctly skip the `TypeSourceInfo` and return defaults or read from trailing objects.

Also fix stale template argument source locations for variable templates: when an explicit instantiation definition follows a prior declaration, `VarTemplateSpecializationDecl::getTemplateArgsAsWritten()` returns the first declaration's locations. Construct fresh `ASTTemplateArgumentListInfo` from the current declarator instead.

Fixes #197797
Fixes https://github.com/llvm/llvm-project/issues/191442#issuecomment-4457732314