### PR TITLE
[LIT] Add --load-limit N option

### DIFF
--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -95,6 +95,16 @@ def parse_args():
         default=os.getenv("LIT_MAX_WORKERS", lit.util.usable_core_count()),
     )
     parser.add_argument(
+        "-jmin",
+        "--threads_min",
+        "--workers_min",
+        dest="workers_min",
+        metavar="N",
+        help="Minimal number of workers used for testing if `--load-limit FRAC` is enabled",
+        type=_positive_int,
+        default=os.getenv("LIT_MIN_WORKERS", 1),
+    )
+    parser.add_argument(
         "-l",
         "--load-limit",
         dest="load_limit_fraction",
@@ -539,6 +549,14 @@ def parse_args():
         print(
             "WARNING: --incremental is deprecated. Failing tests now always run first."
         )
+
+    if opts.workers_min > opts.workers:
+        print(
+            "WARNING: --threads_min %d is bigger than --threads %d. "
+            "Used default --threads_min 1."
+            % (opts.workers_min, opts.workers)
+        )
+        opts.workers_min = 1
 
     if opts.load_limit_fraction is not None and not hasattr(os, "getloadavg"):
         print(

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -95,6 +95,22 @@ def parse_args():
         default=os.getenv("LIT_MAX_WORKERS", lit.util.usable_core_count()),
     )
     parser.add_argument(
+        "-l",
+        "--load-limit",
+        dest="load_limit_fraction",
+        metavar="FRAC",
+        help="Aim to keep the 1-minute system load average near "
+        "FRAC * number-of-CPU-cores, by smoothly adjusting the number "
+        "of concurrent tests up or down (similar to 'make -l'). FRAC "
+        "must be in (0, 2] -- e.g. 0.8 targets 80%% of CPU capacity, "
+        "2 targets 200%% of CPU capacity (Not recommended). "
+        "Concurrency is capped at -j workers and never less than 1, so "
+        "progress is never blocked. Ignored on platforms without "
+        "os.getloadavg().",
+        type=_bounded_float(0, 2, lo_inclusive=False, hi_inclusive=True),
+        default=os.getenv("LIT_LOAD_LIMIT"),
+    )
+    parser.add_argument(
         "--config-prefix",
         dest="configPrefix",
         metavar="NAME",
@@ -524,6 +540,13 @@ def parse_args():
             "WARNING: --incremental is deprecated. Failing tests now always run first."
         )
 
+    if opts.load_limit_fraction is not None and not hasattr(os, "getloadavg"):
+        print(
+            "WARNING: --load-limit is ignored: os.getloadavg() is not "
+            "available on this platform."
+        )
+        opts.load_limit_fraction = None
+
     if opts.numShards or opts.runShard:
         if not opts.numShards or not opts.runShard:
             parser.error("--num-shards and --run-shard must be used together")
@@ -586,6 +609,24 @@ def _float(arg, kind, pred):
             f"conversion error - requires {kind} float, but found '{arg}'"
         )
     return f
+
+
+def _bounded_float(lo, hi, lo_inclusive=True, hi_inclusive=True):
+    """Return an argparse validator for floats in the given range."""
+    lo_op = "[" if lo_inclusive else "("
+    hi_op = "]" if hi_inclusive else ")"
+    desc = "requires number in %s%g, %g%s, but found '{}'" % (lo_op, lo, hi, hi_op)
+    def _check(arg):
+        try:
+            f = float(arg)
+        except ValueError:
+            raise _error(desc, arg)
+        if (lo_inclusive and f < lo) or (not lo_inclusive and f <= lo):
+            raise _error(desc, arg)
+        if (hi_inclusive and f > hi) or (not hi_inclusive and f >= hi):
+            raise _error(desc, arg)
+        return f
+    return _check
 
 
 def _case_insensitive_regex(arg):

--- a/llvm/utils/lit/lit/display.py
+++ b/llvm/utils/lit/lit/display.py
@@ -5,13 +5,19 @@ from argparse import Namespace
 from lit.Test import Test
 
 
