### PR TITLE
[SimplifyCFG] Exempt same-address store from body cap in speculativelyExecuteBB

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -1757,7 +1757,7 @@ static void hoistConditionalLoadsStores(
   Value *MaskFalse = nullptr;
   Value *MaskTrue = nullptr;
   if (Invert.has_value()) {
-    IRBuilder<> Builder(Sel ? Sel : SpeculatedConditionalLoadsStores.back());
+    IRBuilder<> Builder(SpeculatedConditionalLoadsStores.back());
     Mask = Builder.CreateBitCast(
         *Invert ? Builder.CreateXor(Cond, ConstantInt::getTrue(Context)) : Cond,
         VCondTy);
@@ -3294,31 +3294,34 @@ bool SimplifyCFGOpt::speculativelyExecuteBB(CondBrInst *BI,
                                 isSafeCheapLoadStore(&I, TTI) &&
                                 SpeculatedConditionalLoadsStores.size() <
                                     HoistLoadsStoresWithCondFaultingThreshold;
+    // A store with a prior store at the same address is cheap to speculate
+    // so don't count it toward the cap.
+    bool IsMatchedStore = false;
+    if (!IsSafeCheapLoadStore && HoistCondStores && !SpeculatedStoreValue)
+      if (auto *SI = dyn_cast<StoreInst>(&I))
+        if (Value *V = isSafeToSpeculateStore(&I, BB, ThenBB, EndBB)) {
+          SpeculatedStoreValue = V;
+          SpeculatedStore = SI;
+          IsMatchedStore = true;
+        }
     // Not count load/store into cost if target supports conditional faulting
     // b/c it's cheap to speculate it.
     if (IsSafeCheapLoadStore)
       SpeculatedConditionalLoadsStores.push_back(&I);
-    else
+    else if (!IsMatchedStore)
       ++SpeculatedInstructions;
 
     if (SpeculatedInstructions > 1)
       return false;
 
     // Don't hoist the instruction if it's unsafe or expensive.
-    if (!IsSafeCheapLoadStore &&
-        !isSafeToSpeculativelyExecute(&I, BI, Options.AC) &&
-        !(HoistCondStores && !SpeculatedStoreValue &&
-          (SpeculatedStoreValue =
-               isSafeToSpeculateStore(&I, BB, ThenBB, EndBB))))
+    if (!IsSafeCheapLoadStore && !IsMatchedStore &&
+        !isSafeToSpeculativelyExecute(&I, BI, Options.AC))
       return false;
     if (!IsSafeCheapLoadStore && !SpeculatedStoreValue &&
         computeSpeculationCost(&I, TTI) >
             PHINodeFoldingThreshold * TargetTransformInfo::TCC_Basic)
       return false;
-
-    // Store the store speculation candidate.
-    if (!SpeculatedStore && SpeculatedStoreValue)
-      SpeculatedStore = cast<StoreInst>(&I);
 
     // Do not hoist the instruction if any of its operands are defined but not
     // used in BB. The transformation will prevent the operand from
@@ -3356,9 +3359,41 @@ bool SimplifyCFGOpt::speculativelyExecuteBB(CondBrInst *BI,
   LLVM_DEBUG(dbgs() << "SPECULATIVELY EXECUTING BB" << *ThenBB << "\n";);
 
   Instruction *Sel = nullptr;
+
+  // Metadata can be dependent on the condition we are hoisting above.
+  // Strip all UB-implying metadata on the instruction. Drop the debug loc
+  // to avoid making it appear as if the condition is a constant, which would
+  // be misleading while debugging.
+  // Similarly strip attributes that maybe dependent on condition we are
+  // hoisting above.
+  for (auto &I : make_early_inc_range(*ThenBB)) {
+    if (!SpeculatedStoreValue || &I != SpeculatedStore) {
+      I.dropLocation();
+    }
+    I.dropUBImplyingAttrsAndMetadata();
+
+    // Drop ephemeral values.
+    if (EphTracker.contains(&I)) {
+      I.replaceAllUsesWith(PoisonValue::get(I.getType()));
+      I.eraseFromParent();
+    }
+  }
+
+  // Hoist the instructions.
+  // Drop DbgVariableRecords attached to these instructions.
+  for (auto &It : *ThenBB)
+    for (DbgRecord &DR : make_early_inc_range(It.getDbgRecordRange()))
+      // Drop all records except assign-kind DbgVariableRecords (dbg.assign
+      // equivalent).
+      if (DbgVariableRecord *DVR = dyn_cast<DbgVariableRecord>(&DR);
+          !DVR || !DVR->isDbgAssign())
+        It.dropOneDbgRecord(&DR);
+  BB->splice(BI->getIterator(), ThenBB, ThenBB->begin(),
+             std::prev(ThenBB->end()));
+
   // Insert a select of the value of the speculated store.
   if (SpeculatedStoreValue) {
-    IRBuilder<NoFolder> Builder(BI);
+    IRBuilder<NoFolder> Builder(SpeculatedStore);
     Value *OrigV = SpeculatedStore->getValueOperand();
     Value *TrueV = SpeculatedStore->getValueOperand();
     Value *FalseV = SpeculatedStoreValue;
@@ -3400,37 +3435,6 @@ bool SimplifyCFGOpt::speculativelyExecuteBB(CondBrInst *BI,
       if (llvm::is_contained(DbgAssign->location_ops(), OrigV))
         DbgAssign->replaceVariableLocationOp(OrigV, S);
   }
-
-  // Metadata can be dependent on the condition we are hoisting above.
-  // Strip all UB-implying metadata on the instruction. Drop the debug loc
-  // to avoid making it appear as if the condition is a constant, which would
-  // be misleading while debugging.
-  // Similarly strip attributes that maybe dependent on condition we are
-  // hoisting above.
-  for (auto &I : make_early_inc_range(*ThenBB)) {
-    if (!SpeculatedStoreValue || &I != SpeculatedStore) {
-      I.dropLocation();
-    }
-    I.dropUBImplyingAttrsAndMetadata();
-
-    // Drop ephemeral values.
-    if (EphTracker.contains(&I)) {
-      I.replaceAllUsesWith(PoisonValue::get(I.getType()));
-      I.eraseFromParent();
-    }
-  }
-
-  // Hoist the instructions.
-  // Drop DbgVariableRecords attached to these instructions.
-  for (auto &It : *ThenBB)
-    for (DbgRecord &DR : make_early_inc_range(It.getDbgRecordRange()))
-      // Drop all records except assign-kind DbgVariableRecords (dbg.assign
-      // equivalent).
-      if (DbgVariableRecord *DVR = dyn_cast<DbgVariableRecord>(&DR);
-          !DVR || !DVR->isDbgAssign())
-        It.dropOneDbgRecord(&DR);
-  BB->splice(BI->getIterator(), ThenBB, ThenBB->begin(),
-             std::prev(ThenBB->end()));
 
   if (!SpeculatedConditionalLoadsStores.empty())
     hoistConditionalLoadsStores(BI, SpeculatedConditionalLoadsStores, Invert,

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -1744,7 +1744,7 @@ static void hoistConditionalLoadsStores(
   Value *MaskFalse = nullptr;
   Value *MaskTrue = nullptr;
   if (Invert.has_value()) {
-    IRBuilder<> Builder(Sel ? Sel : SpeculatedConditionalLoadsStores.back());
+    IRBuilder<> Builder(SpeculatedConditionalLoadsStores.back());
     Mask = Builder.CreateBitCast(
         *Invert ? Builder.CreateXor(Cond, ConstantInt::getTrue(Context)) : Cond,
         VCondTy);
@@ -3266,31 +3266,34 @@ bool SimplifyCFGOpt::speculativelyExecuteBB(CondBrInst *BI,
                                 isSafeCheapLoadStore(&I, TTI) &&
                                 SpeculatedConditionalLoadsStores.size() <
                                     HoistLoadsStoresWithCondFaultingThreshold;
+    // A store with a prior store at the same address is cheap to speculate
+    // so don't count it toward the cap.
+    bool IsMatchedStore = false;
+    if (!IsSafeCheapLoadStore && HoistCondStores && !SpeculatedStoreValue)
+      if (auto *SI = dyn_cast<StoreInst>(&I))
+        if (Value *V = isSafeToSpeculateStore(&I, BB, ThenBB, EndBB)) {
+          SpeculatedStoreValue = V;
+          SpeculatedStore = SI;
+          IsMatchedStore = true;
+        }
     // Not count load/store into cost if target supports conditional faulting
     // b/c it's cheap to speculate it.
     if (IsSafeCheapLoadStore)
       SpeculatedConditionalLoadsStores.push_back(&I);
-    else
+    else if (!IsMatchedStore)
       ++SpeculatedInstructions;
 
     if (SpeculatedInstructions > 1)
       return false;
 
     // Don't hoist the instruction if it's unsafe or expensive.
-    if (!IsSafeCheapLoadStore &&
-        !isSafeToSpeculativelyExecute(&I, BI, Options.AC) &&
-        !(HoistCondStores && !SpeculatedStoreValue &&
-          (SpeculatedStoreValue =
-               isSafeToSpeculateStore(&I, BB, ThenBB, EndBB))))
+    if (!IsSafeCheapLoadStore && !IsMatchedStore &&
+        !isSafeToSpeculativelyExecute(&I, BI, Options.AC))
       return false;
     if (!IsSafeCheapLoadStore && !SpeculatedStoreValue &&
         computeSpeculationCost(&I, TTI) >
             PHINodeFoldingThreshold * TargetTransformInfo::TCC_Basic)
       return false;
-
-    // Store the store speculation candidate.
-    if (!SpeculatedStore && SpeculatedStoreValue)
-      SpeculatedStore = cast<StoreInst>(&I);
 
     // Do not hoist the instruction if any of its operands are defined but not
     // used in BB. The transformation will prevent the operand from
@@ -3328,9 +3331,41 @@ bool SimplifyCFGOpt::speculativelyExecuteBB(CondBrInst *BI,
   LLVM_DEBUG(dbgs() << "SPECULATIVELY EXECUTING BB" << *ThenBB << "\n";);
 
   Instruction *Sel = nullptr;
+
+  // Metadata can be dependent on the condition we are hoisting above.
+  // Strip all UB-implying metadata on the instruction. Drop the debug loc
+  // to avoid making it appear as if the condition is a constant, which would
+  // be misleading while debugging.
+  // Similarly strip attributes that maybe dependent on condition we are
+  // hoisting above.
+  for (auto &I : make_early_inc_range(*ThenBB)) {
+    if (!SpeculatedStoreValue || &I != SpeculatedStore) {
+      I.dropLocation();
+    }
+    I.dropUBImplyingAttrsAndMetadata();
+
+    // Drop ephemeral values.
+    if (EphTracker.contains(&I)) {
+      I.replaceAllUsesWith(PoisonValue::get(I.getType()));
+      I.eraseFromParent();
+    }
+  }
+
+  // Hoist the instructions.
+  // Drop DbgVariableRecords attached to these instructions.
+  for (auto &It : *ThenBB)
+    for (DbgRecord &DR : make_early_inc_range(It.getDbgRecordRange()))
+      // Drop all records except assign-kind DbgVariableRecords (dbg.assign
+      // equivalent).
+      if (DbgVariableRecord *DVR = dyn_cast<DbgVariableRecord>(&DR);
+          !DVR || !DVR->isDbgAssign())
+        It.dropOneDbgRecord(&DR);
+  BB->splice(BI->getIterator(), ThenBB, ThenBB->begin(),
+             std::prev(ThenBB->end()));
+
   // Insert a select of the value of the speculated store.
   if (SpeculatedStoreValue) {
-    IRBuilder<NoFolder> Builder(BI);
+    IRBuilder<NoFolder> Builder(SpeculatedStore);
     Value *OrigV = SpeculatedStore->getValueOperand();
     Value *TrueV = SpeculatedStore->getValueOperand();
     Value *FalseV = SpeculatedStoreValue;
@@ -3372,37 +3407,6 @@ bool SimplifyCFGOpt::speculativelyExecuteBB(CondBrInst *BI,
       if (llvm::is_contained(DbgAssign->location_ops(), OrigV))
         DbgAssign->replaceVariableLocationOp(OrigV, S);
   }
-
-  // Metadata can be dependent on the condition we are hoisting above.
-  // Strip all UB-implying metadata on the instruction. Drop the debug loc
-  // to avoid making it appear as if the condition is a constant, which would
-  // be misleading while debugging.
-  // Similarly strip attributes that maybe dependent on condition we are
-  // hoisting above.
-  for (auto &I : make_early_inc_range(*ThenBB)) {
-    if (!SpeculatedStoreValue || &I != SpeculatedStore) {
-      I.dropLocation();
-    }
-    I.dropUBImplyingAttrsAndMetadata();
-
-    // Drop ephemeral values.
-    if (EphTracker.contains(&I)) {
-      I.replaceAllUsesWith(PoisonValue::get(I.getType()));
-      I.eraseFromParent();
-    }
-  }
-
-  // Hoist the instructions.
-  // Drop DbgVariableRecords attached to these instructions.
-  for (auto &It : *ThenBB)
-    for (DbgRecord &DR : make_early_inc_range(It.getDbgRecordRange()))
-      // Drop all records except assign-kind DbgVariableRecords (dbg.assign
-      // equivalent).
-      if (DbgVariableRecord *DVR = dyn_cast<DbgVariableRecord>(&DR);
-          !DVR || !DVR->isDbgAssign())
-        It.dropOneDbgRecord(&DR);
-  BB->splice(BI->getIterator(), ThenBB, ThenBB->begin(),
-             std::prev(ThenBB->end()));
 
   if (!SpeculatedConditionalLoadsStores.empty())
     hoistConditionalLoadsStores(BI, SpeculatedConditionalLoadsStores, Invert,

--- a/llvm/test/CodeGen/AArch64/addsub.ll
+++ b/llvm/test/CodeGen/AArch64/addsub.ll
@@ -227,64 +227,61 @@ define void @testing(ptr %var_i32, ptr %var2_i32) {
 ; CHECK-SD:       // %bb.0:
 ; CHECK-SD-NEXT:    ldr w8, [x0]
 ; CHECK-SD-NEXT:    cmp w8, #4095
-; CHECK-SD-NEXT:    b.ne .LBB20_6
+; CHECK-SD-NEXT:    b.ne .LBB20_5
 ; CHECK-SD-NEXT:  // %bb.1: // %test2
 ; CHECK-SD-NEXT:    ldr w9, [x1]
 ; CHECK-SD-NEXT:    add w10, w8, #1
 ; CHECK-SD-NEXT:    str w10, [x0]
 ; CHECK-SD-NEXT:    cmp w9, #3567, lsl #12 // =14610432
-; CHECK-SD-NEXT:    b.lo .LBB20_6
+; CHECK-SD-NEXT:    b.lo .LBB20_5
 ; CHECK-SD-NEXT:  // %bb.2: // %test3
 ; CHECK-SD-NEXT:    add w10, w8, #2
 ; CHECK-SD-NEXT:    cmp w8, #123
 ; CHECK-SD-NEXT:    str w10, [x0]
-; CHECK-SD-NEXT:    b.lt .LBB20_6
+; CHECK-SD-NEXT:    b.lt .LBB20_5
 ; CHECK-SD-NEXT:  // %bb.3: // %test4
 ; CHECK-SD-NEXT:    add w10, w8, #3
 ; CHECK-SD-NEXT:    cmp w9, #321
 ; CHECK-SD-NEXT:    str w10, [x0]
-; CHECK-SD-NEXT:    b.gt .LBB20_6
+; CHECK-SD-NEXT:    b.gt .LBB20_5
 ; CHECK-SD-NEXT:  // %bb.4: // %test5
 ; CHECK-SD-NEXT:    add w10, w8, #4
-; CHECK-SD-NEXT:    cmn w9, #443
-; CHECK-SD-NEXT:    str w10, [x0]
-; CHECK-SD-NEXT:    b.ge .LBB20_6
-; CHECK-SD-NEXT:  // %bb.5: // %test6
 ; CHECK-SD-NEXT:    add w8, w8, #5
+; CHECK-SD-NEXT:    cmn w9, #444
+; CHECK-SD-NEXT:    csel w8, w10, w8, gt
 ; CHECK-SD-NEXT:    str w8, [x0]
-; CHECK-SD-NEXT:  .LBB20_6: // %common.ret
+; CHECK-SD-NEXT:  .LBB20_5: // %common.ret
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: testing:
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    cmp w8, #4095
-; CHECK-GI-NEXT:    b.ne .LBB20_6
+; CHECK-GI-NEXT:    b.ne .LBB20_5
 ; CHECK-GI-NEXT:  // %bb.1: // %test2
 ; CHECK-GI-NEXT:    ldr w9, [x1]
 ; CHECK-GI-NEXT:    add w10, w8, #1
 ; CHECK-GI-NEXT:    str w10, [x0]
 ; CHECK-GI-NEXT:    cmp w9, #3567, lsl #12 // =14610432
-; CHECK-GI-NEXT:    b.lo .LBB20_6
+; CHECK-GI-NEXT:    b.lo .LBB20_5
 ; CHECK-GI-NEXT:  // %bb.2: // %test3
 ; CHECK-GI-NEXT:    add w10, w8, #2
 ; CHECK-GI-NEXT:    cmp w8, #123
 ; CHECK-GI-NEXT:    str w10, [x0]
-; CHECK-GI-NEXT:    b.lt .LBB20_6
+; CHECK-GI-NEXT:    b.lt .LBB20_5
 ; CHECK-GI-NEXT:  // %bb.3: // %test4
 ; CHECK-GI-NEXT:    add w10, w8, #3
 ; CHECK-GI-NEXT:    cmp w9, #321
 ; CHECK-GI-NEXT:    str w10, [x0]
-; CHECK-GI-NEXT:    b.gt .LBB20_6
+; CHECK-GI-NEXT:    b.gt .LBB20_5
 ; CHECK-GI-NEXT:  // %bb.4: // %test5
 ; CHECK-GI-NEXT:    add w10, w8, #4
-; CHECK-GI-NEXT:    cmn w9, #444
-; CHECK-GI-NEXT:    str w10, [x0]
-; CHECK-GI-NEXT:    b.gt .LBB20_6
-; CHECK-GI-NEXT:  // %bb.5: // %test6
 ; CHECK-GI-NEXT:    add w8, w8, #5
+; CHECK-GI-NEXT:    cmn w9, #444
+; CHECK-GI-NEXT:    csel w8, w10, w8, gt
+; CHECK-GI-NEXT:    str w10, [x0]
 ; CHECK-GI-NEXT:    str w8, [x0]
-; CHECK-GI-NEXT:  .LBB20_6: // %common.ret
+; CHECK-GI-NEXT:  .LBB20_5: // %common.ret
 ; CHECK-GI-NEXT:    ret
   %val = load i32, ptr %var_i32
   %val2 = load i32, ptr %var2_i32

--- a/llvm/test/Transforms/SimplifyCFG/X86/hoist-loads-stores-with-cf.ll
+++ b/llvm/test/Transforms/SimplifyCFG/X86/hoist-loads-stores-with-cf.ll
@@ -417,7 +417,7 @@ define i16 @debug_metadata_diassign(i1 %cond, i16 %a, ptr %p) {
 ; LOADONLY-NEXT:    br label [[IF_FALSE]]
 ; LOADONLY:       if.false:
 ; LOADONLY-NEXT:    [[RET:%.*]] = phi i16 [ 2, [[BB0:%.*]] ], [ 3, [[IF_TRUE]] ]
-; LOADONLY-NEXT:      #dbg_assign(i16 [[RET]], [[META8:![0-9]+]], !DIExpression(), [[DIASSIGNID7]], ptr [[P]], !DIExpression(), [[META11:![0-9]+]])
+; LOADONLY-NEXT:      #dbg_assign(i16 [[RET]], [[META8:![0-9]+]], !DIExpression(), [[DIASSIGNID7]], ptr [[P]], !DIExpression(), [[META13:![0-9]+]])
 ; LOADONLY-NEXT:    ret i16 [[RET]]
 ;
 ; NONEONLY-LABEL: @debug_metadata_diassign(
@@ -428,7 +428,7 @@ define i16 @debug_metadata_diassign(i1 %cond, i16 %a, ptr %p) {
 ; NONEONLY-NEXT:    br label [[IF_FALSE]]
 ; NONEONLY:       if.false:
 ; NONEONLY-NEXT:    [[RET:%.*]] = phi i16 [ 2, [[BB0:%.*]] ], [ 3, [[IF_TRUE]] ]
-; NONEONLY-NEXT:      #dbg_assign(i16 [[RET]], [[META8:![0-9]+]], !DIExpression(), [[DIASSIGNID7]], ptr [[P]], !DIExpression(), [[META11:![0-9]+]])
+; NONEONLY-NEXT:      #dbg_assign(i16 [[RET]], [[META8:![0-9]+]], !DIExpression(), [[DIASSIGNID7]], ptr [[P]], !DIExpression(), [[META13:![0-9]+]])
 ; NONEONLY-NEXT:    ret i16 [[RET]]
 ;
 bb0:
@@ -450,8 +450,8 @@ define i32 @hoist_cond_stores(i1 %cond, ptr %p) {
 ; LOADSTORE-NEXT:  entry:
 ; LOADSTORE-NEXT:    store i1 false, ptr [[P:%.*]], align 2
 ; LOADSTORE-NEXT:    [[TMP0:%.*]] = bitcast i1 [[COND:%.*]] to <1 x i1>
-; LOADSTORE-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[COND]], i1 false, i1 false
 ; LOADSTORE-NEXT:    call void @llvm.masked.store.v1i32.p0(<1 x i32> zeroinitializer, ptr align 8 [[P]], <1 x i1> [[TMP0]])
+; LOADSTORE-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[COND]], i1 false, i1 false
 ; LOADSTORE-NEXT:    store i1 [[SPEC_STORE_SELECT]], ptr [[P]], align 2
 ; LOADSTORE-NEXT:    ret i32 0
 ;
@@ -459,8 +459,8 @@ define i32 @hoist_cond_stores(i1 %cond, ptr %p) {
 ; STOREONLY-NEXT:  entry:
 ; STOREONLY-NEXT:    store i1 false, ptr [[P:%.*]], align 2
 ; STOREONLY-NEXT:    [[TMP0:%.*]] = bitcast i1 [[COND:%.*]] to <1 x i1>
-; STOREONLY-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[COND]], i1 false, i1 false
 ; STOREONLY-NEXT:    call void @llvm.masked.store.v1i32.p0(<1 x i32> zeroinitializer, ptr align 8 [[P]], <1 x i1> [[TMP0]])
+; STOREONLY-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[COND]], i1 false, i1 false
 ; STOREONLY-NEXT:    store i1 [[SPEC_STORE_SELECT]], ptr [[P]], align 2
 ; STOREONLY-NEXT:    ret i32 0
 ;
@@ -881,7 +881,7 @@ define void @not_likely_to_execute(ptr %p, ptr %q, i32 %a) {
 ; LOADONLY-LABEL: @not_likely_to_execute(
 ; LOADONLY-NEXT:  entry:
 ; LOADONLY-NEXT:    [[TOBOOL:%.*]] = icmp ne i32 [[A:%.*]], 0
-; LOADONLY-NEXT:    br i1 [[TOBOOL]], label [[IF_THEN:%.*]], label [[IF_END:%.*]], !prof [[PROF12:![0-9]+]]
+; LOADONLY-NEXT:    br i1 [[TOBOOL]], label [[IF_THEN:%.*]], label [[IF_END:%.*]], !prof [[PROF14:![0-9]+]]
 ; LOADONLY:       if.end:
 ; LOADONLY-NEXT:    ret void
 ; LOADONLY:       if.then:
@@ -892,7 +892,7 @@ define void @not_likely_to_execute(ptr %p, ptr %q, i32 %a) {
 ; NONEONLY-LABEL: @not_likely_to_execute(
 ; NONEONLY-NEXT:  entry:
 ; NONEONLY-NEXT:    [[TOBOOL:%.*]] = icmp ne i32 [[A:%.*]], 0
-; NONEONLY-NEXT:    br i1 [[TOBOOL]], label [[IF_THEN:%.*]], label [[IF_END:%.*]], !prof [[PROF12:![0-9]+]]
+; NONEONLY-NEXT:    br i1 [[TOBOOL]], label [[IF_THEN:%.*]], label [[IF_END:%.*]], !prof [[PROF14:![0-9]+]]
 ; NONEONLY:       if.end:
 ; NONEONLY-NEXT:    ret void
 ; NONEONLY:       if.then:

--- a/llvm/test/Transforms/SimplifyCFG/preserve-store-alignment.ll
+++ b/llvm/test/Transforms/SimplifyCFG/preserve-store-alignment.ll
@@ -17,18 +17,16 @@ define i32 @align_both_equal() local_unnamed_addr {
 ; CHECK-NEXT:    [[TOBOOL:%.*]] = icmp eq i64 [[AND]], 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = add nsw <2 x i64> [[TMP0]], splat (i64 2)
 ; CHECK-NEXT:    [[TMP4:%.*]] = select i1 [[TOBOOL]], <2 x i64> [[TMP1]], <2 x i64> [[TMP3]]
+; CHECK-NEXT:    store <2 x i64> [[TMP4]], ptr getelementptr inbounds ([[STRUCT_COUNTERS]], ptr @counters, i64 0, i32 1), align 8
+; CHECK-NEXT:    [[SPEC_SELECT:%.*]] = select i1 [[TOBOOL]], <2 x i64> [[TMP1]], <2 x i64> [[TMP3]]
 ; CHECK-NEXT:    [[AND4:%.*]] = and i64 [[TMP2]], 2
 ; CHECK-NEXT:    [[TOBOOL5:%.*]] = icmp eq i64 [[AND4]], 0
-; CHECK-NEXT:    [[TMP5:%.*]] = add nsw <2 x i64> [[TMP4]], splat (i64 1)
-; CHECK-NEXT:    [[SIMPLIFYCFG_MERGE:%.*]] = select i1 [[TOBOOL5]], <2 x i64> [[TMP4]], <2 x i64> [[TMP5]]
-; CHECK-NEXT:    [[TMP6:%.*]] = xor i1 [[TOBOOL]], true
-; CHECK-NEXT:    [[TMP7:%.*]] = xor i1 [[TOBOOL5]], true
-; CHECK-NEXT:    [[TMP8:%.*]] = or i1 [[TMP6]], [[TMP7]]
-; CHECK-NEXT:    br i1 [[TMP8]], label [[TMP9:%.*]], label [[TMP10:%.*]]
-; CHECK:       9:
+; CHECK-NEXT:    br i1 [[TOBOOL5]], label [[TMP10:%.*]], label [[IF_THEN6:%.*]]
+; CHECK:       if.then6:
+; CHECK-NEXT:    [[SIMPLIFYCFG_MERGE:%.*]] = add nsw <2 x i64> [[SPEC_SELECT]], splat (i64 1)
 ; CHECK-NEXT:    store <2 x i64> [[SIMPLIFYCFG_MERGE]], ptr getelementptr inbounds ([[STRUCT_COUNTERS]], ptr @counters, i64 0, i32 1), align 8
 ; CHECK-NEXT:    br label [[TMP10]]
-; CHECK:       10:
+; CHECK:       if.end9:
 ; CHECK-NEXT:    ret i32 0
 ;
 entry:

--- a/llvm/test/Transforms/SimplifyCFG/speculate-store.ll
+++ b/llvm/test/Transforms/SimplifyCFG/speculate-store.ll
@@ -26,6 +26,54 @@ ret.end:
   ret void
 }
 
+define void @ifconvertstore_with_op(ptr %A, i32 %B, i32 %C) {
+; CHECK-LABEL: @ifconvertstore_with_op(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
+; CHECK-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[CMP]], i32 [[OR]], i32 [[B]]
+; CHECK-NEXT:    store i32 [[SPEC_STORE_SELECT]], ptr [[A]], align 4
+; CHECK-NEXT:    ret void
+;
+entry:
+  store i32 %B, ptr %A
+  %cmp = icmp sgt i32 %C, 0
+  br i1 %cmp, label %if.then, label %ret.end
+
+if.then:
+  %or = or i32 %B, 4
+  store i32 %or, ptr %A
+  br label %ret.end
+
+ret.end:
+  ret void
+}
+
+define void @ifconvertstore_with_op_swapped(ptr %A, i32 %B, i32 %C) {
+; CHECK-LABEL: @ifconvertstore_with_op_swapped(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
+; CHECK-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[CMP]], i32 [[B]], i32 [[OR]]
+; CHECK-NEXT:    store i32 [[SPEC_STORE_SELECT]], ptr [[A]], align 4
+; CHECK-NEXT:    ret void
+;
+entry:
+  store i32 %B, ptr %A
+  %cmp = icmp sgt i32 %C, 0
+  br i1 %cmp, label %ret.end, label %if.then
+
+if.then:
+  %or = or i32 %B, 4
+  store i32 %or, ptr %A
+  br label %ret.end
+
+ret.end:
+  ret void
+}
+
 ; Store to a different location.
 
 define void @noifconvertstore1(ptr %A1, ptr %A2, i32 %B, i32 %C, i32 %D) {

--- a/llvm/test/Transforms/SimplifyCFG/speculate-store.ll
+++ b/llvm/test/Transforms/SimplifyCFG/speculate-store.ll
@@ -483,6 +483,114 @@ ret.end:
   ret void
 }
 
+define void @ifconvertstore_with_op(ptr %A, i32 %B, i32 %C) {
+; CHECK-LABEL: @ifconvertstore_with_op(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label [[IF_THEN:%.*]], label [[RET_END:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
+; CHECK-NEXT:    store i32 [[OR]], ptr [[A]], align 4
+; CHECK-NEXT:    br label [[RET_END]]
+; CHECK:       ret.end:
+; CHECK-NEXT:    ret void
+;
+entry:
+  store i32 %B, ptr %A
+  %cmp = icmp sgt i32 %C, 0
+  br i1 %cmp, label %if.then, label %ret.end
+
+if.then:
+  %or = or i32 %B, 4
+  store i32 %or, ptr %A
+  br label %ret.end
+
+ret.end:
+  ret void
+}
+
+define void @ifconvertstore_with_op_swapped(ptr %A, i32 %B, i32 %C) {
+; CHECK-LABEL: @ifconvertstore_with_op_swapped(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label [[RET_END:%.*]], label [[IF_THEN:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
+; CHECK-NEXT:    store i32 [[OR]], ptr [[A]], align 4
+; CHECK-NEXT:    br label [[RET_END]]
+; CHECK:       ret.end:
+; CHECK-NEXT:    ret void
+;
+entry:
+  store i32 %B, ptr %A
+  %cmp = icmp sgt i32 %C, 0
+  br i1 %cmp, label %ret.end, label %if.then
+
+if.then:
+  %or = or i32 %B, 4
+  store i32 %or, ptr %A
+  br label %ret.end
+
+ret.end:
+  ret void
+}
+
+define void @ifconvertstore_two_ops(ptr %A, i32 %B, i32 %C) {
+; CHECK-LABEL: @ifconvertstore_two_ops(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label [[IF_THEN:%.*]], label [[RET_END:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[OR]], 1
+; CHECK-NEXT:    store i32 [[XOR]], ptr [[A]], align 4
+; CHECK-NEXT:    br label [[RET_END]]
+; CHECK:       ret.end:
+; CHECK-NEXT:    ret void
+;
+entry:
+  store i32 %B, ptr %A
+  %cmp = icmp sgt i32 %C, 0
+  br i1 %cmp, label %if.then, label %ret.end
+if.then:
+  %or = or i32 %B, 4
+  %xor = xor i32 %or, 1
+  store i32 %xor, ptr %A
+  br label %ret.end
+ret.end:
+  ret void
+}
+
+define i32 @ifconvertstore_with_op_and_phi(ptr %A, i32 %B, i32 %C) {
+; CHECK-LABEL: @ifconvertstore_with_op_and_phi(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
+; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
+; CHECK-NEXT:    br i1 [[CMP]], label [[IF_THEN:%.*]], label [[RET_END:%.*]]
+; CHECK:       if.then:
+; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
+; CHECK-NEXT:    store i32 [[OR]], ptr [[A]], align 4
+; CHECK-NEXT:    br label [[RET_END]]
+; CHECK:       ret.end:
+; CHECK-NEXT:    [[R:%.*]] = phi i32 [ [[OR]], [[IF_THEN]] ], [ 0, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    ret i32 [[R]]
+;
+entry:
+  store i32 %B, ptr %A
+  %cmp = icmp sgt i32 %C, 0
+  br i1 %cmp, label %if.then, label %ret.end
+if.then:
+  %or = or i32 %B, 4
+  store i32 %or, ptr %A
+  br label %ret.end
+ret.end:
+  %r = phi i32 [ %or, %if.then ], [ 0, %entry ]
+  ret i32 %r
+}
+
 ; CHECK: !0 = !{!"branch_weights", i32 3, i32 5}
 !0 = !{!"branch_weights", i32 3, i32 5}
 

--- a/llvm/test/Transforms/SimplifyCFG/speculate-store.ll
+++ b/llvm/test/Transforms/SimplifyCFG/speculate-store.ll
@@ -488,12 +488,9 @@ define void @ifconvertstore_with_op(ptr %A, i32 %B, i32 %C) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
-; CHECK-NEXT:    br i1 [[CMP]], label [[IF_THEN:%.*]], label [[RET_END:%.*]]
-; CHECK:       if.then:
 ; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
-; CHECK-NEXT:    store i32 [[OR]], ptr [[A]], align 4
-; CHECK-NEXT:    br label [[RET_END]]
-; CHECK:       ret.end:
+; CHECK-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[CMP]], i32 [[OR]], i32 [[B]]
+; CHECK-NEXT:    store i32 [[SPEC_STORE_SELECT]], ptr [[A]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -515,12 +512,9 @@ define void @ifconvertstore_with_op_swapped(ptr %A, i32 %B, i32 %C) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
-; CHECK-NEXT:    br i1 [[CMP]], label [[RET_END:%.*]], label [[IF_THEN:%.*]]
-; CHECK:       if.then:
 ; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
-; CHECK-NEXT:    store i32 [[OR]], ptr [[A]], align 4
-; CHECK-NEXT:    br label [[RET_END]]
-; CHECK:       ret.end:
+; CHECK-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[CMP]], i32 [[B]], i32 [[OR]]
+; CHECK-NEXT:    store i32 [[SPEC_STORE_SELECT]], ptr [[A]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -569,13 +563,10 @@ define i32 @ifconvertstore_with_op_and_phi(ptr %A, i32 %B, i32 %C) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    store i32 [[B:%.*]], ptr [[A:%.*]], align 4
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp sgt i32 [[C:%.*]], 0
-; CHECK-NEXT:    br i1 [[CMP]], label [[IF_THEN:%.*]], label [[RET_END:%.*]]
-; CHECK:       if.then:
 ; CHECK-NEXT:    [[OR:%.*]] = or i32 [[B]], 4
-; CHECK-NEXT:    store i32 [[OR]], ptr [[A]], align 4
-; CHECK-NEXT:    br label [[RET_END]]
-; CHECK:       ret.end:
-; CHECK-NEXT:    [[R:%.*]] = phi i32 [ [[OR]], [[IF_THEN]] ], [ 0, [[ENTRY:%.*]] ]
+; CHECK-NEXT:    [[SPEC_STORE_SELECT:%.*]] = select i1 [[CMP]], i32 [[OR]], i32 [[B]]
+; CHECK-NEXT:    store i32 [[SPEC_STORE_SELECT]], ptr [[A]], align 4
+; CHECK-NEXT:    [[R:%.*]] = select i1 [[CMP]], i32 [[OR]], i32 0
 ; CHECK-NEXT:    ret i32 [[R]]
 ;
 entry:


### PR DESCRIPTION
speculativelyExecuteBB has logic to hoist a conditional same-address store via isSafeToSpeculateStore but its 1 instruction body cap fires before matched-store recognition. The pattern from #193027 (or + same-address store) is 2 instructions and bails before the hoist path runs.

This patch moves the matched-store detection ahead of the count gate and exempts the store itself from the count. The body op still counts so the existing cap of 1 still applies to non-matched-store cases. This mirrors the exemption already in mergeConditionalStoreToAddress which treats matched stores as free in its cost budget.

From 193027:
```
void f(int *a, int b, int c) {
  if (c) {
    *a &= ~0x4;
    if (b)
      *a |= 0x4;
  }
}
```
The inner if survives because the join block has extra predecessors so mergeConditionalStoreToAddress does not apply and speculativelyExecuteBB gives up on the two instruction body. 
Before:
```
if.then:
  %0 = load i32, ptr %a, align 4
  %and = and i32 %0, -5
  store i32 %and, ptr %a, align 4
  %tobool1.not = icmp eq i32 %b, 0
  br i1 %tobool1.not, label %if.end3, label %if.then2
if.then2:
  %or = or i32 %0, 4
  store i32 %or, ptr %a, align 4
  br label %if.end3
if.end3:                              ; preds = %if.then, %if.then2, %entry
  ret void
```
With this patch, one store and no conditional branch:
```
if.then:
  %0 = load i32, ptr %a, align 4
  %and = and i32 %0, -5
  %tobool1.not = icmp eq i32 %b, 0
  %masksel = select i1 %tobool1.not, i32 0, i32 4
  %spec.store.select = or disjoint i32 %and, %masksel
  store i32 %spec.store.select, ptr %a, align 4
  br label %if.end3
```

Closes #193027.