### PR TITLE
[VPlan] Refine plain CFG iterator name and strengthen assert (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanCFG.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanCFG.h
@@ -262,7 +262,7 @@ vp_depth_first_shallow(const VPBlockBase *G) {
 /// Returns the VPBasicBlocks forming the loop body of a plain (pre-region)
 /// VPlan in reverse post-order starting from \p Header.
 inline SmallVector<VPBasicBlock *>
-vp_plain_cfg_loop_body(VPBasicBlock *Header) {
+vp_rpo_plain_cfg_loop_body(VPBasicBlock *Header) {
   assert(!Header->getParent() && "Header must not be inside a region");
   VPBlockBase *Middle = Header->getPredecessors()[1]->getSuccessors()[0];
   SmallVector<VPBasicBlock *> Result;
@@ -271,8 +271,13 @@ vp_plain_cfg_loop_body(VPBasicBlock *Header) {
   for (VPBasicBlock *VPBB : VPBlockUtils::blocksOnly<VPBasicBlock>(RPOT)) {
     if (VPBB == Middle)
       break;
-    if (!isa<VPIRBasicBlock>(VPBB))
-      Result.push_back(VPBB);
+    // Skip exit blocks.
+    if (isa<VPIRBasicBlock>(VPBB)) {
+      assert(is_contained(Header->getPlan()->getExitBlocks(), VPBB) &&
+             "skipped VPIRBBs must be exit blocks");
+      continue;
+    }
+    Result.push_back(VPBB);
   }
   return Result;
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1168,7 +1168,7 @@ static bool areAllLoadsDereferenceable(VPBasicBlock *HeaderVPBB, Loop *TheLoop,
                                        DominatorTree &DT, AssumptionCache *AC) {
   ScalarEvolution &SE = *PSE.getSE();
   const DataLayout &DL = TheLoop->getHeader()->getDataLayout();
-  for (VPBasicBlock *VPBB : vp_plain_cfg_loop_body(HeaderVPBB)) {
+  for (VPBasicBlock *VPBB : vp_rpo_plain_cfg_loop_body(HeaderVPBB)) {
     for (VPRecipeBase &R : *VPBB) {
       auto *VPI = dyn_cast<VPInstructionWithType>(&R);
       if (!VPI || VPI->getOpcode() != Instruction::Load) {


### PR DESCRIPTION
Address post-commit comments for
https://github.com/llvm/llvm-project/pull/197499:
 * add rpo prefix the name to indicate traversal (similar to other vp_depth_first_ helpers)
 * Added comment about skipped VPIRBBs + assert.