### PR TITLE
[GlobalISel]Allow mixing fixed and scalable vectors for G_INSERT_SUBVECTOR and G_EXTRACT_SUBVECTOR

### DIFF
--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -773,7 +773,7 @@ Extract a vector of destination type from the source vector. The index operand
 represents the starting index from which a subvector is extracted from
 the source vector.
 
-The index must be a constant multiple of the source vector's minimum vector
+The index must be a constant multiple of the destination vector's minimum vector
 length. If the source vector is a scalable vector, then the index is first
 scaled by the runtime scaling factor. The indices extracted from the source
 vector must be valid indices of that vector. If this condition cannot be

--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -785,7 +785,7 @@ not the other way around.
 
 .. code-block:: none
 
-  %3:_(<vscale x 4 x i64>) = G_EXTRACT_SUBVECTOR %2:_(<vscale x 8 x i64>), 2
+  %3:_(<vscale x 4 x i64>) = G_EXTRACT_SUBVECTOR %2:_(<vscale x 8 x i64>), 4
 
 G_CONCAT_VECTORS
 ^^^^^^^^^^^^^^^^

--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -759,6 +759,9 @@ the runtime scaling factor. The indices inserted in the source vector must be
 valid indices of that vector. If this condition cannot be determined statically
 but is false at runtime, then the result vector is undefined.
 
+This operation supports inserting a fixed vector into a scalable vector, but not
+the other way around.
+
 .. code-block:: none
 
   %2:_(<vscale x 4 x i64>) = G_INSERT_SUBVECTOR %0:_(<vscale x 4 x i64>), %1:_(<vscale x 2 x i64>), 0
@@ -777,7 +780,8 @@ vector must be valid indices of that vector. If this condition cannot be
 determined statically but is false at runtime, then the result vector is
 undefined.
 
