### PR TITLE
[lldb] Setup session when calling Python interfaces

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -193,8 +193,8 @@ public:
     }
 
     Locker py_lock(&m_interpreter,
-                   Locker::AcquireLock | Locker::InitSession | Locker::NoSTDIN,
-                   Locker::FreeLock | Locker::TearDownSession);
+                   Locker::AcquireLock | Locker::InitStdio | Locker::NoSTDIN,
+                   Locker::FreeLock | Locker::TearDownStdio);
 
     PythonObject result = {};
 
@@ -415,8 +415,8 @@ public:
                                  error);
 
     Locker py_lock(&m_interpreter,
-                   Locker::AcquireLock | Locker::InitSession | Locker::NoSTDIN,
-                   Locker::FreeLock | Locker::TearDownSession);
+                   Locker::AcquireLock | Locker::InitStdio | Locker::NoSTDIN,
+                   Locker::FreeLock | Locker::TearDownStdio);
 
     // Get the interpreter dictionary.
     auto dict =
@@ -511,8 +511,8 @@ protected:
                                  error);
 
     Locker py_lock(&m_interpreter,
-                   Locker::AcquireLock | Locker::InitSession | Locker::NoSTDIN,
-                   Locker::FreeLock | Locker::TearDownSession);
+                   Locker::AcquireLock | Locker::InitStdio | Locker::NoSTDIN,
+                   Locker::FreeLock | Locker::TearDownStdio);
 
     PythonObject implementor(PyRefType::Borrowed,
                              (PyObject *)m_object_instance_sp->GetValue());

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -192,8 +192,9 @@ public:
         return create_error("Missing scripting object.");
     }
 
-    Locker py_lock(&m_interpreter, Locker::AcquireLock | Locker::NoSTDIN,
-                   Locker::FreeLock);
+    Locker py_lock(&m_interpreter,
+                   Locker::AcquireLock | Locker::InitSession | Locker::NoSTDIN,
+                   Locker::FreeLock | Locker::TearDownSession);
 
     PythonObject result = {};
 
@@ -413,8 +414,9 @@ public:
       return ErrorWithMessage<T>(caller_signature, "missing script class name",
                                  error);
 
-    Locker py_lock(&m_interpreter, Locker::AcquireLock | Locker::NoSTDIN,
-                   Locker::FreeLock);
+    Locker py_lock(&m_interpreter,
+                   Locker::AcquireLock | Locker::InitSession | Locker::NoSTDIN,
+                   Locker::FreeLock | Locker::TearDownSession);
 
     // Get the interpreter dictionary.
     auto dict =
@@ -508,8 +510,9 @@ protected:
       return ErrorWithMessage<T>(caller_signature, "python object ill-formed",
                                  error);
 
