### PR TITLE
[clang][Sema] Diagnose nested local classes defined in a different block scope than their parent

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -54,7 +54,7 @@ C++ Specific Potentially Breaking Changes
   matching the deduction of array sizes from ``int(&)[N]``.
   This is a breaking change for code that depended on the previously deduced type. (#GH195033)
 
-- Clang now correctly rejects nested local classes defined in a different
+- Clang now rejects nested local classes defined in a different
   block scope than their parent class. (#GH193472)
 
 ABI Changes in This Version

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -54,6 +54,9 @@ C++ Specific Potentially Breaking Changes
   matching the deduction of array sizes from ``int(&)[N]``.
   This is a breaking change for code that depended on the previously deduced type. (#GH195033)
 
+- Clang now correctly rejects nested local classes defined in a different
+  block scope than their parent class. (#GH193472)
+
 ABI Changes in This Version
 ---------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10268,8 +10268,7 @@ def err_reference_to_local_in_enclosing_context : Error<
   "reference to local %select{variable|binding}1 %0 declared in enclosing "
   "%select{%3|block literal|lambda expression|context}2">;
 def err_local_nested_class_invalid_scope : Error<
-  "nested local class %0 must be defined in the same block scope as "
-  "its parent class %1">;
+  "nested local class %0 must be defined in the same block scope as %1">;
 def err_capture_binding_openmp : Error<
   "capturing a structured binding is not yet supported in OpenMP">;
 def ext_capture_binding : ExtWarn<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10267,6 +10267,9 @@ def ext_ms_anonymous_record : ExtWarn<
 def err_reference_to_local_in_enclosing_context : Error<
   "reference to local %select{variable|binding}1 %0 declared in enclosing "
   "%select{%3|block literal|lambda expression|context}2">;
+def err_local_nested_class_invalid_scope : Error<
+  "nested local class %0 must be defined in the same block scope as "
+  "its parent class %1">;
 def err_capture_binding_openmp : Error<
   "capturing a structured binding is not yet supported in OpenMP">;
 def ext_capture_binding : ExtWarn<

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18537,7 +18537,7 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
               Diag(NameLoc, diag::err_local_nested_class_invalid_scope)
                   << Name << OutermostClass;
               Diag(OutermostClass->getLocation(), diag::note_previous_decl)
-                  << OutermostClass << OutermostClass->getLocation();
+                  << OutermostClass;
             }
           }
         }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18536,7 +18536,7 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
                 !S->isDeclScope(OutermostClass)) {
               Diag(NameLoc, diag::err_local_nested_class_invalid_scope)
                   << Name << OutermostClass;
-              Diag(OutermostClass->getLocation(), diag::note_previous_decl)
+              Diag(OutermostClass->getLocation(), diag::note_defined_here)
                   << OutermostClass;
             }
           }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -18521,6 +18521,27 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
           Diag(PrevTagDecl->getLocation(), diag::note_previous_declaration);
         }
 
+        // C++ [class.local]p3:
+        //   A class nested within a local class is a local class. A member of
+        //   a local class X shall be declared only in the definition of X or,
+        //   if the member is a nested class, in the nearest enclosing block
+        //   scope of X.
+        if (TUK == TagUseKind::Definition && SS.isValid()) {
+          if (const auto *OutermostClass = dyn_cast<CXXRecordDecl>(PrevDecl)) {
+            while (const auto *ParentClass =
+                       dyn_cast<CXXRecordDecl>(OutermostClass->getParent()))
+              OutermostClass = ParentClass;
+
+            if (OutermostClass->isLocalClass() &&
+                !S->isDeclScope(OutermostClass)) {
+              Diag(NameLoc, diag::err_local_nested_class_invalid_scope)
+                  << Name << OutermostClass;
+              Diag(OutermostClass->getLocation(), diag::note_previous_decl)
+                  << OutermostClass << OutermostClass->getLocation();
+            }
+          }
+        }
+
         if (!Invalid) {
           // If this is a use, just return the declaration we found, unless
           // we have attributes.

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -131,7 +131,9 @@ auto f7 = [] {
 
 struct A {
   void f() {
-    struct B { struct C; };
+    struct B { struct C; }; // #B
     { struct B::C {}; }
+    // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as its parent class 'B'}}
+    //   expected-note@#B {{'B' defined here}}
   }
 };

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -63,11 +63,19 @@ void f4() {
       }
     };
   }
+  struct A {
+    void f() {
+      struct B { struct C; }; // #B
+      { struct B::C {}; }
+      // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as 'B'}}
+      //   expected-note@#B {{'B' defined here}}
+    }
+  };
   {
     struct A { struct B; }; // #A1
     {
       struct A::B {};
-      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as 'A'}}
       //   expected-note@#A1 {{'A' defined here}}
     }
   }
