### PR TITLE
[CIR] Add support for partial array cleanup with ILE

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -719,7 +719,8 @@ void CIRGenFunction::emitCXXAggrConstructorCall(
   QualType elementType;
   mlir::Value numElements = emitArrayLength(arrayType, elementType, arrayBegin);
   emitCXXAggrConstructorCall(ctor, numElements, arrayBegin, e,
-                             newPointerIsChecked, zeroInitialize);
+                             newPointerIsChecked, zeroInitialize,
+                             /*endOfInit=*/Address::invalid());
 }
 
 /// Emit a loop to call a particular constructor for each of several members

--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -731,9 +731,16 @@ void CIRGenFunction::emitCXXAggrConstructorCall(
 /// \param arrayBase a T*, where T is the type constructed by ctor
 /// \param zeroInitialize true if each element should be
 ///   zero-initialized before it is constructed
+/// \param endOfInit if valid, an alloca holding the upper bound of an
+///   already-pushed irregular partial-array EH cleanup. When valid, the
+///   loop body will update this slot before each constructor call so the
+///   caller's cleanup covers loop-constructed elements, and no
+///   partial-destruction region is attached to the resulting
+///   cir::ArrayCtor op.
 void CIRGenFunction::emitCXXAggrConstructorCall(
     const CXXConstructorDecl *ctor, mlir::Value numElements, Address arrayBase,
-    const CXXConstructExpr *e, bool newPointerIsChecked, bool zeroInitialize) {
+    const CXXConstructExpr *e, bool newPointerIsChecked, bool zeroInitialize,
+    Address endOfInit) {
   // It's legal for numElements to be zero.  This can happen both
   // dynamically, because x can be zero in 'new A[x]', and statically,
   // because of GCC extensions that permit zero-length arrays.  There
@@ -788,13 +795,23 @@ void CIRGenFunction::emitCXXAggrConstructorCall(
   {
     RunCleanupsScope scope(*this);
 
+    // When the caller has already pushed an irregular partial-array cleanup
+    // (signalled by a valid endOfInit), our loop body will keep that cleanup's
+    // upper bound up to date, so we don't need a separate per-element
+    // partial-destruction region on the cir::ArrayCtor op.
     bool needsPartialArrayCleanup =
-        getLangOpts().Exceptions && !ctor->getParent()->hasTrivialDestructor();
+        getLangOpts().Exceptions &&
+        !ctor->getParent()->hasTrivialDestructor() && !endOfInit.isValid();
 
     auto emitCtorBody = [&](mlir::OpBuilder &b, mlir::Location l) {
       mlir::BlockArgument arg =
           b.getInsertionBlock()->addArgument(ptrToElmType, l);
       Address curAddr = Address(arg, elementType, eltAlignment);
+      // Extend the caller's irregular partial-array cleanup to cover the
+      // element we're about to construct. If this constructor throws, the
+      // cleanup will destroy every element strictly below this one.
+      if (endOfInit.isValid())
+        builder.createStore(l, arg, endOfInit);
       assert(!cir::MissingFeatures::sanitizers());
       if (zeroInitialize)
         emitNullInitialization(l, curAddr, type);

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1033,10 +1033,6 @@ void CIRGenFunction::emitNewArrayInitializer(
   QualType::DestructionKind dtorKind = elementType.isDestructedType();
   CleanupDeactivationScope deactivation(*this);
 
-  CharUnits elementSize = getContext().getTypeSizeInChars(elementType);
-  CharUnits elementAlign =
-      beginPtr.getAlignment().alignmentOfArrayElement(elementSize);
-
   // Attempt to perform zero-initialization using memset.
   auto tryMemsetInitialization = [&]() -> bool {
     mlir::Location loc = numElements.getLoc();
@@ -1149,16 +1145,17 @@ void CIRGenFunction::emitNewArrayInitializer(
     }
 
     // Enter a partial-destruction Cleanup if necessary.
+    CharUnits elementSize = getContext().getTypeSizeInChars(elementType);
     if (dtorKind) {
       mlir::Location loc = cgm.getLoc(init->getSourceRange());
       endOfInit = createTempAlloca(beginPtr.getType(), getPointerAlign(), loc,
                                    "arrayinit.endOfInit");
-      pushIrregularPartialArrayCleanup(beginPtr.getPointer(), endOfInit,
-                                       elementType, elementAlign,
-                                       getDestroyer(dtorKind));
+      pushIrregularPartialArrayCleanup(
+          beginPtr.getPointer(), endOfInit, elementType,
+          beginPtr.getAlignment().alignmentOfArrayElement(elementSize),
+          getDestroyer(dtorKind));
     }
 
-    CharUnits elementSize = getContext().getTypeSizeInChars(elementType);
     CharUnits startAlign = curPtr.getAlignment();
     unsigned i = 0;
     for (const Expr *ie : initExprs) {

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1031,7 +1031,12 @@ void CIRGenFunction::emitNewArrayInitializer(
   const Expr *init = e->getInitializer();
   Address endOfInit = Address::invalid();
   QualType::DestructionKind dtorKind = elementType.isDestructedType();
-  assert(!cir::MissingFeatures::cleanupDeactivationScope());
+  CleanupDeactivationScope deactivation(*this);
+  bool pushedCleanup = false;
+
+  CharUnits elementSize = getContext().getTypeSizeInChars(elementType);
+  CharUnits elementAlign =
+      beginPtr.getAlignment().alignmentOfArrayElement(elementSize);
 
   // Attempt to perform zero-initialization using memset.
   auto tryMemsetInitialization = [&]() -> bool {
@@ -1146,29 +1151,32 @@ void CIRGenFunction::emitNewArrayInitializer(
 
     // Enter a partial-destruction Cleanup if necessary.
     if (dtorKind) {
-      cgm.errorNYI(ile->getSourceRange(),
-                   "emitNewArrayInitializer: init requires dtor");
-      return;
+      mlir::Location loc = cgm.getLoc(init->getSourceRange());
+      endOfInit = createTempAlloca(beginPtr.getType(), getPointerAlign(), loc,
+                                   "arrayinit.endOfInit");
+      pushIrregularPartialArrayCleanup(beginPtr.getPointer(), endOfInit,
+                                       elementType, elementAlign,
+                                       getDestroyer(dtorKind));
+      pushedCleanup = true;
     }
 
     CharUnits elementSize = getContext().getTypeSizeInChars(elementType);
     CharUnits startAlign = curPtr.getAlignment();
     unsigned i = 0;
     for (const Expr *ie : initExprs) {
+      mlir::Location loc = getLoc(ie->getExprLoc());
+
       // Tell the cleanup that it needs to destroy up to this
       // element.  TODO: some of these stores can be trivially
       // observed to be unnecessary.
-      if (endOfInit.isValid()) {
-        cgm.errorNYI(ie->getSourceRange(),
-                     "emitNewArrayInitializer: update dtor cleanup ptr");
-        return;
-      }
+      if (endOfInit.isValid())
+        builder.createStore(loc, curPtr.getPointer(), endOfInit);
+
       // FIXME: If the last initializer is an incomplete initializer list for
       // an array, and we have an array filler, we can fold together the two
       // initialization loops.
       storeAnyExprIntoOneUnit(*this, ie, ie->getType(), curPtr,
                               AggValueSlot::DoesNotOverlap);
-      mlir::Location loc = getLoc(ie->getExprLoc());
       mlir::Value castOp = builder.createPtrBitcast(
           curPtr.getPointer(), convertTypeForMem(allocType));
       mlir::Value offsetOp = builder.getSignedInt(loc, 1, /*width=*/32);
@@ -1262,7 +1270,7 @@ void CIRGenFunction::emitNewArrayInitializer(
     curPtr = curPtr.withElementType(builder, initType);
     emitCXXAggrConstructorCall(ctor, numElements, curPtr, cce,
                                /*newPointerIsChecked=*/true,
-                               cce->requiresZeroInitialization());
+                               cce->requiresZeroInitialization(), endOfInit);
     if (getContext().getTargetInfo().emitVectorDeletingDtors(
             getContext().getLangOpts())) {
       cgm.errorNYI(e->getSourceRange(),

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -1032,7 +1032,6 @@ void CIRGenFunction::emitNewArrayInitializer(
   Address endOfInit = Address::invalid();
   QualType::DestructionKind dtorKind = elementType.isDestructedType();
   CleanupDeactivationScope deactivation(*this);
-  bool pushedCleanup = false;
 
   CharUnits elementSize = getContext().getTypeSizeInChars(elementType);
   CharUnits elementAlign =
@@ -1157,7 +1156,6 @@ void CIRGenFunction::emitNewArrayInitializer(
       pushIrregularPartialArrayCleanup(beginPtr.getPointer(), endOfInit,
                                        elementType, elementAlign,
                                        getDestroyer(dtorKind));
-      pushedCleanup = true;
     }
 
     CharUnits elementSize = getContext().getTypeSizeInChars(elementType);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1714,7 +1714,7 @@ public:
                                   mlir::Value numElements, Address arrayBase,
                                   const CXXConstructExpr *e,
                                   bool newPointerIsChecked, bool zeroInitialize,
-                                  Address endOfInit = Address::invalid());
+                                  Address endOfInit);
   void emitCXXConstructorCall(const clang::CXXConstructorDecl *d,
                               clang::CXXCtorType type, bool forVirtualBase,
                               bool delegating, AggValueSlot thisAVS,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1713,8 +1713,8 @@ public:
   void emitCXXAggrConstructorCall(const CXXConstructorDecl *ctor,
                                   mlir::Value numElements, Address arrayBase,
                                   const CXXConstructExpr *e,
-                                  bool newPointerIsChecked,
-                                  bool zeroInitialize);
+                                  bool newPointerIsChecked, bool zeroInitialize,
+                                  Address endOfInit = Address::invalid());
   void emitCXXConstructorCall(const clang::CXXConstructorDecl *d,
                               clang::CXXCtorType type, bool forVirtualBase,
                               bool delegating, AggValueSlot thisAVS,

--- a/clang/test/CIR/CodeGenCXX/new-array-init-list-non-trivial-dtor.cpp
+++ b/clang/test/CIR/CodeGenCXX/new-array-init-list-non-trivial-dtor.cpp
@@ -1,0 +1,267 @@
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -fexceptions \
+// RUN:     -fcxx-exceptions -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -fexceptions \
+// RUN:     -fcxx-exceptions -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++11 -triple x86_64-unknown-linux-gnu -fexceptions \
+// RUN:     -fcxx-exceptions %s -emit-llvm -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+struct Throws {
+  Throws(int);
+  Throws();
+  ~Throws();
+};
+
+// Constant-bound array new with a braced initializer list of the same length.
+// There is no constructor loop because the bound matches the number of
+// initialisers, but the partial-destruction cleanup for the init-list portion
+// still has to be emitted because Throws has a non-trivial destructor.
+
+void cleanup_const_exact() { new Throws[3]{1, 2, 3}; }
+
+// In CIR, the irregular partial-array EH cleanup is represented by a
+// cir.cleanup.scope around the three constructor calls whose EH region
+// destroys [BeginPtr, *arrayinit.endOfInit) in reverse. Before each ctor
+// call we update arrayinit.endOfInit so the EH cleanup destroys only the
+// elements that were actually constructed before the throw.
+// CIR-LABEL: cir.func{{.*}} @_Z19cleanup_const_exactv(
+// CIR:   %[[INIT_END:.*]] = cir.alloca {{.*}}, !cir.ptr<!cir.ptr<!rec_Throws>>, ["arrayinit.endOfInit"]
+// CIR:   %[[ELT0:.*]] = cir.cast bitcast %{{.*}} : !cir.ptr<!void> -> !cir.ptr<!rec_Throws>
+// CIR:   cir.cleanup.scope {
+// CIR:     cir.store align(8) %[[ELT0]], %[[INIT_END]]
+// CIR:     cir.call @_ZN6ThrowsC1Ei(%[[ELT0]], %{{.*}})
+// CIR:     %[[ELT1:.*]] = cir.ptr_stride %[[ELT0]], %{{.*}}
+// CIR:     cir.store align(8) %[[ELT1]], %[[INIT_END]]
+// CIR:     cir.call @_ZN6ThrowsC1Ei(%[[ELT1]], %{{.*}})
+// CIR:     %[[ELT2:.*]] = cir.ptr_stride %[[ELT1]], %{{.*}}
+// CIR:     cir.store align(8) %[[ELT2]], %[[INIT_END]]
+// CIR:     cir.call @_ZN6ThrowsC1Ei(%[[ELT2]], %{{.*}})
+// CIR:   } cleanup eh {
+// CIR:     %[[END:.*]] = cir.load align(8) %[[INIT_END]]
+// CIR:     %[[NE:.*]] = cir.cmp ne %[[END]], %[[ELT0]]
+// CIR:     cir.if %[[NE]] {
+// CIR:       cir.do {
+// CIR:         %{{.*}} = cir.ptr_stride %{{.*}}, %{{.*}} : (!cir.ptr<!rec_Throws>, !s64i) -> !cir.ptr<!rec_Throws>
+// CIR:         cir.call @_ZN6ThrowsD1Ev(%{{.*}}) nothrow
+// CIR:       } while {
+// CIR:         cir.cmp ne %{{.*}}, %[[ELT0]]
+// CIR:       }
+// CIR:     }
+// CIR:   }
+// CIR:   cir.call @_ZdaPv(
+
+// CIR-emitted LLVM lowers the same logic to a single landing pad shared by
+// all three init-list invokes; that landing pad runs the reverse-destruction
+// loop using arrayinit.endOfInit as the upper bound and then operator delete[].
+// LLVM-LABEL: define{{.*}} void @_Z19cleanup_const_exactv(
+// LLVM-SAME: personality ptr @__gxx_personality_v0
+// LLVM:   %[[ALLOC:.*]] = call{{.*}}ptr @_Znam(i64 noundef 11)
+// LLVM:   store i64 3, ptr %[[ALLOC]]
+// LLVM:   %[[FIRST:.*]] = getelementptr i8, ptr %[[ALLOC]], i64 8
+// LLVM:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[FIRST]], i32 noundef 1)
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD:.*]]
+// LLVM:   %[[ELT1:.*]] = getelementptr %struct.Throws, ptr %[[FIRST]], i64 1
+// LLVM:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT1]], i32 noundef 2)
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD]]
+// LLVM:   %[[ELT2:.*]] = getelementptr %struct.Throws, ptr %[[ELT1]], i64 1
+// LLVM:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT2]], i32 noundef 3)
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD]]
+// LLVM: [[LPAD]]:
+// LLVM-NEXT: landingpad { ptr, i32 }
+// LLVM-NEXT: cleanup
+// LLVM:   call void @_ZN6ThrowsD1Ev(
+// LLVM:   call void @_ZdaPv(ptr noundef %[[ALLOC]]
+// LLVM:   resume { ptr, i32 }
+
+// OGCG: define{{.*}} void @_Z19cleanup_const_exactv(
+// OGCG-SAME: personality ptr @__gxx_personality_v0
+// OGCG:   %[[INIT_END:.*]] = alloca ptr
+// OGCG:   %[[ALLOC:.*]] = call{{.*}}ptr @_Znam(i64 noundef 11)
+// OGCG:   store i64 3, ptr %[[ALLOC]]
+// OGCG:   %[[FIRST:.*]] = getelementptr inbounds i8, ptr %[[ALLOC]], i64 8
+// OGCG:   store ptr %[[FIRST]], ptr %[[INIT_END]]
+// OGCG:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[FIRST]], i32 noundef 1)
+// OGCG-NEXT: to label %[[CONT0:.*]] unwind label %[[LPAD:.*]]
+// OGCG: [[CONT0]]:
+// OGCG:   %[[ELT1:.*]] = getelementptr inbounds %struct.Throws, ptr %[[FIRST]], i64 1
+// OGCG:   store ptr %[[ELT1]], ptr %[[INIT_END]]
+// OGCG:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT1]], i32 noundef 2)
+// OGCG-NEXT: to label %[[CONT1:.*]] unwind label %[[LPAD]]
+// OGCG: [[CONT1]]:
+// OGCG:   %[[ELT2:.*]] = getelementptr inbounds %struct.Throws, ptr %[[ELT1]], i64 1
+// OGCG:   store ptr %[[ELT2]], ptr %[[INIT_END]]
+// OGCG:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT2]], i32 noundef 3)
+// OGCG-NEXT: to label %[[CONT2:.*]] unwind label %[[LPAD]]
+// OGCG: [[CONT2]]:
+// OGCG:   %{{.*}} = getelementptr inbounds %struct.Throws, ptr %[[ELT2]], i64 1
+// OGCG:   ret void
+//
+// Single landing pad that cleans up however many elements were constructed
+// using %array.init.end as the upper bound, then calls operator delete[].
+// OGCG: [[LPAD]]:
+// OGCG-NEXT: landingpad { ptr, i32 }
+// OGCG-NEXT: cleanup
+// OGCG:   %[[END:.*]] = load ptr, ptr %[[INIT_END]]
+// OGCG:   %[[EMPTY:.*]] = icmp eq ptr %[[FIRST]], %[[END]]
+// OGCG:   br i1 %[[EMPTY]], label %{{.*}}, label %[[DTOR_BODY:.*]]
+// OGCG: [[DTOR_BODY]]:
+// OGCG:   %[[PAST:.*]] = phi ptr [ %[[END]], %[[LPAD]] ]
+// OGCG-SAME: , [ %[[ELT:.*]], %[[DTOR_BODY]] ]
+// OGCG:   %[[ELT]] = getelementptr inbounds %struct.Throws, ptr %[[PAST]], i64 -1
+// OGCG:   call void @_ZN6ThrowsD1Ev(ptr {{[^,]*}} %[[ELT]])
+// OGCG:   call void @_ZdaPv(ptr noundef %[[ALLOC]])
+// OGCG:   resume { ptr, i32 }
+
+// Constant-bound array new where the bound (5) is larger than the number of
+// initialisers (3). The first three elements are initialised from the
+// init-list and the remaining two are default-constructed in a fixed-trip
+// constructor loop.
+//
+// Classic codegen ends up with two landing pads here (one for the init list
+// and one for the loop) and a FIXME noting they could be merged. In CIR we
+// thread arrayinit.endOfInit through the constructor loop body, so the
+// existing irregular partial-array cleanup covers loop-constructed elements
+// as well and the cir.array.ctor lowering does not emit a separate
+// partial-destruction EH scope. The result is a single landing pad in the
+// LLVM output and no inner cir.cleanup.scope around the loop in CIR.
+
+void cleanup_const_partial() { new Throws[5]{1, 2, 3}; }
+
+// CIR-LABEL: cir.func{{.*}} @_Z21cleanup_const_partialv(
+// CIR:   %[[INIT_END:.*]] = cir.alloca {{.*}}, !cir.ptr<!cir.ptr<!rec_Throws>>, ["arrayinit.endOfInit"]
+// CIR:   %[[ELT0:.*]] = cir.cast bitcast %{{.*}} : !cir.ptr<!void> -> !cir.ptr<!rec_Throws>
+// CIR:   cir.cleanup.scope {
+// CIR:     cir.store align(8) %[[ELT0]], %[[INIT_END]]
+// CIR:     cir.call @_ZN6ThrowsC1Ei(%[[ELT0]], %{{.*}})
+// CIR:     %[[ELT1:.*]] = cir.ptr_stride %[[ELT0]], %{{.*}}
+// CIR:     cir.store align(8) %[[ELT1]], %[[INIT_END]]
+// CIR:     cir.call @_ZN6ThrowsC1Ei(%[[ELT1]], %{{.*}})
+// CIR:     %[[ELT2:.*]] = cir.ptr_stride %[[ELT1]], %{{.*}}
+// CIR:     cir.store align(8) %[[ELT2]], %[[INIT_END]]
+// CIR:     cir.call @_ZN6ThrowsC1Ei(%[[ELT2]], %{{.*}})
+// CIR:     %[[REST_BEGIN:.*]] = cir.ptr_stride %[[ELT2]], %{{.*}}
+//
+// Store the start of the constructor-loop range to endOfInit too, so the
+// irregular cleanup that's still active during the loop knows where the
+// init-list ended.
+// CIR:     cir.store align(8) %[[REST_BEGIN]], %[[INIT_END]]
+//
+// The constructor loop is emitted directly inside the irregular cleanup
+// scope -- there is no nested cir.cleanup.scope here. The loop body stores
+// the current element pointer to arrayinit.endOfInit before each ctor call
+// so the existing irregular cleanup destroys [BeginPtr, *endOfInit) on
+// throw and covers loop-constructed elements as well.
+// CIR-NOT:       cir.cleanup.scope
+// CIR:     cir.do {
+// CIR:       %[[CUR:.*]] = cir.load %{{.*}} : !cir.ptr<!cir.ptr<!rec_Throws>>, !cir.ptr<!rec_Throws>
+// CIR:       cir.store align(8) %[[CUR]], %[[INIT_END]]
+// CIR:       cir.call @_ZN6ThrowsC1Ev(%[[CUR]])
+// CIR:     } while {
+// CIR:       cir.cmp ne %{{.*}}, %{{.*}}
+// CIR:     }
+// CIR:   } cleanup eh {
+// CIR:     %[[END:.*]] = cir.load align(8) %[[INIT_END]]
+// CIR:     cir.cmp ne %[[END]], %[[ELT0]]
+// CIR:     cir.call @_ZN6ThrowsD1Ev(%{{.*}}) nothrow
+// CIR:   }
+// CIR:   cir.call @_ZdaPv(
+
+// In the lowered LLVM, all four ctor invokes (three init-list elements plus
+// the loop body's default ctor) share a single landing pad. The cleanup
+// destroys [BeginPtr, *arrayinit.endOfInit) and then calls operator delete[].
+// LLVM-LABEL: define{{.*}} void @_Z21cleanup_const_partialv(
+// LLVM-SAME: personality ptr @__gxx_personality_v0
+// LLVM:   %[[ALLOC:.*]] = call{{.*}}ptr @_Znam(i64 noundef 13)
+// LLVM:   store i64 5, ptr %[[ALLOC]]
+// LLVM:   %[[FIRST:.*]] = getelementptr i8, ptr %[[ALLOC]], i64 8
+// LLVM:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[FIRST]], i32 noundef 1)
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD:.*]]
+// LLVM:   %[[ELT1:.*]] = getelementptr %struct.Throws, ptr %[[FIRST]], i64 1
+// LLVM:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT1]], i32 noundef 2)
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD]]
+// LLVM:   %[[ELT2:.*]] = getelementptr %struct.Throws, ptr %[[ELT1]], i64 1
+// LLVM:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT2]], i32 noundef 3)
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD]]
+//
+// Loop body invokes the default ctor and unwinds to the *same* landing pad.
+// LLVM:   invoke void @_ZN6ThrowsC1Ev(
+// LLVM-NEXT: to label %{{.*}} unwind label %[[LPAD]]
+//
+// Single landing pad shared by all four invokes.
+// LLVM: [[LPAD]]:
+// LLVM-NEXT: landingpad { ptr, i32 }
+// LLVM-NEXT: cleanup
+// LLVM:   call void @_ZN6ThrowsD1Ev(
+// LLVM:   call void @_ZdaPv(ptr noundef %[[ALLOC]]
+// LLVM:   resume { ptr, i32 }
+
+// OGCG: define{{.*}} void @_Z21cleanup_const_partialv(
+// OGCG-SAME: personality ptr @__gxx_personality_v0
+// OGCG:   %[[INIT_END:.*]] = alloca ptr
+// OGCG:   %[[ALLOC:.*]] = call{{.*}}ptr @_Znam(i64 noundef 13)
+// OGCG:   store i64 5, ptr %[[ALLOC]]
+// OGCG:   %[[FIRST:.*]] = getelementptr inbounds i8, ptr %[[ALLOC]], i64 8
+// OGCG:   store ptr %[[FIRST]], ptr %[[INIT_END]]
+// OGCG:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[FIRST]], i32 noundef 1)
+// OGCG-NEXT: to label %[[CONT0:.*]] unwind label %[[LPAD_INIT:.*]]
+// OGCG: [[CONT0]]:
+// OGCG:   %[[ELT1:.*]] = getelementptr inbounds %struct.Throws, ptr %[[FIRST]], i64 1
+// OGCG:   store ptr %[[ELT1]], ptr %[[INIT_END]]
+// OGCG:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT1]], i32 noundef 2)
+// OGCG-NEXT: to label %[[CONT1:.*]] unwind label %[[LPAD_INIT]]
+// OGCG: [[CONT1]]:
+// OGCG:   %[[ELT2:.*]] = getelementptr inbounds %struct.Throws, ptr %[[ELT1]], i64 1
+// OGCG:   store ptr %[[ELT2]], ptr %[[INIT_END]]
+// OGCG:   invoke void @_ZN6ThrowsC1Ei(ptr {{[^,]*}} %[[ELT2]], i32 noundef 3)
+// OGCG-NEXT: to label %[[CONT2:.*]] unwind label %[[LPAD_INIT]]
+// OGCG: [[CONT2]]:
+// OGCG:   %[[REST_BEGIN:.*]] = getelementptr inbounds %struct.Throws, ptr %[[ELT2]], i64 1
+// OGCG:   store ptr %[[REST_BEGIN]], ptr %[[INIT_END]]
+//
+// Default-construct the remaining two elements with a fixed-trip loop. Unlike
+// the VLA case, there is no leading isempty check because the trip count is a
+// non-zero constant.
+// OGCG:   %[[CTOR_END:.*]] = getelementptr inbounds %struct.Throws, ptr %[[REST_BEGIN]], i64 2
+// OGCG:   br label %[[CTOR_LOOP:.*]]
+// OGCG: [[CTOR_LOOP]]:
+// OGCG:   %[[CUR:.*]] = phi ptr [ %[[REST_BEGIN]], %{{.*}} ], [ %[[NEXT:.*]], %{{.*}} ]
+// OGCG:   invoke void @_ZN6ThrowsC1Ev(ptr {{[^,]*}} %[[CUR]])
+// OGCG-NEXT: to label %{{.*}} unwind label %[[LPAD_LOOP:.*]]
+// OGCG:   %[[NEXT]] = getelementptr inbounds %struct.Throws, ptr %[[CUR]], i64 1
+// OGCG:   %[[CTOR_EQ:.*]] = icmp eq ptr %[[NEXT]], %[[CTOR_END]]
+// OGCG:   br i1 %[[CTOR_EQ]], label %[[CTOR_DONE:.*]], label %[[CTOR_LOOP]]
+// OGCG: [[CTOR_DONE]]:
+// OGCG:   ret void
+//
+// Init-list landing pad: cleans up the initialised prefix using
+// %array.init.end and then calls operator delete[].
+// OGCG: [[LPAD_INIT]]:
+// OGCG-NEXT: landingpad { ptr, i32 }
+// OGCG-NEXT: cleanup
+//
+// Loop landing pad: destroys the loop-constructed elements, then falls into
+// the init-list cleanup.
+// OGCG: [[LPAD_LOOP]]:
+// OGCG-NEXT: landingpad { ptr, i32 }
+// OGCG-NEXT: cleanup
+// OGCG:   %[[LOOP_EMPTY:.*]] = icmp eq ptr %[[REST_BEGIN]], %[[CUR]]
+// OGCG:   br i1 %[[LOOP_EMPTY]], label %{{.*}}, label %[[LOOP_DTOR_BODY:.*]]
+// OGCG: [[LOOP_DTOR_BODY]]:
+// OGCG:   %[[LOOP_PAST:.*]] = phi ptr [ %[[CUR]], %[[LPAD_LOOP]] ]
+// OGCG-SAME: , [ %[[LOOP_ELT:.*]], %[[LOOP_DTOR_BODY]] ]
+// OGCG:   %[[LOOP_ELT]] = getelementptr inbounds %struct.Throws, ptr %[[LOOP_PAST]], i64 -1
+// OGCG:   call void @_ZN6ThrowsD1Ev(ptr {{[^,]*}} %[[LOOP_ELT]])
+//
+// Init-list cleanup body: pops elements from current down to the allocation
+// base using array.init.end, then calls operator delete[] and resumes.
+// OGCG:   %[[END:.*]] = load ptr, ptr %[[INIT_END]]
+// OGCG:   %[[INIT_EMPTY:.*]] = icmp eq ptr %[[FIRST]], %[[END]]
+// OGCG:   br i1 %[[INIT_EMPTY]], label %{{.*}}, label %[[INIT_DTOR_BODY:.*]]
+// OGCG: [[INIT_DTOR_BODY]]:
+// OGCG:   %[[INIT_PAST:.*]] = phi ptr
+// OGCG:   %[[INIT_ELT:.*]] = getelementptr inbounds %struct.Throws, ptr %[[INIT_PAST]], i64 -1
+// OGCG:   call void @_ZN6ThrowsD1Ev(ptr {{[^,]*}} %[[INIT_ELT]])
+// OGCG:   call void @_ZdaPv(ptr noundef %[[ALLOC]])
+// OGCG:   resume { ptr, i32 }


### PR DESCRIPTION
This adds support for partial array cleanup when an array of a destructed type is initialized, or partially initialized with an init list expression.

In the case where the array is only partially initialized with the ILE and the remainder gets implicit initialization, the cleanup for both pieces of initialization is handled by the same cleanup scope. This is a difference from classic codegen, but there is a FIXME in the classic codegen implementation suggesting exactly this change.

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh