### PR TITLE
[lldb] Fix data race on shared global ProcessProperties callback

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -263,7 +263,6 @@ let Definition = "process", Path = "target.process" in {
     DefaultFalse,
     Desc<"If true, stop when a shared library is loaded or unloaded.">;
   def DisableLangRuntimeUnwindPlans: Property<"disable-language-runtime-unwindplans", "Boolean">,
-    Global,
     DefaultFalse,
     Desc<"If true, language runtime augmented/overridden backtraces will not be used when printing a stack trace.">;
   def DetachKeepsStopped: Property<"detach-keeps-stopped", "Boolean">,


### PR DESCRIPTION
ProcessProperties::ProcessProperties was installing a per-process value-changed callback on ePropertyDisableLangRuntimeUnwindPlans. The property was declared Global in TargetProperties.td, so OptionValueProperties::CreateLocalCopy shared the underlying OptionValue across every ProcessProperties. Every Process constructor therefore wrote into the same std::function slot, racing with concurrent constructors and silently clobbering any earlier Process's callback.

Found by ThreadSanitizer as part of #197792.