### PR TITLE
[GlobalISel] Add brackets to assert. NFC

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -10660,9 +10660,9 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerVAArg(MachineInstr &MI) {
 
 LegalizerHelper::LegalizeResult LegalizerHelper::lowerMulfix(MachineInstr &MI) {
   unsigned OpCode = MI.getOpcode();
-  assert(OpCode == TargetOpcode::G_SMULFIX ||
-         OpCode == TargetOpcode::G_UMULFIX &&
-             "Operator must be either G_SMULFIX or G_UMULFIX!");
+  assert((OpCode == TargetOpcode::G_SMULFIX ||
+          OpCode == TargetOpcode::G_UMULFIX) &&
+         "Operator must be either G_SMULFIX or G_UMULFIX!");
   auto [Dst, LHS, RHS] = MI.getFirst3Regs();
   LLT Ty = MRI.getType(Dst);
   unsigned Scale = MI.getOperand(3).getImm();


### PR DESCRIPTION
Fixes a `warning: suggest parentheses around ‘&&’ within ‘||’`