### PR TITLE
[clang][NFC] Disentangle `MacroState` from `Preprocessor`

### DIFF
--- a/clang/include/clang/Lex/MacroInfo.h
+++ b/clang/include/clang/Lex/MacroInfo.h
@@ -144,8 +144,8 @@ public:
   /// if they use different identifiers for the function macro parameters.
   /// Otherwise the comparison is lexical and this implements the rules in
   /// C99 6.10.3.
-  bool isIdenticalTo(const MacroInfo &Other, Preprocessor &PP,
-                     bool Syntactically) const;
+  bool isIdenticalTo(const MacroInfo &Other, const SourceManager &SourceMgr,
+                     const LangOptions &LangOpts, bool Syntactically) const;
 
   /// Set or clear the isBuiltinMacro flag.
   void setIsBuiltinMacro(bool Val = true) { IsBuiltinMacro = Val; }

--- a/clang/include/clang/Lex/MacroState.h
+++ b/clang/include/clang/Lex/MacroState.h
@@ -1,0 +1,155 @@
+//===- MacroState.h - C Language Family Macro State  *- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LEX_MACROSTATE_H
+#define LLVM_CLANG_LEX_MACROSTATE_H
+
+#include "clang/Lex/MacroInfo.h"
+#include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/Casting.h"
+
+namespace clang {
+
+class ExternalPreprocessorSource;
+class IdentifierInfo;
+class LangOptions;
+class ModuleMacro;
+class SourceManager;
+class VisibleModuleSet;
+
+using LeafModuleMacrosMap =
+    llvm::DenseMap<const IdentifierInfo *, llvm::TinyPtrVector<ModuleMacro *>>;
+
+struct PPReferences {
+  const VisibleModuleSet &VisibleModules;
+  const LeafModuleMacrosMap &LeafModuleMacros;
+  const SourceManager &SourceMgr;
+  const LangOptions &LangOpts;
+};
+
+/// Information about a name that has been used to define a module macro.
+struct FullModuleMacroInfo {
+  /// The most recent macro directive for this identifier.
+  MacroDirective *MD;
+
+  /// The active module macros for this identifier.
+  llvm::TinyPtrVector<ModuleMacro *> ActiveModuleMacros;
+
+  /// The generation number at which we last updated ActiveModuleMacros.
+  /// \see Preprocessor::VisibleModules.
+  unsigned ActiveModuleMacrosGeneration = 0;
+
+  /// Whether this macro name is ambiguous.
+  bool IsAmbiguous = false;
+
+  /// The module macros that are overridden by this macro.
+  llvm::TinyPtrVector<ModuleMacro *> OverriddenMacros;
+
+  FullModuleMacroInfo(MacroDirective *MD) : MD(MD) {}
+};
+
+/// The state of a macro for an identifier.
+class MacroState {
+  mutable llvm::PointerUnion<MacroDirective *, FullModuleMacroInfo *> State;
+
+  FullModuleMacroInfo *
+  getFullModuleInfo(ExternalPreprocessorSource &ExternalSource,
+                    llvm::BumpPtrAllocator &Allocator, const IdentifierInfo &II,
+                    PPReferences PPRefs) const;
+
+public:
+  MacroState() : MacroState(nullptr) {}
+  MacroState(MacroDirective *MD) : State(MD) {}
+
+  MacroState(MacroState &&O) noexcept : State(O.State) {
+    O.State = (MacroDirective *)nullptr;
+  }
+
+  MacroState &operator=(MacroState &&O) noexcept {
+    auto S = O.State;
+    O.State = (MacroDirective *)nullptr;
+    State = S;
+    return *this;
+  }
+
+  ~MacroState() {
+    if (auto *Info = llvm::dyn_cast_if_present<FullModuleMacroInfo *>(State))
+      Info->~FullModuleMacroInfo();
+  }
+
+  MacroDirective *getLatest() const {
+    if (auto *Info = llvm::dyn_cast_if_present<FullModuleMacroInfo *>(State))
+      return Info->MD;
+    return cast<MacroDirective *>(State);
+  }
+
+  void setLatest(MacroDirective *MD) {
+    if (auto *Info = llvm::dyn_cast_if_present<FullModuleMacroInfo *>(State))
+      Info->MD = MD;
+    else
+      State = MD;
+  }
+
+  ModuleMacroInfo getModuleInfo(ExternalPreprocessorSource &ExternalSource,
+                                llvm::BumpPtrAllocator &Allocator,
+                                const IdentifierInfo &II,
+                                PPReferences PPRefs) const {
+    if (auto *Info = getFullModuleInfo(ExternalSource, Allocator, II, PPRefs))
+      return ModuleMacroInfo{Info->ActiveModuleMacros, Info->IsAmbiguous};
+    return {};
+  }
+
+  MacroDirective::DefInfo findDirectiveAtLoc(SourceLocation Loc,
+                                             SourceManager &SourceMgr) const {
+    // FIXME: Incorporate module macros into the result of this.
+    if (auto *Latest = getLatest())
+      return Latest->findDirectiveAtLoc(Loc, SourceMgr);
+    return {};
+  }
+
+  void overrideActiveModuleMacros(ExternalPreprocessorSource &ExternalSource,
+                                  llvm::BumpPtrAllocator &Allocator,
+                                  const IdentifierInfo &II,
+                                  PPReferences PPRefs) const {
+    if (auto *Info = getFullModuleInfo(ExternalSource, Allocator, II, PPRefs)) {
+      Info->OverriddenMacros.insert(Info->OverriddenMacros.end(),
+                                    Info->ActiveModuleMacros.begin(),
+                                    Info->ActiveModuleMacros.end());
+      Info->ActiveModuleMacros.clear();
+      Info->IsAmbiguous = false;
+    }
+  }
+
+  ArrayRef<ModuleMacro *> getOverriddenMacros() const {
+    if (auto *Info = llvm::dyn_cast_if_present<FullModuleMacroInfo *>(State))
+      return Info->OverriddenMacros;
+    return {};
+  }
+
+  void setOverriddenMacros(llvm::BumpPtrAllocator &allocator,
+                           ArrayRef<ModuleMacro *> Overrides) {
+    auto *Info = llvm::dyn_cast_if_present<FullModuleMacroInfo *>(State);
+    if (!Info) {
+      if (Overrides.empty())
+        return;
+      Info = new (allocator)
+          FullModuleMacroInfo(llvm::cast<MacroDirective *>(State));
+      State = Info;
+    }
+    Info->OverriddenMacros.clear();
+    Info->OverriddenMacros.insert(Info->OverriddenMacros.end(),
+                                  Overrides.begin(), Overrides.end());
+    Info->ActiveModuleMacrosGeneration = 0;
+  }
+};
+
+} // namespace clang
+
+#endif // LLVM_CLANG_LEX_MACROSTATE_H

