### PR TITLE
Fixup"[llvm-ir2vec] Breaking up llvm-ir2vec lib implementation to clean up MIR deps from ir2vec python bindings (#194414)"

### DIFF
--- a/llvm/tools/llvm-ir2vec/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(LLVM_LINK_COMPONENTS
-  # IR processing
   Analysis
   Core
   Support

--- a/llvm/tools/llvm-ir2vec/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/CMakeLists.txt
@@ -1,10 +1,17 @@
 set(LLVM_LINK_COMPONENTS
+  # IR processing
+  Analysis
+  Core
+  Support
+
   # IR reading (used by llvm-ir2vec.cpp directly)
   IRReader
 
   # Machine IR components (for -mode=mir)
+  CodeGen
   MIRParser
   MC
+  Target
 
   # Target initialization (required for MIR parsing)
   AllTargetsAsmParsers

--- a/llvm/tools/llvm-ir2vec/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/lib/CMakeLists.txt
@@ -23,6 +23,10 @@ add_llvm_library(LLVMMIREmbUtils STATIC
   intrinsics_gen
 
   LINK_COMPONENTS
+  Analysis
   CodeGen
+  Core   
+  MIRParser
+  Support
   Target
 )

--- a/llvm/tools/llvm-ir2vec/lib/CMakeLists.txt
+++ b/llvm/tools/llvm-ir2vec/lib/CMakeLists.txt
@@ -23,10 +23,6 @@ add_llvm_library(LLVMMIREmbUtils STATIC
   intrinsics_gen
 
   LINK_COMPONENTS
-  Analysis
   CodeGen
-  Core   
-  MIRParser
-  Support
   Target
 )


### PR DESCRIPTION
llvm-ir2vec and LLVMMIREmbUtils was missing some deps which show up when -DBUILD_SHARED_LIBS=ON. Fixed the Cmakelists.txt to reflect accurate dependencies