### PR TITLE
[MLIR][XeGPU] Temporarily disable XeGPU peephole optimizer for CRI

### DIFF
--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPeepHoleOptimizer.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPeepHoleOptimizer.cpp
@@ -257,10 +257,8 @@ public:
     auto chipStr = xegpu::getChipStr(createNdOp);
     // Check if the chip is supported.
     assert(chipStr &&
-           (chipStr.value() == "pvc" || chipStr.value() == "bmg" ||
-            chipStr.value() == "cri") &&
-           "Expecting target chip to be pvc, bmg or cri for transpose "
-           "optimization.");
+           (chipStr.value() == "pvc" || chipStr.value() == "bmg") &&
+           "Expecting target chip to be pvc, bmg for transpose optimization.");
     const uArch *targetuArch = xegpu::uArch::getUArch(chipStr.value());
 
     auto convertType = tryOptimize(tdescTy, targetuArch);
@@ -574,14 +572,12 @@ struct XeGPUPeepHoleOptimizerPass final
     bool isTargetSupported = false;
     getOperation()->walk([&](gpu::GPUFuncOp funcOp) {
       auto chipStr = xegpu::getChipStr(funcOp);
-      if (chipStr && (chipStr.value() == "pvc" || chipStr.value() == "bmg" ||
-                      chipStr.value() == "cri"))
+      if (chipStr && (chipStr.value() == "pvc" || chipStr.value() == "bmg"))
         isTargetSupported = true;
     });
 
     if (!isTargetSupported) {
-      DBGS() << "XeGPUPeepHoleOptimizerPass only supports PVC, BMG and CRI "
-                "targets."
+      DBGS() << "XeGPUPeepHoleOptimizerPass only supports PVC, BMG targets."
              << "\n";
       return;
     }

--- a/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPeepHoleOptimizer.cpp
+++ b/mlir/lib/Dialect/XeGPU/Transforms/XeGPUPeepHoleOptimizer.cpp
@@ -256,8 +256,7 @@ public:
     // Get the target uArch info.
     auto chipStr = xegpu::getChipStr(createNdOp);
     // Check if the chip is supported.
-    assert(chipStr &&
-           (chipStr.value() == "pvc" || chipStr.value() == "bmg") &&
+    assert(chipStr && (chipStr.value() == "pvc" || chipStr.value() == "bmg") &&
            "Expecting target chip to be pvc, bmg for transpose optimization.");
     const uArch *targetuArch = xegpu::uArch::getUArch(chipStr.value());
 


### PR DESCRIPTION
Temporarily disabling the optimization pass until a fix is ready.
Support for CRI was added in recent PR: https://github.com/llvm/llvm-project/pull/197229
But had post merge issues.