### PR TITLE
[DAG] SimplifyDemandedBits - remove ISD::FREEZE node if all demanded elements are not undef/poison

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -1258,6 +1258,13 @@ bool TargetLowering::SimplifyDemandedBits(
     Known = KnownScl.trunc(BitWidth);
     break;
   }
+  case ISD::FREEZE: {
+    SDValue N0 = Op.getOperand(0);
+    if (TLO.DAG.isGuaranteedNotToBeUndefOrPoison(
+            N0, DemandedElts, UndefPoisonKind::UndefOrPoison, Depth + 1))
+      return TLO.CombineTo(Op, N0);
+    break;
+  }
   case ISD::LOAD: {
     auto *LD = cast<LoadSDNode>(Op);
     if (getTargetConstantFromLoad(LD)) {

--- a/llvm/test/CodeGen/X86/freeze-binary.ll
+++ b/llvm/test/CodeGen/X86/freeze-binary.ll
@@ -867,11 +867,8 @@ define i32 @freeze_ssubo(i32 %a0, i32 %a1, i8 %a2, i8 %a3) nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    movzbl {{[0-9]+}}(%esp), %ecx
-; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:    addb {{[0-9]+}}(%esp), %cl
-; X86-NEXT:    setb %dl
-; X86-NEXT:    movzbl %dl, %ecx
-; X86-NEXT:    subl %ecx, %eax
+; X86-NEXT:    sbbl $0, %eax
 ; X86-NEXT:    subl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    retl
 ;
@@ -899,11 +896,8 @@ define i32 @freeze_usubo(i32 %a0, i32 %a1, i8 %a2, i8 %a3) nounwind {
 ; X86:       # %bb.0:
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    movzbl {{[0-9]+}}(%esp), %ecx
-; X86-NEXT:    xorl %edx, %edx
 ; X86-NEXT:    addb {{[0-9]+}}(%esp), %cl
-; X86-NEXT:    setb %dl
-; X86-NEXT:    movzbl %dl, %ecx
-; X86-NEXT:    subl %ecx, %eax
+; X86-NEXT:    sbbl $0, %eax
 ; X86-NEXT:    subl {{[0-9]+}}(%esp), %eax
 ; X86-NEXT:    retl
 ;


### PR DESCRIPTION
Similar to what we already do in SimplifyDemandedVectorElts