### PR TITLE
[AMDGPU] Fix VOPD assembler validation for GFX12+

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -3994,7 +3994,7 @@ AMDGPUAsmParser::checkVOPDRegBankConstraints(const MCInst &Inst, bool AsVOPD3) {
       Opcode == AMDGPU::V_DUAL_MOV_B32_e32_X_MOV_B32_e32_gfx13 ||
       Opcode == AMDGPU::V_DUAL_MOV_B32_e32_X_MOV_B32_e32_e96_gfx1250 ||
       Opcode == AMDGPU::V_DUAL_MOV_B32_e32_X_MOV_B32_e32_e96_gfx13;
-  bool AllowSameVGPR = isGFX1250Plus();
+  bool AllowSameVGPR = isGFX12Plus();
 
   if (AsVOPD3) { // Literal constants are not allowed with VOPD3.
     for (auto OpName : {OpName::src0X, OpName::src0Y}) {

--- a/llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s
+++ b/llvm/test/MC/AMDGPU/gfx12_asm_vopd_features.s
@@ -47,6 +47,14 @@
 // A VOPD OpY mov_b32 instruction uses SRC2 source-cache if OpX is also mov_b32
 //===----------------------------------------------------------------------===//
 
+//===----------------------------------------------------------------------===//
+// SRCX0 and SRCY0 may use the same bank if they are using the same VGPR; same for
+// VSRCX1 and VSRCY1.
+//===----------------------------------------------------------------------===//
+
+v_dual_add_f32 v2, v2, v5 :: v_dual_mul_f32 v3, v2, v5
+// GFX12: v_dual_add_f32 v2, v2, v5 :: v_dual_mul_f32 v3, v2, v5 ; encoding: [0x02,0x0b,0x06,0xc9,0x02,0x0b,0x02,0x02]
+
 v_dual_add_f32      v255, s105, v2               ::  v_dual_cndmask_b32   v6, s105, v3
 // GFX12: v_dual_add_f32 v255, s105, v2 :: v_dual_cndmask_b32 v6, s105, v3 ; encoding: [0x69,0x04,0x12,0xc9,0x69,0x06,0x06,0xff]
 


### PR DESCRIPTION
The related `codegen` side of this change was already landed by https://github.com/llvm/llvm-project/commit/c510ee553e2057f94c2f023c72abb3c9afec0962 ("[AMDGPU] VOPD: AllowSameVGPR on GFX12"), which changed `GCNVOPDUtils.cpp` to use `hasGFX12Insts()` instead of `hasGFX1250Insts()`. 
However, the assembler validation in `AMDGPUAsmParser.cpp` was not updated to match, causing it to reject valid VOPD instruction pairs that share the same VGPR as src0 on `gfx1200`. 
This fix aligns the assembler with the `codegen` by changing `isGFX1250Plus()` to `isGFX12Plus()` in `checkVOPDRegBankConstraints`, and adds a positive test case to verify same-VGPR src0 pairs assemble correctly on `gfx12`.