### PR TITLE
[clang-doc] Use explicit for single param constructors

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeWriter.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeWriter.cpp
@@ -100,7 +100,7 @@ struct RecordIdDsc {
       : Name(Name), Abbrev(Abbrev) {}
 
   // Is this 'description' valid?
-  operator bool() const {
+  explicit operator bool() const {
     return Abbrev != nullptr && Name.data() != nullptr && !Name.empty();
   }
 

--- a/clang-tools-extra/clang-doc/ClangDoc.cpp
+++ b/clang-tools-extra/clang-doc/ClangDoc.cpp
@@ -24,7 +24,7 @@ namespace doc {
 
 class MapperActionFactory : public tooling::FrontendActionFactory {
 public:
-  MapperActionFactory(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
+  explicit MapperActionFactory(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
   std::unique_ptr<FrontendAction> create() override;
 
 private:
@@ -34,7 +34,7 @@ private:
 std::unique_ptr<FrontendAction> MapperActionFactory::create() {
   class ClangDocAction : public clang::ASTFrontendAction {
   public:
-    ClangDocAction(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
+    explicit ClangDocAction(ClangDocContext CDCtx) : CDCtx(CDCtx) {}
 
     std::unique_ptr<clang::ASTConsumer>
     CreateASTConsumer(clang::CompilerInstance &Compiler,

--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -203,7 +203,7 @@ StringRef Serializer::getInfoRelativePath(const Decl *D) {
 class ClangDocCommentVisitor
     : public ConstCommentVisitor<ClangDocCommentVisitor> {
 public:
-  ClangDocCommentVisitor(CommentInfo &CI) : CurrentCI(CI) {}
+  explicit ClangDocCommentVisitor(CommentInfo &CI) : CurrentCI(CI) {}
 
   void parseComment(const comments::Comment *C);
 

--- a/clang-tools-extra/clang-doc/YAMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/YAMLGenerator.cpp
@@ -195,8 +195,8 @@ template <> struct ScalarTraits<SymbolID> {
 struct QuotedString {
   StringRef Ref;
   QuotedString() = default;
-  QuotedString(StringRef R) : Ref(R) {}
-  operator StringRef() const { return Ref; }
+  explicit QuotedString(StringRef R) : Ref(R) {}
+  explicit operator StringRef() const { return Ref; }
   bool operator==(const QuotedString &Other) const { return Ref == Other.Ref; }
 };
 


### PR DESCRIPTION
This trips up some clang-tidy checks, so add the explicit keyword as
needed to satisfy the lints.