@@ -75,7 +83,7 @@ void f4() {
     struct A { struct B { struct C; }; }; // #A2
     {
       struct A::B::C {};
-      // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as its parent class 'A'}}
+      // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as 'A'}}
       //   expected-note@#A2 {{'A' defined here}}
     }
   }
@@ -84,7 +92,7 @@ void f4() {
     using AliasForA = A;
     {
       struct AliasForA::B {}; 
-      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as 'A'}}
       //   expected-note@#A3 {{'A' defined here}}
     }
   }
@@ -94,7 +102,7 @@ void f4() {
     struct A;
     {
       struct A::B {};
-      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as 'A'}}
       //   expected-note@#A4 {{'A' defined here}}
     }
   }
@@ -105,7 +113,7 @@ void f5() {
   struct A { struct B; }; // #A5
   {
     struct A::B {};
-    // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+    // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as 'A'}}
     //   expected-note@#A5 {{'A' defined here}}
   }
 }
@@ -117,23 +125,14 @@ decltype(auto) f6() {
 
 using X = decltype(f6());
 struct X::A {};
-// expected-error@-1 {{nested local class 'A' must be defined in the same block scope as its parent class 'S'}}
+// expected-error@-1 {{nested local class 'A' must be defined in the same block scope as 'S'}}
 //   expected-note@#S {{'S' defined here}}
 
 auto f7 = [] {
   struct L { struct B; }; // #L
   {
     struct L::B {};
-    // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'L'}}
+    // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as 'L'}}
     //   expected-note@#L {{'L' defined here}}
-  }
-};
-
-struct A {
-  void f() {
-    struct B { struct C; }; // #B
-    { struct B::C {}; }
-    // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as its parent class 'B'}}
-    //   expected-note@#B {{'B' defined here}}
   }
 };

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -26,7 +26,7 @@ void f3(int a) { // #a-param
     struct Y {
       int f() { return a; }
       // expected-error@-1 {{reference to local variable 'a' declared in enclosing function 'f3'}}
-       // expected-note@#a-param {{'a' declared here}}
+      //   expected-note@#a-param {{'a' declared here}}
     };
   };
 }

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -109,3 +109,29 @@ void f5() {
     //   expected-note@#A5 {{'A' defined here}}
   }
 }
