### PR TITLE
[clang][nfc] Guard thread_local in clang/test/CXX/drs/cwg7xx.cpp

### DIFF
--- a/clang/test/CXX/drs/cwg7xx.cpp
+++ b/clang/test/CXX/drs/cwg7xx.cpp
@@ -100,7 +100,7 @@ static_assert(!is_volatile<void()volatile&>::value, "");
 } // namespace cwg713
 
 namespace cwg717 { // cwg717: 3.3
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L && __has_feature(cxx_thread_local)
 void f() {
   thread_local extern int i;
   thread_local extern int& j;


### PR DESCRIPTION
On targets which don't support `thread_local`, such as `arm64-apple-darwin-unknown`, the test would fail with a bunch of `thread-local storage is not supported for the current target` messages. Follow-up to #197732