### PR TITLE
[flang] Recognize effects on non-addressable resources in opt-bufferization

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/OptimizedBufferization.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/OptimizedBufferization.cpp
@@ -164,14 +164,16 @@ static bool haveNonAddressableEffectsConflict(
          const llvm::SmallPtrSetImpl<mlir::SideEffects::Resource *> &set2) {
         if (set1.empty() || set2.empty())
           return false;
-        for (const auto *r1 : set1)
-          for (const auto *r2 : set2)
+        for (const auto *r1 : set1) {
+          for (const auto *r2 : set2) {
             if (!r1->isDisjointFrom(r2)) {
               LLVM_DEBUG(llvm::dbgs()
                          << "resources " << r1->getName() << " and "
                          << r2->getName() << " are not disjoint\n");
               return true;
             }
+          }
+        }
         return false;
       };
   if (accessSameResource(reads1, others2) ||
@@ -298,10 +300,11 @@ ElementalAssignBufferization::findMatch(hlfir::ElementalOp elemental) const {
   mlir::SmallVector<mlir::Value, 1> notToBeWrittenBeforeAssign;
 
   // 1) side effects in the elemental body - it isn't sufficient to just look
-  // for ordered elementals because we also cannot support out of order reads
+  // for ordered elementals because we also cannot support out of order reads.
+  // We can use mlir::getEffectsRecursively(), because the hlfir.elemental's
+  // MemAlloc effect will effectively be ignored below.
   std::optional<mlir::SmallVector<mlir::MemoryEffects::EffectInstance>>
-      elementalEffects = getEffectsBetween(
-          &elemental.getBody()->front(), elemental.getBody()->getTerminator());
+      elementalEffects = mlir::getEffectsRecursively(elemental);
   if (!elementalEffects) {
     LLVM_DEBUG(llvm::dbgs()
                << "operation with unknown effects inside elemental\n");

--- a/flang/lib/Optimizer/HLFIR/Transforms/OptimizedBufferization.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/OptimizedBufferization.cpp
@@ -87,10 +87,16 @@ private:
     hlfir::DestroyOp destroy;
   };
   /// determines if the transformation can be applied to this elemental
-  static std::optional<MatchInfo> findMatch(hlfir::ElementalOp elemental);
+  std::optional<MatchInfo> findMatch(hlfir::ElementalOp elemental) const;
+
+  mlir::AliasAnalysis &aliasAnalysis;
 
 public:
   using mlir::OpRewritePattern<hlfir::ElementalOp>::OpRewritePattern;
+
+  ElementalAssignBufferization(mlir::MLIRContext *ctx,
+                               mlir::AliasAnalysis &aliasAnalysis)
+      : OpRewritePattern{ctx}, aliasAnalysis{aliasAnalysis} {}
 
   llvm::LogicalResult
   matchAndRewrite(hlfir::ElementalOp elemental,
@@ -122,17 +128,73 @@ getEffectsBetween(mlir::Operation *start, mlir::Operation *end) {
   return ret;
 }
 
+/// Given two sets of memory effects checks if they contain
+/// conflicting effects on overlapping non-addressable resources.
+/// Only read-read effects are not conflicting.
+/// If any of the given sets is std::nullopt, the result is true.
+static bool haveNonAddressableEffectsConflict(
+    const std::optional<mlir::SmallVector<mlir::MemoryEffects::EffectInstance>>
+        &effects1,
+    const std::optional<mlir::SmallVector<mlir::MemoryEffects::EffectInstance>>
+        &effects2) {
+  if (!effects1 || !effects2)
+    return true;
+  auto splitEffects =
+      [](const mlir::SmallVector<mlir::MemoryEffects::EffectInstance> &effects)
+      -> std::pair<llvm::SmallPtrSet<mlir::SideEffects::Resource *, 4>,
+                   llvm::SmallPtrSet<mlir::SideEffects::Resource *, 4>> {
+    llvm::SmallPtrSet<mlir::SideEffects::Resource *, 4> reads;
+    llvm::SmallPtrSet<mlir::SideEffects::Resource *, 4> others;
+    for (const mlir::MemoryEffects::EffectInstance &effect : effects) {
+      mlir::SideEffects::Resource *resource = effect.getResource();
+      if (!resource->isAddressable()) {
+        if (mlir::isa<mlir::MemoryEffects::Read>(effect.getEffect()))
+          reads.insert(resource);
+        else
+          others.insert(resource);
+      }
+    }
+    return {std::move(reads), std::move(others)};
+  };
+  auto [reads1, others1] = splitEffects(*effects1);
+  auto [reads2, others2] = splitEffects(*effects2);
+
+  auto accessSameResource =
+      [](const llvm::SmallPtrSetImpl<mlir::SideEffects::Resource *> &set1,
+         const llvm::SmallPtrSetImpl<mlir::SideEffects::Resource *> &set2) {
+        if (set1.empty() || set2.empty())
+          return false;
+        for (const auto *r1 : set1)
+          for (const auto *r2 : set2)
+            if (!r1->isDisjointFrom(r2)) {
+              LLVM_DEBUG(llvm::dbgs()
+                         << "resources " << r1->getName() << " and "
+                         << r2->getName() << " are not disjoint\n");
+              return true;
+            }
+        return false;
+      };
+  if (accessSameResource(reads1, others2) ||
+      accessSameResource(reads2, others1) ||
+      accessSameResource(others1, others2)) {
+    LLVM_DEBUG(
+        llvm::dbgs()
+        << "conflicting effects on overlapping non-addressable resources\n");
+    return true;
+  }
+  return false;
+}
+
 /// If effect is a read or write on val, return whether it aliases.
 /// Otherwise return mlir::AliasResult::NoAlias
 static mlir::AliasResult
 containsReadOrWriteEffectOn(const mlir::MemoryEffects::EffectInstance &effect,
-                            mlir::Value val) {
-  fir::AliasAnalysis aliasAnalysis;
-
+                            mlir::Value val,
+                            mlir::AliasAnalysis &aliasAnalysis) {
   if (mlir::isa<mlir::MemoryEffects::Read, mlir::MemoryEffects::Write>(
           effect.getEffect())) {
     mlir::Value accessedVal = effect.getValue();
-    if (mlir::isa<fir::DebuggingResource>(effect.getResource()))
+    if (!effect.getResource()->isAddressable())
       return mlir::AliasResult::NoAlias;
     if (!accessedVal)
       return mlir::AliasResult::MayAlias;
@@ -162,7 +224,7 @@ containsReadOrWriteEffectOn(const mlir::MemoryEffects::EffectInstance &effect,
 }
 
 std::optional<ElementalAssignBufferization::MatchInfo>
-ElementalAssignBufferization::findMatch(hlfir::ElementalOp elemental) {
+ElementalAssignBufferization::findMatch(hlfir::ElementalOp elemental) const {
   mlir::Operation::user_range users = elemental->getUsers();
   // the only uses of the elemental should be the assignment and the destroy
   if (std::distance(users.begin(), users.end()) != 2) {
@@ -238,15 +300,26 @@ ElementalAssignBufferization::findMatch(hlfir::ElementalOp elemental) {
   // 1) side effects in the elemental body - it isn't sufficient to just look
   // for ordered elementals because we also cannot support out of order reads
   std::optional<mlir::SmallVector<mlir::MemoryEffects::EffectInstance>>
-      effects = getEffectsBetween(&elemental.getBody()->front(),
-                                  elemental.getBody()->getTerminator());
-  if (!effects) {
+      elementalEffects = getEffectsBetween(
+          &elemental.getBody()->front(), elemental.getBody()->getTerminator());
+  if (!elementalEffects) {
     LLVM_DEBUG(llvm::dbgs()
                << "operation with unknown effects inside elemental\n");
     return std::nullopt;
   }
-  for (const mlir::MemoryEffects::EffectInstance &effect : *effects) {
-    mlir::AliasResult res = containsReadOrWriteEffectOn(effect, match.array);
+  std::optional<mlir::SmallVector<mlir::MemoryEffects::EffectInstance>>
+      assignEffects = mlir::getEffectsRecursively(match.assign);
+  if (haveNonAddressableEffectsConflict(elementalEffects, assignEffects)) {
+    LLVM_DEBUG(llvm::dbgs() << "the elemental and assign have conflicting "
+                               "effects on non-addressable resources\n");
+    return std::nullopt;
+  }
+
+  for (const mlir::MemoryEffects::EffectInstance &effect : *elementalEffects) {
+    // TODO: we should probably use AliasAnalysis::getModRef() here,
+    // because it might be more precise in identifying no aliases.
+    mlir::AliasResult res =
+        containsReadOrWriteEffectOn(effect, match.array, aliasAnalysis);
     if (res.isNo()) {
       if (effect.getValue()) {
         if (mlir::isa<mlir::MemoryEffects::Write>(effect.getEffect()))
@@ -310,18 +383,26 @@ ElementalAssignBufferization::findMatch(hlfir::ElementalOp elemental) {
   }
 
   // 2) look for conflicting effects between the elemental and the assignment
-  effects = getEffectsBetween(elemental->getNextNode(), match.assign);
+  std::optional<mlir::SmallVector<mlir::MemoryEffects::EffectInstance>>
+      effects = getEffectsBetween(elemental->getNextNode(), match.assign);
   if (!effects) {
     LLVM_DEBUG(
         llvm::dbgs()
         << "operation with unknown effects between elemental and assign\n");
     return std::nullopt;
   }
+  if (haveNonAddressableEffectsConflict(elementalEffects, effects)) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "the elemental and an operation between elemental and assign "
+                  "have conflicting effects on non-addressable resources\n");
+    return std::nullopt;
+  }
   for (const mlir::MemoryEffects::EffectInstance &effect : *effects) {
     // not safe to access anything written in the elemental as this write
     // will be moved to the assignment
     for (mlir::Value val : notToBeAccessedBeforeAssign) {
-      mlir::AliasResult res = containsReadOrWriteEffectOn(effect, val);
+      mlir::AliasResult res =
+          containsReadOrWriteEffectOn(effect, val, aliasAnalysis);
       if (!res.isNo()) {
         LLVM_DEBUG(llvm::dbgs()
                    << "disallowed side-effect: " << effect.getValue() << " for "
@@ -332,7 +413,8 @@ ElementalAssignBufferization::findMatch(hlfir::ElementalOp elemental) {
     // Anything that is read inside the elemental can only be safely read
     // between the elemental and the assignment.
     for (mlir::Value val : notToBeWrittenBeforeAssign) {
-      mlir::AliasResult res = containsReadOrWriteEffectOn(effect, val);
+      mlir::AliasResult res =
+          containsReadOrWriteEffectOn(effect, val, aliasAnalysis);
       if (!res.isNo() &&
           !mlir::isa<mlir::MemoryEffects::Read>(effect.getEffect())) {
         LLVM_DEBUG(llvm::dbgs()
@@ -512,14 +594,22 @@ class EvaluateIntoMemoryAssignBufferization
 public:
   using mlir::OpRewritePattern<hlfir::EvaluateInMemoryOp>::OpRewritePattern;
 
+  EvaluateIntoMemoryAssignBufferization(mlir::MLIRContext *ctx,
+                                        mlir::AliasAnalysis &aliasAnalysis)
+      : OpRewritePattern{ctx}, aliasAnalysis{aliasAnalysis} {}
+
   llvm::LogicalResult
   matchAndRewrite(hlfir::EvaluateInMemoryOp,
                   mlir::PatternRewriter &rewriter) const override;
+
+private:
+  mlir::AliasAnalysis &aliasAnalysis;
 };
 
 static llvm::LogicalResult
 tryUsingAssignLhsDirectly(hlfir::EvaluateInMemoryOp evalInMem,
-                          mlir::PatternRewriter &rewriter) {
+                          mlir::PatternRewriter &rewriter,
+                          mlir::AliasAnalysis &aliasAnalysis) {
   mlir::Location loc = evalInMem.getLoc();
   hlfir::DestroyOp destroy;
   hlfir::AssignOp assign;
@@ -544,7 +634,6 @@ tryUsingAssignLhsDirectly(hlfir::EvaluateInMemoryOp evalInMem,
   // RHS lengths are the same.
   if (lhs.isCharacter())
     return mlir::failure();
-  fir::AliasAnalysis aliasAnalysis;
   // The region must not read or write the LHS.
   // Note that getModRef is used instead of mlir::MemoryEffects because
   // EvaluateInMemoryOp is typically expected to hold fir.calls and that
@@ -554,7 +643,7 @@ tryUsingAssignLhsDirectly(hlfir::EvaluateInMemoryOp evalInMem,
   // hence getModRef is needed here and below. Also note that getModRef uses
   // mlir::MemoryEffects for operations that do not have special handling in
   // getModRef.
-  if (aliasAnalysis.getModRef(evalInMem.getBody(), lhs).isModOrRef())
+  if (aliasAnalysis.getModRef(evalInMem, lhs).isModOrRef())
     return mlir::failure();
   // Any variables affected between the hlfir.evalInMem and assignment must not
   // be read or written inside the region since it will be moved at the
@@ -568,8 +657,7 @@ tryUsingAssignLhsDirectly(hlfir::EvaluateInMemoryOp evalInMem,
   }
   for (const mlir::MemoryEffects::EffectInstance &effect : *effects) {
     mlir::Value affected = effect.getValue();
-    if (!affected ||
-        aliasAnalysis.getModRef(evalInMem.getBody(), affected).isModOrRef())
+    if (!affected || aliasAnalysis.getModRef(evalInMem, affected).isModOrRef())
       return mlir::failure();
   }
 
@@ -586,7 +674,8 @@ tryUsingAssignLhsDirectly(hlfir::EvaluateInMemoryOp evalInMem,
 llvm::LogicalResult EvaluateIntoMemoryAssignBufferization::matchAndRewrite(
     hlfir::EvaluateInMemoryOp evalInMem,
     mlir::PatternRewriter &rewriter) const {
-  if (mlir::succeeded(tryUsingAssignLhsDirectly(evalInMem, rewriter)))
+  if (mlir::succeeded(
+          tryUsingAssignLhsDirectly(evalInMem, rewriter, aliasAnalysis)))
     return mlir::success();
   // Rewrite to temp + as_expr here so that the assign + as_expr pattern can
   // kick-in for simple types and at least implement the assignment inline
@@ -605,6 +694,9 @@ class OptimizedBufferizationPass
           OptimizedBufferizationPass> {
 public:
   void runOnOperation() override {
+    auto &aliasAnalysis = getAnalysis<mlir::AliasAnalysis>();
+    aliasAnalysis.addAnalysisImplementation(fir::AliasAnalysis{});
+
     mlir::MLIRContext *context = &getContext();
 
     mlir::GreedyRewriteConfig config;
@@ -619,9 +711,10 @@ public:
     // at one place (e.g. we may use some heuristics and
     // choose different optimization strategies).
     // This requires small code reordering in ElementalAssignBufferization.
-    patterns.insert<ElementalAssignBufferization>(context);
+    patterns.insert<ElementalAssignBufferization>(context, aliasAnalysis);
     patterns.insert<BroadcastAssignBufferization>(context);
-    patterns.insert<EvaluateIntoMemoryAssignBufferization>(context);
+    patterns.insert<EvaluateIntoMemoryAssignBufferization>(context,
+                                                           aliasAnalysis);
 
     if (mlir::failed(mlir::applyPatternsGreedily(
             getOperation(), std::move(patterns), config))) {

--- a/flang/test/HLFIR/opt-bufferization-skip-volatile.fir
+++ b/flang/test/HLFIR/opt-bufferization-skip-volatile.fir
@@ -52,7 +52,6 @@ fir.global @_QMtestEarray_src : !fir.array<200xf32>
 fir.global @_QMtestEarray_dst : !fir.array<200xf32>
 
 // Check that 'dst = -volatile_src' is optimized.
-// TODO: opt-bufferization needs to be fixed.
 func.func @volatile_src_nonvolatile_dst() {
   %c1 = arith.constant 1 : index
   %c200 = arith.constant 200 : index
@@ -79,22 +78,21 @@ func.func @volatile_src_nonvolatile_dst() {
 }
 
 // CHECK-LABEL:   func.func @volatile_src_nonvolatile_dst() {
-// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 200 : index
+// CHECK:           %[[CONSTANT_0:.*]] = arith.constant 1 : index
+// CHECK:           %[[CONSTANT_1:.*]] = arith.constant 200 : index
 // CHECK:           %[[ADDRESS_OF_0:.*]] = fir.address_of(@_QMtestEarray_src) : !fir.ref<!fir.array<200xf32>>
 // CHECK:           %[[ADDRESS_OF_1:.*]] = fir.address_of(@_QMtestEarray_dst) : !fir.ref<!fir.array<200xf32>>
-// CHECK:           %[[SHAPE_0:.*]] = fir.shape %[[CONSTANT_0]] : (index) -> !fir.shape<1>
+// CHECK:           %[[SHAPE_0:.*]] = fir.shape %[[CONSTANT_1]] : (index) -> !fir.shape<1>
 // CHECK:           %[[VOLATILE_CAST_0:.*]] = fir.volatile_cast %[[ADDRESS_OF_0]] : (!fir.ref<!fir.array<200xf32>>) -> !fir.ref<!fir.array<200xf32>, volatile>
 // CHECK:           %[[DECLARE_0:.*]]:2 = hlfir.declare %[[VOLATILE_CAST_0]](%[[SHAPE_0]]) {fortran_attrs = #fir.var_attrs<volatile>, uniq_name = "_QMtestEarray_src"} : (!fir.ref<!fir.array<200xf32>, volatile>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>, volatile>, !fir.ref<!fir.array<200xf32>, volatile>)
 // CHECK:           %[[DECLARE_1:.*]]:2 = hlfir.declare %[[ADDRESS_OF_1]](%[[SHAPE_0]]) {uniq_name = "_QMtestEarray_dst"} : (!fir.ref<!fir.array<200xf32>>, !fir.shape<1>) -> (!fir.ref<!fir.array<200xf32>>, !fir.ref<!fir.array<200xf32>>)
-// CHECK:           %[[ELEMENTAL_0:.*]] = hlfir.elemental %[[SHAPE_0]] unordered : (!fir.shape<1>) -> !hlfir.expr<200xf32> {
-// CHECK:           ^bb0(%[[VAL_0:.*]]: index):
+// CHECK:           fir.do_loop %[[VAL_0:.*]] = %[[CONSTANT_0]] to %[[CONSTANT_1]] step %[[CONSTANT_0]] unordered {
 // CHECK:             %[[DESIGNATE_0:.*]] = hlfir.designate %[[DECLARE_0]]#0 (%[[VAL_0]])  : (!fir.ref<!fir.array<200xf32>, volatile>, index) -> !fir.ref<f32, volatile>
 // CHECK:             %[[LOAD_0:.*]] = fir.load %[[DESIGNATE_0]] : !fir.ref<f32, volatile>
 // CHECK:             %[[NEGF_0:.*]] = arith.negf %[[LOAD_0]] : f32
-// CHECK:             hlfir.yield_element %[[NEGF_0]] : f32
+// CHECK:             %[[DESIGNATE_1:.*]] = hlfir.designate %[[DECLARE_1]]#0 (%[[VAL_0]])  : (!fir.ref<!fir.array<200xf32>>, index) -> !fir.ref<f32>
+// CHECK:             hlfir.assign %[[NEGF_0]] to %[[DESIGNATE_1]] : f32, !fir.ref<f32>
 // CHECK:           }
-// CHECK:           hlfir.assign %[[ELEMENTAL_0]] to %[[DECLARE_1]]#0 : !hlfir.expr<200xf32>, !fir.ref<!fir.array<200xf32>>
-// CHECK:           hlfir.destroy %[[ELEMENTAL_0]] : !hlfir.expr<200xf32>
 // CHECK:           return
 // CHECK:         }
 


### PR DESCRIPTION
opt-bufferization has been only handling `fir::DebuggingResource` explicitly. This patch adds support for other non-addressable resources, such as `fir::VolatileMemoryResource`. This allows merging elemental/assign for the `volatile_src_nonvolatile_dst` example in the updated LIT test.