### PR TITLE
 [Lit] Introduce mechanisms for disabling daemonization for a test or test folder

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1380,6 +1380,7 @@ add_subdirectory(include)
 add_subdirectory(lib)
 
 if( LLVM_INCLUDE_UTILS )
+  add_subdirectory(utils/ExampleDaemon)
   add_subdirectory(utils/FileCheck)
   add_subdirectory(utils/PerfectShuffle)
   add_subdirectory(utils/count)

--- a/llvm/docs/DaemonMode.rst
+++ b/llvm/docs/DaemonMode.rst
@@ -1,0 +1,135 @@
+============================
+Running Tools in Daemon Mode
+============================
+
+.. contents::
+   :local:
+
+Introduction
+============
+
+Process creation incurs a significant overhead, especially on Windows. This
+document describes the "daemon mode" execution model for LLVM tools, where
+tools run as persistent daemon processes that can perform many tasks, with
+different arguments and input, in the same process. The original motivation
+for this work is to reduce Lit testing time by replacing tool invocations with
+commands for the daemon - this means that the daemonized tool must be able to
+produce the exact same output as the regular version of the tool.
+
+Adding Daemon Support to a Tool
+===============================
+
+Tools can support daemon mode by implementing the ``LLVMTool`` interface and
+calling ``runWithDaemonSupport(Tool)`` in the main function.
+
+First, the tool's ``main`` function must be refactored into a class implementing
+the ``LLVMTool`` interface. This has two functions, ``run`` and ``resetState``.
+The majority of the body of main (everything aside from ``InitLLVM`` and other
+one-time initialization) must be moved to ``run``. This is the function that is
+called by the daemon for each invocation, and it is also invoked once when the
+tool is run normally. The handling of standard input must also be reworked so that
+the ``StandardInputSource`` provided to ``run`` is respected as standard input.
+For example, ``MemoryBuffer::getSTDIN`` should be replaced by
+``StandardInputSource::getInput()`` and ``MemoryBuffer::getFileOrStdin`` should
+be replaced by ``StandardInputSource::getFileOrInput()``. This is how the daemon
+provides input to the tool, as the input cannot be read from stdin normally
+because the pipe never closes.
+
+``resetState`` must also be implemented, which is responsible for resetting any
+application state, for example command line options, statistics and debug
+counters, for the next invocation. This is not called when the process is run
+normally. Any persistent state which may affect the output and is not reset by
+``resetState`` will cause flaky tests.
+
+Finally, the contents of main that were refactored into ``run`` can be replaced
+by ``runWithDaemonSupport(Tool)``, which will detect the daemon argument and
+either run the tool in daemon mode or run it normally by deferring to ``run``.
+
+Daemon IPC Protocol
+===================
+
+The communication protocol between the daemon and the Lit tester uses four
+pipes: the daemon's ``stdin``, ``stdout`` and ``stderr`` and another pipe,
+called the `status pipe`, for the daemon to communicate responses to Lit.
+
+When the daemon first starts it will send a ``ready`` response to indicate that
+it has initialized correctly and is ready to receive commands.
+
+The daemon accepts `commands` on ``stdin``. Commands must be separated by a
+newline (\n; \r is ignored). The following commands are accepted:
+
+* ``run``: This command takes no arguments. Upon receiving this command, the
+  daemon will run the tool, whose output will be sent on ``stdout`` and ``stderr``
+  as usual (unless ``stderr`` is redirected). When the tool returns, a
+  ``returned`` response indicating the exit code is sent.
+
+* ``arg``: This command is followed by an integer indicating a number of
+  bytes. The daemon will read this many bytes from ``stdin``; this string will
+  be appended to the list of arguments for the next invocation. Arguments are
+  framed in this way to avoid having to worry about escaping a separator char.
+
+* ``input_string``: This command is followed by an integer indicating a number of
+  bytes. The daemon will read this many bytes from ``stdin``; this string will
+  be used as standard input for the next invocation.
+
+* ``input_file``: This command is followed by a file name. The content of this
+  file will be used as standard input for the next invocation.
+
+* ``cd``: This command is followed by a directory name. The current directory
+  for the daemon is changed to the provided directory until the next invocation
+  finishes. This controls the working directory for the tool, and following
+  ``input_file`` and ``cd`` commands until the next ``run``. start from this
+  directory too.
+
+* ``redirect_stderr_to_stdout``: This causes writes to ``stderr`` to be
+  directed through ``stdout`` for the next invocation.
+
+* ``exit``: The daemon will exit.
+
+The daemon may send the following `responses` along the status
+pipe:
+
+* ``ready``: This is sent when the daemon finishes initialization, to
+  indicate it is ready to receive commands.
+
+* ``error``: This is sent when the daemon encounters an error, for example a
+  badly formed command. The daemon will exit after encountering an error. The
+  managing process should re-raise the error, as this indicates incorrect use of
+  the daemon. The response is followed by a string describing the error.
+
+* ``returned``. This is sent when a task finishes executing. The response is
+  followed by an integer representing the exit code from the task.
+
+If the daemon exits unexpectedly while running the tool, this means that the
+tool itself caused the process to exit. The exit code from the daemon should be
+taken as the exit code for the task, and the daemon should be restarted.
+
+Each command and response has a space before its argument. An example exchange
+may look like:
+
+* Command: ``arg 3`` followed by ``opt``
+
+* Command: ``arg 2`` followed by ``-S``
+
+* Command: ``arg 20`` followed by ``--passes=instcombine``
+
+* Command: ``input_file llvm/test/Transforms/InstCombine/range-check.ll``
+
+* Command: ``run``
+
+* (``stdout`` and ``stderr`` are sent as usual.)
+
+* Response: ``returned 0``
+
+* Command: ``bad command``
+
+* Response: ``error Unexpected command: bad command``
+
+Running a Daemon
+================
+
+Tools are invoked in daemon mode by passing ``--daemon`` as the first command
+line argument. Additionally, ``--daemon-status-pipe`` argument must be provided
+to set the file descriptor or Windows file handle on which the status messages
+are sent. This may take the form ``fd:{N}`` indicating a Unix/CRT file descriptor
+or ``handle:{N}`` indicating a Windows file handle.

--- a/llvm/docs/Reference.rst
+++ b/llvm/docs/Reference.rst
@@ -66,6 +66,7 @@ LLVM and API reference documentation.
    TransformMetadata
    TypeMetadata
    XRayFDRFormat
+   DaemonMode
 
 API Reference
 -------------

