### PR TITLE
[libc++] Introduce a private version of in_out_result and use it for copy/move algorithms

### DIFF
--- a/libcxx/include/__algorithm/copy.h
+++ b/libcxx/include/__algorithm/copy.h
@@ -11,6 +11,7 @@
 
 #include <__algorithm/copy_move_common.h>
 #include <__algorithm/for_each_segment.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/min.h>
 #include <__algorithm/specialized_algorithms.h>
 #include <__config>
@@ -19,7 +20,6 @@
 #include <__type_traits/common_type.h>
 #include <__type_traits/enable_if.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -35,7 +35,8 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result);
 
 template <class _InIter, class _Sent, class _OutIter>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter> __copy(_InIter, _Sent, _OutIter);
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
+    __copy(_InIter, _Sent, _OutIter);
 
 struct __copy_impl {
   template <class _InIter,
@@ -45,7 +46,7 @@ struct __copy_impl {
                                                    __iterator_pair<_InIter, _Sent>,
                                                    __single_iterator<_OutIter> >::__has_algorithm,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     while (__first != __last) {
       *__result = *__first;
@@ -53,7 +54,7 @@ struct __copy_impl {
       ++__result;
     }
 
-    return std::make_pair(std::move(__first), std::move(__result));
+    return {std::move(__first), std::move(__result)};
   }
 
   template <class _InIter,
@@ -63,20 +64,20 @@ struct __copy_impl {
                                                   __iterator_pair<_InIter, _Sent>,
                                                   __single_iterator<_OutIter> >::__has_algorithm,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 static __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) {
     return __specialized_algorithm<_Algorithm::__copy, __iterator_pair<_InIter, _Sent>, __single_iterator<_OutIter> >()(
         std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
-      __result = std::__copy(std::move(__lfirst), std::move(__llast), std::move(__result)).second;
+      __result = std::__copy(std::move(__lfirst), std::move(__llast), std::move(__result)).__out_;
     });
-    return std::make_pair(__last, std::move(__result));
+    return {__last, std::move(__result)};
   }
 
   template <class _InIter,
@@ -84,14 +85,14 @@ struct __copy_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
     using _DiffT =
         typename common_type<__iterator_difference_type<_InIter>, __iterator_difference_type<_OutIter> >::type;
 
     if (__first == __last)
-      return std::make_pair(std::move(__first), std::move(__result));
+      return {std::move(__first), std::move(__result)};
 
     auto __local_first      = _Traits::__local(__result);
     auto __segment_iterator = _Traits::__segment(__result);
@@ -99,10 +100,10 @@ struct __copy_impl {
       auto __local_last = _Traits::__end(__segment_iterator);
       auto __size       = std::min<_DiffT>(__local_last - __local_first, __last - __first);
       auto __iters      = std::__copy(__first, __first + __size, __local_first);
-      __first           = std::move(__iters.first);
+      __first           = std::move(__iters.__in_);
 
       if (__first == __last)
-        return std::make_pair(std::move(__first), _Traits::__compose(__segment_iterator, std::move(__iters.second)));
+        return {std::move(__first), _Traits::__compose(__segment_iterator, std::move(__iters.__out_))};
 
       __local_first = _Traits::__begin(++__segment_iterator);
     }
@@ -110,14 +111,14 @@ struct __copy_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_copy_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_In*, _Out*>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _InIter, class _Sent, class _OutIter>
-pair<_InIter, _OutIter> inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
+__in_out_result<_InIter, _OutIter> inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14
 __copy(_InIter __first, _Sent __last, _OutIter __result) {
   return std::__copy_move_unwrap_iters<__copy_impl>(std::move(__first), std::move(__last), std::move(__result));
 }
@@ -125,7 +126,7 @@ __copy(_InIter __first, _Sent __last, _OutIter __result) {
 template <class _InputIterator, class _OutputIterator>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
-  return std::__copy(__first, __last, __result).second;
+  return std::__copy(__first, __last, __result).__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/copy_backward.h
+++ b/libcxx/include/__algorithm/copy_backward.h
@@ -12,6 +12,7 @@
 #include <__algorithm/copy_move_common.h>
 #include <__algorithm/copy_n.h>
 #include <__algorithm/for_each_segment.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/min.h>
 #include <__config>
@@ -23,7 +24,6 @@
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_constructible.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -35,7 +35,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _InIter, class _Sent, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InIter, _OutIter>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
 __copy_backward(_InIter __first, _Sent __last, _OutIter __result);
 
 template <class _Cp, bool _IsConst>
@@ -159,7 +159,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __bit_iterator<_Cp, false> _
 template <class _AlgPolicy>
 struct __copy_backward_impl {
   template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     auto __last_iter          = _IterOps<_AlgPolicy>::next(__first, __last);
     auto __original_last_iter = __last_iter;
@@ -168,17 +168,17 @@ struct __copy_backward_impl {
       *--__result = *--__last_iter;
     }
 
-    return std::make_pair(std::move(__original_last_iter), std::move(__result));
+    return {std::move(__original_last_iter), std::move(__result)};
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment_backward(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
-      __result = std::__copy_backward<_AlgPolicy>(std::move(__lfirst), std::move(__llast), std::move(__result)).second;
+      __result = std::__copy_backward<_AlgPolicy>(std::move(__lfirst), std::move(__llast), std::move(__result)).__out_;
     });
-    return std::make_pair(__last, std::move(__result));
+    return {__last, std::move(__result)};
   }
 
   template <class _InIter,
@@ -186,7 +186,7 @@ struct __copy_backward_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits           = __segmented_iterator_traits<_OutIter>;
     auto __orig_last        = __last;
@@ -194,7 +194,7 @@ struct __copy_backward_impl {
 
     // When the range contains no elements, __result might not be a valid iterator
     if (__first == __last)
-      return std::make_pair(__first, __result);
+      return {__first, __result};
 
     auto __local_last = _Traits::__local(__result);
     while (true) {
@@ -203,36 +203,37 @@ struct __copy_backward_impl {
 
       auto __local_first = _Traits::__begin(__segment_iterator);
       auto __size        = std::min<_DiffT>(__local_last - __local_first, __last - __first);
-      auto __iter        = std::__copy_backward<_AlgPolicy>(__last - __size, __last, __local_last).second;
+      auto __iter        = std::__copy_backward<_AlgPolicy>(__last - __size, __last, __local_last).__out_;
       __last -= __size;
 
       if (__first == __last)
-        return std::make_pair(std::move(__orig_last), _Traits::__compose(__segment_iterator, std::move(__iter)));
+        return {std::move(__orig_last), _Traits::__compose(__segment_iterator, std::move(__iter))};
       --__segment_iterator;
       __local_last = _Traits::__end(__segment_iterator);
     }
   }
 
   template <class _Cp, bool _IsConst>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
              __bit_iterator<_Cp, false> __result) {
     if (__last.__ctz_ == __result.__ctz_)
-      return std::make_pair(__last, std::__copy_backward_aligned(__first, __last, __result));
-    return std::make_pair(__last, std::__copy_backward_unaligned(__first, __last, __result));
+      return {__last, std::__copy_backward_aligned(__first, __last, __result)};
+    return {__last, std::__copy_backward_unaligned(__first, __last, __result)};
   }
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_copy_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_In*, _Out*>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_backward_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _AlgPolicy, class _BidirectionalIterator1, class _Sentinel, class _BidirectionalIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator1, _BidirectionalIterator2>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
 __copy_backward(_BidirectionalIterator1 __first, _Sentinel __last, _BidirectionalIterator2 __result) {
   return std::__copy_move_unwrap_iters<__copy_backward_impl<_AlgPolicy> >(
       std::move(__first), std::move(__last), std::move(__result));
@@ -245,7 +246,7 @@ copy_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _
                     std::is_copy_constructible<_BidirectionalIterator1>::value,
                 "Iterators must be copy constructible.");
 
-  return std::__copy_backward<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).second;
+  return std::__copy_backward<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/copy_move_common.h
+++ b/libcxx/include/__algorithm/copy_move_common.h
@@ -9,21 +9,18 @@
 #ifndef _LIBCPP___ALGORITHM_COPY_MOVE_COMMON_H
 #define _LIBCPP___ALGORITHM_COPY_MOVE_COMMON_H
 
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/unwrap_iter.h>
 #include <__algorithm/unwrap_range.h>
 #include <__config>
 #include <__cstddef/size_t.h>