-Mixing scalable vectors and fixed vectors are not allowed.
+This operation supports extracting a fixed vector from a scalable vector, but
+not the other way around.
 
 .. code-block:: none
 

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1923,8 +1923,8 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     uint64_t SrcMinLen = SrcTy.getElementCount().getKnownMinValue();
-    if (!IsMixedFixedFromScalable &&
-        (Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen)) {
+    if (Idx >= SrcMinLen ||
+        (!IsMixedFixedFromScalable && Idx + DstMinLen > SrcMinLen)) {
       report("Destination type and index must not cause extract to overrun the "
              "source vector",
              MI);

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1903,11 +1903,7 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
-    bool IsMixedFixedFromScalable =
-        DstTy.isFixedVector() && SrcTy.isScalableVector();
-
-    if (!IsMixedFixedFromScalable &&
-        ElementCount::isKnownGT(DstTy.getElementCount(),
+    if (ElementCount::isKnownGT(DstTy.getElementCount(),
                                 SrcTy.getElementCount())) {
       report("Destination vector must be smaller than source vector", MI);
       break;
@@ -1922,6 +1918,8 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
+    bool IsMixedFixedFromScalable =
+        DstTy.isFixedVector() && SrcTy.isScalableVector();
     uint64_t SrcMinLen = SrcTy.getElementCount().getKnownMinValue();
     if (Idx >= SrcMinLen ||
         (!IsMixedFixedFromScalable && Idx + DstMinLen > SrcMinLen)) {

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1857,8 +1857,8 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     uint64_t DstMinLen = DstTy.getElementCount().getKnownMinValue();
-    if (!IsMixedFixedIntoScalable &&
-        (Idx >= DstMinLen || Idx + Src1MinLen > DstMinLen)) {
+    if (Idx >= DstMinLen ||
+        (!IsMixedFixedIntoScalable && Idx + Src1MinLen > DstMinLen)) {
       report("Subvector type and index must not cause insert to overrun the "
              "vector being inserted into",
              MI);

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -1832,12 +1832,16 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
-    if (Src1Ty.isScalable() != DstTy.isScalable()) {
-      report("Vector types must both be fixed or both be scalable", MI);
+    if (!DstTy.isScalable() && Src1Ty.isScalable()) {
+      report("Cannot insert a scalable vector into a fixed length vector", MI);
       break;
     }
 
-    if (ElementCount::isKnownGT(Src1Ty.getElementCount(),
+    bool IsMixedFixedIntoScalable =
+        DstTy.isScalableVector() && Src1Ty.isFixedVector();
+
+    if (!IsMixedFixedIntoScalable &&
+        ElementCount::isKnownGT(Src1Ty.getElementCount(),
                                 DstTy.getElementCount())) {
       report("Second source must be smaller than destination vector", MI);
       break;
@@ -1853,7 +1857,8 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     uint64_t DstMinLen = DstTy.getElementCount().getKnownMinValue();
-    if (Idx >= DstMinLen || Idx + Src1MinLen > DstMinLen) {
+    if (!IsMixedFixedIntoScalable &&
+        (Idx >= DstMinLen || Idx + Src1MinLen > DstMinLen)) {
       report("Subvector type and index must not cause insert to overrun the "
              "vector being inserted into",
              MI);
@@ -1893,12 +1898,16 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
       break;
     }
 
-    if (SrcTy.isScalable() != DstTy.isScalable()) {
-      report("Vector types must both be fixed or both be scalable", MI);
+    if (DstTy.isScalable() && !SrcTy.isScalable()) {
+      report("Cannot extract a scalable vector from a fixed length vector", MI);
       break;
     }
 
-    if (ElementCount::isKnownGT(DstTy.getElementCount(),
+    bool IsMixedFixedFromScalable =
+        DstTy.isFixedVector() && SrcTy.isScalableVector();
+
+    if (!IsMixedFixedFromScalable &&
+        ElementCount::isKnownGT(DstTy.getElementCount(),
                                 SrcTy.getElementCount())) {
       report("Destination vector must be smaller than source vector", MI);
       break;
@@ -1914,7 +1923,8 @@ void MachineVerifier::verifyPreISelGenericInstruction(const MachineInstr *MI) {
     }
 
     uint64_t SrcMinLen = SrcTy.getElementCount().getKnownMinValue();
-    if (Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen) {
+    if (!IsMixedFixedFromScalable &&
+        (Idx >= SrcMinLen || Idx + DstMinLen > SrcMinLen)) {
       report("Destination type and index must not cause extract to overrun the "
              "source vector",
              MI);

--- a/llvm/test/MachineVerifier/test_g_extract_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_extract_subvector.mir
@@ -55,4 +55,8 @@ body: |
 
     ; CHECK: Index must be a multiple of the destination vector's minimum vector length
     %20:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %12, 1
+
+    ; CHECK: Destination type and index must not cause extract to overrun the source vector
+    %21:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 4
+
 ...

--- a/llvm/test/MachineVerifier/test_g_extract_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_extract_subvector.mir
@@ -50,10 +50,10 @@ body: |
     ; CHECK: Destination type and index must not cause extract to overrun the source vector
     %17:_(<3 x s32>) = G_EXTRACT_SUBVECTOR  %15, 3
 
-    ; CHECK: Vector types must both be fixed or both be scalable
+    ; CHECK: Cannot extract a scalable vector from a fixed length vector
     %18:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %15, 0
 
-    ; CHECK: Vector types must both be fixed or both be scalable
+    ; Extracting a fixed vector from a scalable vector is valid.
     %19:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 0
 
     ; CHECK: Index must be a multiple of the destination vector's minimum vector length

--- a/llvm/test/MachineVerifier/test_g_extract_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_extract_subvector.mir
@@ -53,9 +53,6 @@ body: |
     ; CHECK: Cannot extract a scalable vector from a fixed length vector
     %18:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %15, 0
 
-    ; Extracting a fixed vector from a scalable vector is valid.
-    %19:_(<2 x s32>) = G_EXTRACT_SUBVECTOR %12, 0
-
     ; CHECK: Index must be a multiple of the destination vector's minimum vector length
     %20:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR %12, 1
 ...

--- a/llvm/test/MachineVerifier/test_g_insert_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_insert_subvector.mir
@@ -62,4 +62,7 @@ body: |
 
     ; CHECK: Cannot insert a scalable vector into a fixed length vector
     %23:_(<4 x s32>) = G_INSERT_SUBVECTOR %20, %2, 0
+
+    ; CHECK: Subvector type and index must not cause insert to overrun the vector being inserted into
+    %21:_(<vscale x 4 x s32>) = G_INSERT_SUBVECTOR %12, %2, 4
 ...

--- a/llvm/test/MachineVerifier/test_g_insert_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_insert_subvector.mir
@@ -60,6 +60,11 @@ body: |
 
     %20:_(<2 x s32>) = G_IMPLICIT_DEF
 
-    ; CHECK: Vector types must both be fixed or both be scalable
+    ; Inserting a fixed vector into a scalable vector is valid.
     %21:_(<vscale x 1 x s32>) = G_INSERT_SUBVECTOR %12, %20, 2
+
+    %22:_(<4 x s32>) = G_IMPLICIT_DEF
+
+    ; CHECK: Cannot insert a scalable vector into a fixed length vector
+    %23:_(<4 x s32>) = G_INSERT_SUBVECTOR %22, %2, 0
 ...

--- a/llvm/test/MachineVerifier/test_g_insert_subvector.mir
+++ b/llvm/test/MachineVerifier/test_g_insert_subvector.mir
@@ -60,11 +60,6 @@ body: |
 
     %20:_(<2 x s32>) = G_IMPLICIT_DEF
 
-    ; Inserting a fixed vector into a scalable vector is valid.
-    %21:_(<vscale x 1 x s32>) = G_INSERT_SUBVECTOR %12, %20, 2
-
-    %22:_(<4 x s32>) = G_IMPLICIT_DEF
-
     ; CHECK: Cannot insert a scalable vector into a fixed length vector
-    %23:_(<4 x s32>) = G_INSERT_SUBVECTOR %22, %2, 0
+    %23:_(<4 x s32>) = G_INSERT_SUBVECTOR %20, %2, 0
 ...

--- a/llvm/unittests/CodeGen/GlobalISel/MachineIRBuilderTest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/MachineIRBuilderTest.cpp
@@ -500,11 +500,15 @@ TEST_F(AArch64GISelMITest, BuildExtractSubvector) {
   auto SBigVec = B.buildUndef(SVec4x32);
   B.buildExtractSubvector(SVec2x32, SBigVec, 0);
 
+  // Mixed: extract fixed-length <2 x s32> from scalable <vscale x 4 x s32>.
+  B.buildExtractSubvector(Vec2x32, SBigVec, 0);
+
   auto CheckStr = R"(
   ; CHECK: [[DEF:%[0-9]+]]:_(<4 x s32>) = G_IMPLICIT_DEF
   ; CHECK: [[EXTRACT:%[0-9]+]]:_(<2 x s32>) = G_EXTRACT_SUBVECTOR [[DEF]]:_(<4 x s32>), 0
   ; CHECK: [[SDEF:%[0-9]+]]:_(<vscale x 4 x s32>) = G_IMPLICIT_DEF
   ; CHECK: [[SEXTRACT:%[0-9]+]]:_(<vscale x 2 x s32>) = G_EXTRACT_SUBVECTOR [[SDEF]]:_(<vscale x 4 x s32>), 0
+  ; CHECK: [[MIXEDEXTRACT:%[0-9]+]]:_(<2 x s32>) = G_EXTRACT_SUBVECTOR [[SDEF]]:_(<vscale x 4 x s32>), 0
   )";
 
   EXPECT_TRUE(CheckMachineFunction(*MF, CheckStr)) << *MF;
@@ -555,6 +559,9 @@ TEST_F(AArch64GISelMITest, BuildInsertSubvector) {
   auto SSubVec = B.buildUndef(SVec2x32);
   B.buildInsertSubvector(SVec4x32, SBigVec, SSubVec, 0);
 
+  // Mixed: insert fixed-length <2 x s32> into scalable <vscale x 4 x s32>.
+  B.buildInsertSubvector(SVec4x32, SBigVec, SubVec, 0);
+
   auto CheckStr = R"(
   ; CHECK: [[DEF0:%[0-9]+]]:_(<4 x s32>) = G_IMPLICIT_DEF
   ; CHECK: [[DEF1:%[0-9]+]]:_(<2 x s32>) = G_IMPLICIT_DEF
@@ -563,6 +570,7 @@ TEST_F(AArch64GISelMITest, BuildInsertSubvector) {
   ; CHECK: [[SDEF0:%[0-9]+]]:_(<vscale x 4 x s32>) = G_IMPLICIT_DEF
   ; CHECK: [[SDEF1:%[0-9]+]]:_(<vscale x 2 x s32>) = G_IMPLICIT_DEF
   ; CHECK: {{%[0-9]+}}:_(<vscale x 4 x s32>) = G_INSERT_SUBVECTOR [[SDEF0]]:_, [[SDEF1]]:_(<vscale x 2 x s32>), 0
+  ; CHECK: {{%[0-9]+}}:_(<vscale x 4 x s32>) = G_INSERT_SUBVECTOR [[SDEF0]]:_, [[DEF1]]:_(<2 x s32>), 0
   )";
 
   EXPECT_TRUE(CheckMachineFunction(*MF, CheckStr)) << *MF;


### PR DESCRIPTION
I would like to allow `G_INSERT_SUBVECTOR` and `G_EXTRACT_SUBVECTOR` to be used with a scalable and a fix length vector types, similar like the OP's SelectionDAG version. There was already a discussion about this topic by @topperc and @michaelmaitland and @tschuett  in  #108848 .

I need this for RISC-V vector calling convention in GISel. I would love to have the ability to be able to work with vectors in RISC-V GISel. For example in a PR of mine I was asked to think of vectors ( #196636 ), but I couldn't really do that in the RISC-V backend, so I had to move the logic I wrote in that PR for AArch64 and test with vectors there ( #196757, #197018 ). In that case I could do that since it was a generic lowering.

This patch enables us to implement the RISC-V vector calling convention in GlobalISel in a similar manner in which it implemented in SelectionDAG. (in commit https://github.com/llvm/llvm-project/commit/0c5b789c7342ee8384507c3242fc256e23248c4d)
 
In SDAG `INSERT_SUBVECTOR` and `EXTRACT_SUBVECTOR` are used to basically convert the fixed length vector into a variable length vector, to which we can choose the right physical register according to the RISC-V calling convention (since RV vectors are basically always scalable).

For this function:
```llvm
define <4 x i32> @vector_4xi32(<4 x i32> %1) {
  %res = add <4 x i32> %1, %1
  ret <4 x i32> %res
}
```
SDAG gives this DAG:
<img width="402" height="1044" alt="image" src="https://github.com/user-attachments/assets/f348efb9-ea35-493b-bbc2-51b7ba02e89b" />

So if we accept this change or discuss another approach for RISC-V vector cc. I would like to start/continue the implementation of that.