### PR TITLE
[lldb] Skip new tests in TestLinuxCore on Windows and non-x86 targets

### DIFF
--- a/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/TestLinuxCore.py
@@ -1284,6 +1284,8 @@ class LinuxCoreTestCase(TestBase):
 
         self.dbg.DeleteTarget(target)
 
+    @skipIfLLVMTargetMissing("X86")
+    @skipIfWindows
     def test_exe_name_extraction_nt_file(self):
         # This core file has:
         # - NT_FILE entry for the executable with path '/path/nt_file_foo
@@ -1301,6 +1303,8 @@ class LinuxCoreTestCase(TestBase):
         self.assertEqual(exe_module.GetFileSpec().fullpath, "/path/nt_file_foo")
         self.dbg.DeleteTarget(target)
 
+    @skipIfLLVMTargetMissing("X86")
+    @skipIfWindows
     def test_exe_name_extraction_at_execfn(self):
         # This core file has:
         # - AT_EXECFN that points to "/path/execfn_foo"
@@ -1318,6 +1322,8 @@ class LinuxCoreTestCase(TestBase):
         self.assertEqual(exe_module.GetFileSpec().fullpath, "/path/execfn_foo")
         self.dbg.DeleteTarget(target)
 
+    @skipIfLLVMTargetMissing("X86")
+    @skipIfWindows
     def test_exe_name_extraction_nt_prpsinfo(self):
         # This core file has:
         # - NT_PRPSINFO with a pr_fname member set to 'prpsinfo_foo'


### PR DESCRIPTION
This patch must fix broken tests after #197341 on buildbots lldb-remote-linux-win, lldb-x86_64-win and lldb-aarch64-windows.