### PR TITLE
[BAZEL] Add missing hdr_errno_macros to __support_osutil_linux_syscal_wrappers_mmap

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2346,6 +2346,7 @@ libc_support_library(
         ":__support_macros_config",
         ":__support_osutil_syscall",
         ":types_off_t",
+        ":hdr_errno_macros",
     ],
 )
 


### PR DESCRIPTION
This fixes 5d9e711.