### PR TITLE
[libc] Add config option to use memory builtin functions.

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -130,6 +130,10 @@ function(_get_compile_options_from_config output_var)
     libc_add_definition(config_options "LIBC_COPT_MEMCPY_X86_USE_NTA_STORES")
   endif()
 
+  if(LIBC_CONF_USE_MEM_BUILTINS)
+    libc_add_definition(config_options "LIBC_COPT_USE_MEM_BUILTINS")
+  endif()
+
   if(LIBC_TYPES_TIME_T_IS_32_BIT AND LLVM_LIBC_FULL_BUILD)
     libc_add_definition(config_options "LIBC_TYPES_TIME_T_IS_32_BIT")
   endif()

--- a/libc/config/config.json
+++ b/libc/config/config.json
@@ -105,6 +105,10 @@
     "LIBC_CONF_COPT_MEMCPY_X86_USE_NTA_STORES": {
       "value": false,
       "doc": "Use Non-temporal stores in memcpy on x86 to improve performance of large copies."
+    },
+    "LIBC_CONF_USE_MEM_BUILTINS": {
+      "value": false,
+      "doc": "Use builtins for memory utility functions."
     }
   },
   "ctype": {

--- a/libc/src/string/memory_utils/generic/builtin.h
+++ b/libc/src/string/memory_utils/generic/builtin.h
@@ -18,8 +18,9 @@
 namespace LIBC_NAMESPACE_DECL {
 
 #if !__has_builtin(__builtin_memcpy) || !__has_builtin(__builtin_memset) ||    \
-    !__has_builtin(__builtin_memmove)
-#error "Builtin not defined");
+    !__has_builtin(__builtin_memmove) || !__has_builtin(__builtin_memcmp) ||   \
+    !__has_builtin(__builtin_bcmp)
+#error "Builtin not defined"
 #endif
 
 [[maybe_unused]] LIBC_INLINE void
@@ -35,6 +36,17 @@ inline_memcpy_builtin(Ptr dst, CPtr src, size_t count, size_t offset = 0) {
 [[maybe_unused]] LIBC_INLINE static void
 inline_memset_builtin(Ptr dst, uint8_t value, size_t count, size_t offset = 0) {
   __builtin_memset(dst + offset, value, count);
+}
+
+[[maybe_unused]] LIBC_INLINE MemcmpReturnType
+inline_memcmp_builtin(CPtr p1, CPtr p2, size_t count) {
+  return static_cast<int32_t>(__builtin_memcmp(p1, p2, count));
+}
+
+[[maybe_unused]] LIBC_INLINE BcmpReturnType inline_bcmp_builtin(CPtr p1,
+                                                                CPtr p2,
+                                                                size_t count) {
+  return static_cast<uint32_t>(__builtin_bcmp(p1, p2, count));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/string/memory_utils/inline_bcmp.h
+++ b/libc/src/string/memory_utils/inline_bcmp.h
@@ -16,7 +16,10 @@
 
 #include <stddef.h> // size_t
 
-#if defined(LIBC_TARGET_ARCH_IS_X86)
+#if defined(LIBC_COPT_USE_MEM_BUILTINS)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_BCMP inline_bcmp_builtin
+#elif defined(LIBC_TARGET_ARCH_IS_X86)
 #include "src/string/memory_utils/x86_64/inline_bcmp.h"
 #define LIBC_SRC_STRING_MEMORY_UTILS_BCMP inline_bcmp_x86
 #elif defined(LIBC_TARGET_ARCH_IS_AARCH64)

--- a/libc/src/string/memory_utils/inline_memcmp.h
+++ b/libc/src/string/memory_utils/inline_memcmp.h
@@ -15,7 +15,10 @@
 
 #include <stddef.h> // size_t
 
-#if defined(LIBC_TARGET_ARCH_IS_X86)
+#if defined(LIBC_COPT_USE_MEM_BUILTINS)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP inline_memcmp_builtin
+#elif defined(LIBC_TARGET_ARCH_IS_X86)
 #include "src/string/memory_utils/x86_64/inline_memcmp.h"
 #define LIBC_SRC_STRING_MEMORY_UTILS_MEMCMP inline_memcmp_x86
 #elif defined(LIBC_TARGET_ARCH_IS_AARCH64)

--- a/libc/src/string/memory_utils/inline_memcpy.h
+++ b/libc/src/string/memory_utils/inline_memcpy.h
@@ -15,7 +15,10 @@
 
 #include <stddef.h> // size_t
 
-#if defined(LIBC_COPT_MEMCPY_USE_EMBEDDED_TINY)
+#if defined(LIBC_COPT_USE_MEM_BUILTINS)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_builtin
+#elif defined(LIBC_COPT_MEMCPY_USE_EMBEDDED_TINY)
 #include "src/string/memory_utils/generic/byte_per_byte.h"
 #define LIBC_SRC_STRING_MEMORY_UTILS_MEMCPY inline_memcpy_byte_per_byte
 #elif defined(LIBC_TARGET_ARCH_IS_X86)

--- a/libc/src/string/memory_utils/inline_memmove.h
+++ b/libc/src/string/memory_utils/inline_memmove.h
@@ -13,7 +13,12 @@
 #include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
 #include <stddef.h>                          // size_t, ptrdiff_t
 
-#if defined(LIBC_TARGET_ARCH_IS_X86)
+#if defined(LIBC_COPT_USE_MEM_BUILTINS)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
+  inline_memmove_no_small_size
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_FOLLOW_UP inline_memmove_builtin
+#elif defined(LIBC_TARGET_ARCH_IS_X86)
 #include "src/string/memory_utils/x86_64/inline_memmove.h"
 #define LIBC_SRC_STRING_MEMORY_UTILS_MEMMOVE_SMALL_SIZE                        \
   inline_memmove_small_size_x86

--- a/libc/src/string/memory_utils/inline_memset.h
+++ b/libc/src/string/memory_utils/inline_memset.h
@@ -15,7 +15,10 @@
 
 #include <stddef.h> // size_t
 
-#if defined(LIBC_TARGET_ARCH_IS_X86)
+#if defined(LIBC_COPT_USE_MEM_BUILTINS)
+#include "src/string/memory_utils/generic/builtin.h"
+#define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_builtin
+#elif defined(LIBC_TARGET_ARCH_IS_X86)
 #include "src/string/memory_utils/x86_64/inline_memset.h"
 #define LIBC_SRC_STRING_MEMORY_UTILS_MEMSET inline_memset_x86
 #elif defined(LIBC_TARGET_ARCH_IS_ARM)


### PR DESCRIPTION
Add a new CMake and C++ definition configuration option `LIBC_CONF_USE_MEM_BUILTINS` to allow users to use compiler builtins for memory utility functions (memcpy, memset, memmove, memcmp, and bcmp) instead of LLVM libc's internal implementations.  Main use-cases are:
- when users want to bring their own memory functions implementations that are highly optimized for their targets
- improve portability by providing a fallback for targets for which LLVM libc does not have memory utility implementations yet
- to be used for libc/shared functions and their testings, as we expect libc/shared functions to provide their own memory functions.