### PR TITLE
[clangd] Fix crash when server shuts down with in-flight rename or tweak

### DIFF
--- a/clang-tools-extra/clangd/ClangdLSPServer.cpp
+++ b/clang-tools-extra/clangd/ClangdLSPServer.cpp
@@ -808,7 +808,7 @@ void ClangdLSPServer::onCommandApplyEdit(const WorkspaceEdit &WE,
 
 void ClangdLSPServer::onCommandApplyTweak(const TweakArgs &Args,
                                           Callback<llvm::json::Value> Reply) {
-  auto Action = [this, Reply = std::move(Reply)](
+  auto Action = [this, Reply = std::move(Reply), &ServerRef = *Server](
                     llvm::Expected<Tweak::Effect> R) mutable {
     if (!R)
       return Reply(R.takeError());
@@ -825,7 +825,7 @@ void ClangdLSPServer::onCommandApplyTweak(const TweakArgs &Args,
     if (R->ApplyEdits.empty())
       return Reply("Tweak applied.");
 
-    if (auto Err = validateEdits(*Server, R->ApplyEdits))
+    if (auto Err = validateEdits(ServerRef, R->ApplyEdits))
       return Reply(std::move(Err));
 
     WorkspaceEdit WE;
@@ -909,11 +909,11 @@ void ClangdLSPServer::onRename(const RenameParams &Params,
     return Reply(llvm::make_error<LSPError>(
         "onRename called for non-added file", ErrorCode::InvalidParams));
   Server->rename(File, Params.position, Params.newName, Opts.Rename,
-                 [File, Params, Reply = std::move(Reply),
-                  this](llvm::Expected<RenameResult> R) mutable {
+                 [File, Params, Reply = std::move(Reply), &ServerRef = *Server](
+                     llvm::Expected<RenameResult> R) mutable {
                    if (!R)
                      return Reply(R.takeError());
-                   if (auto Err = validateEdits(*Server, R->GlobalChanges))
+                   if (auto Err = validateEdits(ServerRef, R->GlobalChanges))
                      return Reply(std::move(Err));
                    WorkspaceEdit Result;
                    // FIXME: use documentChanges if SupportDocumentChanges is

--- a/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/ClangdLSPServerTests.cpp
@@ -512,6 +512,22 @@ TEST_F(LSPTest, CompletionOutOfRangePosition) {
   ASSERT_TRUE(!!Result) << "Expected a response, not a server crash";
 }
 
+// https://github.com/llvm/llvm-project/issues/196225
+TEST_F(LSPTest, ShutdownDuringRename) {
+  Annotations Code("void ^foo();");
+  auto &Client = start();
+  Client.didOpen("foo.cpp", Code.code());
+  auto &Reply = Client.call("textDocument/rename",
+                            llvm::json::Object{
+                                {"textDocument", Client.documentID("foo.cpp")},
+                                {"position", Code.point()},
+                                {"newName", "bar"},
+                            });
+  stop();
+  auto Result = Reply.take();
+  ASSERT_TRUE(!!Result) << "Expected a response, not a server crash";
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang


### PR DESCRIPTION
Fixes #196225.

Root cause: When clangd shuts down, `ClangdLSPServer`'s destructor calls `Server.reset()` to destroy the `ClangdServer` object. `ClangdServer` then destroys the work scheduler, which blocks and waits for in-flight tasks to finish. If a rename task is in flight, the callback will try to access the now-reset `ClangdLSPServer::Server` in https://github.com/llvm/llvm-project/blob/4f9a7d09f4760ac9c5745e8bb829366d29ff9687/clang-tools-extra/clangd/ClangdLSPServer.cpp#L916-L917

The same issue occurs with `onCommandApplyTweak`, as its callback also accesses `ClangdLSPServer::Server`: https://github.com/llvm/llvm-project/blob/4f9a7d09f4760ac9c5745e8bb829366d29ff9687/clang-tools-extra/clangd/ClangdLSPServer.cpp#L828-L829

A reproducer has been added to #196225.

This PR fixes these issues by capturing a reference to `ClangdServer` and using it in the callbacks instead of the `ClangdLSPServer::Server` optional. The reference is guaranteed to remain valid because the work scheduler syncs while the server is being destroyed.

Includes a unit test that verifies the fix for `rename`. The test for `applyTweak` was omitted because the mocked LSP client would trigger an `ADD_FAILURE()` ("Unexpected server->client call") when intercepting the outgoing `workspace/applyEdit` request. While this could be handled with `EXPECT_NONFATAL_FAILURE_ON_ALL_THREADS`, it would make the test flaky because the task could occasionally finish before the server shuts down. 
