### PR TITLE
[GlobalISel] Fix -Wunused-variable in bef7245

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -10659,7 +10659,7 @@ LegalizerHelper::LegalizeResult LegalizerHelper::lowerVAArg(MachineInstr &MI) {
 }
 
 LegalizerHelper::LegalizeResult LegalizerHelper::lowerMulfix(MachineInstr &MI) {
-  unsigned OpCode = MI.getOpcode();
+  [[maybe_unused]] unsigned OpCode = MI.getOpcode();
   assert((OpCode == TargetOpcode::G_SMULFIX ||
           OpCode == TargetOpcode::G_UMULFIX) &&
          "Operator must be either G_SMULFIX or G_UMULFIX!");


### PR DESCRIPTION
OpCode is unused outside of assertions, so mark it [[maybe_unused]] to
prevent -Wunused-variable in non-asserts builds.