### PR TITLE
[clang-sycl-linker] Report unknown command-line options as errors

### DIFF
--- a/clang/test/Tooling/clang-sycl-linker.ll
+++ b/clang/test/Tooling/clang-sycl-linker.ll
@@ -73,6 +73,11 @@
 ; RUN:   | FileCheck %s --check-prefix=NOTARGET
 ; NOTARGET: Target triple must be specified
 ;
+; Check parser error reporting for unknown options.
+; RUN: not clang-sycl-linker --dry-run --not-a-real-flag -triple=spirv64 %t/input1.bc -o a.out 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=BADOPT
+; BADOPT: unknown argument '--not-a-real-flag'
+;
 ; Input with no entry points still produces an offload image.
 ; RUN: llvm-as %t/no-entry-points.ll -o %t/no-entry-points.bc
 ; RUN: clang-sycl-linker -triple=spirv64 %t/no-entry-points.bc -o %t/no-entry-points.out

--- a/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
+++ b/clang/tools/clang-sycl-linker/ClangSYCLLinker.cpp
@@ -228,7 +228,6 @@ Expected<SmallVector<std::string>> getSYCLDeviceLibs(const ArgList &Args) {
   if (Arg *A = Args.getLastArg(OPT_device_libs_EQ)) {
     if (A->getValues().size() == 0)
       return createStringError(
-          inconvertibleErrorCode(),
           "Number of device library files cannot be zero.");
     for (StringRef Val : A->getValues()) {
       SmallString<128> LibName(LibraryPath);
@@ -236,9 +235,8 @@ Expected<SmallVector<std::string>> getSYCLDeviceLibs(const ArgList &Args) {
       if (llvm::sys::fs::exists(LibName))
         DeviceLibFiles.push_back(std::string(LibName));
       else
-        return createStringError(inconvertibleErrorCode(),
-                                 "\'" + std::string(LibName) + "\'" +
-                                     " SYCL device library file is not found.");
+        return createStringError("'" + LibName +
+                                 "' SYCL device library file is not found.");
     }
   }
   return DeviceLibFiles;
@@ -432,9 +430,7 @@ static Error runAOTCompileIntelGPU(StringRef InputFile, StringRef OutputFile,
   CmdArgs.push_back("-spirv_input");
 
   StringRef Arch(Args.getLastArgValue(OPT_arch_EQ));
-  if (Arch.empty())
-    return createStringError(inconvertibleErrorCode(),
-                             "Arch must be specified for AOT compilation");
+  assert(!Arch.empty() && "Arch must be specified for AOT compilation");
   CmdArgs.push_back("-device");
   CmdArgs.push_back(Arch);
 
@@ -465,7 +461,7 @@ static Error runAOTCompile(StringRef InputFile, StringRef OutputFile,
   if (IsIntelCPUOffloadArch(OA))
     return runAOTCompileIntelCPU(InputFile, OutputFile, Args);
 
-  return createStringError(inconvertibleErrorCode(), "Unsupported arch");
+  llvm_unreachable("runAOTCompile dispatched on unsupported arch");
 }
 
 static constexpr char AttrSYCLModuleId[] = "sycl-module-id";
@@ -745,8 +741,8 @@ int main(int argc, char **argv) {
   const OptTable &Tbl = getOptTable();
   BumpPtrAllocator Alloc;
   StringSaver Saver(Alloc);
-  auto Args = Tbl.parseArgs(argc, argv, OPT_INVALID, Saver, [&](StringRef Err) {
-    reportError(createStringError(inconvertibleErrorCode(), Err));
+  auto Args = Tbl.parseArgs(argc, argv, OPT_UNKNOWN, Saver, [](StringRef Err) {
+    reportError(createStringError(Err));
   });
 
   if (Args.hasArg(OPT_help) || Args.hasArg(OPT_help_hidden)) {


### PR DESCRIPTION
Pass OPT_UNKNOWN (not OPT_INVALID) to OptTable::parseArgs so the error callback fires for unrecognized flags. With OPT_INVALID the filter in parseArgs matches no Args, leaving bogus options silently dropped.

Add a lit test that exercises this path.

Drive-by cleanups in the same area:
- Use the single-argument createStringError() overload where the error code was redundantly inconvertibleErrorCode().
- Drop redundant single-quote escapes and std::string() cast in the device-library-not-found message; use Twine concat directly.
- Replace the dead "Arch must be specified" branch in runAOTCompileIntelGPU with an assert documenting the invariant enforced by the caller (IsIntelGPUOffloadArch implies non-empty arch).
- Replace the unreachable "Unsupported arch" fallthrough in runAOTCompile with llvm_unreachable; the dispatch only enters this function under IsIntelOffloadArch.
- Drop the unused [&] capture on the parseArgs error lambda.

Co-Authored-By: Claude