### PR TITLE
[llvm-profgen] Speed up parsing of MMap events

### DIFF
--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1115,10 +1115,10 @@ bool PerfScriptReader::extractMMapEventForBinary(ProfiledBinary *Binary,
   bool R = false;
   SmallVector<StringRef, 7> Fields;
   if (Line.contains("PERF_RECORD_MMAP2 ")) {
-    static Regex RegMmap2(MMap2Pattern);
+    Regex RegMmap2(MMap2Pattern);
     R = RegMmap2.match(Line, &Fields);
   } else if (Line.contains("PERF_RECORD_MMAP ")) {
-    static Regex RegMmap(MMapPattern);
+    Regex RegMmap(MMapPattern);
     R = RegMmap.match(Line, &Fields);
   } else
     llvm_unreachable("unexpected MMAP event entry");

--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -1079,6 +1079,9 @@ void PerfScriptReader::parseSample(TraceStream &TraceIt) {
 bool PerfScriptReader::extractMMapEventForBinary(ProfiledBinary *Binary,
                                                  StringRef Line,
                                                  MMapEvent &MMap) {
+  if (!Binary->isKernel() && !Line.contains(Binary->getName()) &&
+      !ShowMmapEvents)
+    return false;
   // Parse a MMap2 line like:
   //  PERF_RECORD_MMAP2 2113428/2113428: [0x7fd4efb57000(0x204000) @ 0
   //  08:04 19532229 3585508847]: r-xp /usr/lib64/libdl-2.17.so
@@ -1112,10 +1115,10 @@ bool PerfScriptReader::extractMMapEventForBinary(ProfiledBinary *Binary,
   bool R = false;
   SmallVector<StringRef, 7> Fields;
   if (Line.contains("PERF_RECORD_MMAP2 ")) {
-    Regex RegMmap2(MMap2Pattern);
+    static Regex RegMmap2(MMap2Pattern);
     R = RegMmap2.match(Line, &Fields);
   } else if (Line.contains("PERF_RECORD_MMAP ")) {
-    Regex RegMmap(MMapPattern);
+    static Regex RegMmap(MMapPattern);
     R = RegMmap.match(Line, &Fields);
   } else
     llvm_unreachable("unexpected MMAP event entry");


### PR DESCRIPTION
During the mmap extraction, `extractMMapEventForBinary()` is invoked line by line to parse the perf script(usually 100K to 1M+ lines). This patch tries to early quit when the current line does not contain the Binary name, and this will help to avoid subsequent parsing overhead(baseline behavior uses regex to extract the name, returning false if it doesn't match the current binary).

With this minor change, the execution time of extractMMapEventForBinary() dropped from 13,600ms to 32ms(-99%) in an internal workload test(827K lines).

