### PR TITLE
[flang-rt][test] Skip Driver/safe-trampoline-gnustack.f90 on Solaris

### DIFF
--- a/flang-rt/test/Driver/safe-trampoline-gnustack.f90
+++ b/flang-rt/test/Driver/safe-trampoline-gnustack.f90
@@ -2,6 +2,7 @@
 ! UNSUPPORTED: offload-cuda
 ! UNSUPPORTED: system-darwin
 ! UNSUPPORTED: target=powerpc{{.*}}
+! UNSUPPORTED: target={{.*solaris.*}}
 
 ! Verify that -fsafe-trampoline produces an executable whose
 ! GNU_STACK program header is RW (not RWE), proving W^X compliance.


### PR DESCRIPTION
The `flang-rt :: Driver/safe-trampoline-gnustack.f90` test `FAIL`s on Solaris.  It checks for a `GNU_STACK` section, however that isn't used and not emitted on Solaris, so this patch just skips the test.

Tested on `x86_64-pc-solaris2.11` and `x86_64-pc-linux-gnu`.