--- a/clang/include/clang/Lex/MacroState.h
+++ b/clang/include/clang/Lex/MacroState.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_LEX_MACROSTATE_H
 
 #include "clang/Lex/MacroInfo.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Allocator.h"

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -26,6 +26,7 @@
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Lex/MacroInfo.h"
+#include "clang/Lex/MacroState.h"
 #include "clang/Lex/ModuleLoader.h"
 #include "clang/Lex/ModuleMap.h"
 #include "clang/Lex/PPCallbacks.h"
@@ -873,137 +874,6 @@ private:
   };
   SmallVector<MacroExpandsInfo, 2> DelayedMacroExpandsCallbacks;
 
-  /// Information about a name that has been used to define a module macro.
-  struct FullModuleMacroInfo {
-    /// The most recent macro directive for this identifier.
-    MacroDirective *MD;
-
-    /// The active module macros for this identifier.
-    llvm::TinyPtrVector<ModuleMacro *> ActiveModuleMacros;
-
-    /// The generation number at which we last updated ActiveModuleMacros.
-    /// \see Preprocessor::VisibleModules.
-    unsigned ActiveModuleMacrosGeneration = 0;
-
-    /// Whether this macro name is ambiguous.
-    bool IsAmbiguous = false;
-
-    /// The module macros that are overridden by this macro.
-    llvm::TinyPtrVector<ModuleMacro *> OverriddenMacros;
-
-    FullModuleMacroInfo(MacroDirective *MD) : MD(MD) {}
-  };
-
-  /// The state of a macro for an identifier.
-  class MacroState {
-    mutable llvm::PointerUnion<MacroDirective *, FullModuleMacroInfo *> State;
-
-    FullModuleMacroInfo *getFullModuleInfo(Preprocessor &PP,
-                                           const IdentifierInfo *II) const {
-      if (II->isOutOfDate())
-        PP.updateOutOfDateIdentifier(*II);
-      // FIXME: Find a spare bit on IdentifierInfo and store a
-      //        HasModuleMacros flag.
-      if (!II->hasMacroDefinition() ||
-          (!PP.getLangOpts().Modules &&
-           !PP.getLangOpts().ModulesLocalVisibility) ||
-          !PP.CurSubmoduleState->VisibleModules.getGeneration())
-        return nullptr;
-
-      auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State);
-      if (!Info) {
-        Info = new (PP.getPreprocessorAllocator())
-            FullModuleMacroInfo(cast<MacroDirective *>(State));
-        State = Info;
-      }
-
-      if (PP.CurSubmoduleState->VisibleModules.getGeneration() !=
-          Info->ActiveModuleMacrosGeneration)
-        PP.updateModuleMacroInfo(II, *Info);
-      return Info;
-    }
-
-  public:
-    MacroState() : MacroState(nullptr) {}
-    MacroState(MacroDirective *MD) : State(MD) {}
-
-    MacroState(MacroState &&O) noexcept : State(O.State) {
-      O.State = (MacroDirective *)nullptr;
-    }
-
-    MacroState &operator=(MacroState &&O) noexcept {
-      auto S = O.State;
-      O.State = (MacroDirective *)nullptr;
-      State = S;
-      return *this;
-    }
-
-    ~MacroState() {
-      if (auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State))
-        Info->~FullModuleMacroInfo();
-    }
-
-    MacroDirective *getLatest() const {
-      if (auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State))
-        return Info->MD;
-      return cast<MacroDirective *>(State);
-    }
-
-    void setLatest(MacroDirective *MD) {
-      if (auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State))
-        Info->MD = MD;
-      else
-        State = MD;
-    }
-
-    ModuleMacroInfo getModuleInfo(Preprocessor &PP,
-                                  const IdentifierInfo *II) const {
-      if (auto *Info = getFullModuleInfo(PP, II))
-        return ModuleMacroInfo{Info->ActiveModuleMacros, Info->IsAmbiguous};
-      return {};
-    }
-
-    MacroDirective::DefInfo findDirectiveAtLoc(SourceLocation Loc,
-                                               SourceManager &SourceMgr) const {
-      // FIXME: Incorporate module macros into the result of this.
-      if (auto *Latest = getLatest())
-        return Latest->findDirectiveAtLoc(Loc, SourceMgr);
-      return {};
-    }
-
-    void overrideActiveModuleMacros(Preprocessor &PP, IdentifierInfo *II) {
-      if (auto *Info = getFullModuleInfo(PP, II)) {
-        Info->OverriddenMacros.insert(Info->OverriddenMacros.end(),
-                                      Info->ActiveModuleMacros.begin(),
-                                      Info->ActiveModuleMacros.end());
-        Info->ActiveModuleMacros.clear();
-        Info->IsAmbiguous = false;
-      }
-    }
-
-    ArrayRef<ModuleMacro*> getOverriddenMacros() const {
-      if (auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State))
-        return Info->OverriddenMacros;
-      return {};
-    }
-
-    void setOverriddenMacros(Preprocessor &PP,
-                             ArrayRef<ModuleMacro *> Overrides) {
-      auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State);
-      if (!Info) {
-        if (Overrides.empty())
-          return;
-        Info = new (PP.getPreprocessorAllocator())
-            FullModuleMacroInfo(cast<MacroDirective *>(State));
-        State = Info;
-      }
-      Info->OverriddenMacros.clear();
-      Info->OverriddenMacros.insert(Info->OverriddenMacros.end(),
-                                    Overrides.begin(), Overrides.end());
-      Info->ActiveModuleMacrosGeneration = 0;
-    }
-  };
-
   /// For each IdentifierInfo that was associated with a macro, we
   /// keep a mapping to the history of all macro definitions and #undefs in
   /// the reverse order (the latest one is in the head of the list).