-def create_display(opts, tests, total_tests, workers):
+def create_display(opts, tests, total_tests, workers, load_limit_fraction):
     if opts.print_result_after == "off" and not opts.useProgressBar:
         return NopDisplay()
 
     num_tests = len(tests)
     of_total = (" of %d" % total_tests) if (num_tests != total_tests) else ""
-    header = "-- Testing: %d%s tests, %d workers --" % (num_tests, of_total, workers)
+    parts = [
+        "%d%s tests" % (num_tests, of_total),
+        ", %d workers" % workers,
+        # render load_limit_fraction as a percentage
+        (", load-limit %g%%" % (load_limit_fraction * 100)) if load_limit_fraction is not None else "",
+    ]
+    header = "-- Testing: " + "".join(parts) + " --"
 
     progress_bar = None
     if opts.useProgressBar:

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -270,10 +270,19 @@ def mark_excluded(discovered_tests, selected_tests):
 
 def run_tests(tests, lit_config, opts, discovered_tests):
     workers = min(len(tests), opts.workers)
-    display = lit.display.create_display(opts, tests, discovered_tests, workers)
+    load_limit_fraction = opts.load_limit_fraction
+    display = lit.display.create_display(
+        opts, tests, discovered_tests, workers, load_limit_fraction
+    )
 
     run = lit.run.Run(
-        tests, lit_config, workers, display.update, opts.max_failures, opts.timeout
+        tests,
+        lit_config,
+        workers,
+        display.update,
+        opts.max_failures,
+        opts.timeout,
+        load_limit_fraction,
     )
 
     display.print_header()

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -270,6 +270,7 @@ def mark_excluded(discovered_tests, selected_tests):
 
 def run_tests(tests, lit_config, opts, discovered_tests):
     workers = min(len(tests), opts.workers)
+    workers_min = opts.workers_min
     load_limit_fraction = opts.load_limit_fraction
     display = lit.display.create_display(
         opts, tests, discovered_tests, workers, load_limit_fraction
@@ -279,6 +280,7 @@ def run_tests(tests, lit_config, opts, discovered_tests):
         tests,
         lit_config,
         workers,
+        workers_min,
         display.update,
         opts.max_failures,
         opts.timeout,

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -28,11 +28,12 @@ class Run(object):
     """A concrete, configured testing run."""
 
     def __init__(
-        self, tests, lit_config, workers, progress_callback, max_failures, timeout, load_limit_fraction
+        self, tests, lit_config, workers, workers_min, progress_callback, max_failures, timeout, load_limit_fraction
     ):
         self.tests = tests
         self.lit_config = lit_config
         self.workers = workers
+        self.workers_min = workers_min
         self.progress_callback = progress_callback
         self.max_failures = max_failures
         self.timeout = timeout
@@ -102,7 +103,7 @@ class Run(object):
         #     ramp up to 16 (if load stays low) avoids an initial burst that
         #     would immediately overshoot the limit before the first tick.
         if self.load_limit is not None:
-            initial_ceiling = max(1, min(self.workers, int(self.load_limit)))
+            initial_ceiling = max(self.workers_min, min(self.workers, int(self.load_limit)))
         else:
             initial_ceiling = self.workers
         # Seed last_tick to "now" so the controller honors the initial
@@ -143,9 +144,10 @@ class Run(object):
                 (
                     self.lit_config,
                     semaphores,
+                    self.workers,
+                    self.workers_min,
                     self.load_limit,
                     load_state,
-                    self.workers,
                 ),
             )
             pools.append(pool)

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -36,8 +36,7 @@ class Run(object):
         self.progress_callback = progress_callback
         self.max_failures = max_failures
         self.timeout = timeout
