### PR TITLE
[LICM][NFC] Factor canHoistLoad out of canSinkOrHoistInst into LoopUtils

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -458,11 +458,11 @@ LLVM_ABI bool canSinkOrHoistInst(Instruction &I, AAResults *AA,
 /// Returns true if it is legal to hoist \p LI out of \p CurLoop. This is the
 /// load-specific subset of \c canSinkOrHoistInst: it rejects volatile or
 /// ordered loads, allows constant-memory / invariant.load / invariant.start-
-/// dominated loads unconditionally, and otherwise queries MemorySSA for an
+/// dominated loads unconditionally, and otherwise queries \p MSSA for an
 /// in-loop clobber. \p TargetExecutesOncePerLoop has the same meaning as in
 /// \c canSinkOrHoistInst (set to true when hoisting to the preheader).
 LLVM_ABI bool canHoistLoad(LoadInst &LI, AAResults *AA, DominatorTree *DT,
-                           Loop *CurLoop, MemorySSAUpdater &MSSAU,
+                           Loop *CurLoop, MemorySSA &MSSA,
                            bool TargetExecutesOncePerLoop,
                            SinkAndHoistLICMFlags &LICMFlags,
                            OptimizationRemarkEmitter *ORE = nullptr);

--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -455,6 +455,18 @@ LLVM_ABI bool canSinkOrHoistInst(Instruction &I, AAResults *AA,
                                  SinkAndHoistLICMFlags &LICMFlags,
                                  OptimizationRemarkEmitter *ORE = nullptr);
 
+/// Returns true if it is legal to hoist \p LI out of \p CurLoop. This is the
+/// load-specific subset of \c canSinkOrHoistInst: it rejects volatile or
+/// ordered loads, allows constant-memory / invariant.load / invariant.start-
+/// dominated loads unconditionally, and otherwise queries MemorySSA for an
+/// in-loop clobber. \p TargetExecutesOncePerLoop has the same meaning as in
+/// \c canSinkOrHoistInst (set to true when hoisting to the preheader).
+LLVM_ABI bool canHoistLoad(LoadInst &LI, AAResults *AA, DominatorTree *DT,
+                           Loop *CurLoop, MemorySSAUpdater &MSSAU,
+                           bool TargetExecutesOncePerLoop,
+                           SinkAndHoistLICMFlags &LICMFlags,
+                           OptimizationRemarkEmitter *ORE = nullptr);
+
 /// Returns the llvm.vector.reduce intrinsic that corresponds to the recurrence
 /// kind.
 LLVM_ABI constexpr Intrinsic::ID getReductionIntrinsicID(RecurKind RK);

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1162,7 +1162,7 @@ static MemoryAccess *getClobberingMemoryAccess(MemorySSA &MSSA,
 }
 
 bool llvm::canHoistLoad(LoadInst &LI, AAResults *AA, DominatorTree *DT,
-                        Loop *CurLoop, MemorySSAUpdater &MSSAU,
+                        Loop *CurLoop, MemorySSA &MSSA,
                         bool TargetExecutesOncePerLoop,
                         SinkAndHoistLICMFlags &Flags,
                         OptimizationRemarkEmitter *ORE) {
@@ -1183,13 +1183,12 @@ bool llvm::canHoistLoad(LoadInst &LI, AAResults *AA, DominatorTree *DT,
   if (isLoadInvariantInLoop(&LI, DT, CurLoop))
     return true;
 
-  MemorySSA *MSSA = MSSAU.getMemorySSA();
-  auto *MU = cast<MemoryUse>(MSSA->getMemoryAccess(&LI));
+  auto *MU = cast<MemoryUse>(MSSA.getMemoryAccess(&LI));
 
   bool InvariantGroup = LI.hasMetadata(LLVMContext::MD_invariant_group);
 
   bool Invalidated =
-      pointerInvalidatedByLoop(MSSA, MU, CurLoop, LI, Flags, InvariantGroup);
+      pointerInvalidatedByLoop(&MSSA, MU, CurLoop, LI, Flags, InvariantGroup);
   // Check loop-invariant address because this may also be a sinkable load
   // whose address is not necessarily loop-invariant.
   if (ORE && Invalidated && CurLoop->isLoopInvariant(LI.getPointerOperand()))
@@ -1215,7 +1214,7 @@ bool llvm::canSinkOrHoistInst(Instruction &I, AAResults *AA, DominatorTree *DT,
   MemorySSA *MSSA = MSSAU.getMemorySSA();
   // Loads have extra constraints we have to verify before we can hoist them.
   if (LoadInst *LI = dyn_cast<LoadInst>(&I)) {
-    return canHoistLoad(*LI, AA, DT, CurLoop, MSSAU, TargetExecutesOncePerLoop,
+    return canHoistLoad(*LI, AA, DT, CurLoop, *MSSA, TargetExecutesOncePerLoop,
                         Flags, ORE);
   } else if (CallInst *CI = dyn_cast<CallInst>(&I)) {
     // Don't sink calls which can throw.

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -1161,6 +1161,48 @@ static MemoryAccess *getClobberingMemoryAccess(MemorySSA &MSSA,
   return Source;
 }
 
+bool llvm::canHoistLoad(LoadInst &LI, AAResults *AA, DominatorTree *DT,
+                        Loop *CurLoop, MemorySSAUpdater &MSSAU,
+                        bool TargetExecutesOncePerLoop,
+                        SinkAndHoistLICMFlags &Flags,
+                        OptimizationRemarkEmitter *ORE) {
+  if (!LI.isUnordered())
+    return false; // Don't sink/hoist volatile or ordered atomic loads!
+
+  // Loads from constant memory are always safe to move, even if they end up
+  // in the same alias set as something that ends up being modified.
+  if (!isModSet(AA->getModRefInfoMask(LI.getOperand(0))))
+    return true;
+  if (LI.hasMetadata(LLVMContext::MD_invariant_load))
+    return true;
+
+  if (LI.isAtomic() && !TargetExecutesOncePerLoop)
+    return false; // Don't risk duplicating unordered loads
+
+  // This checks for an invariant.start dominating the load.
+  if (isLoadInvariantInLoop(&LI, DT, CurLoop))
+    return true;
+
+  MemorySSA *MSSA = MSSAU.getMemorySSA();
+  auto *MU = cast<MemoryUse>(MSSA->getMemoryAccess(&LI));
+
+  bool InvariantGroup = LI.hasMetadata(LLVMContext::MD_invariant_group);
+
+  bool Invalidated =
+      pointerInvalidatedByLoop(MSSA, MU, CurLoop, LI, Flags, InvariantGroup);
+  // Check loop-invariant address because this may also be a sinkable load
+  // whose address is not necessarily loop-invariant.
+  if (ORE && Invalidated && CurLoop->isLoopInvariant(LI.getPointerOperand()))
+    ORE->emit([&]() {
+      return OptimizationRemarkMissed(
+                 DEBUG_TYPE, "LoadWithLoopInvariantAddressInvalidated", &LI)
+             << "failed to move load with loop-invariant address "
+                "because the loop may invalidate its value";
+    });
+
+  return !Invalidated;
+}
+
 bool llvm::canSinkOrHoistInst(Instruction &I, AAResults *AA, DominatorTree *DT,
                               Loop *CurLoop, MemorySSAUpdater &MSSAU,
                               bool TargetExecutesOncePerLoop,
@@ -1173,40 +1215,8 @@ bool llvm::canSinkOrHoistInst(Instruction &I, AAResults *AA, DominatorTree *DT,
   MemorySSA *MSSA = MSSAU.getMemorySSA();
   // Loads have extra constraints we have to verify before we can hoist them.
   if (LoadInst *LI = dyn_cast<LoadInst>(&I)) {
-    if (!LI->isUnordered())
-      return false; // Don't sink/hoist volatile or ordered atomic loads!
-
-    // Loads from constant memory are always safe to move, even if they end up
-    // in the same alias set as something that ends up being modified.
-    if (!isModSet(AA->getModRefInfoMask(LI->getOperand(0))))
-      return true;
-    if (LI->hasMetadata(LLVMContext::MD_invariant_load))
-      return true;
-
-    if (LI->isAtomic() && !TargetExecutesOncePerLoop)
-      return false; // Don't risk duplicating unordered loads
-
-    // This checks for an invariant.start dominating the load.
-    if (isLoadInvariantInLoop(LI, DT, CurLoop))
-      return true;
-
-    auto MU = cast<MemoryUse>(MSSA->getMemoryAccess(LI));
-
-    bool InvariantGroup = LI->hasMetadata(LLVMContext::MD_invariant_group);
-
-    bool Invalidated = pointerInvalidatedByLoop(
-        MSSA, MU, CurLoop, I, Flags, InvariantGroup);
-    // Check loop-invariant address because this may also be a sinkable load
-    // whose address is not necessarily loop-invariant.
-    if (ORE && Invalidated && CurLoop->isLoopInvariant(LI->getPointerOperand()))
-      ORE->emit([&]() {
-        return OptimizationRemarkMissed(
-                   DEBUG_TYPE, "LoadWithLoopInvariantAddressInvalidated", LI)
-               << "failed to move load with loop-invariant address "
-                  "because the loop may invalidate its value";
-      });
-
-    return !Invalidated;
+    return canHoistLoad(*LI, AA, DT, CurLoop, MSSAU, TargetExecutesOncePerLoop,
+                        Flags, ORE);
   } else if (CallInst *CI = dyn_cast<CallInst>(&I)) {
     // Don't sink calls which can throw.
     if (CI->mayThrow())


### PR DESCRIPTION
This patch moves the load-only legality logic from `canSinkOrHoistInst` into a new `canHoistLoad` helper, declared in `llvm/Transforms/Utils/LoopUtils.h` and defined in `LICM.cpp`. `canSinkOrHoistInst` delegates to it for `LoadInst`, so its behavior is unchanged.

This exposes the load-hoist check for reuse by other passes (e.g. the GVN min-finding select transform in PR #162259).