### PR TITLE
[MLIR][test] Add lit coverage for cf.br/cond_br/switch under narrow-type emulation

### DIFF
--- a/mlir/test/Dialect/MemRef/emulate-narrow-type-cf-types.mlir
+++ b/mlir/test/Dialect/MemRef/emulate-narrow-type-cf-types.mlir
@@ -1,0 +1,38 @@
+// RUN: mlir-opt --test-emulate-narrow-int="memref-load-bitwidth=8 arith-compute-bitwidth=8" --cse --verify-diagnostics --split-input-file %s | FileCheck %s
+
+// Sub-byte integer scalar carried through a cf.br block-arg. The cf branch
+// pattern (registered via cf::populateCFStructuralTypeConversionsAndLegality
+// in the memref / vector narrow-type emulation wrappers) rewrites both the
+// cf.br operand type and the successor block-arg type using the arith
+// narrow-type integer converter.
+
+// CHECK-LABEL: func.func @cf_br_block_arg_arith_i4
+// CHECK-SAME:    %[[ARG:[A-Za-z0-9_]+]]: i8
+// CHECK:         cf.br ^[[BB1:.+]](%[[ARG]] : i8)
+// CHECK:       ^[[BB1]](%[[BARG:[A-Za-z0-9_]+]]: i8):
+// CHECK:         return %[[BARG]]
+// CHECK-NOT:     i4
+func.func @cf_br_block_arg_arith_i4(%arg: i4) -> i4 {
+  cf.br ^bb1(%arg : i4)
+^bb1(%a: i4):
+  return %a : i4
+}
+
+// -----
+
+// Sub-byte integer vector carried through a cf.br block-arg.
+// cf::populateCFStructuralTypeConversionsAndLegality rewrites both the
+// cf.br operand type and the successor block-arg type using the arith
+// narrow-type vector converter.
+
+// CHECK-LABEL: func.func @cf_br_block_arg_vector_i4
+// CHECK-SAME:    %[[ARG:[A-Za-z0-9_]+]]: vector<8xi8>
+// CHECK:         cf.br ^[[BB1:.+]](%[[ARG]] : vector<8xi8>)
+// CHECK:       ^[[BB1]](%[[BARG:[A-Za-z0-9_]+]]: vector<8xi8>):
+// CHECK:         return %[[BARG]]
+// CHECK-NOT:     vector<8xi4>
+func.func @cf_br_block_arg_vector_i4(%arg: vector<8xi4>) -> vector<8xi4> {
+  cf.br ^bb1(%arg : vector<8xi4>)
+^bb1(%a: vector<8xi4>):
+  return %a : vector<8xi4>
+}

--- a/mlir/test/Dialect/MemRef/emulate-narrow-type-cf.mlir
+++ b/mlir/test/Dialect/MemRef/emulate-narrow-type-cf.mlir
@@ -1,0 +1,78 @@
+// RUN: mlir-opt --test-emulate-narrow-int="memref-load-bitwidth=8 arith-compute-bitwidth=1" --cse --verify-diagnostics --split-input-file %s | FileCheck %s
+
+// Sub-byte memref type carried through cf.br block args. The cf branch
+// pattern (registered by cf::populateCFStructuralTypeConversionsAndLegality)
+// must rewrite both the cf.br operand type and the successor block-arg type
+// to the i8 container, so the downstream uses in the successor block see an
+// i8 source.
+
+// CHECK-LABEL: func.func @cf_br_block_arg_narrow_type
+// CHECK-SAME:    %[[ARG:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>
+// CHECK:         cf.br ^[[BB1:.+]](%[[ARG]] : memref<{{[0-9]+}}xi8>)
+// CHECK:       ^[[BB1]](%[[BARG:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>):
+// CHECK:         return %[[BARG]]
+// CHECK-NOT:     memref<{{[0-9]+}}xi4>
+func.func @cf_br_block_arg_narrow_type(%arg: memref<8xi4>) -> memref<8xi4> {
+  cf.br ^bb1(%arg : memref<8xi4>)
+^bb1(%a: memref<8xi4>):
+  return %a : memref<8xi4>
+}
+
+// -----
+
+// Sub-byte memref carried through both successors of a cf.cond_br. Both
+// branch operand types and both successor block-arg types must be rewritten
+// to the i8 container.
+
+// CHECK-LABEL: func.func @cf_cond_br_block_arg_narrow_type
+// CHECK-SAME:    %[[COND:[A-Za-z0-9_]+]]: i1
+// CHECK-SAME:    %[[A:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>
+// CHECK-SAME:    %[[B:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>
+// CHECK:         cf.cond_br %[[COND]], ^[[BBT:.+]](%[[A]] : memref<{{[0-9]+}}xi8>), ^[[BBF:.+]](%[[B]] : memref<{{[0-9]+}}xi8>)
+// CHECK:       ^[[BBT]](%[[XT:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>):
+// CHECK:         return %[[XT]]
+// CHECK:       ^[[BBF]](%[[XF:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>):
+// CHECK:         return %[[XF]]
+// CHECK-NOT:     memref<{{[0-9]+}}xi4>
+func.func @cf_cond_br_block_arg_narrow_type(%cond: i1, %a: memref<8xi4>, %b: memref<8xi4>) -> memref<8xi4> {
+  cf.cond_br %cond, ^bb1(%a : memref<8xi4>), ^bb2(%b : memref<8xi4>)
+^bb1(%x: memref<8xi4>):
+  return %x : memref<8xi4>
+^bb2(%y: memref<8xi4>):
+  return %y : memref<8xi4>
+}
+
+// -----
+
+// Sub-byte memref carried through the default and case successors of a
+// cf.switch. The branch pattern must rewrite the operand type at every
+// successor edge and the matching block-arg type at every successor.
+
+// CHECK-LABEL: func.func @cf_switch_block_arg_narrow_type
+// CHECK-SAME:    %[[FLAG:[A-Za-z0-9_]+]]: i32
+// CHECK-SAME:    %[[ARG:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>
+// CHECK:         cf.switch %[[FLAG]] : i32, [
+// CHECK:           default: ^[[BBD:.+]](%[[ARG]] : memref<{{[0-9]+}}xi8>)
+// CHECK:           0: ^[[BB0:.+]](%[[ARG]] : memref<{{[0-9]+}}xi8>)
+// CHECK:           1: ^[[BB1:.+]](%[[ARG]] : memref<{{[0-9]+}}xi8>)
+// CHECK:         ]
+// CHECK:       ^[[BBD]](%[[XD:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>):
+// CHECK:         return %[[XD]]
+// CHECK:       ^[[BB0]](%[[X0:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>):
+// CHECK:         return %[[X0]]
+// CHECK:       ^[[BB1]](%[[X1:[A-Za-z0-9_]+]]: memref<{{[0-9]+}}xi8>):
+// CHECK:         return %[[X1]]
+// CHECK-NOT:     memref<{{[0-9]+}}xi4>
+func.func @cf_switch_block_arg_narrow_type(%flag: i32, %arg: memref<8xi4>) -> memref<8xi4> {
+  cf.switch %flag : i32, [
+    default: ^bb1(%arg : memref<8xi4>),
+    0: ^bb2(%arg : memref<8xi4>),
+    1: ^bb3(%arg : memref<8xi4>)
+  ]
+^bb1(%x: memref<8xi4>):
+  return %x : memref<8xi4>
+^bb2(%y: memref<8xi4>):
+  return %y : memref<8xi4>
+^bb3(%z: memref<8xi4>):
+  return %z : memref<8xi4>
+}

