### PR TITLE
[clang-tidy][NFC] Fix modernize-macro-to-enum testcases

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/modernize-macro-to-enum3.h
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/Inputs/macro-to-enum/modernize-macro-to-enum3.h
@@ -17,4 +17,12 @@
 #define RR3_RED 1
 #define RR3_GREEN 2
 #define RR3_BLUE 3
+// CHECK-MESSAGES: :[[@LINE-2]]:1: warning: replace macro with enum
+// CHECK-MESSAGES: :[[@LINE-3]]:9: warning: macro 'RR3_GREEN' defines an integral constant; prefer an enum instead
+// CHECK-MESSAGES: :[[@LINE-3]]:9: warning: macro 'RR3_BLUE' defines an integral constant; prefer an enum instead
+// CHECK-FIXES: #define RR3_RED 1
+// CHECK-FIXES-NEXT: enum {
+// CHECK-FIXES-NEXT: RR3_GREEN = 2,
+// CHECK-FIXES-NEXT: RR3_BLUE = 3
+// CHECK-FIXES-NEXT: };
 #endif

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-headers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/macro-to-enum-headers.cpp
@@ -1,0 +1,15 @@
+// RUN: %check_clang_tidy -std=c++14-or-later \
+// RUN:   -check-header %S/Inputs/macro-to-enum/modernize-macro-to-enum.h \
+// RUN:   -check-header %S/Inputs/macro-to-enum/modernize-macro-to-enum2.h \
+// RUN:   -check-header %S/Inputs/macro-to-enum/modernize-macro-to-enum3.h \
+// RUN:   %s modernize-macro-to-enum %t -- \
+// RUN:   -- -I%S/Inputs/macro-to-enum -fno-delayed-template-parsing
+
+#define HEADER_MAIN 42
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: replace macro with enum [modernize-macro-to-enum]
+// CHECK-MESSAGES: :[[@LINE-2]]:9: warning: macro 'HEADER_MAIN' defines an integral constant; prefer an enum instead
+// CHECK-FIXES: enum {
+// CHECK-FIXES-NEXT: HEADER_MAIN = 42
+// CHECK-FIXES-NEXT: };
+
+#include "modernize-macro-to-enum.h"


### PR DESCRIPTION
Previously these header files are not tested, the new added test case fixes the problem.

As of AI Usage: Codex is used to suggest the new tests
Closes https://github.com/llvm/llvm-project/issues/173530