### PR TITLE
[lldb] Set SO_NOSIGPIPE on platforms that support it

### DIFF
--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -404,7 +404,11 @@ int Socket::SetOption(NativeSocket sockfd, int level, int option_name,
 }
 
 ssize_t Socket::Send(const void *buf, const size_t num_bytes) {
-  return ::send(m_socket, static_cast<const char *>(buf), num_bytes, 0);
+  int flags = 0;
+#if defined(MSG_NOSIGNAL)
+  flags |= MSG_NOSIGNAL;
+#endif
+  return ::send(m_socket, static_cast<const char *>(buf), num_bytes, flags);
 }
 
 void Socket::SetLastError(Status &error) {

--- a/lldb/source/Host/common/Socket.cpp
+++ b/lldb/source/Host/common/Socket.cpp
@@ -444,6 +444,12 @@ NativeSocket Socket::CreateSocket(const int domain, const int type,
   if (sock == kInvalidSocketValue)
     SetLastError(error);
 
+#if defined(SO_NOSIGPIPE)
+  if (Socket::SetOption(sock, SOL_SOCKET, SO_NOSIGPIPE, 1) == -1)
+    LLDB_LOG(GetLog(LLDBLog::Host), "failed to set SO_NOSIGPIPE on fd {0}: {1}",
+             sock, llvm::sys::StrError());
+#endif
+
   return sock;
 }
 

--- a/lldb/source/Host/posix/DomainSocket.cpp
+++ b/lldb/source/Host/posix/DomainSocket.cpp
@@ -95,6 +95,16 @@ llvm::Expected<DomainSocket::Pair> DomainSocket::CreatePair() {
   }
 #endif
 
+#if defined(SO_NOSIGPIPE)
+  Log *log = GetLog(LLDBLog::Host);
+  if (Socket::SetOption(sockets[0], SOL_SOCKET, SO_NOSIGPIPE, 1) == -1)
+    LLDB_LOG(log, "failed to set NO_SIGPIPE on fd {0}: {1}", sockets[0],
+             llvm::sys::StrError());
+  if (Socket::SetOption(sockets[1], SOL_SOCKET, SO_NOSIGPIPE, 1) == -1)
+    LLDB_LOG(log, "failed to set NO_SIGPIPE on fd {0}: {1}", sockets[1],
+             llvm::sys::StrError());
+#endif
+
   return Pair(std::unique_ptr<DomainSocket>(
                   new DomainSocket(ProtocolUnixDomain, sockets[0],
                                    /*should_close=*/true)),

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -11,10 +11,15 @@
 #include "lldb/Host/Config.h"
 #include "lldb/Host/MainLoop.h"
 #include "lldb/Utility/UriParser.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <chrono>
+#if LLDB_ENABLE_POSIX
+#include <cerrno>
+#include <csignal>
+#endif
 #if __linux__
 #include <lldb/Host/linux/AbstractSocket.h>
 #endif
@@ -443,6 +448,34 @@ TEST_F(SocketTest, AbstractSocketFromBoundNativeSocket) {
                                           /*should_close=*/false);
   ASSERT_THAT_EXPECTED(sock, llvm::Succeeded());
   ASSERT_EQ(Socket::ProtocolUnixAbstract, sock->get()->GetSocketProtocol());
+}
+#endif
+
+#if LLDB_ENABLE_POSIX
+TEST_F(SocketTest, DontReceiveSIGPIPE) {
+  static volatile std::sig_atomic_t sigpipe_received;
+  sigpipe_received = 0;
+
+  struct sigaction new_action = {};
+  struct sigaction old_action = {};
+  new_action.sa_handler = [](int) { sigpipe_received = 1; };
+  sigemptyset(&new_action.sa_mask);
+  ASSERT_EQ(0, sigaction(SIGPIPE, &new_action, &old_action));
+  llvm::scope_exit restore_sigpipe(
+      [&] { sigaction(SIGPIPE, &old_action, nullptr); });
+
+  auto pair = Socket::CreatePair();
+  ASSERT_THAT_EXPECTED(pair, llvm::Succeeded());
+  Socket &reader = *pair->first;
+  Socket &writer = *pair->second;
+
+  ASSERT_THAT_ERROR(reader.Close().takeError(), llvm::Succeeded());
+
+  size_t num_bytes = 1;
+  Status err = writer.Write("x", num_bytes);
+  EXPECT_TRUE(err.Fail());
+  EXPECT_EQ(EPIPE, static_cast<int>(err.GetError()));
+  EXPECT_EQ(0, sigpipe_received);
 }
 #endif
 


### PR DESCRIPTION
On macOS, I've seen instances where debugserver goes down very quickly after it starts up (less than 100ms). Normally, LLDB is able to detect when debugserver goes down and report it without bringing down the entire debug session. However that's not happening here. My best guess is that debugserver is going down before LLDB is ready to react to it.

To mitigate this scenario, adopt SO_NOSIGPIPE. Note that this mostly matters for tools that embed liblldb. The LLDB driver ignores all SIGPIPEs.

rdar://173516461