### PR TITLE
[LifetimeSafety] Fix lifetimebound fix-it location for defaulted parameters

### DIFF
--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -240,6 +240,12 @@ public:
       // parsed as a type attribute, not a parameter attribute.
       InsertionPoint = ParmToAnnotate->getBeginLoc();
       FixItText = "[[clang::lifetimebound]] ";
+    } else if (ParmToAnnotate->hasDefaultArg()) {
+      // If the parameter has a default argument, place the attribute after the
+      // named parameter.
+      InsertionPoint =
+          Lexer::getLocForEndOfToken(ParmToAnnotate->getLocation(), 0,
+                                     S.getSourceManager(), S.getLangOpts());
     }
     S.Diag(ParmToAnnotate->getBeginLoc(), DiagID)
         << ParmToAnnotate->getSourceRange()

--- a/clang/lib/Sema/SemaLifetimeSafety.h
+++ b/clang/lib/Sema/SemaLifetimeSafety.h
@@ -242,7 +242,7 @@ public:
       FixItText = "[[clang::lifetimebound]] ";
     } else if (ParmToAnnotate->hasDefaultArg()) {
       // If the parameter has a default argument, place the attribute after the
-      // named parameter.
+      // named argument.
       InsertionPoint =
           Lexer::getLocForEndOfToken(ParmToAnnotate->getLocation(), 0,
                                      S.getSourceManager(), S.getLangOpts());

--- a/clang/test/Sema/warn-lifetime-safety-fixits.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-fixits.cpp
@@ -2,6 +2,13 @@
 // RUN:   -fexperimental-lifetime-safety-tu-analysis \
 // RUN:   -Wlifetime-safety-suggestions -Wno-dangling \
 // RUN:   -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+// RUN: cp %s %t.cpp
+// RUN: %clang_cc1 -std=c++17 -flifetime-safety-inference \
+// RUN:   -fexperimental-lifetime-safety-tu-analysis \
+// RUN:   -Wlifetime-safety-suggestions -Wno-dangling -fixit %t.cpp
+// RUN: %clang_cc1 -fsyntax-only -std=c++17 -flifetime-safety-inference \
+// RUN:   -fexperimental-lifetime-safety-tu-analysis \
+// RUN:   -Werror=lifetime-safety-suggestions -Wno-dangling %t.cpp
 
 struct View;
 
@@ -53,6 +60,12 @@ View param_with_attr(View a [[maybe_unused]]) {
 View param_default(View a = View()) {
   // CHECK: :[[@LINE-1]]:20: warning: parameter in intra-TU function should be marked
   // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:26-[[@LINE-2]]:26}:" {{\[\[}}clang::lifetimebound]]"
+  return a;
+}
+
+int *arr_default(int a[2] = nullptr) {
+  // CHECK: :[[@LINE-1]]:18: warning: parameter in intra-TU function should be marked
+  // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:23-[[@LINE-2]]:23}:" {{\[\[}}clang::lifetimebound]]"
   return a;
 }
 

--- a/clang/test/Sema/warn-lifetime-safety-fixits.cpp
+++ b/clang/test/Sema/warn-lifetime-safety-fixits.cpp
@@ -52,7 +52,7 @@ View param_with_attr(View a [[maybe_unused]]) {
 
 View param_default(View a = View()) {
   // CHECK: :[[@LINE-1]]:20: warning: parameter in intra-TU function should be marked
-  // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:35-[[@LINE-2]]:35}:" {{\[\[}}clang::lifetimebound]]"
+  // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:26-[[@LINE-2]]:26}:" {{\[\[}}clang::lifetimebound]]"
   return a;
 }
 


### PR DESCRIPTION
Earlier, we placed the attribute after the full parameter declaration. Now, in the default-argument case, we place it after the parameter name.

Fixes #192271