@@ -1074,8 +944,7 @@ private:
 
   /// The list of module macros, for each identifier, that are not overridden by
   /// any other module macro.
-  llvm::DenseMap<const IdentifierInfo *, llvm::TinyPtrVector<ModuleMacro *>>
-      LeafModuleMacros;
+  LeafModuleMacrosMap LeafModuleMacros;
 
   /// Macros that we want to warn because they are not used at the end
   /// of the translation unit.
@@ -1215,6 +1084,14 @@ private:
   llvm::DenseMap<const char *, unsigned> RecordedSkippedRanges;
 
   void updateOutOfDateIdentifier(const IdentifierInfo &II) const;
+
+  ModuleMacroInfo getModuleInfo(const MacroState &MS,
+                                const IdentifierInfo &II) {
+    return MS.getModuleInfo(*ExternalSource, BP, II,
+                            PPReferences{CurSubmoduleState->VisibleModules,
+                                         LeafModuleMacros, SourceMgr,
+                                         LangOpts});
+  }
 
 public:
   Preprocessor(const PreprocessorOptions &PPOpts, DiagnosticsEngine &diags,
@@ -1418,7 +1295,7 @@ public:
     while (isa_and_nonnull<VisibilityMacroDirective>(MD))
       MD = MD->getPrevious();
     return MacroDefinition(dyn_cast_or_null<DefMacroDirective>(MD),
-                           S.getModuleInfo(*this, II));
+                           getModuleInfo(S, *II));
   }
 
   MacroDefinition getMacroDefinitionAtLoc(const IdentifierInfo *II,
@@ -1431,7 +1308,7 @@ public:
     if (auto *MD = S.getLatest())
       DI = MD->findDirectiveAtLoc(Loc, getSourceManager());
     // FIXME: Compute the set of active module macros at the specified location.
-    return MacroDefinition(DI.getDirective(), S.getModuleInfo(*this, II));
+    return MacroDefinition(DI.getDirective(), getModuleInfo(S, *II));
   }
 
   /// Given an identifier, return its latest non-imported MacroDirective
