### PR TITLE
[lldb] Fix test timeouts on sanitized builds

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -12,6 +12,7 @@ import os
 import re
 import sys
 import subprocess
+import time
 from typing import Dict, Tuple
 
 # LLDB modules
@@ -1690,24 +1691,20 @@ def read_file_from_process_wd(test, name):
     return read_file_on_target(test, path)
 
 
-def wait_for_file_on_target(testcase, file_path):
-    import time
+def wait_for_file_on_target(testcase, file_path: str):
+    timeout_seconds = 600 if "ASAN_OPTIONS" in os.environ else 120
+    sleep_interval_seconds = 0.5
+    deadline_seconds = time.monotonic() + timeout_seconds
 
-    MAX_ATTEMPTS = 60
-    timeout_seconds = 20 if "ASAN_OPTIONS" in os.environ else 2
-    for i in range(MAX_ATTEMPTS):
+    while time.monotonic() < deadline_seconds:
         command = f"ls {file_path}"
-        err, retcode, msg = testcase.run_platform_command(command)
+        err, retcode, _ = testcase.run_platform_command(command)
         if err.Success() and retcode == 0:
-            break
+            return read_file_on_target(testcase, file_path)
 
-        time.sleep(timeout_seconds)
-    else:
-        testcase.fail(
-            "File %s not found even after %d attempts." % (file_path, max_attempts)
-        )
+        time.sleep(sleep_interval_seconds)
 
-    return read_file_on_target(testcase, file_path)
+    testcase.fail(f"File {file_path} not found after {timeout_seconds} seconds.")
 
 
 def packetlog_get_process_info(log):


### PR DESCRIPTION
Switch to a fixed timeout and a shorter polling interval to reduce wasted time. The total timeout in non-sanitized is 120s (same as the existing implementation) and in sanitized builds, it is 600s matching `lit_config.maxIndividualTestTime`.

Previously, sanitized builds could spend up to 20 seconds idling. While this specific function wouldn't time out itself, it consumed a significant portion of the overall test time budget. This would eventually cause the test to hit the
`lit_config.maxIndividualTestTime` limit (currently 600 seconds).

This delay accumulates quickly in tests with multiple subtests that implicitly rely on `wait_for_file_on_target` (for example, `TestLLDBGdbServer.py`). 
If a test has 5 subtests, it could lose 100 seconds (20s * 5) to idle polling, leaving only 500 seconds for the entire test to finish.