-        if load_limit_fraction is not None:
-            self.load_limit = load_limit_fraction * lit.util.usable_core_count()
+        self.load_limit = load_limit_fraction * lit.util.usable_core_count() if load_limit_fraction is not None else None
         assert workers > 0
 
     def execute(self):

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -28,7 +28,7 @@ class Run(object):
     """A concrete, configured testing run."""
 
     def __init__(
-        self, tests, lit_config, workers, progress_callback, max_failures, timeout
+        self, tests, lit_config, workers, progress_callback, max_failures, timeout, load_limit_fraction
     ):
         self.tests = tests
         self.lit_config = lit_config
@@ -36,6 +36,8 @@ class Run(object):
         self.progress_callback = progress_callback
         self.max_failures = max_failures
         self.timeout = timeout
+        if load_limit_fraction is not None:
+            self.load_limit = load_limit_fraction * lit.util.usable_core_count()
         assert workers > 0
 
     def execute(self):
@@ -80,6 +82,36 @@ class Run(object):
             if v is not None
         }
 
+        # Shared state used by --load-limit (one multiprocessing.Array, all
+        # accesses guarded by the array's internal lock):
+        #   index 0: last_tick - timestamp of the most recent controller
+        #                        adjustment of `ceiling`.
+        #   index 1: running   - number of tests currently executing across
+        #                        all workers.
+        #   index 2: ceiling   - dynamic concurrency ceiling (stored as a
+        #                        float so sub-worker adjustments accumulate
+        #                        smoothly).  See lit.worker._tick_ceiling()
+        #                        for the proportional update rule.  Bounded
+        #                        in [1.0, self.workers].
+        #
+        # Initial ceiling:
+        #   * --load-limit unset  -> workers       (option is a no-op)
+        #   * --load-limit set    -> min(workers, int(load_limit))
+        #     This gives a gentler start: on a busy host the user typically
+        #     asks for e.g. `-j 16 -l 4`, meaning "16 max, but currently keep
+        #     load near 4".  Starting at 4 threads and letting the controller
+        #     ramp up to 16 (if load stays low) avoids an initial burst that
+        #     would immediately overshoot the limit before the first tick.
+        if self.load_limit is not None:
+            initial_ceiling = max(1, min(self.workers, int(self.load_limit)))
+        else:
+            initial_ceiling = self.workers
+        # Seed last_tick to "now" so the controller honors the initial
+        # ceiling for a full LIT_LOAD_TICK interval before adjusting.
+        load_state = multiprocessing.Array(
+            "d", [time.time(), 0.0, float(initial_ceiling)]
+        )
+
         # Windows has a limit of 60 workers per pool, so we need to use multiple pools
         # if we have more workers requested than the limit.
         # Also, allow to override the limit with the LIT_WINDOWS_MAX_WORKERS_PER_POOL environment variable.
@@ -107,7 +139,15 @@ class Run(object):
         pools = []
         for pool_size in workers_per_pool_list:
             pool = multiprocessing.Pool(
-                pool_size, lit.worker.initialize, (self.lit_config, semaphores)
+                pool_size,
+                lit.worker.initialize,
+                (
+                    self.lit_config,
+                    semaphores,
+                    self.load_limit,
+                    load_state,
+                    self.workers,
+                ),
             )
             pools.append(pool)
 

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -97,8 +97,6 @@ def _tick_ceiling(now, load1m):
     int(ceiling), so concurrency only changes once the float crosses an
     integer boundary -- this naturally damps churn near the limit.
     """
-    if not _load_limit:
-        return
     if (now - _load_state[_S_LAST_TICK]) < _LOAD_TICK_INTERVAL:
         return
     _load_state[_S_LAST_TICK] = now
@@ -115,14 +113,15 @@ def _acquire_run_slot():
     a dynamic ceiling whose movement is proportional to the (signed)
     distance between the 1-minute system load and --load-limit; see
     _tick_ceiling().  A new test is admitted when:
-      * running == 0           (forward progress - never wait forever), or
-      * running <  int(ceiling)  (within the current concurrency budget).
+      * running == 0             (forward progress - never wait forever), or
+      * running <  int(ceiling)  (within the current concurrency budget), or
+      * running <  _min_ceiling  (optional).
 
     The ceiling is stored as a float internally so that near-limit
     fluctuations of well under one worker accumulate smoothly instead of
     flipping concurrency on every tick.
     """
