### PR TITLE
[flang] Pass-through fir.volatile_cast in FIR AliasAnalysis.

### DIFF
--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -3003,7 +3003,10 @@ def fir_AddrOfOp : fir_OneResultOp<"address_of", [Pure]> {
   let assemblyFormat = "`(` $symbol `)` attr-dict `:` type($resTy)";
 }
 
-def fir_VolatileCastOp : fir_SimpleOneResultOp<"volatile_cast", [Pure]> {
+def fir_VolatileCastOp
+    : fir_SimpleOneResultOp<
+          "volatile_cast", [Pure, ViewLikeOpInterface,
+                            fir_FortranObjectViewOpInterface]> {
   let summary = "cast between volatile and non-volatile types";
   let description = [{
     Cast between volatile and non-volatile types. The types must be otherwise
@@ -3017,6 +3020,14 @@ def fir_VolatileCastOp : fir_SimpleOneResultOp<"volatile_cast", [Pure]> {
   }];
   let hasVerifier = 1;
   let hasFolder = 1;
+  let extraClassDeclaration = [{
+    // ViewLikeOpInterface methods:
+    mlir::Value getViewSource() { return getValue(); }
+
+    // FortranObjectViewOpInterface methods:
+    mlir::Value getViewSource(mlir::OpResult) { return getValue(); }
+    std::optional<std::int64_t> getViewOffset(mlir::OpResult) { return 0; }
+  }];
 }
 
 def fir_ConvertOp

--- a/flang/test/HLFIR/opt-bufferization-skip-volatile.fir
+++ b/flang/test/HLFIR/opt-bufferization-skip-volatile.fir
@@ -4,13 +4,13 @@
 func.func @minimal_volatile_test() {
   %c1 = arith.constant 1 : index
   %c200 = arith.constant 200 : index
-  
+
   // Create a volatile array
   %1 = fir.address_of(@_QMtestEarray) : !fir.ref<!fir.array<200xf32>>
   %2 = fir.shape %c200 : (index) -> !fir.shape<1>
   %3 = fir.volatile_cast %1 : (!fir.ref<!fir.array<200xf32>>) -> !fir.ref<!fir.array<200xf32>, volatile>
   %4:2 = hlfir.declare %3(%2) {fortran_attrs = #fir.var_attrs<volatile>, uniq_name = "_QMtestEarray"} : (!fir.ref<!fir.array<200xf32>, volatile>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>, volatile>, !fir.ref<!fir.array<200xf32>, volatile>)
-  
+
   // Create an elemental operation that negates each element
   %5 = hlfir.elemental %2 unordered : (!fir.shape<1>) -> !hlfir.expr<200xf32> {
   ^bb0(%arg1: index):
@@ -19,11 +19,11 @@ func.func @minimal_volatile_test() {
     %8 = arith.negf %7 : f32
     hlfir.yield_element %8 : f32
   }
-  
+
   // Assign the result back to the volatile array
   hlfir.assign %5 to %4#0 : !hlfir.expr<200xf32>, !fir.ref<!fir.array<200xf32>, volatile>
   hlfir.destroy %5 : !hlfir.expr<200xf32>
-  
+
   return
 }
 
@@ -47,3 +47,97 @@ fir.global @_QMtestEarray : !fir.array<200xf32>
 // CHECK:           return
 // CHECK:         }
 // CHECK:         fir.global @_QMtestEarray : !fir.array<200xf32>
+
+fir.global @_QMtestEarray_src : !fir.array<200xf32>
+fir.global @_QMtestEarray_dst : !fir.array<200xf32>
+
+// Check that 'dst = -volatile_src' is optimized.
+// TODO: opt-bufferization needs to be fixed.
+func.func @volatile_src_nonvolatile_dst() {
+  %c1 = arith.constant 1 : index
+  %c200 = arith.constant 200 : index
+
+  %1 = fir.address_of(@_QMtestEarray_src) : !fir.ref<!fir.array<200xf32>>
+  %dst = fir.address_of(@_QMtestEarray_dst) : !fir.ref<!fir.array<200xf32>>
+  %2 = fir.shape %c200 : (index) -> !fir.shape<1>
+  %3 = fir.volatile_cast %1 : (!fir.ref<!fir.array<200xf32>>) -> !fir.ref<!fir.array<200xf32>, volatile>
+  %4:2 = hlfir.declare %3(%2) {fortran_attrs = #fir.var_attrs<volatile>, uniq_name = "_QMtestEarray_src"} : (!fir.ref<!fir.array<200xf32>, volatile>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>, volatile>, !fir.ref<!fir.array<200xf32>, volatile>)
+  %dstDecl:2 = hlfir.declare %dst(%2) {uniq_name = "_QMtestEarray_dst"} : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>>, !fir.ref<!fir.array<200xf32>>)
+
+  %5 = hlfir.elemental %2 unordered : (!fir.shape<1>) -> !hlfir.expr<200xf32> {
+  ^bb0(%arg1: index):
+    %6 = hlfir.designate %4#0 (%arg1) : (!fir.ref<!fir.array<200xf32>, volatile>, index) -> !fir.ref<f32, volatile>
+    %7 = fir.load %6 : !fir.ref<f32, volatile>
+    %8 = arith.negf %7 : f32
+    hlfir.yield_element %8 : f32
+  }
+
+  hlfir.assign %5 to %dstDecl#0 : !hlfir.expr<200xf32>, !fir.ref<!fir.array<200xf32>>
+  hlfir.destroy %5 : !hlfir.expr<200xf32>
+
+  return
+}
+
+// CHECK-LABEL:   func.func @volatile_src_nonvolatile_dst() {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 200 : index
+// CHECK:           %[[ADDRESS_OF_0:.*]] = fir.address_of(@_QMtestEarray_src) : !fir.ref<!fir.array<200xf32>>
+// CHECK:           %[[ADDRESS_OF_1:.*]] = fir.address_of(@_QMtestEarray_dst) : !fir.ref<!fir.array<200xf32>>
+// CHECK:           %[[SHAPE_0:.*]] = fir.shape %[[CONSTANT_0]] : (index) -> !fir.shape<1>
+// CHECK:           %[[VOLATILE_CAST_0:.*]] = fir.volatile_cast %[[ADDRESS_OF_0]] : (!fir.ref<!fir.array<200xf32>>) -> !fir.ref<!fir.array<200xf32>, volatile>
+// CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[VOLATILE_CAST_0]](%[[SHAPE_0]]) {fortran_attrs = #fir.var_attrs<volatile>, uniq_name = "_QMtestEarray_src"} : (!fir.ref<!fir.array<200xf32>, volatile>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>, volatile>, !fir.ref<!fir.array<200xf32>, volatile>)
+// CHECK:           %[[DECLARE_1:.*]]:2 = hlfir.declare %[[ADDRESS_OF_1]](%[[SHAPE_0]]) {uniq_name = "_QMtestEarray_dst"} : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>>, !fir.ref<!fir.array<200xf32>>)
+// CHECK:           %[[ELEMENTAL_0:.*]] = hlfir.elemental %[[SHAPE_0]] unordered : (!fir.shape<1>) -> !hlfir.expr<200xf32> {
+// CHECK:           ^bb0(%[[VAL_0:.*]]: index):
+// CHECK:             %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_0]]#0 (%[[VAL_0]])  : (!fir.ref<!fir.array<200xf32>, volatile>, index) -> !fir.ref<f32, volatile>
+// CHECK:             %[[LOAD_0:.*]] = fir.load %[[DESIGNATE_0]] : !fir.ref<f32, volatile>
+// CHECK:             %[[NEGF_0:.*]] = arith.negf %[[LOAD_0]] : f32
+// CHECK:             hlfir.yield_element %[[NEGF_0]] : f32
+// CHECK:           }
+// CHECK:           hlfir.assign %[[ELEMENTAL_0]] to %[[DECLARE_1]]#0 : !hlfir.expr<200xf32>, !fir.ref<!fir.array<200xf32>>
+// CHECK:           hlfir.destroy %[[ELEMENTAL_0]] : !hlfir.expr<200xf32>
+// CHECK:           return
+// CHECK:         }
+
+// Check that 'volatile_dst = -src' is optimized.
+func.func @nonvolatile_src_volatile_dst() {
+  %c1 = arith.constant 1 : index
+  %c200 = arith.constant 200 : index
+
+  %1 = fir.address_of(@_QMtestEarray_dst) : !fir.ref<!fir.array<200xf32>>
+  %dst = fir.address_of(@_QMtestEarray_src) : !fir.ref<!fir.array<200xf32>>
+  %2 = fir.shape %c200 : (index) -> !fir.shape<1>
+  %3 = fir.volatile_cast %1 : (!fir.ref<!fir.array<200xf32>>) -> !fir.ref<!fir.array<200xf32>, volatile>
+  %4:2 = hlfir.declare %3(%2) {fortran_attrs = #fir.var_attrs<volatile>, uniq_name = "_QMtestEarray_dst"} : (!fir.ref<!fir.array<200xf32>, volatile>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>, volatile>, !fir.ref<!fir.array<200xf32>, volatile>)
+  %srcDecl:2 = hlfir.declare %dst(%2) {uniq_name = "_QMtestEarray_src"} : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>>, !fir.ref<!fir.array<200xf32>>)
+
+  %5 = hlfir.elemental %2 unordered : (!fir.shape<1>) -> !hlfir.expr<200xf32> {
+  ^bb0(%arg1: index):
+    %6 = hlfir.designate %srcDecl#0 (%arg1) : (!fir.ref<!fir.array<200xf32>>, index) -> !fir.ref<f32>
+    %7 = fir.load %6 : !fir.ref<f32>
+    %8 = arith.negf %7 : f32
+    hlfir.yield_element %8 : f32
+  }
+
+  hlfir.assign %5 to %4#0 : !hlfir.expr<200xf32>, !fir.ref<!fir.array<200xf32>, volatile>
+  hlfir.destroy %5 : !hlfir.expr<200xf32>
+
+  return
+}
+// CHECK-LABEL:   func.func @nonvolatile_src_volatile_dst() {
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 200 : index
+// CHECK:           %[[ADDRESS_OF_0:.*]] = fir.address_of(@_QMtestEarray_dst) : !fir.ref<!fir.array<200xf32>>
+// CHECK:           %[[ADDRESS_OF_1:.*]] = fir.address_of(@_QMtestEarray_src) : !fir.ref<!fir.array<200xf32>>
+// CHECK:           %[[SHAPE_0:.*]] = fir.shape %[[CONSTANT_1]] : (index) -> !fir.shape<1>
+// CHECK:           %[[VOLATILE_CAST_0:.*]] = fir.volatile_cast %[[ADDRESS_OF_0]] : (!fir.ref<!fir.array<200xf32>>) -> !fir.ref<!fir.array<200xf32>, volatile>
+// CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[VOLATILE_CAST_0]](%[[SHAPE_0]]) {fortran_attrs = #fir.var_attrs<volatile>, uniq_name = "_QMtestEarray_dst"} : (!fir.ref<!fir.array<200xf32>, volatile>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>, volatile>, !fir.ref<!fir.array<200xf32>, volatile>)
+// CHECK:           %[[DECLARE_1:.*]]:2 = hlfir.declare %[[ADDRESS_OF_1]](%[[SHAPE_0]]) {uniq_name = "_QMtestEarray_src"} : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>>, !fir.ref<!fir.array<200xf32>>)
+// CHECK:           fir.do_loop %[[VAL_0:.*]] = %[[CONSTANT_0]] to %[[CONSTANT_1]] step %[[CONSTANT_0]] unordered {
+// CHECK:             %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_1]]#0 (%[[VAL_0]])  : (!fir.ref<!fir.array<200xf32>>, index) -> !fir.ref<f32>
+// CHECK:             %[[LOAD_0:.*]] = fir.load %[[DESIGNATE_0]] : !fir.ref<f32>
+// CHECK:             %[[NEGF_0:.*]] = arith.negf %[[LOAD_0]] : f32
+// CHECK:             %[[DESIGNATE_1:.*]] = hlfir.designate %[[DECLARE_0]]#0 (%[[VAL_0]])  : (!fir.ref<!fir.array<200xf32>, volatile>, index) -> !fir.ref<f32, volatile>
+// CHECK:             hlfir.assign %[[NEGF_0]] to %[[DESIGNATE_1]] : f32, !fir.ref<f32, volatile>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
It should be safe to pass-through `fir.volatile_cast` for the purpose of alias analysis. The missing pass-through prevented optimization of the `nonvolatile_src_volatile_dst` test (see updated LIT test).