-#include <__iterator/iterator_traits.h>
-#include <__memory/pointer_traits.h>
 #include <__string/constexpr_c_functions.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_always_bitcastable.h>
-#include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_constructible.h>
 #include <__type_traits/is_trivially_assignable.h>
 #include <__type_traits/is_volatile.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -57,24 +54,24 @@ struct __can_lower_move_assignment_to_memmove {
 // `memmove` algorithms implementation.
 
 template <class _In, class _Out>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_In*, _Out*>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
 __copy_trivial_impl(_In* __first, _In* __last, _Out* __result) {
   const size_t __n = static_cast<size_t>(__last - __first);
 
   std::__constexpr_memmove(__result, __first, __element_count(__n));
 
-  return std::make_pair(__last, __result + __n);
+  return {__last, __result + __n};
 }
 
 template <class _In, class _Out>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_In*, _Out*>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
 __copy_backward_trivial_impl(_In* __first, _In* __last, _Out* __result) {
   const size_t __n = static_cast<size_t>(__last - __first);
   __result -= __n;
 
   std::__constexpr_memmove(__result, __first, __element_count(__n));
 
-  return std::make_pair(__last, __result);
+  return {__last, __result};
 }
 
 // Iterator unwrapping and dispatching to the correct overload.
@@ -88,12 +85,12 @@ template <class _Algorithm,
           class _Sent,
           class _OutIter,
           __enable_if_t<__can_rewrap<_InIter, _OutIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 pair<_InIter, _OutIter>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 __in_out_result<_InIter, _OutIter>
 __copy_move_unwrap_iters(_InIter __first, _Sent __last, _OutIter __out_first) {
   auto __range  = std::__unwrap_range(__first, std::move(__last));
   auto __result = _Algorithm()(std::move(__range.first), std::move(__range.second), std::__unwrap_iter(__out_first));
-  return std::make_pair(std::__rewrap_range<_Sent>(std::move(__first), std::move(__result.first)),
-                        std::__rewrap_iter(std::move(__out_first), std::move(__result.second)));
+  return {std::__rewrap_range<_Sent>(std::move(__first), std::move(__result.__in_)),
+          std::__rewrap_iter(std::move(__out_first), std::move(__result.__out_))};
 }
 
 template <class _Algorithm,