-    if _load_state is None or _load_limit is None or not _HAS_LOADAVG:
+    if _load_state is None or not _HAS_LOADAVG:
         return
 
     debug = _debug_enabled()
@@ -165,14 +164,18 @@ def _acquire_run_slot():
 
 
 def _release_run_slot():
-    if _load_state is None or _load_limit is None or not _HAS_LOADAVG:
+    if _load_state is None or not _HAS_LOADAVG:
         return
+
+    debug = _debug_enabled()
+
     with _load_state.get_lock():
         if _load_state[_S_RUNNING] > 0:
             _load_state[_S_RUNNING] -= 1
-        running = int(_load_state[_S_RUNNING])
-        ceiling_f = float(_load_state[_S_CEILING])
-    if _debug_enabled():
+            if debug:
+                running = int(_load_state[_S_RUNNING])
+                ceiling_f = float(_load_state[_S_CEILING])
+    if debug:
         load1m = os.getloadavg()[0] if _HAS_LOADAVG else 0.0
         _lit_config.dbg(
             "test done:  pid=%d running=%d ceiling=%d (%.2f) load=%.2f"
@@ -188,12 +191,14 @@ def execute(test):
     Arguments and results of this function are pickled, so they should be cheap
     to copy.
     """
-    _acquire_run_slot()
+    if _load_limit:
+        _acquire_run_slot()
     try:
         with _get_parallelism_semaphore(test):
             result = _execute(test, _lit_config)
     finally:
-        _release_run_slot()
+        if _load_limit:
+            _release_run_slot()
 
     test.setResult(result)
     return test

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -70,9 +70,6 @@ def initialize(
     # https://noswap.com/blog/python-multiprocessing-keyboardinterrupt
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-def _debug_enabled():
-    return _lit_config is not None and getattr(_lit_config, "debug", False)
-
 
 def _tick_ceiling(now, load1m):
     """Adjust the dynamic concurrency ceiling (proportional controller).
@@ -124,8 +121,6 @@ def _acquire_run_slot():
     if _load_state is None or not _HAS_LOADAVG:
         return
 
-    debug = _debug_enabled()
-
     while True:
         load1m = os.getloadavg()[0]
         now = time.time()
@@ -142,45 +137,16 @@ def _acquire_run_slot():
                 _load_state[_S_RUNNING] = running
                 break
 
-        if debug:
-            _lit_config.dbg(
-                "load-limit: pid=%d running=%d "
-                "ceiling=%d (%.2f) load=%.2f limit=%.2f | waiting"
-                % (
-                    os.getpid(), running, ceiling, ceiling_f,
-                    load1m, _load_limit,
-                )
-            )
         # Jittered sleep so all idle workers don't re-check in lockstep.
         time.sleep(_LOAD_POLL_INTERVAL + random.uniform(0.0, _LOAD_POLL_INTERVAL))
-
-    if debug:
-        _lit_config.dbg(
-            "test start: pid=%d running=%d ceiling=%d (%.2f) load=%.2f"
-            % (
-                os.getpid(), running, ceiling, ceiling_f, load1m,
-            )
-        )
-
 
 def _release_run_slot():
     if _load_state is None or not _HAS_LOADAVG:
         return
 
-    debug = _debug_enabled()
-
     with _load_state.get_lock():
         if _load_state[_S_RUNNING] > 0:
             _load_state[_S_RUNNING] -= 1
-            if debug:
-                running = int(_load_state[_S_RUNNING])
-                ceiling_f = float(_load_state[_S_CEILING])
-    if debug:
-        load1m = os.getloadavg()[0] if _HAS_LOADAVG else 0.0
-        _lit_config.dbg(
-            "test done:  pid=%d running=%d ceiling=%d (%.2f) load=%.2f"
-            % (os.getpid(), running, int(ceiling_f), ceiling_f, load1m)
-        )
 
 def execute(test):
     """Run one test in a multiprocessing.Pool

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -46,21 +46,24 @@ _HAS_LOADAVG = hasattr(os, "getloadavg")
 def initialize(
     lit_config,
     parallelism_semaphores,
+    workers_max,
+    workers_min=1,
     load_limit=None,
     load_state=None,
-    max_ceiling=1,
 ):
     """Copy data shared by all test executions into worker processes"""
     global _lit_config
     global _parallelism_semaphores
     global _load_limit
     global _load_state
+    global _min_ceiling
     global _max_ceiling
     _lit_config = lit_config
     _parallelism_semaphores = parallelism_semaphores
     _load_limit = load_limit
     _load_state = load_state
-    _max_ceiling = max(1, int(max_ceiling))
+    _min_ceiling = max(1, int(workers_min))
+    _max_ceiling = max(1, int(workers_max))
 
     # We use the following strategy for dealing with Ctrl+C/KeyboardInterrupt in
     # subprocesses created by the multiprocessing.Pool.
@@ -102,7 +105,7 @@ def _tick_ceiling(now, load1m):
 
     distance = max(-1.0, min(1.0, (load1m - _load_limit) / _load_limit))
     new_ceiling = _load_state[_S_CEILING] - distance * _LOAD_MAX_STEP
-    _load_state[_S_CEILING] = max(1.0, min(float(_max_ceiling), new_ceiling))
+    _load_state[_S_CEILING] = max(float(_min_ceiling), min(float(_max_ceiling), new_ceiling))
 
 
 def _acquire_run_slot():
@@ -119,56 +122,50 @@ def _acquire_run_slot():
     fluctuations of well under one worker accumulate smoothly instead of
     flipping concurrency on every tick.
     """
-    if _load_state is None:
+    if _load_state is None or _load_limit is None or not _HAS_LOADAVG:
         return
 
-    feature_on = bool(_load_limit) and _HAS_LOADAVG
     debug = _debug_enabled()
-    waited = False
 
     while True:
-        load1m = os.getloadavg()[0] if _HAS_LOADAVG else 0.0
+        load1m = os.getloadavg()[0]
         now = time.time()
 
         with _load_state.get_lock():
-            if feature_on:
-                _tick_ceiling(now, load1m)
+            _tick_ceiling(now, load1m)
 
             running = int(_load_state[_S_RUNNING])
             ceiling_f = float(_load_state[_S_CEILING])
             ceiling = int(ceiling_f)
 
-            allow = not feature_on or running == 0 or running < ceiling
-            if allow:
+            if running == 0 or running < _min_ceiling or running < ceiling:
                 running += 1
                 _load_state[_S_RUNNING] = running
                 break
 
         if debug:
             _lit_config.dbg(
-                "load-limit: waiting (pid=%d running=%d "
-                "ceiling=%d (%.2f) load=%.2f limit=%.2f)"
+                "load-limit: pid=%d running=%d "
+                "ceiling=%d (%.2f) load=%.2f limit=%.2f | waiting"
                 % (
                     os.getpid(), running, ceiling, ceiling_f,
                     load1m, _load_limit,
                 )
             )
-        waited = True
         # Jittered sleep so all idle workers don't re-check in lockstep.
         time.sleep(_LOAD_POLL_INTERVAL + random.uniform(0.0, _LOAD_POLL_INTERVAL))
 
     if debug:
         _lit_config.dbg(
-            "test start: pid=%d running=%d ceiling=%d (%.2f) load=%.2f%s"
+            "test start: pid=%d running=%d ceiling=%d (%.2f) load=%.2f"
             % (
                 os.getpid(), running, ceiling, ceiling_f, load1m,
-                " (after wait)" if waited else "",
             )
         )
 
 
 def _release_run_slot():
-    if _load_state is None:
+    if _load_state is None or _load_limit is None or not _HAS_LOADAVG:
         return
     with _load_state.get_lock():
         if _load_state[_S_RUNNING] > 0:

--- a/llvm/utils/lit/lit/worker.py
+++ b/llvm/utils/lit/lit/worker.py
@@ -7,6 +7,7 @@ and store it in global variables. This reduces the cost of each task.
 """
 import contextlib
 import os
+import random
 import signal
 import time
 import traceback
@@ -18,20 +19,168 @@ from lit.TestRunner import TestUpdaterException
 
 _lit_config = None
 _parallelism_semaphores = None
+_load_limit = None
+# Shared multiprocessing.Array('d', [last_tick, running, ceiling]).
+_load_state = None
+# Hard cap on the dynamic ceiling -- the -j value.
+_max_ceiling = 1
 
+# Indices into _load_state.  Must match the layout allocated in run.py.
+_S_LAST_TICK = 0
+_S_RUNNING = 1
+_S_CEILING = 2
 
-def initialize(lit_config, parallelism_semaphores):
+# Tunables for the load-average gate.  Exposed via environment variables
+# so users can experiment without having to recompile or edit the source.
+_LOAD_POLL_INTERVAL = float(os.environ.get("LIT_LOAD_POLL", "1.0"))
+_LOAD_TICK_INTERVAL = float(os.environ.get("LIT_LOAD_TICK", "1.0"))
+# Maximum +/- adjustment of the (float) ceiling per controller tick when the
+# system is saturated (load <= 0 or load >= 2*limit).  Near the limit the
+# adjustment shrinks proportionally, damping oscillations.
+_LOAD_MAX_STEP = float(os.environ.get("LIT_LOAD_STEP", "1.0"))
+
+# Whether os.getloadavg() is available on this platform.  Cached because
+# the gate consults it on every poll iteration.
+_HAS_LOADAVG = hasattr(os, "getloadavg")
+
+def initialize(
+    lit_config,
+    parallelism_semaphores,
+    load_limit=None,
+    load_state=None,
+    max_ceiling=1,
+):
     """Copy data shared by all test executions into worker processes"""
     global _lit_config
     global _parallelism_semaphores
+    global _load_limit
+    global _load_state
+    global _max_ceiling
     _lit_config = lit_config
     _parallelism_semaphores = parallelism_semaphores
+    _load_limit = load_limit
+    _load_state = load_state
+    _max_ceiling = max(1, int(max_ceiling))
 
     # We use the following strategy for dealing with Ctrl+C/KeyboardInterrupt in
     # subprocesses created by the multiprocessing.Pool.
     # https://noswap.com/blog/python-multiprocessing-keyboardinterrupt
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
+def _debug_enabled():
+    return _lit_config is not None and getattr(_lit_config, "debug", False)
+
+
+def _tick_ceiling(now, load1m):
+    """Adjust the dynamic concurrency ceiling (proportional controller).
+
+    Must be called with _load_state's lock held.  Performs at most one
+    adjustment per LIT_LOAD_TICK seconds.  The adjustment is
+    proportional to the normalized signed distance between current load
+    and --load-limit, clamped to a maximum of +/- LIT_LOAD_STEP per
+    tick:
+
+        distance = clamp((load - limit) / limit, -1, +1)
+        delta    = -distance * LIT_LOAD_STEP
+        ceiling  = clamp(ceiling + delta, 1.0, workers)
+
+    Effect:
+      * load == limit       -> delta == 0,        ceiling holds steady
+      * load == 0           -> delta == +STEP,    fastest ramp-up
+      * load == 2 * limit   -> delta == -STEP,    fastest shrink
+      * load just above/below limit -> tiny delta, no oscillation
+
+    The ceiling is stored as a float; the gate compares `running` to
+    int(ceiling), so concurrency only changes once the float crosses an
+    integer boundary -- this naturally damps churn near the limit.
+    """
+    if not _load_limit:
+        return
+    if (now - _load_state[_S_LAST_TICK]) < _LOAD_TICK_INTERVAL:
+        return
+    _load_state[_S_LAST_TICK] = now
+
+    distance = max(-1.0, min(1.0, (load1m - _load_limit) / _load_limit))
+    new_ceiling = _load_state[_S_CEILING] - distance * _LOAD_MAX_STEP
+    _load_state[_S_CEILING] = max(1.0, min(float(_max_ceiling), new_ceiling))
+
+
+def _acquire_run_slot():
+    """Block until it is OK to start a new test.
+
+    With --load-limit set, the number of concurrent tests is governed by
+    a dynamic ceiling whose movement is proportional to the (signed)
+    distance between the 1-minute system load and --load-limit; see
+    _tick_ceiling().  A new test is admitted when:
+      * running == 0           (forward progress - never wait forever), or
+      * running <  int(ceiling)  (within the current concurrency budget).
+
+    The ceiling is stored as a float internally so that near-limit
+    fluctuations of well under one worker accumulate smoothly instead of
+    flipping concurrency on every tick.
+    """
+    if _load_state is None:
+        return
+
+    feature_on = bool(_load_limit) and _HAS_LOADAVG
+    debug = _debug_enabled()
+    waited = False
+
+    while True:
+        load1m = os.getloadavg()[0] if _HAS_LOADAVG else 0.0
+        now = time.time()
+
+        with _load_state.get_lock():
+            if feature_on:
+                _tick_ceiling(now, load1m)
+
+            running = int(_load_state[_S_RUNNING])
+            ceiling_f = float(_load_state[_S_CEILING])
+            ceiling = int(ceiling_f)
+
+            allow = not feature_on or running == 0 or running < ceiling
+            if allow:
+                running += 1
+                _load_state[_S_RUNNING] = running
+                break
+
+        if debug:
+            _lit_config.dbg(
+                "load-limit: waiting (pid=%d running=%d "
+                "ceiling=%d (%.2f) load=%.2f limit=%.2f)"
+                % (
+                    os.getpid(), running, ceiling, ceiling_f,
+                    load1m, _load_limit,
+                )
+            )
+        waited = True
+        # Jittered sleep so all idle workers don't re-check in lockstep.
+        time.sleep(_LOAD_POLL_INTERVAL + random.uniform(0.0, _LOAD_POLL_INTERVAL))
+
+    if debug:
+        _lit_config.dbg(
+            "test start: pid=%d running=%d ceiling=%d (%.2f) load=%.2f%s"
+            % (
+                os.getpid(), running, ceiling, ceiling_f, load1m,
+                " (after wait)" if waited else "",
+            )
+        )
+
+
+def _release_run_slot():
+    if _load_state is None:
+        return
+    with _load_state.get_lock():
+        if _load_state[_S_RUNNING] > 0:
+            _load_state[_S_RUNNING] -= 1
+        running = int(_load_state[_S_RUNNING])
+        ceiling_f = float(_load_state[_S_CEILING])
+    if _debug_enabled():
+        load1m = os.getloadavg()[0] if _HAS_LOADAVG else 0.0
+        _lit_config.dbg(
+            "test done:  pid=%d running=%d ceiling=%d (%.2f) load=%.2f"
+            % (os.getpid(), running, int(ceiling_f), ceiling_f, load1m)
+        )
 
 def execute(test):
     """Run one test in a multiprocessing.Pool
@@ -42,8 +191,12 @@ def execute(test):
     Arguments and results of this function are pickled, so they should be cheap
     to copy.
     """
-    with _get_parallelism_semaphore(test):
-        result = _execute(test, _lit_config)
+    _acquire_run_slot()
+    try:
+        with _get_parallelism_semaphore(test):
+            result = _execute(test, _lit_config)
+    finally:
+        _release_run_slot()
 
     test.setResult(result)
     return test

--- a/llvm/utils/lit/tests/load-average.py
+++ b/llvm/utils/lit/tests/load-average.py
@@ -1,0 +1,36 @@
+# Create a directory with 20 files and check the limit message.
+
+# RUN: rm -Rf %t.dir && mkdir -p %t.dir
+# RUN: %{python} -c "for i in range(20): open(rf'%t.dir/file{i}.txt', 'w').write('RUN:')"
+
+# RUN:  echo "import lit.formats" > %t.dir/lit.cfg
+# RUN:  echo "config.name = \"top-level-suite\"" >> %t.dir/lit.cfg
+# RUN:  echo "config.suffixes = [\".txt\"]" >> %t.dir/lit.cfg
+# RUN:  echo "config.test_format = lit.formats.ShTest()" >> %t.dir/lit.cfg
+
+# RUN: %{lit} -s %t.dir/ -j100 --load-limit 0.01 > %t.out 2>&1
+# CHECK: load-limit 1%
+# CHECK: Passed: 20
+
+# RUN: %{lit} -s %t.dir/ -l0.2 >> %t.out 2>&1
+# CHECK: load-limit 20%
+# CHECK: Passed: 20
+
+# RUN: %{lit} -s %t.dir/ -j5 -l0.6 >> %t.out 2>&1
+# CHECK: load-limit 60%
+# CHECK: Passed: 20
+
+# RUN: %{lit} -s %t.dir/ -j10 -l0.8 >> %t.out 2>&1
+# CHECK: load-limit 80%
+# CHECK: Passed: 20
+
+# RUN: %{lit} -s %t.dir/ -j100 -l 0 >> %t.out 2>&1 || true
+# CHECK: lit: error: argument -l/--load-limit: requires number in (0, 2], but found '0'
+
+# RUN: %{lit} -s %t.dir/ -j100 --load-limit 2.1 >> %t.out 2>&1 || true
+# CHECK: lit: error: argument -l/--load-limit: requires number in (0, 2], but found '2.1'
+
+# RUN: %{lit} -s %t.dir/ -j100 -l five >> %t.out 2>&1 || true
+# CHECK: lit: error: argument -l/--load-limit: requires number in (0, 2], but found 'five'
+
+# RUN: cat %t.out | FileCheck %s


### PR DESCRIPTION
**Problem:** 
When LIT runs multiple instances on a single server, it's impossible to dynamically manage the overall server load. This can be a problem for automated testing.

**Solution:**
Add an option which can dynamically control the number of threads using machine `load average` information.
`--load-limit (0..2]` -- float value which is > 0, and max value is 2 (200%).
`--load-limit 0.1` -- use 10% of CPU
`--load-limit 0.8` -- use 80% of CPU
`--load-limit 1`    -- use 100% of CPU
`--load-limit 2`    -- use 200% of CPU
`--load-limit abc` -- Error
`--load-limit -1`   -- Error
`--load-limit 0`    -- Error
`--load-limit 2.1` -- Error

Also `-jmin/--workers_min/--threads_min M` options is added. It sets the minimum number of threads when load average is higher than a limit.

**Main use case:**
`-j NPROC -l NPROC -jmin NPROC/2` -- this will utilize machine on 100%, but if additional load will be added, then LIT will free some recourses.

**Behaviour:**
1. If `--load-limit N` is not passed -- no changes
2. If `-j 10 --load-limit 20` -- LIT will run with 10 threads, if load will grow > 20, then LIT will start to reduce number of threads. If load will be lower than 20, then LIT will start to increase number of threads, but not more than 10.
3. If `-j 20 --load-limit 10` -- LIT will start with 10 threads and will control number of threads using machine load-average information. Can be useful if jobs wait something.
4. 2 instances of LIT with  `-j 20 --load-limit 20` -- both will start with 20 threads, and will reduce number of threads based on machine load average information. 
NOTE: The 1-minute load average has some lag, so there will always be fluctuations in the number of threads, especially at the beginning.

**TODO:**
1. Debug info can be deleted

