### PR TITLE
host-byteorder-little-endian derictaive to typedef-different-types.test

### DIFF
--- a/llvm/test/tools/dsymutil/AArch64/typedef-different-types.test
+++ b/llvm/test/tools/dsymutil/AArch64/typedef-different-types.test
@@ -1,3 +1,5 @@
+# REQUIRES: host-byteorder-little-endian
+#
 # RUN: rm -rf %t && split-file %s %t && cd %t
 #
 # RUN: yaml2obj a.yaml -o a.o


### PR DESCRIPTION
The test case introduced in https://github.com/llvm/llvm-project/pull/195749/changes#diff-d9b34bdc428ca5518742902b1226065daa6a89d3fe056e10bc29615b57aa2deb fails on AIX (https://lab.llvm.org/staging/#/builders/231/builds/610/steps/6/logs/FAIL__LLVM__typedef-different-types_test) due to AIX being big endian, add requires directive similar to https://github.com/llvm/llvm-project/issues/190481