### PR TITLE
[LLVM][MLIR] Fix TU-local entity exposure for C++20 module compatibility

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -427,29 +427,29 @@ using opStatus = APFloatBase::opStatus;
 using cmpResult = APFloatBase::cmpResult;
 using fltCategory = APFloatBase::fltCategory;
 using ExponentType = APFloatBase::ExponentType;
-static constexpr uninitializedTag uninitialized = APFloatBase::uninitialized;
-static constexpr roundingMode rmNearestTiesToEven =
+inline constexpr uninitializedTag uninitialized = APFloatBase::uninitialized;
+inline constexpr roundingMode rmNearestTiesToEven =
     APFloatBase::rmNearestTiesToEven;
-static constexpr roundingMode rmNearestTiesToAway =
+inline constexpr roundingMode rmNearestTiesToAway =
     APFloatBase::rmNearestTiesToAway;
-static constexpr roundingMode rmTowardNegative = APFloatBase::rmTowardNegative;
-static constexpr roundingMode rmTowardPositive = APFloatBase::rmTowardPositive;
-static constexpr roundingMode rmTowardZero = APFloatBase::rmTowardZero;
-static constexpr unsigned integerPartWidth = APFloatBase::integerPartWidth;
-static constexpr cmpResult cmpEqual = APFloatBase::cmpEqual;
-static constexpr cmpResult cmpLessThan = APFloatBase::cmpLessThan;
-static constexpr cmpResult cmpGreaterThan = APFloatBase::cmpGreaterThan;
-static constexpr cmpResult cmpUnordered = APFloatBase::cmpUnordered;
-static constexpr opStatus opOK = APFloatBase::opOK;
-static constexpr opStatus opInvalidOp = APFloatBase::opInvalidOp;
-static constexpr opStatus opDivByZero = APFloatBase::opDivByZero;
-static constexpr opStatus opOverflow = APFloatBase::opOverflow;
-static constexpr opStatus opUnderflow = APFloatBase::opUnderflow;
-static constexpr opStatus opInexact = APFloatBase::opInexact;
-static constexpr fltCategory fcInfinity = APFloatBase::fcInfinity;
-static constexpr fltCategory fcNaN = APFloatBase::fcNaN;
-static constexpr fltCategory fcNormal = APFloatBase::fcNormal;
-static constexpr fltCategory fcZero = APFloatBase::fcZero;
+inline constexpr roundingMode rmTowardNegative = APFloatBase::rmTowardNegative;
+inline constexpr roundingMode rmTowardPositive = APFloatBase::rmTowardPositive;
+inline constexpr roundingMode rmTowardZero = APFloatBase::rmTowardZero;
+inline constexpr unsigned integerPartWidth = APFloatBase::integerPartWidth;
+inline constexpr cmpResult cmpEqual = APFloatBase::cmpEqual;
+inline constexpr cmpResult cmpLessThan = APFloatBase::cmpLessThan;
+inline constexpr cmpResult cmpGreaterThan = APFloatBase::cmpGreaterThan;
+inline constexpr cmpResult cmpUnordered = APFloatBase::cmpUnordered;
+inline constexpr opStatus opOK = APFloatBase::opOK;
+inline constexpr opStatus opInvalidOp = APFloatBase::opInvalidOp;
+inline constexpr opStatus opDivByZero = APFloatBase::opDivByZero;
+inline constexpr opStatus opOverflow = APFloatBase::opOverflow;
+inline constexpr opStatus opUnderflow = APFloatBase::opUnderflow;
+inline constexpr opStatus opInexact = APFloatBase::opInexact;
+inline constexpr fltCategory fcInfinity = APFloatBase::fcInfinity;
+inline constexpr fltCategory fcNaN = APFloatBase::fcNaN;
+inline constexpr fltCategory fcNormal = APFloatBase::fcNormal;
+inline constexpr fltCategory fcZero = APFloatBase::fcZero;
 
 class IEEEFloat final {
 public:

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -398,7 +398,7 @@ using check_has_free_function_rbegin =
     decltype(adl_rbegin(std::declval<Range &>()));
 
 template <typename Range>
-static constexpr bool HasFreeFunctionRBegin =
+inline constexpr bool HasFreeFunctionRBegin =
     is_detected<check_has_free_function_rbegin, Range>::value;
 } // namespace detail
 
