### PR TITLE
[clang][deps] Reuse `ModuleDepCollector`

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -113,17 +113,6 @@ getInitialStableDirs(const CompilerInstance &ScanInstance);
 std::optional<PrebuiltModulesAttrsMap>
 computePrebuiltModulesASTMap(CompilerInstance &ScanInstance,
                              SmallVector<StringRef> &StableDirs);
-
-/// Create the dependency collector that will collect the produced
-/// dependencies. May return the created ModuleDepCollector depending
-/// on the scanning format.
-std::shared_ptr<ModuleDepCollector> initializeScanInstanceDependencyCollector(
-    CompilerInstance &ScanInstance,
-    std::unique_ptr<DependencyOutputOptions> DepOutputOpts,
-    DependencyScanningService &Service, CompilerInvocation &Inv,
-    DependencyActionController &Controller,
-    PrebuiltModulesAttrsMap PrebuiltModulesASTMap,
-    SmallVector<StringRef> &StableDirs);
 } // namespace dependencies
 } // namespace clang
 

--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -132,6 +132,8 @@ public:
   /// invocation, (e.g. disable implicit modules, add explicit module paths).
   void applyDiscoveredDependencies(CompilerInvocation &CI);
 
+  void clearLocalState();
+
 private:
   friend ModuleDepCollectorPP;
 
@@ -146,7 +148,7 @@ private:
   const PrebuiltModulesAttrsMap PrebuiltModulesASTMap;
   /// Directory paths known to be stable through an active development and build
   /// cycle.
-  const ArrayRef<StringRef> StableDirs;
+  const SmallVector<StringRef> StableDirs;
   /// Path to the main source file.
   std::string MainFile;
   /// Non-modular file dependencies. This includes the main source file and

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -168,6 +168,8 @@ class CompilerInstanceWithContext {
   // Compiler Instance
   std::unique_ptr<CompilerInstance> CIPtr;
 
+  std::shared_ptr<dependencies::ModuleDepCollector> MDC;
+
   // Source location offset.
   int32_t SrcLocOffset = 0;
 

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -505,21 +505,6 @@ dependencies::createDependencyOutputOptions(
   return Opts;
 }
 
-std::shared_ptr<ModuleDepCollector>
-dependencies::initializeScanInstanceDependencyCollector(
-    CompilerInstance &ScanInstance,
-    std::unique_ptr<DependencyOutputOptions> DepOutputOpts,
-    DependencyScanningService &Service, CompilerInvocation &Inv,
-    DependencyActionController &Controller,
-    PrebuiltModulesAttrsMap PrebuiltModulesASTMap,
-    SmallVector<StringRef> &StableDirs) {
-  auto MDC = std::make_shared<ModuleDepCollector>(
-      Service, std::move(DepOutputOpts), ScanInstance, Controller, Inv,
-      std::move(PrebuiltModulesASTMap), StableDirs);
-  ScanInstance.addDependencyCollector(MDC);
-  return MDC;
-}
-
 /// Manages (and terminates) the asynchronous compilation of modules.
 class AsyncModuleCompiles {
   std::mutex Mutex;
@@ -768,9 +753,10 @@ bool DependencyScanningAction::runInvocation(
 
   auto DepOutputOpts = createDependencyOutputOptions(*OriginalInvocation);
 
-  MDC = initializeScanInstanceDependencyCollector(
-      ScanInstance, std::move(DepOutputOpts), Service, *OriginalInvocation,
-      Controller, *MaybePrebuiltModulesASTMap, StableDirs);
+  MDC = std::make_shared<ModuleDepCollector>(
+      Service, std::move(DepOutputOpts), ScanInstance, Controller,
+      *OriginalInvocation, *MaybePrebuiltModulesASTMap, StableDirs);
+  ScanInstance.addDependencyCollector(MDC);
 
   if (ScanInstance.getDiagnostics().hasErrorOccurred())
     return false;

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -459,6 +459,17 @@ void ModuleDepCollector::applyDiscoveredDependencies(CompilerInvocation &CI) {
   }
 }
 
+void ModuleDepCollector::clearLocalState() {
+  MainFile.clear();
+  FileDeps.clear();
+  DirectPrebuiltModularDeps.clear();
+  DirectModularDeps.clear();
+  DirectImports.clear();
+  VisibleModules.clear();
+  ProvidedStdCXXModule.reset();
+  RequiredStdCXXModules.clear();
+}
+
 static bool isSafeToIgnoreCWD(const CowCompilerInvocation &CI) {
   // Check if the command line input uses relative paths.
   // It is not safe to ignore the current working directory if any of the
@@ -657,8 +668,20 @@ void ModuleDepCollector::run(DependencyConsumer &Consumer) {
   Consumer.handleProvidedAndRequiredStdCXXModules(MDC.ProvidedStdCXXModule,
                                                   MDC.RequiredStdCXXModules);
 
-  for (auto &&I : MDC.ModularDeps)
-    Consumer.handleModuleDependency(*I.second);
+  llvm::DenseSet<serialization::ModuleFile *> HandledModuleDependencies;
+  std::function<void(serialization::ModuleFile *)> HandleModuleDependency =
+      [&](serialization::ModuleFile *MF) {
+        if (HandledModuleDependencies.insert(MF).second) {
+          for (serialization::ModuleFile *MFI : MF->Imports)
+            HandleModuleDependency(MFI);
+          auto It = MDC.ModularDeps.find(MF);
+          if (It != MDC.ModularDeps.end())
+            Consumer.handleModuleDependency(*It->second);
+        }
+      };
+
+  for (serialization::ModuleFile *MF : MDC.DirectModularDeps)
+    HandleModuleDependency(MF);
 
   for (serialization::ModuleFile *MF : MDC.DirectModularDeps) {
     auto It = MDC.ModularDeps.find(MF);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -516,6 +516,10 @@ bool CompilerInstanceWithContext::initialize(
   // CompilerInstance::ExecuteAction to perform scanning.
   CI.createTarget();
 
+  MDC = std::make_shared<ModuleDepCollector>(
+      Worker.Service, std::make_unique<DependencyOutputOptions>(*OutputOpts),
+      CI, Controller, *OriginalInvocation, PrebuiltModuleASTMap, StableDirs);
+
   return true;
 }
 
@@ -543,13 +547,7 @@ bool CompilerInstanceWithContext::computeDependencies(
     CI.getPreprocessor().removePPCallbacks();
   });
 
-  auto MDC = initializeScanInstanceDependencyCollector(
-      CI, std::make_unique<DependencyOutputOptions>(*OutputOpts),
-      Worker.Service,
-      /* The MDC's constructor makes a copy of the OriginalInvocation, so
-      we can pass it in without worrying that it might be changed across
-      invocations of computeDependencies. */
-      *OriginalInvocation, Controller, PrebuiltModuleASTMap, StableDirs);
+  CI.addDependencyCollector(MDC);
 
   CompilerInvocation ModuleInvocation(*OriginalInvocation);
   if (!Controller.initialize(CI, ModuleInvocation))
@@ -612,6 +610,7 @@ bool CompilerInstanceWithContext::computeDependencies(
 
   MDC->run(Consumer);
   MDC->applyDiscoveredDependencies(ModuleInvocation);
+  MDC->clearLocalState();
 
   if (!Controller.finalize(CI, ModuleInvocation))
     return false;


### PR DESCRIPTION
This PR starts reusing `ModuleDepCollector` across calls to `CompilerInstanceWithContext::computeDependencies()`. This allows reusing parts of the dependency graph constructed in previous calls, skipping lots of work on some workloads.