### PR TITLE
[OpenACC] Fix invalid using inside of an openacc directive

### DIFF
--- a/clang/lib/Parse/ParseOpenACC.cpp
+++ b/clang/lib/Parse/ParseOpenACC.cpp
@@ -608,18 +608,18 @@ unsigned getOpenACCScopeFlags(OpenACCDirectiveKind DirKind) {
   case OpenACCDirectiveKind::Kernels:
     // Mark this as a BreakScope/ContinueScope as well as a compute construct
     // so that we can diagnose trying to 'break'/'continue' inside of one.
-    return Scope::BreakScope | Scope::ContinueScope |
+    return Scope::BreakScope | Scope::ContinueScope | Scope::DeclScope |
            Scope::OpenACCComputeConstructScope;
   case OpenACCDirectiveKind::ParallelLoop:
   case OpenACCDirectiveKind::SerialLoop:
   case OpenACCDirectiveKind::KernelsLoop:
     // Mark this as a BreakScope/ContinueScope as well as a compute construct
     // so that we can diagnose trying to 'break'/'continue' inside of one.
-    return Scope::BreakScope | Scope::ContinueScope |
+    return Scope::BreakScope | Scope::ContinueScope | Scope::DeclScope |
            Scope::OpenACCComputeConstructScope |
            Scope::OpenACCLoopConstructScope;
   case OpenACCDirectiveKind::Loop:
-    return Scope::OpenACCLoopConstructScope;
+    return Scope::DeclScope | Scope::OpenACCLoopConstructScope;
   case OpenACCDirectiveKind::Data:
   case OpenACCDirectiveKind::EnterData:
   case OpenACCDirectiveKind::ExitData:

--- a/clang/test/ParserOpenACC/gh197858.cpp
+++ b/clang/test/ParserOpenACC/gh197858.cpp
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 %s -verify -fopenacc
+
+void func() {
+#pragma acc parallel
+  using i; // expected-error{{using declaration requires a qualified name}}
+#pragma acc loop
+  using j; // expected-error{{using declaration requires a qualified name}}
+#pragma acc parallel loop
+  using k; // expected-error{{using declaration requires a qualified name}}
+}


### PR DESCRIPTION
Bug report #197858 comes up with a reproducer where an invalid `using` declaration checks the Scope it is in, and asserts if it isn't in a DeclScope.  Since all of the important directives that create scopes end up causing a new scope anyway, this patch adds 'DeclScope' to the parse scope for an OpenACC directive.  This follows the guidance of the OpenMP directives.

Fixes: #197858