@@ -1680,7 +1680,7 @@ using check_has_free_function_size =
     decltype(adl_size(std::declval<Range &>()));
 
 template <typename Range>
-static constexpr bool HasFreeFunctionSize =
+inline constexpr bool HasFreeFunctionSize =
     is_detected<check_has_free_function_size, Range>::value;
 } // namespace detail
 
@@ -1923,7 +1923,7 @@ using check_has_member_contains_t =
     decltype(std::declval<Range &>().contains(std::declval<const Element &>()));
 
 template <typename Range, typename Element>
-static constexpr bool HasMemberContains =
+inline constexpr bool HasMemberContains =
     is_detected<check_has_member_contains_t, Range, Element>::value;
 
 template <typename Range, typename Element>
@@ -1932,7 +1932,7 @@ using check_has_member_find_t =
              std::declval<Range &>().end());
 
 template <typename Range, typename Element>
-static constexpr bool HasMemberFind =
+inline constexpr bool HasMemberFind =
     is_detected<check_has_member_find_t, Range, Element>::value;
 
 } // namespace detail

--- a/llvm/include/llvm/ADT/SetOperations.h
+++ b/llvm/include/llvm/ADT/SetOperations.h
@@ -25,7 +25,7 @@ using check_has_member_remove_if_t =
     decltype(std::declval<Set>().remove_if(std::declval<Fn>()));
 
 template <typename Set, typename Fn>
-static constexpr bool HasMemberRemoveIf =
+inline constexpr bool HasMemberRemoveIf =
     is_detected<check_has_member_remove_if_t, Set, Fn>::value;
 
 template <typename Set>
@@ -33,7 +33,7 @@ using check_has_member_erase_iter_t =
     decltype(std::declval<Set>().erase(std::declval<Set>().begin()));
 
 template <typename Set>
-static constexpr bool HasMemberEraseIter =
+inline constexpr bool HasMemberEraseIter =
     is_detected<check_has_member_erase_iter_t, Set>::value;
 
 } // namespace detail

