### PR TITLE
Llvm-objcopy crashes with unreachable error when (de)compression requested without selected value available

### DIFF
--- a/llvm/lib/ObjCopy/ELF/ELFObjcopy.cpp
+++ b/llvm/lib/ObjCopy/ELF/ELFObjcopy.cpp
@@ -242,6 +242,13 @@ Error Object::compressOrDecompressSections(const CommonConfig &Config) {
         ToReplace.emplace_back(
             &Sec, [=] { return &addSection<DecompressedSection>(*CS); });
     } else if (*CType != DebugCompressionType::None) {
+      // compression::compress would call llvm_unreachable if the requested
+      // format is unsupported in this LLVM build, so reject it here.
+      if (const char *Reason = compression::getReasonIfUnsupported(
+              compression::formatFor(*CType)))
+        return createStringError(errc::invalid_argument,
+                                 "failed to compress section '" + Sec.Name +
+                                     "': " + Reason);
       ToReplace.emplace_back(&Sec, [=, S = &Sec] {
         return &addSection<CompressedSection>(
             CompressedSection(*S, *CType, Is64Bits));

--- a/llvm/test/tools/llvm-objcopy/ELF/compress-sections-zlib-unsupported.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/compress-sections-zlib-unsupported.test
@@ -1,0 +1,31 @@
+# UNSUPPORTED: zlib
+## Verify that (de)compression requests using zlib produce a friendly error
+## rather than crashing via llvm_unreachable when zlib is not built into LLVM.
+
+# RUN: yaml2obj %s -o %t
+
+## --compress-sections is not validated at option-parsing time, so the check
+## must come from the library layer in compressOrDecompressSections.
+# RUN: not llvm-objcopy --compress-sections '.debug_str=zlib' %t /dev/null 2>&1 | FileCheck %s --check-prefix=COMPRESS -DFILE=%t
+
+# COMPRESS: error: '[[FILE]]': failed to compress section '.debug_str': LLVM was not built with LLVM_ENABLE_ZLIB or did not find zlib at build time
+
+# RUN: not llvm-objcopy --decompress-debug-sections %t /dev/null 2>&1 | FileCheck %s --check-prefix=DECOMPRESS -DFILE=%t
+
+# DECOMPRESS: error: '[[FILE]]': failed to decompress section '.debug_info': LLVM was not built with LLVM_ENABLE_ZLIB or did not find zlib at build time
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Type:         SHT_PROGBITS
+    Name:         .debug_info
+    Flags:        [ SHF_COMPRESSED ]
+    AddressAlign: 8
+    Content:      "010000000000000001000000000000000100000000000000789c63040000020002"
+  - Name:         .debug_str
+    Type:         SHT_PROGBITS
+    Content:      "00"

--- a/llvm/test/tools/llvm-objcopy/ELF/compress-sections-zstd-unsupported.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/compress-sections-zstd-unsupported.test
@@ -1,0 +1,31 @@
+# UNSUPPORTED: zstd
+## Verify that (de)compression requests using zstd produce a friendly error
+## rather than crashing via llvm_unreachable when zstd is not built into LLVM.
+
+# RUN: yaml2obj %s -o %t
+
+## --compress-sections is not validated at option-parsing time, so the check
+## must come from the library layer in compressOrDecompressSections.
+# RUN: not llvm-objcopy --compress-sections '.debug_str=zstd' %t /dev/null 2>&1 | FileCheck %s --check-prefix=COMPRESS -DFILE=%t
+
+# COMPRESS: error: '[[FILE]]': failed to compress section '.debug_str': LLVM was not built with LLVM_ENABLE_ZSTD or did not find zstd at build time
+
+# RUN: not llvm-objcopy --decompress-debug-sections %t /dev/null 2>&1 | FileCheck %s --check-prefix=DECOMPRESS -DFILE=%t
+
+# DECOMPRESS: error: '[[FILE]]': failed to decompress section '.debug_info': LLVM was not built with LLVM_ENABLE_ZSTD or did not find zstd at build time
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+Sections:
+  - Type:         SHT_PROGBITS
+    Name:         .debug_info
+    Flags:        [ SHF_COMPRESSED ]
+    AddressAlign: 8
+    Content:      "0200000000000000010000000000000001000000000000000000000000"
+  - Name:         .debug_str
+    Type:         SHT_PROGBITS
+    Content:      "00"


### PR DESCRIPTION
## Summary
Root cause: `Object::compressOrDecompressSections` constructs `CompressedSection` (whose constructor calls `compression::compress`) without first checking `compression::getReasonIfUnsupported`, so `--compress-sections <glob>=zlib|zstd` triggers `llvm_unreachable` when the requested format is unsupported in the current LLVM build.

Change: Added a `compression::getReasonIfUnsupported(compression::formatFor(*CType))` guard in `compressOrDecompressSections` (`llvm/lib/ObjCopy/ELF/ELFObjcopy.cpp`) before queueing a `CompressedSection`, returning a `createStringError` that names the offending section and reason.

Closes https://github.com/llvm/llvm-project/issues/197877