### PR TITLE
[lldb] Make use of ConstString(StringRef) where applicable (NFC)

### DIFF
--- a/lldb/source/API/SBAttachInfo.cpp
+++ b/lldb/source/API/SBAttachInfo.cpp
@@ -279,7 +279,7 @@ const char *SBAttachInfo::GetScriptedProcessClassName() const {
 
   // Constify this string so that it is saved in the string pool.  Otherwise it
   // would be freed when this function goes out of scope.
-  ConstString class_name(metadata_sp->GetClassName().data());
+  ConstString class_name(metadata_sp->GetClassName());
   return class_name.AsCString(nullptr);
 }
 

--- a/lldb/source/API/SBLaunchInfo.cpp
+++ b/lldb/source/API/SBLaunchInfo.cpp
@@ -249,7 +249,7 @@ const char *SBLaunchInfo::GetShell() {
 
   // Constify this string so that it is saved in the string pool.  Otherwise it
   // would be freed when this function goes out of scope.
-  ConstString shell(m_opaque_sp->GetShell().GetPath().c_str());
+  ConstString shell(m_opaque_sp->GetShell().GetPath());
   return shell.AsCString(nullptr);
 }
 
@@ -342,7 +342,7 @@ const char *SBLaunchInfo::GetScriptedProcessClassName() const {
 
   // Constify this string so that it is saved in the string pool.  Otherwise it
   // would be freed when this function goes out of scope.
-  ConstString class_name(metadata_sp->GetClassName().data());
+  ConstString class_name(metadata_sp->GetClassName());
   return class_name.AsCString(nullptr);
 }
 

--- a/lldb/source/API/SBModule.cpp
+++ b/lldb/source/API/SBModule.cpp
@@ -587,7 +587,7 @@ const char *SBModule::GetTriple() {
   // Unique the string so we don't run into ownership issues since the const
   // strings put the string into the string pool once and the strings never
   // comes out
-  ConstString const_triple(triple.c_str());
+  ConstString const_triple(triple);
   return const_triple.GetCString();
 }
 

--- a/lldb/source/API/SBModuleSpec.cpp
+++ b/lldb/source/API/SBModuleSpec.cpp
@@ -117,7 +117,7 @@ const char *SBModuleSpec::GetTriple() {
   // Unique the string so we don't run into ownership issues since the const
   // strings put the string into the string pool once and the strings never
   // comes out
-  ConstString const_triple(triple.c_str());
+  ConstString const_triple(triple);
   return const_triple.GetCString();
 }
 