-    Locker py_lock(&m_interpreter, Locker::AcquireLock | Locker::NoSTDIN,
-                   Locker::FreeLock);
+    Locker py_lock(&m_interpreter,
+                   Locker::AcquireLock | Locker::InitSession | Locker::NoSTDIN,
+                   Locker::FreeLock | Locker::TearDownSession);
 
     PythonObject implementor(PyRefType::Borrowed,
                              (PyObject *)m_object_instance_sp->GetValue());

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -656,8 +656,9 @@ bool ScriptInterpreterPythonImpl::EnterSession(uint16_t on_entry_flags,
     run_string.PutCString("; lldb.frame = lldb.thread.GetSelectedFrame ()");
     run_string.PutCString("')");
   } else if (on_entry_flags & Locker::InitDebugger) {
-    // If we aren't initing the globals, we should still always set the
-    // debugger (since that is always unique.)
+    // In non-interactive mode (e.g. type summaries), initialize the debugger
+    // only if requested. This should not be used in new extensions and is kept
+    // for backwards compatibility.
     run_string.Printf("run_one_line (%s, 'lldb.debugger_unique_id = %" PRIu64,
                       m_dictionary_name.c_str(), m_debugger.GetID());
     run_string.Printf(

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -369,8 +369,7 @@ bool ScriptInterpreterPythonImpl::Locker::DoFreeLock() {
 bool ScriptInterpreterPythonImpl::Locker::DoTearDownSession() {
   if (!m_python_interpreter)
     return false;
-  m_python_interpreter->LeaveSession(m_on_leave & TearDownGlobals,
-                                     m_on_leave & TearDownStdio);
+  m_python_interpreter->LeaveSession(m_on_leave);
   return true;
 }
 
@@ -550,13 +549,12 @@ ScriptInterpreterPythonImpl::CreateInstance(Debugger &debugger) {
   return std::make_shared<ScriptInterpreterPythonImpl>(debugger);
 }
 
-void ScriptInterpreterPythonImpl::LeaveSession(bool clear_globals,
-                                               bool clear_stdio) {
+void ScriptInterpreterPythonImpl::LeaveSession(uint16_t leave_flags) {
   Log *log = GetLog(LLDBLog::Script);
   if (log)
     log->PutCString("ScriptInterpreterPythonImpl::LeaveSession()");
 
-  if (clear_globals) {
+  if (leave_flags & Locker::TearDownGlobals) {
     // Unset the LLDB global variables.
     RunSimpleString("lldb.debugger = None; lldb.target = None; lldb.process "
                     "= None; lldb.thread = None; lldb.frame = None");
@@ -567,7 +565,7 @@ void ScriptInterpreterPythonImpl::LeaveSession(bool clear_globals,
   // up believing we have no thread state and PyImport_AddModule will crash if
   // that is the case - since that seems to only happen when destroying the
   // SBDebugger, we can make do without clearing up stdout and stderr
-  if (clear_stdio && PyThreadState_GetDict()) {
+  if ((leave_flags & Locker::TearDownStdio) && PyThreadState_GetDict()) {
     PythonDictionary &sys_module_dict = GetSysModuleDictionary();
     if (sys_module_dict.IsValid()) {
       if (m_saved_stdin.IsValid()) {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -322,14 +322,13 @@ void ScriptInterpreterPython::Terminate() {
 ScriptInterpreterPythonImpl::Locker::Locker(
     ScriptInterpreterPythonImpl *py_interpreter, uint16_t on_entry,
     uint16_t on_leave, FileSP in, FileSP out, FileSP err)
-    : ScriptInterpreterLocker(),
-      m_teardown_session((on_leave & TearDownSession) == TearDownSession),
+    : ScriptInterpreterLocker(), m_on_leave(on_leave),
       m_python_interpreter(py_interpreter) {
   DoAcquireLock();
-  if ((on_entry & InitSession) == InitSession) {
+  if (on_entry & InitSessionMask) {
     if (!DoInitSession(on_entry, in, out, err)) {
       // Don't teardown the session if we didn't init it.
-      m_teardown_session = false;
+      m_on_leave &= ~TearDownSessionMask;
     }
   }
 }
@@ -370,12 +369,13 @@ bool ScriptInterpreterPythonImpl::Locker::DoFreeLock() {
 bool ScriptInterpreterPythonImpl::Locker::DoTearDownSession() {
   if (!m_python_interpreter)
     return false;
-  m_python_interpreter->LeaveSession();
+  m_python_interpreter->LeaveSession(m_on_leave & TearDownGlobals,
+                                     m_on_leave & TearDownStdio);
   return true;
 }
 
 ScriptInterpreterPythonImpl::Locker::~Locker() {
-  if (m_teardown_session)
+  if (m_on_leave & TearDownSessionMask)
     DoTearDownSession();
   DoFreeLock();
 }
@@ -550,21 +550,24 @@ ScriptInterpreterPythonImpl::CreateInstance(Debugger &debugger) {
   return std::make_shared<ScriptInterpreterPythonImpl>(debugger);
 }
 
-void ScriptInterpreterPythonImpl::LeaveSession() {
+void ScriptInterpreterPythonImpl::LeaveSession(bool clear_globals,
+                                               bool clear_stdio) {
   Log *log = GetLog(LLDBLog::Script);
   if (log)
     log->PutCString("ScriptInterpreterPythonImpl::LeaveSession()");
 
-  // Unset the LLDB global variables.
-  RunSimpleString("lldb.debugger = None; lldb.target = None; lldb.process "
-                  "= None; lldb.thread = None; lldb.frame = None");
+  if (clear_globals) {
+    // Unset the LLDB global variables.
+    RunSimpleString("lldb.debugger = None; lldb.target = None; lldb.process "
+                    "= None; lldb.thread = None; lldb.frame = None");
+  }
 
   // checking that we have a valid thread state - since we use our own
   // threading and locking in some (rare) cases during cleanup Python may end
   // up believing we have no thread state and PyImport_AddModule will crash if
   // that is the case - since that seems to only happen when destroying the
   // SBDebugger, we can make do without clearing up stdout and stderr
-  if (PyThreadState_GetDict()) {
+  if (clear_stdio && PyThreadState_GetDict()) {
     PythonDictionary &sys_module_dict = GetSysModuleDictionary();
     if (sys_module_dict.IsValid()) {
       if (m_saved_stdin.IsValid()) {
@@ -639,6 +642,10 @@ bool ScriptInterpreterPythonImpl::EnterSession(uint16_t on_entry_flags,
 
   StreamString run_string;
 
+  assert((on_entry_flags & (Locker::InitGlobals | Locker::InitDebugger)) !=
+             (Locker::InitGlobals | Locker::InitDebugger) &&
+         "InitGlobals and InitDebugger are mutually exclusive");
+
   if (on_entry_flags & Locker::InitGlobals) {
     run_string.Printf("run_one_line (%s, 'lldb.debugger_unique_id = %" PRIu64,
                       m_dictionary_name.c_str(), m_debugger.GetID());
@@ -650,7 +657,7 @@ bool ScriptInterpreterPythonImpl::EnterSession(uint16_t on_entry_flags,
     run_string.PutCString("; lldb.thread = lldb.process.GetSelectedThread ()");
     run_string.PutCString("; lldb.frame = lldb.thread.GetSelectedFrame ()");
     run_string.PutCString("')");
-  } else {
+  } else if (on_entry_flags & Locker::InitDebugger) {
     // If we aren't initing the globals, we should still always set the
     // debugger (since that is always unique.)
     run_string.Printf("run_one_line (%s, 'lldb.debugger_unique_id = %" PRIu64,
@@ -661,11 +668,13 @@ bool ScriptInterpreterPythonImpl::EnterSession(uint16_t on_entry_flags,
     run_string.PutCString("')");
   }
 
-  RunSimpleString(run_string.GetData());
-  run_string.Clear();
+  if (!run_string.Empty()) {
+    RunSimpleString(run_string.GetData());
+    run_string.Clear();
+  }
 
   PythonDictionary &sys_module_dict = GetSysModuleDictionary();
-  if (sys_module_dict.IsValid()) {
+  if ((on_entry_flags & Locker::InitStdio) && sys_module_dict.IsValid()) {
     lldb::FileSP top_in_sp;
     lldb::LockableStreamFileSP top_out_sp, top_err_sp;
     if (!in_sp || !out_sp || !err_sp || !*in_sp || !*out_sp || !*err_sp)
@@ -835,8 +844,9 @@ bool ScriptInterpreterPythonImpl::ExecuteOneLine(
       // happen.
       Locker locker(
           this,
-          Locker::AcquireLock | Locker::InitSession |
-              (options.GetSetLLDBGlobals() ? Locker::InitGlobals : 0) |
+          Locker::AcquireLock | Locker::InitStdio |
+              (options.GetSetLLDBGlobals() ? Locker::InitGlobals
+                                           : Locker::InitDebugger) |
               ((result && result->GetInteractive()) ? 0 : Locker::NoSTDIN),
           Locker::FreeAcquiredLock | Locker::TearDownSession,
           io_redirect.GetInputFile(), io_redirect.GetOutputFile(),
@@ -962,8 +972,9 @@ bool ScriptInterpreterPythonImpl::ExecuteOneLineWithReturn(
   ScriptInterpreterIORedirect &io_redirect = **io_redirect_or_error;
 
   Locker locker(this,
-                Locker::AcquireLock | Locker::InitSession |
-                    (options.GetSetLLDBGlobals() ? Locker::InitGlobals : 0) |
+                Locker::AcquireLock | Locker::InitStdio |
+                    (options.GetSetLLDBGlobals() ? Locker::InitGlobals
+                                                 : Locker::InitDebugger) |
                     Locker::NoSTDIN,
                 Locker::FreeAcquiredLock | Locker::TearDownSession,
                 io_redirect.GetInputFile(), io_redirect.GetOutputFile(),
@@ -1086,8 +1097,9 @@ Status ScriptInterpreterPythonImpl::ExecuteMultipleLines(
   ScriptInterpreterIORedirect &io_redirect = **io_redirect_or_error;
 
   Locker locker(this,
-                Locker::AcquireLock | Locker::InitSession |
-                    (options.GetSetLLDBGlobals() ? Locker::InitGlobals : 0) |
+                Locker::AcquireLock | Locker::InitStdio |
+                    (options.GetSetLLDBGlobals() ? Locker::InitGlobals
+                                                 : Locker::InitDebugger) |
                     Locker::NoSTDIN,
                 Locker::FreeAcquiredLock | Locker::TearDownSession,
                 io_redirect.GetInputFile(), io_redirect.GetOutputFile(),

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -381,7 +381,7 @@ public:
   bool EnterSession(uint16_t on_entry_flags, lldb::FileSP in, lldb::FileSP out,
                     lldb::FileSP err);
 
-  void LeaveSession(bool clear_globals = true, bool reset_stdio = true);
+  void LeaveSession(uint16_t leave_flags);
 
   uint32_t IsExecutingPython() {
     std::lock_guard<std::mutex> guard(m_mutex);

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -305,16 +305,29 @@ public:
   public:
     enum OnEntry {
       AcquireLock = 0x0001,
-      InitSession = 0x0002,
-      InitGlobals = 0x0004,
-      NoSTDIN = 0x0008
+      InitStdio = 0x0002,
+      /// Set lldb.debugger. Mutually exclusive with `InitGlobals`.
+      InitDebugger = 0x0004,
+      /// Set lldb.{debugger,target,process,thread,frame}. Mutually exclusive
+      /// with `InitDebugger`.
+      InitGlobals = 0x0008,
+      NoSTDIN = 0x0010,
+
+      InitSession = InitStdio | InitDebugger,
+
+      InitSessionMask = InitStdio | InitDebugger | InitGlobals,
     };
 
     enum OnLeave {
       FreeLock = 0x0001,
       FreeAcquiredLock = 0x0002, // do not free the lock if we already held it
                                  // when calling constructor
-      TearDownSession = 0x0004
+      TearDownGlobals = 0x0004,
+      TearDownStdio = 0x0008,
+
+      TearDownSession = TearDownGlobals | TearDownStdio,
+
+      TearDownSessionMask = TearDownGlobals | TearDownStdio,
     };
 
     Locker(ScriptInterpreterPythonImpl *py_interpreter,
@@ -335,7 +348,7 @@ public:
 
     bool DoTearDownSession();
 
-    bool m_teardown_session;
+    uint16_t m_on_leave;
     ScriptInterpreterPythonImpl *m_python_interpreter;
     PyGILState_STATE m_GILState;
   };
@@ -368,7 +381,7 @@ public:
   bool EnterSession(uint16_t on_entry_flags, lldb::FileSP in, lldb::FileSP out,
                     lldb::FileSP err);
 
-  void LeaveSession();
+  void LeaveSession(bool clear_globals = true, bool reset_stdio = true);
 
   uint32_t IsExecutingPython() {
     std::lock_guard<std::mutex> guard(m_mutex);
@@ -457,7 +470,7 @@ public:
         ScriptInterpreterPythonImpl::Locker locker(
             m_python,
             ScriptInterpreterPythonImpl::Locker::AcquireLock |
-                ScriptInterpreterPythonImpl::Locker::InitSession |
+                ScriptInterpreterPythonImpl::Locker::InitStdio |
                 ScriptInterpreterPythonImpl::Locker::InitGlobals,
             ScriptInterpreterPythonImpl::Locker::FreeAcquiredLock |
                 ScriptInterpreterPythonImpl::Locker::TearDownSession);


### PR DESCRIPTION
When using the Python interfaces like scripted frame providers in lldb-dap, Python's `print` statements don't show in the output window. They do show when done in synthetic children or summaries.

This is because when calling the interface functions/methods, the stdout/stderr handles were never changed. This PR fixes the issue by passing `InitSession` (and `TearDownSession`) to the `Locker`. As a side effect, this will also set `lldb.debugger`.