### PR TITLE
[lldb] Make CommandObject::GetTarget filter out the dummy target

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -478,7 +478,13 @@ public:
     return m_debugger.GetTargetList().GetSelectedTarget();
   }
 
-  ExecutionContext GetExecutionContext() const;
+  /// Returns the execution context the interpreter should run a command in.
+  /// If `adopt_dummy_target` is true and no real target is selected, the
+  /// dummy target is substituted in. Pass false from CommandObject paths
+  /// where the command hasn't opted into the dummy via
+  /// eCommandAllowsDummyTarget, so callers can't inadvertently end up
+  /// operating on the dummy.
+  ExecutionContext GetExecutionContext(bool adopt_dummy_target = true) const;
 
   lldb::PlatformSP GetPlatform(bool prefer_target_platform);
 

--- a/lldb/include/lldb/Interpreter/CommandObject.h
+++ b/lldb/include/lldb/Interpreter/CommandObject.h
@@ -379,11 +379,14 @@ protected:
 
   Target &GetDummyTarget();
 
-  // This is for use in the command interpreter, and returns the most relevant
-  // target. In order of priority, that's the target from the command object's
-  // execution context, the target from the interpreter's execution context, the
-  // selected target or the dummy target.
-  Target &GetTarget();
+  /// Get the target this command should operate on. Prefers the frozen
+  /// execution context in the command object, falling back to the
+  /// interpreter's execution context. The dummy target is filtered out unless
+  /// the command has one of the eCommandRequires{Target,Process,Thread,Frame}
+  /// flags (in which case CheckRequirements has already guaranteed a real
+  /// target) or has opted in via eCommandAllowsDummyTarget. Returns null when
+  /// no target is available.
+  Target *GetTarget();
 
   // If a command needs to use the "current" thread, use this call. Command
   // objects will have an ExecutionContext to use, and that may or may not have

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1235,7 +1235,14 @@ FLAGS_ENUM(CommandFlags){
     ///
     /// Verifies that the process is being traced by a Trace plug-in, if it
     /// isn't the command will fail with an appropriate error message.
-    eCommandProcessMustBeTraced = (1u << 8)};
+    eCommandProcessMustBeTraced = (1u << 8),
+    /// eCommandAllowsDummyTarget
+    ///
+    /// Indicates that the command can legitimately operate on the dummy target
+    /// (e.g. `breakpoint set` priming future targets). Without this flag,
+    /// CommandObject::GetTarget filters the dummy target out and returns null
+    /// when no real target is selected.
+    eCommandAllowsDummyTarget = (1u << 9)};
 
 /// Whether a summary should cap how much data it returns to users or not.
 enum TypeSummaryCapping {

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -391,7 +391,8 @@ class CommandObjectBreakpointAddAddress : public CommandObjectParsed {
 public:
   CommandObjectBreakpointAddAddress(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint add address",
-                            "Add breakpoints by raw address", nullptr) {
+                            "Add breakpoints by raw address", nullptr,
+                            eCommandAllowsDummyTarget) {
     CommandArgumentData bp_id_arg;
 
     // Define the first (and only) variant of this arg.
@@ -537,7 +538,7 @@ public:
             interpreter, "breakpoint add exception",
             "Add breakpoints on language exceptions.  If no language is "
             "specified, break on exceptions for all supported languages",
-            nullptr) {
+            nullptr, eCommandAllowsDummyTarget) {
     // Define the first (and only) variant of this arg.
     AddSimpleArgumentList(eArgTypeLanguage, eArgRepeatStar);
 
@@ -607,8 +608,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
     BreakpointSP bp_sp;
     LanguageType exception_language = eLanguageTypeUnknown;
 
@@ -631,14 +632,14 @@ protected:
     const bool internal = false;
     bool catch_bp = (m_options.m_exception_stage & eExceptionStageCatch) != 0;
     bool throw_bp = (m_options.m_exception_stage & eExceptionStageThrow) != 0;
-    bp_sp = target.CreateExceptionBreakpoint(
+    bp_sp = target->CreateExceptionBreakpoint(
         exception_language, catch_bp, throw_bp, internal,
         &m_options.m_exception_extra_args, &precond_error);
     if (precond_error.Fail()) {
       result.AppendErrorWithFormat(
           "Error setting extra exception arguments: %s",
           precond_error.AsCString());
-      target.RemoveBreakpointByID(bp_sp->GetID());
+      target->RemoveBreakpointByID(bp_sp->GetID());
       return;
     }
 
@@ -652,7 +653,7 @@ protected:
       // breakpoints.  They can get set in the dummy target, and we won't know
       // how to actually set the breakpoint till we know what version of the
       // relevant LanguageRuntime gets loaded.
-      if (&target == &GetDummyTarget())
+      if (target == &GetDummyTarget())
         output_stream.Printf("Breakpoint set in dummy target, will get copied "
                              "into future targets.\n");
       result.SetStatus(eReturnStatusSuccessFinishResult);
@@ -680,7 +681,8 @@ public:
   CommandObjectBreakpointAddFile(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "breakpoint add file",
-            "Add breakpoints on lines in specified source files", nullptr) {
+            "Add breakpoints on lines in specified source files", nullptr,
+            eCommandAllowsDummyTarget) {
     CommandArgumentEntry arg1;
     CommandArgumentData linespec_arg;
     CommandArgumentData no_arg;
@@ -865,8 +867,8 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     bool internal = false;
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
     // FIXME: At present we can only make file & line breakpoints for one file
     // and line pair. It wouldn't be hard to extend that, but I'm not adding
     // features at this point so I'll leave that for a future patch.  For now,
@@ -882,7 +884,7 @@ protected:
         // The argument is a plain number.  Treat that as a line number, and
         // allow it if we can find a default file & line.
         std::string error_msg;
-        if (!GetDefaultFile(target, m_exe_ctx.GetFramePtr(), default_file,
+        if (!GetDefaultFile(*target, m_exe_ctx.GetFramePtr(), default_file,
                             result)) {
           result.AppendErrorWithFormatv("Couldn't find default file for line "
                                         "input: {0} - {1}",
@@ -912,7 +914,7 @@ protected:
     LazyBool check_inlines = eLazyBoolCalculate;
 
     OptionValueFileColonLine &this_spec = m_options.m_line_specs[0];
-    bp_sp = target.CreateBreakpoint(
+    bp_sp = target->CreateBreakpoint(
         &(m_options.m_modules), this_spec.GetFileSpec(),
         this_spec.GetLineNumber(), this_spec.GetColumnNumber(),
         m_options.m_offset_addr, check_inlines, m_options.m_skip_prologue,
@@ -924,7 +926,7 @@ protected:
       Stream &output_stream = result.GetOutputStream();
       bp_sp->GetDescription(&output_stream, lldb::eDescriptionLevelInitial,
                             /*show_locations=*/false);
-      if (&target == &GetDummyTarget())
+      if (target == &GetDummyTarget())
         output_stream.Printf("Breakpoint set in dummy target, will get copied "
                              "into future targets.\n");
       else {
@@ -961,7 +963,7 @@ public:
   CommandObjectBreakpointAddName(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint add name",
                             "Add breakpoints matching function or symbol names",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     // FIXME: Add a completer that's aware of the name match style.
     // Define the first (and only) variant of this arg.
     AddSimpleArgumentList(eArgTypeFunctionOrSymbol, eArgRepeatPlus);
@@ -1073,8 +1075,8 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     const bool internal = false;
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
     // Parse the argument list - this is a simple list of names.
     std::vector<std::string> func_names;
     for (const Args::ArgEntry &this_arg : command) {
@@ -1082,7 +1084,7 @@ protected:
     }
     BreakpointSP bp_sp;
     if (!(m_options.m_lookup_style & eNameMatchStyleRegex))
-      bp_sp = target.CreateBreakpoint(
+      bp_sp = target->CreateBreakpoint(
           &m_options.m_modules, &m_options.m_files, func_names,
           (FunctionNameType)m_options.m_lookup_style, m_options.m_language,
           m_options.m_offset_addr, m_options.m_skip_prologue, internal,
@@ -1109,7 +1111,7 @@ protected:
         return;
       }
 
-      bp_sp = target.CreateFuncRegexBreakpoint(
+      bp_sp = target->CreateFuncRegexBreakpoint(
           &(m_options.m_modules), &(m_options.m_files), std::move(regexp),
           m_options.m_language, m_options.m_skip_prologue, internal,
           m_options.m_hardware);
@@ -1120,7 +1122,7 @@ protected:
       Stream &output_stream = result.GetOutputStream();
       bp_sp->GetDescription(&output_stream, lldb::eDescriptionLevelInitial,
                             /*show_locations=*/false);
-      if (&target == &GetDummyTarget())
+      if (target == &GetDummyTarget())
         output_stream.Printf("Breakpoint set in dummy target, will get copied "
                              "into future targets.\n");
       else {
@@ -1154,7 +1156,8 @@ public:
   CommandObjectBreakpointAddPattern(CommandInterpreter &interpreter)
       : CommandObjectRaw(interpreter, "breakpoint add pattern",
                          "Add breakpoints matching patterns in the source text",
-                         "breakpoint add pattern [options] -- <pattern>") {
+                         "breakpoint add pattern [options] -- <pattern>",
+                         eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeRegularExpression, eArgRepeatPlain);
     // Now add all the options groups.
     m_all_options.Append(&m_bp_opts, LLDB_OPT_SET_ALL, LLDB_OPT_SET_1);
@@ -1275,15 +1278,15 @@ protected:
       return;
     }
 
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     BreakpointSP bp_sp;
     const size_t num_files = m_options.m_files.GetSize();
 
     if (num_files == 0 && !m_options.m_all_files) {
       FileSpec file;
-      if (!GetDefaultFile(target, m_exe_ctx.GetFramePtr(), file, result)) {
+      if (!GetDefaultFile(*target, m_exe_ctx.GetFramePtr(), file, result)) {
         result.AppendError(
             "No files provided and could not find default file.");
         return;
@@ -1299,7 +1302,7 @@ protected:
           llvm::toString(std::move(err)).c_str());
       return;
     }
-    bp_sp = target.CreateSourceRegexBreakpoint(
+    bp_sp = target->CreateSourceRegexBreakpoint(
         &(m_options.m_modules), &(m_options.m_files), m_options.m_func_names,
         std::move(regexp), internal, m_options.m_hardware,
         m_options.m_move_to_nearest_code);
@@ -1310,7 +1313,7 @@ protected:
       Stream &output_stream = result.GetOutputStream();
       bp_sp->GetDescription(&output_stream, lldb::eDescriptionLevelInitial,
                             /*show_locations=*/false);
-      if (&target == &GetDummyTarget())
+      if (target == &GetDummyTarget())
         output_stream.Printf("Breakpoint set in dummy target, will get copied "
                              "into future targets.\n");
       else {
@@ -1347,7 +1350,8 @@ public:
   CommandObjectBreakpointAddScripted(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "breakpoint add scripted",
-            "Add breakpoints using a scripted breakpoint resolver.", nullptr),
+            "Add breakpoints using a scripted breakpoint resolver.", nullptr,
+            eCommandAllowsDummyTarget),
         m_python_class_options("scripted breakpoint", true, 'P') {
     // We're picking up all the normal options, commands and disable.
     m_all_options.Append(&m_python_class_options,
@@ -1411,19 +1415,19 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     BreakpointSP bp_sp;
     Status error;
-    bp_sp = target.CreateScriptedBreakpoint(
+    bp_sp = target->CreateScriptedBreakpoint(
         m_python_class_options.GetName().c_str(), &(m_options.m_modules),
         &(m_options.m_files), false, m_options.m_hardware,
         m_python_class_options.GetStructuredData(), &error);
     if (error.Fail()) {
       result.AppendErrorWithFormat(
           "error setting extra exception arguments: %s", error.AsCString());
-      target.RemoveBreakpointByID(bp_sp->GetID());
+      target->RemoveBreakpointByID(bp_sp->GetID());
       return;
     }
 
@@ -1433,7 +1437,7 @@ protected:
       Stream &output_stream = result.GetOutputStream();
       bp_sp->GetDescription(&output_stream, lldb::eDescriptionLevelInitial,
                             /*show_locations=*/false);
-      if (&target == &GetDummyTarget())
+      if (target == &GetDummyTarget())
         output_stream.Printf("Breakpoint set in dummy target, will get copied "
                              "into future targets.\n");
       else {
@@ -1522,7 +1526,7 @@ public:
       : CommandObjectParsed(
             interpreter, "breakpoint set",
             "Sets a breakpoint or set of breakpoints in the executable.",
-            "breakpoint set <cmd-options>"),
+            "breakpoint set <cmd-options>", eCommandAllowsDummyTarget),
         m_python_class_options("scripted breakpoint", true, 'P') {
     // We're picking up all the normal options, commands and disable.
     m_all_options.Append(&m_python_class_options,
@@ -1794,8 +1798,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     // The following are the various types of breakpoints that could be set:
     //   1).  -f -l -p  [-s -g]   (setting breakpoint by source location)
@@ -1841,7 +1845,7 @@ protected:
       FileSpec file;
       const size_t num_files = m_options.m_filenames.GetSize();
       if (num_files == 0) {
-        if (!GetDefaultFile(target, m_exe_ctx.GetFramePtr(), file, result)) {
+        if (!GetDefaultFile(*target, m_exe_ctx.GetFramePtr(), file, result)) {
           result.AppendError("no file supplied and no default file available.");
           return;
         }
@@ -1855,7 +1859,7 @@ protected:
       // Only check for inline functions if
       LazyBool check_inlines = eLazyBoolCalculate;
 
-      bp_sp = target.CreateBreakpoint(
+      bp_sp = target->CreateBreakpoint(
           &(m_options.m_modules), file, m_options.m_line_num,
           m_options.m_column, m_options.m_offset_addr, check_inlines,
           m_options.m_skip_prologue, internal, m_options.m_hardware,
@@ -1871,11 +1875,11 @@ protected:
       if (num_modules_specified == 1) {
         const FileSpec &file_spec =
             m_options.m_modules.GetFileSpecAtIndex(0);
-        bp_sp = target.CreateAddressInModuleBreakpoint(
+        bp_sp = target->CreateAddressInModuleBreakpoint(
             m_options.m_load_addr, internal, file_spec, m_options.m_hardware);
       } else if (num_modules_specified == 0) {
-        bp_sp = target.CreateBreakpoint(m_options.m_load_addr, internal,
-                                        m_options.m_hardware);
+        bp_sp = target->CreateBreakpoint(m_options.m_load_addr, internal,
+                                         m_options.m_hardware);
       } else {
         result.AppendError("Only one shared library can be specified for "
                            "address breakpoints.");
@@ -1890,7 +1894,7 @@ protected:
       if (name_type_mask == 0)
         name_type_mask = eFunctionNameTypeAuto;
 
-      bp_sp = target.CreateBreakpoint(
+      bp_sp = target->CreateBreakpoint(
           &(m_options.m_modules), &(m_options.m_filenames),
           m_options.m_func_names, name_type_mask, m_options.m_language,
           m_options.m_offset_addr, m_options.m_skip_prologue, internal,
@@ -1916,7 +1920,7 @@ protected:
         return;
       }
 
-      bp_sp = target.CreateFuncRegexBreakpoint(
+      bp_sp = target->CreateFuncRegexBreakpoint(
           &(m_options.m_modules), &(m_options.m_filenames), std::move(regexp),
           m_options.m_language, m_options.m_skip_prologue, internal,
           m_options.m_hardware);
@@ -1927,7 +1931,7 @@ protected:
 
       if (num_files == 0 && !m_options.m_all_files) {
         FileSpec file;
-        if (!GetDefaultFile(target, m_exe_ctx.GetFramePtr(), file, result)) {
+        if (!GetDefaultFile(*target, m_exe_ctx.GetFramePtr(), file, result)) {
           result.AppendError(
               "No files provided and could not find default file.");
           return;
@@ -1943,14 +1947,14 @@ protected:
             llvm::toString(std::move(err)).c_str());
         return;
       }
-      bp_sp = target.CreateSourceRegexBreakpoint(
+      bp_sp = target->CreateSourceRegexBreakpoint(
           &(m_options.m_modules), &(m_options.m_filenames),
           m_options.m_source_regex_func_names, std::move(regexp), internal,
           m_options.m_hardware, m_options.m_move_to_nearest_code);
     } break;
     case eSetTypeException: {
       Status precond_error;
-      bp_sp = target.CreateExceptionBreakpoint(
+      bp_sp = target->CreateExceptionBreakpoint(
           m_options.m_exception_language, m_options.m_catch_bp,
           m_options.m_throw_bp, internal, &m_options.m_exception_extra_args,
           &precond_error);
@@ -1958,21 +1962,21 @@ protected:
         result.AppendErrorWithFormat(
             "Error setting extra exception arguments: %s",
             precond_error.AsCString());
-        target.RemoveBreakpointByID(bp_sp->GetID());
+        target->RemoveBreakpointByID(bp_sp->GetID());
         return;
       }
     } break;
     case eSetTypeScripted: {
 
       Status error;
-      bp_sp = target.CreateScriptedBreakpoint(
+      bp_sp = target->CreateScriptedBreakpoint(
           m_python_class_options.GetName().c_str(), &(m_options.m_modules),
           &(m_options.m_filenames), false, m_options.m_hardware,
           m_python_class_options.GetStructuredData(), &error);
       if (error.Fail()) {
         result.AppendErrorWithFormat(
             "Error setting extra exception arguments: %s", error.AsCString());
-        target.RemoveBreakpointByID(bp_sp->GetID());
+        target->RemoveBreakpointByID(bp_sp->GetID());
         return;
       }
     } break;
@@ -1987,11 +1991,11 @@ protected:
       if (!m_options.m_breakpoint_names.empty()) {
         Status name_error;
         for (auto name : m_options.m_breakpoint_names) {
-          target.AddNameToBreakpoint(bp_sp, name.c_str(), name_error);
+          target->AddNameToBreakpoint(bp_sp, name.c_str(), name_error);
           if (name_error.Fail()) {
             result.AppendErrorWithFormat("Invalid breakpoint name: %s",
                                          name.c_str());
-            target.RemoveBreakpointByID(bp_sp->GetID());
+            target->RemoveBreakpointByID(bp_sp->GetID());
             return;
           }
         }
@@ -2003,7 +2007,7 @@ protected:
       const bool show_locations = false;
       bp_sp->GetDescription(&output_stream, lldb::eDescriptionLevelInitial,
                             show_locations);
-      if (&target == &GetDummyTarget())
+      if (target == &GetDummyTarget())
         output_stream.Printf("Breakpoint set in dummy target, will get copied "
                              "into future targets.\n");
       else {
@@ -2042,7 +2046,7 @@ public:
                             "created breakpoint.  "
                             "With the exception of -e, -d and -i, passing an "
                             "empty argument clears the modification.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);
 
     m_options.Append(&m_bp_opts,
@@ -2065,15 +2069,15 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = m_dummy_opts.m_use_dummy ? GetDummyTarget() : GetTarget();
-
+    Target *target = m_dummy_opts.m_use_dummy ? &GetDummyTarget() : GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
     BreakpointIDList valid_bp_ids;
 
     CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-        command, &target, result, &valid_bp_ids,
+        command, target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::disablePerm);
 
     if (result.Succeeded()) {
@@ -2083,7 +2087,7 @@ protected:
 
         if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
           Breakpoint *bp =
-              target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+              target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
           if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
             BreakpointLocation *location =
                 bp->FindLocationByID(cur_bp_id.GetLocationID()).get();
@@ -2114,7 +2118,7 @@ public:
       : CommandObjectParsed(interpreter, "enable",
                             "Enable the specified disabled breakpoint(s). If "
                             "no breakpoints are specified, enable all of them.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);
   }
 
@@ -2129,12 +2133,12 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    const BreakpointList &breakpoints = target->GetBreakpointList();
 
     size_t num_breakpoints = breakpoints.GetSize();
 
@@ -2145,7 +2149,7 @@ protected:
 
     if (command.empty()) {
       // No breakpoint selected; enable all currently set breakpoints.
-      target.EnableAllowedBreakpoints();
+      target->EnableAllowedBreakpoints();
       result.AppendMessageWithFormatv(
           "All breakpoints enabled. ({0} breakpoints)", num_breakpoints);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -2165,7 +2169,7 @@ protected:
 
           if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
             Breakpoint *breakpoint =
-                target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+                target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
             if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
               BreakpointLocation *location =
                   breakpoint->FindLocationByID(cur_bp_id.GetLocationID()).get();
@@ -2201,7 +2205,7 @@ public:
             "Disable the specified breakpoint(s) without deleting "
             "them.  If none are specified, disable all "
             "breakpoints.",
-            nullptr) {
+            nullptr, eCommandAllowsDummyTarget) {
     SetHelpLong(
         "Disable the specified breakpoint(s) without deleting them.  \
 If none are specified, disable all breakpoints."
@@ -2238,11 +2242,12 @@ the second re-enables the first location.");
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    const BreakpointList &breakpoints = target->GetBreakpointList();
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
@@ -2252,7 +2257,7 @@ protected:
 
     if (command.empty()) {
       // No breakpoint selected; disable all currently set breakpoints.
-      target.DisableAllowedBreakpoints();
+      target->DisableAllowedBreakpoints();
       result.AppendMessageWithFormatv(
           "All breakpoints disabled. ({0} breakpoints)\n", num_breakpoints);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -2273,7 +2278,7 @@ protected:
 
           if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
             Breakpoint *breakpoint =
-                target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+                target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
             if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
               BreakpointLocation *location =
                   breakpoint->FindLocationByID(cur_bp_id.GetLocationID()).get();
@@ -2311,7 +2316,8 @@ public:
   CommandObjectBreakpointList(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "breakpoint list",
-            "List some or all breakpoints at configurable levels of detail.") {
+            "List some or all breakpoints at configurable levels of detail.",
+            nullptr, eCommandAllowsDummyTarget) {
 
     // Define the first (and only) variant of this arg.
     AddSimpleArgumentList(eArgTypeBreakpointID, eArgRepeatOptional);
@@ -2375,12 +2381,12 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = m_options.m_use_dummy ? GetDummyTarget() : GetTarget();
-
+    Target *target = m_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     const BreakpointList &breakpoints =
-        target.GetBreakpointList(m_options.m_internal);
+        target->GetBreakpointList(m_options.m_internal);
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList(m_options.m_internal).GetListMutex(lock);
+    target->GetBreakpointList(m_options.m_internal).GetListMutex(lock);
 
     size_t num_breakpoints = breakpoints.GetSize();
 
@@ -2406,14 +2412,14 @@ protected:
       // Particular breakpoints selected; show info about that breakpoint.
       BreakpointIDList valid_bp_ids;
       CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-          command, &target, result, &valid_bp_ids,
+          command, target, result, &valid_bp_ids,
           BreakpointName::Permissions::PermissionKinds::listPerm);
 
       if (result.Succeeded()) {
         for (size_t i = 0; i < valid_bp_ids.GetSize(); ++i) {
           BreakpointID cur_bp_id = valid_bp_ids.GetBreakpointIDAtIndex(i);
           Breakpoint *breakpoint =
-              target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+              target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
           AddBreakpointDescription(&output_stream, breakpoint,
                                    m_options.m_level);
         }
@@ -2444,7 +2450,8 @@ public:
       : CommandObjectParsed(interpreter, "breakpoint clear",
                             "Delete or disable breakpoints matching the "
                             "specified source file and line.",
-                            "breakpoint clear <cmd-options>") {}
+                            "breakpoint clear <cmd-options>",
+                            eCommandAllowsDummyTarget) {}
 
   ~CommandObjectBreakpointClear() override = default;
 
@@ -2494,8 +2501,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     // The following are the various types of breakpoints that could be
     // cleared:
     //   1). -f -l (clearing breakpoint by source location)
@@ -2506,9 +2513,9 @@ protected:
       break_type = eClearTypeFileAndLine;
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
-    BreakpointList &breakpoints = target.GetBreakpointList();
+    BreakpointList &breakpoints = target->GetBreakpointList();
     size_t num_breakpoints = breakpoints.GetSize();
 
     // Early return if there's no breakpoint at all.
@@ -2541,7 +2548,7 @@ protected:
           if (loc_coll.GetSize() == 0) {
             bp->GetDescription(&ss, lldb::eDescriptionLevelBrief);
             ss.EOL();
-            target.RemoveBreakpointByID(bp->GetID());
+            target->RemoveBreakpointByID(bp->GetID());
             ++num_cleared;
           }
         }
@@ -2579,7 +2586,7 @@ public:
       : CommandObjectParsed(interpreter, "breakpoint delete",
                             "Delete the specified breakpoint(s).  If no "
                             "breakpoints are specified, delete them all.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);
   }
 
@@ -2643,13 +2650,14 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = m_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target = m_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     result.Clear();
     
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
-    BreakpointList &breakpoints = target.GetBreakpointList();
+    BreakpointList &breakpoints = target->GetBreakpointList();
 
     size_t num_breakpoints = breakpoints.GetSize();
 
@@ -2666,7 +2674,7 @@ protected:
               true)) {
         result.AppendMessage("Operation cancelled...");
       } else {
-        target.RemoveAllowedBreakpoints();
+        target->RemoveAllowedBreakpoints();
         result.AppendMessageWithFormatv(
             "All breakpoints removed. ({0} breakpoint{1})", num_breakpoints,
             num_breakpoints > 1 ? "s" : "");
@@ -2685,7 +2693,7 @@ protected:
 
       if (!command.empty()) {
         CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-            command, &target, result, &excluded_bp_ids,
+            command, target, result, &excluded_bp_ids,
             BreakpointName::Permissions::PermissionKinds::deletePerm);
         if (!result.Succeeded())
           return;
@@ -2719,7 +2727,7 @@ protected:
       if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
         if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
           Breakpoint *breakpoint =
-              target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+              target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
           BreakpointLocation *location =
               breakpoint->FindLocationByID(cur_bp_id.GetLocationID()).get();
           // It makes no sense to try to delete individual locations, so we
@@ -2732,7 +2740,7 @@ protected:
             ++disable_count;
           }
         } else {
-          target.RemoveBreakpointByID(cur_bp_id.GetBreakpointID());
+          target->RemoveBreakpointByID(cur_bp_id.GetBreakpointID());
           ++delete_count;
         }
       }
@@ -2887,7 +2895,8 @@ public:
             "the breakpoint, otherwise only the options specified will be set "
             "on the name.",
             "breakpoint name configure <command-options> "
-            "<breakpoint-name-list>") {
+            "<breakpoint-name-list>",
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeBreakpointName, eArgRepeatOptional);
 
     m_option_group.Append(&m_bp_opts, LLDB_OPT_SET_ALL, LLDB_OPT_SET_1);
@@ -2911,10 +2920,10 @@ protected:
       return;
     }
 
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
     // Make a pass through first to see that all the names are legal.
     for (auto &entry : command.entries()) {
@@ -2931,7 +2940,7 @@ protected:
     if (m_bp_id.m_breakpoint.OptionWasSet()) {
       lldb::break_id_t bp_id =
           m_bp_id.m_breakpoint.GetValueAs<uint64_t>().value_or(0);
-      bp_sp = target.GetBreakpointByID(bp_id);
+      bp_sp = target->GetBreakpointByID(bp_id);
       if (!bp_sp) {
         result.AppendErrorWithFormatv("Could not find specified breakpoint {0}",
                                       bp_id);
@@ -2942,7 +2951,7 @@ protected:
     Status error;
     for (auto &entry : command.entries()) {
       ConstString name(entry.c_str());
-      BreakpointName *bp_name = target.FindBreakpointName(name, true, error);
+      BreakpointName *bp_name = target->FindBreakpointName(name, true, error);
       if (!bp_name)
         continue;
       if (m_bp_id.m_help_string.OptionWasSet())
@@ -2952,12 +2961,12 @@ protected:
                              .c_str());
 
       if (bp_sp)
-        target.ConfigureBreakpointName(*bp_name, bp_sp->GetOptions(),
-                                       m_access_options.GetPermissions());
+        target->ConfigureBreakpointName(*bp_name, bp_sp->GetOptions(),
+                                        m_access_options.GetPermissions());
       else
-        target.ConfigureBreakpointName(*bp_name,
-                                       m_bp_opts.GetBreakpointOptions(),
-                                       m_access_options.GetPermissions());
+        target->ConfigureBreakpointName(*bp_name,
+                                        m_bp_opts.GetBreakpointOptions(),
+                                        m_access_options.GetPermissions());
     }
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
@@ -2974,7 +2983,8 @@ public:
   CommandObjectBreakpointNameAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "add", "Add a name to the breakpoints provided.",
-            "breakpoint name add <command-options> <breakpoint-id-list>") {
+            "breakpoint name add <command-options> <breakpoint-id-list>",
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeBreakpointID, eArgRepeatOptional);
 
     m_option_group.Append(&m_name_options, LLDB_OPT_SET_1, LLDB_OPT_SET_ALL);
@@ -2999,13 +3009,13 @@ protected:
       return;
     }
 
-    Target &target =
-        m_name_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_name_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    const BreakpointList &breakpoints = target->GetBreakpointList();
 
     size_t num_breakpoints = breakpoints.GetSize();
     if (num_breakpoints == 0) {
@@ -3016,7 +3026,7 @@ protected:
     // Particular breakpoint selected; disable that breakpoint.
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointIDs(
-        command, &target, result, &valid_bp_ids,
+        command, target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::listPerm);
 
     if (result.Succeeded()) {
@@ -3032,7 +3042,7 @@ protected:
         lldb::break_id_t bp_id =
             valid_bp_ids.GetBreakpointIDAtIndex(index).GetBreakpointID();
         BreakpointSP bp_sp = breakpoints.FindBreakpointByID(bp_id);
-        target.AddNameToBreakpoint(bp_sp, bp_name, error);
+        target->AddNameToBreakpoint(bp_sp, bp_name, error);
       }
     }
   }
@@ -3048,7 +3058,8 @@ public:
       : CommandObjectParsed(
             interpreter, "delete",
             "Delete a name from the breakpoints provided.",
-            "breakpoint name delete <command-options> <breakpoint-id-list>") {
+            "breakpoint name delete <command-options> <breakpoint-id-list>",
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeBreakpointID, eArgRepeatOptional);
 
     m_option_group.Append(&m_name_options, LLDB_OPT_SET_1, LLDB_OPT_SET_ALL);
@@ -3073,13 +3084,13 @@ protected:
       return;
     }
 
-    Target &target =
-        m_name_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_name_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    const BreakpointList &breakpoints = target->GetBreakpointList();
 
     size_t num_breakpoints = breakpoints.GetSize();
     if (num_breakpoints == 0) {
@@ -3090,7 +3101,7 @@ protected:
     // Particular breakpoint selected; disable that breakpoint.
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointIDs(
-        command, &target, result, &valid_bp_ids,
+        command, target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::deletePerm);
 
     if (result.Succeeded()) {
@@ -3104,7 +3115,7 @@ protected:
         lldb::break_id_t bp_id =
             valid_bp_ids.GetBreakpointIDAtIndex(index).GetBreakpointID();
         BreakpointSP bp_sp = breakpoints.FindBreakpointByID(bp_id);
-        target.RemoveNameFromBreakpoint(bp_sp, bp_name);
+        target->RemoveNameFromBreakpoint(bp_sp, bp_name);
       }
     }
   }
@@ -3121,7 +3132,8 @@ public:
                             "List either the names for a breakpoint or info "
                             "about a given name.  With no arguments, lists all "
                             "names",
-                            "breakpoint name list <command-options>") {
+                            "breakpoint name list <command-options>",
+                            eCommandAllowsDummyTarget) {
     m_option_group.Append(&m_name_options, LLDB_OPT_SET_3, LLDB_OPT_SET_ALL);
     m_option_group.Finalize();
   }
@@ -3132,12 +3144,12 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_name_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_name_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     std::vector<std::string> name_list;
     if (command.empty()) {
-      target.GetBreakpointNames(name_list);
+      target->GetBreakpointNames(name_list);
     } else {
       for (const Args::ArgEntry &arg : command) {
         name_list.push_back(arg.c_str());
@@ -3151,7 +3163,7 @@ protected:
         // First print out the options for the name:
         Status error;
         BreakpointName *bp_name =
-            target.FindBreakpointName(ConstString(name), false, error);
+            target->FindBreakpointName(ConstString(name), false, error);
         if (bp_name) {
           StreamString s;
           result.AppendMessageWithFormatv("Name: {0}", name);
@@ -3160,9 +3172,9 @@ protected:
           }
 
           std::unique_lock<std::recursive_mutex> lock;
-          target.GetBreakpointList().GetListMutex(lock);
+          target->GetBreakpointList().GetListMutex(lock);
 
-          BreakpointList &breakpoints = target.GetBreakpointList();
+          BreakpointList &breakpoints = target->GetBreakpointList();
           bool any_set = false;
           for (BreakpointSP bp_sp : breakpoints.Breakpoints()) {
             if (bp_sp->MatchesName(name.c_str())) {
@@ -3316,7 +3328,7 @@ public:
       : CommandObjectParsed(interpreter, "breakpoint read",
                             "Read and set the breakpoints previously saved to "
                             "a file with \"breakpoint write\".  ",
-                            nullptr) {}
+                            nullptr, eCommandAllowsDummyTarget) {}
 
   ~CommandObjectBreakpointRead() override = default;
 
@@ -3444,16 +3456,16 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
     FileSpec input_spec(m_options.m_filename);
     FileSystem::Instance().Resolve(input_spec);
     BreakpointIDList new_bps;
-    Status error = target.CreateBreakpointsFromFile(input_spec,
-                                                    m_options.m_names, new_bps);
+    Status error = target->CreateBreakpointsFromFile(
+        input_spec, m_options.m_names, new_bps);
 
     if (!error.Success()) {
       result.AppendError(error.AsCString());
@@ -3470,7 +3482,7 @@ protected:
       result.AppendMessage("New breakpoints:");
       for (size_t i = 0; i < num_breakpoints; ++i) {
         BreakpointID bp_id = new_bps.GetBreakpointIDAtIndex(i);
-        Breakpoint *bp = target.GetBreakpointList()
+        Breakpoint *bp = target->GetBreakpointList()
                              .FindBreakpointByID(bp_id.GetBreakpointID())
                              .get();
         if (bp)
@@ -3497,7 +3509,7 @@ public:
                             "Write the breakpoints listed to a file that can "
                             "be read in with \"breakpoint read\".  "
                             "If given no arguments, writes all breakpoints.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     CommandObject::AddIDsArgumentData(eBreakpointArgs);
   }
 
@@ -3554,10 +3566,10 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetBreakpointList().GetListMutex(lock);
+    target->GetBreakpointList().GetListMutex(lock);
 
     BreakpointIDList valid_bp_ids;
     if (!command.empty()) {
@@ -3572,8 +3584,8 @@ protected:
     }
     FileSpec file_spec(m_options.m_filename);
     FileSystem::Instance().Resolve(file_spec);
-    Status error = target.SerializeBreakpointsToFile(file_spec, valid_bp_ids,
-                                                     m_options.m_append);
+    Status error = target->SerializeBreakpointsToFile(file_spec, valid_bp_ids,
+                                                      m_options.m_append);
     if (!error.Success()) {
       result.AppendErrorWithFormat("error serializing breakpoints: %s",
                                    error.AsCString());
@@ -3593,7 +3605,7 @@ public:
   CommandObjectBreakpointOverrideAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint override add",
                             "Add a scripted breakpoint override resolver.",
-                            nullptr),
+                            nullptr, eCommandAllowsDummyTarget),
         m_python_class_options("breakpoint override resolver", true, 'P') {
     // We're picking up all the normal options, commands and disable.
     m_all_options.Append(&m_python_class_options,
@@ -3643,9 +3655,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
-    llvm::Expected<lldb::user_id_t> id = target.AddBreakpointResolverOverride(
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
+    llvm::Expected<lldb::user_id_t> id = target->AddBreakpointResolverOverride(
         m_python_class_options.GetName(),
         m_python_class_options.GetStructuredData(), m_options.m_description);
     if (id) {
@@ -3669,7 +3681,7 @@ public:
   CommandObjectBreakpointOverrideDelete(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "breakpoint override delete",
                             "Delete a scripted breakpoint override resolver.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeIndex, eArgRepeatOptional);
     m_all_options.Append(&m_dummy_options, LLDB_OPT_SET_1, LLDB_OPT_SET_1);
     m_all_options.Finalize();
@@ -3681,13 +3693,13 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
       if (m_interpreter.Confirm("Delete all breakpoint overrides?", false)) {
-        target.ClearBreakpointResolverOverrides();
+        target->ClearBreakpointResolverOverrides();
       }
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
       return;
@@ -3697,7 +3709,7 @@ protected:
       uint64_t id;
       bool success;
       if (!entry.ref().getAsInteger(0, id))
-        success = target.RemoveBreakpointResolverOverride(id);
+        success = target->RemoveBreakpointResolverOverride(id);
       else {
         result.AppendErrorWithFormatv("Index not an integer: {0}", entry.ref());
         result.SetStatus(eReturnStatusFailed);
@@ -3722,8 +3734,8 @@ public:
   CommandObjectBreakpointOverrideList(CommandInterpreter &interpreter)
       : CommandObjectParsed(
             interpreter, "breakpoint override list",
-            "List the current scripted breakpoint override resolvers.",
-            nullptr) {
+            "List the current scripted breakpoint override resolvers.", nullptr,
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeIndex, eArgRepeatOptional);
     m_all_options.Append(&m_dummy_options, LLDB_OPT_SET_1, LLDB_OPT_SET_1);
     m_all_options.Finalize();
@@ -3735,8 +3747,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target =
-        m_dummy_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target =
+        m_dummy_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
     const size_t argc = command.GetArgumentCount();
     std::vector<uint64_t> idxs;
@@ -3753,7 +3765,7 @@ protected:
         }
       }
     }
-    target.DescribeBreakpointOverrides(result.GetOutputStream(), idxs);
+    target->DescribeBreakpointOverrides(result.GetOutputStream(), idxs);
     if (idxs.empty()) {
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else {

--- a/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpointCommand.cpp
@@ -37,7 +37,7 @@ public:
                             "commands previously added to it."
                             "  If no breakpoint is specified, adds the "
                             "commands to the last created breakpoint.",
-                            nullptr),
+                            nullptr, eCommandAllowsDummyTarget),
         IOHandlerDelegateMultiline("DONE",
                                    IOHandlerDelegate::Completion::LLDBCommand),
         m_func_options("breakpoint command", false, 'F') {
@@ -109,7 +109,7 @@ Note that the global variable 'lldb.frame' will NOT be updated when \
 this function is called, so be sure to use the 'frame' argument. The 'frame' argument \
 can get you to the thread via frame.GetThread(), the thread can get you to the \
 process via thread.GetProcess(), and the process can get you back to the target \
-via process.GetTarget()."
+via process.GetTarget()->"
         R"(
 
 )"
@@ -324,9 +324,9 @@ are no syntax errors may indicate that a function was declared but never called.
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = m_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target = m_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    const BreakpointList &breakpoints = target->GetBreakpointList();
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
@@ -344,7 +344,7 @@ protected:
 
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-        command, &target, result, &valid_bp_ids,
+        command, target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::listPerm);
 
     m_bp_options_vec.clear();
@@ -356,7 +356,7 @@ protected:
         BreakpointID cur_bp_id = valid_bp_ids.GetBreakpointIDAtIndex(i);
         if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
           Breakpoint *bp =
-              target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+              target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
           if (cur_bp_id.GetLocationID() == LLDB_INVALID_BREAK_ID) {
             // This breakpoint does not have an associated location.
             m_bp_options_vec.push_back(bp->GetOptions());
@@ -446,7 +446,7 @@ public:
   CommandObjectBreakpointCommandDelete(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "delete",
                             "Delete the set of commands from a breakpoint.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeBreakpointID);
   }
 
@@ -491,9 +491,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = m_options.m_use_dummy ? GetDummyTarget() : GetTarget();
+    Target *target = m_options.m_use_dummy ? &GetDummyTarget() : GetTarget();
 
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    const BreakpointList &breakpoints = target->GetBreakpointList();
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
@@ -509,7 +509,7 @@ protected:
 
     BreakpointIDList valid_bp_ids;
     CommandObjectMultiwordBreakpoint::VerifyBreakpointOrLocationIDs(
-        command, &target, result, &valid_bp_ids,
+        command, target, result, &valid_bp_ids,
         BreakpointName::Permissions::PermissionKinds::listPerm);
 
     if (result.Succeeded()) {
@@ -518,7 +518,7 @@ protected:
         BreakpointID cur_bp_id = valid_bp_ids.GetBreakpointIDAtIndex(i);
         if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
           Breakpoint *bp =
-              target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+              target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
           if (cur_bp_id.GetLocationID() != LLDB_INVALID_BREAK_ID) {
             BreakpointLocationSP bp_loc_sp(
                 bp->FindLocationByID(cur_bp_id.GetLocationID()));
@@ -558,9 +558,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
-    const BreakpointList &breakpoints = target.GetBreakpointList();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    const BreakpointList &breakpoints = target->GetBreakpointList();
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
@@ -585,7 +585,7 @@ protected:
         BreakpointID cur_bp_id = valid_bp_ids.GetBreakpointIDAtIndex(i);
         if (cur_bp_id.GetBreakpointID() != LLDB_INVALID_BREAK_ID) {
           Breakpoint *bp =
-              target.GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
+              target->GetBreakpointByID(cur_bp_id.GetBreakpointID()).get();
 
           if (bp) {
             BreakpointLocationSP bp_loc_sp;

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -34,7 +34,8 @@ CommandObjectDWIMPrint::CommandObjectDWIMPrint(CommandInterpreter &interpreter)
     : CommandObjectRaw(interpreter, "dwim-print",
                        "Print a variable or expression.",
                        "dwim-print [<variable-name> | <expression>]",
-                       eCommandProcessMustBePaused | eCommandTryTargetAPILock) {
+                       eCommandProcessMustBePaused | eCommandTryTargetAPILock |
+                           eCommandAllowsDummyTarget) {
 
   AddSimpleArgumentList(eArgTypeVarName);
 

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -256,7 +256,7 @@ CommandObjectDisassemble::CheckRangeSize(std::vector<AddressRange> ranges,
   StreamString msg;
   msg << "not disassembling " << what << " because it is very large ";
   for (const AddressRange &r : ranges)
-    r.Dump(&msg, &GetTarget(), Address::DumpStyleLoadAddress,
+    r.Dump(&msg, GetTarget(), Address::DumpStyleLoadAddress,
            Address::DumpStyleFileAddress);
   msg << ". To disassemble specify an instruction count limit, start/stop "
          "addresses or use the --force option";
@@ -282,15 +282,16 @@ CommandObjectDisassemble::GetContainingAddressRanges() {
     }
   };
 
-  Target &target = GetTarget();
-  if (target.HasLoadedSections()) {
+  Target *target = GetTarget();
+  assert(target && "target guaranteed by eCommandRequiresTarget");
+  if (target->HasLoadedSections()) {
     Address symbol_containing_address;
-    if (target.ResolveLoadAddress(m_options.symbol_containing_addr,
-                                  symbol_containing_address)) {
+    if (target->ResolveLoadAddress(m_options.symbol_containing_addr,
+                                   symbol_containing_address)) {
       get_ranges(symbol_containing_address);
     }
   } else {
-    for (lldb::ModuleSP module_sp : target.GetImages().Modules()) {
+    for (lldb::ModuleSP module_sp : target->GetImages().Modules()) {
       Address file_address;
       if (module_sp->ResolveFileAddress(m_options.symbol_containing_addr,
                                         file_address)) {
@@ -374,8 +375,8 @@ CommandObjectDisassemble::GetNameRanges(CommandReturnObject &result) {
 
   // Find functions matching the given name.
   SymbolContextList sc_list;
-  GetTarget().GetImages().FindFunctions(name, eFunctionNameTypeAuto,
-                                        function_options, sc_list);
+  GetTarget()->GetImages().FindFunctions(name, eFunctionNameTypeAuto,
+                                         function_options, sc_list);
 
   std::vector<AddressRange> ranges;
   llvm::Error range_errs = llvm::Error::success();
@@ -466,10 +467,10 @@ CommandObjectDisassemble::GetRangesForSelectedMode(
 
 void CommandObjectDisassemble::DoExecute(Args &command,
                                          CommandReturnObject &result) {
-  Target &target = GetTarget();
-
+  Target *target = GetTarget();
+  assert(target && "target guaranteed by eCommandRequiresTarget");
   if (!m_options.arch.IsValid())
-    m_options.arch = target.GetArchitecture();
+    m_options.arch = target->GetArchitecture();
 
   if (!m_options.arch.IsValid()) {
     result.AppendError(
@@ -569,7 +570,7 @@ void CommandObjectDisassemble::DoExecute(Args &command,
       } else {
         result.AppendErrorWithFormat(
             "Failed to disassemble memory at 0x%8.8" PRIx64,
-            cur_range.GetBaseAddress().GetLoadAddress(&target));
+            cur_range.GetBaseAddress().GetLoadAddress(target));
       }
     }
     if (print_sc_header)

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -261,7 +261,8 @@ CommandObjectExpression::CommandObjectExpression(
                        "thread.  Displays any returned value "
                        "with LLDB's default formatting.",
                        "",
-                       eCommandProcessMustBePaused | eCommandTryTargetAPILock),
+                       eCommandProcessMustBePaused | eCommandTryTargetAPILock |
+                           eCommandAllowsDummyTarget),
       IOHandlerDelegate(IOHandlerDelegate::Completion::Expression),
       m_format_options(eFormatDefault),
       m_repl_option(LLDB_OPT_SET_1, false, "repl", 'r', "Drop into REPL", false,
@@ -606,12 +607,13 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
       return;
 
     if (m_repl_option.GetOptionValue().GetCurrentValue()) {
-      Target &target = GetTarget();
+      Target *target = GetTarget();
+      assert(target && "target guaranteed by eCommandAllowsDummyTarget");
       // Drop into REPL
       m_expr_lines.clear();
       m_expr_line_count = 0;
 
-      Debugger &debugger = target.GetDebugger();
+      Debugger &debugger = target->GetDebugger();
 
       // Check if the LLDB command interpreter is sitting on top of a REPL
       // that launched it...
@@ -626,12 +628,12 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
         // interpreter, so just push one
         bool initialize = false;
         Status repl_error;
-        REPLSP repl_sp(target.GetREPL(repl_error, m_command_options.language,
+        REPLSP repl_sp(target->GetREPL(repl_error, m_command_options.language,
                                        nullptr, false));
 
         if (!repl_sp) {
           initialize = true;
-          repl_sp = target.GetREPL(repl_error, m_command_options.language,
+          repl_sp = target->GetREPL(repl_error, m_command_options.language,
                                     nullptr, true);
           if (repl_error.Fail()) {
             result.SetError(std::move(repl_error));
@@ -676,11 +678,12 @@ void CommandObjectExpression::DoExecute(llvm::StringRef command,
     indent = pos;
   result.SetDiagnosticIndent(indent);
 
-  Target &target = GetTarget();
+  Target *target = GetTarget();
+  assert(target && "target guaranteed by eCommandAllowsDummyTarget");
   if (EvaluateExpression(expr, result.GetOutputStream(),
                          result.GetErrorStream(), result)) {
 
-    if (!m_fixed_expression.empty() && target.GetEnableNotifyAboutFixIts()) {
+    if (!m_fixed_expression.empty() && target->GetEnableNotifyAboutFixIts()) {
       CommandHistory &history = m_interpreter.GetCommandHistory();
       // FIXME: Can we figure out what the user actually typed (e.g. some alias
       // for expr???)

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -836,7 +836,7 @@ protected:
                                            m_cmd_name);
 
     // Increment statistics.
-    TargetStats &target_stats = GetTarget().GetStatistics();
+    TargetStats &target_stats = GetTarget()->GetStatistics();
     if (result.Succeeded())
       target_stats.GetFrameVariableStats().NotifySuccess();
     else
@@ -927,7 +927,8 @@ protected:
 public:
   CommandObjectFrameRecognizerAdd(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "frame recognizer add",
-                            "Add a new frame recognizer.", nullptr) {
+                            "Add a new frame recognizer.", nullptr,
+                            eCommandAllowsDummyTarget) {
     SetHelpLong(R"(
 Frame recognizers allow for retrieving information about special frames based on
 ABI, arguments or other special properties of that frame, even without source
@@ -1021,14 +1022,14 @@ void CommandObjectFrameRecognizerAdd::DoExecute(Args &command,
     auto module = std::make_shared<RegularExpression>(m_options.m_module);
     auto func =
         std::make_shared<RegularExpression>(m_options.m_symbols.front());
-    GetTarget().GetFrameRecognizerManager().AddRecognizer(
+    GetTarget()->GetFrameRecognizerManager().AddRecognizer(
         recognizer_sp, module, func, Mangled::NamePreference::ePreferDemangled,
         m_options.m_first_instruction_only);
   } else {
     auto module = ConstString(m_options.m_module);
     std::vector<ConstString> symbols(m_options.m_symbols.begin(),
                                      m_options.m_symbols.end());
-    GetTarget().GetFrameRecognizerManager().AddRecognizer(
+    GetTarget()->GetFrameRecognizerManager().AddRecognizer(
         recognizer_sp, module, symbols,
         Mangled::NamePreference::ePreferDemangled,
         m_options.m_first_instruction_only);
@@ -1042,13 +1043,14 @@ class CommandObjectFrameRecognizerClear : public CommandObjectParsed {
 public:
   CommandObjectFrameRecognizerClear(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "frame recognizer clear",
-                            "Delete all frame recognizers.", nullptr) {}
+                            "Delete all frame recognizers.", nullptr,
+                            eCommandAllowsDummyTarget) {}
 
   ~CommandObjectFrameRecognizerClear() override = default;
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    GetTarget().GetFrameRecognizerManager().RemoveAllRecognizers();
+    GetTarget()->GetFrameRecognizerManager().RemoveAllRecognizers();
     result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 };
@@ -1102,7 +1104,7 @@ public:
     if (request.GetCursorIndex() != 0)
       return;
 
-    GetTarget().GetFrameRecognizerManager().ForEach(
+    GetTarget()->GetFrameRecognizerManager().ForEach(
         [&request](uint32_t rid, bool enabled, std::string rname,
                    std::string module,
                    llvm::ArrayRef<lldb_private::ConstString> symbols,
@@ -1139,7 +1141,8 @@ public:
   CommandObjectFrameRecognizerEnable(CommandInterpreter &interpreter)
       : CommandObjectWithFrameRecognizerArg(
             interpreter, "frame recognizer enable",
-            "Enable a frame recognizer by id.", nullptr) {
+            "Enable a frame recognizer by id.", nullptr,
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeRecognizerID);
   }
 
@@ -1148,7 +1151,7 @@ public:
 protected:
   void DoExecuteWithId(CommandReturnObject &result,
                        uint32_t recognizer_id) override {
-    auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
+    auto &recognizer_mgr = GetTarget()->GetFrameRecognizerManager();
     if (!recognizer_mgr.SetEnabledForID(recognizer_id, true)) {
       result.AppendErrorWithFormat("'%u' is not a valid recognizer id",
                                    recognizer_id);
@@ -1164,7 +1167,8 @@ public:
   CommandObjectFrameRecognizerDisable(CommandInterpreter &interpreter)
       : CommandObjectWithFrameRecognizerArg(
             interpreter, "frame recognizer disable",
-            "Disable a frame recognizer by id.", nullptr) {
+            "Disable a frame recognizer by id.", nullptr,
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeRecognizerID);
   }
 
@@ -1173,7 +1177,7 @@ public:
 protected:
   void DoExecuteWithId(CommandReturnObject &result,
                        uint32_t recognizer_id) override {
-    auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
+    auto &recognizer_mgr = GetTarget()->GetFrameRecognizerManager();
     if (!recognizer_mgr.SetEnabledForID(recognizer_id, false)) {
       result.AppendErrorWithFormat("'%u' is not a valid recognizer id",
                                    recognizer_id);
@@ -1189,7 +1193,8 @@ public:
   CommandObjectFrameRecognizerDelete(CommandInterpreter &interpreter)
       : CommandObjectWithFrameRecognizerArg(
             interpreter, "frame recognizer delete",
-            "Delete an existing frame recognizer by id.", nullptr) {
+            "Delete an existing frame recognizer by id.", nullptr,
+            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeRecognizerID);
   }
 
@@ -1198,7 +1203,7 @@ public:
 protected:
   void DoExecuteWithId(CommandReturnObject &result,
                        uint32_t recognizer_id) override {
-    auto &recognizer_mgr = GetTarget().GetFrameRecognizerManager();
+    auto &recognizer_mgr = GetTarget()->GetFrameRecognizerManager();
     if (!recognizer_mgr.RemoveRecognizerWithID(recognizer_id)) {
       result.AppendErrorWithFormat("'%u' is not a valid recognizer id",
                                    recognizer_id);
@@ -1212,15 +1217,15 @@ class CommandObjectFrameRecognizerList : public CommandObjectParsed {
 public:
   CommandObjectFrameRecognizerList(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "frame recognizer list",
-                            "Show a list of active frame recognizers.",
-                            nullptr) {}
+                            "Show a list of active frame recognizers.", nullptr,
+                            eCommandAllowsDummyTarget) {}
 
   ~CommandObjectFrameRecognizerList() override = default;
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     bool any_printed = false;
-    GetTarget().GetFrameRecognizerManager().ForEach(
+    GetTarget()->GetFrameRecognizerManager().ForEach(
         [&result,
          &any_printed](uint32_t recognizer_id, bool enabled, std::string name,
                        std::string module, llvm::ArrayRef<ConstString> symbols,
@@ -1255,7 +1260,7 @@ public:
       : CommandObjectParsed(
             interpreter, "frame recognizer info",
             "Show which frame recognizer is applied a stack frame (if any).",
-            nullptr) {
+            nullptr, eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeFrameIndex);
   }
 
@@ -1294,7 +1299,8 @@ protected:
     }
 
     auto recognizer =
-        GetTarget().GetFrameRecognizerManager().GetRecognizerForFrame(frame_sp);
+        GetTarget()->GetFrameRecognizerManager().GetRecognizerForFrame(
+            frame_sp);
 
     Stream &output_stream = result.GetOutputStream();
     output_stream.Printf("frame %d ", frame_index);

--- a/lldb/source/Commands/CommandObjectPlatform.cpp
+++ b/lldb/source/Commands/CommandObjectPlatform.cpp
@@ -250,9 +250,7 @@ protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     Stream &ostrm = result.GetOutputStream();
 
-    Target *target = &GetTarget();
-    if (target->IsDummyTarget())
-      target = nullptr;
+    Target *target = GetTarget();
     PlatformSP platform_sp;
     if (target)
       platform_sp = target->GetPlatform();
@@ -1071,7 +1069,8 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = &GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     PlatformSP platform_sp = target->GetPlatform();
     if (!platform_sp) {
       platform_sp = GetDebugger().GetPlatformList().GetSelectedPlatform();
@@ -1115,7 +1114,7 @@ protected:
         Debugger &debugger = GetDebugger();
 
         if (argc == 0) {
-          // If no arguments were given to the command, use target.run-args.
+          // If no arguments were given to the command, use target->run-args.
           Args target_run_args;
           target->GetRunArguments(target_run_args);
           m_options.launch_info.GetArguments().AppendArguments(target_run_args);
@@ -1219,9 +1218,7 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = &GetTarget();
-    if (target->IsDummyTarget())
-      target = nullptr;
+    Target *target = GetTarget();
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();
@@ -1468,9 +1465,7 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target *target = &GetTarget();
-    if (target->IsDummyTarget())
-      target = nullptr;
+    Target *target = GetTarget();
     PlatformSP platform_sp;
     if (target) {
       platform_sp = target->GetPlatform();

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -143,7 +143,8 @@ public:
 
 protected:
   void DoExecute(Args &launch_args, CommandReturnObject &result) override {
-    Target *target = &GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     // If our listener is nullptr, users aren't allows to launch
     ModuleSP exe_module_sp = target->GetExecutableModule();
 
@@ -167,7 +168,7 @@ protected:
     // (i.e. enabled if the platform supports it). First check if the process
     // launch options explicitly turn on/off
     // disabling ASLR.  If so, use that setting;
-    // otherwise, use the 'settings target.disable-aslr' setting.
+    // otherwise, use the 'settings target->disable-aslr' setting.
     bool disable_aslr = false;
     if (m_options.disable_aslr != eLazyBoolCalculate) {
       // The user specified an explicit setting on the process launch line.
@@ -175,7 +176,7 @@ protected:
       disable_aslr = (m_options.disable_aslr == eLazyBoolYes);
     } else {
       // The user did not explicitly specify whether to disable ASLR.  Fall
-      // back to the target.disable-aslr setting.
+      // back to the target->disable-aslr setting.
       disable_aslr = target->GetDisableASLR();
     }
 
@@ -313,9 +314,7 @@ protected:
     PlatformSP platform_sp(
         GetDebugger().GetPlatformList().GetSelectedPlatform());
 
-    Target *target = &GetTarget();
-    if (target->IsDummyTarget())
-      target = nullptr;
+    Target *target = GetTarget();
     // N.B. The attach should be synchronous.  It doesn't help much to get the
     // prompt back between initiating the attach and the target actually
     // stopping.  So even if the interpreter is set to be asynchronous, we wait
@@ -528,7 +527,8 @@ protected:
         }
       }
 
-      Target &target = GetTarget();
+      Target *target = GetTarget();
+      assert(target && "target guaranteed by eCommandRequiresProcess");
       BreakpointIDList run_to_bkpt_ids;
       // Don't pass an empty run_to_breakpoint list, as Verify will look for the
       // default breakpoint.
@@ -556,7 +556,7 @@ protected:
         // the breakpoint.location specifications since the latter require
         // special handling.  We also figure out whether there's at least one
         // specifier in the set that is enabled.
-        BreakpointList &bkpt_list = target.GetBreakpointList();
+        BreakpointList &bkpt_list = target->GetBreakpointList();
         std::unordered_set<break_id_t> bkpts_seen;
         std::unordered_set<break_id_t> bkpts_with_locs_seen;
         BreakpointIDList with_locs;
@@ -691,7 +691,7 @@ protected:
       }
 
       // Now re-enable the breakpoints we disabled:
-      BreakpointList &bkpt_list = target.GetBreakpointList();
+      BreakpointList &bkpt_list = target->GetBreakpointList();
       for (break_id_t bp_id : bkpts_disabled) {
         BreakpointSP bp_sp = bkpt_list.FindBreakpointByID(bp_id);
         if (bp_sp)
@@ -917,9 +917,7 @@ protected:
     Status error;
     Debugger &debugger = GetDebugger();
     PlatformSP platform_sp = m_interpreter.GetPlatform(true);
-    Target *target = &GetTarget();
-    if (target->IsDummyTarget())
-      target = nullptr;
+    Target *target = GetTarget();
     ProcessSP process_sp =
         debugger.GetAsyncExecution()
             ? platform_sp->ConnectProcess(command.GetArgumentAtIndex(0),
@@ -1591,7 +1589,7 @@ public:
                             "Manage LLDB handling of OS signals for the "
                             "current target process.  Defaults to showing "
                             "current policy.",
-                            nullptr) {
+                            nullptr, eCommandAllowsDummyTarget) {
     SetHelpLong("\nIf no signals are specified but one or more actions are, "
                 "and there is a live process, update them all.  If no action "
                 "is specified, list the current values.\n"
@@ -1665,13 +1663,13 @@ public:
 
 protected:
   void DoExecute(Args &signal_args, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     // Any signals that are being set should be added to the Target's
     // DummySignals so they will get applied on rerun, etc.
     // If we have a process, however, we can do a more accurate job of vetting
     // the user's options.
-    ProcessSP process_sp = target.GetProcessSP();
+    ProcessSP process_sp = target->GetProcessSP();
 
     std::optional<bool> stop_action = {};
     std::optional<bool> pass_action = {};
@@ -1734,14 +1732,14 @@ protected:
     // If we were just asked to print the target values, do that here and
     // return:
     if (m_options.only_target_values) {
-      target.PrintDummySignals(result.GetOutputStream(), signal_args);
+      target->PrintDummySignals(result.GetOutputStream(), signal_args);
       result.SetStatus(eReturnStatusSuccessFinishResult);
       return;
     }
 
     // This handles clearing values:
     if (m_options.do_clear) {
-      target.ClearDummySignals(signal_args);
+      target->ClearDummySignals(signal_args);
       if (m_options.dummy)
         GetDummyTarget().ClearDummySignals(signal_args);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -1791,9 +1789,9 @@ protected:
 
         // If there were no actions, we're just listing, don't add the dummy:
         if (!no_actions)
-          target.AddDummySignal(arg.ref(), set_lazy_bool(pass_action),
-                                set_lazy_bool(notify_action),
-                                set_lazy_bool(stop_action));
+          target->AddDummySignal(arg.ref(), set_lazy_bool(pass_action),
+                                 set_lazy_bool(notify_action),
+                                 set_lazy_bool(stop_action));
       }
     } else {
       // No signal specified, if any command options were specified, update ALL
@@ -1824,8 +1822,7 @@ protected:
       PrintSignalInformation(result.GetOutputStream(), signal_args,
                              num_signals_set, signals_sp);
     else
-      target.PrintDummySignals(result.GetOutputStream(),
-          signal_args);
+      target->PrintDummySignals(result.GetOutputStream(), signal_args);
 
     if (num_signals_set > 0)
       result.SetStatus(eReturnStatusSuccessFinishResult);

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -142,8 +142,8 @@ protected:
     uint32_t start_line = m_options.start_line;
     uint32_t end_line = m_options.end_line;
     uint32_t num_lines = m_options.num_lines;
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_matches = 0;
     // Dump all the line entries for the file in the list.
     ConstString last_module_file_name;
@@ -177,7 +177,7 @@ protected:
         }
         // Dump the line entry.
         line_entry.GetDescription(&strm, lldb::eDescriptionLevelBrief, cu,
-                                  &target, /*show_address_only=*/false);
+                                  target, /*show_address_only=*/false);
         strm << "\n";
         last_module_file_name = module_file_name;
         num_matches++;
@@ -197,8 +197,8 @@ protected:
     uint32_t start_line = m_options.start_line;
     uint32_t end_line = m_options.end_line;
     uint32_t num_lines = m_options.num_lines;
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_matches = 0;
     assert(module);
     if (cu) {
@@ -250,7 +250,7 @@ protected:
               cu_header_printed = true;
             }
             line_entry.GetDescription(&strm, lldb::eDescriptionLevelBrief, cu,
-                                      &target, /*show_address_only=*/false);
+                                      target, /*show_address_only=*/false);
             strm << "\n";
 
             // Anymore after this one?
@@ -301,8 +301,9 @@ protected:
     Address so_addr;
     size_t num_matches = 0;
     assert(module_list.GetSize() > 0);
-    Target &target = GetTarget();
-    if (!target.HasLoadedSections()) {
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (!target->HasLoadedSections()) {
       // The target isn't loaded yet, we need to lookup the file address in all
       // modules.  Note: the module list option does not apply to addresses.
       const size_t num_modules = module_list.GetSize();
@@ -328,7 +329,7 @@ protected:
     } else {
       // The target has some things loaded, resolve this address to a compile
       // unit + file + line and display
-      if (target.ResolveLoadAddress(addr, so_addr)) {
+      if (target->ResolveLoadAddress(addr, so_addr)) {
         ModuleSP module_sp(so_addr.GetModule());
         // Check to make sure this module is in our list.
         if (module_sp && module_list.GetIndexForModule(module_sp.get()) !=
@@ -370,8 +371,9 @@ protected:
     SymbolContextList sc_list_funcs;
     ConstString name(m_options.symbol_name);
     SymbolContextList sc_list_lines;
-    Target &target = GetTarget();
-    uint32_t addr_byte_size = target.GetArchitecture().GetAddressByteSize();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    uint32_t addr_byte_size = target->GetArchitecture().GetAddressByteSize();
 
     ModuleFunctionSearchOptions function_options;
     function_options.include_symbols = false;
@@ -380,7 +382,7 @@ protected:
     // Note: module_list can't be const& because FindFunctionSymbols isn't
     // const.
     ModuleList module_list =
-        (m_module_list.GetSize() > 0) ? m_module_list : target.GetImages();
+        (m_module_list.GetSize() > 0) ? m_module_list : target->GetImages();
     module_list.FindFunctions(name, eFunctionNameTypeAuto, function_options,
                               sc_list_funcs);
     size_t num_matches = sc_list_funcs.GetSize();
@@ -419,7 +421,7 @@ protected:
         // sc_list_lines.
         const Address &base_address = range.GetBaseAddress();
         const addr_t size = range.GetByteSize();
-        lldb::addr_t start_addr = base_address.GetLoadAddress(&target);
+        lldb::addr_t start_addr = base_address.GetLoadAddress(target);
         if (start_addr == LLDB_INVALID_ADDRESS)
           start_addr = base_address.GetFileAddress();
         lldb::addr_t end_addr = start_addr + size;
@@ -458,11 +460,12 @@ protected:
 
   // Dump the line entries found for the address specified in the option.
   bool DumpLinesForAddress(CommandReturnObject &result) {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     SymbolContextList sc_list;
 
     StreamString error_strm;
-    if (!GetSymbolContextsForAddress(target.GetImages(), m_options.address,
+    if (!GetSymbolContextsForAddress(target->GetImages(), m_options.address,
                                      sc_list, error_strm)) {
       result.AppendErrorWithFormat("%s", error_strm.GetData());
       return false;
@@ -482,9 +485,10 @@ protected:
   bool DumpLinesForFile(CommandReturnObject &result) {
     FileSpec file_spec(m_options.file_name);
     const char *filename = m_options.file_name.c_str();
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     const ModuleList &module_list =
-        (m_module_list.GetSize() > 0) ? m_module_list : target.GetImages();
+        (m_module_list.GetSize() > 0) ? m_module_list : target->GetImages();
 
     bool displayed_something = false;
     const size_t num_modules = module_list.GetSize();
@@ -531,8 +535,8 @@ protected:
   }
 
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     // Collect the list of modules to search.
     m_module_list.Clear();
     if (!m_options.modules.empty()) {
@@ -540,7 +544,7 @@ protected:
         FileSpec module_file_spec(m_options.modules[i]);
         if (module_file_spec) {
           ModuleSpec module_spec(module_file_spec);
-          target.GetImages().FindModules(module_spec, m_module_list);
+          target->GetImages().FindModules(module_spec, m_module_list);
           if (m_module_list.IsEmpty())
             result.AppendWarningWithFormatv("no module found for '{0}'",
                                             m_options.modules[i]);
@@ -550,7 +554,7 @@ protected:
         result.AppendError("no modules match the input");
         return;
       }
-    } else if (target.GetImages().GetSize() == 0) {
+    } else if (target->GetImages().GetSize() == 0) {
       result.AppendError("the target has no associated executable images");
       return;
     }
@@ -769,8 +773,8 @@ protected:
     }
 
     if (sc.function) {
-      Target &target = GetTarget();
-
+      Target *target = GetTarget();
+      assert(target && "target guaranteed by eCommandRequiresTarget");
       SupportFileNSP start_file = std::make_shared<SupportFile>();
       uint32_t start_line;
       uint32_t end_line;
@@ -830,7 +834,7 @@ protected:
           "File: {0}", start_file->GetSpecOnly().GetPath().c_str());
       // We don't care about the column here.
       const uint32_t column = 0;
-      return target.GetSourceManager().DisplaySourceLinesWithLineNumbers(
+      return target->GetSourceManager().DisplaySourceLinesWithLineNumbers(
           start_file, line_no, column, 0, m_options.num_lines, "",
           &result.GetOutputStream(), GetBreakpointLocations());
     } else {
@@ -899,19 +903,19 @@ protected:
   }
 
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     if (!m_options.symbol_name.empty()) {
       SymbolContextList sc_list;
       ConstString name(m_options.symbol_name);
 
       // Displaying the source for a symbol. Search for function named name.
-      FindMatchingFunctions(target, name, sc_list);
+      FindMatchingFunctions(*target, name, sc_list);
       if (sc_list.GetSize() == 0) {
         // If we didn't find any functions with that name, try searching for
         // symbols that line up exactly with function addresses.
         SymbolContextList sc_list_symbols;
-        FindMatchingFunctionSymbols(target, name, sc_list_symbols);
+        FindMatchingFunctionSymbols(*target, name, sc_list_symbols);
         for (const SymbolContext &sc : sc_list_symbols) {
           if (sc.symbol && sc.symbol->ValueIsAddress()) {
             const Address &base_address = sc.symbol->GetAddressRef();
@@ -952,10 +956,10 @@ protected:
       StreamString error_strm;
       SymbolContextList sc_list;
 
-      if (!target.HasLoadedSections()) {
+      if (!target->HasLoadedSections()) {
         // The target isn't loaded yet, we need to lookup the file address in
         // all modules
-        const ModuleList &module_list = target.GetImages();
+        const ModuleList &module_list = target->GetImages();
         const size_t num_modules = module_list.GetSize();
         for (size_t i = 0; i < num_modules; ++i) {
           ModuleSP module_sp(module_list.GetModuleAtIndex(i));
@@ -979,7 +983,7 @@ protected:
       } else {
         // The target has some things loaded, resolve this address to a compile
         // unit + file + line and display
-        if (target.ResolveLoadAddress(m_options.address, so_addr)) {
+        if (target->ResolveLoadAddress(m_options.address, so_addr)) {
           ModuleSP module_sp(so_addr.GetModule());
           if (module_sp) {
             SymbolContext sc;
@@ -1014,7 +1018,7 @@ protected:
             m_breakpoint_locations.Reset(sc.comp_unit->GetPrimaryFile(), 0,
                                          show_inlines);
             SearchFilterForUnconstrainedSearches target_search_filter(
-                target.shared_from_this());
+                target->shared_from_this());
             target_search_filter.Search(m_breakpoint_locations);
           }
 
@@ -1040,10 +1044,9 @@ protected:
               (GetDebugger().GetStopShowColumn() != eStopShowColumnNone)
                   ? sc.line_entry.column
                   : 0;
-          target.GetSourceManager().DisplaySourceLinesWithLineNumbers(
-              sc.comp_unit->GetPrimarySupportFile(),
-              sc.line_entry.line, column, lines_to_back_up,
-              m_options.num_lines - lines_to_back_up, "->",
+          target->GetSourceManager().DisplaySourceLinesWithLineNumbers(
+              sc.comp_unit->GetPrimarySupportFile(), sc.line_entry.line, column,
+              lines_to_back_up, m_options.num_lines - lines_to_back_up, "->",
               &result.GetOutputStream(), GetBreakpointLocations());
           result.SetStatus(eReturnStatusSuccessFinishResult);
         }
@@ -1054,12 +1057,12 @@ protected:
       // exact same list command twice in a row, it is more likely because you
       // typed it once, then typed it again
       if (m_options.start_line == 0) {
-        if (target.GetSourceManager().DisplayMoreWithLineNumbers(
+        if (target->GetSourceManager().DisplayMoreWithLineNumbers(
                 &result.GetOutputStream(), m_options.num_lines,
                 m_options.reverse, GetBreakpointLocations())) {
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
-          if (target.GetSourceManager().AtLastLine(m_options.reverse)) {
+          if (target->GetSourceManager().AtLastLine(m_options.reverse)) {
             result.AppendNoteWithFormatv(
                 "Reached {0} of the file, no more to page",
                 m_options.reverse ? "beginning" : "end");
@@ -1074,20 +1077,20 @@ protected:
 
         if (m_options.show_bp_locs) {
           SourceManager::FileSP last_file_sp(
-              target.GetSourceManager().GetLastFile());
+              target->GetSourceManager().GetLastFile());
           if (last_file_sp) {
             const bool show_inlines = true;
             m_breakpoint_locations.Reset(
                 last_file_sp->GetSupportFile()->GetSpecOnly(), 0, show_inlines);
             SearchFilterForUnconstrainedSearches target_search_filter(
-                target.shared_from_this());
+                target->shared_from_this());
             target_search_filter.Search(m_breakpoint_locations);
           }
         } else
           m_breakpoint_locations.Clear();
 
         const uint32_t column = 0;
-        if (target.GetSourceManager()
+        if (target->GetSourceManager()
                 .DisplaySourceLinesWithLineNumbersUsingLastFile(
                     m_options.start_line, // Line to display
                     m_options.num_lines,  // Lines after line to
@@ -1102,7 +1105,7 @@ protected:
       //      const char *filename = m_options.file_name.c_str();
       FileSpec file_spec(m_options.file_name);
       bool check_inlines = false;
-      const InlineStrategy inline_strategy = target.GetInlineStrategy();
+      const InlineStrategy inline_strategy = target->GetInlineStrategy();
       if (inline_strategy == eInlineBreakpointsAlways ||
           (inline_strategy == eInlineBreakpointsHeaders &&
            !file_spec.IsSourceImplementationFile()))
@@ -1118,7 +1121,7 @@ protected:
           if (module_file_spec) {
             ModuleSpec module_spec(module_file_spec);
             matching_modules.Clear();
-            target.GetImages().FindModules(module_spec, matching_modules);
+            target->GetImages().FindModules(module_spec, matching_modules);
             num_matches += matching_modules.ResolveSymbolContextsForFileSpec(
                 file_spec, 1, check_inlines,
                 SymbolContextItem(eSymbolContextModule |
@@ -1128,7 +1131,7 @@ protected:
           }
         }
       } else {
-        num_matches = target.GetImages().ResolveSymbolContextsForFileSpec(
+        num_matches = target->GetImages().ResolveSymbolContextsForFileSpec(
             file_spec, 1, check_inlines,
             eSymbolContextModule | eSymbolContextCompUnit |
                 eSymbolContextLineEntry,
@@ -1171,7 +1174,7 @@ protected:
             m_breakpoint_locations.Reset(sc.comp_unit->GetPrimaryFile(), 0,
                                          show_inlines);
             SearchFilterForUnconstrainedSearches target_search_filter(
-                target.shared_from_this());
+                target->shared_from_this());
             target_search_filter.Search(m_breakpoint_locations);
           } else
             m_breakpoint_locations.Clear();
@@ -1187,7 +1190,7 @@ protected:
           // print. Instead, we want to print the one from the line entry.
           SupportFileNSP found_file_sp = sc.line_entry.file_sp;
 
-          target.GetSourceManager().DisplaySourceLinesWithLineNumbers(
+          target->GetSourceManager().DisplaySourceLinesWithLineNumbers(
               found_file_sp, m_options.start_line, column, 0,
               m_options.num_lines, "", &result.GetOutputStream(),
               GetBreakpointLocations());

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1042,7 +1042,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     const size_t argc = command.GetArgumentCount();
     if (argc & 1) {
       result.AppendError("add requires an even number of arguments\n");
@@ -1057,7 +1058,7 @@ protected:
                     "pair: '%s' -> '%s'",
                     from, to);
           bool last_pair = ((argc - i) == 2);
-          target.GetImageSearchPathList().Append(
+          target->GetImageSearchPathList().Append(
               from, to, last_pair); // Notify if this is the last pair
           result.SetStatus(eReturnStatusSuccessFinishNoResult);
         } else {
@@ -1086,9 +1087,10 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     bool notify = true;
-    target.GetImageSearchPathList().Clear(notify);
+    target->GetImageSearchPathList().Clear(notify);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
   }
 };
@@ -1146,6 +1148,7 @@ public:
       return;
 
     Target *target = m_exe_ctx.GetTargetPtr();
+
     const PathMappingList &list = target->GetImageSearchPathList();
     const size_t num = list.GetSize();
     ConstString old_path, new_path;
@@ -1160,7 +1163,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     size_t argc = command.GetArgumentCount();
     // check for at least 3 arguments and an odd number of parameters
     if (argc >= 3 && argc & 1) {
@@ -1183,8 +1187,8 @@ protected:
 
         if (from[0] && to[0]) {
           bool last_pair = ((argc - i) == 2);
-          target.GetImageSearchPathList().Insert(from, to, insert_idx,
-                                                 last_pair);
+          target->GetImageSearchPathList().Insert(from, to, insert_idx,
+                                                  last_pair);
           result.SetStatus(eReturnStatusSuccessFinishNoResult);
         } else {
           if (from[0])
@@ -1215,8 +1219,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    target.GetImageSearchPathList().Dump(&result.GetOutputStream());
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    target->GetImageSearchPathList().Dump(&result.GetOutputStream());
     result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 };
@@ -1237,7 +1242,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     if (command.GetArgumentCount() != 1) {
       result.AppendError("query requires one argument\n");
       return;
@@ -1245,7 +1251,7 @@ protected:
 
     ConstString orig(command.GetArgumentAtIndex(0));
     ConstString transformed;
-    if (target.GetImageSearchPathList().RemapPath(orig, transformed))
+    if (target->GetImageSearchPathList().RemapPath(orig, transformed))
       result.GetOutputStream().Printf("%s\n", transformed.GetCString());
     else
       result.GetOutputStream().Printf("%s\n", orig.GetCString());
@@ -1914,13 +1920,13 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     size_t num_dumped = 0;
     if (command.GetArgumentCount() == 0) {
       // Dump all headers for all modules images
       num_dumped = DumpModuleObjfileHeaders(result.GetOutputStream(),
-                                            target.GetImages());
+                                            target->GetImages());
       if (num_dumped == 0) {
         result.AppendError("the target has no associated executable images");
       }
@@ -1932,7 +1938,7 @@ protected:
            (arg_cstr = command.GetArgumentAtIndex(arg_idx)) != nullptr;
            ++arg_idx) {
         size_t num_matched =
-            FindModulesByName(&target, arg_cstr, module_list, true);
+            FindModulesByName(target, arg_cstr, module_list, true);
         if (num_matched == 0) {
           result.AppendWarningWithFormatv(
               "unable to find an image that matches '{0}'", arg_cstr);
@@ -2011,7 +2017,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_dumped = 0;
     Mangled::NamePreference name_preference =
         (m_options.m_prefer_mangled ? Mangled::ePreferMangled
@@ -2019,7 +2026,7 @@ protected:
 
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
-      const ModuleList &module_list = target.GetImages();
+      const ModuleList &module_list = target->GetImages();
       std::lock_guard<std::recursive_mutex> guard(module_list.GetMutex());
       const size_t num_modules = module_list.GetSize();
       if (num_modules > 0) {
@@ -2052,7 +2059,7 @@ protected:
            ++arg_idx) {
         ModuleList module_list;
         const size_t num_matches =
-            FindModulesByName(&target, arg_cstr, module_list, true);
+            FindModulesByName(target, arg_cstr, module_list, true);
         if (num_matches > 0) {
           for (ModuleSP module_sp : module_list.Modules()) {
             if (module_sp) {
@@ -2105,12 +2112,13 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_dumped = 0;
 
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
-      const size_t num_modules = target.GetImages().GetSize();
+      const size_t num_modules = target->GetImages().GetSize();
       if (num_modules == 0) {
         result.AppendError("the target has no associated executable images");
         return;
@@ -2127,7 +2135,7 @@ protected:
         num_dumped++;
         DumpModuleSections(
             m_interpreter, result.GetOutputStream(),
-            target.GetImages().GetModulePointerAtIndex(image_idx));
+            target->GetImages().GetModulePointerAtIndex(image_idx));
       }
     } else {
       // Dump specified images (by basename or fullpath)
@@ -2137,7 +2145,7 @@ protected:
            ++arg_idx) {
         ModuleList module_list;
         const size_t num_matches =
-            FindModulesByName(&target, arg_cstr, module_list, true);
+            FindModulesByName(target, arg_cstr, module_list, true);
         if (num_matches > 0) {
           for (size_t i = 0; i < num_matches; ++i) {
             if (INTERRUPT_REQUESTED(GetDebugger(),
@@ -2254,9 +2262,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
-    const ModuleList &module_list = target.GetImages();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    const ModuleList &module_list = target->GetImages();
     const size_t num_modules = module_list.GetSize();
     if (num_modules == 0) {
       result.AppendError("the target has no associated executable images");
@@ -2284,7 +2292,7 @@ protected:
     for (const Args::ArgEntry &arg : command.entries()) {
       ModuleList module_list;
       const size_t num_matches =
-          FindModulesByName(&target, arg.c_str(), module_list, true);
+          FindModulesByName(target, arg.c_str(), module_list, true);
       if (num_matches == 0) {
         // Check the global list
         std::lock_guard<std::recursive_mutex> guard(
@@ -2329,12 +2337,13 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_dumped = 0;
 
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
-      const ModuleList &target_modules = target.GetImages();
+      const ModuleList &target_modules = target->GetImages();
       std::lock_guard<std::recursive_mutex> guard(target_modules.GetMutex());
       const size_t num_modules = target_modules.GetSize();
       if (num_modules == 0) {
@@ -2360,7 +2369,7 @@ protected:
            ++arg_idx) {
         ModuleList module_list;
         const size_t num_matches =
-            FindModulesByName(&target, arg_cstr, module_list, true);
+            FindModulesByName(target, arg_cstr, module_list, true);
         if (num_matches > 0) {
           for (size_t i = 0; i < num_matches; ++i) {
             if (INTERRUPT_REQUESTED(GetDebugger(), "Interrupted dumping {0} "
@@ -2551,13 +2560,14 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     uint32_t num_dumped = 0;
 
     StructuredData::Array separate_debug_info_lists_by_module;
     if (command.GetArgumentCount() == 0) {
       // Dump all sections for all modules images
-      const ModuleList &target_modules = target.GetImages();
+      const ModuleList &target_modules = target->GetImages();
       std::lock_guard<std::recursive_mutex> guard(target_modules.GetMutex());
       const size_t num_modules = target_modules.GetSize();
       if (num_modules == 0) {
@@ -2586,7 +2596,7 @@ protected:
            ++arg_idx) {
         ModuleList module_list;
         const size_t num_matches =
-            FindModulesByName(&target, arg_cstr, module_list, true);
+            FindModulesByName(target, arg_cstr, module_list, true);
         if (num_matches > 0) {
           for (size_t i = 0; i < num_matches; ++i) {
             if (INTERRUPT_REQUESTED(GetDebugger(),
@@ -2741,7 +2751,8 @@ protected:
   OptionGroupFile m_symbol_file;
 
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     bool flush = false;
 
     const size_t argc = args.GetArgumentCount();
@@ -2757,7 +2768,7 @@ protected:
         Status error;
         if (PluginManager::DownloadObjectAndSymbolFile(module_spec, error)) {
           ModuleSP module_sp(
-              target.GetOrCreateModule(module_spec, true /* notify */));
+              target->GetOrCreateModule(module_spec, true /* notify */));
           if (module_sp) {
             result.SetStatus(eReturnStatusSuccessFinishResult);
             return;
@@ -2814,10 +2825,10 @@ protected:
             module_spec.GetSymbolFileSpec() =
                 m_symbol_file.GetOptionValue().GetCurrentValue();
           if (!module_spec.GetArchitecture().IsValid())
-            module_spec.GetArchitecture() = target.GetArchitecture();
+            module_spec.GetArchitecture() = target->GetArchitecture();
           Status error;
-          ModuleSP module_sp(
-              target.GetOrCreateModule(module_spec, true /* notify */, &error));
+          ModuleSP module_sp(target->GetOrCreateModule(
+              module_spec, true /* notify */, &error));
           if (!module_sp) {
             const char *error_cstr = error.AsCString();
             if (error_cstr)
@@ -2846,7 +2857,7 @@ protected:
     }
 
     if (flush) {
-      ProcessSP process = target.GetProcessSP();
+      ProcessSP process = target->GetProcessSP();
       if (process)
         process->Flush();
     }
@@ -2891,7 +2902,8 @@ public:
 
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     const bool load = m_load_option.GetOptionValue().GetCurrentValue();
     const bool set_pc = m_pc_option.GetOptionValue().GetCurrentValue();
 
@@ -2903,7 +2915,7 @@ protected:
     if (load) {
       if (!m_file_option.GetOptionValue().OptionWasSet() &&
           !m_uuid_option_group.GetOptionValue().OptionWasSet()) {
-        ModuleList &module_list = target.GetImages();
+        ModuleList &module_list = target->GetImages();
         if (module_list.GetSize() == 1) {
           search_using_module_spec = true;
           module_spec.GetFileSpec() =
@@ -2918,7 +2930,7 @@ protected:
       const bool use_global_module_list = true;
       ModuleList module_list;
       const size_t num_matches = FindModulesByName(
-          &target, arg_cstr, module_list, use_global_module_list);
+          target, arg_cstr, module_list, use_global_module_list);
       if (num_matches == 1) {
         module_spec.GetFileSpec() =
             module_list.GetModuleAtIndex(0)->GetFileSpec();
@@ -2941,7 +2953,7 @@ protected:
 
     if (search_using_module_spec) {
       ModuleList matching_modules;
-      target.GetImages().FindModules(module_spec, matching_modules);
+      target->GetImages().FindModules(module_spec, matching_modules);
       const size_t num_matches = matching_modules.GetSize();
 
       char path[PATH_MAX];
@@ -2958,7 +2970,7 @@ protected:
                   const addr_t slide =
                       m_slide_option.GetOptionValue().GetCurrentValue();
                   const bool slide_is_offset = true;
-                  module->SetLoadAddress(target, slide, slide_is_offset,
+                  module->SetLoadAddress(*target, slide, slide_is_offset,
                                          changed);
                 } else {
                   result.AppendError("one or more section name + load "
@@ -2990,8 +3002,8 @@ protected:
                               sect_name);
                           break;
                         } else {
-                          if (target.SetSectionLoadAddress(section_sp,
-                                                           load_addr))
+                          if (target->SetSectionLoadAddress(section_sp,
+                                                            load_addr))
                             changed = true;
                           result.AppendMessageWithFormatv(
                               "section '{0}' loaded at {1:x}", sect_name,
@@ -3022,13 +3034,13 @@ protected:
               }
 
               if (changed) {
-                target.ModulesDidLoad(matching_modules);
+                target->ModulesDidLoad(matching_modules);
                 Process *process = m_exe_ctx.GetProcessPtr();
                 if (process)
                   process->Flush();
               }
               if (load) {
-                ProcessSP process = target.CalculateProcess();
+                ProcessSP process = target->CalculateProcess();
                 Address file_entry = objfile->GetEntryPointAddress();
                 if (!process) {
                   result.AppendError("No process");
@@ -3039,7 +3051,7 @@ protected:
                   return;
                 }
                 std::vector<ObjectFile::LoadableData> loadables(
-                    objfile->GetLoadableData(target));
+                    objfile->GetLoadableData(*target));
                 if (loadables.size() == 0) {
                   result.AppendError("No loadable sections");
                   return;
@@ -3053,7 +3065,7 @@ protected:
                   ThreadList &thread_list = process->GetThreadList();
                   RegisterContextSP reg_context(
                       thread_list.GetSelectedThread()->GetRegisterContext());
-                  addr_t file_entry_addr = file_entry.GetLoadAddress(&target);
+                  addr_t file_entry_addr = file_entry.GetLoadAddress(target);
                   if (!reg_context->SetPC(file_entry_addr)) {
                     result.AppendErrorWithFormat("failed to set PC value to "
                                                  "0x%" PRIx64,
@@ -3183,7 +3195,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     const bool use_global_module_list = m_options.m_use_global_module_list;
     // Define a local module list here to ensure it lives longer than any
     // "locker" object which might lock its contents below (through the
@@ -3194,10 +3207,10 @@ protected:
 
     if (m_options.m_module_addr != LLDB_INVALID_ADDRESS) {
       Address module_address;
-      if (module_address.SetLoadAddress(m_options.m_module_addr, &target)) {
+      if (module_address.SetLoadAddress(m_options.m_module_addr, target)) {
         ModuleSP module_sp(module_address.GetModule());
         if (module_sp) {
-          PrintModule(target, module_sp.get(), 0, strm);
+          PrintModule(*target, module_sp.get(), 0, strm);
           result.SetStatus(eReturnStatusSuccessFinishResult);
         } else {
           result.AppendErrorWithFormat(
@@ -3228,13 +3241,13 @@ protected:
           guard.lock();
           num_modules = Module::GetNumberAllocatedModules();
         } else {
-          module_list_ptr = &target.GetImages();
+          module_list_ptr = &target->GetImages();
         }
       } else {
         for (const Args::ArgEntry &arg : command) {
           // Dump specified images (by basename or fullpath)
           const size_t num_matches = FindModulesByName(
-              &target, arg.c_str(), module_list, use_global_module_list);
+              target, arg.c_str(), module_list, use_global_module_list);
           if (num_matches == 0) {
             if (argc == 1) {
               result.AppendErrorWithFormat("no modules found that match '%s'",
@@ -3268,7 +3281,7 @@ protected:
           }
 
           const size_t indent = strm.Printf("[%3u] ", image_idx);
-          PrintModule(target, module, indent, strm);
+          PrintModule(*target, module, indent, strm);
         }
         result.SetStatus(eReturnStatusSuccessFinishResult);
       } else {
@@ -3973,9 +3986,9 @@ public:
       return false;
     case eLookupTypeType:
       if (!m_options.m_str.empty()) {
-        if (LookupTypeHere(&GetTarget(), m_interpreter,
-                           result.GetOutputStream(), *sym_ctx.module_sp,
-                           m_options.m_str.c_str(), m_options.m_use_regex)) {
+        if (LookupTypeHere(GetTarget(), m_interpreter, result.GetOutputStream(),
+                           *sym_ctx.module_sp, m_options.m_str.c_str(),
+                           m_options.m_use_regex)) {
           result.SetStatus(eReturnStatusSuccessFinishResult);
           return true;
         }
@@ -4052,7 +4065,7 @@ public:
     case eLookupTypeType:
       if (!m_options.m_str.empty()) {
         if (LookupTypeInModule(
-                &GetTarget(), m_interpreter, result.GetOutputStream(), module,
+                GetTarget(), m_interpreter, result.GetOutputStream(), module,
                 m_options.m_str.c_str(), m_options.m_use_regex)) {
           result.SetStatus(eReturnStatusSuccessFinishResult);
           return true;
@@ -4075,7 +4088,8 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     bool syntax_error = false;
     uint32_t i;
     uint32_t num_successful_lookups = 0;
@@ -4096,7 +4110,7 @@ protected:
 
       // Dump all sections for all other modules
 
-      const ModuleList &target_modules = target.GetImages();
+      const ModuleList &target_modules = target->GetImages();
       std::lock_guard<std::recursive_mutex> guard(target_modules.GetMutex());
       if (target_modules.GetSize() == 0) {
         result.AppendError("the target has no associated executable images");
@@ -4118,7 +4132,7 @@ protected:
            ++i) {
         ModuleList module_list;
         const size_t num_matches =
-            FindModulesByName(&target, arg_cstr, module_list, false);
+            FindModulesByName(target, arg_cstr, module_list, false);
         if (num_matches > 0) {
           for (size_t j = 0; j < num_matches; ++j) {
             Module *module = module_list.GetModulePointerAtIndex(j);
@@ -4445,6 +4459,7 @@ protected:
         m_file_option.GetOptionValue().GetCurrentValue();
 
     Target *target = m_exe_ctx.GetTargetPtr();
+
     ModuleSP module_sp(target->GetImages().FindFirstModule(module_spec));
     if (module_sp) {
       module_spec.GetFileSpec() = module_sp->GetFileSpec();
@@ -4860,7 +4875,7 @@ public:
                             "appropriately defined Python class.  You can also "
                             "add filters so the hook only runs a certain stop "
                             "points.",
-                            "target stop-hook add"),
+                            "target stop-hook add", eCommandAllowsDummyTarget),
         IOHandlerDelegateMultiline("DONE",
                                    IOHandlerDelegate::Completion::LLDBCommand),
         m_python_class_options("scripted stop-hook", true, 'P') {
@@ -4942,7 +4957,7 @@ protected:
                                " aborted, no commands.\n",
                                m_stop_hook_sp->GetID());
         }
-        GetTarget().UndoCreateStopHook(m_stop_hook_sp->GetID());
+        GetTarget()->UndoCreateStopHook(m_stop_hook_sp->GetID());
       } else {
         // The IOHandler editor is only for command lines stop hooks:
         Target::StopHookCommandLine *hook_ptr =
@@ -4964,17 +4979,18 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     m_stop_hook_sp.reset();
 
-    Target &target = GetTarget();
-    Target::StopHookSP new_hook_sp =
-        target.CreateStopHook(m_python_class_options.GetName().empty() ?
-                               Target::StopHook::StopHookKind::CommandBased
-                               : Target::StopHook::StopHookKind::ScriptBased);
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    Target::StopHookSP new_hook_sp = target->CreateStopHook(
+        m_python_class_options.GetName().empty()
+            ? Target::StopHook::StopHookKind::CommandBased
+            : Target::StopHook::StopHookKind::ScriptBased);
 
     //  First step, make the specifier.
     std::unique_ptr<SymbolContextSpecifier> specifier_up;
     if (m_options.m_sym_ctx_specified) {
       specifier_up =
-          std::make_unique<SymbolContextSpecifier>(target.shared_from_this());
+          std::make_unique<SymbolContextSpecifier>(target->shared_from_this());
 
       if (!m_options.m_module_name.empty()) {
         specifier_up->AddSpecification(
@@ -5060,7 +5076,7 @@ protected:
         // FIXME: Set the stop hook ID counter back.
         result.AppendErrorWithFormat("Couldn't add stop hook: %s",
                                      error.AsCString());
-        target.UndoCreateStopHook(new_hook_sp->GetID());
+        target->UndoCreateStopHook(new_hook_sp->GetID());
         return;
       }
     } else {
@@ -5086,9 +5102,9 @@ private:
 class CommandObjectTargetStopHookDelete : public CommandObjectParsed {
 public:
   CommandObjectTargetStopHookDelete(CommandInterpreter &interpreter)
-      : CommandObjectParsed(interpreter, "target stop-hook delete",
-                            "Delete a stop-hook.",
-                            "target stop-hook delete [<idx>]") {
+      : CommandObjectParsed(
+            interpreter, "target stop-hook delete", "Delete a stop-hook.",
+            "target stop-hook delete [<idx>]", eCommandAllowsDummyTarget) {
     SetHelpLong(
         R"(
 Deletes the stop hook by index.
@@ -5113,7 +5129,8 @@ it was deleted.
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     // FIXME: see if we can use the breakpoint id style parser?
     size_t num_args = command.GetArgumentCount();
     if (num_args == 0) {
@@ -5121,7 +5138,7 @@ protected:
         result.SetStatus(eReturnStatusFailed);
         return;
       } else {
-        target.RemoveAllStopHooks();
+        target->RemoveAllStopHooks();
       }
     } else {
       for (size_t i = 0; i < num_args; i++) {
@@ -5131,7 +5148,7 @@ protected:
                                        command.GetArgumentAtIndex(i));
           return;
         }
-        if (!target.RemoveStopHookByID(user_id)) {
+        if (!target->RemoveStopHookByID(user_id)) {
           result.AppendErrorWithFormat("unknown stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
           return;
@@ -5151,7 +5168,9 @@ public:
   CommandObjectTargetStopHookEnableDisable(CommandInterpreter &interpreter,
                                            bool enable, const char *name,
                                            const char *help, const char *syntax)
-      : CommandObjectParsed(interpreter, name, help, syntax), m_enable(enable) {
+      : CommandObjectParsed(interpreter, name, help, syntax,
+                            eCommandAllowsDummyTarget),
+        m_enable(enable) {
     AddSimpleArgumentList(eArgTypeStopHookID, eArgRepeatStar);
   }
 
@@ -5167,13 +5186,14 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     // FIXME: see if we can use the breakpoint id style parser?
     size_t num_args = command.GetArgumentCount();
     bool success;
 
     if (num_args == 0) {
-      target.SetAllStopHooksActiveState(m_enable);
+      target->SetAllStopHooksActiveState(m_enable);
     } else {
       for (size_t i = 0; i < num_args; i++) {
         lldb::user_id_t user_id;
@@ -5182,7 +5202,7 @@ protected:
                                        command.GetArgumentAtIndex(i));
           return;
         }
-        success = target.SetStopHookActiveStateByID(user_id, m_enable);
+        success = target->SetStopHookActiveStateByID(user_id, m_enable);
         if (!success) {
           result.AppendErrorWithFormat("unknown stop hook id: \"%s\"",
                                        command.GetArgumentAtIndex(i));
@@ -5207,7 +5227,8 @@ class CommandObjectTargetStopHookList : public CommandObjectParsed {
 public:
   CommandObjectTargetStopHookList(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "target stop-hook list",
-                            "List all stop-hooks.") {}
+                            "List all stop-hooks.", nullptr,
+                            eCommandAllowsDummyTarget) {}
 
   ~CommandObjectTargetStopHookList() override = default;
 
@@ -5248,10 +5269,10 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     bool printed_hook = false;
-    for (auto &hook : target.GetStopHooks(m_options.m_internal)) {
+    for (auto &hook : target->GetStopHooks(m_options.m_internal)) {
       if (printed_hook)
         result.GetOutputStream().PutCString("\n");
       hook->GetDescription(result.GetOutputStream(), eDescriptionLevelFull);
@@ -5476,7 +5497,7 @@ public:
       : CommandObjectParsed(
             interpreter, "target hook add",
             "Add a hook to be executed on target lifecycle events.",
-            "target hook add"),
+            "target hook add", eCommandAllowsDummyTarget),
         IOHandlerDelegateMultiline("DONE",
                                    IOHandlerDelegate::Completion::LLDBCommand),
         m_python_class_options("scripted hook", false, 'P') {
@@ -5562,7 +5583,7 @@ protected:
                                " aborted, no commands.\n",
                                m_hook_sp->GetID());
         }
-        GetTarget().UndoCreateHook(m_hook_sp->GetID());
+        GetTarget()->UndoCreateHook(m_hook_sp->GetID());
       } else {
         auto *hook = static_cast<Target::HookCommandLine *>(m_hook_sp.get());
         hook->SetActionFromString(line);
@@ -5580,8 +5601,8 @@ protected:
 
   void DoExecute(Args &command, CommandReturnObject &result) override {
     m_hook_sp.reset();
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     bool is_python_class = !m_python_class_options.GetName().empty();
 
     // Command-based hooks require at least one explicit trigger.
@@ -5596,7 +5617,7 @@ protected:
         is_python_class ? Target::Hook::HookKind::ScriptBased
                         : Target::Hook::HookKind::CommandBased;
 
-    Target::HookSP new_hook_sp = target.CreateHook(hook_kind);
+    Target::HookSP new_hook_sp = target->CreateHook(hook_kind);
 
     if (!is_python_class) {
       // Build trigger mask from explicit command-line flags.
@@ -5617,7 +5638,7 @@ protected:
     // Set up symbol context specifier if filter options were provided.
     if (m_options.m_sym_ctx_specified) {
       auto specifier_up =
-          std::make_unique<SymbolContextSpecifier>(target.shared_from_this());
+          std::make_unique<SymbolContextSpecifier>(target->shared_from_this());
 
       if (!m_options.m_module_name.empty())
         specifier_up->AddSpecification(
@@ -5685,7 +5706,7 @@ protected:
       if (callback_error.Fail()) {
         result.AppendErrorWithFormat("couldn't add hook: %s",
                                      callback_error.AsCString());
-        target.UndoCreateHook(new_hook_sp->GetID());
+        target->UndoCreateHook(new_hook_sp->GetID());
         return;
       }
       result.AppendMessageWithFormatv("Hook #{0} added.\n",
@@ -5711,7 +5732,8 @@ class CommandObjectTargetHookDelete : public CommandObjectParsed {
 public:
   CommandObjectTargetHookDelete(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "target hook delete", "Delete a hook.",
-                            "target hook delete [<id>]") {
+                            "target hook delete [<id>]",
+                            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeStopHookID, eArgRepeatStar);
   }
 
@@ -5719,13 +5741,14 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     if (command.GetArgumentCount() == 0) {
       if (!m_interpreter.Confirm("Delete all hooks?", true)) {
         result.SetStatus(eReturnStatusFailed);
         return;
       }
-      target.RemoveAllHooks();
+      target->RemoveAllHooks();
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
       return;
     }
@@ -5737,7 +5760,7 @@ protected:
                                      command.GetArgumentAtIndex(i));
         return;
       }
-      if (!target.RemoveHookByID(user_id)) {
+      if (!target->RemoveHookByID(user_id)) {
         result.AppendErrorWithFormat("unknown hook id: \"%s\"",
                                      command.GetArgumentAtIndex(i));
         return;
@@ -5754,7 +5777,9 @@ public:
   CommandObjectTargetHookEnableDisable(CommandInterpreter &interpreter,
                                        bool enable, const char *name,
                                        const char *help, const char *syntax)
-      : CommandObjectParsed(interpreter, name, help, syntax), m_enable(enable) {
+      : CommandObjectParsed(interpreter, name, help, syntax,
+                            eCommandAllowsDummyTarget),
+        m_enable(enable) {
     AddSimpleArgumentList(eArgTypeStopHookID, eArgRepeatStar);
   }
 
@@ -5762,11 +5787,11 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     // No IDs = apply to all hooks.
     if (command.GetArgumentCount() == 0) {
-      target.SetAllHooksEnabledState(m_enable);
+      target->SetAllHooksEnabledState(m_enable);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
       return;
     }
@@ -5778,7 +5803,7 @@ protected:
                                      command.GetArgumentAtIndex(i));
         return;
       }
-      if (!target.SetHookEnabledStateByID(user_id, m_enable)) {
+      if (!target->SetHookEnabledStateByID(user_id, m_enable)) {
         result.AppendErrorWithFormat("unknown hook id: \"%s\"",
                                      command.GetArgumentAtIndex(i));
         return;
@@ -5840,7 +5865,8 @@ public:
       : CommandObjectParsed(interpreter, "target hook modify",
                             "Modify trigger settings on a hook.",
                             "target hook modify [--enable-trigger <name>] "
-                            "[--disable-trigger <name>] [<id>]") {
+                            "[--disable-trigger <name>] [<id>]",
+                            eCommandAllowsDummyTarget) {
     AddSimpleArgumentList(eArgTypeStopHookID, eArgRepeatOptional);
     SetHelpLong(R"help(
 Modify trigger settings on command-based hooks. Scripted hooks derive their
@@ -5873,8 +5899,8 @@ protected:
   }
 
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     if (m_options.m_enable_trigger.empty() &&
         m_options.m_disable_trigger.empty()) {
       result.AppendError("at least one of --enable-trigger or "
@@ -5885,12 +5911,12 @@ protected:
     // Resolve the hook ID. Default to last added if not specified.
     Target::HookSP hook_sp;
     if (command.GetArgumentCount() == 0) {
-      size_t num_hooks = target.GetNumHooks();
+      size_t num_hooks = target->GetNumHooks();
       if (num_hooks == 0) {
         result.AppendError("no hooks exist");
         return;
       }
-      hook_sp = target.GetHookAtIndex(num_hooks - 1);
+      hook_sp = target->GetHookAtIndex(num_hooks - 1);
     } else {
       lldb::user_id_t user_id;
       if (!llvm::to_integer(command.GetArgumentAtIndex(0), user_id)) {
@@ -5898,7 +5924,7 @@ protected:
                                      command.GetArgumentAtIndex(0));
         return;
       }
-      hook_sp = target.GetHookByID(user_id);
+      hook_sp = target->GetHookByID(user_id);
       if (!hook_sp) {
         result.AppendErrorWithFormat("unknown hook id: \"%s\"",
                                      command.GetArgumentAtIndex(0));
@@ -5949,19 +5975,20 @@ class CommandObjectTargetHookList : public CommandObjectParsed {
 public:
   CommandObjectTargetHookList(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "target hook list", "List all hooks.",
-                            "target hook list") {}
+                            "target hook list", eCommandAllowsDummyTarget) {}
 
   ~CommandObjectTargetHookList() override = default;
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    size_t num_hooks = target.GetNumHooks();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    size_t num_hooks = target->GetNumHooks();
     if (num_hooks == 0) {
       result.GetOutputStream().PutCString("No hooks.\n");
     } else {
       for (size_t i = 0; i < num_hooks; i++) {
-        Target::HookSP hook_sp = target.GetHookAtIndex(i);
+        Target::HookSP hook_sp = target->GetHookAtIndex(i);
         if (hook_sp)
           hook_sp->GetDescription(result.GetOutputStream(),
                                   eDescriptionLevelFull);
@@ -6018,7 +6045,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     // Go over every scratch TypeSystem and dump to the command output.
-    for (lldb::TypeSystemSP ts : GetTarget().GetScratchTypeSystems())
+    for (lldb::TypeSystemSP ts : GetTarget()->GetScratchTypeSystems())
       if (ts)
         ts->Dump(result.GetOutputStream().AsRawOstream(), "",
                  GetCommandInterpreter().GetDebugger().GetUseColor());
@@ -6043,8 +6070,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    target.DumpSectionLoadList(result.GetOutputStream());
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    target->DumpSectionLoadList(result.GetOutputStream());
     result.SetStatus(eReturnStatusSuccessFinishResult);
   }
 };
@@ -6105,6 +6133,7 @@ protected:
         m_class_options.GetName(), m_class_options.GetStructuredData());
 
     Target *target = m_exe_ctx.GetTargetPtr();
+
     if (!target)
       target = &GetDebugger().GetDummyTarget();
 

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1068,7 +1068,7 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     bool synchronous_execution = m_interpreter.GetSynchronous();
 
-    Target *target = &GetTarget();
+    Target *target = GetTarget();
 
     Process *process = m_exe_ctx.GetProcessPtr();
     if (process == nullptr) {

--- a/lldb/source/Commands/CommandObjectType.cpp
+++ b/lldb/source/Commands/CommandObjectType.cpp
@@ -2764,7 +2764,8 @@ public:
 protected:
   void DoExecute(llvm::StringRef command,
                  CommandReturnObject &result) override {
-    Target *target = &GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresFrame");
     Thread *thread = GetDefaultThread();
     if (!thread) {
       result.AppendError("no default thread");

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -201,9 +201,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
-    if (ProcessSP process_sp = target.GetProcessSP()) {
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (ProcessSP process_sp = target->GetProcessSP()) {
       if (process_sp->IsAlive()) {
         std::optional<uint32_t> num_supported_hardware_watchpoints =
             process_sp->GetWatchpointSlotCount();
@@ -215,10 +215,10 @@ protected:
       }
     }
 
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    const WatchpointList &watchpoints = target->GetWatchpointList();
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetWatchpointList().GetListMutex(lock);
+    target->GetWatchpointList().GetListMutex(lock);
 
     size_t num_watchpoints = watchpoints.GetSize();
 
@@ -242,7 +242,7 @@ protected:
       // Particular watchpoints selected; enable them.
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
-              target, command, wp_ids)) {
+              *target, command, wp_ids)) {
         result.AppendError("invalid watchpoints specification");
         return;
       }
@@ -286,14 +286,15 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    if (!CheckTargetForWatchpointOperations(target, result))
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (!CheckTargetForWatchpointOperations(*target, result))
       return;
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetWatchpointList().GetListMutex(lock);
+    target->GetWatchpointList().GetListMutex(lock);
 
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    const WatchpointList &watchpoints = target->GetWatchpointList();
 
     size_t num_watchpoints = watchpoints.GetSize();
 
@@ -304,7 +305,7 @@ protected:
 
     if (command.GetArgumentCount() == 0) {
       // No watchpoint selected; enable all currently set watchpoints.
-      target.EnableAllWatchpoints();
+      target->EnableAllWatchpoints();
       result.AppendMessageWithFormatv(
           "All watchpoints enabled. ({0} watchpoints)",
           (uint64_t)num_watchpoints);
@@ -313,7 +314,7 @@ protected:
       // Particular watchpoints selected; enable them.
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
-              target, command, wp_ids)) {
+              *target, command, wp_ids)) {
         result.AppendError("invalid watchpoints specification");
         return;
       }
@@ -321,7 +322,7 @@ protected:
       int count = 0;
       const size_t size = wp_ids.size();
       for (size_t i = 0; i < size; ++i)
-        if (target.EnableWatchpointByID(wp_ids[i]))
+        if (target->EnableWatchpointByID(wp_ids[i]))
           ++count;
       result.AppendMessageWithFormatv("{0} watchpoints enabled.", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -355,14 +356,15 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    if (!CheckTargetForWatchpointOperations(target, result))
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (!CheckTargetForWatchpointOperations(*target, result))
       return;
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetWatchpointList().GetListMutex(lock);
+    target->GetWatchpointList().GetListMutex(lock);
 
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    const WatchpointList &watchpoints = target->GetWatchpointList();
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
@@ -372,7 +374,7 @@ protected:
 
     if (command.GetArgumentCount() == 0) {
       // No watchpoint selected; disable all currently set watchpoints.
-      if (target.DisableAllWatchpoints()) {
+      if (target->DisableAllWatchpoints()) {
         result.AppendMessageWithFormatv(
             "All watchpoints disabled. ({0} watchpoints)",
             (uint64_t)num_watchpoints);
@@ -384,7 +386,7 @@ protected:
       // Particular watchpoints selected; disable them.
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
-              target, command, wp_ids)) {
+              *target, command, wp_ids)) {
         result.AppendError("invalid watchpoints specification");
         return;
       }
@@ -392,7 +394,7 @@ protected:
       int count = 0;
       const size_t size = wp_ids.size();
       for (size_t i = 0; i < size; ++i)
-        if (target.DisableWatchpointByID(wp_ids[i]))
+        if (target->DisableWatchpointByID(wp_ids[i]))
           ++count;
       result.AppendMessageWithFormatv("{0} watchpoints disabled.\n", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -464,14 +466,15 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    if (!CheckTargetForWatchpointOperations(target, result))
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (!CheckTargetForWatchpointOperations(*target, result))
       return;
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetWatchpointList().GetListMutex(lock);
+    target->GetWatchpointList().GetListMutex(lock);
 
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    const WatchpointList &watchpoints = target->GetWatchpointList();
 
     size_t num_watchpoints = watchpoints.GetSize();
 
@@ -487,7 +490,7 @@ protected:
               true)) {
         result.AppendMessage("Operation cancelled...");
       } else {
-        target.RemoveAllWatchpoints();
+        target->RemoveAllWatchpoints();
         result.AppendMessageWithFormatv(
             "All watchpoints removed. ({0} watchpoints)",
             (uint64_t)num_watchpoints);
@@ -498,7 +501,7 @@ protected:
 
     // Particular watchpoints selected; delete them.
     std::vector<uint32_t> wp_ids;
-    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
+    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(*target, command,
                                                                wp_ids)) {
       result.AppendError("invalid watchpoints specification");
       return;
@@ -507,7 +510,7 @@ protected:
     int count = 0;
     const size_t size = wp_ids.size();
     for (size_t i = 0; i < size; ++i)
-      if (target.RemoveWatchpointByID(wp_ids[i]))
+      if (target->RemoveWatchpointByID(wp_ids[i]))
         ++count;
     result.AppendMessageWithFormatv("{0} watchpoints deleted.", count);
     result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -584,14 +587,15 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    if (!CheckTargetForWatchpointOperations(target, result))
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (!CheckTargetForWatchpointOperations(*target, result))
       return;
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetWatchpointList().GetListMutex(lock);
+    target->GetWatchpointList().GetListMutex(lock);
 
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    const WatchpointList &watchpoints = target->GetWatchpointList();
 
     size_t num_watchpoints = watchpoints.GetSize();
 
@@ -601,7 +605,7 @@ protected:
     }
 
     if (command.GetArgumentCount() == 0) {
-      target.IgnoreAllWatchpoints(m_options.m_ignore_count);
+      target->IgnoreAllWatchpoints(m_options.m_ignore_count);
       result.AppendMessageWithFormatv(
           "All watchpoints ignored. ({0} watchpoints)",
           (uint64_t)num_watchpoints);
@@ -610,7 +614,7 @@ protected:
       // Particular watchpoints selected; ignore them.
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
-              target, command, wp_ids)) {
+              *target, command, wp_ids)) {
         result.AppendError("invalid watchpoints specification");
         return;
       }
@@ -618,7 +622,7 @@ protected:
       int count = 0;
       const size_t size = wp_ids.size();
       for (size_t i = 0; i < size; ++i)
-        if (target.IgnoreWatchpointByID(wp_ids[i], m_options.m_ignore_count))
+        if (target->IgnoreWatchpointByID(wp_ids[i], m_options.m_ignore_count))
           ++count;
       result.AppendMessageWithFormatv("{0} watchpoints ignored.", count);
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -703,14 +707,15 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-    if (!CheckTargetForWatchpointOperations(target, result))
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    if (!CheckTargetForWatchpointOperations(*target, result))
       return;
 
     std::unique_lock<std::recursive_mutex> lock;
-    target.GetWatchpointList().GetListMutex(lock);
+    target->GetWatchpointList().GetListMutex(lock);
 
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    const WatchpointList &watchpoints = target->GetWatchpointList();
 
     size_t num_watchpoints = watchpoints.GetSize();
 
@@ -720,14 +725,14 @@ protected:
     }
 
     if (command.GetArgumentCount() == 0) {
-      WatchpointSP watch_sp = target.GetLastCreatedWatchpoint();
+      WatchpointSP watch_sp = target->GetLastCreatedWatchpoint();
       watch_sp->SetCondition(m_options.m_condition.c_str());
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
       // Particular watchpoints selected; set condition on them.
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
-              target, command, wp_ids)) {
+              *target, command, wp_ids)) {
         result.AppendError("invalid watchpoints specification");
         return;
       }
@@ -804,7 +809,8 @@ protected:
   }
 
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     StackFrame *frame = m_exe_ctx.GetFramePtr();
 
     // If no argument is present, issue an error message.  There's no way to
@@ -851,8 +857,8 @@ protected:
 
       Status error(Variable::GetValuesForVariableExpressionPath(
           command.GetArgumentAtIndex(0),
-          m_exe_ctx.GetBestExecutionContextScope(), GetVariableCallback,
-          &target, variable_list, valobj_list));
+          m_exe_ctx.GetBestExecutionContextScope(), GetVariableCallback, target,
+          variable_list, valobj_list));
 
       if (valobj_list.GetSize())
         valobj_sp = valobj_list.GetValueObjectAtIndex(0);
@@ -902,7 +908,7 @@ protected:
 
     error.Clear();
     WatchpointSP watch_sp =
-        target.CreateWatchpoint(addr, size, &compiler_type, watch_type, error);
+        target->CreateWatchpoint(addr, size, &compiler_type, watch_type, error);
     if (!watch_sp) {
       result.AppendErrorWithFormat(
           "Watchpoint creation failed (addr=0x%" PRIx64 ", size=%" PRIu64
@@ -989,7 +995,8 @@ protected:
     m_option_group.NotifyOptionParsingStarting(
         &exe_ctx); // This is a raw command, so notify the option group
 
-    Target &target = GetTarget();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
     StackFrame *frame = m_exe_ctx.GetFramePtr();
 
     OptionsWithRaw args(raw_command);
@@ -1032,7 +1039,7 @@ protected:
       options.SetLanguage(m_option_watchpoint.language_type);
 
     ExpressionResults expr_result =
-        target.EvaluateExpression(expr, frame, valobj_sp, options);
+        target->EvaluateExpression(expr, frame, valobj_sp, options);
     if (expr_result != eExpressionCompleted) {
       result.AppendError("expression evaluation of address to watch failed");
       result.AppendErrorWithFormat("expression evaluated: \n%s", expr.data());
@@ -1052,7 +1059,7 @@ protected:
     if (m_option_watchpoint.watch_size.GetCurrentValue() != 0)
       size = m_option_watchpoint.watch_size.GetCurrentValue();
     else
-      size = target.GetArchitecture().GetAddressByteSize();
+      size = target->GetArchitecture().GetAddressByteSize();
 
     // Now it's time to create the watchpoint.
     uint32_t watch_type;
@@ -1094,7 +1101,7 @@ protected:
 
     Status error;
     WatchpointSP watch_sp =
-        target.CreateWatchpoint(addr, size, &compiler_type, watch_type, error);
+        target->CreateWatchpoint(addr, size, &compiler_type, watch_type, error);
     if (watch_sp) {
       watch_sp->SetWatchSpec(std::string(expr));
       Stream &output_stream = result.GetOutputStream();

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -98,7 +98,7 @@ described above.  Note that the global variable 'lldb.frame' will NOT be updated
 this function is called, so be sure to use the 'frame' argument. The 'frame' argument \
 can get you to the thread via frame.GetThread(), the thread can get you to the \
 process via thread.GetProcess(), and the process can get you back to the target \
-via process.GetTarget()."
+via process.GetTarget()->"
         R"(
 
 )"
@@ -356,9 +356,9 @@ are no syntax errors may indicate that a function was declared but never called.
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    const WatchpointList &watchpoints = target->GetWatchpointList();
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
@@ -374,7 +374,7 @@ protected:
     }
 
     std::vector<uint32_t> valid_wp_ids;
-    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
+    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(*target, command,
                                                                valid_wp_ids)) {
       result.AppendError("invalid watchpoints specification");
       return;
@@ -385,7 +385,7 @@ protected:
     for (size_t i = 0; i < count; ++i) {
       uint32_t cur_wp_id = valid_wp_ids.at(i);
       if (cur_wp_id != LLDB_INVALID_WATCH_ID) {
-        Watchpoint *wp = target.GetWatchpointList().FindByID(cur_wp_id).get();
+        Watchpoint *wp = target->GetWatchpointList().FindByID(cur_wp_id).get();
         // Sanity check wp first.
         if (wp == nullptr)
           continue;
@@ -451,9 +451,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    const WatchpointList &watchpoints = target->GetWatchpointList();
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
@@ -468,7 +468,7 @@ protected:
     }
 
     std::vector<uint32_t> valid_wp_ids;
-    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
+    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(*target, command,
                                                                valid_wp_ids)) {
       result.AppendError("invalid watchpoints specification");
       return;
@@ -479,7 +479,7 @@ protected:
     for (size_t i = 0; i < count; ++i) {
       uint32_t cur_wp_id = valid_wp_ids.at(i);
       if (cur_wp_id != LLDB_INVALID_WATCH_ID) {
-        Watchpoint *wp = target.GetWatchpointList().FindByID(cur_wp_id).get();
+        Watchpoint *wp = target->GetWatchpointList().FindByID(cur_wp_id).get();
         if (wp)
           wp->ClearCallback();
       } else {
@@ -506,9 +506,9 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    Target &target = GetTarget();
-
-    const WatchpointList &watchpoints = target.GetWatchpointList();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandRequiresTarget");
+    const WatchpointList &watchpoints = target->GetWatchpointList();
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
@@ -523,7 +523,7 @@ protected:
     }
 
     std::vector<uint32_t> valid_wp_ids;
-    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
+    if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(*target, command,
                                                                valid_wp_ids)) {
       result.AppendError("invalid watchpoints specification");
       return;
@@ -534,7 +534,7 @@ protected:
     for (size_t i = 0; i < count; ++i) {
       uint32_t cur_wp_id = valid_wp_ids.at(i);
       if (cur_wp_id != LLDB_INVALID_WATCH_ID) {
-        Watchpoint *wp = target.GetWatchpointList().FindByID(cur_wp_id).get();
+        Watchpoint *wp = target->GetWatchpointList().FindByID(cur_wp_id).get();
 
         if (wp) {
           const WatchpointOptions *wp_options = wp->GetOptions();

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -3282,11 +3282,11 @@ void CommandInterpreter::FindCommandsForApropos(llvm::StringRef search_word,
                            m_alias_dict);
 }
 
-ExecutionContext CommandInterpreter::GetExecutionContext() const {
+ExecutionContext
+CommandInterpreter::GetExecutionContext(bool adopt_dummy_target) const {
   return !m_overriden_exe_contexts.empty()
              ? m_overriden_exe_contexts.top()
-             : m_debugger.GetSelectedExecutionContext(
-                   /*adopt_dummy_target=*/true);
+             : m_debugger.GetSelectedExecutionContext(adopt_dummy_target);
 }
 
 void CommandInterpreter::OverrideExecutionContext(

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -179,10 +179,13 @@ bool CommandObject::CheckRequirements(CommandReturnObject &result) {
 
   // Lock down the interpreter's execution context prior to running the command
   // so we guarantee the selected target, process, thread and frame can't go
-  // away during the execution
-  m_exe_ctx = m_interpreter.GetExecutionContext();
-
+  // away during the execution. The dummy target is only adopted when the
+  // command opts in via eCommandAllowsDummyTarget, so other commands won't
+  // accidentally see it through m_exe_ctx.
   const uint32_t flags = GetFlags().Get();
+  const bool adopt_dummy_target = flags & eCommandAllowsDummyTarget;
+  m_exe_ctx = m_interpreter.GetExecutionContext(adopt_dummy_target);
+
   if (flags & (eCommandRequiresTarget | eCommandRequiresProcess |
                eCommandRequiresThread | eCommandRequiresFrame |
                eCommandTryTargetAPILock)) {
@@ -783,22 +786,20 @@ Target *CommandObject::GetTarget() {
   // Prefer the frozen execution context in the command object, falling back
   // to the interpreter's execution context for paths like multi-line
   // expressions or breakpoint callbacks that run after DoExecute has
-  // finished.
+  // finished. Both honor eCommandAllowsDummyTarget when deciding whether to
+  // substitute the dummy target, so no post-hoc filtering is needed.
+  const uint32_t flags = GetFlags().Get();
+  const bool adopt_dummy_target = flags & eCommandAllowsDummyTarget;
   Target *target = m_exe_ctx.GetTargetPtr();
   if (!target)
-    target = m_interpreter.GetExecutionContext().GetTargetPtr();
+    target =
+        m_interpreter.GetExecutionContext(adopt_dummy_target).GetTargetPtr();
 
-  // CheckRequirements has already guaranteed a real (non-dummy) target for
-  // commands declaring any of the Requires flags, so we can return it as-is.
-  // Commands that legitimately operate on the dummy target opt in via
-  // eCommandAllowsDummyTarget. Otherwise, filter the dummy out so commands
-  // can't accidentally act on it.
-  const uint32_t flags = GetFlags().Get();
-  if (flags & (eCommandRequiresTarget | eCommandRequiresProcess |
-               eCommandRequiresThread | eCommandRequiresFrame |
-               eCommandAllowsDummyTarget))
-    return target;
-  return (target && target->IsDummyTarget()) ? nullptr : target;
+  // CheckRequirements has already guaranteed a non-dummy target for any
+  // command declaring a Requires* flag.
+  assert(target || !(flags & (eCommandRequiresTarget | eCommandRequiresProcess |
+                              eCommandRequiresThread | eCommandRequiresFrame)));
+  return target;
 }
 
 Thread *CommandObject::GetDefaultThread() {

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -779,15 +779,26 @@ Target &CommandObject::GetDummyTarget() {
   return m_interpreter.GetDebugger().GetDummyTarget();
 }
 
-Target &CommandObject::GetTarget() {
-  // Prefer the frozen execution context in the command object.
-  if (Target *target = m_exe_ctx.GetTargetPtr())
-    return *target;
+Target *CommandObject::GetTarget() {
+  // Prefer the frozen execution context in the command object, falling back
+  // to the interpreter's execution context for paths like multi-line
+  // expressions or breakpoint callbacks that run after DoExecute has
+  // finished.
+  Target *target = m_exe_ctx.GetTargetPtr();
+  if (!target)
+    target = m_interpreter.GetExecutionContext().GetTargetPtr();
 
-  // Fallback to the command interpreter's execution context in case we get
-  // called after DoExecute has finished. For example, when doing multi-line
-  // expression that uses an input reader or breakpoint callbacks.
-  return m_interpreter.GetExecutionContext().GetTargetRef();
+  // CheckRequirements has already guaranteed a real (non-dummy) target for
+  // commands declaring any of the Requires flags, so we can return it as-is.
+  // Commands that legitimately operate on the dummy target opt in via
+  // eCommandAllowsDummyTarget. Otherwise, filter the dummy out so commands
+  // can't accidentally act on it.
+  const uint32_t flags = GetFlags().Get();
+  if (flags & (eCommandRequiresTarget | eCommandRequiresProcess |
+               eCommandRequiresThread | eCommandRequiresFrame |
+               eCommandAllowsDummyTarget))
+    return target;
+  return (target && target->IsDummyTarget()) ? nullptr : target;
 }
 
 Thread *CommandObject::GetDefaultThread() {

--- a/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
+++ b/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
@@ -741,8 +741,10 @@ class EnableCommand : public CommandObjectParsed {
 public:
   EnableCommand(CommandInterpreter &interpreter, bool enable, const char *name,
                 const char *help, const char *syntax)
-      : CommandObjectParsed(interpreter, name, help, syntax), m_enable(enable),
-        m_options_sp(enable ? new EnableOptions() : nullptr) {}
+      : CommandObjectParsed(interpreter, name, help, syntax,
+                            eCommandAllowsDummyTarget),
+        m_enable(enable), m_options_sp(enable ? new EnableOptions() : nullptr) {
+  }
 
 protected:
   void AppendStrictSourcesWarning(CommandReturnObject &result,
@@ -784,10 +786,10 @@ protected:
 
     // Now check if we have a running process.  If so, we should instruct the
     // process monitor to enable/disable DarwinLog support now.
-    Target &target = GetTarget();
-
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
     // Grab the active process.
-    auto process_sp = target.GetProcessSP();
+    auto process_sp = target->GetProcessSP();
     if (!process_sp) {
       // No active process, so there is nothing more to do right now.
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
@@ -858,7 +860,8 @@ public:
       : CommandObjectParsed(interpreter, "status",
                             "Show whether Darwin log supported is available"
                             " and enabled.",
-                            "plugin structured-data darwin-log status") {}
+                            "plugin structured-data darwin-log status",
+                            eCommandAllowsDummyTarget) {}
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
@@ -866,8 +869,9 @@ protected:
 
     // Figure out if we've got a process.  If so, we can tell if DarwinLog is
     // available for that process.
-    Target &target = GetTarget();
-    auto process_sp = target.GetProcessSP();
+    Target *target = GetTarget();
+    assert(target && "target guaranteed by eCommandAllowsDummyTarget");
+    auto process_sp = target->GetProcessSP();
     if (!process_sp) {
       stream.PutCString("Availability: unknown (requires process)\n");
       stream.PutCString("Enabled: not applicable "


### PR DESCRIPTION
Follow-up to #197805. Make CommandObject::GetTarget the canonical target accessor for command code, and tighten its semantics so that DoExecute methods can't accidentally operate on the dummy target.

GetTarget now returns Target* instead of Target&. The result is the target from the command's frozen execution context, falling back to the interpreter's execution context. The dummy target is filtered out and replaced with nullptr unless the command opts in via one of the eCommandRequires{Target,Process,Thread,Frame} flags (in which case CheckRequirements has already guaranteed a real target) or via the new eCommandAllowsDummyTarget flag.

This is the first half of the cleanup discussed at the end of #197805. A follow-up will audit DoExecute methods that still reach for GetSelectedTarget or m_exe_ctx.GetTargetPtr() directly and migrate them to GetTarget.