### PR TITLE
[SPIR-V] Support 1x1 result in matrix multiply combiner

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCombinerHelper.cpp
@@ -397,6 +397,9 @@ void SPIRVCombinerHelper::applyMatrixMultiply(MachineInstr &MI) const {
   SmallVector<Register, 16> ResultScalars =
       computeDotProducts(RowsA, ColsB, SpvVecType, GR);
 
-  Builder.buildBuildVector(ResReg, ResultScalars);
+  if (ResultScalars.size() == 1)
+    Builder.buildCopy(ResReg, ResultScalars[0]);
+  else
+    Builder.buildBuildVector(ResReg, ResultScalars);
   MI.eraseFromParent();
 }

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -360,7 +360,8 @@ class SPIRVLegalizePointerCastImpl {
       GR->buildAssignPtr(B, ElemTy, ElementPtr);
 
       // Extract the element from the vector and store it.
-      Value *Element = makeExtractElement(B, ElemTy, SrcVector, I);
+      Value *Element =
+          E == 1 ? SrcVector : makeExtractElement(B, ElemTy, SrcVector, I);
       StoreInst *SI = B.CreateStore(Element, ElementPtr);
       SI->setAlignment(Alignment);
     }

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-multiply.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-multiply.ll
@@ -141,15 +141,17 @@ define internal void @test_matrix_multiply_f32_1x2_2x2_vec() {
 }
 
 ; Test Matrix Multiply 1x2 * 2x1 float (Result 1x1 scalar - OpDot)
-; TODO(171175): The SPIR-V backend does not legalize single element vectors.
-; CHECK-DISABLE: ; -- Begin function test_matrix_multiply_f32_1x2_2x1_scalar
-; define internal void @test_matrix_multiply_f32_1x2_2x1_scalar() {
-;   %1 = load <2 x float>, ptr addrspace(10) @private_v2f32
-;   %2 = load <2 x float>, ptr addrspace(10) @private_v2f32
-;   %3 = call <1 x float> @llvm.matrix.multiply.v1f32.v2f32.v2f32(<2 x float> %1, <2 x float> %2, i32 1, i32 2, i32 1)
-;   store <1 x float> %3, ptr addrspace(10) @private_v1f32
-;   ret void
-; }
+; CHECK-LABEL: ; -- Begin function test_matrix_multiply_f32_1x2_2x1_scalar
+; CHECK:       %[[A_1x2:[0-9]+]] = OpCompositeInsert %[[V2F32_ID]] {{.*}} {{.*}} 1
+; CHECK:       %[[B_2x1:[0-9]+]] = OpCompositeInsert %[[V2F32_ID]] {{.*}} {{.*}} 1
+; CHECK:       %[[#]] = OpDot %[[Float_ID]] %[[A_1x2]] %[[B_2x1]]
+define internal void @test_matrix_multiply_f32_1x2_2x1_scalar() {
+  %1 = load <2 x float>, ptr addrspace(10) @private_v2f32
+  %2 = load <2 x float>, ptr addrspace(10) @private_v2f32
+  %3 = call <1 x float> @llvm.matrix.multiply.v1f32.v2f32.v2f32(<2 x float> %1, <2 x float> %2, i32 1, i32 2, i32 1)
+  store <1 x float> %3, ptr addrspace(10) @private_v1f32
+  ret void
+}
 
 define void @main() #0 {
   ret void
@@ -160,6 +162,6 @@ declare <4 x i32> @llvm.matrix.multiply.v4i32.v4i32.v4i32(<4 x i32>, <4 x i32>, 
 declare <4 x float> @llvm.matrix.multiply.v4f32.v6f32.v6f32(<6 x float>, <6 x float>, i32, i32, i32)
 declare <2 x float> @llvm.matrix.multiply.v2f32.v4f32.v2f32(<4 x float>, <2 x float>, i32, i32, i32)
 declare <2 x float> @llvm.matrix.multiply.v2f32.v2f32.v4f32(<2 x float>, <4 x float>, i32, i32, i32)
-; declare <1 x float> @llvm.matrix.multiply.v1f32.v2f32.v2f32(<2 x float>, <2 x float>, i32, i32, i32)
+declare <1 x float> @llvm.matrix.multiply.v1f32.v2f32.v2f32(<2 x float>, <2 x float>, i32, i32, i32)
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
Emit a copy instead of G_BUILD_VECTOR for the scalarized 1-element result, and skip extractelement when storing a 1-element vector to a [1 x T] array

Enable the previously-disabled 1x2 * 2x1 test