### PR TITLE
[DWARFVerifier] Don't require .dwo for non-skeleton CUs

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1773,11 +1773,8 @@ void DWARFVerifier::verifyNameIndexEntries(
     // call to properly deal with it. It isn't clear that getNonSkeletonUnitDIE
     // will return the unit DIE of DU if we aren't able to get the .dwo file,
     // but that is what the function currently does.
-    // A DW_AT_(GNU_)dwo_id alone does not make a CU a skeleton: a regular
-    // DW_TAG_compile_unit is allowed to carry a DWO id (e.g. -gmodules emits
-    // one on each module CU). A CU is a skeleton CU only when DWARF 5+ tags
-    // it as DW_TAG_skeleton_unit, or when, in older DWARF, the CU has no
-    // children because the body lives in the .dwo.
+    // A CU is a skeleton CU only when DWARF 5+ tags it as DW_TAG_skeleton_unit,
+    // or when, in older DWARF, the CU has no children.
     DWARFDie UnitDie = DU->getUnitDIE();
     auto IsSkeletonCU = [&]() {
       if (DU->getVersion() >= 5)

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1773,15 +1773,26 @@ void DWARFVerifier::verifyNameIndexEntries(
     // call to properly deal with it. It isn't clear that getNonSkeletonUnitDIE
     // will return the unit DIE of DU if we aren't able to get the .dwo file,
     // but that is what the function currently does.
+    // A DW_AT_(GNU_)dwo_id alone does not make a CU a skeleton: a regular
+    // DW_TAG_compile_unit is allowed to carry a DWO id (e.g. -gmodules emits
+    // one on each module CU). A CU is a skeleton CU only when DWARF 5+ tags
+    // it as DW_TAG_skeleton_unit, or when, in older DWARF, the CU has no
+    // children because the body lives in the .dwo.
+    DWARFDie UnitDie = DU->getUnitDIE();
+    auto IsSkeletonCU = [&]() {
+      if (DU->getVersion() >= 5)
+        return UnitDie.getTag() == dwarf::DW_TAG_skeleton_unit;
+      return !UnitDie.hasChildren();
+    };
+    bool IsSkeleton = DU->getDWOId() && IsSkeletonCU();
     DWARFUnit *NonSkeletonUnit = nullptr;
-    if (DU->getDWOId()) {
+    if (IsSkeleton) {
       auto Iter = CUOffsetsToDUMap.find(DU->getOffset());
       NonSkeletonUnit = Iter->second;
     } else {
       NonSkeletonUnit = DU;
     }
-    DWARFDie UnitDie = DU->getUnitDIE();
-    if (DU->getDWOId() && !NonSkeletonUnit->isDWOUnit()) {
+    if (IsSkeleton && !NonSkeletonUnit->isDWOUnit()) {
       ErrorCategory.Report("Unable to get load .dwo file", [&]() {
         error() << formatv(
             "Name Index @ {0:x}: Entry @ {1:x} unable to load "

--- a/llvm/test/tools/llvm-dwarfdump/verify_debug_names_compile_unit_with_dwo_id.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/verify_debug_names_compile_unit_with_dwo_id.yaml
@@ -1,0 +1,62 @@
+# Verify the .debug_names verifier does not treat a non-skeleton
+# DW_TAG_compile_unit as a skeleton just because it carries a
+# DW_AT_GNU_dwo_id. -gmodules emits inline module DIE trees with a
+# DW_AT_GNU_dwo_id attribute on a regular DW_TAG_compile_unit (not a
+# DW_TAG_skeleton_unit), and there is no .dwo to load.
+
+# RUN: yaml2obj %s -o %t.o
+# RUN: llvm-dwarfdump --verify %t.o | FileCheck %s
+
+# CHECK: Verifying .debug_names...
+# CHECK-NOT: error
+# CHECK: No errors.
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+DWARF:
+  debug_str:
+    - ''
+    - 'int'
+  debug_abbrev:
+    - Table:
+        - Code:     1
+          Tag:      DW_TAG_compile_unit
+          Children: DW_CHILDREN_yes
+          Attributes:
+            - Attribute: DW_AT_GNU_dwo_id
+              Form:      DW_FORM_data8
+        - Code:     2
+          Tag:      DW_TAG_base_type
+          Children: DW_CHILDREN_no
+          Attributes:
+            - Attribute: DW_AT_name
+              Form:      DW_FORM_strp
+            - Attribute: DW_AT_byte_size
+              Form:      DW_FORM_data1
+            - Attribute: DW_AT_encoding
+              Form:      DW_FORM_data1
+  debug_info:
+    - Version:    5
+      UnitType:   DW_UT_compile
+      AddrSize:   8
+      Entries:
+        - AbbrCode: 1
+          Values:
+            - Value: 0x1122334455667788 ## DW_AT_GNU_dwo_id
+        - AbbrCode: 2
+          Values:
+            - Value: 0x00000001         ## DW_AT_name -> "int"
+            - Value: 0x04               ## DW_AT_byte_size
+            - Value: 0x05               ## DW_AT_encoding (DW_ATE_signed)
+        - AbbrCode: 0
+Sections:
+  ## .debug_names with a single name "int" -> DW_TAG_base_type DIE at offset
+  ## 0x15 in the CU above (CU header 0xC + 9 bytes of CU DIE).
+  - Name:            .debug_names
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x4
+    Content:         '4B00000005000000010000000000000000000000010000000100000009000000080000004C4C564D3037303000000000010000003080880B0100000000000000012403130419000000011500000000'


### PR DESCRIPTION
The presence of `DW_AT_(GNU_)dwo_id` alone does not make a compile unit a skeleton: a regular `DW_TAG_compile_unit` is allowed to carry a DWO id. DWARF 5 marks skeleton CUs with `DW_TAG_skeleton_unit` while older pre DWARF 5 identifies them by absence of children.

Before this change, the verifier would any CU whose header reported a DWO id as a skeleton, then tried and failed to load its (non-existent) .dwo and reported an error. This updates the verifier to gate the check on the CU being an actual skeleton CU.