### PR TITLE
[RISCV] Fix mask policy in convertSameMaskVMergeToVMv

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
@@ -371,6 +371,13 @@ bool RISCVVectorPeephole::convertSameMaskVMergeToVMv(MachineInstr &MI) {
                            TII->getRegClass(True->getDesc(), 1));
   }
 
+  // If True is mask agnostic, we need to make it mask undisturbed.
+  if (RISCVII::hasVecPolicyOp(True->getDesc().TSFlags)) {
+    MachineOperand &PolicyOp =
+        True->getOperand(RISCVII::getVecPolicyOpNum(True->getDesc()));
+    PolicyOp.setImm(PolicyOp.getImm() & ~RISCVVType::MASK_AGNOSTIC);
+  }
+
   MI.setDesc(TII->get(NewOpc));
   MI.removeOperand(2); // False operand
   MI.removeOperand(3); // Mask operand

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-to-vmv.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-to-vmv.mir
@@ -200,7 +200,7 @@ body: |
     ; CHECK-NEXT: %pt:vr = COPY $v8
     ; CHECK-NEXT: %false:vrnov0 = COPY $v9
     ; CHECK-NEXT: %mask:vmv0 = COPY $v0
-    ; CHECK-NEXT: %true:vrnov0 = PseudoVADD_VV_M1_MASK %false, $noreg, $noreg, %mask, 2 /* vl */, 5 /* e32 */, 3 /* ta, ma */
+    ; CHECK-NEXT: %true:vrnov0 = PseudoVADD_VV_M1_MASK %false, $noreg, $noreg, %mask, 2 /* vl */, 5 /* e32 */, 1 /* ta, mu */
     ; CHECK-NEXT: [[PseudoVMV_V_V_M1_:%[0-9]+]]:vr = PseudoVMV_V_V_M1 %pt, %true, 1 /* vl */, 5 /* e32 */, 0 /* tu, mu */
     %pt:vrnov0 = COPY $v8
     %false:vrnov0 = COPY $v9

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-vmerge-to-vmv.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-vmerge-to-vmv.ll
@@ -90,7 +90,7 @@ define <vscale x 2 x i32> @preserve_false(ptr %p, <vscale x 2 x i32> %pt, <vscal
 define <vscale x 2 x i32> @preserve_false_avl_known_le(ptr %p, <vscale x 2 x i32> %pt, <vscale x 2 x i32> %false, <vscale x 2 x i1> %mask) {
 ; CHECK-LABEL: preserve_false_avl_known_le:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vsetivli zero, 1, e32, m1, ta, ma
+; CHECK-NEXT:    vsetivli zero, 1, e32, m1, ta, mu
 ; CHECK-NEXT:    vle32.v v9, (a0), v0.t
 ; CHECK-NEXT:    vsetvli zero, zero, e32, m1, tu, ma
 ; CHECK-NEXT:    vmv.v.v v8, v9


### PR DESCRIPTION
In convertSameMaskVMergeToVMv, we try to change a vmerge to a vmv.v.v if the true operand is masked in such a way it guarantees the masked off elements are the same.

However vmerge.vvm and vmv.v.v are always mask undisturbed. If we want to reuse the masking in the true operand we need to also change its policy to mask undisturbed.

This fixes a miscompile that can be seen with llvm.masked.sdiv instructions after #191377 under certain conditions, detected by https://lab.llvm.org/buildbot/#/builders/214/builds/2795. The llvm.masked.sdiv instructions produced a mask agnostic PseudoVDIV that had a PseudoVMERGE_VVM merged into them without updating the policy.