--- a/llvm/include/llvm/Support/AMDGPUAddrSpace.h
+++ b/llvm/include/llvm/Support/AMDGPUAddrSpace.h
@@ -140,7 +140,7 @@ enum : unsigned {
 namespace impl {
 // TODO: Move this into mapToDWARFAddrSpace when we switch to C++23
 // (see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2647r1.html)
-static constexpr unsigned LLVMToDWARFAddrSpaceMapping[] = {
+inline constexpr unsigned LLVMToDWARFAddrSpaceMapping[] = {
     DWARFAS::GENERIC,     //< AMDGPUAS::FLAT_ADDRESS
     DWARFAS::GLOBAL,      //< AMDGPUAS::GLOBAL_ADDRESS
     DWARFAS::REGION,      //< AMDGPUAS::REGION_ADDRESS

--- a/llvm/include/llvm/Support/CheckedArithmetic.h
+++ b/llvm/include/llvm/Support/CheckedArithmetic.h
@@ -19,7 +19,7 @@
 #include <optional>
 #include <type_traits>
 
-namespace {
+namespace llvm::detail {
 
 /// Utility function to apply a given method of \c APInt \p F to \p LHS and
 /// \p RHS.
@@ -27,15 +27,16 @@ namespace {
 template <typename T, typename F>
 std::enable_if_t<std::is_integral_v<T> && sizeof(T) * 8 <= 64, std::optional<T>>
 checkedOp(T LHS, T RHS, F Op, bool Signed = true) {
-  llvm::APInt ALHS(sizeof(T) * 8, LHS, Signed);
-  llvm::APInt ARHS(sizeof(T) * 8, RHS, Signed);
+  APInt ALHS(sizeof(T) * 8, LHS, Signed);
+  APInt ARHS(sizeof(T) * 8, RHS, Signed);
   bool Overflow;
-  llvm::APInt Out = (ALHS.*Op)(ARHS, Overflow);
+  APInt Out = (ALHS.*Op)(ARHS, Overflow);
   if (Overflow)
     return std::nullopt;
   return Signed ? Out.getSExtValue() : Out.getZExtValue();
 }
-}
+
+} // namespace llvm::detail
 
 namespace llvm {
 
@@ -45,7 +46,7 @@ namespace llvm {
 template <typename T>
 std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedAdd(T LHS,
                                                                    T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::sadd_ov);
+  return detail::checkedOp(LHS, RHS, &APInt::sadd_ov);
 }
 
 /// Subtract two signed integers \p LHS and \p RHS.
@@ -54,7 +55,7 @@ std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedAdd(T LHS,
 template <typename T>
 std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedSub(T LHS,
                                                                    T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::ssub_ov);
+  return detail::checkedOp(LHS, RHS, &APInt::ssub_ov);
 }
 
 /// Multiply two signed integers \p LHS and \p RHS.
@@ -63,7 +64,7 @@ std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedSub(T LHS,
 template <typename T>
 std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedMul(T LHS,
                                                                    T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::smul_ov);
+  return detail::checkedOp(LHS, RHS, &APInt::smul_ov);
 }
 
 /// Multiply A and B, and add C to the resulting product.
@@ -83,7 +84,7 @@ std::enable_if_t<std::is_signed_v<T>, std::optional<T>> checkedMulAdd(T A, T B,
 template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, std::optional<T>>
 checkedAddUnsigned(T LHS, T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::uadd_ov, /*Signed=*/false);
+  return detail::checkedOp(LHS, RHS, &APInt::uadd_ov, /*Signed=*/false);
 }
 
 /// Multiply two unsigned integers \p LHS and \p RHS.
@@ -92,7 +93,7 @@ checkedAddUnsigned(T LHS, T RHS) {
 template <typename T>
 std::enable_if_t<std::is_unsigned_v<T>, std::optional<T>>
 checkedMulUnsigned(T LHS, T RHS) {
-  return checkedOp(LHS, RHS, &llvm::APInt::umul_ov, /*Signed=*/false);
+  return detail::checkedOp(LHS, RHS, &APInt::umul_ov, /*Signed=*/false);
 }
 
 /// Multiply unsigned integers A and B, and add C to the resulting product.

--- a/mlir/include/mlir/IR/AffineMap.h
+++ b/mlir/include/mlir/IR/AffineMap.h
@@ -31,6 +31,24 @@ namespace mlir {
 
 namespace detail {
 struct AffineMapStorage;
+
+/// Calculates maximum dimension and symbol positions from the expressions
+/// in `exprsLists` and stores them in `maxDim` and `maxSym` respectively.
+template <typename AffineExprContainer>
+void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
+                        int64_t &maxDim, int64_t &maxSym) {
+  for (const auto &exprs : exprsList) {
+    for (auto expr : exprs) {
+      expr.walk([&maxDim, &maxSym](AffineExpr e) {
+        if (auto d = dyn_cast<AffineDimExpr>(e))
+          maxDim = std::max(maxDim, static_cast<int64_t>(d.getPosition()));
+        if (auto s = dyn_cast<AffineSymbolExpr>(e))
+          maxSym = std::max(maxSym, static_cast<int64_t>(s.getPosition()));
+      });
+    }
+  }
+}
+
 } // namespace detail
 
 class Attribute;
@@ -689,23 +707,6 @@ SmallVector<T> applyPermutationMap(AffineMap map, llvm::ArrayRef<T> source) {
     }
   }
   return result;
-}
-
-/// Calculates maximum dimension and symbol positions from the expressions
-/// in `exprsLists` and stores them in `maxDim` and `maxSym` respectively.
-template <typename AffineExprContainer>
-static void getMaxDimAndSymbol(ArrayRef<AffineExprContainer> exprsList,
-                               int64_t &maxDim, int64_t &maxSym) {
-  for (const auto &exprs : exprsList) {
-    for (auto expr : exprs) {
-      expr.walk([&maxDim, &maxSym](AffineExpr e) {
-        if (auto d = dyn_cast<AffineDimExpr>(e))
-          maxDim = std::max(maxDim, static_cast<int64_t>(d.getPosition()));
-        if (auto s = dyn_cast<AffineSymbolExpr>(e))
-          maxSym = std::max(maxSym, static_cast<int64_t>(s.getPosition()));
-      });
-    }
-  }
 }
 
 } // namespace mlir

--- a/mlir/include/mlir/IR/DialectImplementation.h
+++ b/mlir/include/mlir/IR/DialectImplementation.h
@@ -17,8 +17,8 @@
 #include "mlir/IR/OpImplementation.h"
 #include <type_traits>
 
-namespace {
-
+namespace mlir {
+namespace detail {
 // reference https://stackoverflow.com/a/16000226
 template <typename T, typename = void>
 struct HasStaticDialectName : std::false_type {};
@@ -29,10 +29,7 @@ struct HasStaticDialectName<
            std::is_same<::llvm::StringLiteral,
                         std::decay_t<decltype(T::dialectName)>>::value,
            void>::type> : std::true_type {};
-
-} // namespace
-
-namespace mlir {
+} // namespace detail
 
 //===----------------------------------------------------------------------===//
 // DialectAsmPrinter
@@ -79,7 +76,7 @@ struct FieldParser<
     AttributeT, std::enable_if_t<std::is_base_of<Attribute, AttributeT>::value,
                                  AttributeT>> {
   static FailureOr<AttributeT> parse(AsmParser &parser) {
-    if constexpr (HasStaticDialectName<AttributeT>::value) {
+    if constexpr (detail::HasStaticDialectName<AttributeT>::value) {
       parser.getContext()->getOrLoadDialect(AttributeT::dialectName);
     }
     AttributeT value;
@@ -132,7 +129,7 @@ struct FieldParser<
     std::enable_if_t<std::is_base_of<Attribute, AttributeT>::value,
                      std::optional<AttributeT>>> {
   static FailureOr<std::optional<AttributeT>> parse(AsmParser &parser) {
-    if constexpr (HasStaticDialectName<AttributeT>::value) {
+    if constexpr (detail::HasStaticDialectName<AttributeT>::value) {
       parser.getContext()->getOrLoadDialect(AttributeT::dialectName);
     }
     AttributeT attr;

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -1595,8 +1595,8 @@ using detect_has_any_fold_trait =
 /// Returns the result of folding a trait that implements a `foldTrait` function
 /// that is specialized for operations that have a single result.
 template <typename Trait>
-static std::enable_if_t<detect_has_single_result_fold_trait<Trait>::value,
-                        LogicalResult>
+std::enable_if_t<detect_has_single_result_fold_trait<Trait>::value,
+                 LogicalResult>
 foldTrait(Operation *op, ArrayRef<Attribute> operands,
           SmallVectorImpl<OpFoldResult> &results) {
   assert(op->hasTrait<OpTrait::OneResult>() &&
@@ -1617,7 +1617,7 @@ foldTrait(Operation *op, ArrayRef<Attribute> operands,
 /// Returns the result of folding a trait that implements a generalized
 /// `foldTrait` function that is supports any operation type.
 template <typename Trait>
-static std::enable_if_t<detect_has_fold_trait<Trait>::value, LogicalResult>
+std::enable_if_t<detect_has_fold_trait<Trait>::value, LogicalResult>
 foldTrait(Operation *op, ArrayRef<Attribute> operands,
           SmallVectorImpl<OpFoldResult> &results) {
   // If a previous trait has already been folded and replaced this operation, we
@@ -1625,8 +1625,7 @@ foldTrait(Operation *op, ArrayRef<Attribute> operands,
   return results.empty() ? Trait::foldTrait(op, operands, results) : failure();
 }
 template <typename Trait>
-static inline std::enable_if_t<!detect_has_any_fold_trait<Trait>::value,
-                               LogicalResult>
+inline std::enable_if_t<!detect_has_any_fold_trait<Trait>::value, LogicalResult>
 foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
   return failure();
 }
@@ -1634,8 +1633,8 @@ foldTrait(Operation *, ArrayRef<Attribute>, SmallVectorImpl<OpFoldResult> &) {
 /// Given a tuple type containing a set of traits, return the result of folding
 /// the given operation.
 template <typename... Ts>
-static LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
-                                SmallVectorImpl<OpFoldResult> &results) {
+LogicalResult foldTraits(Operation *op, ArrayRef<Attribute> operands,
+                         SmallVectorImpl<OpFoldResult> &results) {
   return success((succeeded(foldTrait<Ts>(op, operands, results)) || ...));
 }
 

--- a/mlir/include/mlir/IR/OpImplementation.h
+++ b/mlir/include/mlir/IR/OpImplementation.h
@@ -21,7 +21,8 @@
 #include "llvm/Support/SMLoc.h"
 #include <optional>
 
-namespace {
+namespace mlir {
+namespace detail {
 // reference https://stackoverflow.com/a/16000226
 template <typename T, typename = void>
 struct HasStaticName : std::false_type {};
@@ -32,9 +33,7 @@ struct HasStaticName<T,
                          std::is_same<::llvm::StringLiteral,
                                       std::decay_t<decltype(T::name)>>::value,
                          void>::type> : std::true_type {};
-} // namespace
-
-namespace mlir {
+} // namespace detail
 class AsmParsedResourceEntry;
 class AsmResourceBuilder;
 class Builder;
@@ -1313,7 +1312,7 @@ public:
     if (!result) {
       InFlightDiagnostic diag =
           emitError(loc, "invalid kind of type specified");
-      if constexpr (HasStaticName<TypeT>::value)
+      if constexpr (detail::HasStaticName<TypeT>::value)
         diag << ": expected " << TypeT::name << ", but found " << type;
       return diag;
     }
@@ -1350,7 +1349,7 @@ public:
     if (!result) {
       InFlightDiagnostic diag =
           emitError(loc, "invalid kind of type specified");
-      if constexpr (HasStaticName<TypeT>::value)
+      if constexpr (detail::HasStaticName<TypeT>::value)
         diag << ": expected " << TypeT::name << ", but found " << type;
       return diag;
     }
@@ -1392,7 +1391,7 @@ public:
     if (!result) {
       InFlightDiagnostic diag =
           emitError(loc, "invalid kind of type specified");
-      if constexpr (HasStaticName<TypeType>::value)
+      if constexpr (detail::HasStaticName<TypeType>::value)
         diag << ": expected " << TypeType::name << ", but found " << type;
       return diag;
     }

--- a/mlir/include/mlir/IR/PDLPatternMatch.h.inc
+++ b/mlir/include/mlir/IR/PDLPatternMatch.h.inc
@@ -642,8 +642,8 @@ void assertArgs(PatternRewriter &rewriter, ArrayRef<PDLValue> values,
 
 /// Store a single result within the result list.
 template <typename T>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results, T &&value) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             T &&value) {
   ProcessPDLValue<T>::processAsResult(rewriter, results,
                                       std::forward<T>(value));
   return success();
@@ -651,9 +651,8 @@ static LogicalResult processResults(PatternRewriter &rewriter,
 
 /// Store a std::pair<> as individual results within the result list.
 template <typename T1, typename T2>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    std::pair<T1, T2> &&pair) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             std::pair<T1, T2> &&pair) {
   if (failed(processResults(rewriter, results, std::move(pair.first))) ||
       failed(processResults(rewriter, results, std::move(pair.second))))
     return failure();
@@ -662,9 +661,8 @@ static LogicalResult processResults(PatternRewriter &rewriter,
 
 /// Store a std::tuple<> as individual results within the result list.
 template <typename... Ts>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    std::tuple<Ts...> &&tuple) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             std::tuple<Ts...> &&tuple) {
   auto applyFn = [&](auto &&...args) {
     return (succeeded(processResults(rewriter, results, std::move(args))) &&
             ...);
@@ -679,9 +677,8 @@ inline LogicalResult processResults(PatternRewriter &rewriter,
   return result;
 }
 template <typename T>
-static LogicalResult processResults(PatternRewriter &rewriter,
-                                    PDLResultList &results,
-                                    FailureOr<T> &&result) {
+LogicalResult processResults(PatternRewriter &rewriter, PDLResultList &results,
+                             FailureOr<T> &&result) {
   if (failed(result))
     return failure();
   return processResults(rewriter, results, std::move(*result));

--- a/mlir/include/mlir/Interfaces/Utils/InferIntRangeCommon.h
+++ b/mlir/include/mlir/Interfaces/Utils/InferIntRangeCommon.h
@@ -34,8 +34,8 @@ using InferRangeFn =
 using InferIntegerValueRangeFn =
     std::function<IntegerValueRange(ArrayRef<IntegerValueRange>)>;
 
-static constexpr unsigned indexMinWidth = 32;
-static constexpr unsigned indexMaxWidth = 64;
+inline constexpr unsigned indexMinWidth = 32;
+inline constexpr unsigned indexMaxWidth = 64;
 
 enum class CmpMode : uint32_t { Both, Signed, Unsigned };
 

--- a/mlir/include/mlir/Pass/PassOptions.h
+++ b/mlir/include/mlir/Pass/PassOptions.h
@@ -57,11 +57,11 @@ using has_stream_operator = llvm::is_detected<has_stream_operator_trait, T>;
 
 /// Utility methods for printing option values.
 template <typename ParserT>
-static void printOptionValue(raw_ostream &os, const bool &value) {
+void printOptionValue(raw_ostream &os, const bool &value) {
   os << (value ? StringRef("true") : StringRef("false"));
 }
 template <typename ParserT>
-static void printOptionValue(raw_ostream &os, const std::string &str) {
+void printOptionValue(raw_ostream &os, const std::string &str) {
   // Check if the string needs to be escaped before writing it to the ostream.
   const size_t spaceIndex = str.find_first_of(' ');
   const size_t escapeIndex =
@@ -75,7 +75,7 @@ static void printOptionValue(raw_ostream &os, const std::string &str) {
     os << "}";
 }
 template <typename ParserT, typename DataT>
-static void printOptionValue(raw_ostream &os, const DataT &value) {
+void printOptionValue(raw_ostream &os, const DataT &value) {
   if constexpr (has_stream_operator<DataT>::value)
     os << value;
   else

--- a/mlir/lib/Dialect/SparseTensor/IR/Detail/Var.cpp
+++ b/mlir/lib/Dialect/SparseTensor/IR/Detail/Var.cpp
@@ -59,8 +59,8 @@ bool Ranks::isValid(DimLvlExpr expr) const {
   // Compute the maximum identifiers for symbol-vars and dim/lvl-vars
   // (each `DimLvlExpr` only allows one kind of non-symbol variable).
   int64_t maxSym = -1, maxVar = -1;
-  mlir::getMaxDimAndSymbol<ArrayRef<AffineExpr>>({{expr.getAffineExpr()}},
-                                                 maxVar, maxSym);
+  mlir::detail::getMaxDimAndSymbol<ArrayRef<AffineExpr>>(
+      {{expr.getAffineExpr()}}, maxVar, maxSym);
   return maxSym < getSymRank() && maxVar < getRank(expr.getAllowedVarKind());
 }
 

--- a/mlir/lib/IR/AffineMap.cpp
+++ b/mlir/lib/IR/AffineMap.cpp
@@ -297,7 +297,7 @@ inferFromExprList(ArrayRef<AffineExprContainer> exprsList,
   if (exprsList.empty())
     return {};
   int64_t maxDim = -1, maxSym = -1;
-  getMaxDimAndSymbol(exprsList, maxDim, maxSym);
+  detail::getMaxDimAndSymbol(exprsList, maxDim, maxSym);
   SmallVector<AffineMap, 4> maps;
   maps.reserve(exprsList.size());
   for (const auto &exprs : exprsList)

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -1214,8 +1214,8 @@ willBeValidAffineMap(unsigned dimCount, unsigned symbolCount,
                      ArrayRef<AffineExpr> results) {
   int64_t maxDimPosition = -1;
   int64_t maxSymbolPosition = -1;
-  getMaxDimAndSymbol(ArrayRef<ArrayRef<AffineExpr>>(results), maxDimPosition,
-                     maxSymbolPosition);
+  detail::getMaxDimAndSymbol(ArrayRef<ArrayRef<AffineExpr>>(results),
+                             maxDimPosition, maxSymbolPosition);
   if ((maxDimPosition >= dimCount) || (maxSymbolPosition >= symbolCount)) {
     LDBG()
         << "maximum dimensional identifier position in result expression must "


### PR DESCRIPTION
Fix TU-local entity exposure issues across LLVM and MLIR that prevent
compilation with C++20 modules (GCC and Clang).

## Changes
- Convert namespace-scope `static constexpr` to `inline constexpr`
- Move static helper functions into `detail::` namespaces
- Move SFINAE helpers from anonymous namespaces into `detail::` namespaces

This affects ~40+ instances in ADT headers and various MLIR include files.

## Motivation
C++20 modules treat exposure of TU-local entities (via templates or public
interfaces) as ill-formed in many cases. These changes restore module
compatibility without functional or ABI impact.

`inline constexpr` is the modern replacement for `static constexpr` at
namespace scope. Moving helpers to `detail::` properly hides internal
implementation details.

## Testing
No functional changes. Builds successfully with `-DLLVM_ENABLE_MODULES=ON`.
No new tests required.