+
+decltype(auto) f6() {
+  struct S { struct A; }; // #S
+  return S();
+}
+
+using X = decltype(f6());
+struct X::A {};
+// expected-error@-1 {{nested local class 'A' must be defined in the same block scope as its parent class 'S'}}
+//   expected-note@#S {{'S' defined here}}
+
+auto f7 = [] {
+  struct L { struct B; }; // #L
+  {
+    struct L::B {};
+    // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'L'}}
+    //   expected-note@#L {{'L' defined here}}
+  }
+};
+
+struct A {
+  void f() {
+    struct B { struct C; };
+    { struct B::C {}; }
+  }
+};

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify -verify-directives %s
 
 void f1() {
   struct X {
@@ -21,10 +21,12 @@ void f2() {
 }
 
 // A class nested within a local class is a local class.
-void f3(int a) { // expected-note{{'a' declared here}}
+void f3(int a) { // #a-param
   struct X {
     struct Y {
-      int f() { return a; } // expected-error{{reference to local variable 'a' declared in enclosing function 'f3'}}
+      int f() { return a; }
+      // expected-error@-1 {{reference to local variable 'a' declared in enclosing function 'f3'}}
+       // expected-note@#a-param {{'a' declared here}}
     };
   };
 }
@@ -62,30 +64,38 @@ void f4() {
     };
   }
   {
-    struct A { struct B; }; // expected-note {{'A' declared here}}
+    struct A { struct B; }; // #A1
     {
-      struct A::B {}; // expected-error {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      struct A::B {};
+      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      //   expected-note@#A1 {{'A' declared here}}
     }
   }
   {
-    struct A { struct B { struct C; }; }; // expected-note {{'A' declared here}}
+    struct A { struct B { struct C; }; }; // #A2
     {
-      struct A::B::C {}; // expected-error {{nested local class 'C' must be defined in the same block scope as its parent class 'A'}}
+      struct A::B::C {};
+      // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as its parent class 'A'}}
+      //   expected-note@#A2 {{'A' declared here}}
     }
   }
   {
-    struct A { struct B; }; // expected-note {{'A' declared here}}
+    struct A { struct B; }; // #A3
     using AliasForA = A;
     {
-      struct AliasForA::B {}; // expected-error {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      struct AliasForA::B {}; 
+      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      //   expected-note@#A3 {{'A' declared here}}
     }
   }
 }
 
 template <typename>
 void f5() {
-  struct A { struct B; }; // expected-note {{'A' declared here}}
+  struct A { struct B; }; // #A4
   {
-    struct A::B {}; // expected-error {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+    struct A::B {};
+    // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+    //   expected-note@#A4 {{'A' declared here}}
   }
 }

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -68,7 +68,7 @@ void f4() {
     {
       struct A::B {};
       // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
-      //   expected-note@#A1 {{'A' declared here}}
+      //   expected-note@#A1 {{'A' defined here}}
     }
   }
   {
@@ -76,7 +76,7 @@ void f4() {
     {
       struct A::B::C {};
       // expected-error@-1 {{nested local class 'C' must be defined in the same block scope as its parent class 'A'}}
-      //   expected-note@#A2 {{'A' declared here}}
+      //   expected-note@#A2 {{'A' defined here}}
     }
   }
   {
@@ -85,17 +85,27 @@ void f4() {
     {
       struct AliasForA::B {}; 
       // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
-      //   expected-note@#A3 {{'A' declared here}}
+      //   expected-note@#A3 {{'A' defined here}}
+    }
+  }
+  {
+    struct A;
+    struct A { struct B; }; // #A4
+    struct A;
+    {
+      struct A::B {};
+      // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+      //   expected-note@#A4 {{'A' defined here}}
     }
   }
 }
 
 template <typename>
 void f5() {
-  struct A { struct B; }; // #A4
+  struct A { struct B; }; // #A5
   {
     struct A::B {};
     // expected-error@-1 {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
-    //   expected-note@#A4 {{'A' declared here}}
+    //   expected-note@#A5 {{'A' defined here}}
   }
 }

--- a/clang/test/CXX/class/class.local/p3.cpp
+++ b/clang/test/CXX/class/class.local/p3.cpp
@@ -1,10 +1,10 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s 
+// RUN: %clang_cc1 -fsyntax-only -verify %s
 
 void f1() {
   struct X {
     struct Y;
   };
-  
+
   struct X::Y {
     void f() {}
   };
@@ -13,7 +13,7 @@ void f1() {
 void f2() {
   struct X {
     struct Y;
-    
+
     struct Y {
       void f() {}
     };
@@ -27,4 +27,65 @@ void f3(int a) { // expected-note{{'a' declared here}}
       int f() { return a; } // expected-error{{reference to local variable 'a' declared in enclosing function 'f3'}}
     };
   };
+}
+
+void f4() {
+  {
+    struct A {
+      struct B;
+      struct B {};
+    };
+  }
+  {
+    struct A { struct B; };
+    struct A::B {};
+  }
+  {
+    struct A { struct B; };
+    {
+      struct A { struct B; };
+      struct A::B {};
+    }
+    struct A::B {};
+  }
+  {
+    struct A { struct B; };
+    struct A::B { struct C; };
+    struct A::B::C {};
+  }
+  {
+    struct A {
+      void f() {
+        struct B { struct C; };
+        struct B::C {};
+      }
+    };
+  }
+  {
+    struct A { struct B; }; // expected-note {{'A' declared here}}
+    {
+      struct A::B {}; // expected-error {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+    }
+  }
+  {
+    struct A { struct B { struct C; }; }; // expected-note {{'A' declared here}}
+    {
+      struct A::B::C {}; // expected-error {{nested local class 'C' must be defined in the same block scope as its parent class 'A'}}
+    }
+  }
+  {
+    struct A { struct B; }; // expected-note {{'A' declared here}}
+    using AliasForA = A;
+    {
+      struct AliasForA::B {}; // expected-error {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+    }
+  }
+}
+
+template <typename>
+void f5() {
+  struct A { struct B; }; // expected-note {{'A' declared here}}
+  {
+    struct A::B {}; // expected-error {{nested local class 'B' must be defined in the same block scope as its parent class 'A'}}
+  }
 }


### PR DESCRIPTION
Fixes #193472.

[[class.local]/3](https://eel.is/c++draft/class.local#3) says:

> A class nested within a local class is a local class. A member of a local class `X` shall be declared only in the definition of `X` or, __if the member is a nested class, in the nearest enclosing block scope of X__.

In other words:

```cpp
void f() {
  struct X { struct S; };
  struct X::S {}; // okay

  struct X { struct S; };
  {
    struct X::S {}; // error
  }
}
```

To save anyone from a misconception that confused me for a bit: the body of a class is not a block scope! [[basic.scope.block]/1](https://eel.is/c++draft/basic.scope.block#1). So the following example is well-formed, because `A`, `X`, and `S` are all in the same block scope (`f`'s *compound-statement*):

```cpp
void f() {
  struct A { struct X { struct S; }; };
  struct A::X::S {}; // okay
}
```