### PR TITLE
[mlir][spirv] Remove ConstantLike trait from spirv.ARM.GraphConstant

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGraphOps.td
@@ -116,7 +116,7 @@ def InGraphScope : PredOpTrait<
 
 // -----
 
-def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, Pure, ConstantLike]> {
+def SPIRV_GraphConstantARMOp : SPIRV_GraphARMOp<"GraphConstant", [InGraphScope, Pure]> {
   let summary = "Declare a graph constant.";
 
   let description = [{


### PR DESCRIPTION
Operations with the `ConstantLike` trait can always be folded into a concrete attribute value. However, the `spirv.ARM.GraphConstant` op cannot be folded, because its GraphConstantID is merely a unique identifier used to map to the actual constants defined in the SPIR-V module. Therefore, the `ConstantLike` trait should be removed from `pirv.ARM.GraphConstant`. Fixes #197970.