--- a/llvm/include/llvm/Support/DaemonDriver.h
+++ b/llvm/include/llvm/Support/DaemonDriver.h
@@ -1,0 +1,35 @@
+//===- llvm/Support/DaemonDriver.h - Daemon driver interface ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides the function `runWithDaemonSupport` to run a tool
+// which implements `LLVMTool` as a daemon, as described in
+// docs/DaemonDriver.rst.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_DAEMONDRIVER_H
+#define LLVM_SUPPORT_DAEMONDRIVER_H
+
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/ToolInterface.h"
+
+namespace llvm {
+/// This function checks for the `--daemon` command line option and, if it is
+/// present, runs the given tool in daemon mode, as described in
+/// `docs/DaemonMode.rst`. Otherwise, the tool is run
+/// with standard input as the input source - a normal invocation. One-time
+/// initialization logic, for example constructing `InitLLVM` and initializing
+/// passes, should be performed before this function is called. Per-invocation
+/// initialization logic, for example parsing command line options or setting up
+/// the pass pipeline, should be performed inside of the tool's `run` function.
+/// The invoke function is responsible for resetting all global state that may
+/// affect its output on the next invocation.
+LLVM_ABI int runWithDaemonSupport(LLVMTool &Tool, int Argc, char **Argv);
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_DAEMONDRIVER_H

--- a/llvm/include/llvm/Support/ToolInterface.h
+++ b/llvm/include/llvm/Support/ToolInterface.h
@@ -1,0 +1,99 @@
+//===- llvm/Support/ToolInterface.h - Abstract tool interface ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Abstract class for LLVM tools that can be re-invoked in the same process.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_TOOLINTERFACE_H
+#define LLVM_SUPPORT_TOOLINTERFACE_H
+
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include <memory>
+
+namespace llvm {
+
+/// Many tools operate on standard input, which is problematic for in-process
+/// execution/daemonization as the process may not want to close its standard
+/// input stream. This class allows the tools to function as if a different
+/// source, either an in-memory string or a file on disk, were standard input.
+/// Tool implementations should read from this class instead of standard input,
+/// for example using `StandardInputSource::getInput` instead of
+/// `MemoryBuffer::getSTDIN` and `StandardInputSource::getFileOrInput` instead
+/// of `MemoryBuffer::getFileOrSTDIN`.
+class LLVM_ABI StandardInputSource final {
+public:
+  /// Construct a `StandardInputSource` that draws input from the process's
+  /// standard input stream. This is used for regular tool invocations.
+  static StandardInputSource fromStdin() {
+    return StandardInputSource(Kind::Stdin, std::string());
+  }
+
+  /// Construct a `StandardInputSource` that draws input from a file.
+  static StandardInputSource fromFile(std::string &&Filename) {
+    return StandardInputSource(Kind::File, std::move(Filename));
+  }
+
+  /// Construct a `StandardInputSource` that pretends that the given string
+  /// is the contents of standard input.
+  static StandardInputSource fromString(std::string &&StringValue) {
+    return StandardInputSource(Kind::String, std::move(StringValue));
+  }
+
+  /// Replacement for `MemoryBuffer::getSTDIN`. The returned memory buffer
+  /// always has the identifier "<stdin>".
+  ErrorOr<std::unique_ptr<MemoryBuffer>> getInput() const;
+
+  /// Replacement for `MemoryBuffer::getFileOrInput`. Returns `getInput()` if
+  /// the file name is "-", otherwise returns a memory buffer of the file.
+  ErrorOr<std::unique_ptr<MemoryBuffer>> getFileOrInput(StringRef Filename,
+                                                        bool IsText) const {
+    if (Filename == "-")
+      return getInput();
+
+    return MemoryBuffer::getFile(Filename, IsText);
+  }
+
+private:
+  enum class Kind {
+    Stdin,
+    File,
+    String,
+  };
+
+  StandardInputSource(Kind SourceKind, std::string &&StringValue)
+      : SourceKind(SourceKind), StringValue(StringValue) {}
+
+  Kind SourceKind;
+  std::string StringValue;
+};
+
+/// This class represents a shared interface for LLVM tools that can be
+/// re-invoked in the same process, for example when run by the daemon driver.
+class LLVM_ABI LLVMTool {
+public:
+  virtual ~LLVMTool() = default;
+
+  /// This is the function called to run the tool with a given input and set of
+  /// arguments. All code to run the tool except for one-time initialization and
+  /// finalization (for example `InitLLVM`) should be done in this function.
+  ///
+  /// Note that as `run` may use global state, it is not thread-safe.
+  virtual int run(int Argc, char **Argv,
+                  const StandardInputSource &InputSource) = 0;
+
+  /// This function is called between `run` invocations to reset any persistent
+  /// state, for example static command line options, statistics and debug
+  /// counters, for the next invocation. This function is not called when the
+  /// tool is run normally.
+  virtual void resetState() = 0;
+};
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_TOOLINTERFACE_H

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -178,6 +178,7 @@ add_llvm_component_library(LLVMSupport
   CrashRecoveryContext.cpp
   CSKYAttributes.cpp
   CSKYAttributeParser.cpp
+  DaemonDriver.cpp
   DataExtractor.cpp
   Debug.cpp
   DebugCounter.cpp
@@ -268,6 +269,7 @@ add_llvm_component_library(LLVMSupport
   ThreadPool.cpp
   TimeProfiler.cpp
   Timer.cpp
+  ToolInterface.cpp
   ToolOutputFile.cpp
   TrieRawHashMap.cpp
   Twine.cpp

--- a/llvm/lib/Support/DaemonDriver.cpp
+++ b/llvm/lib/Support/DaemonDriver.cpp
@@ -1,0 +1,531 @@
+//===- llvm/Support/DaemonDriver.cpp - Daemon driver interface ---- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the interface for tools to be run in "daemon mode",
+// following the IPC protocol as described in docs/DaemonMode.rst.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/DaemonDriver.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/raw_ostream.h"
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <system_error>
+
+#if defined _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace llvm;
+
+// Windows emulated POSIX functions are prefixed by `_`.
+#ifdef _WIN32
+#define CLOSE_FN ::_close
+#define DUP_FN ::_dup
+#define DUP2_FN ::_dup2
+#else
+#define CLOSE_FN ::close
+#define DUP_FN ::dup
+#define DUP2_FN ::dup2
+#endif
+
+// Standard stream fileno macros are not defined on Windows.
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
+
+namespace {
+namespace util {
+/// RAII mechanism to redirect a file descriptor to the file pointed to by a
+/// different file descriptor. The destructor will reset the file descriptor to
+/// its original file.
+class ScopedFileRedirect {
+public:
+  /// Redirect `FromFd` to the same file as `ToFd` for the lifetime of this
+  /// object.
+  ScopedFileRedirect(int FromFd, int ToFd) : FromFd(FromFd) {
+    // Store a copy of the original file so that we can restore the original fd
+    // to this copy.
+    CopyFd = DUP_FN(FromFd);
+
+    // Close the source fd and reopen it to the target fd.
+    DUP2_FN(ToFd, FromFd);
+  }
+
+  ~ScopedFileRedirect() {
+    if (Moved)
+      return;
+
+    // Close the source fd and reopen it to the original file.
+    DUP2_FN(CopyFd, FromFd);
+
+    // Close the copied file descriptor, as it's no longer needed.
+    CLOSE_FN(CopyFd);
+  }
+
+  ScopedFileRedirect(ScopedFileRedirect &&Other) {
+    *this = Other;
+    Other.Moved = true;
+  }
+  ScopedFileRedirect &operator=(ScopedFileRedirect &&Other) {
+    *this = Other;
+    Other.Moved = true;
+    return *this;
+  }
+
+private:
+  ScopedFileRedirect(const ScopedFileRedirect &Other) = default;
+  ScopedFileRedirect &operator=(const ScopedFileRedirect &Other) = default;
+
+  int FromFd;
+  int CopyFd;
+  bool Moved = false;
+};
+
+static ErrorOr<std::string> readNextLine(FILE *File) {
+  std::string Result;
+  raw_string_ostream ResultOS(Result);
+
+  constexpr size_t BufSize = 512;
+  char Buf[BufSize];
+
+  // Read from the file, appending to the result, until a new line character
+  // is found.
+  while (std::fgets(Buf, BufSize, File)) {
+    ResultOS << Buf;
+
+    if (std::strchr(Buf, '\n'))
+      break;
+  }
+
+  if (std::ferror(File))
+    return std::make_error_code(static_cast<std::errc>(errno));
+
+  return Result;
+}
+
+} // namespace util
+
+/// Status code returned if the daemon fails to initialize, for example due to
+/// incorrect command line arguments.
+constexpr int StatusInitError = 2;
+/// Status code returned if the daemon receives a malformed command.
+constexpr int StatusCommandError = 3;
+
+/// This should only be used before the status pipe is set up - after,
+/// errors are reported to the user via the status pipe.
+[[noreturn]] static void reportInitError(const Twine &Err) {
+  errs() << "[daemon] Error: " << Err << "\n";
+  std::exit(StatusInitError);
+}
+
+/// Returns true if ``--daemon`` is passed as the first command line argument.
+static bool detectDaemonArg(int Argc, char **Argv) {
+  // `--daemon` must be the first argument.
+  return Argc >= 2 && Argv[1] == StringRef("--daemon");
+}
+
+struct DaemonCommandLineOptions {
+  bool DaemonModeEnabled;
+  std::string StatusPipe;
+};
+
+// Creates the command line options for configuring the daemon. The returned
+// reference points to a static struct where the option values will be stored.
+static const DaemonCommandLineOptions &initializeDaemonCommandLineOptions() {
+  // This is declared as a static local variables in this function rather than
+  // a static global variable as is common in LLVM to avoid adding global
+  // constructors and destructors to the program, which is forbidden in the
+  // Support library.
+  static DaemonCommandLineOptions Options;
+
+  static cl::opt<bool, true> DaemonModeEnabledOpt(
+      "daemon", cl::location(Options.DaemonModeEnabled), cl::init(false));
+
+  static cl::opt<std::string, true> StatusPipeOpt(
+      "daemon-status-pipe",
+      cl::desc("File to which the daemon tool will send status messages. May "
+               "be 'path:{filepath}', 'fd:{file descriptor}' or "
+               "'handle:{Windows file handle}'"),
+      cl::location(Options.StatusPipe), cl::init(""));
+
+  return Options;
+}
+
+/// Command sent to invoke the tool.
+struct RunCommand {
+  static constexpr StringRef Prefix = "run";
+
+  static Expected<RunCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    if (!Remaining.empty())
+      return createStringError("Unexpected trailing characters in command");
+
+    return RunCommand();
+  }
+};
+
+/// Command providing a command line argument for the tool as a framed string.
+struct ArgCommand {
+  static constexpr StringRef Prefix = "arg";
+
+  static Expected<ArgCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    size_t ExpectedLength;
+    if (Remaining.consumeInteger(10, ExpectedLength))
+      return createStringError("Expected integer");
+
+    if (!Remaining.empty())
+      return createStringError("Unexpected trailing characters in command");
+
+    return ArgCommand{ExpectedLength};
+  }
+
+  size_t ExpectedLength;
+};
+
+// Command providing a framed string to use as standard input for the tool.
+struct InputStringCommand {
+  static constexpr StringRef Prefix = "input_string";
+
+  static Expected<InputStringCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    size_t ExpectedLength;
+    if (Remaining.consumeInteger(10, ExpectedLength))
+      return createStringError("Expected integer");
+
+    if (!Remaining.trim().empty())
+      return createStringError("Unexpected trailing characters in command");
+
+    return InputStringCommand{ExpectedLength};
+  }
+
+  size_t ExpectedLength;
+};
+
+// Command providing a file path whose contents will be used as the standard
+// input for the tool.
+struct InputFileCommand {
+  static constexpr StringRef Prefix = "input_file";
+
+  static Expected<InputFileCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    return InputFileCommand{Remaining};
+  }
+
+  StringRef Path;
+};
+
+// Command changing the current working directory for the daemon.
+struct ChangeDirectoryCommand {
+  static constexpr StringRef Prefix = "cd";
+
+  static Expected<ChangeDirectoryCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    return ChangeDirectoryCommand{Remaining};
+  }
+
+  StringRef Path;
+};
+
+/// Command telling the daemon to send the tool's standard error content through
+/// its standard output stream, to maintain the ordering between stderr and
+/// stdout.
+struct RedirectStderrToStdoutCommand {
+  static constexpr StringRef Prefix = "redirect_stderr_to_stdout";
+
+  static Expected<RedirectStderrToStdoutCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    if (!Remaining.empty())
+      return createStringError("Unexpected trailing characters in command");
+
+    return RedirectStderrToStdoutCommand();
+  }
+};
+
+/// Command telling the daemon to exit.
+struct ExitCommand {
+  static constexpr StringRef Prefix = "exit";
+
+  static Expected<ExitCommand> parse(StringRef Remaining) {
+    Remaining = Remaining.trim();
+
+    if (!Remaining.empty())
+      return createStringError("Unexpected trailing characters in command");
+
+    return ExitCommand();
+  }
+};
+
+/// State to be configured for the next invocation.
+struct InvocationOptions {
+  void reset() { *this = InvocationOptions(); }
+
+  /// String which tool shall pretend is the contents of stdin.
+  std::vector<std::string> Args;
+  StandardInputSource InputSource = StandardInputSource::fromString("");
+  bool RedirectStderrToStdout = false;
+};
+
+/// This class implements the daemon driver functionality.
+class DaemonDriver {
+public:
+  DaemonDriver(LLVMTool &Tool, const DaemonCommandLineOptions &Options)
+      : Tool(Tool), StatusPipeOS(createStatusPipeOS(Options.StatusPipe)),
+        OriginalWorkingDirectory(std::filesystem::current_path()),
+        WorkingDirectoryChanged(false) {};
+
+  int run() {
+    // Ensure stdin is in binary mode to prevent newline translation on Windows
+    // - this not only breaks binary input but also muddles the number of
+    // characters read.
+    if (const std::error_code EC = sys::ChangeStdinToBinary())
+      exitWithError(Twine("Couldn't switch stdin to binary mode: ") +
+                    EC.message());
+
+    // Inform the user that the daemon is ready to receive commands.
+    respondReady();
+
+    while (!feof(stdin)) {
+      const ErrorOr<std::string> Command = util::readNextLine(stdin);
+      if (!Command) {
+        exitWithError(Twine("Error reading standard input: ") +
+                      Command.getError().message());
+      }
+
+      // The command is parsed from left to right, with surrounding whitespace
+      // ignored.
+      StringRef Remaining = StringRef(*Command).trim();
+
+      if (Remaining.empty() || Remaining.starts_with(';')) {
+        // Empty command or comment. These are supported so that tests can be
+        // made more readable.
+        continue;
+      }
+
+      if (tryParseCommand<RunCommand>(Remaining)) {
+        const int ExitCode = runTool();
+        respondReturned(ExitCode);
+        NextInvocation.reset();
+        resetWorkingDirectory();
+      } else if (const std::optional<ArgCommand> Parsed =
+                     tryParseCommand<ArgCommand>(Remaining)) {
+        NextInvocation.Args.push_back(
+            readStringFromStdin(Parsed->ExpectedLength));
+      } else if (const std::optional<InputStringCommand> Parsed =
+                     tryParseCommand<InputStringCommand>(Remaining)) {
+        NextInvocation.InputSource = StandardInputSource::fromString(
+            readStringFromStdin(Parsed->ExpectedLength));
+      } else if (const std::optional<InputFileCommand> Parsed =
+                     tryParseCommand<InputFileCommand>(Remaining)) {
+        NextInvocation.InputSource =
+            StandardInputSource::fromFile(std::string(Parsed->Path));
+      } else if (const std::optional<ChangeDirectoryCommand> Parsed =
+                     tryParseCommand<ChangeDirectoryCommand>(Remaining)) {
+        changeWorkingDirectory(Parsed->Path);
+      } else if (tryParseCommand<RedirectStderrToStdoutCommand>(Remaining)) {
+        NextInvocation.RedirectStderrToStdout = true;
+      } else if (tryParseCommand<ExitCommand>(Remaining)) {
+        break;
+      } else {
+        exitWithError("Unexpected command: " + *Command);
+      }
+    }
+
+    return 0;
+  }
+
+private:
+  static constexpr StringRef ResponseReady = "ready";
+  static constexpr StringRef ResponseReturned = "returned";
+  static constexpr StringRef ResponseError = "error";
+
+  static std::unique_ptr<raw_ostream>
+  createStatusPipeOS(StringRef StatusPipeString) {
+    // `StatusPipeString` may be:
+    // - "path:{file path}"
+    // - "fd:{file descriptor}"
+    // - "handle:{Windows file handle}" (Windows-only)
+    constexpr StringRef ErrorContext = "Parsing option 'daemon-status-pipe': ";
+
+    if (StatusPipeString.consume_front("path:")) {
+      std::error_code EC;
+      auto Writer =
+          std::make_unique<raw_fd_ostream>(StatusPipeString.trim(), EC);
+      if (EC) {
+        reportInitError(ErrorContext + "Couldn't open file '" +
+                        StatusPipeString + "': " + EC.message());
+      }
+      Writer->SetUnbuffered();
+      return Writer;
+    }
+
+    int Fd;
+    if (StatusPipeString.consume_front("fd:")) {
+      const bool Err = StatusPipeString.consumeInteger(10, Fd);
+      if (Err) {
+        reportInitError(ErrorContext + "expected integer "
+                                       "after 'fd:'.");
+      }
+    } else if (StatusPipeString.consume_front("handle:")) {
+#ifdef _WIN32
+      int Handle;
+      bool Err = StatusPipeString.consumeInteger(10, Handle);
+      if (Err) {
+        reportInitError(ErrorContext +
+                        "Parsing option 'daemon-status-pipe': expected integer "
+                        "after 'handle:'.");
+      }
+
+      Fd = _open_osfhandle(Handle, 0);
+#else
+      reportInitError(ErrorContext + "'handle' may only "
+                                     "be specified on Windows");
+#endif
+    } else {
+      reportInitError(ErrorContext + "Unexpected value : '" + StatusPipeString +
+                      "'");
+    }
+
+    // Only close the status pipe if it is not a standard stream.
+    const bool ShouldClose = Fd != STDOUT_FILENO && Fd != STDERR_FILENO;
+    return std::make_unique<raw_fd_ostream>(Fd, ShouldClose,
+                                            /*unbuffered=*/true);
+  }
+
+  template <typename Command>
+  std::optional<Command> tryParseCommand(StringRef Remaining) const {
+    if (!Remaining.consume_front(Command::Prefix))
+      return {};
+
+    Expected<Command> CommandOrError = Command::parse(Remaining);
+    if (!CommandOrError)
+      exitWithError(CommandOrError.takeError());
+
+    return *CommandOrError;
+  }
+
+  template <typename E> [[noreturn]] void exitWithError(const E &Err) const {
+    *StatusPipeOS << ResponseError << " " << Err << "\n";
+    StatusPipeOS->flush();
+    std::exit(StatusCommandError);
+  }
+
+  void respondReady() const {
+    *StatusPipeOS << ResponseReady << "\n";
+    StatusPipeOS->flush();
+  }
+
+  void respondReturned(const int ExitCode) const {
+    *StatusPipeOS << ResponseReturned << ' ' << ExitCode << "\n";
+    StatusPipeOS->flush();
+  }
+
+  int runTool() const {
+    // Convert arguments to C strings, so that they can be passed via
+    // `argc`.
+    SmallVector<char *, 16> ArgsCStr;
+    ArgsCStr.reserve(NextInvocation.Args.size());
+    for (const std::string &Arg : NextInvocation.Args) {
+      // NB: Since C++11, `std::string` is required to have a null terminator
+      // after the data.
+      ArgsCStr.push_back(const_cast<char *>(Arg.data()));
+    }
+
+    std::optional<util::ScopedFileRedirect> StderrRedirect;
+    if (NextInvocation.RedirectStderrToStdout)
+      StderrRedirect.emplace(STDERR_FILENO, STDOUT_FILENO);
+
+    const int ExitCode =
+        Tool.run(ArgsCStr.size(), ArgsCStr.data(), NextInvocation.InputSource);
+
+    Tool.resetState();
+
+    // Important to flush `stdout` and `stderr` after `resetState()`, in case
+    // `resetState()` had any output (for example if an error was encountered).
+    outs().flush();
+    errs().flush();
+
+    return ExitCode;
+  }
+
+  std::string readStringFromStdin(const size_t Len) const {
+    // Read `Len` bytes into `Dest`.
+    std::string Dest;
+    Dest.resize(Len);
+    const size_t Read = fread(Dest.data(), sizeof(char), Len, stdin);
+
+    // Make sure the expected number of bytes was read.
+    if (Read != Len)
+      exitWithError("Missing bytes: expected " + Twine(Len) + " got " +
+                    Twine(Read));
+
+    return Dest;
+  }
+
+  void changeWorkingDirectory(const StringRef Path) {
+    std::filesystem::path FsPath(Path.str());
+    if (!std::filesystem::is_directory(FsPath))
+      exitWithError(Twine("cd: '") + Path + "' is not a directory.");
+
+    std::filesystem::current_path(FsPath);
+    WorkingDirectoryChanged = true;
+  }
+
+  void resetWorkingDirectory() {
+    if (!WorkingDirectoryChanged)
+      return;
+
+    std::filesystem::current_path(OriginalWorkingDirectory);
+    WorkingDirectoryChanged = false;
+  }
+
+  LLVMTool &Tool;
+  InvocationOptions NextInvocation;
+  std::unique_ptr<raw_ostream> StatusPipeOS;
+  std::filesystem::path OriginalWorkingDirectory;
+  bool WorkingDirectoryChanged;
+};
+
+static int runDaemonMode(LLVMTool &Tool, int Argc, char **Argv) {
+  // Parse daemon command line options.
+  const DaemonCommandLineOptions &Options =
+      initializeDaemonCommandLineOptions();
+  cl::ParseCommandLineOptions(Argc, Argv);
+
+  return DaemonDriver(Tool, Options).run();
+}
+} // namespace
+
+LLVM_ABI int llvm::runWithDaemonSupport(LLVMTool &Tool, int Argc, char **Argv) {
+  if (detectDaemonArg(Argc, Argv))
+    return runDaemonMode(Tool, Argc, Argv);
+
+  return Tool.run(Argc, Argv, StandardInputSource::fromStdin());
+}

