### PR TITLE
[lldb] Skip TestBytecode tests on Windows

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/bytecode-summary/TestBytecodeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-summary/TestBytecodeSummary.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    @skipIfWindows
     def test(self):
         self.build()
         if self.TraceOn():

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    @skipIfWindows
     def test_synthetic(self):
         self.build()
         if self.TraceOn():
@@ -21,6 +22,7 @@ class TestCase(TestBase):
 
         self.expect("v acc", matching=False, substrs=["password"])
 
+    @skipIfWindows
     def test_update_reuse(self):
         self.build()
 


### PR DESCRIPTION
This patch must fix broken tests after #197808 on Windows (the lldb-x86_64-win buildbot).