### PR TITLE
[ValueTracking][test] Update pr92217 test case to not assume sqrt is not constexpr.

### DIFF
--- a/llvm/test/Transforms/InstCombine/known-bits.ll
+++ b/llvm/test/Transforms/InstCombine/known-bits.ll
@@ -1785,14 +1785,14 @@ define i32 @test_none(float nofpclass(all) %x) {
 
 ; We cannot make assumptions about the sign of result of sqrt
 ; when the input is a negative value (except for -0).
-define i1 @pr92217() {
+define i1 @pr92217(float nofpclass(nan zero pnorm psub pinf) %a) {
 ; CHECK-LABEL: @pr92217(
-; CHECK-NEXT:    [[X:%.*]] = call float @llvm.sqrt.f32(float f0xF6F5F4F3)
+; CHECK-NEXT:    [[X:%.*]] = call float @llvm.sqrt.f32(float [[A:%.*]])
 ; CHECK-NEXT:    [[Y:%.*]] = bitcast float [[X]] to i32
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
-  %x = call float @llvm.sqrt.f32(float 0xC6DEBE9E60000000)
+  %x = call float @llvm.sqrt.f32(float %a)
   %y = bitcast float %x to i32
   %cmp = icmp slt i32 %y, 0
   ret i1 %cmp

--- a/llvm/test/Transforms/InstCombine/known-bits.ll
+++ b/llvm/test/Transforms/InstCombine/known-bits.ll
@@ -1785,8 +1785,8 @@ define i32 @test_none(float nofpclass(all) %x) {
 
 ; We cannot make assumptions about the sign of result of sqrt
 ; when the input is a negative value (except for -0).
-define i1 @pr92217(float nofpclass(nan zero pnorm psub pinf) %a) {
-; CHECK-LABEL: @pr92217(
+define i1 @pr92217_sqrt_negative_input(float nofpclass(nan zero pnorm psub pinf) %a) {
+; CHECK-LABEL: @pr92217_sqrt_negative_input(
 ; CHECK-NEXT:    [[X:%.*]] = call float @llvm.sqrt.f32(float [[A:%.*]])
 ; CHECK-NEXT:    [[Y:%.*]] = bitcast float [[X]] to i32
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 0
@@ -1798,21 +1798,8 @@ define i1 @pr92217(float nofpclass(nan zero pnorm psub pinf) %a) {
   ret i1 %cmp
 }
 
-define i1 @sqrt_negative_input(float nofpclass(nan zero pnorm psub pinf) %a) {
-; CHECK-LABEL: @sqrt_negative_input(
-; CHECK-NEXT:    [[X:%.*]] = call float @llvm.sqrt.f32(float [[A:%.*]])
-; CHECK-NEXT:    [[Y:%.*]] = bitcast float [[X]] to i32
-; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[Y]], 0
-; CHECK-NEXT:    ret i1 [[CMP]]
-;
-  %x = call float @llvm.sqrt.f32(float %a)
-  %y = bitcast float %x to i32
-  %cmp = icmp slt i32 %y, 0
-  ret i1 %cmp
-}
-
-define i1 @sqrt_negative_input_nnan(float nofpclass(nan zero pnorm psub pinf) %a) {
-; CHECK-LABEL: @sqrt_negative_input_nnan(
+define i1 @pr92217_sqrt_negative_input_nnan(float nofpclass(nan zero pnorm psub pinf) %a) {
+; CHECK-LABEL: @pr92217_sqrt_negative_input_nnan(
 ; CHECK-NEXT:    ret i1 false
 ;
   %x = call nnan float @llvm.sqrt.f32(float %a)


### PR DESCRIPTION
After ffad84af3e71d4ad330bcb363aa99c7171e33fbb, the call in `@pr92217` to `@llvm.sqrt.f32` on a specific floating point value can be inlined with the actual result instead of happening at runtime, causing the `@pr92217` method to be replaced with a single `ret i1 false`.

The test case below, `@sqrt_negative_input`, still verifies that if we have a negative value *and we don't know what it is* (i.e. it can't be constexpr'd away), then we can't make assumptions about the return value. That's all we really need. So delete the test case with a constant value and just leave the remaining ones, but rename them to preserve the link to http://llvm.org/pr92217.