### PR TITLE
[Offload] Fix missing dependency on generated OffloadAPI headers

### DIFF
--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(PluginCommon OBJECT
   src/OffloadError.cpp
   src/Utils/ELF.cpp
 )
-add_dependencies(PluginCommon intrinsics_gen PluginErrcodes)
+add_dependencies(PluginCommon intrinsics_gen PluginErrcodes OffloadAPI)
 
 # Only enable JIT for those targets that LLVM can support.
 set(supported_jit_targets AMDGPU NVPTX)


### PR DESCRIPTION
Summary:
These are included in the plugins but not a dependency

Fixes: https://github.com/llvm/llvm-project/issues/196690
