### PR TITLE
[AArch64] Do not pass debug insn to liveness analysis

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
+++ b/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
@@ -521,7 +521,8 @@ int AArch64A57FPLoadBalancingImpl::scavengeRegister(Chain *G, Color C,
   MachineBasicBlock::iterator ChainEnd = G->end();
   while (I != ChainEnd) {
     --I;
-    Units.stepBackward(*I);
+    if (!I->isDebugInstr())
+      Units.stepBackward(*I);
   }
 
   // Check which register units are alive throughout the chain.


### PR DESCRIPTION
Fix another stepBackward location.

Debug instructions must not affect liveness analysis. stepBackward has an assertion failure on debug instructions after https://github.com/llvm/llvm-project/pull/193104.