### PR TITLE
[VPlan] Skip FindLast reductions with malformed blends.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1793,7 +1793,7 @@ bool VPlanTransforms::handleFindLastReductions(VPlan &Plan) {
     if (HeaderMask && !match(BackedgeSelect,
                              m_Select(m_Specific(HeaderMask),
                                       m_VPValue(CondSelect), m_Specific(PhiR))))
-      llvm_unreachable("expected header mask select");
+      return false;
 
     VPValue *Cond = nullptr, *Op1 = nullptr, *Op2 = nullptr;
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -5686,7 +5686,7 @@ void VPlanTransforms::optimizeFindIVReductions(VPlan &Plan,
         !match(BackedgeVal,
                m_Select(m_Specific(HeaderMask),
                         m_VPSingleDefRecipe(FindLastSelect), m_Specific(PhiR))))
-      llvm_unreachable("expected header mask select");
+      continue;
 
     // Get the find-last expression from the find-last select of the reduction
     // phi. The find-last select should be a select between the phi and the

--- a/llvm/test/Transforms/LoopVectorize/AArch64/conditional-scalar-assignment-fold-tail.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/conditional-scalar-assignment-fold-tail.ll
@@ -133,3 +133,32 @@ latch:
 exit:
   ret i32 %select.data
 }
+
+; Check that we do not crash when the backedge of a find-last-like reduction
+; phi is the phi itself (e.g. because a blend with a poison incoming was
+; simplified away).
+define i8 @findlast_blend_with_poison(i8 %e, i1 %c) {
+; CHECK-LABEL: define i8 @findlast_blend_with_poison(
+; CHECK-NOT:    vector.body
+;
+entry:
+  br label %loop.header
+
+loop.header:
+  %reduc = phi i8 [ %e, %entry ], [ %reduc.next, %loop.latch ]
+  %iv = phi i32 [ 0, %entry ], [ %iv.next, %loop.latch ]
+  br i1 %c, label %loop.latch, label %other
+
+other:
+  br label %loop.latch
+
+loop.latch:
+  %reduc.next = phi i8 [ poison, %other ], [ %reduc, %loop.header ]
+  %iv.next = add nuw nsw i32 %iv, 1
+  %ec = icmp ult i32 %iv.next, 7
+  br i1 %ec, label %loop.header, label %exit
+
+exit:
+  %fr = freeze i8 %reduc.next
+  ret i8 %fr
+}


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/197701 exposed a case where we end up with an unsupported backedge select for FindLast reductions.

Replace unreachable with a bail out to avoid miscompile/crash.

Fixes https://github.com/llvm/llvm-project/issues/197701