--- a/mlir/test/lib/Dialect/MemRef/CMakeLists.txt
+++ b/mlir/test/lib/Dialect/MemRef/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_library(MLIRMemRefTestPasses
   MLIRTestDialect
   )
 mlir_target_link_libraries(MLIRMemRefTestPasses PUBLIC
+  MLIRControlFlowTransforms
   MLIRPass
   MLIRMemRefDialect
   MLIRMemRefTransforms

--- a/mlir/test/lib/Dialect/MemRef/TestEmulateNarrowType.cpp
+++ b/mlir/test/lib/Dialect/MemRef/TestEmulateNarrowType.cpp
@@ -11,6 +11,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/NarrowTypeEmulationConverter.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/ControlFlow/Transforms/StructuralTypeConversions.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
@@ -34,9 +36,9 @@ struct TestEmulateNarrowTypePass
       : PassWrapper(pass) {}
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry
-        .insert<arith::ArithDialect, func::FuncDialect, memref::MemRefDialect,
-                vector::VectorDialect, affine::AffineDialect>();
+    registry.insert<arith::ArithDialect, cf::ControlFlowDialect,
+                    func::FuncDialect, memref::MemRefDialect,
+                    vector::VectorDialect, affine::AffineDialect>();
   }
   StringRef getArgument() const final { return "test-emulate-narrow-int"; }
   StringRef getDescription() const final {
@@ -103,6 +105,9 @@ struct TestEmulateNarrowTypePass
         typeConverter, patterns, disableAtomicRMW, assumeAligned);
     vector::populateVectorNarrowTypeEmulationPatterns(
         typeConverter, patterns, disableAtomicRMW, assumeAligned);
+
+    cf::populateCFStructuralTypeConversionsAndLegality(typeConverter, patterns,
+                                                       target);
 
     if (failed(applyPartialConversion(op, target, std::move(patterns))))
       signalPassFailure();


### PR DESCRIPTION
Wires `cf::populateCFStructuralTypeConversionsAndLegality` into the
in-tree `TestEmulateNarrowType` pass and adds lit coverage that
exercises `cf.br` / `cf.cond_br` / `cf.switch` operand and successor
block-argument rewriting when emulating sub-byte element types:

* `memref<NxiW>` carried across `cf.br` / `cf.cond_br` / `cf.switch`.
* Sub-byte integer scalars across `cf.br`.
* Sub-byte integer vectors across `cf.br`.

This PR initially added thin wrapper functions
(`memref::populateMemRefNarrowTypeEmulationCFPatterns`,
`vector::populateVectorNarrowTypeEmulationCFPatterns`) over
`cf::populateCFStructuralTypeConversionsAndLegality`. Per review
feedback those wrappers were redundant, so callers (including the
in-tree test pass) now call `cf::populateCFStructuralTypeConversionsAndLegality`
directly. Net contribution is the test-pass plumbing and the new lit
tests demonstrating that the existing cf structural type conversion
correctly handles narrow-type-emulated values.