### PR TITLE
[clang][deps] Move `ModuleDepCollectorPP` to .cpp file

### DIFF
--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -76,37 +76,6 @@ private:
   std::set<StringRef> ModuleFileDependents;
 };
 
-class ModuleDepCollector;
-
-/// Callback that records textual includes and direct modular includes/imports
-/// during preprocessing. At the end of the main file, it also collects
-/// transitive modular dependencies and passes everything to the
-/// \c DependencyConsumer of the parent \c ModuleDepCollector.
-class ModuleDepCollectorPP final : public PPCallbacks {
-public:
-  ModuleDepCollectorPP(ModuleDepCollector &MDC) : MDC(MDC) {}
-
-  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
-                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
-                        SourceLocation Loc) override;
-  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
-                  OptionalFileEntryRef File,
-                  SrcMgr::CharacteristicKind FileType) override;
-  void InclusionDirective(SourceLocation HashLoc, const Token &IncludeTok,
-                          StringRef FileName, bool IsAngled,
-                          CharSourceRange FilenameRange,
-                          OptionalFileEntryRef File, StringRef SearchPath,
-                          StringRef RelativePath, const Module *SuggestedModule,
-                          bool ModuleImported,
-                          SrcMgr::CharacteristicKind FileType) override;
-  void moduleImport(SourceLocation ImportLoc, ModuleIdPath Path,
-                    const Module *Imported) override;
-
-private:
-  /// The parent dependency collector.
-  ModuleDepCollector &MDC;
-};
-
 /// Collects modular and non-modular dependencies of the main file by attaching
 /// \c ModuleDepCollectorPP to the preprocessor.
 class ModuleDepCollector final : public DependencyCollector {
@@ -133,7 +102,7 @@ public:
   void applyDiscoveredDependencies(CompilerInvocation &CI);
 
 private:
-  friend ModuleDepCollectorPP;
+  class ModuleDepCollectorPP;
 
   /// The parent dependency scanning service.
   DependencyScanningService &Service;
@@ -182,7 +151,7 @@ private:
   /// A pointer to the preprocessor callback so we can invoke it directly
   /// if needed. The callback is created and added to a Preprocessor instance by
   /// attachToPreprocessor and the Preprocessor instance owns it.
-  ModuleDepCollectorPP *CollectorPPPtr = nullptr;
+  PPCallbacks *CollectorPPPtr = nullptr;
 
   void handleImport(const Module *Imported);
 

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -525,57 +525,66 @@ void ModuleDepCollector::associateWithContextHash(
   assert(Inserted && "duplicate module mapping");
 }
 
-void ModuleDepCollectorPP::LexedFileChanged(FileID FID,
-                                            LexedFileChangeReason Reason,
-                                            SrcMgr::CharacteristicKind FileType,
-                                            FileID PrevFID,
-                                            SourceLocation Loc) {
-  if (Reason != LexedFileChangeReason::EnterFile)
-    return;
+/// Callback that records textual includes and direct modular includes/imports
+/// during preprocessing.
+class ModuleDepCollector::ModuleDepCollectorPP final : public PPCallbacks {
+  /// The parent dependency collector.
+  ModuleDepCollector &MDC;
 
-  SourceManager &SM = MDC.ScanInstance.getSourceManager();
+public:
+  ModuleDepCollectorPP(ModuleDepCollector &MDC) : MDC(MDC) {}
 
-  // Dependency generation really does want to go all the way to the
-  // file entry for a source location to find out what is depended on.
-  // We do not want #line markers to affect dependency generation!
-  if (std::optional<StringRef> Filename = SM.getNonBuiltinFilenameForID(FID))
-    MDC.addFileDep(llvm::sys::path::remove_leading_dotslash(*Filename));
-}
+  void LexedFileChanged(FileID FID, LexedFileChangeReason Reason,
+                        SrcMgr::CharacteristicKind FileType, FileID PrevFID,
+                        SourceLocation Loc) override {
+    if (Reason != LexedFileChangeReason::EnterFile)
+      return;
 
-void ModuleDepCollectorPP::HasInclude(SourceLocation Loc, StringRef FileName,
-                                      bool IsAngled, OptionalFileEntryRef File,
-                                      SrcMgr::CharacteristicKind FileType) {
-  if (File)
-    MDC.addFileDep(File->getName());
-}
+    SourceManager &SM = MDC.ScanInstance.getSourceManager();
 
-void ModuleDepCollectorPP::InclusionDirective(
-    SourceLocation HashLoc, const Token &IncludeTok, StringRef FileName,
-    bool IsAngled, CharSourceRange FilenameRange, OptionalFileEntryRef File,
-    StringRef SearchPath, StringRef RelativePath, const Module *SuggestedModule,
-    bool ModuleImported, SrcMgr::CharacteristicKind FileType) {
-  if (!File && !ModuleImported) {
-    // This is a non-modular include that HeaderSearch failed to find. Add it
-    // here as `FileChanged` will never see it.
-    MDC.addFileDep(FileName);
-  }
-  MDC.handleImport(SuggestedModule);
-}
-
-void ModuleDepCollectorPP::moduleImport(SourceLocation ImportLoc,
-                                        ModuleIdPath Path,
-                                        const Module *Imported) {
-  auto &PP = MDC.ScanInstance.getPreprocessor();
-  if (PP.getLangOpts().CPlusPlusModules && PP.isImportingCXXNamedModules()) {
-    P1689ModuleInfo RequiredModule;
-    RequiredModule.ModuleName = Path[0].getIdentifierInfo()->getName().str();
-    RequiredModule.Type = P1689ModuleInfo::ModuleType::NamedCXXModule;
-    MDC.RequiredStdCXXModules.push_back(std::move(RequiredModule));
-    return;
+    // Dependency generation really does want to go all the way to the
+    // file entry for a source location to find out what is depended on.
+    // We do not want #line markers to affect dependency generation!
+    if (std::optional<StringRef> Filename = SM.getNonBuiltinFilenameForID(FID))
+      MDC.addFileDep(llvm::sys::path::remove_leading_dotslash(*Filename));
   }
 
-  MDC.handleImport(Imported);
-}
+  void HasInclude(SourceLocation Loc, StringRef FileName, bool IsAngled,
+                  OptionalFileEntryRef File,
+                  SrcMgr::CharacteristicKind FileType) override {
+    if (File)
+      MDC.addFileDep(File->getName());
+  }
+
+  void InclusionDirective(SourceLocation HashLoc, const Token &IncludeTok,
+                          StringRef FileName, bool IsAngled,
+                          CharSourceRange FilenameRange,
+                          OptionalFileEntryRef File, StringRef SearchPath,
+                          StringRef RelativePath, const Module *SuggestedModule,
+                          bool ModuleImported,
+                          SrcMgr::CharacteristicKind FileType) override {
+    if (!File && !ModuleImported) {
+      // This is a non-modular include that HeaderSearch failed to find. Add it
+      // here as `FileChanged` will never see it.
+      MDC.addFileDep(FileName);
+    }
+    MDC.handleImport(SuggestedModule);
+  }
+
+  void moduleImport(SourceLocation ImportLoc, ModuleIdPath Path,
+                    const Module *Imported) override {
+    auto &PP = MDC.ScanInstance.getPreprocessor();
+    if (PP.getLangOpts().CPlusPlusModules && PP.isImportingCXXNamedModules()) {
+      P1689ModuleInfo RequiredModule;
+      RequiredModule.ModuleName = Path[0].getIdentifierInfo()->getName().str();
+      RequiredModule.Type = P1689ModuleInfo::ModuleType::NamedCXXModule;
+      MDC.RequiredStdCXXModules.push_back(std::move(RequiredModule));
+      return;
+    }
+
+    MDC.handleImport(Imported);
+  }
+};
 
 void ModuleDepCollector::handleImport(const Module *Imported) {
   auto &MDC = *this;


### PR DESCRIPTION
This PR moves the `ModuleDepCollectorPP` type into the .cpp file. It's an implementation detail that the header doesn't need to expose.