### PR TITLE
[IRReader][NFC] Make IRReader respect StandardInputSource 

### DIFF
--- a/llvm/include/llvm/IRReader/IRReader.h
+++ b/llvm/include/llvm/IRReader/IRReader.h
@@ -18,6 +18,7 @@
 #include "llvm/AsmParser/AsmParserContext.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/ToolInterface.h"
 #include <memory>
 
 namespace llvm {
@@ -60,10 +61,13 @@ parseIR(MemoryBufferRef Buffer, SMDiagnostic &Err, LLVMContext &Context,
 /// Otherwise, attempt to parse it as LLVM Assembly and return a Module
 /// for it.
 /// \param DataLayoutCallback Override datalayout in the llvm assembly.
-LLVM_ABI std::unique_ptr<Module>
-parseIRFile(StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
-            ParserCallbacks Callbacks = {},
-            AsmParserContext *ParserContext = nullptr);
+/// \param StdinSource Read from a different source instead of STDIN, for
+///        in-process tool execution. This is provided to the tool's run
+///        function, for example by the daemon driver.
+LLVM_ABI std::unique_ptr<Module> parseIRFile(
+    StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
+    ParserCallbacks Callbacks = {}, AsmParserContext *ParserContext = nullptr,
+    const StandardInputSource &StdinSource = StandardInputSource::fromStdin());
 }
 
 #endif

--- a/llvm/include/llvm/Support/ToolInterface.h
+++ b/llvm/include/llvm/Support/ToolInterface.h
@@ -1,0 +1,99 @@
+//===- llvm/Support/ToolInterface.h - Abstract tool interface ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Abstract class for LLVM tools that can be re-invoked in the same process.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_TOOLINTERFACE_H
+#define LLVM_SUPPORT_TOOLINTERFACE_H
+
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include <memory>
+
+namespace llvm {
+
+/// Many tools operate on standard input, which is problematic for in-process
+/// execution/daemonization as the process may not want to close its standard
+/// input stream. This class allows the tools to function as if a different
+/// source, either an in-memory string or a file on disk, were standard input.
+/// Tool implementations should read from this class instead of standard input,
+/// for example using `StandardInputSource::getInput` instead of
+/// `MemoryBuffer::getSTDIN` and `StandardInputSource::getFileOrInput` instead
+/// of `MemoryBuffer::getFileOrSTDIN`.
+class LLVM_ABI StandardInputSource final {
+public:
+  /// Construct a `StandardInputSource` that draws input from the process's
+  /// standard input stream. This is used for regular tool invocations.
+  static StandardInputSource fromStdin() {
+    return StandardInputSource(Kind::Stdin, std::string());
+  }
+
+  /// Construct a `StandardInputSource` that draws input from a file.
+  static StandardInputSource fromFile(std::string &&Filename) {
+    return StandardInputSource(Kind::File, std::move(Filename));
+  }
+
+  /// Construct a `StandardInputSource` that pretends that the given string
+  /// is the contents of standard input.
+  static StandardInputSource fromString(std::string &&StringValue) {
+    return StandardInputSource(Kind::String, std::move(StringValue));
+  }
+
+  /// Replacement for `MemoryBuffer::getSTDIN`. The returned memory buffer
+  /// always has the identifier "<stdin>".
+  ErrorOr<std::unique_ptr<MemoryBuffer>> getInput() const;
+
+  /// Replacement for `MemoryBuffer::getFileOrInput`. Returns `getInput()` if
+  /// the file name is "-", otherwise returns a memory buffer of the file.
+  ErrorOr<std::unique_ptr<MemoryBuffer>> getFileOrInput(StringRef Filename,
+                                                        bool IsText) const {
+    if (Filename == "-")
+      return getInput();
+
+    return MemoryBuffer::getFile(Filename, IsText);
+  }
+
+private:
+  enum class Kind {
+    Stdin,
+    File,
+    String,
+  };
+
+  StandardInputSource(Kind SourceKind, std::string &&StringValue)
+      : SourceKind(SourceKind), StringValue(StringValue) {}
+
+  Kind SourceKind;
+  std::string StringValue;
+};
+
+/// This class represents a shared interface for LLVM tools that can be
+/// re-invoked in the same process, for example when run by the daemon driver.
+class LLVM_ABI LLVMTool {
+public:
+  virtual ~LLVMTool() = default;
+
+  /// This is the function called to run the tool with a given input and set of
+  /// arguments. All code to run the tool except for one-time initialization and
+  /// finalization (for example `InitLLVM`) should be done in this function.
+  ///
+  /// Note that as `run` may use global state, it is not thread-safe.
+  virtual int run(int Argc, char **Argv,
+                  const StandardInputSource &InputSource) = 0;
+
+  /// This function is called between `run` invocations to reset any persistent
+  /// state, for example static command line options, statistics and debug
+  /// counters, for the next invocation. This function is not called when the
+  /// tool is run normally.
+  virtual void resetState() = 0;
+};
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_TOOLINTERFACE_H

--- a/llvm/lib/IRReader/IRReader.cpp
+++ b/llvm/lib/IRReader/IRReader.cpp
@@ -92,12 +92,12 @@ std::unique_ptr<Module> llvm::parseIR(MemoryBufferRef Buffer, SMDiagnostic &Err,
                        ParserContext);
 }
 
-std::unique_ptr<Module> llvm::parseIRFile(StringRef Filename, SMDiagnostic &Err,
-                                          LLVMContext &Context,
-                                          ParserCallbacks Callbacks,
-                                          AsmParserContext *ParserContext) {
+std::unique_ptr<Module>
+llvm::parseIRFile(StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
+                  ParserCallbacks Callbacks, AsmParserContext *ParserContext,
+                  const StandardInputSource &StdinSource) {
   ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
-      MemoryBuffer::getFileOrSTDIN(Filename, /*IsText=*/true);
+      StdinSource.getFileOrInput(Filename, /*IsText=*/true);
   if (std::error_code EC = FileOrErr.getError()) {
     Err = SMDiagnostic(Filename, SourceMgr::DK_Error,
                        "Could not open input file: " + EC.message());

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -268,6 +268,7 @@ add_llvm_component_library(LLVMSupport
   ThreadPool.cpp
   TimeProfiler.cpp
   Timer.cpp
+  ToolInterface.cpp
   ToolOutputFile.cpp
   TrieRawHashMap.cpp
   Twine.cpp

--- a/llvm/lib/Support/ToolInterface.cpp
+++ b/llvm/lib/Support/ToolInterface.cpp
@@ -1,0 +1,68 @@
+//===- llvm/Support/ToolInterface.cpp - Abstract tool interface -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Abstract class for LLVM tools that can be re-invoked in the same process.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/ToolInterface.h"
+
+using namespace llvm;
+
+namespace {
+/// Wraps a `MemoryBuffer`, overriding the identifier returned from
+/// `getBufferIdentifier`. This is needed to daemonize lots of tests which
+/// include the buffer identifier in check lines as the module ID.
+class NameOverrideMemoryBuffer : public MemoryBuffer {
+public:
+  NameOverrideMemoryBuffer(std::unique_ptr<MemoryBuffer> &&MB,
+                           StringRef Identifier)
+      : MemoryBuffer(), Inner(std::move(MB)), Identifier(Identifier) {
+    init(Inner->getBufferStart(), Inner->getBufferEnd(),
+         /*RequiresNullTerminator=*/false);
+  }
+
+  StringRef getBufferIdentifier() const override { return Identifier; }
+
+  void dontNeedIfMmap() override { return Inner->dontNeedIfMmap(); }
+
+  void willNeedIfMmap() override { return Inner->willNeedIfMmap(); }
+
+  BufferKind getBufferKind() const override { return Inner->getBufferKind(); }
+
+private:
+  std::unique_ptr<MemoryBuffer> Inner;
+  std::string Identifier;
+};
+
+} // namespace
+
+ErrorOr<std::unique_ptr<MemoryBuffer>>
+llvm::StandardInputSource::getInput() const {
+  // Always pretend to be standard input, so that tests which are affected by
+  // the buffer identifier do not get broken. (For example if there is a check
+  // string that includes the module name)
+  constexpr StringRef BufferIdentifier = "<stdin>";
+
+  switch (SourceKind) {
+  case Kind::Stdin: {
+    return MemoryBuffer::getSTDIN();
+  }
+  case Kind::File: {
+    auto Buffer = MemoryBuffer::getFile(StringValue, /*IsText=*/true);
+    if (!Buffer)
+      return Buffer.getError();
+
+    return std::make_unique<NameOverrideMemoryBuffer>(std::move(*Buffer),
+                                                      BufferIdentifier);
+  }
+  case Kind::String: {
+    return MemoryBuffer::getMemBuffer(StringValue, BufferIdentifier);
+  }
+  }
+}


### PR DESCRIPTION
This PR is dependent on https://github.com/llvm/llvm-project/pull/193706 which introduces the `StandardInputSource` interface, which is used by tools executed in-process (for example for the purpose of daemonized testing) to act as if input from another source is coming from STDIN. The changes in the first commit in this PR are from that branch, so please review from the 2nd commit.

This PR updates the `parseIRFile` function in IRReader to accept a `StandardInputSource` as a parameter, and call its `getFileOrInput` function instead of `MemoryBuffer::getFileOrSTDIN()`. This is required for daemonizing opt and llc.