### PR TITLE
[libc] Disable GCC 12 waccess passes to fix ICE in environ_internal

### DIFF
--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -72,7 +72,9 @@ set(environ_internal_gcc12_workaround "")
 if((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND
    (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12") AND
    (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13"))
-  set(environ_internal_gcc12_workaround "-Wno-stringop-overflow")
+  set(environ_internal_gcc12_workaround "-Wno-stringop-overflow"
+      "-fdisable-tree-waccess1" "-fdisable-tree-waccess2"
+      "-fdisable-tree-waccess3")
 endif()
 
 add_object_library(


### PR DESCRIPTION
The waccess pass in GCC 12 consistently segmentation faults when analyzing the memory allocations in environ_internal.cpp. This change disables the relevant tree-waccess passes for this specific file, avoiding the ICE without requiring intrusive code refactoring.

Assisted-by: Automated tooling, human reviewed.