### PR TITLE
[NFC] Clarify behavior of ownership_holds in docs

### DIFF
--- a/clang/docs/analyzer/user-docs/Annotations.rst
+++ b/clang/docs/analyzer/user-docs/Annotations.rst
@@ -207,7 +207,7 @@ Use this attribute to mark functions that take ownership of memory and will deal
 
   void __attribute((ownership_holds(malloc, 2))) store_in_table(int key, record_t *val);
 
-The annotations ``ownership_takes`` and ``ownership_holds`` both prevent memory leak reports (concerning the specified parameter); the difference between them is that using taken memory is a use-after-free error, while using held memory is assumed to be legitimate. (However, releasing the held memory or passing it to another holding call is reported by the analyzer as an "attempt to release non-owned memory".)
+The annotations ``ownership_takes`` and ``ownership_holds`` both prevent memory leak reports (concerning the specified parameter); the difference between them is that using taken memory is a use-after-free error, while using held memory is assumed to be legitimate. However, releasing the held memory or passing it to another holding call is reported by the analyzer as an "attempt to release non-owned memory".
 
 
 Mac OS X API Annotations

--- a/clang/docs/analyzer/user-docs/Annotations.rst
+++ b/clang/docs/analyzer/user-docs/Annotations.rst
@@ -207,7 +207,8 @@ Use this attribute to mark functions that take ownership of memory and will deal
 
   void __attribute((ownership_holds(malloc, 2))) store_in_table(int key, record_t *val);
 
-The annotations ``ownership_takes`` and ``ownership_holds`` both prevent memory leak reports (concerning the specified parameter); the difference between them is that using taken memory is a use-after-free error, while using held memory is assumed to be legitimate.
+The annotations ``ownership_takes`` and ``ownership_holds`` both prevent memory leak reports (concerning the specified parameter); the difference between them is that using taken memory is a use-after-free error, while using held memory is assumed to be legitimate. (However, releasing the held memory or passing it to another holding call is reported by the analyzer as an "attempt to release non-owned memory".)
+
 
 Mac OS X API Annotations
 ________________________

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1663,9 +1663,9 @@ safely deallocated with the standard ``free()``.
 The annotations ``ownership_takes`` and ``ownership_holds`` both prevent memory
 leak reports (concerning the specified parameter); the difference between them
 is that using taken memory is a use-after-free error, while using held memory
-is assumed to be legitimate. (However, releasing the held memory or passing it
+is assumed to be legitimate. However, releasing the held memory or passing it
 to another holding call is reported by the analyzer as an "attempt to release
-non-owned memory".)
+non-owned memory".
 
 Example:
 

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1663,7 +1663,9 @@ safely deallocated with the standard ``free()``.
 The annotations ``ownership_takes`` and ``ownership_holds`` both prevent memory
 leak reports (concerning the specified parameter); the difference between them
 is that using taken memory is a use-after-free error, while using held memory
-is assumed to be legitimate.
+is assumed to be legitimate. (However, releasing the held memory or passing it
+to another holding call is reported by the analyzer as an "attempt to release
+non-owned memory".)
 
 Example:
 


### PR DESCRIPTION
I misunderstood the behavior of the attribute `ownership_holds` based on the claim that "using held memory is assumed to be legitimate".

To avoid similar misunderstandings in the future, I'm adding an extra sentence to the documentation.

(This question came up during the discussion of #196798)