### PR TITLE
[lldb] Include synthetic variables in `GetVariables(bool...)`

### DIFF
--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -664,6 +664,9 @@ SBValueList SBFrame::GetVariables(bool arguments, bool locals, bool statics,
     options.SetIncludeRuntimeSupportValues(include_runtime_support_values);
     options.SetUseDynamic(use_dynamic);
 
+    // Assume that if we have any synthetic variables, they should be included.
+    options.SetIncludeSynthetic(true);
+
     value_list = GetVariables(options);
   }
   return value_list;
@@ -692,6 +695,10 @@ lldb::SBValueList SBFrame::GetVariables(bool arguments, bool locals,
   options.SetInScopeOnly(in_scope_only);
   options.SetIncludeRuntimeSupportValues(include_runtime_support_values);
   options.SetUseDynamic(use_dynamic);
+
+  // Assume that if we have any synthetic variables, they should be included.
+  options.SetIncludeSynthetic(true);
+
   return GetVariables(options);
 }
 

--- a/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
@@ -827,6 +827,24 @@ class ScriptedFrameProviderTestCase(TestBase):
         self.assertTrue(variables.IsValid())
         self.assertTrue(variables.GetValueAtIndex(0).name == "_handler_one")
 
+        # Ensure that we get synthetic variables in the other overloads.
+        # (arguments, locals, statics, in_scope_only)
+        variables = frame0.GetVariables(False, False, False, False)
+        self.assertTrue(variables.IsValid())
+        self.assertTrue(variables.GetValueAtIndex(0).name == "_handler_one")
+
+        # (arguments, locals, statics, in_scope_only, use_dynamic)
+        variables = frame0.GetVariables(
+            False, False, False, False, lldb.eNoDynamicValues
+        )
+        self.assertTrue(variables.IsValid())
+        self.assertTrue(variables.GetValueAtIndex(0).name == "_handler_one")
+
+        # FIXME: Synthetic variables are never in scope.
+        variables = frame0.GetVariables(False, False, False, True)
+        self.assertFalse(variables.IsValid())
+        self.assertEqual(variables.GetSize(), 0)
+
         # Check the `frame variable` command(s) handle synthetic variables the
         # way we expect by printing them.
         self.expect("frame var", substrs=["variable_in_main", "_handler_one"])


### PR DESCRIPTION
Synthetic frame variables can be included in `SBFrame::GetVariables` by passing an `SBVariablesOptions` with `SetIncludeSynthetic(true)`. However, they're not included in the other two overloads.
With the same reason they're included in `frame variable`, they should be included in these overloads. If the user doesn't want them included there, they can use the overload taking `SBVariablesOptions`.

This almost enables them to be shown in lldb-dap's variables. They're currently filtered out if `in_scope_only` is specified. Not sure what the proper fix is. Maybe they should skip that check.