### PR TITLE
[lldb] Change ValueObject::Clone to take StringRef (NFC)

### DIFF
--- a/lldb/include/lldb/Expression/ExpressionVariable.h
+++ b/lldb/include/lldb/Expression/ExpressionVariable.h
@@ -58,7 +58,7 @@ public:
     m_frozen_sp->GetValue().SetCompilerType(compiler_type);
   }
 
-  void SetName(ConstString name) { m_frozen_sp->SetName(name); }
+  void SetName(llvm::StringRef name) { m_frozen_sp->SetName(name); }
 
   // this function is used to copy the address-of m_live_sp into m_frozen_sp
   // this is necessary because the results of certain cast and pointer-

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -569,7 +569,7 @@ public:
   /// Change the name of the current ValueObject. Should *not* be used from a
   /// synthetic child provider as it would change the name of the non synthetic
   /// child as well.
-  void SetName(ConstString name) { m_name = name; }
+  void SetName(llvm::StringRef name) { m_name = ConstString(name); }
 
   struct AddrAndType {
     lldb::addr_t address = LLDB_INVALID_ADDRESS;
@@ -628,7 +628,7 @@ public:
   /// ValueObject as its parent. It should be used when we want to change the
   /// name of a ValueObject without modifying the actual ValueObject itself
   /// (e.g. sythetic child provider).
-  virtual lldb::ValueObjectSP Clone(ConstString new_name);
+  virtual lldb::ValueObjectSP Clone(llvm::StringRef new_name);
 
   virtual lldb::ValueObjectSP AddressOf(Status &error);
 

--- a/lldb/include/lldb/ValueObject/ValueObjectCast.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectCast.h
@@ -20,14 +20,13 @@
 #include <optional>
 
 namespace lldb_private {
-class ConstString;
 
 /// A ValueObject that represents a given value represented as a different type.
 class ValueObjectCast : public ValueObject {
 public:
   ~ValueObjectCast() override;
 
-  static lldb::ValueObjectSP Create(ValueObject &parent, ConstString name,
+  static lldb::ValueObjectSP Create(ValueObject &parent, llvm::StringRef name,
                                     const CompilerType &cast_type);
 
   llvm::Expected<uint64_t> GetByteSize() override;
@@ -47,7 +46,7 @@ public:
   }
 
 protected:
-  ValueObjectCast(ValueObject &parent, ConstString name,
+  ValueObjectCast(ValueObject &parent, llvm::StringRef name,
                   const CompilerType &cast_type);
 
   bool UpdateValue() override;

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -437,7 +437,7 @@ lldb::SBValue SBValue::CreateValueFromExpression(const char *name,
     new_value_sp = value_sp->CreateChildValueObjectFromExpression(
         name, expression, exe_ctx, options.ref());
     if (new_value_sp)
-      new_value_sp->SetName(ConstString(name));
+      new_value_sp->SetName(name);
   }
   sb_value.SetSP(new_value_sp);
   return sb_value;
@@ -1104,7 +1104,7 @@ lldb::SBValue SBValue::EvaluateExpression(const char *expr,
                                 value_sp.get());
 
   if (name)
-    res_val_sp->SetName(ConstString(name));
+    res_val_sp->SetName(name);
 
   SBValue result;
   result.SetSP(res_val_sp, options.GetFetchDynamicValue());
@@ -1314,7 +1314,7 @@ lldb::SBValue SBValue::Clone(const char *new_name) {
   lldb::ValueObjectSP value_sp(GetSP(locker));
 
   if (value_sp)
-    return lldb::SBValue(value_sp->Clone(ConstString(new_name)));
+    return lldb::SBValue(value_sp->Clone(new_name));
   else
     return lldb::SBValue();
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -1801,7 +1801,7 @@ void ClangExpressionDeclMap::AddOneRegister(NameSearchContext &context,
   m_found_entities.AddNewlyConstructedVariable(entity);
 
   std::string decl_name(context.m_decl_name.getAsString());
-  entity->SetName(ConstString(decl_name));
+  entity->SetName(decl_name);
   entity->SetRegisterInfo(reg_info);
   entity->EnableParserVars(GetParserID());
   ClangExpressionVariable::ParserVars *parser_vars =
@@ -1950,7 +1950,7 @@ void ClangExpressionDeclMap::AddOneFunction(NameSearchContext &context,
   m_found_entities.AddNewlyConstructedVariable(entity);
 
   std::string decl_name(context.m_decl_name.getAsString());
-  entity->SetName(ConstString(decl_name));
+  entity->SetName(decl_name);
   entity->SetCompilerType(function_clang_type);
   entity->EnableParserVars(GetParserID());
 

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericOptional.cpp
@@ -128,7 +128,7 @@ ValueObjectSP GenericOptionalFrontend::GetChildAtIndex(uint32_t _idx) {
   if (!holder_type)
     return ValueObjectSP();
 
-  return val_sp->Clone(ConstString("Value"));
+  return val_sp->Clone("Value");
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -398,7 +398,7 @@ lldb_private::formatters::LibcxxSharedPtrSyntheticFrontEnd::Update() {
   if (!cast_ptr_sp)
     return lldb::ChildCacheState::eRefetch;
 
-  m_ptr_obj = cast_ptr_sp->Clone(ConstString("pointer")).get();
+  m_ptr_obj = cast_ptr_sp->Clone("pointer").get();
 
   lldb::ValueObjectSP cntrl_sp(valobj_sp->GetChildMemberWithName("__cntrl_"));
 
@@ -492,18 +492,18 @@ lldb_private::formatters::LibcxxUniquePtrSyntheticFrontEnd::Update() {
   if (is_compressed_pair) {
     if (ValueObjectSP value_pointer_sp =
             GetFirstValueOfLibCXXCompressedPair(*ptr_sp))
-      m_value_ptr_sp = value_pointer_sp->Clone(ConstString("pointer"));
+      m_value_ptr_sp = value_pointer_sp->Clone("pointer");
 
     if (ValueObjectSP deleter_sp =
             GetSecondValueOfLibCXXCompressedPair(*ptr_sp))
-      m_deleter_sp = deleter_sp->Clone(ConstString("deleter"));
+      m_deleter_sp = deleter_sp->Clone("deleter");
   } else {
-    m_value_ptr_sp = ptr_sp->Clone(ConstString("pointer"));
+    m_value_ptr_sp = ptr_sp->Clone("pointer");
 
     if (ValueObjectSP deleter_sp =
             valobj_sp->GetChildMemberWithName("__deleter_"))
       if (deleter_sp->GetNumChildrenIgnoringErrors() > 0)
-        m_deleter_sp = deleter_sp->Clone(ConstString("deleter"));
+        m_deleter_sp = deleter_sp->Clone("deleter");
   }
 
   return lldb::ChildCacheState::eRefetch;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxAtomic.cpp
@@ -127,7 +127,7 @@ lldb::ValueObjectSP
 lldb_private::formatters::LibcxxStdAtomicSyntheticFrontEnd::GetChildAtIndex(
     uint32_t idx) {
   if (idx == 0)
-    return m_real_child->GetSP()->Clone(ConstString("Value"));
+    return m_real_child->GetSP()->Clone("Value");
   return nullptr;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -350,14 +350,14 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::GetChildAtIndex(
   // all items named __value_
   StreamString name;
   name.Printf("[%" PRIu64 "]", (uint64_t)idx);
-  auto potential_child_sp = key_val_sp->Clone(ConstString(name.GetString()));
+  auto potential_child_sp = key_val_sp->Clone(name.GetString());
   if (potential_child_sp) {
     switch (potential_child_sp->GetNumChildrenIgnoringErrors()) {
     case 1: {
       auto child0_sp = potential_child_sp->GetChildAtIndex(0);
       if (child0_sp &&
           (child0_sp->GetName() == g_cc_ || child0_sp->GetName() == g_cc))
-        potential_child_sp = child0_sp->Clone(ConstString(name.GetString()));
+        potential_child_sp = child0_sp->Clone(name.GetString());
       break;
     }
     case 2: {
@@ -366,7 +366,7 @@ lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::GetChildAtIndex(
       if (child0_sp &&
           (child0_sp->GetName() == g_cc_ || child0_sp->GetName() == g_cc) &&
           child1_sp && child1_sp->GetName() == g_nc)
-        potential_child_sp = child0_sp->Clone(ConstString(name.GetString()));
+        potential_child_sp = child0_sp->Clone(name.GetString());
       break;
     }
     }
@@ -453,12 +453,12 @@ lldb_private::formatters::LibCxxMapIteratorSyntheticFrontEnd::Update() {
   //
   // std::map stores the actual key/value pair in value_type::__cc_ (or
   // previously __cc).
-  key_value_sp = key_value_sp->Clone(ConstString("pair"));
+  key_value_sp = key_value_sp->Clone("pair");
   if (key_value_sp->GetNumChildrenIgnoringErrors() == 1) {
     auto child0_sp = key_value_sp->GetChildAtIndex(0);
     if (child0_sp &&
         (child0_sp->GetName() == "__cc_" || child0_sp->GetName() == "__cc"))
-      key_value_sp = child0_sp->Clone(ConstString("pair"));
+      key_value_sp = child0_sp->Clone("pair");
   }
 
   m_pair_sp = key_value_sp;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -73,8 +73,7 @@ ValueObjectSP TupleFrontEnd::GetChildAtIndex(uint32_t idx) {
 
   ValueObjectSP elem_sp = holder_sp->GetChildAtIndex(0);
   if (elem_sp)
-    m_elements[idx] =
-        elem_sp->Clone(llvm::formatv("[{0}]", idx).str()).get();
+    m_elements[idx] = elem_sp->Clone(llvm::formatv("[{0}]", idx).str()).get();
 
   if (m_elements[idx])
     return m_elements[idx]->GetSP();

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxTuple.cpp
@@ -74,7 +74,7 @@ ValueObjectSP TupleFrontEnd::GetChildAtIndex(uint32_t idx) {
   ValueObjectSP elem_sp = holder_sp->GetChildAtIndex(0);
   if (elem_sp)
     m_elements[idx] =
-        elem_sp->Clone(ConstString(llvm::formatv("[{0}]", idx).str())).get();
+        elem_sp->Clone(llvm::formatv("[{0}]", idx).str()).get();
 
   if (m_elements[idx])
     return m_elements[idx]->GetSP();

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -362,12 +362,12 @@ lldb::ChildCacheState lldb_private::formatters::
   //
   // std::unordered_map stores the actual key/value pair in
   // __hash_value_type::__cc_ (or previously __cc).
-  auto potential_child_sp = key_value_sp->Clone(ConstString("pair"));
+  auto potential_child_sp = key_value_sp->Clone("pair");
   if (potential_child_sp)
     if (potential_child_sp->GetNumChildrenIgnoringErrors() == 1)
       if (auto child0_sp = potential_child_sp->GetChildAtIndex(0);
           child0_sp->GetName() == "__cc_" || child0_sp->GetName() == "__cc")
-        potential_child_sp = child0_sp->Clone(ConstString("pair"));
+        potential_child_sp = child0_sp->Clone("pair");
 
   m_pair_sp = potential_child_sp;
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -267,7 +267,7 @@ ValueObjectSP VariantFrontEnd::GetChildAtIndex(uint32_t idx) {
   if (!head_value)
     return {};
 
-  return head_value->Clone(ConstString("Value"));
+  return head_value->Clone("Value");
 }
 
 SyntheticChildrenFrontEnd *

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -381,7 +381,7 @@ lldb::ChildCacheState LibStdcppSharedPtrSyntheticFrontEnd::Update() {
   if (!cast_ptr_sp)
     return lldb::ChildCacheState::eRefetch;
 
-  m_ptr_obj = cast_ptr_sp->Clone(ConstString("pointer")).get();
+  m_ptr_obj = cast_ptr_sp->Clone("pointer").get();
 
   return lldb::ChildCacheState::eRefetch;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppTuple.cpp
@@ -75,7 +75,7 @@ lldb::ChildCacheState LibStdcppTupleSyntheticFrontEnd::Update() {
         if (value_sp) {
           StreamString name;
           name.Printf("[%zd]", m_members.size());
-          m_members.push_back(value_sp->Clone(ConstString(name.GetString())).get());
+          m_members.push_back(value_sp->Clone(name.GetString()).get());
         }
       }
     }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -95,7 +95,7 @@ lldb::ChildCacheState LibStdcppUniquePtrSyntheticFrontEnd::Update() {
   if (!ptr_obj)
     return lldb::ChildCacheState::eRefetch;
 
-  m_ptr_obj = ptr_obj->Clone(ConstString("pointer")).get();
+  m_ptr_obj = ptr_obj->Clone("pointer").get();
 
   // Add a 'deleter' child if there was a non-empty deleter type specified.
   //
@@ -107,7 +107,7 @@ lldb::ChildCacheState LibStdcppUniquePtrSyntheticFrontEnd::Update() {
       llvm::expectedToOptional(ptr_obj->GetByteSize()).value_or(0)) {
     ValueObjectSP del_obj = tuple_frontend->GetChildAtIndex(1);
     if (del_obj)
-      m_del_obj = del_obj->Clone(ConstString("deleter")).get();
+      m_del_obj = del_obj->Clone("deleter").get();
   }
 
   return lldb::ChildCacheState::eRefetch;

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlAtomic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlAtomic.cpp
@@ -52,7 +52,7 @@ lldb::ValueObjectSP
 lldb_private::formatters::MsvcStlAtomicSyntheticFrontEnd::GetChildAtIndex(
     uint32_t idx) {
   if (idx == 0 && m_storage && m_element_type.IsValid())
-    return m_storage->Cast(m_element_type)->Clone(ConstString("Value"));
+    return m_storage->Cast(m_element_type)->Clone("Value");
   return nullptr;
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -157,7 +157,7 @@ lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::Update() {
   if (!cast_ptr_sp)
     return lldb::ChildCacheState::eRefetch;
 
-  m_ptr_obj = cast_ptr_sp->Clone(ConstString("pointer")).get();
+  m_ptr_obj = cast_ptr_sp->Clone("pointer").get();
   return lldb::ChildCacheState::eRefetch;
 }
 
@@ -252,11 +252,11 @@ lldb_private::formatters::MsvcStlUniquePtrSyntheticFrontEnd::Update() {
     return lldb::ChildCacheState::eRefetch;
 
   if (auto value_ptr_sp = pair_sp->GetChildMemberWithName("_Myval2"))
-    m_value_ptr_sp = value_ptr_sp->Clone(ConstString("pointer"));
+    m_value_ptr_sp = value_ptr_sp->Clone("pointer");
 
   // Only present if the deleter is non-empty
   if (auto deleter_sp = pair_sp->GetChildMemberWithName("_Myval1"))
-    m_deleter_sp = deleter_sp->Clone(ConstString("deleter"));
+    m_deleter_sp = deleter_sp->Clone("deleter");
 
   return lldb::ChildCacheState::eRefetch;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTree.cpp
@@ -315,7 +315,7 @@ lldb_private::formatters::MsvcStlTreeSyntheticFrontEnd::GetChildAtIndex(
   // all items named _Myval
   StreamString name;
   name.Printf("[%" PRIu64 "]", (uint64_t)idx);
-  return val_sp->Clone(ConstString(name.GetString()));
+  return val_sp->Clone(name.GetString());
 }
 
 lldb::ChildCacheState

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTuple.cpp
@@ -76,7 +76,7 @@ ValueObjectSP TupleFrontEnd::GetChildAtIndex(uint32_t idx) {
     return nullptr;
 
   m_elements[idx] =
-      val_sp->Clone(ConstString(llvm::formatv("[{0}]", idx).str())).get();
+      val_sp->Clone(llvm::formatv("[{0}]", idx).str()).get();
   return m_elements[idx]->GetSP();
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTuple.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlTuple.cpp
@@ -75,8 +75,7 @@ ValueObjectSP TupleFrontEnd::GetChildAtIndex(uint32_t idx) {
   if (!val_sp)
     return nullptr;
 
-  m_elements[idx] =
-      val_sp->Clone(llvm::formatv("[{0}]", idx).str()).get();
+  m_elements[idx] = val_sp->Clone(llvm::formatv("[{0}]", idx).str()).get();
   return m_elements[idx]->GetSP();
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVariant.cpp
@@ -182,7 +182,7 @@ ValueObjectSP VariantFrontEnd::GetChildAtIndex(uint32_t idx) {
   if (!head_sp)
     return nullptr;
 
-  return head_sp->Clone(ConstString("Value"));
+  return head_sp->Clone("Value");
 }
 
 SyntheticChildrenFrontEnd *formatters::MsvcStlVariantSyntheticFrontEndCreator(

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1877,7 +1877,7 @@ ValueObjectSP ValueObject::GetSyntheticArrayMember(size_t index,
       if (synthetic_child) {
         AddSyntheticChild(index_const_str, synthetic_child);
         synthetic_child_sp = synthetic_child->GetSP();
-        synthetic_child_sp->SetName(ConstString(index_str));
+        synthetic_child_sp->SetName(index_str);
         synthetic_child_sp->m_flags.m_is_array_item_for_pointer = true;
       }
     }
@@ -1913,7 +1913,7 @@ ValueObjectSP ValueObject::GetSyntheticBitFieldChild(uint32_t from, uint32_t to,
       if (synthetic_child) {
         AddSyntheticChild(index_const_str, synthetic_child);
         synthetic_child_sp = synthetic_child->GetSP();
-        synthetic_child_sp->SetName(ConstString(index_str));
+        synthetic_child_sp->SetName(index_str);
         synthetic_child_sp->m_flags.m_is_bitfield_for_scalar = true;
       }
     }
@@ -2981,7 +2981,7 @@ ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
       std::move(error));
 }
 
-lldb::ValueObjectSP ValueObject::Clone(ConstString new_name) {
+lldb::ValueObjectSP ValueObject::Clone(llvm::StringRef new_name) {
   return ValueObjectCast::Create(*this, new_name, GetCompilerType());
 }
 
@@ -3563,7 +3563,7 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromExpression(
   target_sp->EvaluateExpression(expression, exe_ctx.GetFrameSP().get(),
                                 retval_sp, options);
   if (retval_sp && !name.empty())
-    retval_sp->SetName(ConstString(name));
+    retval_sp->SetName(name);
   return retval_sp;
 }
 
@@ -3590,7 +3590,7 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromAddress(
         if (do_deref)
           ptr_result_valobj_sp = ptr_result_valobj_sp->Dereference(err);
         if (ptr_result_valobj_sp && !name.empty())
-          ptr_result_valobj_sp->SetName(ConstString(name));
+          ptr_result_valobj_sp->SetName(name);
       }
       return ptr_result_valobj_sp;
     }
@@ -3607,7 +3607,7 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromData(
       LLDB_INVALID_ADDRESS, parent ? parent->GetManager() : nullptr);
   new_value_sp->SetAddressTypeOfChildren(eAddressTypeLoad);
   if (new_value_sp && !name.empty())
-    new_value_sp->SetName(ConstString(name));
+    new_value_sp->SetName(name);
   return new_value_sp;
 }
 

--- a/lldb/source/ValueObject/ValueObjectCast.cpp
+++ b/lldb/source/ValueObject/ValueObjectCast.cpp
@@ -16,21 +16,17 @@
 #include "lldb/ValueObject/ValueObject.h"
 #include <optional>
 
-namespace lldb_private {
-class ConstString;
-}
-
 using namespace lldb_private;
 
 lldb::ValueObjectSP ValueObjectCast::Create(ValueObject &parent,
-                                            ConstString name,
+                                            llvm::StringRef name,
                                             const CompilerType &cast_type) {
   ValueObjectCast *cast_valobj_ptr =
       new ValueObjectCast(parent, name, cast_type);
   return cast_valobj_ptr->GetSP();
 }
 
-ValueObjectCast::ValueObjectCast(ValueObject &parent, ConstString name,
+ValueObjectCast::ValueObjectCast(ValueObject &parent, llvm::StringRef name,
                                  const CompilerType &cast_type)
     : ValueObject(parent), m_cast_type(cast_type) {
   SetName(name);

--- a/lldb/source/ValueObject/ValueObjectMemory.cpp
+++ b/lldb/source/ValueObject/ValueObjectMemory.cpp
@@ -63,7 +63,7 @@ ValueObjectMemory::ValueObjectMemory(ExecutionContextScope *exe_scope,
       m_compiler_type() {
   // Do not attempt to construct one of these objects with no variable!
   assert(m_type_sp.get() != nullptr);
-  SetName(ConstString(name));
+  SetName(name);
   m_value.SetContext(Value::ContextType::LLDBType, m_type_sp.get());
   TargetSP target_sp(GetTargetSP());
   lldb::addr_t load_address = m_address.GetLoadAddress(target_sp.get());
@@ -94,7 +94,7 @@ ValueObjectMemory::ValueObjectMemory(ExecutionContextScope *exe_scope,
 
   TargetSP target_sp(GetTargetSP());
 
-  SetName(ConstString(name));
+  SetName(name);
   m_value.SetCompilerType(m_compiler_type);
   lldb::addr_t load_address = m_address.GetLoadAddress(target_sp.get());
   if (load_address != LLDB_INVALID_ADDRESS) {

--- a/lldb/source/ValueObject/ValueObjectVTable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVTable.cpp
@@ -26,7 +26,7 @@ public:
                          uint64_t addr_size)
       : ValueObject(parent), m_func_idx(func_idx), m_addr_size(addr_size) {
     SetFormat(eFormatPointer);
-    SetName(ConstString(llvm::formatv("[{0}]", func_idx).str()));
+    SetName(llvm::formatv("[{0}]", func_idx).str());
   }
 
   ~ValueObjectVTableChild() override = default;


### PR DESCRIPTION
Make `ValueObject`'s name being a `ConstString` more of an implementation detail by changing `Clone` and `SetName` take a `StringRef`.