### PR TITLE
[clang][CodeGen] Fix crash in CGDebugInfo on incomplete record type (#156352)

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1290,7 +1290,7 @@ static SmallString<256> getTypeIdentifier(const TagType *Ty, CodeGenModule &CGM,
   if (!needsTypeIdentifier(TD, CGM, TheCU))
     return Identifier;
   if (const auto *RD = dyn_cast<CXXRecordDecl>(TD))
-    if (RD->getDefinition())
+    if (RD->isCompleteDefinition())
       if (RD->isDynamicClass() &&
           CGM.getVTableLinkage(RD) == llvm::GlobalValue::ExternalLinkage)
         return Identifier;

--- a/clang/test/CodeGenCXX/debug-info-template-incomplete-record.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-incomplete-record.cpp
@@ -1,83 +1,32 @@
-// RUN: %clang_cc1 -std=c++20 -debug-info-kind=standalone -fvisibility=hidden \
-// RUN:   -O2 -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -std=c++17 -debug-info-kind=standalone -O2 \
+// RUN:   -triple x86_64-linux-gnu -emit-llvm %s -o /dev/null
 //
-// Verify that we don't crash when generating debug info for a template class
-// that is still being defined when its forward declaration is needed. The bug
-// was that getTypeIdentifier() called getVTableLinkage() on a record that was
-// only "being defined" (not yet complete), which triggered premature
-// ASTRecordLayout computation and cached a layout with zero fields. Later,
-// CollectRecordFields used the stale cached layout and crashed on an
-// out-of-bounds field offset access.
+// REQUIRES: asserts
+//
+// Verify we don't crash when generating debug info for a polymorphic
+// template class that is still being defined when its type identifier is
+// requested.
+//
+// getTypeIdentifier() called getVTableLinkage() on a record that was only
+// "being defined" (not yet complete). getVTableLinkage() in turn calls
+// ItaniumCXXABI::canSpeculativelyEmitVTable(), which builds the vtable
+// layout via FinalOverriders, which calls getASTRecordLayout() on the
+// incomplete type, triggering:
+//   Assertion `D->isCompleteDefinition() &&
+//              "Cannot layout type before complete!"' failed.
+// In release (no-asserts) builds the same path silently caches a layout
+// with zero fields, leading to an out-of-bounds field offset crash later
+// in CollectRecordFields.
 
-class a;
-template<class>
-class b;
-class c
-{
-public:
-   using d = a;
+struct l;
+template <typename> struct b;
+template <typename> struct f {
+  struct e;
+  b<l> *p;
 };
-template<class>
-class f;
-template<class e>
-class h
-{
-   using j = typename e::j;
-   j k();
+template <typename e> struct b {
+  virtual ~b();
+  typename f<e>::e x();
 };
-class l;
-class m
-{
-   using i = f<l>;
-   i n();
-};
-template<class>
-class f
-{
-public:
-   using e = l;
-   using o = e;
-   using d = b<e>;
-   d *p;
-};
-class L;
-class q
-{
-public:
-   using j = L;
-};
-class r
-{
-   ~r();
-   h<q> s;
-};
-r::~r() = default;
-class l
-{
-public:
-   using j = m;
-   using g = c;
-};
-class J
-{
-   h<l> t;
-};
-class a
-{
-public:
-   virtual ~a();
-};
-template<class e>
-class b : e::g::d
-{
-   using u = typename f<e>::o;
-   int v;
-};
-class L : J
-{
-};
-extern template class b<l>;
-
-// Just verify we produce debug info for b<l> with its field v.
-// CHECK: !DICompositeType(tag: DW_TAG_class_type, name: "b<l>"
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "v"
+f<l> *s;
+extern template struct b<l>;

--- a/clang/test/CodeGenCXX/debug-info-template-incomplete-record.cpp
+++ b/clang/test/CodeGenCXX/debug-info-template-incomplete-record.cpp
@@ -1,0 +1,83 @@
+// RUN: %clang_cc1 -std=c++20 -debug-info-kind=standalone -fvisibility=hidden \
+// RUN:   -O2 -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s
+//
+// Verify that we don't crash when generating debug info for a template class
+// that is still being defined when its forward declaration is needed. The bug
+// was that getTypeIdentifier() called getVTableLinkage() on a record that was
+// only "being defined" (not yet complete), which triggered premature
+// ASTRecordLayout computation and cached a layout with zero fields. Later,
+// CollectRecordFields used the stale cached layout and crashed on an
+// out-of-bounds field offset access.
+
+class a;
+template<class>
+class b;
+class c
+{
+public:
+   using d = a;
+};
+template<class>
+class f;
+template<class e>
+class h
+{
+   using j = typename e::j;
+   j k();
+};
+class l;
+class m
+{
+   using i = f<l>;
+   i n();
+};
+template<class>
+class f
+{
+public:
+   using e = l;
+   using o = e;
+   using d = b<e>;
+   d *p;
+};
+class L;
+class q
+{
+public:
+   using j = L;
+};
+class r
+{
+   ~r();
+   h<q> s;
+};
+r::~r() = default;
+class l
+{
+public:
+   using j = m;
+   using g = c;
+};
+class J
+{
+   h<l> t;
+};
+class a
+{
+public:
+   virtual ~a();
+};
+template<class e>
+class b : e::g::d
+{
+   using u = typename f<e>::o;
+   int v;
+};
+class L : J
+{
+};
+extern template class b<l>;
+
+// Just verify we produce debug info for b<l> with its field v.
+// CHECK: !DICompositeType(tag: DW_TAG_class_type, name: "b<l>"
+// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "v"


### PR DESCRIPTION
Fix a crash when generating debug info for a template class that is
still being defined when its forward declaration is needed.

getTypeIdentifier() called getVTableLinkage() on a record that was only
"being defined" (not yet complete), which triggered premature
ASTRecordLayout computation and cached a layout with zero fields. Later,
CollectRecordFields used the stale cached layout and crashed on an
out-of-bounds field offset access.

Replace getDefinition() with isCompleteDefinition() to correctly skip
records whose definition is not yet complete.

Fixes #156352