### PR TITLE
[clang][CUDA] Add new new CUDA and PTX versions

### DIFF
--- a/clang/include/clang/Basic/BuiltinsNVPTX.td
+++ b/clang/include/clang/Basic/BuiltinsNVPTX.td
@@ -97,7 +97,7 @@ multiclass PTX_InstantiateLoop<list<int> ptx_list> {
   }
 }
 
-defm PTX : PTX_InstantiateLoop<[90, 88, 87, 86, 85, 84, 83, 82, 81, 80, 78, 77, 76, 75, 74, 73, 72, 71, 70, 65, 64, 63, 62, 61, 60, 42]>;
+defm PTX : PTX_InstantiateLoop<[92, 91, 90, 88, 87, 86, 85, 84, 83, 82, 81, 80, 78, 77, 76, 75, 74, 73, 72, 71, 70, 65, 64, 63, 62, 61, 60, 42]>;
 
 class NVPTXBuiltin<string prototype> : TargetBuiltin {
   let Spellings = [NAME];

--- a/clang/include/clang/Basic/Cuda.h
+++ b/clang/include/clang/Basic/Cuda.h
@@ -49,9 +49,11 @@ enum class CudaVersion {
   CUDA_128,
   CUDA_129,
   CUDA_130,
-  FULLY_SUPPORTED = CUDA_128,
+  CUDA_131,
+  CUDA_132,
+  FULLY_SUPPORTED = CUDA_132,
   PARTIALLY_SUPPORTED =
-      CUDA_129, // Partially supported. Proceed with a warning.
+      CUDA_132, // Partially supported. Proceed with a warning.
   NEW = 10000,  // Too new. Issue a warning, but allow using it.
 };
 const char *CudaVersionToString(CudaVersion V);

--- a/clang/lib/Basic/Cuda.cpp
+++ b/clang/lib/Basic/Cuda.cpp
@@ -46,6 +46,8 @@ static const CudaVersionMapEntry CudaNameVersionMap[] = {
     CUDA_ENTRY(12, 8),
     CUDA_ENTRY(12, 9),
     CUDA_ENTRY(13, 0),
+    CUDA_ENTRY(13, 1),
+    CUDA_ENTRY(13, 2),
     {"", CudaVersion::NEW, llvm::VersionTuple(std::numeric_limits<int>::max())},
     {"unknown", CudaVersion::UNKNOWN, {}} // End of list tombstone.
 };

--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -91,6 +91,12 @@ CudaVersion getCudaVersion(uint32_t raw_version) {
     return CudaVersion::CUDA_128;
   if (raw_version < 13000)
     return CudaVersion::CUDA_129;
+  if (raw_version < 13010)
+    return CudaVersion::CUDA_130;
+  if (raw_version < 13020)
+    return CudaVersion::CUDA_131;
+  if (raw_version < 13030)
+    return CudaVersion::CUDA_132;
   return CudaVersion::NEW;
 }
 
@@ -685,6 +691,9 @@ void NVPTX::getNVPTXTargetFeatures(const Driver &D, const llvm::Triple &Triple,
   case CudaVersion::CUDA_##CUDA_VER:                                           \
     PtxFeature = "+ptx" #PTX_VER;                                              \
     break;
+    CASE_CUDA_VERSION(132, 92);
+    CASE_CUDA_VERSION(131, 91);
+    CASE_CUDA_VERSION(130, 90);
     CASE_CUDA_VERSION(129, 88);
     CASE_CUDA_VERSION(128, 87);
     CASE_CUDA_VERSION(126, 85);


### PR DESCRIPTION
PTX 9.1 and 9.2 already exists in LLVM, so this change just plumbs these versions into clang to allow using newer instructions when we're compiling with cuda-13.x