@@ -101,7 +98,7 @@ template <class _Algorithm,
           class _Sent,
           class _OutIter,
           __enable_if_t<!__can_rewrap<_InIter, _OutIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 pair<_InIter, _OutIter>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 __in_out_result<_InIter, _OutIter>
 __copy_move_unwrap_iters(_InIter __first, _Sent __last, _OutIter __out_first) {
   return _Algorithm()(std::move(__first), std::move(__last), std::move(__out_first));
 }

--- a/libcxx/include/__algorithm/copy_n.h
+++ b/libcxx/include/__algorithm/copy_n.h
@@ -10,13 +10,13 @@
 #define _LIBCPP___ALGORITHM_COPY_N_H
 
 #include <__algorithm/copy.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/iterator_operations.h>
 #include <__config>
 #include <__iterator/iterator_traits.h>
 #include <__type_traits/enable_if.h>
 #include <__utility/convert_to_integral.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -31,7 +31,7 @@ template <class _AlgPolicy,
           class _InIter,
           class _OutIter,
           __enable_if_t<__has_random_access_iterator_category<_InIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InIter, _OutIter>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
 __copy_n(_InIter __first, typename _IterOps<_AlgPolicy>::template __difference_type<_InIter> __n, _OutIter __result) {
   return std::__copy(__first, __first + __n, std::move(__result));
 }