--- a/llvm/lib/Support/ToolInterface.cpp
+++ b/llvm/lib/Support/ToolInterface.cpp
@@ -1,0 +1,68 @@
+//===- llvm/Support/ToolInterface.cpp - Abstract tool interface -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Abstract class for LLVM tools that can be re-invoked in the same process.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/ToolInterface.h"
+
+using namespace llvm;
+
+namespace {
+/// Wraps a `MemoryBuffer`, overriding the identifier returned from
+/// `getBufferIdentifier`. This is needed to daemonize lots of tests which
+/// include the buffer identifier in check lines as the module ID.
+class NameOverrideMemoryBuffer : public MemoryBuffer {
+public:
+  NameOverrideMemoryBuffer(std::unique_ptr<MemoryBuffer> &&MB,
+                           StringRef Identifier)
+      : MemoryBuffer(), Inner(std::move(MB)), Identifier(Identifier) {
+    init(Inner->getBufferStart(), Inner->getBufferEnd(),
+         /*RequiresNullTerminator=*/false);
+  }
+
+  StringRef getBufferIdentifier() const override { return Identifier; }
+
+  void dontNeedIfMmap() override { return Inner->dontNeedIfMmap(); }
+
+  void willNeedIfMmap() override { return Inner->willNeedIfMmap(); }
+
+  BufferKind getBufferKind() const override { return Inner->getBufferKind(); }
+
+private:
+  std::unique_ptr<MemoryBuffer> Inner;
+  std::string Identifier;
+};
+
+} // namespace
+
+ErrorOr<std::unique_ptr<MemoryBuffer>>
+llvm::StandardInputSource::getInput() const {
+  // Always pretend to be standard input, so that tests which are affected by
+  // the buffer identifier do not get broken. (For example if there is a check
+  // string that includes the module name)
+  constexpr StringRef BufferIdentifier = "<stdin>";
+
+  switch (SourceKind) {
+  case Kind::Stdin: {
+    return MemoryBuffer::getSTDIN();
+  }
+  case Kind::File: {
+    auto Buffer = MemoryBuffer::getFile(StringValue, /*IsText=*/true);
+    if (!Buffer)
+      return Buffer.getError();
+
+    return std::make_unique<NameOverrideMemoryBuffer>(std::move(*Buffer),
+                                                      BufferIdentifier);
+  }
+  case Kind::String: {
+    return MemoryBuffer::getMemBuffer(StringValue, BufferIdentifier);
+  }
+  }
+}

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -73,6 +73,7 @@ set(LLVM_TEST_DEPENDS_COMMON
 set(LLVM_TEST_DEPENDS
   ${LLVM_TEST_DEPENDS_COMMON}
   LLVMWindowsDriver
+  ExampleDaemon
   llc
   lli
   lli-child-target

--- a/llvm/test/Support/DaemonDriver/change-directory.test
+++ b/llvm/test/Support/DaemonDriver/change-directory.test
@@ -1,0 +1,57 @@
+RUN: split-file %s %t
+RUN: mkdir %t/A
+RUN: echo "ABC" > %t/A/b
+RUN: cd %t
+RUN: not ExampleDaemon < %t/daemon-commands --daemon --daemon-status-pipe=path:%t/status > %t/stdout 2> %t/stderr
+RUN: FileCheck < %t/status %s --check-prefix=CHECK-STATUS --strict-whitespace
+RUN: FileCheck < %t/stdout %s --check-prefix=CHECK-STDOUT --strict-whitespace -DTEST_DIR=%S -DTEMP_DIR=%t
+END.
+
+CHECK-STATUS: ready
+
+CHECK-STATUS-NEXT: returned 0
+CHECK-STDOUT: [[TEMP_DIR]]
+
+CHECK-STATUS-NEXT: returned 0
+CHECK-STDOUT-NEXT: [[TEMP_DIR]]{{[\/\\]}}A
+
+CHECK-STATUS-NEXT: returned 0
+CHECK-STDOUT-NEXT: [[TEMP_DIR]]
+
+CHECK-STATUS-NEXT: returned 3
+
+CHECK-STATUS-NEXT: error cd: './DoesNotExist' is not a directory.
+
+;--- daemon-commands
+arg 13
+ExampleDaemon
+arg 25
+--print-current-directory
+run
+
+; Checking that we can change directory.
+cd ./A
+arg 13
+ExampleDaemon
+arg 25
+--print-current-directory
+run
+
+; Checking that the directory is properly reset.
+arg 13
+ExampleDaemon
+arg 25
+--print-current-directory
+run
+
+; Checking that input_file is properly scoped to the current directory.
+cd ./A
+arg 13
+ExampleDaemon
+input_file ./b
+run
+
+cd ./DoesNotExist
+arg 13
+ExampleDaemon
+run

--- a/llvm/test/Support/DaemonDriver/error-status-pipe-handle-unix.test
+++ b/llvm/test/Support/DaemonDriver/error-status-pipe-handle-unix.test
@@ -1,0 +1,5 @@
+# This test verifies that the daemon gives the correct error message when a
+# Windows file handle is provided for `--daemon-status-pipe` on Unix
+REQUIRES: !system-windows
+RUN: not ExampleDaemon --daemon --daemon-status-pipe=handle:0 2>&1 | FileCheck %s --match-full-lines
+CHECK: [daemon] Error: Parsing option 'daemon-status-pipe': 'handle' may only be specified on Windows

--- a/llvm/test/Support/DaemonDriver/error-status-pipe-invalid-file.test
+++ b/llvm/test/Support/DaemonDriver/error-status-pipe-invalid-file.test
@@ -1,0 +1,4 @@
+# This test verifies that the daemon gives the correct error message when an
+# invalid path is provided for the status pipe.
+RUN: not ExampleDaemon --daemon --daemon-status-pipe=path:does/not/exist 2>&1 | FileCheck %s --match-full-lines
+CHECK: [daemon] Error: Parsing option 'daemon-status-pipe': Couldn't open file 'does/not/exist': {{.*}}

--- a/llvm/test/Support/DaemonDriver/file-input.test
+++ b/llvm/test/Support/DaemonDriver/file-input.test
@@ -1,0 +1,51 @@
+# This test verifies that the tool gives the correct output when the input is
+# provided with "in.file".
+RUN: split-file %s %t
+
+RUN: sed 's@TEMPDIR@%{/t:regex_replacement}@g' %t/daemon-commands | ExampleDaemon --daemon --daemon-status-pipe=path:%t/status > %t/stdout 2> %t/stderr
+RUN: FileCheck < %t/stdout %s --check-prefix=CHECK-STDOUT --strict-whitespace
+RUN: FileCheck < %t/stderr %s --check-prefix=CHECK-STDERR --strict-whitespace
+RUN: FileCheck < %t/status %s --check-prefix=CHECK-STATUS --strict-whitespace
+END.
+CHECK-STATUS: ready
+
+# 1st command.
+CHECK-STATUS-NEXT: returned 2
+CHECK-STDOUT: ace
+CHECK-STDERR: BD
+
+# 2nd command.
+CHECK-STATUS-NEXT: returned 4
+CHECK-STDOUT-NEXT: BDFH
+CHECK-STDERR-SAME: aceg
+
+# 3rd command.
+CHECK-STATUS-NEXT: returned 0
+CHECK-STDOUT-NEXT: aaaa
+
+;--- daemon-commands
+arg 13
+ExampleDaemon
+input_file TEMPDIR/input-file-1
+run
+
+arg 13
+ExampleDaemon
+arg 28
+--separate-lowercase-instead
+input_file TEMPDIR/input-file-2
+run
+
+arg 13
+ExampleDaemon
+input_file TEMPDIR/input-file-3
+run
+
+exit
+
+;--- input-file-1
+aBcDe
+;--- input-file-2
+aBcDeFgH
+;--- input-file-3
+aaaa

--- a/llvm/test/Support/DaemonDriver/redirect-stderr.test
+++ b/llvm/test/Support/DaemonDriver/redirect-stderr.test
@@ -1,0 +1,35 @@
+# This test verifies the "redirect_stdout_to_stderr" command does as it says,
+# and that stderr is properly reset for the next command.
+RUN: split-file %s %t
+RUN: ExampleDaemon < %t/daemon-commands --daemon --daemon-status-pipe=path:%t/status > %t/stdout 2> %t/stderr
+RUN: FileCheck < %t/stdout %s --check-prefix=CHECK-STDOUT --strict-whitespace
+RUN: FileCheck < %t/stderr %s --check-prefix=CHECK-STDERR --strict-whitespace
+RUN: FileCheck < %t/status %s --check-prefix=CHECK-STATUS --strict-whitespace
+END.
+CHECK-STATUS: ready
+
+# 1nd command.
+CHECK-STATUS-NEXT: returned 4
+CHECK-STDOUT: aBcDeFgH
+
+# 2nd command.
+CHECK-STATUS-NEXT: returned 4
+CHECK-STDOUT-SAME: aaaa
+CHECK-STDERR: AAAA
+
+;--- daemon-commands
+arg 13
+ExampleDaemon
+input_string 8
+aBcDeFgH
+redirect_stderr_to_stdout
+run
+
+; Checking that stderr is correctly reset.
+arg 13
+ExampleDaemon
+input_string 8
+aaaaAAAA
+run
+exit
+

--- a/llvm/test/Support/DaemonDriver/run-twice.test
+++ b/llvm/test/Support/DaemonDriver/run-twice.test
@@ -1,0 +1,17 @@
+# This test verifies that the tool can be run twice. The `ExampleDaemon` makes 
+# sure that `resetState()` was called.
+RUN: split-file %s %t
+RUN: ExampleDaemon < %t/daemon-commands --daemon --daemon-status-pipe=path:%t/status
+RUN: FileCheck %s < %t/status --match-full-lines
+CHECK: ready
+CHECK-NEXT: returned 0
+CHECK-NEXT: returned 0
+
+;--- daemon-commands
+arg 13
+ExampleDaemon
+run
+arg 13
+ExampleDaemon
+run
+exit

--- a/llvm/test/Support/DaemonDriver/str-input.test
+++ b/llvm/test/Support/DaemonDriver/str-input.test
@@ -1,0 +1,46 @@
+# This test verifies that the tool gives the correct output when the input is
+# provided with "in.str".
+RUN: split-file %s %t
+RUN: ExampleDaemon --daemon --daemon-status-pipe=path:%t/status < %t/daemon-commands > %t/stdout 2> %t/stderr
+RUN: FileCheck < %t/stdout %s --check-prefix=CHECK-STDOUT --strict-whitespace
+RUN: FileCheck < %t/stderr %s --check-prefix=CHECK-STDERR --strict-whitespace
+RUN: FileCheck < %t/status %s --check-prefix=CHECK-STATUS --strict-whitespace
+END.
+CHECK-STATUS: ready
+
+# 1st command.
+CHECK-STATUS-NEXT: returned 2
+CHECK-STDOUT: ace
+CHECK-STDERR: BD
+
+# 2nd command.
+CHECK-STATUS-NEXT: returned 4
+CHECK-STDOUT-SAME: BDFH
+CHECK-STDERR-SAME: aceg
+
+# 3rd command.
+CHECK-STATUS-NEXT: returned 0
+CHECK-STDOUT-SAME: aaaa
+
+;--- daemon-commands
+arg 13
+ExampleDaemon
+input_string 5
+aBcDe
+run
+
+arg 13
+ExampleDaemon
+arg 28
+--separate-lowercase-instead
+input_string 8
+aBcDeFgH
+run 
+
+arg 13
+ExampleDaemon
+input_string 4
+aaaa
+run
+
+exit

--- a/llvm/test/Support/DaemonDriver/tool-exits-process.test
+++ b/llvm/test/Support/DaemonDriver/tool-exits-process.test
@@ -1,0 +1,13 @@
+# This test verifies that the daemon driver behaves as expected when the tool
+# itself causes the process to exit. (In this case, the daemon driver exits)
+RUN: split-file %s %t
+RUN: ExampleDaemon --daemon --daemon-status-pipe=path:%t/status < %t/daemon-commands
+RUN: FileCheck < %t/status %s
+CHECK: ready
+
+;--- daemon-commands
+arg 13
+ExampleDaemon
+arg 14
+--exit-process
+run 

--- a/llvm/test/Support/DaemonDriver/verify-example-daemon.test
+++ b/llvm/test/Support/DaemonDriver/verify-example-daemon.test
@@ -1,0 +1,9 @@
+This test is verifying that the "ExampleDaemon" tool works as expected when run
+normally (not in daemon mode).
+RUN: echo "testTESTtestTEST" | not ExampleDaemon >%t.stdout 2>%t.stderr
+RUN: FileCheck < %t.stdout %s --check-prefix=CHECK-STDOUT-1
+END.
+CHECK-STDOUT-1: testtest
+RUN: FileCheck < %t.stderr %s --check-prefix=CHECK-STDERR-1
+CHECK-STDERR-1: TESTTEST
+

--- a/llvm/utils/ExampleDaemon/CMakeLists.txt
+++ b/llvm/utils/ExampleDaemon/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_llvm_utility(ExampleDaemon
+    ExampleDaemon.cpp
+  )
+
+target_link_libraries(ExampleDaemon PRIVATE LLVMSupport)
+

--- a/llvm/utils/ExampleDaemon/ExampleDaemon.cpp
+++ b/llvm/utils/ExampleDaemon/ExampleDaemon.cpp
@@ -1,0 +1,104 @@
+//===- ExampleDaemon.cpp - Example tool for testing daemon driverexampledaemon.c
+//----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is an example tool used for testing the daemon driver functionality.
+// The tool reads input from stdin character-by-character and prints
+// uppercase letters on `stderr` and everything else on `stdout`. It
+// returns the number of times a letter was printed to `stderr`.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/DaemonDriver.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/ToolInterface.h"
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+using namespace llvm;
+
+// Global variable used to check that `resetState` is properly called between
+// invocations.
+constexpr int PersistentStateInit = 0;
+static int PersistentState = PersistentStateInit;
+
+static cl::opt<bool> SeparateLowercaseInstead(
+    "separate-lowercase-instead",
+    cl::desc("This option is used to test that command line arguments are "
+             "passed correctly by the daemon driver."),
+    cl::init(false));
+
+static cl::opt<bool>
+    PrintCurrentDirectory("print-current-directory",
+                          cl::desc("This option is used to test the ability of "
+                                   "the daemon to change working directory."),
+                          cl::init(false));
+
+static cl::opt<bool>
+    ExitProcess("exit-process",
+                cl::desc("This option is used to test the behaviour of "
+                         "the daemon when the tool itself exits."),
+                cl::init(false));
+
+class ExampleTool : public LLVMTool {
+public:
+  virtual int run(int Argc, char **Argv,
+                  const StandardInputSource &InputSource) override {
+    // Make sure that `PersistentState` has been reset.
+    assert(PersistentState == PersistentStateInit &&
+           "Persistent state should have been reset.");
+    PersistentState = 1;
+
+    cl::ParseCommandLineOptions(Argc, Argv);
+
+    if (PrintCurrentDirectory)
+      llvm::outs() << std::filesystem::current_path().string() << "\n";
+
+    if (ExitProcess)
+      std::exit(0);
+
+    // Read standard input or get it from `StdinOverride`.
+    std::unique_ptr<MemoryBuffer> InputContent;
+    ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
+        InputSource.getFileOrInput("-", /*IsText=*/false);
+    if (const std::error_code Err = FileOrErr.getError()) {
+      errs() << "Error reading standard input: " << Err.message() << "\n";
+      return 1;
+    }
+    InputContent.swap(FileOrErr.get());
+
+    int StderrCount = 0;
+    for (const char Char : InputContent->getBuffer()) {
+      if (SeparateLowercaseInstead ? islower(Char) : isupper(Char)) {
+        errs() << Char;
+        errs().flush();
+        StderrCount += 1;
+      } else {
+        outs() << Char;
+        outs().flush();
+      }
+    }
+
+    return StderrCount;
+  };
+
+  virtual void resetState() override {
+    PersistentState = PersistentStateInit;
+    cl::ResetAllOptionOccurrences();
+  }
+};
+
+int main(int argc, char **argv) {
+  InitLLVM X(argc, argv);
+
+  ExampleTool Tool;
+  return runWithDaemonSupport(Tool, argc, argv);
+}

--- a/llvm/utils/ExampleDaemon/README
+++ b/llvm/utils/ExampleDaemon/README
@@ -1,0 +1,6 @@
+This is an example tool used for testing the daemon driver functionality.
+The tool reads input from stdin character-by-character and prints
+uppercase letters on `stderr` and everything else on `stdout`. It
+returns the number of times a letter was printed to `stderr`. It also takes
+one command line argument which causes it to print lowercase letters to
+`stderr` instead.

--- a/llvm/utils/lit/CMakeLists.txt
+++ b/llvm/utils/lit/CMakeLists.txt
@@ -22,7 +22,7 @@ add_custom_target(prepare-check-lit
 # Add rules for lit's own test suite
 add_lit_testsuite(check-lit "Running lit's tests"
   ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS "FileCheck" "not" "split-file" "prepare-check-lit"
+  DEPENDS "FileCheck" "ExampleDaemon" "not" "split-file" "prepare-check-lit"
 )
 
 # For IDEs

--- a/llvm/utils/lit/lit/InprocBuiltins.py
+++ b/llvm/utils/lit/lit/InprocBuiltins.py
@@ -1,87 +1,304 @@
+from __future__ import annotations
+
+import abc
 import getopt
+import io
 import os
 import pathlib
-import platform
 import shutil
 import stat
 import subprocess
-from io import StringIO
+from dataclasses import dataclass
+from typing import Callable, Optional
 
 import lit.util
+from lit.ShCommands import Command
 from lit.ShellEnvironment import (
     InternalShellError,
-    ShellCommandResult,
-    expand_glob_expressions,
+    ShellEnvironment,
     kIsWindows,
-    processRedirects,
     updateEnv,
 )
 
 
-def executeBuiltinCd(cmd, shenv):
+class InprocBuiltinIOObject(abc.ABC):
+    """
+    Base class for IO streams used for in-process built-ins. This class has two
+    specializations: InprocBuiltinIOFile, wrapping a file open in text mode, and
+    InprocBuiltinIOMemory, wrapping a BytesIO object. These streams provide
+    a text IO interface, but support reading and writing binary data too.
+
+    The main reason that this exists is to solve the conflict that binary IO is
+    required for daemonized testing, as many tests involve tools reading and
+    writing binary files and piping binary data between themselves, but on z/OS
+    files must be opened in text mode so that the character encoding is correct.
+    So we need an IO object that can be both a file open in text mode and a
+    in-memory stream that can store binary data.
+    """
+
+    @abc.abstractmethod
+    def read(self) -> str:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def read_binary(self) -> bytes:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def write(self, data: str) -> int:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def write_binary(self, data: bytes) -> int:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def seek(self, pos: int):
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def flush(self):
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def get_filename(self) -> str | None:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def get_encoding(self) -> str | None:
+        raise NotImplemented
+
+
+@dataclass
+class InprocBuiltinIOFile(InprocBuiltinIOObject):
+    """
+    Specialization of InprocBuiltinIOObject wrapping a file which is open in
+    text mode. Files must be opened in text mode so that character encoding
+    tags are correctly handled on z/OS. Binary IO is still supported via the
+    OS APIs (needed for daemonized testing).
+    """
+
+    file: io.TextIOBase
+
+    def read(self) -> str:
+        return self.file.read()
+
+    def read_binary(self) -> bytes:
+        self.file.flush()
+        data = bytearray()
+        chunk_size = 1024
+
+        while True:
+            chunk = os.read(self.file.fileno(), chunk_size)
+            if not chunk:
+                break
+            data.extend(chunk)
+
+        return bytes(data)
+
+    def write(self, data: str) -> int:
+        return self.file.write(data)
+
+    def write_binary(self, data: bytes) -> int:
+        self.file.flush()
+        return os.write(self.file.fileno(), data)
+
+    def seek(self, pos: int):
+        self.file.seek(pos)
+
+    def flush(self):
+        self.file.flush()
+
+    def get_filename(self) -> str | None:
+        if hasattr(self.file, "name") and isinstance(self.file.name, str):
+            return self.file.name
+        return None
+
+    def get_encoding(self) -> str | None:
+        return str(self.file.encoding)
+
+
+@dataclass
+class InprocBuiltinIOMemory(InprocBuiltinIOObject):
+    """
+    Specialization of InprocBuiltinIOObject wrapping an in-memory binary stream.
+    """
+
+    obj: io.BytesIO
+    encoding: str = "utf-8"
+
+    def read(self) -> str:
+        return self.obj.read().decode(self.encoding, errors="replace")
+
+    def read_binary(self) -> bytes:
+        return self.obj.read()
+
+    def write(self, data: str) -> int:
+        return self.obj.write(data.encode(self.encoding, errors="replace"))
+
+    def write_binary(self, data: bytes) -> int:
+        return self.obj.write(data)
+
+    def seek(self, pos: int):
+        self.obj.seek(pos)
+
+    def flush(self):
+        pass
+
+    def get_filename(self) -> str | None:
+        return None
+
+    def get_encoding(self) -> str | None:
+        return self.encoding
+
+
+class InprocBuiltinIO:
+    """
+    Holds IO streams for an inproc builtin invocation.
+
+    NB: If stderr is redirected to be the same stream as stdout, then
+    `stder == stdout` is True.
+    """
+
+    stdin: InprocBuiltinIOObject
+    stdout: InprocBuiltinIOObject
+    stderr: InprocBuiltinIOObject
+
+    def __init__(self, stdin, stdout, stderr):
+        """
+        Configure the IO streams for an in-process builtin command in
+        the same way that IO streams are configured when calling
+        `subprocess.Popen`.
+
+        Each of stdin, stdout and stderr may be:
+        - A file object open in binary mode.
+        - `subprocess.PIPE`
+        - `subprocess.STDOUT` (for stderr)
+        - None
+        """
+
+        # If stderr is redirected to stdout, we make sure to use the same
+        # stream for both so that the order of output is preserved.
+        stderr_redirected_to_stdout = (
+            stdout == subprocess.PIPE and stderr == subprocess.STDOUT
+        )
+
+        # Replace sentinel values with in-memory streams.
+        def resolve_io_obj(stream) -> InprocBuiltinIOObject:
+            if stream == subprocess.PIPE or stream is None:
+                return InprocBuiltinIOMemory(io.BytesIO())
+            elif isinstance(stream, InprocBuiltinIOObject):
+                return stream
+            else:
+                return InprocBuiltinIOFile(stream)
+
+        self.stdin = resolve_io_obj(stdin)
+        self.stdout = resolve_io_obj(stdout)
+        if stderr_redirected_to_stdout:
+            # Make sure stderr and stdout are directed to the same stream.
+            self.stderr = self.stdout
+        else:
+            self.stderr = resolve_io_obj(stderr)
+
+
+InprocBuiltinExecuteFn = Callable[
+    [Command, "list[str]", ShellEnvironment, InprocBuiltinIO],
+    int,
+]
+"""
+Function called by an in-process builtin command.
+Parameters:
+    - `cmd`: The command itself.
+    - `args`: glob-expanded list of arguments (including argv[0] as the program name).
+    - `shenv`: The shell environment.
+    - `io`: Holds the input and output streams for the invocation. These are file-like objects (files, StringIO)
+
+The return value is the exit code.
+"""
+
+
+@dataclass
+class InprocBuiltin:
+    """
+    Represents a command that is run as an in-process builtins.
+    """
+
+    execute: InprocBuiltinExecuteFn
+
+
+def executeBuiltinCd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinCd - Change the current directory."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'cd' supports only one argument")
     # Update the cwd in the parent environment.
-    shenv.change_dir(cmd.args[1])
+    shenv.change_dir(args[1])
     # The cd builtin always succeeds. If the directory does not exist, the
     # following Popen calls will fail instead.
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinPushd(cmd, shenv):
+def executeBuiltinPushd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinPushd - Change the current dir and save the old."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'pushd' supports only one argument")
     shenv.dirStack.append(shenv.cwd)
-    shenv.change_dir(cmd.args[1])
-    return ShellCommandResult(cmd, "", "", 0, False)
+    shenv.change_dir(args[1])
+    return 0
 
 
-def executeBuiltinPopd(cmd, shenv):
+def executeBuiltinPopd(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinPopd - Restore a previously saved working directory."""
-    if len(cmd.args) != 1:
+    if len(args) != 1:
         raise InternalShellError(cmd, "'popd' does not support arguments")
     if not shenv.dirStack:
         raise InternalShellError(cmd, "popd: directory stack empty")
     shenv.cwd = shenv.dirStack.pop()
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinExport(cmd, shenv):
+def executeBuiltinExport(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """executeBuiltinExport - Set an environment variable."""
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'export' supports only one argument")
-    updateEnv(shenv, cmd.args)
-    return ShellCommandResult(cmd, "", "", 0, False)
+    updateEnv(shenv, args)
+    return 0
 
 
-def executeBuiltinEcho(cmd, shenv):
+def executeBuiltinEcho(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
     """Interpret a redirected echo or @echo command"""
     opened_files = []
-    stdin, stdout, stderr = processRedirects(cmd, subprocess.PIPE, shenv, opened_files)
-    if stdin != subprocess.PIPE or stderr != subprocess.PIPE:
-        raise InternalShellError(
-            cmd, f"stdin and stderr redirects not supported for {cmd.args[0]}"
-        )
 
-    # Some tests have un-redirected echo commands to help debug test failures.
-    # Buffer our output and return it to the caller.
-    is_redirected = True
-    if stdout == subprocess.PIPE:
-        is_redirected = False
-        stdout = StringIO()
-    elif kIsWindows:
+    stdout = io.stdout
+    if (
+        kIsWindows
+        and isinstance(io.stdout, InprocBuiltinIOFile)
+        and io.stdout.get_filename()
+    ):
         # Reopen stdout with `newline=""` to avoid CRLF translation.
         # The versions of echo we are replacing on Windows all emit plain LF,
         # and the LLVM tests now depend on this.
-        stdout = open(stdout.name, stdout.mode, encoding="utf-8", newline="")
+        stdout = open(
+            io.stdout.get_filename(),
+            io.stdout.file.mode,
+            encoding="utf-8",
+            newline="",
+        )
         opened_files.append((None, None, stdout, None))
 
     # Implement echo flags. We only support -e and -n, and not yet in
     # combination. We have to ignore unknown flags, because `echo "-D FOO"`
     # prints the dash.
-    args = cmd.args[1:]
+    args = args[1:]
     interpret_escapes = False
     write_newline = True
     while len(args) >= 1 and args[0] in ("-e", "-n"):
@@ -109,15 +326,15 @@ def executeBuiltinEcho(cmd, shenv):
     for name, mode, f, path in opened_files:
         f.close()
 
-    output = "" if is_redirected else stdout.getvalue()
-    return ShellCommandResult(cmd, output, "", 0, False)
+    return 0
 
 
-def executeBuiltinMkdir(cmd, cmd_shenv):
+def executeBuiltinMkdir(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinMkdir - Create new directories."""
-    args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
-        opts, args = getopt.gnu_getopt(args, "p")
+        opts, args = getopt.gnu_getopt(args[1:], "p")
     except getopt.GetoptError as err:
         raise InternalShellError(cmd, "Unsupported: 'mkdir':  %s" % str(err))
 
@@ -131,7 +348,6 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
     if len(args) == 0:
         raise InternalShellError(cmd, "Error: 'mkdir' is missing an operand")
 
-    stderr = StringIO()
     exitCode = 0
     for dir in args:
         dir = pathlib.Path(dir)
@@ -144,16 +360,17 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
             try:
                 dir.mkdir(exist_ok=True)
             except OSError as err:
-                stderr.write("Error: 'mkdir' command failed, %s\n" % str(err))
+                io.stderr.write(("Error: 'mkdir' command failed, %s\n" % str(err)))
                 exitCode = 1
-    return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
+    return exitCode
 
 
-def executeBuiltinRm(cmd, cmd_shenv):
+def executeBuiltinRm(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinRm - Removes (deletes) files or directories."""
-    args = expand_glob_expressions(cmd.args, cmd_shenv.cwd)[1:]
     try:
-        opts, args = getopt.gnu_getopt(args, "frR", ["--recursive"])
+        opts, args = getopt.gnu_getopt(args[1:], "frR", ["--recursive"])
     except getopt.GetoptError as err:
         raise InternalShellError(cmd, "Unsupported: 'rm':  %s" % str(err))
 
@@ -176,7 +393,6 @@ def executeBuiltinRm(cmd, cmd_shenv):
         os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
         os.remove(path)
 
-    stderr = StringIO()
     exitCode = 0
     for path in args:
         cwd = cmd_shenv.cwd
@@ -189,9 +405,9 @@ def executeBuiltinRm(cmd, cmd_shenv):
                 os.remove(path)
             elif os.path.isdir(path):
                 if not recursive:
-                    stderr.write("Error: %s is a directory\n" % path)
+                    io.stderr.write(("Error: %s is a directory\n" % path))
                     exitCode = 1
-                if platform.system() == "Windows":
+                if kIsWindows:
                     # NOTE: use ctypes to access `SHFileOperationsW` on Windows to
                     # use the NT style path to get access to long file paths which
                     # cannot be removed otherwise.
@@ -255,26 +471,28 @@ def executeBuiltinRm(cmd, cmd_shenv):
                     os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | stat.S_IWRITE)
                 os.remove(path)
         except OSError as err:
-            stderr.write("Error: 'rm' command failed, %s" % str(err))
+            io.stderr.write(("Error: 'rm' command failed, %s" % str(err)))
             exitCode = 1
-    return ShellCommandResult(cmd, "", stderr.getvalue(), exitCode, False)
+    return exitCode
 
 
-def executeBuiltinUmask(cmd, shenv):
+def executeBuiltinUmask(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinUmask - Change the current umask."""
     if os.name != "posix":
         raise InternalShellError(cmd, "'umask' not supported on this system")
-    if len(cmd.args) != 2:
+    if len(args) != 2:
         raise InternalShellError(cmd, "'umask' supports only one argument")
     try:
         # Update the umask in the parent environment.
-        shenv.umask = int(cmd.args[1], 8)
+        shenv.umask = int(args[1], 8)
     except ValueError as err:
         raise InternalShellError(cmd, "Error: 'umask': %s" % str(err))
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
 
 
-def executeBuiltinUlimit(cmd, shenv):
+def executeBuiltinUlimit(cmd: Command, args: list[str], shenv, io: InprocBuiltinIO):
     """executeBuiltinUlimit - Change the current limits."""
     try:
         # Try importing the resource module (available on POSIX systems) and
@@ -282,34 +500,59 @@ def executeBuiltinUlimit(cmd, shenv):
         import resource
     except ImportError:
         raise InternalShellError(cmd, "'ulimit' not supported on this system")
-    if len(cmd.args) != 3:
+    if len(args) != 3:
         raise InternalShellError(cmd, "'ulimit' requires two arguments")
     try:
-        if cmd.args[2] == "unlimited":
+        if args[2] == "unlimited":
             new_limit = resource.RLIM_INFINITY
         else:
-            new_limit = int(cmd.args[2])
+            new_limit = int(args[2])
     except ValueError as err:
         raise InternalShellError(cmd, "Error: 'ulimit': %s" % str(err))
-    if cmd.args[1] == "-v":
+    if args[1] == "-v":
         if new_limit != resource.RLIM_INFINITY:
             new_limit = new_limit * 1024
         shenv.ulimit["RLIMIT_AS"] = new_limit
-    elif cmd.args[1] == "-n":
+    elif args[1] == "-n":
         shenv.ulimit["RLIMIT_NOFILE"] = new_limit
-    elif cmd.args[1] == "-s":
+    elif args[1] == "-s":
         if new_limit != resource.RLIM_INFINITY:
             new_limit = new_limit * 1024
         shenv.ulimit["RLIMIT_STACK"] = new_limit
-    elif cmd.args[1] == "-f":
+    elif args[1] == "-f":
         shenv.ulimit["RLIMIT_FSIZE"] = new_limit
     else:
-        raise InternalShellError(
-            cmd, "'ulimit' does not support option: %s" % cmd.args[1]
-        )
-    return ShellCommandResult(cmd, "", "", 0, False)
+        raise InternalShellError(cmd, "'ulimit' does not support option: %s" % args[1])
+    return 0
 
 
-def executeBuiltinColon(cmd, cmd_shenv):
+def executeBuiltinColon(
+    cmd: Command, args: list[str], cmd_shenv: ShellEnvironment, io: InprocBuiltinIO
+):
     """executeBuiltinColon - Discard arguments and exit with status 0."""
-    return ShellCommandResult(cmd, "", "", 0, False)
+    return 0
+
+
+def get_default_inproc_builtins() -> dict[str, InprocBuiltin]:
+    """
+    get_default_inproc_builtins - Returns the map of command names to Lit's
+    in-process built-in implementations.
+    The entries are a pair of the callable for the builtin and a bool
+    that determines whether this inproc builtin may fall back to a
+    command of the same name in cases where in-proc builtins cannot be
+    used (e.g. as the argument to not --crash).
+    """
+
+    return {
+        "@echo": InprocBuiltin(executeBuiltinEcho),
+        "cd": InprocBuiltin(executeBuiltinCd),
+        "export": InprocBuiltin(executeBuiltinExport),
+        "echo": InprocBuiltin(executeBuiltinEcho),
+        "mkdir": InprocBuiltin(executeBuiltinMkdir),
+        "popd": InprocBuiltin(executeBuiltinPopd),
+        "pushd": InprocBuiltin(executeBuiltinPushd),
+        "rm": InprocBuiltin(executeBuiltinRm),
+        "ulimit": InprocBuiltin(executeBuiltinUlimit),
+        "umask": InprocBuiltin(executeBuiltinUmask),
+        ":": InprocBuiltin(executeBuiltinColon),
+    }

--- a/llvm/utils/lit/lit/InprocBuiltins.py
+++ b/llvm/utils/lit/lit/InprocBuiltins.py
@@ -224,6 +224,9 @@ class InprocBuiltin:
     """
 
     execute: InprocBuiltinExecuteFn
+    # Identifies this in-process built-in as the daemonized replacement for a
+    # LLVM tool. This is used for disabling daemon tools.
+    llvm_daemon_tool_identifier: str | None = None
 
 
 def executeBuiltinCd(

--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -293,6 +293,10 @@ class Test:
             self.previous_elapsed = abs(time)
             self.previous_failure = time < 0
 
+        # LLVM daemon tools which have been disabled for this test by
+        # "DISABLE_DAEMON:".
+        self.disabled_llvm_daemon_tools = []
+
     def setResult(self, result):
         assert self.result is None, "result already set"
         assert isinstance(result, Result), "unexpected result type"

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, annotations
 
+import abc
 import os
 import pathlib
 import re
@@ -10,13 +11,21 @@ import sys
 import tempfile
 import threading
 import traceback
+import typing
+from dataclasses import dataclass
+from typing import Any
 
-import lit.InprocBuiltins as InprocBuiltins
 import lit.ShUtil as ShUtil
 import lit.Test as Test
 import lit.util
 from lit.BooleanExpression import BooleanExpression
-from lit.ShCommands import Command
+from lit.InprocBuiltins import (
+    InprocBuiltin,
+    InprocBuiltinIO,
+    InprocBuiltinIOMemory,
+    get_default_inproc_builtins,
+)
+from lit.ShCommands import Command, Pipeline
 from lit.ShellEnvironment import (
     InternalShellError,
     ShellCommandResult,
@@ -159,7 +168,7 @@ class TimeoutHelper(object):
             self._doneKillPass = True
 
 
-def executeShCmd(cmd, shenv, results, timeout=0):
+def executeShCmd(cmd, shenv, results, timeout=0, extra_inproc_builtins={}):
     """
     Wrapper around _executeShCmd that handles
     timeout
@@ -170,7 +179,9 @@ def executeShCmd(cmd, shenv, results, timeout=0):
     if timeout > 0:
         timeoutHelper.startTimer()
     try:
-        finalExitCode = _executeShCmd(cmd, shenv, results, timeoutHelper)
+        finalExitCode = _executeShCmd(
+            cmd, shenv, results, timeoutHelper, extra_inproc_builtins
+        )
     except InternalShellError:
         e = sys.exc_info()[1]
         finalExitCode = 127
@@ -183,6 +194,108 @@ def executeShCmd(cmd, shenv, results, timeout=0):
         timeoutInfo = "Reached timeout of {} seconds".format(timeout)
 
     return (finalExitCode, timeoutInfo)
+
+
+@dataclass
+class InprocBuiltinResult:
+    """
+    Result of invoking an in-process builtin command. This stores its exit code
+    and stdout/stderr streams.
+    """
+
+    exit_code: int
+    stdout: typing.TextIO
+    stderr: typing.TextIO
+
+
+class CommandInvocation(abc.ABC):
+    """
+    Result of invoking a command: implementations hold either a Popen for an
+    out-of-proc command or an InprocCommandResult for an in-process command.
+    This is designed to mirror the functionality of Popen for in-process
+    commands too.
+    """
+
+    @abc.abstractmethod
+    def wait(self) -> int:
+        """
+        Wraps `Popen.wait`. For in-process builtin commands, there is nothing
+        to wait for, so just returns the exit code.
+        """
+
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def communicate(self) -> tuple[str, str]:
+        """
+        Wraps `Popen.communicate`. For in-process builtin commands, this is
+        the same as `read_output`.
+        """
+
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def stdout(self) -> typing.TextIO:
+        raise NotImplemented
+
+    @abc.abstractmethod
+    def stderr(self) -> typing.TextIO:
+        raise NotImplemented
+
+
+@dataclass
+class ProcessInvocation(CommandInvocation):
+    """
+    CommandInvocation wrapping a `subprocess.Popen`; the result of invoking an
+    out-of-process command.
+    """
+
+    popen: subprocess.Popen
+
+    def wait(self) -> int:
+        return self.popen.wait()
+
+    def communicate(self) -> tuple[str, str]:
+        return self.popen.communicate()
+
+    def stdout(self) -> typing.TextIO:
+        return self.popen.stdout
+
+    def stderr(self) -> typing.TextIO:
+        return self.popen.stderr
+
+
+@dataclass
+class InprocBuiltinInvocation(CommandInvocation):
+    """
+    CommandInvocation wrapping an `InprocBuiltinResult`; the result of invoking an
+    in-process builtin command.
+    """
+
+    result: InprocBuiltinResult
+
+    def wait(self) -> int:
+        # In-process builtins are not run asynchronously.
+        return self.result.exit_code
+
+    def communicate(self) -> tuple[str, str]:
+        if self.stdout():
+            stdout = self.stdout().read()
+        else:
+            stdout = ""
+
+        if self.stderr():
+            stderr = self.stderr().read()
+        else:
+            stderr = ""
+
+        return stdout, stderr
+
+    def stdout(self) -> typing.TextIO:
+        return self.result.stdout
+
+    def stderr(self) -> typing.TextIO:
+        return self.result.stderr
 
 
 def _expandLateSubstitutions(cmd, arguments, cwd, normalize_slashes=False):
@@ -211,7 +324,142 @@ def _expandLateSubstitutions(cmd, arguments, cwd, normalize_slashes=False):
     return arguments
 
 
-def _executeShCmd(cmd, shenv, results, timeoutHelper):
+def invoke_process(
+    pipeline: Pipeline,
+    command: Command,
+    command_index: int,
+    args: list[str],
+    stdin: Any,
+    stdout: Any,
+    stderr: Any,
+    piped_input: bytes | None,
+    shenv: ShellEnvironment,
+    cmd_shenv: ShellEnvironment,
+    stderrIsStdout: bool,
+    stderrTempFiles: list[Any],
+    builtin_commands_dir: str,
+    timeoutHelper: TimeoutHelper,
+) -> ProcessInvocation:
+    if not stderrIsStdout:
+        # Don't allow stderr on a PIPE except for the last
+        # process, this could deadlock.
+        #
+        # FIXME: This is slow, but so is deadlock.
+        if stderr == subprocess.PIPE and command != pipeline.commands[-1]:
+            stderr = tempfile.TemporaryFile(mode="w+b")
+            stderrTempFiles.append((command_index, stderr))
+
+    # Resolve the executable path ourselves.
+    executable = None
+    # For paths relative to cwd, use the cwd of the shell environment.
+    if args[0].startswith("."):
+        exe_in_cwd = os.path.join(cmd_shenv.cwd, args[0])
+        if os.path.isfile(exe_in_cwd):
+            executable = exe_in_cwd
+    if not executable:
+        # Use the path from cmd_shenv by default, but if the environment variable
+        # is unset (like if the user is using env -i), use the standard path.
+        path = cmd_shenv.env["PATH"] if "PATH" in cmd_shenv.env else shenv.env["PATH"]
+        executable = lit.util.which(args[0], path)
+    if not executable:
+        raise InternalShellError(command, "%r: command not found" % args[0])
+
+    # On Windows, do our own command line quoting for better compatibility
+    # with some core utility distributions.
+    if kIsWindows:
+        args = quote_windows_command(args)
+
+    # Handle any resource limits. We do this by launching the command with
+    # a wrapper that sets the necessary limits. We use a wrapper rather than
+    # setting the limits in process as we cannot reraise the limits back to
+    # their defaults without elevated permissions.
+    if cmd_shenv.ulimit:
+        executable = sys.executable
+        args.insert(0, sys.executable)
+        args.insert(1, os.path.join(builtin_commands_dir, "_launch_with_limit.py"))
+        for limit in cmd_shenv.ulimit:
+            cmd_shenv.env["LIT_INTERNAL_ULIMIT_" + limit] = str(cmd_shenv.ulimit[limit])
+
+    try:
+        # TODO(boomanaiden154): We currently wrap the subprocess.Popen with
+        # os.umask as the umask argument in subprocess.Popen is not
+        # available before Python 3.9. Once LLVM requires at least Python
+        # 3.9, this code should be updated to use umask argument.
+        old_umask = -1
+        if cmd_shenv.umask != -1:
+            old_umask = os.umask(cmd_shenv.umask)
+        proc = subprocess.Popen(
+            args,
+            cwd=cmd_shenv.cwd,
+            executable=executable,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            env=cmd_shenv.env,
+            close_fds=kUseCloseFDs,
+            universal_newlines=True,
+            errors="replace",
+        )
+        if old_umask != -1:
+            os.umask(old_umask)
+
+        # Let the helper know about this process
+        timeoutHelper.addProcess(proc)
+    except OSError as e:
+        raise InternalShellError(
+            command, "Could not create process ({}) due to {}".format(executable, e)
+        )
+
+    if piped_input:
+        try:
+            os.write(proc.stdin.fileno(), piped_input)
+        except BrokenPipeError:
+            # There are some tests which pipe the output of echo into a
+            # subsequent command which isn't actually reading STDIN.
+            # This can result in a broken pipe error if the process
+            # has already closed by now, so we can just swallow
+            # the exception.
+            pass
+
+    # Immediately close stdin for any process taking stdin from us.
+    if stdin == subprocess.PIPE:
+        proc.stdin.close()
+        proc.stdin = None
+
+    return ProcessInvocation(proc)
+
+
+def invoke_inproc_builtin(
+    inproc_builtin: InprocBuiltin,
+    command: Command,
+    args: list[str],
+    stdin: Any,
+    stdout: Any,
+    stderr: Any,
+    cmd_shenv: ShellEnvironment,
+):
+    builtin_io = InprocBuiltinIO(stdin, stdout, stderr)
+
+    exit_code = inproc_builtin.execute(command, args, cmd_shenv, builtin_io)
+
+    # Make sure that the output is flushed, in case the next process
+    # tries to read it from a file (as temporary files are not closed
+    # until the end of the test, it may not yet be flushed).
+    builtin_io.stdout.seek(0)
+    builtin_io.stderr.seek(0)
+    builtin_io.stdout.flush()
+    builtin_io.stderr.flush()
+
+    return InprocBuiltinInvocation(
+        result=InprocBuiltinResult(
+            exit_code=exit_code,
+            stdout=builtin_io.stdout if stdout == subprocess.PIPE else None,
+            stderr=builtin_io.stderr if stderr == subprocess.PIPE else None,
+        ),
+    )
+
+
+def _executeShCmd(cmd, shenv, results, timeoutHelper, extra_inproc_builtins):
     if timeoutHelper.timeoutReached():
         # Prevent further recursion if the timeout has been hit
         # as we should try avoid launching more processes.
@@ -219,31 +467,43 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
     if isinstance(cmd, ShUtil.Seq):
         if cmd.op == ";":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
-            return _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
+            return _executeShCmd(
+                cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
 
         if cmd.op == "&":
             raise InternalShellError(cmd, "unsupported shell operator: '&'")
 
         if cmd.op == "||":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
             if res != 0:
-                res = _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+                res = _executeShCmd(
+                    cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+                )
             return res
 
         if cmd.op == "&&":
-            res = _executeShCmd(cmd.lhs, shenv, results, timeoutHelper)
+            res = _executeShCmd(
+                cmd.lhs, shenv, results, timeoutHelper, extra_inproc_builtins
+            )
             if res is None:
                 return res
 
             if res == 0:
-                res = _executeShCmd(cmd.rhs, shenv, results, timeoutHelper)
+                res = _executeShCmd(
+                    cmd.rhs, shenv, results, timeoutHelper, extra_inproc_builtins
+                )
             return res
 
         raise ValueError("Unknown shell command: %r" % cmd.op)
     assert isinstance(cmd, ShUtil.Pipeline)
 
-    procs = []
+    invocations = []
     proc_not_counts = []
     proc_not_fail_if_crash = []
     default_stdin = subprocess.PIPE
@@ -254,19 +514,8 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
     builtin_commands_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "builtin_commands"
     )
-    inproc_builtins = {
-        "cd": InprocBuiltins.executeBuiltinCd,
-        "export": InprocBuiltins.executeBuiltinExport,
-        "echo": InprocBuiltins.executeBuiltinEcho,
-        "@echo": InprocBuiltins.executeBuiltinEcho,
-        "mkdir": InprocBuiltins.executeBuiltinMkdir,
-        "popd": InprocBuiltins.executeBuiltinPopd,
-        "pushd": InprocBuiltins.executeBuiltinPushd,
-        "rm": InprocBuiltins.executeBuiltinRm,
-        "ulimit": InprocBuiltins.executeBuiltinUlimit,
-        "umask": InprocBuiltins.executeBuiltinUmask,
-        ":": InprocBuiltins.executeBuiltinColon,
-    }
+    inproc_builtins = get_default_inproc_builtins()
+    inproc_builtins.update(extra_inproc_builtins)
     # To avoid deadlock, we use a single stderr stream for piped
     # output. This is null until we have seen some output using
     # stderr.
@@ -326,40 +575,26 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
             else:
                 break
 
-        # Handle in-process builtins.
-        #
-        # Handle "echo" as a builtin if it is not part of a pipeline. This
-        # greatly speeds up tests that construct input files by repeatedly
-        # echo-appending to a file.
-        # FIXME: Standardize on the builtin echo implementation. We can use a
-        # temporary file to sidestep blocking pipe write issues.
-
         # Ensure args[0] is hashable.
         args[0] = expand_glob(args[0], cmd_shenv.cwd)[0]
 
+        # Decide if this command can be run as an in-process builtin.
+
+        # FIXME: Standardize on the builtin echo implementation. We can use a
+        # temporary file to sidestep blocking pipe write issues.
         inproc_builtin = inproc_builtins.get(args[0], None)
-        if inproc_builtin and (args[0] != "echo" or len(cmd.commands) == 1):
-            # env calling an in-process builtin is useless, so we take the safe
-            # approach of complaining.
-            if not cmd_shenv is shenv:
-                raise InternalShellError(
-                    j, "Error: 'env' cannot call '{}'".format(args[0])
-                )
+
+        error = None
+        if inproc_builtin:
+            # not --crash cannot call in-process builtins.
             if not_crash:
-                raise InternalShellError(
-                    j, "Error: 'not --crash' cannot call" " '{}'".format(args[0])
-                )
-            if len(cmd.commands) != 1:
-                raise InternalShellError(
-                    j,
-                    "Unsupported: '{}' cannot be part" " of a pipeline".format(args[0]),
-                )
-            result = inproc_builtin(Command(args, j.redirects), cmd_shenv)
-            if not_count % 2:
-                result.exitCode = int(not result.exitCode)
-            result.command.args = j.args
-            results.append(result)
-            return result.exitCode
+                error = "Error: 'not --crash' cannot call" " '{}'".format(args[0])
+            # env cannot call in-process builtins.
+            if not cmd_shenv is shenv:
+                error = "Error: 'env' cannot call '{}'".format(args[0])
+
+            if error:
+                raise InternalShellError(j, error)
 
         # Resolve any out-of-process builtin command before adding back 'not'
         # commands.
@@ -402,107 +637,68 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         else:
             stderrIsStdout = False
 
-            # Don't allow stderr on a PIPE except for the last
-            # process, this could deadlock.
-            #
-            # FIXME: This is slow, but so is deadlock.
-            if stderr == subprocess.PIPE and j != cmd.commands[-1]:
-                stderr = tempfile.TemporaryFile(mode="w+b")
-                stderrTempFiles.append((i, stderr))
-
-        # Resolve the executable path ourselves.
-        executable = None
-        # For paths relative to cwd, use the cwd of the shell environment.
-        if args[0].startswith("."):
-            exe_in_cwd = os.path.join(cmd_shenv.cwd, args[0])
-            if os.path.isfile(exe_in_cwd):
-                executable = exe_in_cwd
-        if not executable:
-            # Use the path from cmd_shenv by default, but if the environment variable
-            # is unset (like if the user is using env -i), use the standard path.
-            path = (
-                cmd_shenv.env["PATH"] if "PATH" in cmd_shenv.env else shenv.env["PATH"]
-            )
-            executable = lit.util.which(args[0], path)
-        if not executable:
-            raise InternalShellError(j, "%r: command not found" % args[0])
-
         # Replace uses of /dev/null with temporary files.
         if kAvoidDevNull:
-            for i, arg in enumerate(args):
+            for arg_index, arg in enumerate(args):
                 if isinstance(arg, str) and kDevNull in arg:
                     f = tempfile.NamedTemporaryFile(delete=False)
                     f.close()
                     named_temp_files.append(f.name)
-                    args[i] = arg.replace(kDevNull, f.name)
+                    args[arg_index] = arg.replace(kDevNull, f.name)
 
         # Expand all glob expressions
         args = expand_glob_expressions(args, cmd_shenv.cwd)
 
-        # On Windows, do our own command line quoting for better compatibility
-        # with some core utility distributions.
-        if kIsWindows:
-            args = quote_windows_command(args)
-
-        # Handle any resource limits. We do this by launching the command with
-        # a wrapper that sets the necessary limits. We use a wrapper rather than
-        # setting the limits in process as we cannot reraise the limits back to
-        # their defaults without elevated permissions.
-        if cmd_shenv.ulimit:
-            executable = sys.executable
-            args.insert(0, sys.executable)
-            args.insert(1, os.path.join(builtin_commands_dir, "_launch_with_limit.py"))
-            for limit in cmd_shenv.ulimit:
-                cmd_shenv.env["LIT_INTERNAL_ULIMIT_" + limit] = str(
-                    cmd_shenv.ulimit[limit]
-                )
-
-        try:
-            # TODO(boomanaiden154): We currently wrap the subprocess.Popen with
-            # os.umask as the umask argument in subprocess.Popen is not
-            # available before Python 3.9. Once LLVM requires at least Python
-            # 3.9, this code should be updated to use umask argument.
-            old_umask = -1
-            if cmd_shenv.umask != -1:
-                old_umask = os.umask(cmd_shenv.umask)
-            procs.append(
-                subprocess.Popen(
+        if inproc_builtin:
+            invocations.append(
+                invoke_inproc_builtin(
+                    inproc_builtin,
+                    j,
                     args,
-                    cwd=cmd_shenv.cwd,
-                    executable=executable,
-                    stdin=stdin,
-                    stdout=stdout,
-                    stderr=stderr,
-                    env=cmd_shenv.env,
-                    close_fds=kUseCloseFDs,
-                    universal_newlines=True,
-                    errors="replace",
+                    stdin,
+                    stdout,
+                    stderr,
+                    cmd_shenv,
                 )
             )
-            if old_umask != -1:
-                os.umask(old_umask)
-            proc_not_counts.append(not_count)
-            if not not_crash and not_args == ["not"]:
-                proc_not_fail_if_crash.append(True)
-            else:
-                proc_not_fail_if_crash.append(False)
-            # Let the helper know about this process
-            timeoutHelper.addProcess(procs[-1])
-        except OSError as e:
-            raise InternalShellError(
-                j, "Could not create process ({}) due to {}".format(executable, e)
+        else:
+            # If the stdin source is the output stream of a in-process
+            # builtin, read it in order to provide it to the process.
+            piped_input = None
+            if isinstance(stdin, InprocBuiltinIOMemory):
+                piped_input = stdin.read_binary()
+                stdin = subprocess.PIPE
+
+            invocations.append(
+                invoke_process(
+                    cmd,
+                    j,
+                    i,
+                    args,
+                    stdin,
+                    stdout,
+                    stderr,
+                    piped_input,
+                    shenv,
+                    cmd_shenv,
+                    stderrIsStdout,
+                    stderrTempFiles,
+                    builtin_commands_dir,
+                    timeoutHelper,
+                )
             )
 
-        # Immediately close stdin for any process taking stdin from us.
-        if stdin == subprocess.PIPE:
-            procs[-1].stdin.close()
-            procs[-1].stdin = None
+        proc_not_counts.append(not_count)
+        if not not_crash and not_args == ["not"]:
+            proc_not_fail_if_crash.append(True)
+        else:
+            proc_not_fail_if_crash.append(False)
 
         # Update the current stdin source.
         if stdout == subprocess.PIPE:
-            default_stdin = procs[-1].stdout
+            default_stdin = invocations[-1].stdout()
         elif stderrIsStdout:
-            default_stdin = procs[-1].stderr
+            default_stdin = invocations[-1].stderr()
         else:
             default_stdin = subprocess.PIPE
 
@@ -514,18 +710,19 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         f.close()
 
     # FIXME: There is probably still deadlock potential here. Yawn.
-    procData = [None] * len(procs)
-    procData[-1] = procs[-1].communicate()
+    procData = [None] * len(invocations)
+    procData[-1] = invocations[-1].communicate()
 
-    for i in range(len(procs) - 1):
-        if procs[i].stdout is not None:
-            out = procs[i].stdout.read()
+    for i in range(len(invocations) - 1):
+        if invocations[i].stdout():
+            out = invocations[i].stdout().read()
         else:
             out = ""
-        if procs[i].stderr is not None:
-            err = procs[i].stderr.read()
+        if invocations[i].stderr():
+            err = invocations[i].stderr().read()
         else:
             err = ""
+
         procData[i] = (out, err)
 
     # Read stderr out of the temp files.
@@ -536,7 +733,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
     exitCode = None
     for i, (out, err) in enumerate(procData):
-        res = procs[i].wait()
+        res = invocations[i].wait()
         # Detect Ctrl-C in subprocess.
         if res == -signal.SIGINT:
             raise KeyboardInterrupt
@@ -658,7 +855,13 @@ def formatOutput(title, data, limit=None):
 # function), out contains only stdout from the script, err contains only stderr
 # from the script, and there is no execution trace.
 def executeScriptInternal(
-    test, litConfig, tmpBase, commands, cwd, debug=True
+    test,
+    litConfig,
+    tmpBase,
+    commands,
+    cwd,
+    debug=True,
+    extra_inproc_builtins={},
 ) -> tuple[str, str, int, str | None, str | None]:
     cmds = []
     update_output = None
@@ -703,7 +906,11 @@ def executeScriptInternal(
     shenv.env["LIT_CURRENT_TESTCASE"] = test.getFullName()
 
     exitCode, timeoutInfo = executeShCmd(
-        cmd, shenv, results, timeout=litConfig.maxIndividualTestTime
+        cmd,
+        shenv,
+        results,
+        timeout=litConfig.maxIndividualTestTime,
+        extra_inproc_builtins=extra_inproc_builtins,
     )
 
     out = err = ""
@@ -1809,7 +2016,14 @@ def parseIntegratedTestScript(test, additional_parsers=[], require_script=True):
     return script
 
 
-def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Result:
+def _runShTest(
+    test,
+    litConfig,
+    useExternalSh,
+    script,
+    tmpBase,
+    extra_inproc_builtins={},
+) -> lit.Test.Result:
     # Always returns the tuple (out, err, exitCode, timeoutInfo, status).
     def runOnce(
         execdir,
@@ -1845,7 +2059,12 @@ def _runShTest(test, litConfig, useExternalSh, script, tmpBase) -> lit.Test.Resu
                 res = executeScript(test, litConfig, tmpBase, scriptCopy, execdir)
             else:
                 res = executeScriptInternal(
-                    test, litConfig, tmpBase, scriptCopy, execdir
+                    test,
+                    litConfig,
+                    tmpBase,
+                    scriptCopy,
+                    execdir,
+                    extra_inproc_builtins=extra_inproc_builtins,
                 )
         except ScriptFatal as e:
             out = f"# " + "\n# ".join(str(e).splitlines()) + "\n"
@@ -1922,7 +2141,12 @@ def _expandLateSubstitutionsExternal(commandLine):
     return commandLine
 
 def executeShTest(
-    test, litConfig, useExternalSh, extra_substitutions=[], preamble_commands=[]
+    test,
+    litConfig,
+    useExternalSh,
+    extra_substitutions=[],
+    preamble_commands=[],
+    extra_inproc_builtins={},
 ):
     if test.config.unsupported:
         return lit.Test.Result(Test.UNSUPPORTED, "Test is unsupported")
@@ -1959,4 +2183,11 @@ def executeShTest(
         for index, command in enumerate(script):
             script[index] = _expandLateSubstitutionsExternal(command)
 
-    return _runShTest(test, litConfig, useExternalSh, script, tmpBase)
+    return _runShTest(
+        test,
+        litConfig,
+        useExternalSh,
+        script,
+        tmpBase,
+        extra_inproc_builtins=extra_inproc_builtins,
+    )

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1894,6 +1894,7 @@ def _parseKeywords(sourcepath, additional_parsers=[], require_script=True):
         IntegratedTestKeywordParser(
             "REDEFINE:", ParserKind.REDEFINE, initial_value=script
         ),
+        IntegratedTestKeywordParser("DISABLE_DAEMON:", ParserKind.SPACE_LIST),
     ]
     keyword_parsers = {p.keyword: p for p in builtin_parsers}
 
@@ -1985,6 +1986,8 @@ def parseIntegratedTestScript(test, additional_parsers=[], require_script=True):
     test.unsupported += parsed["UNSUPPORTED:"] or []
     if parsed["ALLOW_RETRIES:"]:
         test.allowed_retries = parsed["ALLOW_RETRIES:"][0]
+    if parsed["DISABLE_DAEMON:"]:
+        test.disabled_llvm_daemon_tools = parsed["DISABLE_DAEMON:"]
 
     # Enforce REQUIRES:
     missing_required_features = test.getMissingRequiredFeatures()
@@ -2161,6 +2164,15 @@ def executeShTest(
 
     if litConfig.noExecute:
         return lit.Test.Result(Test.PASS)
+
+    # Remove in-process built-ins corresponding to daemon tools that were
+    # disabled by "DISABLE_DAEMON:".
+    extra_inproc_builtins = {
+        key: inproc_builtin
+        for key, inproc_builtin in extra_inproc_builtins.items()
+        if inproc_builtin.llvm_daemon_tool_identifier
+        not in test.disabled_llvm_daemon_tools
+    }
 
     tmpDir, tmpBase = getTempPaths(test)
     substitutions = list(extra_substitutions)

--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -19,11 +19,16 @@ class ShTest(FileBasedTest):
     """
 
     def __init__(
-        self, execute_external=False, extra_substitutions=[], preamble_commands=[]
+        self,
+        execute_external=False,
+        extra_substitutions=[],
+        preamble_commands=[],
+        extra_inproc_builtins={},
     ):
         self.execute_external = execute_external
         self.extra_substitutions = extra_substitutions
         self.preamble_commands = preamble_commands
+        self.extra_inproc_builtins = extra_inproc_builtins
 
     def execute(self, test, litConfig):
         return lit.TestRunner.executeShTest(
@@ -32,4 +37,5 @@ class ShTest(FileBasedTest):
             self.execute_external,
             self.extra_substitutions,
             self.preamble_commands,
+            self.extra_inproc_builtins,
         )

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import errno
 
+import lit.llvm.daemon_config
 import lit.util
 from lit.llvm.subst import FindTool
 from lit.llvm.subst import ToolSubst
@@ -911,3 +912,18 @@ class LLVMConfig(object):
         self.add_tool_substitutions(tool_substitutions)
 
         return was_found
+
+    def use_daemon_tool(self, tool_dir: str, tool_name: str) -> bool:
+        """
+        Add in-process built-in for a daemonized tool.
+        This should be called once per daemonized tool.
+
+        Returns true if the daemon tool was added.
+        """
+
+        return lit.llvm.daemon_config.use_daemon_tool(
+            self.config,
+            self.lit_config,
+            tool_dir,
+            tool_name,
+        )

--- a/llvm/utils/lit/lit/llvm/daemon_config.py
+++ b/llvm/utils/lit/lit/llvm/daemon_config.py
@@ -82,3 +82,16 @@ def use_daemon_tool(
     ] = get_daemon_tool_inproc_builtin(tool_name, executable)
 
     return True
+
+
+def disable_daemon_tool(testing_config: TestingConfig, tool_name: str):
+    """
+    Remove the in-process built-in responsible for invoking the given tool as
+    a daemon, so that the tool is run normally instead.
+    """
+
+    testing_config.test_format.extra_inproc_builtins = {
+        key: inproc_builtin
+        for key, inproc_builtin in testing_config.test_format.extra_inproc_builtins.items()
+        if inproc_builtin.llvm_daemon_tool_identifier != tool_name
+    }

--- a/llvm/utils/lit/lit/llvm/daemon_config.py
+++ b/llvm/utils/lit/lit/llvm/daemon_config.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import functools
+
+import lit.util
+from lit.InprocBuiltins import InprocBuiltin
+from lit.LitConfig import LitConfig
+from lit.llvm.daemon_tool import DaemonTool, invoke_llvm_daemon_tool
+from lit.TestingConfig import TestingConfig
+
+
+def check_daemon_support(executable: str) -> bool:
+    """
+    Check that the executable at the given executable path supports being run
+    as an LLVM daemon tool, by testing that we receive the `ready` message
+    when starting the daemon.
+    """
+
+    try:
+        daemon = DaemonTool(executable)
+        daemon.start_daemon()
+        daemon.send_commands(["exit"])
+    except:
+        return False
+
+    return True
+
+
+def get_daemon_tool_inproc_builtin(
+    tool_name: str,
+    executable: str,
+) -> InprocBuiltin:
+    result = InprocBuiltin(
+        functools.partial(invoke_llvm_daemon_tool, executable),
+    )
+    # Command which the in-process built-in falls back to in situations where
+    # running as an in-process built-in doesn't make sense, or daemonization is
+    # disabled for this tool.
+    result.fallback_command = executable
+    # Identifies this in-process built-in as the daemonized replacement for the
+    # given tool name; used to implement DISALLOW_DAEMONIZATION: {tool}.
+    result.llvm_daemon_tool_identifier = tool_name
+    return result
+
+
+def use_daemon_tool(
+    testing_config: TestingConfig,
+    lit_config: LitConfig,
+    tool_dir: str,
+    tool_name: str,
+    inproc_builtin_key_override: str | None = None,
+) -> bool:
+    """
+    Add the in-process built-in for running an LLVM tool in daemon mode.
+    The key for the in-process built-in is the absolute path to the tool,
+    so that it automatically replaces uses of the tool in testing, unless
+    `inproc_builtin_key_override` is specified, in which case it will
+    be the string provided via that parameter.
+    """
+
+    # Find the absolute path to the executable in the tool directory. executable = lit.util.which(daemon_tool, tool_dir)
+    executable = lit.util.which(tool_name, tool_dir)
+    if not executable:
+        lit_config.warning(
+            f"Could not find executable for requested daemon tool "
+            f"{tool_name} in {tool_dir}."
+        )
+        return False
+
+    if not check_daemon_support(executable):
+        lit_config.warning(
+            f"Executable {executable} does not support running as an LLVM "
+            f"daemon tool."
+        )
+        return False
+
+    # Register an in-process built-in to run the tool in daemon mode. This
+    # replaces invocations to the tool.
+    key = inproc_builtin_key_override if inproc_builtin_key_override else executable
+    testing_config.test_format.extra_inproc_builtins[
+        key
+    ] = get_daemon_tool_inproc_builtin(tool_name, executable)
+
+    return True

--- a/llvm/utils/lit/lit/llvm/daemon_tool.py
+++ b/llvm/utils/lit/lit/llvm/daemon_tool.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from threading import Thread
+from typing import Any, Callable, Optional, Tuple
+
+try:
+    from queue import Empty, Queue
+except ImportError:
+    from Queue import Empty, Queue
+
+from lit.InprocBuiltins import InprocBuiltinIO
+from lit.ShCommands import Command
+from lit.ShellEnvironment import ShellEnvironment, kIsWindows
+
+if kIsWindows:
+    import msvcrt
+
+    # Required for `set_blocking`.
+    from ctypes import POINTER, WinError, byref, c_wchar, windll
+    from ctypes.wintypes import BOOL, DWORD, HANDLE
+
+
+debug = os.environ.get("LLVM_LIT_TRACE_DAEMON_COMMUNICATION", "0") == "1"
+"""
+Output a trace of data sent to and received from the daemon process.
+"""
+
+
+def remove_prefix(string: str, prefix: str) -> str:
+    # FIXME: Once Python 3.9+ is required, replace uses of this with
+    # `str.removeprefix`.
+    if string.startswith(prefix):
+        return string[len(prefix) :]
+    return string
+
+
+def set_blocking(pipefd: int, blocking: bool):
+    """
+    Cross-platform replacement for `os.set_blocking`.
+    """
+    # `os.set_blocking` is not available on Windows until Python 3.12, so
+    # we reimplement it using SetNamedPipeHandleState, as is used in the
+    # CPython implementation:
+    #   https://github.com/python/cpython/blob/6304eb1f5b93f682bff558befe4a7b9585f4601e/Python/fileutils.c#L2849
+    #
+    # FIXME: Once Python 3.12+ is required, replace uses of this with
+    # `os.setblocking`
+
+    if not kIsWindows:
+        os.set_blocking(pipefd, blocking)
+        return
+
+    handle = msvcrt.get_osfhandle(pipefd)
+    mode = DWORD()
+
+    windll.kernel32.GetNamedPipeHandleStateW.restype = BOOL
+    windll.kernel32.GetNamedPipeHandleStateW.argtypes = [
+        HANDLE,  # hNamedPipe
+        POINTER(DWORD),  # [optional] lpState
+        POINTER(DWORD),  # [optional] lpCurInstances
+        POINTER(DWORD),  # [optional] lpMaxCollectionCount
+        POINTER(DWORD),  # [optional] lpCollectDataTimeout
+        POINTER(c_wchar),  # [optional] lpUserName
+        DWORD,  # nMaxUserNameSize
+    ]
+    ok = windll.kernel32.GetNamedPipeHandleStateW(
+        handle,
+        byref(mode),
+        None,
+        None,
+        None,
+        None,
+        0,
+    )
+    if not ok:
+        raise WinError()
+
+    PIPE_NOWAIT = 1
+    if blocking:
+        mode.value &= ~PIPE_NOWAIT
+    else:
+        mode.value |= PIPE_NOWAIT
+
+    windll.kernel32.SetNamedPipeHandleState.restype = BOOL
+    windll.kernel32.SetNamedPipeHandleState.argtypes = [
+        HANDLE,  # hNamedPipe
+        POINTER(DWORD),  # [optional] lpMode
+        POINTER(DWORD),  # [optional] lpMaxCollectionCount
+        POINTER(DWORD),  # [optional] lpCollectDataTimeout
+    ]
+    ok = windll.kernel32.SetNamedPipeHandleState(
+        handle,
+        byref(mode),
+        None,
+        None,
+    )
+    if not ok:
+        raise WinError()
+
+
+class DaemonError(Exception):
+    """
+    Exception raised when the daemon tool sends an error message.
+    """
+
+    def __init__(self, message: str):
+        super().__init__()
+        self.message = remove_prefix(message, "error ")
+
+    def __str__(self) -> str:
+        return f"Error from daemon: {self.message}"
+
+
+class UnexpectedDaemonOutput(Exception):
+    """
+    Exception raised when the daemon tool sends an unexpected message.
+    """
+
+    def __init__(self, message: bytes):
+        super().__init__()
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"Unexpected message from daemon: {self.message}"
+
+
+class DaemonExited(Exception):
+    """
+    Exception raised when the daemon exits unexpectedly.
+    """
+
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+
+    def __init__(self, exit_code: int, stdout: bytes, stderr: bytes):
+        super().__init__()
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self) -> str:
+        return "Daemon exited unexpectedly with code {}.\nstdout:\n{}\nstderr:\n{}\n".format(
+            self.exit_code, self.stdout, self.stderr
+        )
+
+
+def async_read_status_pipe(daemon):
+    """
+    Runs in the background, reading from the status pipe from the daemon
+    process and writing it to a queue. We use a queue so that the pipe can be
+    read with blocking (via `get`) and without (via `get_nowait`)
+    """
+
+    while daemon.is_alive():
+        line = daemon.status_pipe.readline()
+        if debug:
+            print("from status pipe:", line)
+        daemon.status_pipe_queue.put(line)
+    daemon.status_pipe_queue.put(b"")
+
+
+class DaemonTool:
+    executable_path: str
+    daemon_proc: Optional[subprocess.Popen]
+    status_pipe: Any
+    status_pipe_queue: Queue
+    status_pipe_reader_thread: Optional[Thread]
+
+    def __init__(self, executable_path: str):
+        self.executable_path = executable_path
+        self.daemon_proc = None
+        self.status_pipe = None
+        self.status_pipe_queue = Queue()
+        self.status_pipe_reader_thread = None
+
+    def is_alive(self):
+        if not self.daemon_proc:
+            return False
+        if not isinstance(self.daemon_proc, subprocess.Popen):
+            return False
+
+        return self.daemon_proc.poll() is None
+
+    def start_daemon(self):
+        assert not self.is_alive(), "start_daemon called but daemon is already alive."
+
+        # Close the old status pipe.
+        if self.status_pipe:
+            self.status_pipe.close()
+
+        # Kill the old status pipe reading thread.
+        if self.status_pipe_reader_thread:
+            self.status_pipe_reader_thread.join()
+
+        # Clear the status pipe queue, to avoid issues caused by lingering
+        # messages.
+        self.status_pipe_queue = Queue()
+
+        # Create a new status pipe for the daemon process.
+        # This will be used by the daemon to communicate its status, including
+        # exit codes.
+        status_pipe_reader, status_pipe_writer = os.pipe()
+
+        # Make sure that the write end of the status pipe gets inherited
+        # by the daemon.
+        os.set_inheritable(status_pipe_writer, True)
+        if kIsWindows:
+            status_pipe_handle = msvcrt.get_osfhandle(status_pipe_writer)
+            os.set_handle_inheritable(status_pipe_handle, True)
+
+        args = [
+            self.executable_path,
+            "--daemon",
+        ]
+        # On Windows, only the file handle (not the file descriptor) is
+        # inherited.
+        if kIsWindows:
+            args.append(f"--daemon-status-pipe=handle:{status_pipe_handle}")
+            startupinfo = subprocess.STARTUPINFO(
+                lpAttributeList={"handle_list": [status_pipe_handle]},
+            )
+            pass_fds = ()
+        else:
+            args.append(f"--daemon-status-pipe=fd:{status_pipe_writer}")
+            startupinfo = None
+            pass_fds = [status_pipe_writer]
+
+        self.daemon_proc = subprocess.Popen(
+            args=args,
+            text=False,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            pass_fds=pass_fds,
+            startupinfo=startupinfo,
+        )
+
+        # Close our status pipe writer, as we only read from the pipe.
+        os.close(status_pipe_writer)
+
+        set_blocking(self.daemon_proc.stdout.fileno(), False)
+        set_blocking(self.daemon_proc.stderr.fileno(), False)
+
+        # Start the status pipe reader thread.
+        self.status_pipe = open(status_pipe_reader, "rb")
+        self.status_pipe_reader_thread = Thread(
+            target=async_read_status_pipe,
+            args=[self],
+            daemon=True,
+        )
+        self.status_pipe_reader_thread.start()
+
+        # Check initialization status.
+        self.expect_response(b"ready")
+
+    def invoke(
+        self,
+        args: list[str],
+        shenv: ShellEnvironment,
+        stdin: Any,
+        stdout: Any,
+        stderr: Any,
+    ) -> int:
+        # Ensure the daemon is alive.
+        if not self.is_alive():
+            self.start_daemon()
+
+        commands: list[str | bytes] = []
+
+        # Set the CWD for the daemon.
+        abs_cwd = os.path.abspath(shenv.cwd)
+        if abs_cwd != os.getcwd():
+            commands.append(f"cd {abs_cwd}")
+
+        # Set the arguments for the tool.
+        for arg in args:
+            arg_bytes = arg.encode()
+            commands.append(f"arg {len(arg_bytes)}")
+            commands.append(arg_bytes)
+
+        # Set the input for the tool.
+        if stdin.get_filename():
+            # If the input is a named file, we provide it to the daemon via the
+            # "input_file" command.
+            commands.append(f"input_file {stdin.get_filename()}")
+        else:
+            # Otherwise, read the input and provide it via stdin.
+            stdin_bytes = stdin.read_binary()
+            if stdin_bytes:
+                commands.append(f"input_string {len(stdin_bytes)}")
+                commands.append(stdin_bytes)
+        # If stdout and stderr are the same stream (which will be the case if
+        # stderr is redirected to stdout), inform the daemon to send stderr
+        # over stdout. We do this to make sure that the order of output is
+        # preserved.
+        if stderr == stdout:
+            commands.append("redirect_stderr_to_stdout")
+
+        commands.append("run")
+        self.send_commands(commands)
+        exit_code, stdout_bytes, stderr_bytes = self.collect_invocation_output()
+
+        # Make sure the streams are flushed.
+        if stderr == stdout:
+            stdout.write_binary(stdout_bytes)
+            stdout.flush()
+        else:
+            stdout.write_binary(stdout_bytes)
+            stdout.flush()
+            stderr.write_binary(stderr_bytes)
+            stderr.flush()
+
+        return exit_code
+
+    def collect_invocation_output(self) -> Tuple[int, bytes, bytes]:
+        # Wait for a message on the status pipe, indicating the result of the
+        # command, while continually reading all output from the daemon on
+        # its output streams. It is important to read the output continually
+        # rather than reading it all at the end to avoid deadlock if the pipe
+        # becomes full.
+        message = b""
+        stdout = b""
+        stderr = b""
+        while self.is_alive():
+            # Read output from stdout and stderr so far.
+            stdout += self.read_output_so_far(self.daemon_proc.stdout)
+            stderr += self.read_output_so_far(self.daemon_proc.stderr)
+
+            # Check for a message from the status pipe, indicating that the
+            # task has finished.
+            try:
+                # It is important not to block forever, as this would cause
+                # the worker to hang if the pipe becomes full. However, it is
+                # also important to wait a bit, as otherwise Lit spinning in
+                # this loop consumes significant CPU time, reducing the testing
+                # performance. The timeout of 0.01 seconds seems to be a good
+                # compromise.
+                message = self.status_pipe_queue.get(block=True, timeout=0.01)
+                break
+            except Empty:
+                continue
+
+        # Make sure to read the remainder of the bytes in the output streams.
+        stdout += self.read_output_so_far(self.daemon_proc.stdout)
+        stderr += self.read_output_so_far(self.daemon_proc.stderr)
+
+        # Check that the message indicates that the task was completed.
+        try:
+            self.check_response(
+                message,
+                lambda message: message.startswith(b"returned"),
+            )
+
+            # The exit code is stored in the message.
+            exit_code = int(remove_prefix(message.decode(), "returned").strip())
+            return (exit_code, stdout, stderr)
+        except DaemonExited as e:
+            # The daemon exited during execution of the task, indicating that
+            # the LLVM code crashed or otherwise called `exit`.
+            # However the LLVM code exited, the exit code returned by the daemon
+            # process is the same as the code that the tool would have returned
+            # if run separately, so this is correct to use as the exit code for
+            # the test.
+            stdout += e.stdout
+            stderr += e.stderr
+            return (e.exit_code, stdout, stderr)
+
+    def read_output_so_far(self, pipe: Any) -> bytes:
+        """
+        Read all of the bytes currently in the pipe, which must be in non-
+        blocking mode.
+        """
+
+        output = b""
+        while self.is_alive():
+            chunk = pipe.read()
+            if not chunk:
+                break
+            output += chunk
+
+        return output
+
+    def send_commands(self, commands: list[str | bytes]):
+        if debug:
+            print(f"sending commands: {commands}")
+        daemon_input = (
+            b"\n".join(
+                command.encode() if isinstance(command, str) else command
+                for command in commands
+            )
+            + b"\n"
+        )
+        os.write(self.daemon_proc.stdin.fileno(), daemon_input)
+
+    def check_response(
+        self,
+        message: Optional[bytes],
+        predicate: Callable[[bytes], bool],
+    ):
+        """
+        Given a message read from the daemon's status pipe, checks that the
+        message matches the predicate. Otherwise, raises the appropriate
+        exception (DaemonError, DaemonExited, UnexpectedDaemonOutput)
+        """
+
+        if not message:
+            # On Windows, we must change these streams back to blocking mode
+            # for the output to be captured by `communicate()`.
+            set_blocking(self.daemon_proc.stdout.fileno(), True)
+            set_blocking(self.daemon_proc.stderr.fileno(), True)
+
+            stdout, stderr = self.daemon_proc.communicate()
+            raise DaemonExited(self.daemon_proc.returncode, stdout, stderr)
+
+        if predicate(message.strip()):
+            return
+
+        if message.startswith(b"error"):
+            raise DaemonError(message.decode())
+
+        raise UnexpectedDaemonOutput(message)
+
+    def expect_response(self, expected: bytes):
+        self.check_response(
+            self.status_pipe_queue.get(), lambda received: received == expected
+        )
+
+    def close(self):
+        if not self.is_alive():
+            return
+
+        self.send_commands(["exit"])
+
+        try:
+            self.daemon_proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            self.daemon_proc.kill()
+
+
+daemons: dict[str, DaemonTool] = {}
+"""
+Dictionary storing the existing daemon for a given tool path. This is how
+existing daemons are remembered between invocations.
+"""
+
+
+def invoke_llvm_daemon_tool(
+    executable_path: str,
+    cmd: Command,
+    args: list[str],
+    shenv: ShellEnvironment,
+    io: InprocBuiltinIO,
+):
+    """
+    Function called by the in-process builtins that are invoking daemon tools.
+    """
+
+    # Find the daemon corresponding to this tool executable, or create one.
+    daemon = daemons.get(executable_path, None)
+    if not daemon:
+        daemon = DaemonTool(executable_path)
+        daemons[executable_path] = daemon
+
+    args[0] = executable_path
+    return daemon.invoke(args, shenv, io.stdin, io.stdout, io.stderr)

--- a/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/disabled-folder/lit.local.cfg
+++ b/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/disabled-folder/lit.local.cfg
@@ -1,0 +1,3 @@
+import lit.llvm.daemon_config
+
+lit.llvm.daemon_config.disable_daemon_tool(config, "ExampleDaemon")

--- a/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/disabled-folder/try-using-exampledaemon.txt
+++ b/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/disabled-folder/try-using-exampledaemon.txt
@@ -1,0 +1,3 @@
+# This test should fail, as the ExampleDaemon is unregistered as a daemon in the
+# Lit config, so %invoke-ExampleDaemon is no longer a known command.
+RUN: %invoke-ExampleDaemon

--- a/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/disabled-test.txt
+++ b/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/disabled-test.txt
@@ -1,0 +1,5 @@
+# This test should fail, because the ExampleDaemon in-process built-in is
+# disabled by the "DISABLE_DAEMON" directive, so the %invoke-ExampleDaemon
+# command should not be found.
+DISABLE_DAEMON: ExampleDaemon
+RUN: %invoke-ExampleDaemon

--- a/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/lit.cfg
@@ -1,0 +1,21 @@
+import os
+import lit.llvm
+import lit.llvm.daemon_config
+from lit.formats import ShTest
+
+config.llvm_tools_dir = os.environ["LIT_LLVM_TOOLS_DIR"]
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+config.name = "llvm-daemon-integration"
+config.suffixes = [".txt"]
+config.test_format = ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+lit.llvm.daemon_config.use_daemon_tool(
+    config,
+    lit_config,
+    config.llvm_tools_dir,
+    "ExampleDaemon",
+    inproc_builtin_key_override="%invoke-ExampleDaemon",
+)

--- a/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/use-daemon.txt
+++ b/llvm/utils/lit/tests/Inputs/llvm-daemon-integration/use-daemon.txt
@@ -1,0 +1,25 @@
+NB: ExampleDaemon reads input on stdin and outputs uppercase letters and
+everything else to stdin. Its return code is the number of characters
+encountered.
+
+# Testing that we can invoke the daemon.
+RUN: %invoke-ExampleDaemon
+
+# Testing that we can invoke the daemon more times.
+RUN: %invoke-ExampleDaemon
+RUN: %invoke-ExampleDaemon
+
+# Testing that stdin and stdout work as expected.
+RUN: echo "abcABC" | not %invoke-ExampleDaemon | grep -x "abc"
+
+# Testing that redirecting stderr to stdout works as expected.
+RUN: echo "aBcDeFgH" | not %invoke-ExampleDaemon 2>&1 | grep -x "aBcDeFgH"
+
+# Testing that redirecting stderr and stdout to separate files works as expected.
+RUN: echo "aBcDeFgH" | not %invoke-ExampleDaemon >%t.stdout 2>%t.stderr
+RUN: grep -x "aceg" %t.stdout
+RUN: grep -x "BDFH" %t.stderr
+
+# Testing that the daemon is restarted after it exits.
+RUN: %invoke-ExampleDaemon --exit-process
+RUN: %invoke-ExampleDaemon

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/custom_inproc_builtins.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/custom_inproc_builtins.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from lit.InprocBuiltins import InprocBuiltinIO
+from lit.ShCommands import Command
+from lit.ShellEnvironment import ShellEnvironment
+
+
+def returns_0(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    return 0
+
+
+def returns_1(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    return 1
+
+
+def custom_echo(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    io.stdout.write(args[1])
+    return 0
+
+
+def echo_to_stderr(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+):
+    io.stderr.write(args[1])
+    return 0

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/lit.cfg
@@ -1,0 +1,23 @@
+import os
+import sys
+import lit.formats
+from lit.InprocBuiltins import InprocBuiltin
+
+# Import the module containing the custom in-process builtins.
+# NB: These cannot be defined in the lit.cfg module.
+sys.path.append(os.path.dirname(__file__))
+import custom_inproc_builtins
+
+config.name = "shtest-custom-inproc-builtins"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest(
+    extra_inproc_builtins={
+        "returns_0": InprocBuiltin(custom_inproc_builtins.returns_0),
+        "returns_1": InprocBuiltin(custom_inproc_builtins.returns_1),
+        "custom_echo": InprocBuiltin(custom_inproc_builtins.custom_echo),
+        "echo_to_stderr": InprocBuiltin(custom_inproc_builtins.echo_to_stderr),
+    }
+)
+config.test_source_root = None
+config.test_exec_root = None
+

--- a/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/use-custom-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-custom-inproc-builtins/use-custom-inproc-builtins.txt
@@ -1,0 +1,13 @@
+RUN: returns_0
+RUN: not returns_1
+
+RUN: custom_echo "hello" > %t1
+RUN: grep -x "hello" < %t1
+
+RUN: custom_echo ", world" >> %t1
+RUN: grep -x "hello, world" < %t1
+
+RUN: echo_to_stderr "goodbye" 2> %t2
+RUN: grep -x "goodbye" < %t2
+RUN: echo_to_stderr ", for now" 2>> %t2
+RUN: grep -x "goodbye, for now" < %t2

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/custom_inproc_builtins.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/custom_inproc_builtins.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from lit.InprocBuiltins import InprocBuiltinIO
+from lit.ShCommands import Command
+from lit.ShellEnvironment import ShellEnvironment
+
+
+def execute_print_out_err(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
+    args = args[1:]
+
+    if len(args) != 2:
+        io.stderr.write("Expected two arguments.")
+        return 1
+
+    io.stdout.write(args[0])
+    io.stderr.write(args[1])
+
+    return 0
+
+
+def execute_uppercaser(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
+    io.stdout.write(io.stdin.read().upper())
+
+    return 0
+
+
+def execute_streq(
+    cmd: Command, args: list[str], shenv: ShellEnvironment, io: InprocBuiltinIO
+) -> int:
+    args = args[1:]
+
+    if len(args) != 1:
+        io.stderr.write("Expected one argument.")
+        return 2
+
+    return int(io.stdin.read() != args[0])

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/extra-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/extra-inproc-builtins.txt
@@ -1,0 +1,23 @@
+This test verifies that the custom in-process builtins defined in lit.cfg
+are working as expected.
+
+Testing "streq"
+
+Testing "print_out_err"
+RUN: print_out_err "hello stdout" "hello stderr" > %t.out 2> %t.err
+RUN: grep -x "hello stdout" %t.out
+RUN: grep -x "hello stderr" %t.err
+
+Testing redirection in append mode.
+RUN: print_out_err "1" "2" >> %t.out 2>> %t.err
+RUN: grep -x "hello stdout1" %t.out
+RUN: grep -x "hello stderr2" %t.err
+
+RUN: not print_out_err > %t.out 2> %t.err
+RUN: streq < %t.out ""
+RUN: streq < %t.err "Expected two arguments."
+
+Testing "uppercaser"
+RUN: echo "testtest" > %t.lowercase
+RUN: uppercaser < %t.lowercase > %t.uppercase
+RUN: grep -x "TESTTEST" < %t.uppercase

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/lit.cfg
@@ -1,0 +1,20 @@
+import sys
+import os
+import lit.formats
+from lit.InprocBuiltins import InprocBuiltin
+
+sys.path.append(os.path.dirname(__file__))
+from custom_inproc_builtins import execute_print_out_err, execute_uppercaser, execute_streq
+
+
+config.name = "shtest-pipelined-inproc-builtins"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest(
+    extra_inproc_builtins={
+        "print_out_err": InprocBuiltin(execute_print_out_err),
+        "uppercaser": InprocBuiltin(execute_uppercaser),
+        "streq": InprocBuiltin(execute_streq),
+    },
+)
+config.test_source_root = None
+config.test_exec_root = None

--- a/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/pipelined-inproc-builtins.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-pipelined-inproc-builtins/pipelined-inproc-builtins.txt
@@ -1,0 +1,27 @@
+Piping inproc builtin into inproc builtin into normal command.
+RUN: echo "hello" | uppercaser | grep -Fx "HELLO"
+
+Piping normal command into inproc builtin into normal command.
+RUN: echo "abcd" > %t
+RUN: cat %t | uppercaser | grep -Fx "ABCD"
+
+Redirecting stdin for inproc builtin from file.
+RUN: echo "lll" > %t
+RUN: uppercaser < %t | grep -Fx "LLL"
+
+Piping stderr, but not stdout, from normal command into inproc builtin.
+RUN: not cat does_not_exist.txt 2>&1 >/dev/null | uppercaser | streq "[ERRNO 2] NO SUCH FILE OR DIRECTORY: 'DOES_NOT_EXIST.TXT'"
+
+Piping stderr, and but stdout, from inproc builtin into normal command.
+RUN: print_out_err "ignoreme" "err" 2>&1 >/dev/null | grep -Fx "err"
+
+Piping stderr, but not stdout, from inproc builtin into inproc builtin.
+RUN: print_out_err "ignoreme" "err" 2>&1 >/dev/null | streq "err"
+
+Redirecting stderr to stdout for inproc builtin and piping it into another inproc builtin.
+RUN: print_out_err "aaa" "bbb" 2>&1 | streq "aaabbb"
+
+Redirecting stderr to stdout for inproc builtin and piping it into a regular process.
+RUN: print_out_err "aaa" "bbb" 2>&1 | grep "aaabbb"
+
+END.

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/colon-error.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/colon-error.txt
@@ -1,3 +1,0 @@
-# Check error on an unsupported ":". (cannot be part of a pipeline)
-#
-# RUN: : | echo "hello"

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/mkdir-error-0.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/mkdir-error-0.txt
@@ -1,3 +1,0 @@
-# Check error on a unsupported mkdir (cannot be part of a pipeline).
-#
-# RUN: mkdir -p temp | rm -rf temp

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/rm-error-0.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/rm-error-0.txt
@@ -1,3 +1,0 @@
-# Check error on a unsupported rm. (cannot be part of a pipeline)
-#
-# RUN: rm -rf temp | echo "hello"

--- a/llvm/utils/lit/tests/lit.cfg
+++ b/llvm/utils/lit/tests/lit.cfg
@@ -41,6 +41,14 @@ else:
     lit_path = os.path.join(config.test_source_root, "..")
 lit_path = os.path.abspath(lit_path)
 
+if llvm_src_root:
+    # Add a feature for tests that require a LLVM build to run, for example
+    # testing LLVM daemon tool integration.
+    config.available_features.add("have-llvm-build")
+
+    # Add environment variables to inform the tests of the LLVM tools directory.
+    config.environment["LIT_LLVM_TOOLS_DIR"] = config.llvm_tools_dir
+
 # Required because some tests import the lit module
 if llvm_config:
     llvm_config.with_environment("PYTHONPATH", lit_path, append_path=True)

--- a/llvm/utils/lit/tests/llvm-daemon-integration.py
+++ b/llvm/utils/lit/tests/llvm-daemon-integration.py
@@ -1,0 +1,8 @@
+## Test the integration with LLVM daemon tools.
+#
+# REQUIRES: have-llvm-build
+# RUN: %{lit} %{inputs}/llvm-daemon-integration \
+# RUN: | FileCheck --match-full-lines %s
+# END.
+
+# CHECK: PASS: llvm-daemon-integration :: use-daemon.txt ({{.*}})

--- a/llvm/utils/lit/tests/llvm-daemon-integration.py
+++ b/llvm/utils/lit/tests/llvm-daemon-integration.py
@@ -19,4 +19,17 @@
 # CHECK-NEXT: # `-----------------------------
 # CHECK-NEXT: # error: command failed with exit status: 127
 
+# CHECK: FAIL: llvm-daemon-integration :: disabled-test.txt ({{.*}})
+# CHECK-NEXT: {{\*+}} TEST 'llvm-daemon-integration :: disabled-test.txt' FAILED {{\*+}}
+# CHECK-NEXT: Exit Code: 127
+# CHECK-EMPTY:
+# CHECK-NEXT: Command Output (stdout):
+# CHECK-NEXT: --
+# CHECK-NEXT: # RUN: at line {{.*}}
+# CHECK-NEXT: %invoke-ExampleDaemon
+# CHECK-NEXT: # executed command: %invoke-ExampleDaemon
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | '%invoke-ExampleDaemon': command not found
+# CHECK-NEXT: # `-----------------------------
+# CHECK-NEXT: # error: command failed with exit status: 127
 # CHECK: PASS: llvm-daemon-integration :: use-daemon.txt ({{.*}})

--- a/llvm/utils/lit/tests/llvm-daemon-integration.py
+++ b/llvm/utils/lit/tests/llvm-daemon-integration.py
@@ -1,8 +1,22 @@
 ## Test the integration with LLVM daemon tools.
 #
 # REQUIRES: have-llvm-build
-# RUN: %{lit} %{inputs}/llvm-daemon-integration \
+# RUN: not %{lit} -v %{inputs}/llvm-daemon-integration \
 # RUN: | FileCheck --match-full-lines %s
 # END.
+
+# CHECK: FAIL: llvm-daemon-integration :: disabled-folder/try-using-exampledaemon.txt ({{.*}})
+# CHECK-NEXT: {{\*+}} TEST 'llvm-daemon-integration :: disabled-folder/try-using-exampledaemon.txt' FAILED {{\*+}}
+# CHECK-NEXT: Exit Code: 127
+# CHECK-EMPTY:
+# CHECK-NEXT: Command Output (stdout):
+# CHECK-NEXT: --
+# CHECK-NEXT: # RUN: at line {{.*}}
+# CHECK-NEXT: %invoke-ExampleDaemon
+# CHECK-NEXT: # executed command: %invoke-ExampleDaemon
+# CHECK-NEXT: # .---command stderr------------
+# CHECK-NEXT: # | '%invoke-ExampleDaemon': command not found
+# CHECK-NEXT: # `-----------------------------
+# CHECK-NEXT: # error: command failed with exit status: 127
 
 # CHECK: PASS: llvm-daemon-integration :: use-daemon.txt ({{.*}})

--- a/llvm/utils/lit/tests/shtest-custom-inproc-builtins.py
+++ b/llvm/utils/lit/tests/shtest-custom-inproc-builtins.py
@@ -1,0 +1,10 @@
+## This test provides some custom in-process built-ins via the lit.cfg, and
+## verifies that their output can be redirected correctly.
+#
+# RUN: %{lit} -v %{inputs}/shtest-custom-inproc-builtins \
+# RUN: | FileCheck -match-full-lines %s
+# END.
+
+# CHECK: PASS: shtest-custom-inproc-builtins :: use-custom-inproc-builtins.txt ({{[^)]*}})
+
+# CHECK: Passed: 1 ({{[^)]*}})

--- a/llvm/utils/lit/tests/shtest-glob.py
+++ b/llvm/utils/lit/tests/shtest-glob.py
@@ -4,8 +4,7 @@
 # RUN: | FileCheck -dump-input=fail -match-full-lines --implicit-check-not=Error: %s
 # END.
 
-# CHECK: UNRESOLVED: shtest-glob :: glob-echo.txt ({{[^)]*}})
-# CHECK: TypeError: string argument expected, got 'GlobItem'
+# CHECK: PASS: shtest-glob :: glob-echo.txt ({{[^)]*}})
 
 # CHECK:      FAIL: shtest-glob :: glob-mkdir.txt ({{[^)]*}})
 # CHECK:      # | Error: 'mkdir' command failed, {{.*}}example_file1.input'

--- a/llvm/utils/lit/tests/shtest-pipelined-inproc-builtins.py
+++ b/llvm/utils/lit/tests/shtest-pipelined-inproc-builtins.py
@@ -1,0 +1,12 @@
+## This test suite tests pipelining in-process builtins.
+## This test suite has some extra in-process builtin registered in the config:
+## - uppercaser: Reads input on stdin, converts the string to uppercase and
+##   outputs the result on stderr.
+## - print_out_err: Writes the first argument to stdout, and the second to stderr.
+## - streq: Returns 0 if the first argument and the input from stdin are equal, 1 otherwise.
+
+# RUN: %{lit} -v %{inputs}/shtest-pipelined-inproc-builtins | FileCheck %s -match-full-lines
+# END.
+
+# CHECK: PASS: shtest-pipelined-inproc-builtins :: extra-inproc-builtins.txt ({{.*}})
+# CHECK: PASS: shtest-pipelined-inproc-builtins :: pipelined-inproc-builtins.txt ({{.*}})

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -12,14 +12,6 @@
 
 # CHECK: -- Testing:
 
-# CHECK: FAIL: shtest-shell :: colon-error.txt
-# CHECK: *** TEST 'shtest-shell :: colon-error.txt' FAILED ***
-# CHECK: :
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | Unsupported: ':' cannot be part of a pipeline
-# CHECK: # error: command failed with exit status: 127
-# CHECK: ***
-
 # CHECK: PASS: shtest-shell :: continuations.txt
 
 # CHECK: PASS: shtest-shell :: dev-null.txt
@@ -497,37 +489,10 @@
 # CHECK-NEXT: # error: command failed with exit status: 1
 #      CHECK: ***
 
-# CHECK: FAIL: shtest-shell :: echo-at-redirect-stderr.txt
-# CHECK: *** TEST 'shtest-shell :: echo-at-redirect-stderr.txt' FAILED ***
-# CHECK: @echo 2> {{.*}}
-# CHECK: # executed command: @echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for @echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-at-redirect-stdin.txt
-# CHECK: *** TEST 'shtest-shell :: echo-at-redirect-stdin.txt' FAILED ***
-# CHECK: @echo < {{.*}}
-# CHECK: # executed command: @echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for @echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-redirect-stderr.txt
-# CHECK: *** TEST 'shtest-shell :: echo-redirect-stderr.txt' FAILED ***
-# CHECK: echo 2> {{.*}}
-# CHECK: # executed command: echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for echo
-# CHECK: error: command failed with exit status:
-
-# CHECK: FAIL: shtest-shell :: echo-redirect-stdin.txt
-# CHECK: *** TEST 'shtest-shell :: echo-redirect-stdin.txt' FAILED ***
-# CHECK: echo < {{.*}}
-# CHECK: # executed command: echo
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | stdin and stderr redirects not supported for echo
-# CHECK: error: command failed with exit status:
+# CHECK: PASS: shtest-shell :: echo-at-redirect-stderr.txt
+# CHECK: PASS: shtest-shell :: echo-at-redirect-stdin.txt
+# CHECK: PASS: shtest-shell :: echo-redirect-stderr.txt
+# CHECK: PASS: shtest-shell :: echo-redirect-stdin.txt
 
 # CHECK: FAIL: shtest-shell :: error-0.txt
 # CHECK: *** TEST 'shtest-shell :: error-0.txt' FAILED ***
@@ -556,14 +521,6 @@
 # CHECK: Unsupported redirect:
 # CHECK: ***
 
-# CHECK: FAIL: shtest-shell :: mkdir-error-0.txt
-# CHECK: *** TEST 'shtest-shell :: mkdir-error-0.txt' FAILED ***
-# CHECK: mkdir -p temp | rm -rf temp
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | Unsupported: 'mkdir' cannot be part of a pipeline
-# CHECK: # error: command failed with exit status: 127
-# CHECK: ***
-
 # CHECK: FAIL: shtest-shell :: mkdir-error-1.txt
 # CHECK: *** TEST 'shtest-shell :: mkdir-error-1.txt' FAILED ***
 # CHECK: mkdir -p -m 777 temp
@@ -586,14 +543,6 @@
 # CHECK: ***
 
 # CHECK: PASS: shtest-shell :: redirects.txt
-
-# CHECK: FAIL: shtest-shell :: rm-error-0.txt
-# CHECK: *** TEST 'shtest-shell :: rm-error-0.txt' FAILED ***
-# CHECK: rm -rf temp | echo "hello"
-# CHECK: # .---command stderr{{-*}}
-# CHECK: # | Unsupported: 'rm' cannot be part of a pipeline
-# CHECK: # error: command failed with exit status: 127
-# CHECK: ***
 
 # CHECK: FAIL: shtest-shell :: rm-error-1.txt
 # CHECK: *** TEST 'shtest-shell :: rm-error-1.txt' FAILED ***
@@ -634,4 +583,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (37)
+# CHECK: Failed Tests (30)


### PR DESCRIPTION
This PR is dependent on https://github.com/llvm/llvm-project/pull/197924; the changes in the first commit in this PR are from that PR and its dependencies. Please review from the 2nd commit onwards.

This PR introduces two mechanisms for tests that fail when daemonization is enabled to opt out of daemonization. Both work by removing the in-process built in which is responsible for invoking the daemon instead of running the tool normally, so that tools are run normally instead.
 
Daemonization can be disabled for a specific tool in one specific test by adding the

```
DISABLE_DAEMON: {tool name}
```

directive to the test, for example:

```
DISABLE_DAEMON: opt
```

Daemonization can be disabled for a whole directory of tests by calling `daemon_config.disable_daemon_tool` in the `lit.local.cfg`, for example:

```
import lit.llvm.daemon_config
lit.llvm.daemon_config.disable_daemon_tool(config, "opt")
```

The name passed should be the same name passed to `use_daemon_tool` when daemonization was enabled for the tool.

With each commit I have added tests to verify that the mechanism indeed disables the in-process built-in, within the existing `llvm-daemon-integration` Lit tests. As these tests register the in-process built-in for ExampleDaemon under a special key, "%invoke-ExampleDaemon", unregistering the daemon will cause this to no longer refer to a command, so the tests that try to use it fail - this is how we make sure the in-process built-in was removed.