--- a/lldb/source/API/SBPlatform.cpp
+++ b/lldb/source/API/SBPlatform.cpp
@@ -103,7 +103,7 @@ const char *SBPlatformConnectOptions::GetURL() {
 
   if (m_opaque_ptr->m_url.empty())
     return nullptr;
-  return ConstString(m_opaque_ptr->m_url.c_str()).GetCString();
+  return ConstString(m_opaque_ptr->m_url).GetCString();
 }
 
 void SBPlatformConnectOptions::SetURL(const char *url) {
@@ -206,7 +206,7 @@ const char *SBPlatformShellCommand::GetShell() {
 
   if (m_opaque_ptr->m_shell.empty())
     return nullptr;
-  return ConstString(m_opaque_ptr->m_shell.c_str()).GetCString();
+  return ConstString(m_opaque_ptr->m_shell).GetCString();
 }
 
 void SBPlatformShellCommand::SetShell(const char *shell_interpreter) {
@@ -223,7 +223,7 @@ const char *SBPlatformShellCommand::GetCommand() {
 
   if (m_opaque_ptr->m_command.empty())
     return nullptr;
-  return ConstString(m_opaque_ptr->m_command.c_str()).GetCString();
+  return ConstString(m_opaque_ptr->m_command).GetCString();
 }
 
 void SBPlatformShellCommand::SetCommand(const char *shell_command) {
@@ -240,7 +240,7 @@ const char *SBPlatformShellCommand::GetWorkingDirectory() {
 
   if (m_opaque_ptr->m_working_dir.empty())
     return nullptr;
-  return ConstString(m_opaque_ptr->m_working_dir.c_str()).GetCString();
+  return ConstString(m_opaque_ptr->m_working_dir).GetCString();
 }
 
 void SBPlatformShellCommand::SetWorkingDirectory(const char *path) {
@@ -286,7 +286,7 @@ const char *SBPlatformShellCommand::GetOutput() {
 
   if (m_opaque_ptr->m_output.empty())
     return nullptr;
-  return ConstString(m_opaque_ptr->m_output.c_str()).GetCString();
+  return ConstString(m_opaque_ptr->m_output).GetCString();
 }
 
 // SBPlatform
@@ -422,7 +422,7 @@ const char *SBPlatform::GetTriple() {
     if (arch.IsValid()) {
       // Const-ify the string so we don't need to worry about the lifetime of
       // the string
-      return ConstString(arch.GetTriple().getTriple().c_str()).GetCString();
+      return ConstString(arch.GetTriple().getTriple()).GetCString();
     }
   }
   return nullptr;
@@ -452,7 +452,7 @@ const char *SBPlatform::GetOSDescription() {
     if (!s.empty()) {
       // Const-ify the string so we don't need to worry about the lifetime of
       // the string
-      return ConstString(s.c_str()).GetCString();
+      return ConstString(s).GetCString();
     }
   }
   return nullptr;

--- a/lldb/source/API/SBProcessInfo.cpp
+++ b/lldb/source/API/SBProcessInfo.cpp
@@ -183,5 +183,5 @@ const char *SBProcessInfo::GetTriple() {
   if (!arch.IsValid())
     return nullptr;
 
-  return ConstString(arch.GetTriple().getTriple().c_str()).GetCString();
+  return ConstString(arch.GetTriple().getTriple()).GetCString();
 }

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1665,7 +1665,7 @@ const char *SBTarget::GetTriple() {
     // Unique the string so we don't run into ownership issues since the const
     // strings put the string into the string pool once and the strings never
     // comes out
-    ConstString const_triple(triple.c_str());
+    ConstString const_triple(triple);
     return const_triple.GetCString();
   }
   return nullptr;
@@ -1689,7 +1689,7 @@ const char *SBTarget::GetABIName() {
 
   if (TargetSP target_sp = GetSP()) {
     std::string abi_name(target_sp->GetABIName().str());
-    ConstString const_name(abi_name.c_str());
+    ConstString const_name(abi_name);
     return const_name.GetCString();
   }
   return nullptr;

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1661,7 +1661,7 @@ const char *SBTarget::GetTriple() {
   LLDB_INSTRUMENT_VA(this);
 
   if (TargetSP target_sp = GetSP()) {
-    std::string triple(target_sp->GetArchitecture().GetTriple().str());
+    const std::string &triple = target_sp->GetArchitecture().GetTriple().str();
     // Unique the string so we don't run into ownership issues since the const
     // strings put the string into the string pool once and the strings never
     // comes out
@@ -1688,8 +1688,7 @@ const char *SBTarget::GetABIName() {
   LLDB_INSTRUMENT_VA(this);
 
   if (TargetSP target_sp = GetSP()) {
-    std::string abi_name(target_sp->GetABIName().str());
-    ConstString const_name(abi_name);
+    ConstString const_name(target_sp->GetABIName());
     return const_name.GetCString();
   }
   return nullptr;
@@ -1699,7 +1698,7 @@ const char *SBTarget::GetLabel() const {
   LLDB_INSTRUMENT_VA(this);
 
   if (TargetSP target_sp = GetSP())
-    return ConstString(target_sp->GetLabel().data()).AsCString(nullptr);
+    return ConstString(target_sp->GetLabel()).AsCString(nullptr);
   return nullptr;
 }
 

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -65,7 +65,7 @@ BreakpointResolverName::BreakpointResolverName(
       m_match_type(Breakpoint::Exact), m_language(language),
       m_skip_prologue(skip_prologue) {
   for (const std::string &name : names) {
-    AddNameLookup(ConstString(name.c_str(), name.size()), name_type_mask);
+    AddNameLookup(ConstString(name), name_type_mask);
   }
 }
 

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -2529,7 +2529,7 @@ protected:
     switch (break_type) {
     case eClearTypeFileAndLine: // Breakpoint by source position
     {
-      const ConstString filename(m_options.m_filename.c_str());
+      const ConstString filename(m_options.m_filename);
       BreakpointLocationCollection loc_coll;
 
       for (size_t i = 0; i < num_breakpoints; ++i) {
@@ -3147,8 +3147,7 @@ protected:
     if (name_list.empty()) {
       result.AppendMessage("No breakpoint names found.");
     } else {
-      for (const std::string &name_str : name_list) {
-        const char *name = name_str.c_str();
+      for (const std::string &name : name_list) {
         // First print out the options for the name:
         Status error;
         BreakpointName *bp_name =
@@ -3166,7 +3165,7 @@ protected:
           BreakpointList &breakpoints = target.GetBreakpointList();
           bool any_set = false;
           for (BreakpointSP bp_sp : breakpoints.Breakpoints()) {
-            if (bp_sp->MatchesName(name)) {
+            if (bp_sp->MatchesName(name.c_str())) {
               StreamString s;
               any_set = true;
               bp_sp->GetDescription(&s, eDescriptionLevelBrief);

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -366,7 +366,7 @@ CommandObjectDisassemble::GetCurrentLineRanges() {
 
 llvm::Expected<std::vector<AddressRange>>
 CommandObjectDisassemble::GetNameRanges(CommandReturnObject &result) {
-  ConstString name(m_options.func_name.c_str());
+  ConstString name(m_options.func_name);
 
   ModuleFunctionSearchOptions function_options;
   function_options.include_symbols = true;

--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -453,7 +453,7 @@ protected:
         }
       }
 
-      ConstString lookup_type_name(type_str.c_str());
+      ConstString lookup_type_name(type_str);
       StackFrame *frame = m_exe_ctx.GetFramePtr();
       ModuleSP search_first;
       if (frame)

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -368,7 +368,7 @@ protected:
   // the option.
   bool DumpLinesInFunctions(CommandReturnObject &result) {
     SymbolContextList sc_list_funcs;
-    ConstString name(m_options.symbol_name.c_str());
+    ConstString name(m_options.symbol_name);
     SymbolContextList sc_list_lines;
     Target &target = GetTarget();
     uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
@@ -903,7 +903,7 @@ protected:
 
     if (!m_options.symbol_name.empty()) {
       SymbolContextList sc_list;
-      ConstString name(m_options.symbol_name.c_str());
+      ConstString name(m_options.symbol_name);
 
       // Displaying the source for a symbol. Search for function named name.
       FindMatchingFunctions(target, name, sc_list);

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3564,7 +3564,7 @@ protected:
     SymbolContextList sc_list;
 
     if (m_options.m_type == eLookupTypeFunctionOrSymbol) {
-      ConstString function_name(m_options.m_str.c_str());
+      ConstString function_name(m_options.m_str);
       ModuleFunctionSearchOptions function_options;
       function_options.include_symbols = true;
       function_options.include_inlines = false;

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -470,7 +470,7 @@ protected:
 
                 lldb::TypeCategoryImplSP category;
                 DataVisualization::Categories::GetCategory(
-                    ConstString(options->m_category.c_str()), category);
+                    ConstString(options->m_category), category);
 
                 Status error;
 
@@ -689,7 +689,7 @@ protected:
                       .SetSkipReferences(m_command_options.m_skip_references));
     else
       entry = std::make_shared<TypeFormatImpl_EnumType>(
-          ConstString(m_command_options.m_custom_type_name.c_str()),
+          ConstString(m_command_options.m_custom_type_name),
           TypeFormatImpl::Flags()
               .SetCascades(m_command_options.m_cascade)
               .SetSkipPointers(m_command_options.m_skip_pointers)
@@ -1597,7 +1597,7 @@ bool CommandObjectTypeSummaryAdd::AddSummary(ConstString type_name,
                                              std::string category_name,
                                              Status *error) {
   lldb::TypeCategoryImplSP category;
-  DataVisualization::Categories::GetCategory(ConstString(category_name.c_str()),
+  DataVisualization::Categories::GetCategory(ConstString(category_name),
                                              category);
 
   if (match_type == eFormatterMatchExact) {
@@ -2205,8 +2205,8 @@ bool CommandObjectTypeSynthAdd::Execute_PythonClass(
   // now I have a valid provider, let's add it to every type
 
   lldb::TypeCategoryImplSP category;
-  DataVisualization::Categories::GetCategory(
-      ConstString(m_options.m_category.c_str()), category);
+  DataVisualization::Categories::GetCategory(ConstString(m_options.m_category),
+                                             category);
 
   Status error;
 
@@ -2242,7 +2242,7 @@ bool CommandObjectTypeSynthAdd::AddSynth(ConstString type_name,
                                          std::string category_name,
                                          Status *error) {
   lldb::TypeCategoryImplSP category;
-  DataVisualization::Categories::GetCategory(ConstString(category_name.c_str()),
+  DataVisualization::Categories::GetCategory(ConstString(category_name),
                                              category);
 
   if (match_type == eFormatterMatchExact) {
@@ -2383,8 +2383,8 @@ private:
                  FilterFormatType type, std::string category_name,
                  Status *error) {
     lldb::TypeCategoryImplSP category;
-    DataVisualization::Categories::GetCategory(
-        ConstString(category_name.c_str()), category);
+    DataVisualization::Categories::GetCategory(ConstString(category_name),
+                                               category);
 
     if (type == eRegularFilter) {
       if (FixArrayTypeNameWithRegex(type_name))
@@ -2506,7 +2506,7 @@ protected:
 
     lldb::TypeCategoryImplSP category;
     DataVisualization::Categories::GetCategory(
-        ConstString(m_options.m_category.c_str()), category);
+        ConstString(m_options.m_category), category);
 
     Status error;
 

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -1020,7 +1020,7 @@ IRExecutionUnit::MemoryManager::GetSymbolAddressAndPresence(
     const std::string &Name, bool &missing_weak) {
   Log *log = GetLog(LLDBLog::Expressions);
 
-  ConstString name_cs(Name.c_str());
+  ConstString name_cs(Name);
 
   lldb::addr_t ret = m_parent.FindSymbol(name_cs, missing_weak);
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1008,7 +1008,7 @@ void ClangASTImporter::BuildNamespaceMap(const clang::NamespaceDecl *decl) {
     std::string namespace_string = decl->getDeclName().getAsString();
 
     context_md->m_map_completer->CompleteNamespaceMap(
-        new_map, ConstString(namespace_string.c_str()), parent_map);
+        new_map, ConstString(namespace_string), parent_map);
   }
 
   context_md->m_namespace_maps[decl] = new_map;

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.cpp
@@ -163,7 +163,7 @@ bool ClangASTSource::FindExternalVisibleDeclsByName(
     }
   }
 
-  ConstString const_decl_name(decl_name.c_str());
+  ConstString const_decl_name(decl_name);
 
   const char *uniqued_const_decl_name = const_decl_name.GetCString();
   if (m_active_lookups.find(uniqued_const_decl_name) !=
@@ -334,7 +334,7 @@ clang::ObjCInterfaceDecl *ClangASTSource::GetCompleteObjCInterface(
   if (!language_runtime)
     return nullptr;
 
-  ConstString class_name(interface_decl->getNameAsString().c_str());
+  ConstString class_name(interface_decl->getNameAsString());
 
   lldb::TypeSP complete_type_sp(
       language_runtime->LookupInCompleteClassCache(class_name));
@@ -499,7 +499,7 @@ void ClangASTSource::FindExternalLexicalDecls(
 void ClangASTSource::FindExternalVisibleDecls(NameSearchContext &context) {
   assert(m_ast_context);
 
-  const ConstString name(context.m_decl_name.getAsString().c_str());
+  const auto name = context.m_decl_name.getAsString();
 
   Log *log = GetLog(LLDBLog::Expressions);
 
@@ -581,7 +581,7 @@ void ClangASTSource::FindExternalVisibleDecls(
 
   SymbolContextList sc_list;
 
-  const ConstString name(context.m_decl_name.getAsString().c_str());
+  const ConstString name(context.m_decl_name.getAsString());
   if (IgnoreName(name, true))
     return;
 
@@ -643,7 +643,7 @@ void ClangASTSource::FindExternalVisibleDecls(
 void ClangASTSource::FillNamespaceMap(
     NameSearchContext &context, lldb::ModuleSP module_sp,
     const CompilerDeclContext &namespace_decl) {
-  const ConstString name(context.m_decl_name.getAsString().c_str());
+  const ConstString name(context.m_decl_name.getAsString());
   if (IgnoreName(name, true))
     return;
 
@@ -1077,7 +1077,7 @@ void ClangASTSource::FindObjCMethodDecls(NameSearchContext &context) {
 
     if (std::shared_ptr<ClangModulesDeclVendor> modules_decl_vendor =
             GetClangModulesDeclVendor()) {
-      ConstString interface_name(interface_decl->getNameAsString().c_str());
+      ConstString interface_name(interface_decl->getNameAsString());
       bool append = false;
       uint32_t max_matches = 1;
       std::vector<CompilerDecl> decls;
@@ -1195,7 +1195,7 @@ void ClangASTSource::FindObjCPropertyAndIvarDecls(NameSearchContext &context) {
   DeclFromUser<const ObjCInterfaceDecl> origin_iface_decl(
       parser_iface_decl.GetOrigin(*m_ast_importer_sp));
 
-  ConstString class_name(parser_iface_decl->getNameAsString().c_str());
+  ConstString class_name(parser_iface_decl->getNameAsString());
 
   LLDB_LOG(log,
            "ClangASTSource::FindObjCPropertyAndIvarDecls on "

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -666,7 +666,7 @@ void ClangExpressionDeclMap::FindExternalVisibleDecls(
     NameSearchContext &context) {
   assert(m_ast_context);
 
-  const ConstString name(context.m_decl_name.getAsString().c_str());
+  const auto name = context.m_decl_name.getAsString();
 
   Log *log = GetLog(LLDBLog::Expressions);
 
@@ -1370,7 +1370,7 @@ void ClangExpressionDeclMap::FindExternalVisibleDecls(
 
   Log *log = GetLog(LLDBLog::Expressions);
 
-  const ConstString name(context.m_decl_name.getAsString().c_str());
+  const ConstString name(context.m_decl_name.getAsString());
   if (IgnoreName(name, false))
     return;
 
@@ -1601,7 +1601,7 @@ ClangExpressionDeclMap::AddExpressionVariable(NameSearchContext &context,
     var_decl = context.AddVarDecl(pt.GetLValueReferenceType());
 
   std::string decl_name(context.m_decl_name.getAsString());
-  ConstString entity_name(decl_name.c_str());
+  ConstString entity_name(decl_name);
   ClangExpressionVariable *entity(new ClangExpressionVariable(valobj));
   m_found_entities.AddNewlyConstructedVariable(entity);
 
@@ -1748,7 +1748,7 @@ void ClangExpressionDeclMap::AddOneGenericVariable(NameSearchContext &context,
   NamedDecl *var_decl = context.AddVarDecl(parser_type);
 
   std::string decl_name(context.m_decl_name.getAsString());
-  ConstString entity_name(decl_name.c_str());
+  ConstString entity_name(decl_name);
   ClangExpressionVariable *entity(new ClangExpressionVariable(
       m_parser_vars->m_exe_ctx.GetBestExecutionContextScope(), entity_name,
       user_type, m_parser_vars->m_target_info.byte_order,
@@ -1801,7 +1801,7 @@ void ClangExpressionDeclMap::AddOneRegister(NameSearchContext &context,
   m_found_entities.AddNewlyConstructedVariable(entity);
 
   std::string decl_name(context.m_decl_name.getAsString());
-  entity->SetName(ConstString(decl_name.c_str()));
+  entity->SetName(ConstString(decl_name));
   entity->SetRegisterInfo(reg_info);
   entity->EnableParserVars(GetParserID());
   ClangExpressionVariable::ParserVars *parser_vars =
@@ -1950,7 +1950,7 @@ void ClangExpressionDeclMap::AddOneFunction(NameSearchContext &context,
   m_found_entities.AddNewlyConstructedVariable(entity);
 
   std::string decl_name(context.m_decl_name.getAsString());
-  entity->SetName(ConstString(decl_name.c_str()));
+  entity->SetName(ConstString(decl_name));
   entity->SetCompilerType(function_clang_type);
   entity->EnableParserVars(GetParserID());
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -891,8 +891,7 @@ bool IRForTarget::RewritePersistentAlloc(llvm::Instruction *persistent_alloc) {
       m_decl_map->GetTypeSystem()->GetType(decl->getType()));
 
   StringRef decl_name(decl->getName());
-  lldb_private::ConstString persistent_variable_name(decl_name.data(),
-                                                     decl_name.size());
+  lldb_private::ConstString persistent_variable_name(decl_name);
   if (!m_decl_map->AddPersistentVariable(decl, persistent_variable_name,
                                          result_decl_type, false, false))
     return false;
@@ -1074,7 +1073,7 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
 bool IRForTarget::HandleSymbol(Value *symbol) {
   lldb_private::Log *log(GetLog(LLDBLog::Expressions));
 
-  lldb_private::ConstString name(symbol->getName().str().c_str());
+  lldb_private::ConstString name(symbol->getName());
 
   lldb::addr_t symbol_addr =
       m_decl_map->GetSymbolAddress(name, lldb::eSymbolTypeAny);
@@ -1138,7 +1137,7 @@ bool IRForTarget::HandleObjCClass(Value *classlist_reference) {
     return false;
 
   StringRef name(initializer->getName());
-  lldb_private::ConstString name_cstr(name.str().c_str());
+  lldb_private::ConstString name_cstr(name);
   lldb::addr_t class_ptr =
       m_decl_map->GetSymbolAddress(name_cstr, lldb::eSymbolTypeObjCClass);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -133,8 +133,7 @@ public:
     }
 
     ValueObjectSP child_sp(struct_sp->GetSyntheticChildAtOffset(
-        child_byte_offset, child_type, true,
-        ConstString(child_name.c_str(), child_name.size())));
+        child_byte_offset, child_type, true, ConstString(child_name)));
 
     return child_sp;
   }

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -192,7 +192,7 @@ ObjCLanguage::GetMethodNameVariants(ConstString method_name) const {
 
   if (objc_method->IsClassMethod() || objc_method->IsInstanceMethod()) {
     if (!name_sans_category.empty())
-      variant_names.emplace_back(ConstString(name_sans_category.c_str()),
+      variant_names.emplace_back(ConstString(name_sans_category),
                                  lldb::eFunctionNameTypeFull);
   } else {
     StreamString strm;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -661,7 +661,7 @@ ConstString ClassDescriptorV2::GetClassName() {
       if (!Read_class_row(process, *objc_class, class_ro, class_rw))
         return m_name;
 
-      m_name = ConstString(class_ro->m_name.c_str());
+      m_name = ConstString(class_ro->m_name);
     }
   }
   return m_name;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1352,7 +1352,7 @@ size_t AppleObjCRuntimeV2::GetByteOffsetForIvar(CompilerType &parent_ast_type,
     buffer.append(class_name.GetStringRef());
     buffer.push_back('.');
     buffer.append(ivar_name);
-    ConstString ivar_const_str(buffer.c_str());
+    ConstString ivar_const_str(buffer);
 
     // Try to get the ivar offset address from the symbol table first using the
     // name we created above
@@ -1522,7 +1522,7 @@ public:
       if (!err.Success())
         return element();
 
-      return element(ConstString(key_string.c_str()),
+      return element(ConstString(key_string),
                      (ObjCLanguageRuntime::ObjCISA)value);
     }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -759,7 +759,7 @@ Status PlatformDarwinKernel::GetSharedModuleKext(
 
   // Treat the file's path as a kext bundle ID (e.g.
   // "com.apple.driver.AppleIRController") and search our kext index.
-  ConstString kext_bundle(platform_file.GetPath().c_str());
+  ConstString kext_bundle(platform_file.GetPath());
   // First look through the kext bundles that had a dsym next to them
   if (m_name_to_kext_path_map_with_dsyms.count(kext_bundle) > 0) {
     for (BundleIDToKextIterator it = m_name_to_kext_path_map_with_dsyms.begin();

--- a/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedFrame.cpp
@@ -152,7 +152,7 @@ const char *ScriptedFrame::GetFunctionName() {
   std::optional<std::string> function_name = GetInterface()->GetFunctionName();
   if (!function_name)
     return StackFrame::GetFunctionName();
-  return ConstString(function_name->c_str()).AsCString(nullptr);
+  return ConstString(*function_name).AsCString(nullptr);
 }
 
 const char *ScriptedFrame::GetDisplayFunctionName() {
@@ -161,7 +161,7 @@ const char *ScriptedFrame::GetDisplayFunctionName() {
       GetInterface()->GetDisplayFunctionName();
   if (!function_name)
     return StackFrame::GetDisplayFunctionName();
-  return ConstString(function_name->c_str()).AsCString(nullptr);
+  return ConstString(*function_name).AsCString(nullptr);
 }
 
 bool ScriptedFrame::IsInlined() { return GetInterface()->IsInlined(); }

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -94,7 +94,7 @@ const char *ScriptedThread::GetName() {
   std::optional<std::string> thread_name = GetInterface()->GetName();
   if (!thread_name)
     return nullptr;
-  return ConstString(thread_name->c_str()).AsCString(nullptr);
+  return ConstString(*thread_name).AsCString(nullptr);
 }
 
 const char *ScriptedThread::GetQueueName() {
@@ -102,7 +102,7 @@ const char *ScriptedThread::GetQueueName() {
   std::optional<std::string> queue_name = GetInterface()->GetQueue();
   if (!queue_name)
     return nullptr;
-  return ConstString(queue_name->c_str()).AsCString(nullptr);
+  return ConstString(*queue_name).AsCString(nullptr);
 }
 
 void ScriptedThread::WillResume(StateType resume_state) {}

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -311,7 +311,7 @@ void ManualDWARFIndex::IndexUnitImpl(DWARFUnit &unit,
                   objc_method->GetClassNameWithCategory());
               ConstString objc_selector_name(objc_method->GetSelector());
               ConstString objc_fullname_no_category_name(
-                  objc_method->GetFullNameWithoutCategory().c_str());
+                  objc_method->GetFullNameWithoutCategory());
               ConstString class_name_no_category(objc_method->GetClassName());
               set.function_fullnames.Insert(ConstString(name), ref);
               if (class_name_with_category)

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -5529,7 +5529,7 @@ void TypeSystemClang::ForEachEnumerator(
       for (enum_pos = enum_decl->enumerator_begin(),
           enum_end_pos = enum_decl->enumerator_end();
            enum_pos != enum_end_pos; ++enum_pos) {
-        ConstString name(enum_pos->getNameAsString().c_str());
+        ConstString name(enum_pos->getNameAsString());
         if (!callback(integer_type, name, enum_pos->getInitVal()))
           break;
       }

--- a/lldb/source/Symbol/Symbol.cpp
+++ b/lldb/source/Symbol/Symbol.cpp
@@ -208,7 +208,7 @@ bool Symbol::SetReExportedSymbolSharedLibrary(const FileSpec &fspec) {
     // For eSymbolTypeReExported, the "const char *" from a ConstString is used
     // as the offset in the address range base address.
     m_addr_range.SetByteSize(
-        (uintptr_t)ConstString(fspec.GetPath().c_str()).GetCString());
+        (uintptr_t)ConstString(fspec.GetPath()).GetCString());
     return true;
   }
   return false;

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -1082,7 +1082,7 @@ bool SymbolContextSpecifier::SymbolContextMatches(const SymbolContext &sc) {
     // First check the current block, and if it is inlined, get the inlined
     // function name:
     bool was_inlined = false;
-    ConstString func_name(m_function_spec.c_str());
+    ConstString func_name(m_function_spec);
 
     if (sc.block != nullptr) {
       const InlineFunctionInfo *inline_info =

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -506,7 +506,7 @@ std::optional<CompilerType> DILParser::ParseBuiltinType() {
 
   if (type_name.size() > 0) {
     lldb::TargetSP target_sp = m_ctx_scope->CalculateTarget();
-    ConstString const_type_name(type_name.c_str());
+    ConstString const_type_name(type_name);
     for (auto type_system_sp : target_sp->GetScratchTypeSystems())
       if (auto compiler_type =
               type_system_sp->GetBuiltinTypeByName(const_type_name))

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2923,7 +2923,7 @@ ValueObjectSP ValueObject::AddressOf(Status &error) {
             new lldb_private::DataBufferHeap(&addr, sizeof(lldb::addr_t)));
         m_addr_of_valobj_sp = ValueObjectConstResult::Create(
             exe_ctx.GetBestExecutionContextScope(),
-            compiler_type.GetPointerType(), ConstString(name.c_str()), buffer,
+            compiler_type.GetPointerType(), ConstString(name), buffer,
             endian::InlHostByteOrder(), exe_ctx.GetAddressByteSize(),
             LLDB_INVALID_ADDRESS, this->GetManager());
       }

--- a/lldb/source/ValueObject/ValueObjectConstResultImpl.cpp
+++ b/lldb/source/ValueObject/ValueObjectConstResultImpl.cpp
@@ -184,7 +184,7 @@ lldb::ValueObjectSP ValueObjectConstResultImpl::AddressOf(Status &error) {
     ExecutionContext exe_ctx(m_impl_backend->GetExecutionContextRef());
     m_address_of_backend = ValueObjectConstResult::Create(
         exe_ctx.GetBestExecutionContextScope(), compiler_type.GetPointerType(),
-        ConstString(new_name.c_str()), buffer, endian::InlHostByteOrder(),
+        ConstString(new_name), buffer, endian::InlHostByteOrder(),
         exe_ctx.GetAddressByteSize(), LLDB_INVALID_ADDRESS,
         m_impl_backend->GetManager());
 


### PR DESCRIPTION
Replace `ConstString(char *)`, mostly with the `StringRef` constructor. Eliminates some unnecessary `strlen`, and a few copies.