### PR TITLE
[lldb][windows] Fix second-chance exception delivery on lldb-server

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.cpp
@@ -458,9 +458,6 @@ NativeProcessWindows::OnDebugException(bool first_chance,
   ProcessDebugger::OnDebugException(first_chance, record);
 
   static bool initial_stop = false;
-  if (!first_chance) {
-    SetState(eStateStopped, false);
-  }
 
   switch (record.GetExceptionCode()) {
   case DWORD(STATUS_SINGLE_STEP):
@@ -582,6 +579,9 @@ NativeProcessWindows::OnDebugException(bool first_chance,
              record.GetExceptionCode(), record.GetExceptionAddress(),
              first_chance);
 
+    if (first_chance)
+      return ExceptionResult::SendToApplication;
+
     std::string desc;
     llvm::raw_string_ostream desc_stream(desc);
     desc_stream << "Exception "
@@ -593,12 +593,7 @@ NativeProcessWindows::OnDebugException(bool first_chance,
 
     SetState(eStateStopped, true);
 
-    // For non-breakpoints, give the application a chance to handle the
-    // exception first.
-    if (first_chance)
-      return ExceptionResult::SendToApplication;
-    else
-      return ExceptionResult::BreakInDebugger;
+    return ExceptionResult::BreakInDebugger;
   }
   }
 }


### PR DESCRIPTION
Currently, all tests that wait for the debugger to stop when the process crashes time out on Windows under `LLDB_USE_LLDB_SERVER=1` because of 2 issues:

1. The `if (!first_chance) SetState(eStateStopped, false)` before the switch silently advances `m_state` on every second-chance event. The `default:` branch later calls `SetState(eStateStopped, true)` but this is never reached because `state == m_state`. The client is waiting for a reply that is never sent.

2. The `default:` branch's first-chance handling stops all threads and then returns `SendToApplication`, which tells Windows `DBG_EXCEPTION_NOT_HANDLED`. This hangs the process, the second-chance event never arrives. `ProcessWindows` is a no-op on first-chance non-breakpoint exceptions because of this: it just returns `ExceptionResult::SendToApplication` with no `StopThread/SetState`.

This patch fixes both issues and prevents the following tests from timing out:
```
lldb-api :: functionalities/breakpoint/breakpoint_conditions/crashing_condition/TestCrashingCondition.py
lldb-api :: functionalities/builtin-debugtrap/TestBuiltinDebugTrap.py
lldb-api :: functionalities/inferior-assert/TestInferiorAssert.py
lldb-api :: functionalities/inferior-crashing/TestInferiorCrashingStep.py
lldb-api :: functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
lldb-api :: functionalities/location-list-lookup/TestLocationListLookup.py
```

rdar://177425581