### PR TITLE
[lldb] Avoid unnecessary strlen of mangled names in ConstString (NFC)

### DIFF
--- a/lldb/source/Utility/ConstString.cpp
+++ b/lldb/source/Utility/ConstString.cpp
@@ -98,16 +98,17 @@ public:
       // Since the entry is read only, and we derive the entry entirely from
       // the pointer, we don't need the lock.
       const StringPoolEntryType &entry = GetStringMapEntryFromKeyData(ccstr);
-      return entry.getKey().size();
+      return entry.getKeyLength();
     }
     return 0;
   }
 
   StringPoolValueType GetMangledCounterpart(const char *ccstr) {
     if (ccstr != nullptr) {
-      const PoolEntry &pool = selectPool(llvm::StringRef(ccstr));
+      const StringPoolEntryType &entry = GetStringMapEntryFromKeyData(ccstr);
+      const PoolEntry &pool = selectPool(entry.getKey());
       std::shared_lock<PoolMutex> lock(pool.m_mutex);
-      return GetStringMapEntryFromKeyData(ccstr).getValue();
+      return entry.getValue();
     }
     return nullptr;
   }
@@ -146,10 +147,10 @@ public:
     return nullptr;
   }
 
-  const char *
-  GetConstCStringAndSetMangledCounterPart(llvm::StringRef demangled,
-                                          const char *mangled_ccstr) {
+  const char *GetConstCStringAndSetMangledCounterPart(llvm::StringRef demangled,
+                                                      llvm::StringRef mangled) {
     const char *demangled_ccstr = nullptr;
+    const char *const mangled_ccstr = mangled.data();
 
     {
       const uint32_t demangled_hash = StringPool::hash(demangled);
@@ -170,9 +171,10 @@ public:
     {
       // Now assign the demangled const string as the counterpart of the
       // mangled const string...
-      PoolEntry &pool = selectPool(llvm::StringRef(mangled_ccstr));
+      StringPoolEntryType &entry = GetStringMapEntryFromKeyData(mangled_ccstr);
+      PoolEntry &pool = selectPool(mangled);
       std::lock_guard<PoolMutex> lock(pool.m_mutex);
-      GetStringMapEntryFromKeyData(mangled_ccstr).setValue(demangled_ccstr);
+      entry.setValue(demangled_ccstr);
     }
 
     // Return the constant demangled C string
@@ -341,7 +343,7 @@ void ConstString::SetString(llvm::StringRef s) {
 void ConstString::SetStringWithMangledCounterpart(llvm::StringRef demangled,
                                                   ConstString mangled) {
   m_string = StringPool().GetConstCStringAndSetMangledCounterPart(
-      demangled, mangled.m_string);
+      demangled, mangled.GetStringRef());
 }
 
 bool ConstString::GetMangledCounterpart(ConstString &counterpart) const {

--- a/lldb/source/Utility/ConstString.cpp
+++ b/lldb/source/Utility/ConstString.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Utility/Stream.h"
 
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/DJB.h"
@@ -103,12 +104,12 @@ public:
     return 0;
   }
 
-  StringPoolValueType GetMangledCounterpart(const char *ccstr) {
+  StringPoolValueType GetMangledCounterpart(llvm::StringRef str) {
+    const char *const ccstr = str.data();
     if (ccstr != nullptr) {
-      const StringPoolEntryType &entry = GetStringMapEntryFromKeyData(ccstr);
-      const PoolEntry &pool = selectPool(entry.getKey());
+      const PoolEntry &pool = selectPool(str);
       std::shared_lock<PoolMutex> lock(pool.m_mutex);
-      return entry.getValue();
+      return GetStringMapEntryFromKeyData(ccstr).getValue();
     }
     return nullptr;
   }
@@ -171,10 +172,9 @@ public:
     {
       // Now assign the demangled const string as the counterpart of the
       // mangled const string...
-      StringPoolEntryType &entry = GetStringMapEntryFromKeyData(mangled_ccstr);
       PoolEntry &pool = selectPool(mangled);
       std::lock_guard<PoolMutex> lock(pool.m_mutex);
-      entry.setValue(demangled_ccstr);
+      GetStringMapEntryFromKeyData(mangled_ccstr).setValue(demangled_ccstr);
     }
 
     // Return the constant demangled C string
@@ -347,7 +347,7 @@ void ConstString::SetStringWithMangledCounterpart(llvm::StringRef demangled,
 }
 
 bool ConstString::GetMangledCounterpart(ConstString &counterpart) const {
-  counterpart.m_string = StringPool().GetMangledCounterpart(m_string);
+  counterpart.m_string = StringPool().GetMangledCounterpart(GetStringRef());
   return (bool)counterpart;
 }
 


### PR DESCRIPTION
C++ mangled names are known to be quite long at times. This change makes use of available length data, instead of using the `StringRef(const char *)` constructor which calls `strlen`.

The main detail is to replace `selectPool(llvm::StringRef(raw))` with a call to `selectPool` using an readily available StringRef.