@@ -40,7 +40,7 @@ template <class _AlgPolicy,
           class _InIter,
           class _OutIter,
           __enable_if_t<!__has_random_access_iterator_category<_InIter>::value, int> = 0>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InIter, _OutIter>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InIter, _OutIter>
 __copy_n(_InIter __first, typename _IterOps<_AlgPolicy>::template __difference_type<_InIter> __n, _OutIter __result) {
   while (__n != 0) {
     *__result = *__first;
@@ -48,7 +48,7 @@ __copy_n(_InIter __first, typename _IterOps<_AlgPolicy>::template __difference_t
     ++__result;
     --__n;
   }
-  return std::make_pair(std::move(__first), std::move(__result));
+  return {std::move(__first), std::move(__result)};
 }
 
 // The InputIterator case is handled specially here because it's been written in a way to avoid incrementing __first
@@ -84,7 +84,7 @@ copy_n(_InputIterator __first, _Size __n, _OutputIterator __result) {
   using _IntegralSize       = decltype(std::__convert_to_integral(__n));
   _IntegralSize __converted = __n;
   return std::__copy_n<_ClassicAlgPolicy>(__first, __iterator_difference_type<_InputIterator>(__converted), __result)
-      .second;
+      .__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/in_out_result.h
+++ b/libcxx/include/__algorithm/in_out_result.h
@@ -49,6 +49,20 @@ struct in_out_result {
 
 #endif // _LIBCPP_STD_VER >= 20
 
+template <class _InIter, class _OutIter>
+struct __in_out_result {
+  _InIter __in_;
+  _OutIter __out_;
+
+#if _LIBCPP_STD_VER >= 20
+  template <class _InIter2, class _OutIter2>
+    requires convertible_to<_InIter, _InIter2> && convertible_to<_OutIter, _OutIter2>
+  constexpr operator ranges::in_out_result<_InIter2, _OutIter2>() && {
+    return {std::move(__in_), std::move(__out_)};
+  }
+#endif
+};
+
 _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS

--- a/libcxx/include/__algorithm/move.h
+++ b/libcxx/include/__algorithm/move.h
@@ -12,6 +12,7 @@
 #include <__algorithm/copy.h>
 #include <__algorithm/copy_move_common.h>
 #include <__algorithm/for_each_segment.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/min.h>
 #include <__config>
@@ -22,7 +23,6 @@
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_constructible.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -34,30 +34,30 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _InIter, class _Sent, class _OutIter>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
 __move(_InIter __first, _Sent __last, _OutIter __result);
 
 template <class _AlgPolicy>
 struct __move_impl {
   template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     while (__first != __last) {
       *__result = _IterOps<_AlgPolicy>::__iter_move(__first);
       ++__first;
       ++__result;
     }
-    return std::make_pair(std::move(__first), std::move(__result));
+    return {std::move(__first), std::move(__result)};
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
-      __result = std::__move<_AlgPolicy>(__lfirst, __llast, std::move(__result)).second;
+      __result = std::__move<_AlgPolicy>(__lfirst, __llast, std::move(__result)).__out_;
     });
-    return std::make_pair(__last, std::move(__result));
+    return {__last, std::move(__result)};
   }
 
   template <class _InIter,
@@ -65,14 +65,14 @@ struct __move_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
     using _DiffT =
         typename common_type<__iterator_difference_type<_InIter>, __iterator_difference_type<_OutIter> >::type;
 
     if (__first == __last)
-      return std::make_pair(std::move(__first), std::move(__result));
+      return {std::move(__first), std::move(__result)};
 
     auto __local_first      = _Traits::__local(__result);
     auto __segment_iterator = _Traits::__segment(__result);
@@ -80,17 +80,18 @@ struct __move_impl {
       auto __local_last = _Traits::__end(__segment_iterator);
       auto __size       = std::min<_DiffT>(__local_last - __local_first, __last - __first);
       auto __iters      = std::__move<_AlgPolicy>(__first, __first + __size, __local_first);
-      __first           = std::move(__iters.first);
+      __first           = std::move(__iters.__in_);
 
       if (__first == __last)
-        return std::make_pair(std::move(__first), _Traits::__compose(__segment_iterator, std::move(__iters.second)));
+        return {std::move(__first), _Traits::__compose(__segment_iterator, std::move(__iters.__out_))};
 
       __local_first = _Traits::__begin(++__segment_iterator);
     }
   }
 
   template <class _Cp, bool _IsConst>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
              __bit_iterator<_Cp, false> __result) {
@@ -99,14 +100,14 @@ struct __move_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_move_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_In*, _Out*>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _AlgPolicy, class _InIter, class _Sent, class _OutIter>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
 __move(_InIter __first, _Sent __last, _OutIter __result) {
   return std::__copy_move_unwrap_iters<__move_impl<_AlgPolicy> >(
       std::move(__first), std::move(__last), std::move(__result));
@@ -118,7 +119,7 @@ move(_InputIterator __first, _InputIterator __last, _OutputIterator __result) {
   static_assert(is_copy_constructible<_InputIterator>::value, "Iterators has to be copy constructible.");
   static_assert(is_copy_constructible<_OutputIterator>::value, "The output iterator has to be copy constructible.");
 
-  return std::__move<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).second;
+  return std::__move<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/move_backward.h
+++ b/libcxx/include/__algorithm/move_backward.h
@@ -12,6 +12,7 @@
 #include <__algorithm/copy_backward.h>
 #include <__algorithm/copy_move_common.h>
 #include <__algorithm/for_each_segment.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/min.h>
 #include <__config>
@@ -34,13 +35,13 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _AlgPolicy, class _BidirectionalIterator1, class _Sentinel, class _BidirectionalIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator1, _BidirectionalIterator2>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
 __move_backward(_BidirectionalIterator1 __first, _Sentinel __last, _BidirectionalIterator2 __result);
 
 template <class _AlgPolicy>
 struct __move_backward_impl {
   template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
     auto __last_iter          = _IterOps<_AlgPolicy>::next(__first, __last);
     auto __original_last_iter = __last_iter;
@@ -49,17 +50,17 @@ struct __move_backward_impl {
       *--__result = _IterOps<_AlgPolicy>::__iter_move(--__last_iter);
     }
 
-    return std::make_pair(std::move(__original_last_iter), std::move(__result));
+    return {std::move(__original_last_iter), std::move(__result)};
   }
 
   template <class _InIter, class _OutIter, __enable_if_t<__is_segmented_iterator_v<_InIter>, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using __local_iterator = typename __segmented_iterator_traits<_InIter>::__local_iterator;
     std::__for_each_segment_backward(__first, __last, [&__result](__local_iterator __lfirst, __local_iterator __llast) {
-      __result = std::__move_backward<_AlgPolicy>(std::move(__lfirst), std::move(__llast), std::move(__result)).second;
+      __result = std::__move_backward<_AlgPolicy>(std::move(__lfirst), std::move(__llast), std::move(__result)).__out_;
     });
-    return std::make_pair(__last, std::move(__result));
+    return {__last, std::move(__result)};
   }
 
   template <class _InIter,
@@ -67,7 +68,7 @@ struct __move_backward_impl {
             __enable_if_t<__has_random_access_iterator_category<_InIter>::value &&
                               !__is_segmented_iterator_v<_InIter> && __is_segmented_iterator_v<_OutIter>,
                           int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
   operator()(_InIter __first, _InIter __last, _OutIter __result) const {
     using _Traits = __segmented_iterator_traits<_OutIter>;
     using _DiffT =
@@ -75,7 +76,7 @@ struct __move_backward_impl {
 
     // When the range contains no elements, __result might not be a valid iterator
     if (__first == __last)
-      return std::make_pair(__first, __result);
+      return {__first, __result};
 
     auto __orig_last = __last;
 
@@ -84,18 +85,19 @@ struct __move_backward_impl {
     while (true) {
       auto __local_first = _Traits::__begin(__segment_iterator);
       auto __size        = std::min<_DiffT>(__local_last - __local_first, __last - __first);
-      auto __iter        = std::__move_backward<_AlgPolicy>(__last - __size, __last, __local_last).second;
+      auto __iter        = std::__move_backward<_AlgPolicy>(__last - __size, __last, __local_last).__out_;
       __last -= __size;
 
       if (__first == __last)
-        return std::make_pair(std::move(__orig_last), _Traits::__compose(__segment_iterator, std::move(__iter)));
+        return {std::move(__orig_last), _Traits::__compose(__segment_iterator, std::move(__iter))};
 
       __local_last = _Traits::__end(--__segment_iterator);
     }
   }
 
   template <class _Cp, bool _IsConst>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
+  _LIBCPP_HIDE_FROM_ABI
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
              __bit_iterator<_Cp, false> __result) {
@@ -104,14 +106,14 @@ struct __move_backward_impl {
 
   // At this point, the iterators have been unwrapped so any `contiguous_iterator` has been unwrapped to a pointer.
   template <class _In, class _Out, __enable_if_t<__can_lower_move_assignment_to_memmove<_In, _Out>::value, int> = 0>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_In*, _Out*>
+  _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_In*, _Out*>
   operator()(_In* __first, _In* __last, _Out* __result) const {
     return std::__copy_backward_trivial_impl(__first, __last, __result);
   }
 };
 
 template <class _AlgPolicy, class _BidirectionalIterator1, class _Sentinel, class _BidirectionalIterator2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_BidirectionalIterator1, _BidirectionalIterator2>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_BidirectionalIterator1, _BidirectionalIterator2>
 __move_backward(_BidirectionalIterator1 __first, _Sentinel __last, _BidirectionalIterator2 __result) {
   static_assert(std::is_copy_constructible<_BidirectionalIterator1>::value &&
                     std::is_copy_constructible<_BidirectionalIterator1>::value,
@@ -124,7 +126,7 @@ __move_backward(_BidirectionalIterator1 __first, _Sentinel __last, _Bidirectiona
 template <class _BidirectionalIterator1, class _BidirectionalIterator2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _BidirectionalIterator2
 move_backward(_BidirectionalIterator1 __first, _BidirectionalIterator1 __last, _BidirectionalIterator2 __result) {
-  return std::__move_backward<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).second;
+  return std::__move_backward<_ClassicAlgPolicy>(std::move(__first), std::move(__last), std::move(__result)).__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/ranges_copy.h
+++ b/libcxx/include/__algorithm/ranges_copy.h
@@ -41,16 +41,14 @@ struct __copy {
     requires indirectly_copyable<_InIter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
-    auto __ret = std::__copy(std::move(__first), std::move(__last), std::move(__result));
-    return {std::move(__ret.first), std::move(__ret.second)};
+    return std::__copy(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <input_range _Range, weakly_incrementable _OutIter>
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __r, _OutIter __result) const {
-    auto __ret = std::__copy(ranges::begin(__r), ranges::end(__r), std::move(__result));
-    return {std::move(__ret.first), std::move(__ret.second)};
+    return std::__copy(ranges::begin(__r), ranges::end(__r), std::move(__result));
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_copy_backward.h
+++ b/libcxx/include/__algorithm/ranges_copy_backward.h
@@ -40,16 +40,14 @@ struct __copy_backward {
     requires indirectly_copyable<_InIter1, _InIter2>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_backward_result<_InIter1, _InIter2>
   operator()(_InIter1 __first, _Sent1 __last, _InIter2 __result) const {
-    auto __ret = std::__copy_backward<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
-    return {std::move(__ret.first), std::move(__ret.second)};
+    return std::__copy_backward<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <bidirectional_range _Range, bidirectional_iterator _Iter>
     requires indirectly_copyable<iterator_t<_Range>, _Iter>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_backward_result<borrowed_iterator_t<_Range>, _Iter>
   operator()(_Range&& __r, _Iter __result) const {
-    auto __ret = std::__copy_backward<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), std::move(__result));
-    return {std::move(__ret.first), std::move(__ret.second)};
+    return std::__copy_backward<_RangeAlgPolicy>(ranges::begin(__r), ranges::end(__r), std::move(__result));
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_copy_n.h
+++ b/libcxx/include/__algorithm/ranges_copy_n.h
@@ -38,8 +38,7 @@ struct __copy_n {
     requires indirectly_copyable<_Ip, _Op>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_n_result<_Ip, _Op>
   operator()(_Ip __first, iter_difference_t<_Ip> __n, _Op __result) const {
-    auto __res = std::__copy_n<_RangeAlgPolicy>(std::move(__first), __n, std::move(__result));
-    return {std::move(__res.first), std::move(__res.second)};
+    return std::__copy_n<_RangeAlgPolicy>(std::move(__first), __n, std::move(__result));
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_move.h
+++ b/libcxx/include/__algorithm/ranges_move.h
@@ -36,25 +36,18 @@ template <class _InIter, class _OutIter>
 using move_result = in_out_result<_InIter, _OutIter>;
 
 struct __move {
-  template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr static move_result<_InIter, _OutIter>
-  __move_impl(_InIter __first, _Sent __last, _OutIter __result) {
-    auto __ret = std::__move<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
-    return {std::move(__ret.first), std::move(__ret.second)};
-  }
-
   template <input_iterator _InIter, sentinel_for<_InIter> _Sent, weakly_incrementable _OutIter>
     requires indirectly_movable<_InIter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr move_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
-    return __move_impl(std::move(__first), std::move(__last), std::move(__result));
+    return std::__move<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <input_range _Range, weakly_incrementable _OutIter>
     requires indirectly_movable<iterator_t<_Range>, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr move_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result) const {
-    return __move_impl(ranges::begin(__range), ranges::end(__range), std::move(__result));
+    return std::__move<_RangeAlgPolicy>(ranges::begin(__range), ranges::end(__range), std::move(__result));
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_move_backward.h
+++ b/libcxx/include/__algorithm/ranges_move_backward.h
@@ -38,25 +38,18 @@ template <class _InIter, class _OutIter>
 using move_backward_result = in_out_result<_InIter, _OutIter>;
 
 struct __move_backward {
-  template <class _InIter, class _Sent, class _OutIter>
-  _LIBCPP_HIDE_FROM_ABI constexpr static move_backward_result<_InIter, _OutIter>
-  __move_backward_impl(_InIter __first, _Sent __last, _OutIter __result) {
-    auto __ret = std::__move_backward<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
-    return {std::move(__ret.first), std::move(__ret.second)};
-  }
-
   template <bidirectional_iterator _InIter, sentinel_for<_InIter> _Sent, bidirectional_iterator _OutIter>
     requires indirectly_movable<_InIter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr move_backward_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result) const {
-    return __move_backward_impl(std::move(__first), std::move(__last), std::move(__result));
+    return std::__move_backward<_RangeAlgPolicy>(std::move(__first), std::move(__last), std::move(__result));
   }
 
   template <bidirectional_range _Range, bidirectional_iterator _Iter>
     requires indirectly_movable<iterator_t<_Range>, _Iter>
   _LIBCPP_HIDE_FROM_ABI constexpr move_backward_result<borrowed_iterator_t<_Range>, _Iter>
   operator()(_Range&& __range, _Iter __result) const {
-    return __move_backward_impl(ranges::begin(__range), ranges::end(__range), std::move(__result));
+    return std::__move_backward<_RangeAlgPolicy>(ranges::begin(__range), ranges::end(__range), std::move(__result));
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_set_difference.h
+++ b/libcxx/include/__algorithm/ranges_set_difference.h
@@ -14,16 +14,13 @@
 #include <__algorithm/set_difference.h>
 #include <__config>
 #include <__functional/identity.h>
-#include <__functional/invoke.h>
 #include <__functional/ranges_operations.h>
 #include <__iterator/concepts.h>
 #include <__iterator/mergeable.h>
 #include <__ranges/access.h>
 #include <__ranges/concepts.h>
 #include <__ranges/dangling.h>
-#include <__type_traits/decay.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -60,9 +57,8 @@ struct __set_difference {
       _Comp __comp   = {},
       _Proj1 __proj1 = {},
       _Proj2 __proj2 = {}) const {
-    auto __ret = std::__set_difference(
+    return std::__set_difference(
         __first1, __last1, __first2, __last2, __result, ranges::__make_projected_comp(__comp, __proj1, __proj2));
-    return {std::move(__ret.first), std::move(__ret.second)};
   }
 
   template <input_range _Range1,
@@ -79,14 +75,13 @@ struct __set_difference {
              _Comp __comp   = {},
              _Proj1 __proj1 = {},
              _Proj2 __proj2 = {}) const {
-    auto __ret = std::__set_difference(
+    return std::__set_difference(
         ranges::begin(__range1),
         ranges::end(__range1),
         ranges::begin(__range2),
         ranges::end(__range2),
         __result,
         ranges::__make_projected_comp(__comp, __proj1, __proj2));
-    return {std::move(__ret.first), std::move(__ret.second)};
   }
 };
 

--- a/libcxx/include/__algorithm/rotate.h
+++ b/libcxx/include/__algorithm/rotate.h
@@ -39,7 +39,7 @@ __rotate_left(_ForwardIterator __first, _ForwardIterator __last) {
   using _Ops = _IterOps<_AlgPolicy>;
 
   value_type __tmp       = _Ops::__iter_move(__first);
-  _ForwardIterator __lm1 = std::__move<_AlgPolicy>(_Ops::next(__first), __last, __first).second;
+  _ForwardIterator __lm1 = std::__move<_AlgPolicy>(_Ops::next(__first), __last, __first).__out_;
   *__lm1                 = std::move(__tmp);
   return __lm1;
 }
@@ -52,7 +52,7 @@ __rotate_right(_BidirectionalIterator __first, _BidirectionalIterator __last) {
 
   _BidirectionalIterator __lm1 = _Ops::prev(__last);
   value_type __tmp             = _Ops::__iter_move(__lm1);
-  _BidirectionalIterator __fp1 = std::__move_backward<_AlgPolicy>(__first, __lm1, std::move(__last)).second;
+  _BidirectionalIterator __fp1 = std::__move_backward<_AlgPolicy>(__first, __lm1, std::move(__last)).__out_;
   *__first                     = std::move(__tmp);
   return __fp1;
 }

--- a/libcxx/include/__algorithm/set_difference.h
+++ b/libcxx/include/__algorithm/set_difference.h
@@ -12,12 +12,10 @@
 #include <__algorithm/comp.h>
 #include <__algorithm/comp_ref_type.h>
 #include <__algorithm/copy.h>
+#include <__algorithm/in_out_result.h>
 #include <__config>
-#include <__functional/identity.h>
-#include <__iterator/iterator_traits.h>
 #include <__type_traits/remove_cvref.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -29,7 +27,8 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Comp, class _InIter1, class _Sent1, class _InIter2, class _Sent2, class _OutIter>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<__remove_cvref_t<_InIter1>, __remove_cvref_t<_OutIter> >
+_LIBCPP_HIDE_FROM_ABI
+_LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<__remove_cvref_t<_InIter1>, __remove_cvref_t<_OutIter> >
 __set_difference(
     _InIter1&& __first1, _Sent1&& __last1, _InIter2&& __first2, _Sent2&& __last2, _OutIter&& __result, _Comp&& __comp) {
   while (__first1 != __last1 && __first2 != __last2) {
@@ -56,7 +55,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_d
     _OutputIterator __result,
     _Compare __comp) {
   return std::__set_difference<__comp_ref_type<_Compare> >(__first1, __last1, __first2, __last2, __result, __comp)
-      .second;
+      .__out_;
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator>
@@ -66,7 +65,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator set_d
     _InputIterator2 __first2,
     _InputIterator2 __last2,
     _OutputIterator __result) {
-  return std::__set_difference(__first1, __last1, __first2, __last2, __result, __less<>()).second;
+  return std::__set_difference(__first1, __last1, __first2, __last2, __result, __less<>()).__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/set_symmetric_difference.h
+++ b/libcxx/include/__algorithm/set_symmetric_difference.h
@@ -46,7 +46,7 @@ __set_symmetric_difference(
     if (__first2 == __last2) {
       auto __ret1 = std::__copy(std::move(__first1), std::move(__last1), std::move(__result));
       return __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>(
-          std::move(__ret1.first), std::move(__first2), std::move((__ret1.second)));
+          std::move(__ret1.__in_), std::move(__first2), std::move((__ret1.__out_)));
     }
     if (__comp(*__first1, *__first2)) {
       *__result = *__first1;
@@ -64,7 +64,7 @@ __set_symmetric_difference(
   }
   auto __ret2 = std::__copy(std::move(__first2), std::move(__last2), std::move(__result));
   return __set_symmetric_difference_result<_InIter1, _InIter2, _OutIter>(
-      std::move(__first1), std::move(__ret2.first), std::move((__ret2.second)));
+      std::move(__first1), std::move(__ret2.__in_), std::move((__ret2.__out_)));
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>

--- a/libcxx/include/__algorithm/set_union.h
+++ b/libcxx/include/__algorithm/set_union.h
@@ -45,7 +45,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __set_union_result<_InIter1,
     if (__first2 == __last2) {
       auto __ret1 = std::__copy(std::move(__first1), std::move(__last1), std::move(__result));
       return __set_union_result<_InIter1, _InIter2, _OutIter>(
-          std::move(__ret1.first), std::move(__first2), std::move((__ret1.second)));
+          std::move(__ret1.__in_), std::move(__first2), std::move((__ret1.__out_)));
     }
     if (__comp(*__first2, *__first1)) {
       *__result = *__first2;
@@ -60,7 +60,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __set_union_result<_InIter1,
   }
   auto __ret2 = std::__copy(std::move(__first2), std::move(__last2), std::move(__result));
   return __set_union_result<_InIter1, _InIter2, _OutIter>(
-      std::move(__first1), std::move(__ret2.first), std::move((__ret2.second)));
+      std::move(__first1), std::move(__ret2.__in_), std::move((__ret2.__out_)));
 }
 
 template <class _InputIterator1, class _InputIterator2, class _OutputIterator, class _Compare>

--- a/libcxx/include/__algorithm/shift_left.h
+++ b/libcxx/include/__algorithm/shift_left.h
@@ -55,7 +55,7 @@ __shift_left(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::templat
     }
   }
 
-  _Iter __result = std::__move<_AlgPolicy>(__m, __last, __first).second;
+  _Iter __result = std::__move<_AlgPolicy>(__m, __last, __first).__out_;
   return {std::move(__first), std::move(__result)};
 }
 

--- a/libcxx/include/__algorithm/shift_right.h
+++ b/libcxx/include/__algorithm/shift_right.h
@@ -53,7 +53,7 @@ __shift_right(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::templa
     _Iter __m = __first;
     _IterOps<_AlgPolicy>::advance(__m, (__size - __n));
     auto __ret = std::__move_backward<_AlgPolicy>(std::move(__first), std::move(__m), __end);
-    return pair<_Iter, _Iter>(std::move(__ret.second), std::move(__end));
+    return pair<_Iter, _Iter>(std::move(__ret.__out_), std::move(__end));
   } else if constexpr (derived_from<_IterCategory, bidirectional_iterator_tag>) {
     _Iter __end = _IterOps<_AlgPolicy>::next(__first, __last);
     if constexpr (sized_sentinel_for<_Sent, _Iter>) {
@@ -69,7 +69,7 @@ __shift_right(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::templa
       --__m;
     }
     auto __ret = std::__move_backward<_AlgPolicy>(std::move(__first), std::move(__m), __end);
-    return pair<_Iter, _Iter>(std::move(__ret.second), std::move(__end));
+    return pair<_Iter, _Iter>(std::move(__ret.__out_), std::move(__end));
   } else {
     _Iter __ret = __first;
     for (; __n > 0; --__n) {
@@ -99,7 +99,7 @@ __shift_right(_Iter __first, _Sent __last, typename _IterOps<_AlgPolicy>::templa
     _Iter __mid = __first;
     while (true) {
       if (__lead == __last) {
-        __trail = std::__move<_AlgPolicy>(__mid, __ret, __trail).second;
+        __trail = std::__move<_AlgPolicy>(__mid, __ret, __trail).__out_;
         std::__move<_AlgPolicy>(std::move(__first), std::move(__mid), std::move(__trail));
         return pair<_Iter, _Iter>(__ret, std::move(__lead));
       }

--- a/libcxx/include/__bit_reference
+++ b/libcxx/include/__bit_reference
@@ -16,6 +16,7 @@
 #include <__algorithm/copy_n.h>
 #include <__algorithm/equal.h>
 #include <__algorithm/fill_n.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/min.h>
 #include <__algorithm/rotate.h>
 #include <__algorithm/specialized_algorithms.h>
@@ -34,7 +35,6 @@
 #include <__type_traits/desugars_to.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_constant_evaluated.h>
-#include <__type_traits/is_same.h>
 #include <__type_traits/is_unsigned.h>
 #include <__type_traits/void_t.h>
 #include <__utility/pair.h>
@@ -705,13 +705,13 @@ struct __specialized_algorithm<_Algorithm::__copy,
   }
 
   _LIBCPP_HIDE_FROM_ABI
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 static pair<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
+  _LIBCPP_CONSTEXPR_SINCE_CXX20 static __in_out_result<__bit_iterator<_Cp, _IsConst>, __bit_iterator<_Cp, false> >
   operator()(__bit_iterator<_Cp, _IsConst> __first,
              __bit_iterator<_Cp, _IsConst> __last,
              __bit_iterator<_Cp, false> __result) {
     if (__first.__ctz_ == __result.__ctz_)
-      return std::make_pair(__last, __aligned_impl(__first, __last, __result));
-    return std::make_pair(__last, __unaligned_impl(__first, __last, __result));
+      return {__last, __aligned_impl(__first, __last, __result)};
+    return {__last, __unaligned_impl(__first, __last, __result)};
   }
 };
 

--- a/libcxx/include/__iterator/ostreambuf_iterator.h
+++ b/libcxx/include/__iterator/ostreambuf_iterator.h
@@ -10,6 +10,7 @@
 #ifndef _LIBCPP___ITERATOR_OSTREAMBUF_ITERATOR_H
 #define _LIBCPP___ITERATOR_OSTREAMBUF_ITERATOR_H
 
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/specialized_algorithms.h>
 #include <__config>
 #include <__cstddef/ptrdiff_t.h>
@@ -19,7 +20,6 @@
 #include <__iterator/iterator.h>
 #include <__iterator/iterator_traits.h>
 #include <__type_traits/is_same.h>
-#include <__utility/pair.h>
 #include <iosfwd> // for forward declaration of ostreambuf_iterator
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -78,14 +78,14 @@ struct __specialized_algorithm<_Algorithm::__copy,
                                __single_iterator<ostreambuf_iterator<_CharT, _Traits> > > {
   static const bool __has_algorithm = is_same<const _CharT, const _InCharT>::value;
 
-  _LIBCPP_HIDE_FROM_ABI static pair<_InCharT*, ostreambuf_iterator<_CharT, _Traits> >
+  _LIBCPP_HIDE_FROM_ABI static __in_out_result<_InCharT*, ostreambuf_iterator<_CharT, _Traits> >
   operator()(_InCharT* __first, _InCharT* __last, ostreambuf_iterator<_CharT, _Traits> __result) {
     auto __size = __last - __first;
     if (__result.__sbuf_ && __size > 0) {
       if (__result.__sbuf_->sputn(__first, __last - __first) != __size)
         __result.__sbuf_ = nullptr;
     }
-    return pair<_InCharT*, ostreambuf_iterator<_CharT, _Traits> >(__last, __result);
+    return {__last, __result};
   }
 };
 

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -1030,10 +1030,10 @@ vector<_Tp, _Allocator>::__assign_with_size(_Iterator __first, _Sentinel __last,
   if (__new_size <= capacity()) {
     auto const __size = size();
     if (__new_size > __size) {
-      auto __mid = std::__copy_n<_AlgPolicy>(std::move(__first), __size, this->__begin_).first;
+      auto __mid = std::__copy_n<_AlgPolicy>(std::move(__first), __size, this->__begin_).__in_;
       __construct_at_end(std::move(__mid), std::move(__last), __new_size - __size);
     } else {
-      pointer __m = std::__copy(std::move(__first), __last, this->__begin_).second;
+      pointer __m = std::__copy(std::move(__first), __last, this->__begin_).__out_;
       this->__destruct_at_end(__m);
     }
   } else {

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -475,7 +475,10 @@ module std [system] {
       export std.iterator.aliasing_iterator
     }
     module move_backward                          { header "__algorithm/move_backward.h" }
-    module move                                   { header "__algorithm/move.h" }
+    module move                                   {
+      header "__algorithm/move.h"
+      export std.algorithm.in_out_result
+    }
     module next_permutation                       { header "__algorithm/next_permutation.h" }
     module none_of                                { header "__algorithm/none_of.h" }
     module nth_element                            { header "__algorithm/nth_element.h" }
@@ -853,7 +856,10 @@ module std [system] {
     module unique_copy                            { header "__algorithm/unique_copy.h" }
     module unique                                 { header "__algorithm/unique.h" }
     module unwrap_iter                            { header "__algorithm/unwrap_iter.h" }
-    module unwrap_range                           { header "__algorithm/unwrap_range.h" }
+    module unwrap_range                           {
+      header "__algorithm/unwrap_range.h"
+      export std.utility.pair
+    }
     module upper_bound                            { header "__algorithm/upper_bound.h" }
 
     header "algorithm"


### PR DESCRIPTION
This patch introduces a new `__in_out_result`, which is an internal back-ported version of `in_out_result`, and is convertible to that when it exists. This improves the readability of the code, since it replaces uses of `first` and `second` with `__in_` and `__out_`, making it clear which iterator is accessed.

Other algorithms will be updated in separate patches.