### PR TITLE
[libc] Reduce number of iterations in threading tests.

### DIFF
--- a/libc/test/integration/src/__support/threads/cndvar_test.cpp
+++ b/libc/test/integration/src/__support/threads/cndvar_test.cpp
@@ -19,8 +19,8 @@
 
 namespace {
 
-constexpr int THREAD_COUNT = 16;
-constexpr int NUM_ITERATIONS = 250;
+constexpr int THREAD_COUNT = 4;
+constexpr int NUM_ITERATIONS = 10;
 
 struct QueueState {
   LIBC_NAMESPACE::CndVar cnd{false};

--- a/libc/test/integration/src/pthread/pthread_cond_test.cpp
+++ b/libc/test/integration/src/pthread/pthread_cond_test.cpp
@@ -35,10 +35,10 @@
 
 namespace {
 
-constexpr size_t PRODUCER_COUNT = 10;
-constexpr size_t CONSUMER_COUNT = 10;
+constexpr size_t PRODUCER_COUNT = 4;
+constexpr size_t CONSUMER_COUNT = 4;
 constexpr size_t ITEMS_PER_PRODUCER = 80;
-constexpr int NUM_ITERATIONS = 10;
+constexpr int NUM_ITERATIONS = 4;
 
 enum class TimeoutMode {
   Disabled,


### PR DESCRIPTION
Previously the threading tests were running noticeably slowly and
causing flakey timeouts on some buildbots (e.g.
https://lab.llvm.org/buildbot/#/builders/71/builds/48420)