@@ -2608,11 +2485,6 @@ private:
   /// Determine whether we need to create module macros for #defines in the
   /// current context.
   bool needModuleMacros() const;
-
-  /// Update the set of active module macros and ambiguity flag for a module
-  /// macro name.
-  void updateModuleMacroInfo(const IdentifierInfo *II,
-                             FullModuleMacroInfo &Info);
 
   DefMacroDirective *AllocateDefMacroDirective(MacroInfo *MI,
                                                SourceLocation Loc);

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1706,7 +1706,8 @@ static void checkConfigMacro(Preprocessor &PP, StringRef ConfigMacro,
     PP.Diag(CurrentDefinition->getDefinitionLoc(),
             diag::note_module_def_undef_here)
       << false;
-  } else if (!CurrentDefinition->isIdenticalTo(*CmdLineDefinition, PP,
+  } else if (!CurrentDefinition->isIdenticalTo(*CmdLineDefinition, SourceMgr,
+                                               PP.getLangOpts(),
                                                /*Syntactically=*/true)) {
     // The macro definitions differ.
     PP.Diag(ImportLoc, diag::warn_module_config_macro_undef)

--- a/clang/lib/Lex/CMakeLists.txt
+++ b/clang/lib/Lex/CMakeLists.txt
@@ -15,6 +15,7 @@ add_clang_library(clangLex
   LiteralSupport.cpp
   MacroArgs.cpp
   MacroInfo.cpp
+  MacroState.cpp
   ModuleMap.cpp
   ModuleMapFile.cpp
   PPCaching.cpp

--- a/clang/lib/Lex/MacroInfo.cpp
+++ b/clang/lib/Lex/MacroInfo.cpp
@@ -86,7 +86,9 @@ unsigned MacroInfo::getDefinitionLengthSlow(const SourceManager &SM) const {
 /// if they use different identifiers for the function macro parameters.
 /// Otherwise the comparison is lexical and this implements the rules in
 /// C99 6.10.3.
-bool MacroInfo::isIdenticalTo(const MacroInfo &Other, Preprocessor &PP,
+bool MacroInfo::isIdenticalTo(const MacroInfo &Other,
+                              const SourceManager &SourceMgr,
+                              const LangOptions &LangOpts,
                               bool Syntactically) const {
   bool Lexically = !Syntactically;
 
@@ -136,8 +138,11 @@ bool MacroInfo::isIdenticalTo(const MacroInfo &Other, Preprocessor &PP,
       continue;
     }
 
+    auto getSpelling = [&](const Token &token) {
+      return Lexer::getSpelling(token, SourceMgr, LangOpts);
+    };
     // Otherwise, check the spelling.
-    if (PP.getSpelling(A) != PP.getSpelling(B))
+    if (getSpelling(A) != getSpelling(B))
       return false;
   }
 

--- a/clang/lib/Lex/MacroState.cpp
+++ b/clang/lib/Lex/MacroState.cpp
@@ -1,0 +1,120 @@
+#include "clang/Lex/MacroState.h"
+
+#include "clang/Basic/IdentifierTable.h"
+#include "clang/Basic/LangOptions.h"
+#include "clang/Basic/Module.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Lex/ExternalPreprocessorSource.h"
+#include "clang/Lex/MacroInfo.h"
+
+namespace clang {
+
+/// Update the set of active module macros and ambiguity flag for a module
+/// macro name.
+static void updateModuleMacroInfo(const IdentifierInfo &II,
+                                  FullModuleMacroInfo &Info,
+                                  PPReferences PPRefs) {
+  assert(Info.ActiveModuleMacrosGeneration !=
+             PPRefs.VisibleModules.getGeneration() &&
+         "don't need to update this macro name info");
+  Info.ActiveModuleMacrosGeneration = PPRefs.VisibleModules.getGeneration();
+
+  auto Leaf = PPRefs.LeafModuleMacros.find(&II);
+  if (Leaf == PPRefs.LeafModuleMacros.end()) {
+    // No imported macros at all: nothing to do.
+    return;
+  }
+
+  Info.ActiveModuleMacros.clear();
+
+  // Every macro that's locally overridden is overridden by a visible macro.
+  llvm::DenseMap<ModuleMacro *, int> NumHiddenOverrides;
+  for (auto *O : Info.OverriddenMacros)
+    NumHiddenOverrides[O] = -1;
+
+  // Collect all macros that are not overridden by a visible macro.
+  llvm::SmallVector<ModuleMacro *, 16> Worklist;
+  for (auto *LeafMM : Leaf->second) {
+    assert(LeafMM->getNumOverridingMacros() == 0 && "leaf macro overridden");
+    if (NumHiddenOverrides.lookup(LeafMM) == 0)
+      Worklist.push_back(LeafMM);
+  }
+  while (!Worklist.empty()) {
+    auto *MM = Worklist.pop_back_val();
+    if (PPRefs.VisibleModules.isVisible(MM->getOwningModule())) {
+      // We only care about collecting definitions; undefinitions only act
+      // to override other definitions.
+      if (MM->getMacroInfo())
+        Info.ActiveModuleMacros.push_back(MM);
+    } else {
+      for (auto *O : MM->overrides())
+        if ((unsigned)++NumHiddenOverrides[O] == O->getNumOverridingMacros())
+          Worklist.push_back(O);
+    }
+  }
+  // Our reverse postorder walk found the macros in reverse order.
+  std::reverse(Info.ActiveModuleMacros.begin(), Info.ActiveModuleMacros.end());
+
+  // Determine whether the macro name is ambiguous.
+  MacroInfo *MI = nullptr;
+  bool IsSystemMacro = true;
+  bool IsAmbiguous = false;
+  if (auto *MD = Info.MD) {
+    while (isa_and_nonnull<VisibilityMacroDirective>(MD))
+      MD = MD->getPrevious();
+    if (auto *DMD = dyn_cast_or_null<DefMacroDirective>(MD)) {
+      MI = DMD->getInfo();
+      IsSystemMacro &= PPRefs.SourceMgr.isInSystemHeader(DMD->getLocation());
+    }
+  }
+  for (auto *Active : Info.ActiveModuleMacros) {
+    auto *NewMI = Active->getMacroInfo();
+
+    // Before marking the macro as ambiguous, check if this is a case where
+    // both macros are in system headers. If so, we trust that the system
+    // did not get it wrong. This also handles cases where Clang's own
+    // headers have a different spelling of certain system macros:
+    //   #define LONG_MAX __LONG_MAX__ (clang's limits.h)
+    //   #define LONG_MAX 0x7fffffffffffffffL (system's limits.h)
+    //
+    // FIXME: Remove the defined-in-system-headers check. clang's limits.h
+    // overrides the system limits.h's macros, so there's no conflict here.
+    if (MI && NewMI != MI &&
+        !MI->isIdenticalTo(*NewMI, PPRefs.SourceMgr, PPRefs.LangOpts,
+                           /*Syntactically=*/true))
+      IsAmbiguous = true;
+    IsSystemMacro &=
+        Active->getOwningModule()->IsSystem ||
+        PPRefs.SourceMgr.isInSystemHeader(NewMI->getDefinitionLoc());
+    MI = NewMI;
+  }
+  Info.IsAmbiguous = IsAmbiguous && !IsSystemMacro;
+}
+
+FullModuleMacroInfo *
+MacroState::getFullModuleInfo(ExternalPreprocessorSource &ExternalSource,
+                              llvm::BumpPtrAllocator &Allocator,
+                              const IdentifierInfo &II,
+                              PPReferences PPRefs) const {
+  if (II.isOutOfDate())
+    ExternalSource.updateOutOfDateIdentifier(II);
+  // FIXME: Find a spare bit on IdentifierInfo and store a
+  //        HasModuleMacros flag.
+  if (!II.hasMacroDefinition() ||
+      (!PPRefs.LangOpts.Modules && !PPRefs.LangOpts.ModulesLocalVisibility) ||
+      !PPRefs.VisibleModules.getGeneration())
+    return nullptr;
+
+  auto *Info = dyn_cast_if_present<FullModuleMacroInfo *>(State);
+  if (!Info) {
+    Info = new (Allocator) FullModuleMacroInfo(cast<MacroDirective *>(State));
+    State = Info;
+  }
+
+  if (PPRefs.VisibleModules.getGeneration() !=
+      Info->ActiveModuleMacrosGeneration)
+    updateModuleMacroInfo(II, *Info, PPRefs);
+  return Info;
+}
+
+} // namespace clang

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -3349,8 +3349,8 @@ void Preprocessor::HandleDefineDirective(
   // When skipping just warn about macros that do not match.
   if (SkippingUntilPCHThroughHeader) {
     const MacroInfo *OtherMI = getMacroInfo(MacroNameTok.getIdentifierInfo());
-    if (!OtherMI || !MI->isIdenticalTo(*OtherMI, *this,
-                             /*Syntactic=*/LangOpts.MicrosoftExt))
+    if (!OtherMI || !MI->isIdenticalTo(*OtherMI, SourceMgr, LangOpts,
+                                       /*Syntactic=*/LangOpts.MicrosoftExt))
       Diag(MI->getDefinitionLoc(), diag::warn_pp_macro_def_mismatch_with_pch)
           << MacroNameTok.getIdentifierInfo();
     // Issue the diagnostic but allow the change if msvc extensions are enabled
@@ -3377,7 +3377,7 @@ void Preprocessor::HandleDefineDirective(
       // Warn if it changes the tokens.
       if ((!getDiagnostics().getSuppressSystemWarnings() ||
            !SourceMgr.isInSystemHeader(DefineTok.getLocation())) &&
-          !MI->isIdenticalTo(*OtherMI, *this,
+          !MI->isIdenticalTo(*OtherMI, SourceMgr, LangOpts,
                              /*Syntactic=*/LangOpts.MicrosoftExt)) {
         Diag(MI->getDefinitionLoc(), diag::warn_pp_objc_macro_redef_ignored);
       }
@@ -3401,7 +3401,8 @@ void Preprocessor::HandleDefineDirective(
       // Macros must be identical.  This means all tokens and whitespace
       // separation must be the same.  C99 6.10.3p2.
       else if (!OtherMI->isAllowRedefinitionsWithoutWarning() &&
-               !MI->isIdenticalTo(*OtherMI, *this, /*Syntactic=*/LangOpts.MicrosoftExt)) {
+               !MI->isIdenticalTo(*OtherMI, SourceMgr, LangOpts,
+                                  /*Syntactic=*/LangOpts.MicrosoftExt)) {
         Diag(MI->getDefinitionLoc(), diag::ext_pp_macro_redef)
           << MacroNameTok.getIdentifierInfo();
         Diag(OtherMI->getDefinitionLoc(), diag::note_previous_definition);

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -737,7 +737,8 @@ void Preprocessor::EnterSubmodule(Module *M, SourceLocation ImportLoc,
         continue;
 
       MacroState MS(Macro.second.getLatest());
-      MS.setOverriddenMacros(*this, Macro.second.getOverriddenMacros());
+      MS.setOverriddenMacros(getPreprocessorAllocator(),
+                             Macro.second.getOverriddenMacros());
       State.Macros.insert(std::make_pair(Macro.first, std::move(MS)));
     }
   }
@@ -860,7 +861,7 @@ Module *Preprocessor::LeaveSubmodule(bool ForPragma) {
           // This macro is exposed to the rest of this compilation as a
           // ModuleMacro; we don't need to track its MacroDirective any more.
           Macro.setLatest(nullptr);
-          Macro.setOverriddenMacros(*this, {});
+          Macro.setOverriddenMacros(getPreprocessorAllocator(), {});
         }
         break;
       }

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -74,7 +74,10 @@ void Preprocessor::appendMacroDirective(IdentifierInfo *II, MacroDirective *MD){
   auto *OldMD = StoredMD.getLatest();
   MD->setPrevious(OldMD);
   StoredMD.setLatest(MD);
-  StoredMD.overrideActiveModuleMacros(*this, II);
+  StoredMD.overrideActiveModuleMacros(
+      *ExternalSource, BP, *II,
+      PPReferences{CurSubmoduleState->VisibleModules, LeafModuleMacros,
+                   SourceMgr, LangOpts});
 
   if (needModuleMacros()) {
     // Track that we created a new macro directive, so we know we should
@@ -175,84 +178,6 @@ ModuleMacro *Preprocessor::getModuleMacro(Module *Mod,
   return ModuleMacros.FindNodeOrInsertPos(ID, InsertPos);
 }
 
-void Preprocessor::updateModuleMacroInfo(const IdentifierInfo *II,
-                                         FullModuleMacroInfo &Info) {
-  assert(Info.ActiveModuleMacrosGeneration !=
-             CurSubmoduleState->VisibleModules.getGeneration() &&
-         "don't need to update this macro name info");
-  Info.ActiveModuleMacrosGeneration =
-      CurSubmoduleState->VisibleModules.getGeneration();
-
-  auto Leaf = LeafModuleMacros.find(II);
-  if (Leaf == LeafModuleMacros.end()) {
-    // No imported macros at all: nothing to do.
-    return;
-  }
-
-  Info.ActiveModuleMacros.clear();
-
-  // Every macro that's locally overridden is overridden by a visible macro.
-  llvm::DenseMap<ModuleMacro *, int> NumHiddenOverrides;
-  for (auto *O : Info.OverriddenMacros)
-    NumHiddenOverrides[O] = -1;
-
-  // Collect all macros that are not overridden by a visible macro.
-  llvm::SmallVector<ModuleMacro *, 16> Worklist;
-  for (auto *LeafMM : Leaf->second) {
-    assert(LeafMM->getNumOverridingMacros() == 0 && "leaf macro overridden");
-    if (NumHiddenOverrides.lookup(LeafMM) == 0)
-      Worklist.push_back(LeafMM);
-  }
-  while (!Worklist.empty()) {
-    auto *MM = Worklist.pop_back_val();
-    if (CurSubmoduleState->VisibleModules.isVisible(MM->getOwningModule())) {
-      // We only care about collecting definitions; undefinitions only act
-      // to override other definitions.
-      if (MM->getMacroInfo())
-        Info.ActiveModuleMacros.push_back(MM);
-    } else {
-      for (auto *O : MM->overrides())
-        if ((unsigned)++NumHiddenOverrides[O] == O->getNumOverridingMacros())
-          Worklist.push_back(O);
-    }
-  }
-  // Our reverse postorder walk found the macros in reverse order.
-  std::reverse(Info.ActiveModuleMacros.begin(), Info.ActiveModuleMacros.end());
-
-  // Determine whether the macro name is ambiguous.
-  MacroInfo *MI = nullptr;
-  bool IsSystemMacro = true;
-  bool IsAmbiguous = false;
-  if (auto *MD = Info.MD) {
-    while (isa_and_nonnull<VisibilityMacroDirective>(MD))
-      MD = MD->getPrevious();
-    if (auto *DMD = dyn_cast_or_null<DefMacroDirective>(MD)) {
-      MI = DMD->getInfo();
-      IsSystemMacro &= SourceMgr.isInSystemHeader(DMD->getLocation());
-    }
-  }
-  for (auto *Active : Info.ActiveModuleMacros) {
-    auto *NewMI = Active->getMacroInfo();
-
-    // Before marking the macro as ambiguous, check if this is a case where
-    // both macros are in system headers. If so, we trust that the system
-    // did not get it wrong. This also handles cases where Clang's own
-    // headers have a different spelling of certain system macros:
-    //   #define LONG_MAX __LONG_MAX__ (clang's limits.h)
-    //   #define LONG_MAX 0x7fffffffffffffffL (system's limits.h)
-    //
-    // FIXME: Remove the defined-in-system-headers check. clang's limits.h
-    // overrides the system limits.h's macros, so there's no conflict here.
-    if (MI && NewMI != MI &&
-        !MI->isIdenticalTo(*NewMI, *this, /*Syntactically=*/true))
-      IsAmbiguous = true;
-    IsSystemMacro &= Active->getOwningModule()->IsSystem ||
-                     SourceMgr.isInSystemHeader(NewMI->getDefinitionLoc());
-    MI = NewMI;
-  }
-  Info.IsAmbiguous = IsAmbiguous && !IsSystemMacro;
-}
-
 void Preprocessor::dumpMacroInfo(const IdentifierInfo *II) {
   ArrayRef<ModuleMacro*> Leaf;
   auto LeafIt = LeafModuleMacros.find(II);
@@ -265,7 +190,7 @@ void Preprocessor::dumpMacroInfo(const IdentifierInfo *II) {
 
   llvm::errs() << "MacroState " << State << " " << II->getNameStart();
   const auto ModuleInfo =
-      State ? State->getModuleInfo(*this, II) : ModuleMacroInfo{};
+      State ? getModuleInfo(*State, *II) : ModuleMacroInfo{};
   if (ModuleInfo.IsAmbiguous)
     llvm::errs() << " ambiguous";
   if (State && !State->getOverriddenMacros().empty()) {


### PR DESCRIPTION
`Preprocessor` contains a map of `IdentifierInfo` to `MacroState`; this is reasonable -- the macro state is part of the overall preprocessor state. `MacroState` depends on `Preprocessor`; this is less reasonable and means that to understand `MacroState` you must first understand `Preprocessor`, but to understand `Preprocessor` you must first understand `MacroState`.

Move `MacroState` to its own file. This pulls along `FullModuleMacroInfo` since a `MacroState` is either a `MacroDirective` or a `FullModuleMacroInfo`.

Replace all `Preprocessor` parameters with only the components of `Preprocessor` that we actually need. This gives us a simpler layering where `Preprocessor` code knows about `MacroState` but `MacroState` code does not know about `Preprocessor`.

`updateModuleMacroInfo` used to be a private member function of `Preprocessor`, but its purpose is to manage `MacroState`. Instead have `MacroState` use it as an implementation detail function.

Add a new type, `PPReferences`, to bundle up references to state that `MacroState` needs as read-only other than the `IdentifierInfo` (since that's conceptually a different kind of thing).

This change also required changing `MacroInfo::isIdenticalTo` to accept the useful components of `Preprocessor` rather than the whole `Preprocessor`.