### PR TITLE
[offload] Remove `omptarget` references from tests

### DIFF
--- a/offload/test/mapping/alloc_fail.c
+++ b/offload/test/mapping/alloc_fail.c
@@ -2,9 +2,9 @@
 // RUN: %libomptarget-run-fail-generic 2>&1 \
 // RUN: | %fcheck-generic
 
-// CHECK: omptarget message: explicit extension not allowed: host address specified is 0x{{.*}} (8 bytes), but device allocation maps to host at 0x{{.*}} (8 bytes)
-// CHECK: omptarget error: Call to getTargetPointer returned null pointer (device failure or illegal mapping).
-// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: message: explicit extension not allowed: host address specified is 0x{{.*}} (8 bytes), but device allocation maps to host at 0x{{.*}} (8 bytes)
+// CHECK: error: Call to getTargetPointer returned null pointer (device failure or illegal mapping).
+// CHECK: fatal error 1: failure of target construct while offloading is mandatory
 
 int main() {
   int arr[4] = {0, 1, 2, 3};

--- a/offload/test/mapping/map_ordering_tgt_alloc_present_tofrom.c
+++ b/offload/test/mapping/map_ordering_tgt_alloc_present_tofrom.c
@@ -10,11 +10,11 @@ int main() {
   fprintf(stderr, "addr=%p, size=%ld\n", &x, sizeof(x));
 
   // clang-format off
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget error: Pointer 0x{{0*}}[[#HOST_ADDR]] was not present on the device upon entry to the region.
-  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: omptarget error: Failed to process data before launching the kernel.
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: error: Pointer 0x{{0*}}[[#HOST_ADDR]] was not present on the device upon entry to the region.
+  // CHECK: error: Call to targetDataBegin failed, abort target.
+  // CHECK: error: Failed to process data before launching the kernel.
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
   // clang-format on
 #pragma omp target map(alloc : x) map(present, alloc : x) map(tofrom : x)
   {

--- a/offload/test/mapping/ompx_hold/omp_target_disassociate_ptr.c
+++ b/offload/test/mapping/ompx_hold/omp_target_disassociate_ptr.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
 #pragma omp target data map(ompx_hold, alloc : X)
 #endif
   {
-    //      CHECK: omptarget error: Trying to disassociate a pointer with a
+    //      CHECK: error: Trying to disassociate a pointer with a
     // CHECK-SAME: non-zero hold reference count
     // CHECK-NEXT: omp_target_disassociate_ptr failed
     if (omp_target_disassociate_ptr(&X, DevNum)) {

--- a/offload/test/mapping/padding_not_mapped.c
+++ b/offload/test/mapping/padding_not_mapped.c
@@ -34,9 +34,9 @@ int main() {
   #pragma omp target update from(s.x) // should have no effect
   fprintf(stderr, "s.x = %d\n", s.x);
 
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
   #pragma omp target enter data map(present, alloc: s.x)
 
   return 0;

--- a/offload/test/mapping/present/target.c
+++ b/offload/test/mapping/present/target.c
@@ -18,11 +18,11 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: omptarget error: Failed to process data before launching the kernel.
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: error: Call to targetDataBegin failed, abort target.
+  // CHECK: error: Failed to process data before launching the kernel.
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target map(present, alloc : i)
   ;
 

--- a/offload/test/mapping/present/target_array_extension.c
+++ b/offload/test/mapping/present/target_array_extension.c
@@ -70,12 +70,12 @@ int main() {
   // CHECK: arr is present
   fprintf(stderr, "arr is present\n");
 
-  // CHECK: omptarget message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
-  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: omptarget error: Failed to process data before launching the kernel.
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
+  // CHECK: error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: error: Call to targetDataBegin failed, abort target.
+  // CHECK: error: Failed to process data before launching the kernel.
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target map(present, tofrom : arr[LARGE])

--- a/offload/test/mapping/present/target_data.c
+++ b/offload/test/mapping/present/target_data.c
@@ -18,8 +18,8 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(present, alloc : i)
   ;
 

--- a/offload/test/mapping/present/target_data_array_extension.c
+++ b/offload/test/mapping/present/target_data_array_extension.c
@@ -70,10 +70,10 @@ int main() {
   // CHECK: arr is present
   fprintf(stderr, "arr is present\n");
 
-  // CHECK: omptarget message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
-  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: explicit extension not allowed: host address specified is 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes), but device allocation maps to host at 0x{{0*}}[[#SMALL_ADDR]] ([[#SMALL_BYTES]] bytes)
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#LARGE_ADDR]] ([[#LARGE_BYTES]] bytes)
+  // CHECK: error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target data map(present, tofrom : arr[LARGE])

--- a/offload/test/mapping/present/target_enter_data.c
+++ b/offload/test/mapping/present/target_enter_data.c
@@ -18,9 +18,9 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target enter data map(present, alloc : i)
 
   // CHECK-NOT: i is present

--- a/offload/test/mapping/present/target_exit_data_delete.c
+++ b/offload/test/mapping/present/target_exit_data_delete.c
@@ -17,8 +17,8 @@ int main() {
   // CHECK: i was present
   fprintf(stderr, "i was present\n");
 
-// CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+// CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target exit data map(present, delete : i)
 
   // CHECK-NOT: i was present

--- a/offload/test/mapping/present/target_exit_data_release.c
+++ b/offload/test/mapping/present/target_exit_data_release.c
@@ -17,8 +17,8 @@ int main() {
   // CHECK: i was present
   fprintf(stderr, "i was present\n");
 
-// CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+// CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target exit data map(present, release : i)
 
   // CHECK-NOT: i was present

--- a/offload/test/mapping/present/target_update.c
+++ b/offload/test/mapping/present/target_update.c
@@ -32,8 +32,8 @@ int main() {
   // CHECK: i is present
   fprintf(stderr, "i is present\n");
 
-  // CHECK: omptarget message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target update CLAUSE(present : i)
 
   // CHECK-NOT: i is present

--- a/offload/test/mapping/present/target_update_array_extension.c
+++ b/offload/test/mapping/present/target_update_array_extension.c
@@ -66,8 +66,8 @@ int main() {
   // CHECK: arr is present
   fprintf(stderr, "arr is present\n");
 
-  // CHECK: omptarget message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' motion modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] ([[#SIZE]] bytes)
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[SMALL])
   {
 #pragma omp target update CLAUSE(present : arr[LARGE])

--- a/offload/test/mapping/present/zero_length_array_section.c
+++ b/offload/test/mapping/present/zero_length_array_section.c
@@ -20,11 +20,11 @@ int main() {
 
   // arr[0:0] doesn't create an actual mapping in the first directive.
   //
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
-  // CHECK: omptarget error: Call to getTargetPointer returned null pointer ('present' map type modifier).
-  // CHECK: omptarget error: Call to targetDataBegin failed, abort target.
-  // CHECK: omptarget error: Failed to process data before launching the kernel.
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
+  // CHECK: error: Call to getTargetPointer returned null pointer ('present' map type modifier).
+  // CHECK: error: Call to targetDataBegin failed, abort target.
+  // CHECK: error: Failed to process data before launching the kernel.
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target data map(alloc : arr[0 : 0])
 #pragma omp target map(present, alloc : arr[0 : 0])
   ;

--- a/offload/test/mapping/present/zero_length_array_section_exit.c
+++ b/offload/test/mapping/present/zero_length_array_section_exit.c
@@ -19,8 +19,8 @@ int main() {
 
   // arr[0:0] doesn't create an actual mapping in the first directive.
   //
-  // CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
-  // CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+  // CHECK: message: device mapping required by 'present' map type modifier does not exist for host address 0x{{0*}}[[#HOST_ADDR]] (0 bytes)
+  // CHECK: fatal error 1: failure of target construct while offloading is mandatory
 #pragma omp target enter data map(alloc : arr[0 : 0])
 #pragma omp target exit data map(present, release : arr[0 : 0])
 

--- a/offload/test/mapping/use_device_addr/target_wrong_use_device_addr.c
+++ b/offload/test/mapping/use_device_addr/target_wrong_use_device_addr.c
@@ -16,7 +16,7 @@ int main() {
 
 #pragma omp target data map(to : x[0 : 10])
   {
-// CHECK: omptarget device 0 info: variable x does not have a valid device
+// CHECK: device 0 info: variable x does not have a valid device
 // counterpart
 #pragma omp target data use_device_addr(x)
     {

--- a/offload/test/offloading/fortran/dump_map_tables.f90
+++ b/offload/test/offloading/fortran/dump_map_tables.f90
@@ -23,7 +23,7 @@ program map_dump_example
     A(i)=0
   enddo
 ! clang-format off
-! CHECK: omptarget device 0 info: OpenMP Host-Device pointer mappings after block
+! CHECK: device 0 info: OpenMP Host-Device pointer mappings after block
 ! CHECK-NEXT: omptarget device 0 info: Host Ptr Target Ptr Size (B) DynRefCount HoldRefCount Declaration
 ! CHECK-NEXT: omptarget device 0 info: {{(0x[0-9a-f]{16})}} {{(0x[0-9a-f]{16})}}  20000000 1 0 a(:n) at {{.*}}:[[@LINE-8]]:11
 ! clang-format on

--- a/offload/test/offloading/fortran/target-defaultmap-present.f90
+++ b/offload/test/offloading/fortran/target-defaultmap-present.f90
@@ -31,4 +31,4 @@ program map_present
     call target_data_not_present()
 end program
 
-!CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}
+!CHECK: message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}

--- a/offload/test/offloading/fortran/target_map_ompx_hold.f90
+++ b/offload/test/offloading/fortran/target_map_ompx_hold.f90
@@ -10,7 +10,7 @@ program ompx_hold
     implicit none
     integer :: presence_check
 
-!CHECK-NOT: omptarget message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}
+!CHECK-NOT: message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}
 !$omp target data map(ompx_hold, tofrom: presence_check)
 !$omp target exit data map(delete: presence_check)
 !$omp target map(present, tofrom: presence_check)
@@ -18,7 +18,7 @@ program ompx_hold
 !$omp end target
 !$omp end target data
 
-!CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}
+!CHECK: message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}
 !$omp target data map(tofrom: presence_check)
 !$omp target exit data map(delete: presence_check)
 !$omp target map(present, tofrom: presence_check)

--- a/offload/test/offloading/fortran/target_map_present_fail.f90
+++ b/offload/test/offloading/fortran/target_map_present_fail.f90
@@ -33,4 +33,4 @@ program map_present
     call target_data_not_present()
 end program
 
-!CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}
+!CHECK: message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}

--- a/offload/test/offloading/mandatory_but_no_devices.c
+++ b/offload/test/offloading/mandatory_but_no_devices.c
@@ -86,7 +86,7 @@
 #include <omp.h>
 #include <stdio.h>
 
-// CHECK: omptarget fatal error 1: failure of target construct while offloading is mandatory
+// CHECK: fatal error 1: failure of target construct while offloading is mandatory
 int main(void) {
   int X;
 #pragma omp DIR device(omp_get_initial_device())

--- a/offload/test/offloading/struct_mapping_with_pointers.cpp
+++ b/offload/test/offloading/struct_mapping_with_pointers.cpp
@@ -37,11 +37,11 @@ int main() {
   /// when mapping the struct happens after the mapping of the pointers.
 
   // clang-format off
-  // CHECK: omptarget --> Entry  0: Base=0x{{0*}}[[DAT_HST_PTR_BASE:.*]], Begin=0x{{0*}}[[DAT_HST_PTR_BASE]], Size=288, Type=0x{{0*}}1, Name=unknown
-  // CHECK: omptarget --> Entry  1: Base=0x{{0*}}[[DATUM_HST_PTEE_BASE:.*]], Begin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], Size=40, Type=0x{{0*}}1, Name=unknown
-  // CHECK: omptarget --> Entry  2: Base=0x{{0*}}[[DAT_HST_PTR_BASE]], Begin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], Size=8, Type=0x{{0*}}4000, Name=unknown
-  // CHECK: omptarget --> Entry  3: Base=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE:.*]], Begin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], Size=80, Type=0x{{0*}}1, Name=unknown
-  // CHECK: omptarget --> Entry  4: Base=0x{{0*}}[[MORE_DATUM_HST_PTR_BASE:.*]], Begin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], Size=8, Type=0x{{0*}}4000, Name=unknown
+  // CHECK: --> Entry  0: Base=0x{{0*}}[[DAT_HST_PTR_BASE:.*]], Begin=0x{{0*}}[[DAT_HST_PTR_BASE]], Size=288, Type=0x{{0*}}1, Name=unknown
+  // CHECK: --> Entry  1: Base=0x{{0*}}[[DATUM_HST_PTEE_BASE:.*]], Begin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], Size=40, Type=0x{{0*}}1, Name=unknown
+  // CHECK: --> Entry  2: Base=0x{{0*}}[[DAT_HST_PTR_BASE]], Begin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], Size=8, Type=0x{{0*}}4000, Name=unknown
+  // CHECK: --> Entry  3: Base=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE:.*]], Begin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], Size=80, Type=0x{{0*}}1, Name=unknown
+  // CHECK: --> Entry  4: Base=0x{{0*}}[[MORE_DATUM_HST_PTR_BASE:.*]], Begin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], Size=8, Type=0x{{0*}}4000, Name=unknown
   // clang-format on
 
   /// The struct will be mapped in the same order as the above entries.
@@ -49,45 +49,45 @@ int main() {
   /// First argument is the struct itself and it will be mapped once.
 
   // clang-format off
-  // CHECK: omptarget --> Looking up mapping(HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], Size=288)...
+  // CHECK: --> Looking up mapping(HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], Size=288)...
   // CHECK: PluginInterface --> MemoryManagerTy::allocate: size 288 with host pointer 0x{{0*}}[[DAT_HST_PTR_BASE]].
-  // CHECK: omptarget --> Creating new map entry with HstPtrBase=0x{{0*}}[[DAT_HST_PTR_BASE]], HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtAllocBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE:.*]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=1, HoldRefCount=0, Name=unknown
-  // CHECK: omptarget --> Moving 288 bytes (hst:0x{{0*}}[[DAT_HST_PTR_BASE]]) -> (tgt:0x{{0*}}[[DAT_DEVICE_PTR_BASE]])
+  // CHECK: --> Creating new map entry with HstPtrBase=0x{{0*}}[[DAT_HST_PTR_BASE]], HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtAllocBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE:.*]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=1, HoldRefCount=0, Name=unknown
+  // CHECK: --> Moving 288 bytes (hst:0x{{0*}}[[DAT_HST_PTR_BASE]]) -> (tgt:0x{{0*}}[[DAT_DEVICE_PTR_BASE]])
   // clang-format on
 
   /// Second argument is dat.datum[ : 10]:
   // clang-format off
-  // CHECK: omptarget --> Looking up mapping(HstPtrBegin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], Size=40)...
+  // CHECK: --> Looking up mapping(HstPtrBegin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], Size=40)...
   // CHECK: PluginInterface --> MemoryManagerTy::allocate: size 40 with host pointer 0x{{0*}}[[DATUM_HST_PTEE_BASE]].
-  // CHECK: omptarget --> Creating new map entry with HstPtrBase=0x{{0*}}[[DATUM_HST_PTEE_BASE]], HstPtrBegin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], TgtAllocBegin=0x[[DATUM_DEVICE_PTR_BASE:.*]], TgtPtrBegin=0x{{0*}}[[DATUM_DEVICE_PTR_BASE]], Size=40, DynRefCount=1, HoldRefCount=0, Name=unknown
-  // CHECK: omptarget --> Moving 40 bytes (hst:0x{{0*}}[[DATUM_HST_PTEE_BASE]]) -> (tgt:0x{{0*}}[[DATUM_DEVICE_PTR_BASE]])
+  // CHECK: --> Creating new map entry with HstPtrBase=0x{{0*}}[[DATUM_HST_PTEE_BASE]], HstPtrBegin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], TgtAllocBegin=0x[[DATUM_DEVICE_PTR_BASE:.*]], TgtPtrBegin=0x{{0*}}[[DATUM_DEVICE_PTR_BASE]], Size=40, DynRefCount=1, HoldRefCount=0, Name=unknown
+  // CHECK: --> Moving 40 bytes (hst:0x{{0*}}[[DATUM_HST_PTEE_BASE]]) -> (tgt:0x{{0*}}[[DATUM_DEVICE_PTR_BASE]])
   // clang-format on
 
   /// Third argument conditionally attaches data.datum -> dat.datum[:]
-  // CHECK: omptarget --> Deferring ATTACH map-type processing for argument 2
+  // CHECK: --> Deferring ATTACH map-type processing for argument 2
 
   /// Fourth argument is dat.more_datum[ : 10]:
   // clang-format off
-  // CHECK: omptarget --> Looking up mapping(HstPtrBegin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], Size=80)...
-  // CHECK: omptarget --> Creating new map entry with HstPtrBase=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], HstPtrBegin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], TgtAllocBegin=0x{{0*}}[[MORE_DATUM_DEVICE_PTR_BASE:.*]], TgtPtrBegin=0x{{0*}}[[MORE_DATUM_DEVICE_PTR_BASE]], Size=80, DynRefCount=1, HoldRefCount=0, Name=unknown
-  // CHECK: omptarget --> Moving 80 bytes (hst:0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]]) -> (tgt:0x{{0*}}[[MORE_DATUM_DEVICE_PTR_BASE]])
+  // CHECK: --> Looking up mapping(HstPtrBegin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], Size=80)...
+  // CHECK: --> Creating new map entry with HstPtrBase=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], HstPtrBegin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], TgtAllocBegin=0x{{0*}}[[MORE_DATUM_DEVICE_PTR_BASE:.*]], TgtPtrBegin=0x{{0*}}[[MORE_DATUM_DEVICE_PTR_BASE]], Size=80, DynRefCount=1, HoldRefCount=0, Name=unknown
+  // CHECK: --> Moving 80 bytes (hst:0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]]) -> (tgt:0x{{0*}}[[MORE_DATUM_DEVICE_PTR_BASE]])
   // clang-format on
 
   /// Fifth argument conditionally attaches data.more_datum -> dat.more_datum[:]
   // clang-format off
-  // CHECK: omptarget --> Deferring ATTACH map-type processing for argument 4
+  // CHECK: --> Deferring ATTACH map-type processing for argument 4
   // clang-format on
 
   /// Attach entries are handled at the end
   // clang-format off
-  // CHECK: omptarget --> Processing 2 deferred ATTACH map entries
-  // CHECK: omptarget --> Processing ATTACH entry 0: HstPtr=0x{{0*}}[[DAT_HST_PTR_BASE]], HstPteeBegin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], PtrSize=8, MapType=0x{{0*}}4000
-  // CHECK: omptarget --> Attach pointee 0x{{0*}}[[DATUM_HST_PTEE_BASE]] was newly allocated: yes
-  // CHECK: omptarget --> Update pointer (0x{{.*}}) -> [0x{{.*}}]
+  // CHECK: --> Processing 2 deferred ATTACH map entries
+  // CHECK: --> Processing ATTACH entry 0: HstPtr=0x{{0*}}[[DAT_HST_PTR_BASE]], HstPteeBegin=0x{{0*}}[[DATUM_HST_PTEE_BASE]], PtrSize=8, MapType=0x{{0*}}4000
+  // CHECK: --> Attach pointee 0x{{0*}}[[DATUM_HST_PTEE_BASE]] was newly allocated: yes
+  // CHECK: --> Update pointer (0x{{.*}}) -> [0x{{.*}}]
 
-  // CHECK: omptarget --> Processing ATTACH entry 1: HstPtr=0x{{0*}}[[MORE_DATUM_HST_PTR_BASE]], HstPteeBegin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], PtrSize=8, MapType=0x{{0*}}4000
-  // CHECK: omptarget --> Attach pointee 0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]] was newly allocated: yes
-  // CHECK: omptarget --> Update pointer (0x{{.*}}) -> [0x{{.*}}]
+  // CHECK: --> Processing ATTACH entry 1: HstPtr=0x{{0*}}[[MORE_DATUM_HST_PTR_BASE]], HstPteeBegin=0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]], PtrSize=8, MapType=0x{{0*}}4000
+  // CHECK: --> Attach pointee 0x{{0*}}[[MORE_DATUM_HST_PTEE_BASE]] was newly allocated: yes
+  // CHECK: --> Update pointer (0x{{.*}}) -> [0x{{.*}}]
   // clang-format on
 
 #pragma omp target enter data map(to : dat.datum[ : 10])                       \
@@ -95,9 +95,9 @@ int main() {
 
   /// Checks induced by having a target region:
   // clang-format off
-  // CHECK: omptarget --> Entry  0: Base=0x{{0*}}[[DAT_HST_PTR_BASE]], Begin=0x{{0*}}[[DAT_HST_PTR_BASE]], Size=288, Type=0x{{0*}}223, Name=unknown
-  // CHECK: omptarget --> Mapping exists (implicit) with HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=2 (incremented), HoldRefCount=0, Name=unknown
-  // CHECK: omptarget --> Obtained target argument 0x{{0*}}[[DAT_DEVICE_PTR_BASE]] from host pointer 0x{{0*}}[[DAT_HST_PTR_BASE]]
+  // CHECK: --> Entry  0: Base=0x{{0*}}[[DAT_HST_PTR_BASE]], Begin=0x{{0*}}[[DAT_HST_PTR_BASE]], Size=288, Type=0x{{0*}}223, Name=unknown
+  // CHECK: --> Mapping exists (implicit) with HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=2 (incremented), HoldRefCount=0, Name=unknown
+  // CHECK: --> Obtained target argument 0x{{0*}}[[DAT_DEVICE_PTR_BASE]] from host pointer 0x{{0*}}[[DAT_HST_PTR_BASE]]
   // clang-format on
 
 #pragma omp target
@@ -113,15 +113,15 @@ int main() {
 
   /// Post-target region checks:
   // clang-format off
-  // CHECK: omptarget --> Mapping exists with HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=1 (decremented), HoldRefCount=0
+  // CHECK: --> Mapping exists with HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=1 (decremented), HoldRefCount=0
   // clang-format on
 
 #pragma omp target exit data map(from : dat)
 
   /// Target data end checks:
   // clang-format off
-  // CHECK: omptarget --> Mapping exists with HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=0 (decremented, delayed deletion), HoldRefCount=0
-  // CHECK: omptarget --> Moving 288 bytes (tgt:0x{{0*}}[[DAT_DEVICE_PTR_BASE]]) -> (hst:0x{{0*}}[[DAT_HST_PTR_BASE]])
+  // CHECK: --> Mapping exists with HstPtrBegin=0x{{0*}}[[DAT_HST_PTR_BASE]], TgtPtrBegin=0x{{0*}}[[DAT_DEVICE_PTR_BASE]], Size=288, DynRefCount=0 (decremented, delayed deletion), HoldRefCount=0
+  // CHECK: --> Moving 288 bytes (tgt:0x{{0*}}[[DAT_DEVICE_PTR_BASE]]) -> (hst:0x{{0*}}[[DAT_HST_PTR_BASE]])
   // clang-format on
 
   // CHECK: dat.xi = 4

--- a/offload/test/offloading/target_map_for_member_data.cpp
+++ b/offload/test/offloading/target_map_for_member_data.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
   return 0;
 }
 // clang-format off
-// CHECK: omptarget --> Entry  0: Base=[[DAT_HST_PTR_BASE:0x.*]], Begin=[[DAT_HST_PTR_BASE]], Size=12
-// CHECK: omptarget --> Entry  1: Base=[[DAT_HST_PTR_BASE]], Begin=[[DAT_HST_PTR_BASE]], Size=4,
-// CHECK: omptarget --> Entry  2: Base=[[DAT_HST_PTR_BASE]], Begin=[[DATUM_HST_PTR_BASE:0x.*]], Size=8,
+// CHECK: --> Entry  0: Base=[[DAT_HST_PTR_BASE:0x.*]], Begin=[[DAT_HST_PTR_BASE]], Size=12
+// CHECK: --> Entry  1: Base=[[DAT_HST_PTR_BASE]], Begin=[[DAT_HST_PTR_BASE]], Size=4,
+// CHECK: --> Entry  2: Base=[[DAT_HST_PTR_BASE]], Begin=[[DATUM_HST_PTR_BASE:0x.*]], Size=8,
 // clang-format on


### PR DESCRIPTION
Make check lines more generic so that we can move and rename components
without breaking the tests

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>