### PR TITLE
[clang-doc][nfc] Silence tidy warning about anonymous namespace

### DIFF
--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -26,7 +26,6 @@ namespace clang {
 namespace doc {
 namespace serialize {
 
-namespace {
 static StringRef exprToString(const clang::Expr *E) {
   clang::LangOptions Opts;
   clang::PrintingPolicy Policy(Opts);
@@ -35,7 +34,6 @@ static StringRef exprToString(const clang::Expr *E) {
   E->printPretty(OS, nullptr, Policy);
   return internString(Result);
 }
-} // namespace
 
 SymbolID hashUSR(llvm::StringRef USR) {
   return llvm::SHA1::hash(arrayRefFromStringRef(USR));


### PR DESCRIPTION
clang-tidy complains that we should prefer static over the anonymous
namespace, despite the API being static in addition to being in the
anonymous namespace. We can silence the diagnostic by simply removing
the namespace declaration.