### PR TITLE
[libc] Fix shadowing in printf

### DIFF
--- a/libc/src/stdio/printf_core/float_dec_converter_limited.h
+++ b/libc/src/stdio/printf_core/float_dec_converter_limited.h
@@ -59,15 +59,9 @@ namespace LIBC_NAMESPACE_DECL {
 namespace printf_core {
 
 enum class ConversionType { E, F, G };
-#ifdef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
-using StorageType = UInt128;
-#else
-using StorageType = fputil::FPBits<long double>::StorageType;
-#endif // LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
 
 constexpr unsigned MAX_DIGITS = 39;
 constexpr size_t DF_BITS = 320;
-constexpr char DECIMAL_POINT = '.';
 
 struct DigitsInput {
   // Input mantissa, stored with the explicit leading 1 bit (if any) at the
@@ -84,8 +78,7 @@ struct DigitsInput {
   // Constructor which accepts a mantissa direct from a floating-point format,
   // and shifts it up to the top of the UInt128 so that a function consuming
   // this struct afterwards doesn't have to remember which format it came from.
-  DigitsInput(int32_t fraction_len, StorageType mantissa_, int exponent_,
-              Sign sign)
+  DigitsInput(int32_t fraction_len, UInt128 mantissa_, int exponent_, Sign sign)
       : mantissa(UInt128(mantissa_) << (127 - fraction_len)),
         exponent(exponent_), sign(sign) {
     if (!(mantissa & (UInt128(1) << 127)) && mantissa != 0) {
@@ -383,8 +376,9 @@ DigitsOutput decimal_digits(DigitsInput input, int precision, bool e_mode) {
 template <WriteMode write_mode>
 LIBC_INLINE int
 convert_float_inner(Writer<write_mode> *writer, const FormatSection &to_conv,
-                    int32_t fraction_len, int exponent, StorageType mantissa,
+                    int32_t fraction_len, int exponent, UInt128 mantissa,
                     Sign sign, ConversionType ctype) {
+  constexpr char DECIMAL_POINT = '.';
   // If to_conv doesn't specify a precision, the precision defaults to 6.
   unsigned precision = to_conv.precision < 0 ? 6 : to_conv.precision;
 
@@ -639,7 +633,7 @@ LIBC_INLINE int convert_float_outer(Writer<write_mode> *writer,
                                     ConversionType ctype) {
 #ifndef LIBC_TYPES_LONG_DOUBLE_IS_DOUBLE_DOUBLE
   if (to_conv.length_modifier == LengthModifier::L) {
-    StorageType float_raw = to_conv.conv_val_raw;
+    fputil::FPBits<long double>::StorageType float_raw = to_conv.conv_val_raw;
     fputil::FPBits<long double> float_bits(float_raw);
     if (!float_bits.is_inf_or_nan()) {
       return convert_float_typed<long double>(writer, to_conv, float_bits,


### PR DESCRIPTION
The 320 bit float converter defined StorageType and DECIMAL_POINT
outside of its functions. This caused issues with other definitions of
the same variables after #197516.
