### PR TITLE
[AMDGPU] Drop target requirements in test

### DIFF
--- a/llvm/test/CodeGen/MIR/AMDGPU/parse-cfi-unsigned-error.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/parse-cfi-unsigned-error.mir
@@ -1,7 +1,5 @@
 # RUN: not llc -mtriple=amdgcn -mcpu=gfx908 -run-pass=none -filetype=null %s 2>&1 | FileCheck %s
 
-# REQUIRES: amdgpu-registered-target
-
 # Test MIParser::parseCFIUnsigned
 
 name: test


### PR DESCRIPTION
These were only necessary when the test was in the wrong folder. Now
that the test is in the right folder, it will only be marked as
supported when AMDGPU is enabled as a target, so the additional
requirement in the test is redundant.