### PR TITLE
[X86] isExtractSubvectorCheap - fix typo in vXi1 extraction test

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -3563,8 +3563,9 @@ bool X86TargetLowering::isExtractSubvectorCheap(EVT ResVT, EVT SrcVT,
   // Mask vectors support all subregister combinations and operations that
   // extract half of vector.
   if (ResVT.getVectorElementType() == MVT::i1)
-    return Index == 0 || ((ResVT.getSizeInBits() == SrcVT.getSizeInBits()*2) &&
-                          (Index == ResVT.getVectorNumElements()));
+    return Index == 0 ||
+           ((ResVT.getSizeInBits() * 2 == SrcVT.getSizeInBits()) &&
+            (Index == ResVT.getVectorNumElements()));
 
   return (Index % ResVT.getVectorNumElements()) == 0;
 }

--- a/llvm/test/CodeGen/X86/vector-replicaton-i1-mask.ll
+++ b/llvm/test/CodeGen/X86/vector-replicaton-i1-mask.ll
@@ -687,27 +687,41 @@ define void @mask_replication_factor3_vf16(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor3_vf16:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovw (%rdi), %k1
-; AVX512BW-NEXT:    vpternlogd {{.*#+}} zmm0 {%k1} {z} = -1
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm1 = [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestmd %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm2 = [10,11,11,11,12,12,12,13,13,13,14,14,14,15,15,15]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm2, %zmm2
-; AVX512BW-NEXT:    vptestmd %zmm2, %zmm2, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm3 = [5,5,6,6,6,7,7,7,8,8,8,9,9,9,10,10]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm3, %zmm0
-; AVX512BW-NEXT:    vptestmd %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor3_vf16:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovw (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,21,21,22,22,22,23,23,23,24,24,24,25,25,25,26,26,42,43,43,43,44,44,44,45,45,45,46,46,46,47,47,47,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm1 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm2 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor3_vf16:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovw (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,5,5,6,6,6,7,7,7,8,8,8,9,9,9,10,10,10,11,11,11,12,12,12,13,13,13,14,14,14,15,15,15,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm1 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm2 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %tgt.mask = shufflevector <16 x i1> %src.mask, <16 x i1> poison, <48 x i32> <i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15>
@@ -799,466 +813,75 @@ define void @mask_replication_factor3_vf32(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor3_vf32:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovd (%rdi), %k0
-; AVX512BW-NEXT:    kshiftrd $1, %k0, %k1
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw (%rdi), %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k3
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k5
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $2, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $3, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $4, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k6
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $2, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $5, %k0, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $27, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k4
-; AVX512BW-NEXT:    kshiftrd $26, %k0, %k1
-; AVX512BW-NEXT:    kmovd %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovq %k7, %k2
-; AVX512BW-NEXT:    kmovw %k7, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $28, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $29, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $30, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $5, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $31, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k7
-; AVX512BW-NEXT:    kshiftrw $2, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $21, %k0, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $22, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $23, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $24, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $25, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $16, %k0, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $17, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $18, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $19, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $20, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $11, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrd $10, %k0, %k4
-; AVX512BW-NEXT:    kmovd %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k4, %k2
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $12, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $13, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $14, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $5, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $15, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm4 {%k2} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $14, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $6, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $13, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $7, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $8, %k0, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $9, %k0, %k0
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k2, %k0
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k2
-; AVX512BW-NEXT:    korw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor3_vf32:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovd (%rdi), %k1
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k1, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,21,21,22,22,22,23,23,23,24,24,24,25,25,25,26,26,42,43,43,43,44,44,44,45,45,45,46,46,46,47,47,47,48,48,48,49,49,49,50,50,50,51,51,51,52,52,52,53]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k1, %zmm0
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512BW-ONLY-NEXT:    movl $1, %eax
+; AVX512BW-ONLY-NEXT:    kmovd %eax, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqu16 %zmm0, %zmm1 {%k1}
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm2 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm3 = [21,21,22,22,22,23,23,23,24,24,24,25,25,25,26,26,26,27,27,27,28,28,28,29,29,29,30,30,30,31,31,31]
+; AVX512BW-ONLY-NEXT:    vpermw %zmm0, %zmm3, %zmm0
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm0 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm3 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm4 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm5 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor3_vf32:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovd (%rdi), %k1
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,5,5,6,6,6,7,7,7,8,8,8,9,9,9,10,10,10,11,11,11,12,12,12,13,13,13,14,14,14,15,15,15,16,16,16,17,17,17,18,18,18,19,19,19,20,20,20,21]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    movl $1, %eax
+; AVX512VBMI-ONLY-NEXT:    kmovd %eax, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqu16 %zmm1, %zmm0 {%k1}
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [21,21,22,22,22,23,23,23,24,24,24,25,25,25,26,26,26,27,27,27,28,28,28,29,29,29,30,30,30,31,31,31]
+; AVX512VBMI-ONLY-NEXT:    vpermw %zmm1, %zmm2, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm1 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm2 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k0, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k0, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm4 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm5 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %tgt.mask = shufflevector <32 x i1> %src.mask, <32 x i1> poison, <96 x i32> <i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31>
@@ -1406,888 +1029,103 @@ define void @mask_replication_factor3_vf64(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor3_vf64:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovq (%rdi), %k0
-; AVX512BW-NEXT:    kshiftrq $1, %k0, %k1
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw (%rdi), %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k3
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $2, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovq %k3, %k5
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $3, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $4, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k6
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $2, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $5, %k0, %k2
-; AVX512BW-NEXT:    kmovq %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $59, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrq $58, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kmovq %k7, %k3
-; AVX512BW-NEXT:    kmovw %k7, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $60, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $61, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $62, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $63, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k7
-; AVX512BW-NEXT:    kshiftrw $2, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 704(%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $53, %k0, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $54, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $55, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $56, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $57, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 640(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $48, %k0, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $49, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $50, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $51, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $52, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $43, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrq $42, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k3
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $44, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $45, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $46, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $47, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm4 {%k2} {z}
-; AVX512BW-NEXT:    kshiftrq $37, %k0, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $38, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $39, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $40, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $41, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $32, %k0, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $33, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $34, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $35, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $36, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $27, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrq $26, %k0, %k3
-; AVX512BW-NEXT:    kmovq %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $28, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $29, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $30, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $31, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm7 {%k2} {z}
-; AVX512BW-NEXT:    kshiftrq $21, %k0, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $22, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $23, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $24, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrq $25, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm8 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $16, %k0, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $17, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $18, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $19, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrq $20, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm9 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $11, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrq $10, %k0, %k3
-; AVX512BW-NEXT:    kmovq %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $12, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $13, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $14, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $15, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm10 {%k2} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 8-byte Reload
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $6, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $7, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $8, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrq $9, %k0, %k0
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k2, %k0
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k2
-; AVX512BW-NEXT:    korw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm11 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm11, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm10, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 640(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 704(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor3_vf64:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,4,5,4,5]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[5,5,6,6,6,7,7,7,8,8,8,9,9,9,10,10,26,27,27,27,28,28,28,29,29,29,30,30,30,31,31,31,32,32,32,33,33,33,34,34,34,35,35,35,36,36,36,37,53,53,54,54,54,55,55,55,56,56,56,57,57,57,58,58]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[4,5,6,7,6,7,6,7]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[10,11,11,11,12,12,12,13,13,13,14,14,14,15,15,15,16,16,16,17,17,17,18,18,18,19,19,19,20,20,20,21,37,37,38,38,38,39,39,39,40,40,40,41,41,41,42,42,58,59,59,59,60,60,60,61,61,61,62,62,62,63,63,63]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,21,21,22,22,22,23,23,23,24,24,24,25,25,25,26,26,42,43,43,43,44,44,44,45,45,45,46,46,46,47,47,47,48,48,48,49,49,49,50,50,50,51,51,51,52,52,52,53]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm1 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm2 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm3 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm4 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm5 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm7 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm8 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm9 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm10 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm11 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm11, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm10, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 640(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 704(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor3_vf64:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [21,21,22,22,22,23,23,23,24,24,24,25,25,25,26,26,26,27,27,27,28,28,28,29,29,29,30,30,30,31,31,31,32,32,32,33,33,33,34,34,34,35,35,35,36,36,36,37,37,37,38,38,38,39,39,39,40,40,40,41,41,41,42,42]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [42,43,43,43,44,44,44,45,45,45,46,46,46,47,47,47,48,48,48,49,49,49,50,50,50,51,51,51,52,52,52,53,53,53,54,54,54,55,55,55,56,56,56,57,57,57,58,58,58,59,59,59,60,60,60,61,61,61,62,62,62,63,63,63]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,1,1,1,2,2,2,3,3,3,4,4,4,5,5,5,6,6,6,7,7,7,8,8,8,9,9,9,10,10,10,11,11,11,12,12,12,13,13,13,14,14,14,15,15,15,16,16,16,17,17,17,18,18,18,19,19,19,20,20,20,21]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm1 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm2 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm3 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm4 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm5 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm7 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm8 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm9 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm10 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm11 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm11, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm10, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 640(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 704(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask = load <64 x i1>, ptr %in.maskvec, align 64
   %tgt.mask = shufflevector <64 x i1> %src.mask, <64 x i1> poison, <192 x i32> <i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 32, i32 32, i32 32, i32 33, i32 33, i32 33, i32 34, i32 34, i32 34, i32 35, i32 35, i32 35, i32 36, i32 36, i32 36, i32 37, i32 37, i32 37, i32 38, i32 38, i32 38, i32 39, i32 39, i32 39, i32 40, i32 40, i32 40, i32 41, i32 41, i32 41, i32 42, i32 42, i32 42, i32 43, i32 43, i32 43, i32 44, i32 44, i32 44, i32 45, i32 45, i32 45, i32 46, i32 46, i32 46, i32 47, i32 47, i32 47, i32 48, i32 48, i32 48, i32 49, i32 49, i32 49, i32 50, i32 50, i32 50, i32 51, i32 51, i32 51, i32 52, i32 52, i32 52, i32 53, i32 53, i32 53, i32 54, i32 54, i32 54, i32 55, i32 55, i32 55, i32 56, i32 56, i32 56, i32 57, i32 57, i32 57, i32 58, i32 58, i32 58, i32 59, i32 59, i32 59, i32 60, i32 60, i32 60, i32 61, i32 61, i32 61, i32 62, i32 62, i32 62, i32 63, i32 63, i32 63>
   %data = call <192 x i32> @llvm.masked.load.v192i32.p0(ptr %in.vec, i32 64, <192 x i1> %tgt.mask, <192 x i32> poison)
@@ -3360,37 +2198,71 @@ define void @mask_replication_factor5_vf16(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor5_vf16:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovw (%rdi), %k1
-; AVX512BW-NEXT:    vpternlogd {{.*#+}} zmm0 {%k1} {z} = -1
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm1 = [0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestmd %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm2 = [12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm2, %zmm2
-; AVX512BW-NEXT:    vptestmd %zmm2, %zmm2, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm3 = [9,9,10,10,10,10,10,11,11,11,11,11,12,12,12,12]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm3, %zmm3
-; AVX512BW-NEXT:    vptestmd %zmm3, %zmm3, %k1
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm4 = [6,6,6,7,7,7,7,7,8,8,8,8,8,9,9,9]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm4, %zmm4
-; AVX512BW-NEXT:    vptestmd %zmm4, %zmm4, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm4 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm5 = [3,3,3,3,4,4,4,4,4,5,5,5,5,5,6,6]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm5, %zmm0
-; AVX512BW-NEXT:    vptestmd %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor5_vf16:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovw (%rdi), %k1
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k1, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3,19,19,19,19,20,20,20,20,20,21,21,21,21,21,22,22,38,38,38,39,39,39,39,39,40,40,40,40,40,41,41,41,57,57,58,58,58,58,58,59,59,59,59,59,60,60,60,60]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k1, %zmm0
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512BW-ONLY-NEXT:    movl $1, %eax
+; AVX512BW-ONLY-NEXT:    kmovd %eax, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqu16 %zmm0, %zmm1 {%k2}
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k2, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    vpternlogd {{.*#+}} zmm2 {%k1} {z} = -1
+; AVX512BW-ONLY-NEXT:    vpmovsxbd {{.*#+}} zmm3 = [12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15]
+; AVX512BW-ONLY-NEXT:    vpermd %zmm2, %zmm3, %zmm2
+; AVX512BW-ONLY-NEXT:    vptestmd %zmm2, %zmm2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm2 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm4 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor5_vf16:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovw (%rdi), %k1
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3,4,4,4,4,4,5,5,5,5,5,6,6,6,6,6,7,7,7,7,7,8,8,8,8,8,9,9,9,9,9,10,10,10,10,10,11,11,11,11,11,12,12,12,12]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    movl $1, %eax
+; AVX512VBMI-ONLY-NEXT:    kmovd %eax, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqu16 %zmm1, %zmm0 {%k2}
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm0, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    vpternlogd {{.*#+}} zmm1 {%k1} {z} = -1
+; AVX512VBMI-ONLY-NEXT:    vpmovsxbd {{.*#+}} zmm2 = [12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15]
+; AVX512VBMI-ONLY-NEXT:    vpermd %zmm1, %zmm2, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vptestmd %zmm1, %zmm1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm1 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm2 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm3 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm4 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %tgt.mask = shufflevector <16 x i1> %src.mask, <16 x i1> poison, <80 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15>
@@ -3518,718 +2390,93 @@ define void @mask_replication_factor5_vf32(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor5_vf32:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovd (%rdi), %k5
-; AVX512BW-NEXT:    kshiftrd $1, %k5, %k1
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k6
-; AVX512BW-NEXT:    kmovw (%rdi), %k2
-; AVX512BW-NEXT:    kandw %k6, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k7
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k7, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k3
-; AVX512BW-NEXT:    kshiftrd $2, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $3, %k5, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $29, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrd $28, %k5, %k1
-; AVX512BW-NEXT:    kmovd %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kandw %k6, %k1, %k3
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $30, %k5, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $31, %k5, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm1 {%k2} {z}
-; AVX512BW-NEXT:    kshiftrd $25, %k5, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kandw %k6, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrd $26, %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k7
-; AVX512BW-NEXT:    kshiftrw $13, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrd $27, %k5, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $22, %k5, %k0
-; AVX512BW-NEXT:    kmovd %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k6, %k6
-; AVX512BW-NEXT:    kshiftrd $23, %k5, %k7
-; AVX512BW-NEXT:    kmovq %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k7
-; AVX512BW-NEXT:    kshiftrw $12, %k7, %k5
-; AVX512BW-NEXT:    korw %k5, %k6, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $24, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $2, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k7, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm3 {%k2} {z}
-; AVX512BW-NEXT:    kshiftrd $19, %k0, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k6
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k4, %k4
-; AVX512BW-NEXT:    kshiftrd $20, %k0, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $10, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $9, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $8, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $7, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrd $21, %k0, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kandw %k3, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $5, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $3, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $2, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm4 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $16, %k0, %k1
-; AVX512BW-NEXT:    kandw %k7, %k1, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $17, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $18, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k4
-; AVX512BW-NEXT:    kshiftrw $5, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $13, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $12, %k0, %k3
-; AVX512BW-NEXT:    kmovd %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $14, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $15, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm6 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $9, %k0, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrd $10, %k0, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $13, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $12, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kandw %k7, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $10, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $9, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrd $11, %k0, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $7, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $6, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $5, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kandw %k3, %k4, %k4
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $2, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $14, %k7, %k3
-; AVX512BW-NEXT:    korw %k3, %k4, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm7 {%k3} {z}
-; AVX512BW-NEXT:    kshiftrd $6, %k0, %k4
-; AVX512BW-NEXT:    kmovd %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k4, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $13, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $7, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $8, %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm8 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $14, %k5, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k5, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k5, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $4, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $5, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm9 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor5_vf32:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovd (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[0,1,2,3,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15,16,16,16,16,16,17,17,17,17,17,18,18,18,18,18,19,35,35,35,35,36,36,36,36,36,37,37,37,37,37,38,38,54,54,54,55,55,55,55,55,56,56,56,56,56,57,57,57]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3,19,19,19,19,20,20,20,20,20,21,21,21,21,21,22,22,38,38,38,39,39,39,39,39,40,40,40,40,40,41,41,41,57,57,58,58,58,58,58,59,59,59,59,59,60,60,60,60]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [25,25,26,26,26,26,26,27,27,27,27,27,28,28,28,28,28,29,29,29,29,29,30,30,30,30,30,31,31,31,31,31]
+; AVX512BW-ONLY-NEXT:    vpermw %zmm1, %zmm2, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm1 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm2 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm3 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm4 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm6 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm7 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm8 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm9 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor5_vf32:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovd (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15,16,16,16,16,16,17,17,17,17,17,18,18,18,18,18,19,19,19,19,19,20,20,20,20,20,21,21,21,21,21,22,22,22,22,22,23,23,23,23,23,24,24,24,24,24,25,25,25]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3,4,4,4,4,4,5,5,5,5,5,6,6,6,6,6,7,7,7,7,7,8,8,8,8,8,9,9,9,9,9,10,10,10,10,10,11,11,11,11,11,12,12,12,12]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [25,25,26,26,26,26,26,27,27,27,27,27,28,28,28,28,28,29,29,29,29,29,30,30,30,30,30,31,31,31,31,31]
+; AVX512VBMI-ONLY-NEXT:    vpermw %zmm1, %zmm2, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm1 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm2 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm3 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm4 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm6 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm7 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm8 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm9 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %tgt.mask = shufflevector <32 x i1> %src.mask, <32 x i1> poison, <160 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 31, i32 31>
@@ -4445,1342 +2692,159 @@ define void @mask_replication_factor5_vf64(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor5_vf64:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovq (%rdi), %k5
-; AVX512BW-NEXT:    kshiftrq $1, %k5, %k0
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kmovw (%rdi), %k2
-; AVX512BW-NEXT:    kandw %k1, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k2, %k0
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k3
-; AVX512BW-NEXT:    kshiftrq $2, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k7
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k7, %k7
-; AVX512BW-NEXT:    kshiftrw $2, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k7, %k7
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k6
-; AVX512BW-NEXT:    kandw %k6, %k7, %k7
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $3, %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k7, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $4, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $5, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $6, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k6
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k6} {z}
-; AVX512BW-NEXT:    kandw %k2, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $7, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $8, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $9, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $10, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $11, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $12, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k6
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrq $13, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $14, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $15, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $16, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $17, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $18, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $19, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $20, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $21, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $22, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $23, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $24, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $25, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $26, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $27, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $28, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k6
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k6} {z}
-; AVX512BW-NEXT:    kandw %k2, %k1, %k0
-; AVX512BW-NEXT:    kshiftrq $29, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $30, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $31, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $32, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $33, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $34, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $35, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $36, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $37, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $38, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $39, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $40, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $41, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k7} {z}
-; AVX512BW-NEXT:    kandw %k3, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $42, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $43, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $44, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k6
-; AVX512BW-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrq $45, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $46, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $47, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $48, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $49, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $50, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $51, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $52, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $53, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $54, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $55, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $56, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $57, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $58, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $59, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $60, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k6
-; AVX512BW-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrq $61, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $62, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $63, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k5, %k2
-; AVX512BW-NEXT:    korw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor5_vf64:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[6,7,6,7,6,7,6,7]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[3,3,3,3,4,4,4,4,4,5,5,5,5,5,6,6,22,22,22,23,23,23,23,23,24,24,24,24,24,25,25,25,41,41,42,42,42,42,42,43,43,43,43,43,44,44,44,44,60,61,61,61,61,61,62,62,62,62,62,63,63,63,63,63]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[4,5,4,5,4,5,6,7]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[6,6,6,7,7,7,7,7,8,8,8,8,8,9,9,9,25,25,26,26,26,26,26,27,27,27,27,27,28,28,28,28,44,45,45,45,45,45,46,46,46,46,46,47,47,47,47,47,48,48,48,48,48,49,49,49,49,49,50,50,50,50,50,51]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,4,5,4,5]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[9,9,10,10,10,10,10,11,11,11,11,11,12,12,12,12,28,29,29,29,29,29,30,30,30,30,30,31,31,31,31,31,32,32,32,32,32,33,33,33,33,33,34,34,34,34,34,35,51,51,51,51,52,52,52,52,52,53,53,53,53,53,54,54]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[0,1,2,3,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15,16,16,16,16,16,17,17,17,17,17,18,18,18,18,18,19,35,35,35,35,36,36,36,36,36,37,37,37,37,37,38,38,54,54,54,55,55,55,55,55,56,56,56,56,56,57,57,57]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k4
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3,19,19,19,19,20,20,20,20,20,21,21,21,21,21,22,22,38,38,38,39,39,39,39,39,40,40,40,40,40,41,41,41,57,57,58,58,58,58,58,59,59,59,59,59,60,60,60,60]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k5, %k6
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k5, %k6
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k5, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k4, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k4, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k4, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k3, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor5_vf64:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [51,51,51,51,52,52,52,52,52,53,53,53,53,53,54,54,54,54,54,55,55,55,55,55,56,56,56,56,56,57,57,57,57,57,58,58,58,58,58,59,59,59,59,59,60,60,60,60,60,61,61,61,61,61,62,62,62,62,62,63,63,63,63,63]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [38,38,38,39,39,39,39,39,40,40,40,40,40,41,41,41,41,41,42,42,42,42,42,43,43,43,43,43,44,44,44,44,44,45,45,45,45,45,46,46,46,46,46,47,47,47,47,47,48,48,48,48,48,49,49,49,49,49,50,50,50,50,50,51]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [25,25,26,26,26,26,26,27,27,27,27,27,28,28,28,28,28,29,29,29,29,29,30,30,30,30,30,31,31,31,31,31,32,32,32,32,32,33,33,33,33,33,34,34,34,34,34,35,35,35,35,35,36,36,36,36,36,37,37,37,37,37,38,38]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [12,13,13,13,13,13,14,14,14,14,14,15,15,15,15,15,16,16,16,16,16,17,17,17,17,17,18,18,18,18,18,19,19,19,19,19,20,20,20,20,20,21,21,21,21,21,22,22,22,22,22,23,23,23,23,23,24,24,24,24,24,25,25,25]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3,4,4,4,4,4,5,5,5,5,5,6,6,6,6,6,7,7,7,7,7,8,8,8,8,8,9,9,9,9,9,10,10,10,10,10,11,11,11,11,11,12,12,12,12]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k5, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k5, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k5, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k4, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k4, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k4, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k3, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask = load <64 x i1>, ptr %in.maskvec, align 64
   %tgt.mask = shufflevector <64 x i1> %src.mask, <64 x i1> poison, <320 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 31, i32 31, i32 32, i32 32, i32 32, i32 32, i32 32, i32 33, i32 33, i32 33, i32 33, i32 33, i32 34, i32 34, i32 34, i32 34, i32 34, i32 35, i32 35, i32 35, i32 35, i32 35, i32 36, i32 36, i32 36, i32 36, i32 36, i32 37, i32 37, i32 37, i32 37, i32 37, i32 38, i32 38, i32 38, i32 38, i32 38, i32 39, i32 39, i32 39, i32 39, i32 39, i32 40, i32 40, i32 40, i32 40, i32 40, i32 41, i32 41, i32 41, i32 41, i32 41, i32 42, i32 42, i32 42, i32 42, i32 42, i32 43, i32 43, i32 43, i32 43, i32 43, i32 44, i32 44, i32 44, i32 44, i32 44, i32 45, i32 45, i32 45, i32 45, i32 45, i32 46, i32 46, i32 46, i32 46, i32 46, i32 47, i32 47, i32 47, i32 47, i32 47, i32 48, i32 48, i32 48, i32 48, i32 48, i32 49, i32 49, i32 49, i32 49, i32 49, i32 50, i32 50, i32 50, i32 50, i32 50, i32 51, i32 51, i32 51, i32 51, i32 51, i32 52, i32 52, i32 52, i32 52, i32 52, i32 53, i32 53, i32 53, i32 53, i32 53, i32 54, i32 54, i32 54, i32 54, i32 54, i32 55, i32 55, i32 55, i32 55, i32 55, i32 56, i32 56, i32 56, i32 56, i32 56, i32 57, i32 57, i32 57, i32 57, i32 57, i32 58, i32 58, i32 58, i32 58, i32 58, i32 59, i32 59, i32 59, i32 59, i32 59, i32 60, i32 60, i32 60, i32 60, i32 60, i32 61, i32 61, i32 61, i32 61, i32 61, i32 62, i32 62, i32 62, i32 62, i32 62, i32 63, i32 63, i32 63, i32 63, i32 63>
   %data = call <320 x i32> @llvm.masked.load.v320i32.p0(ptr %in.vec, i32 64, <320 x i1> %tgt.mask, <320 x i32> poison)
@@ -6005,27 +3069,41 @@ define void @mask_replication_factor6_vf8(ptr %in.maskvec, ptr %in.vec, ptr %out
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor6_vf8:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovw (%rdi), %k1
-; AVX512BW-NEXT:    vpternlogd {{.*#+}} zmm0 {%k1} {z} = -1
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm1 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestmd %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm2 = [5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm2, %zmm2
-; AVX512BW-NEXT:    vptestmd %zmm2, %zmm2, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm3 = [2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm3, %zmm0
-; AVX512BW-NEXT:    vptestmd %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor6_vf8:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovw (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vpbroadcastq %xmm0, %zmm0
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,18,18,19,19,19,19,19,19,20,20,20,20,20,20,21,21,37,37,37,37,38,38,38,38,38,38,39,39,39,39,39,39,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm1 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm2 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor6_vf8:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovw (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm1 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm2 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
   %tgt.mask = shufflevector <8 x i1> %src.mask, <8 x i1> poison, <48 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7>
@@ -6119,42 +3197,75 @@ define void @mask_replication_factor6_vf16(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor6_vf16:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovw (%rdi), %k1
-; AVX512BW-NEXT:    vpternlogd {{.*#+}} zmm0 {%k1} {z} = -1
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm1 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestmd %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm2 = [13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm2, %zmm2
-; AVX512BW-NEXT:    vptestmd %zmm2, %zmm2, %k1
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm3 = [10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm3, %zmm3
-; AVX512BW-NEXT:    vptestmd %zmm3, %zmm3, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm4 = [8,8,8,8,8,8,9,9,9,9,9,9,10,10,10,10]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm4, %zmm4
-; AVX512BW-NEXT:    vptestmd %zmm4, %zmm4, %k1
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm4 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm5 = [5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm5, %zmm5
-; AVX512BW-NEXT:    vptestmd %zmm5, %zmm5, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm6 = [2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm6, %zmm0
-; AVX512BW-NEXT:    vptestmd %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor6_vf16:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovw (%rdi), %k1
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k1, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,18,18,19,19,19,19,19,19,20,20,20,20,20,20,21,21,37,37,37,37,38,38,38,38,38,38,39,39,39,39,39,39,56,56,56,56,56,56,57,57,57,57,57,57,58,58,58,58]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k1, %zmm0
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512BW-ONLY-NEXT:    movl $1, %eax
+; AVX512BW-ONLY-NEXT:    kmovd %eax, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqu16 %zmm0, %zmm1 {%k1}
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm2 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm3 = [10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15]
+; AVX512BW-ONLY-NEXT:    vpermw %zmm0, %zmm3, %zmm0
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm0 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm3 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm4 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm5 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor6_vf16:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovw (%rdi), %k1
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,8,8,8,8,8,8,9,9,9,9,9,9,10,10,10,10]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    movl $1, %eax
+; AVX512VBMI-ONLY-NEXT:    kmovd %eax, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqu16 %zmm1, %zmm0 {%k1}
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15]
+; AVX512VBMI-ONLY-NEXT:    vpermw %zmm1, %zmm2, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm1 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm2 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k0, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k0, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm4 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm5 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
   %tgt.mask = shufflevector <16 x i1> %src.mask, <16 x i1> poison, <96 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15>
@@ -6300,849 +3411,103 @@ define void @mask_replication_factor6_vf32(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor6_vf32:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovd (%rdi), %k5
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kmovw (%rdi), %k1
-; AVX512BW-NEXT:    kandw %k0, %k1, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k7
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k7, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k1, %k2
-; AVX512BW-NEXT:    kshiftrd $1, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k6
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $2, %k5, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k3
-; AVX512BW-NEXT:    kmovd %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k3, %k2
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k4, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $29, %k5, %k0
-; AVX512BW-NEXT:    kmovd %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k4
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $30, %k5, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kandw %k6, %k1, %k4
-; AVX512BW-NEXT:    kshiftrd $31, %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $14, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $1, %k4, %k4
-; AVX512BW-NEXT:    korw %k1, %k4, %k1
-; AVX512BW-NEXT:    vmovdqa32 704(%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $26, %k5, %k4
-; AVX512BW-NEXT:    kmovd %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrd $27, %k5, %k7
-; AVX512BW-NEXT:    kmovq %k5, %k2
-; AVX512BW-NEXT:    kmovd %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k7
-; AVX512BW-NEXT:    kshiftrw $13, %k7, %k5
-; AVX512BW-NEXT:    korw %k5, %k6, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $12, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $28, %k2, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k5, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    vmovdqa32 640(%rsi), %zmm2 {%k2} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $24, %k0, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $25, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $3, %k4, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k4, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k4, %k2, %k1
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $21, %k7, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kandw %k6, %k3, %k3
-; AVX512BW-NEXT:    kshiftrd $22, %k7, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k4
-; AVX512BW-NEXT:    kshiftrd $23, %k7, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $2, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $14, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $1, %k4, %k4
-; AVX512BW-NEXT:    korw %k3, %k4, %k3
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm4 {%k3} {z}
-; AVX512BW-NEXT:    kmovq %k7, %k4
-; AVX512BW-NEXT:    kshiftrd $18, %k7, %k6
-; AVX512BW-NEXT:    kmovd %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $19, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $20, %k4, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k0, %k2, %k1
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    kmovq %k4, %k0
-; AVX512BW-NEXT:    kshiftrd $16, %k4, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $17, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k3, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $13, %k0, %k3
-; AVX512BW-NEXT:    kmovd %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k5
-; AVX512BW-NEXT:    kmovw %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k5, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k5, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k5, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $14, %k0, %k3
-; AVX512BW-NEXT:    kmovq %k0, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k3
-; AVX512BW-NEXT:    kshiftrd $15, %k7, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $14, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    korw %k2, %k3, %k2
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm7 {%k2} {z}
-; AVX512BW-NEXT:    kmovq %k7, %k2
-; AVX512BW-NEXT:    kshiftrd $10, %k7, %k0
-; AVX512BW-NEXT:    kmovd %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $11, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kshiftrd $12, %k2, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k5, %k4
-; AVX512BW-NEXT:    kshiftlw $1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $1, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k1, %k4, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm8 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $8, %k2, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kandw %k0, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k4, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrd $9, %k2, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $3, %k5, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k5, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k5, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm9 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $5, %k1, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kandw %k6, %k2, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k7
-; AVX512BW-NEXT:    kshiftrw $14, %k7, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k7, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k7, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrd $6, %k1, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $7, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k4
-; AVX512BW-NEXT:    kshiftrd $7, %k1, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $2, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k4, %k4
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $14, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k4, %k4
-; AVX512BW-NEXT:    kshiftlw $1, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $1, %k4, %k4
-; AVX512BW-NEXT:    korw %k3, %k4, %k3
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm10 {%k3} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 4-byte Reload
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $14, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrd $3, %k1, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kshiftrw $13, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k4, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrd $4, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k3, %k0
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k2
-; AVX512BW-NEXT:    korw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k7, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm11 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm11, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm10, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 640(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 704(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor6_vf32:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovd (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[0,1,0,1,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,29,29,29,29,30,30,30,30,30,30,31,31,31,31,31,31,32,32,32,32,32,32,33,33,33,33,33,33,34,34,34,34,50,50,51,51,51,51,51,51,52,52,52,52,52,52,53,53]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,24,24,24,24,24,24,25,25,25,25,25,25,26,26,26,26,42,42,43,43,43,43,43,43,44,44,44,44,44,44,45,45,61,61,61,61,62,62,62,62,62,62,63,63,63,63,63,63]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,18,18,19,19,19,19,19,19,20,20,20,20,20,20,21,21,37,37,37,37,38,38,38,38,38,38,39,39,39,39,39,39,56,56,56,56,56,56,57,57,57,57,57,57,58,58,58,58]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm1 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm2 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm3 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm4 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm5 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm7 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm8 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm9 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm10 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm11 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm11, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm10, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 640(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 704(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor6_vf32:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovd (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15,16,16,16,16,16,16,17,17,17,17,17,17,18,18,18,18,18,18,19,19,19,19,19,19,20,20,20,20,20,20,21,21]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [21,21,21,21,22,22,22,22,22,22,23,23,23,23,23,23,24,24,24,24,24,24,25,25,25,25,25,25,26,26,26,26,26,26,27,27,27,27,27,27,28,28,28,28,28,28,29,29,29,29,29,29,30,30,30,30,30,30,31,31,31,31,31,31]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,8,8,8,8,8,8,9,9,9,9,9,9,10,10,10,10]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm1 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm2 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm3 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm4 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm5 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm7 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm8 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm9 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm10 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm11 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm11, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm10, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 640(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 704(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %tgt.mask = shufflevector <32 x i1> %src.mask, <32 x i1> poison, <192 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 31, i32 31, i32 31>
@@ -7392,1601 +3757,190 @@ define void @mask_replication_factor6_vf64(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor6_vf64:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovq (%rdi), %k5
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kmovw (%rdi), %k0
-; AVX512BW-NEXT:    kandw %k1, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k0
-; AVX512BW-NEXT:    korw %k0, %k3, %k0
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $1, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k3
-; AVX512BW-NEXT:    kshiftrq $2, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k3, %k3
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k7
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k7, %k7
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k0, %k6, %k6
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k5, %k3
-; AVX512BW-NEXT:    kshiftrq $3, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $4, %k3, %k1
-; AVX512BW-NEXT:    kmovq %k3, %k7
-; AVX512BW-NEXT:    kmovq %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $5, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k7} {z}
-; AVX512BW-NEXT:    kandw %k4, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $6, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $7, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $8, %k7, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $9, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $10, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $11, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $12, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $13, %k7, %k1
-; AVX512BW-NEXT:    kmovq %k7, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k2, %k7
-; AVX512BW-NEXT:    kshiftrq $14, %k2, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $15, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $16, %k7, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $17, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k7, %k4
-; AVX512BW-NEXT:    kshiftrq $18, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $19, %k4, %k1
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $20, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $21, %k7, %k1
-; AVX512BW-NEXT:    kmovq %k7, %k3
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k3, %k5
-; AVX512BW-NEXT:    kshiftrq $22, %k3, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $23, %k5, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k1} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $24, %k5, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $25, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $26, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftrq $27, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $28, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $29, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $30, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $31, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k1} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $32, %k7, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $33, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k7, %k5
-; AVX512BW-NEXT:    kshiftrq $34, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $35, %k5, %k1
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $36, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $37, %k7, %k1
-; AVX512BW-NEXT:    kmovq %k7, %k3
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k3, %k7
-; AVX512BW-NEXT:    kshiftrq $38, %k3, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $39, %k7, %k6
-; AVX512BW-NEXT:    kmovq %k7, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $40, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $41, %k5, %k1
-; AVX512BW-NEXT:    kmovq %k5, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $42, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kshiftrq $43, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $44, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $45, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k7} {z}
-; AVX512BW-NEXT:    kandw %k5, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $46, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $47, %k5, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k1} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $48, %k7, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $49, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k7, %k5
-; AVX512BW-NEXT:    kshiftrq $50, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $51, %k5, %k1
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $52, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $53, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $54, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $55, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1280(%rsi), %zmm20 {%k1} {z}
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $56, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $57, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $58, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1344(%rsi), %zmm21 {%k7} {z}
-; AVX512BW-NEXT:    kandw %k2, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $59, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $60, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $61, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1408(%rsi), %zmm22 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $62, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $63, %k5, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k2, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 1472(%rsi), %zmm23 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm23, 1472(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm22, 1408(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm21, 1344(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm20, 1280(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor6_vf64:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[6,7,6,7,6,7,6,7]
+; AVX512BW-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm2 = [5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,8,8,8,8,8,8,9,9,9,9,9,9,10,10,10,10,10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15]
+; AVX512BW-ONLY-NEXT:    vpshufb %zmm2, %zmm1, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[4,5,4,5,6,7,6,7]
+; AVX512BW-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm3 = [10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15,0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5]
+; AVX512BW-ONLY-NEXT:    vpshufb %zmm3, %zmm1, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[4,5,4,5,4,5,4,5]
+; AVX512BW-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm4 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,8,8,8,8,8,8,9,9,9,9,9,9,10,10,10,10]
+; AVX512BW-ONLY-NEXT:    vpshufb %zmm4, %zmm1, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb %zmm2, %zmm1, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k4
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[0,1,0,1,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb %zmm3, %zmm1, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k5
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb %zmm4, %zmm0, %zmm0
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k6
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k6, %k7
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k7} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k6, %k7
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k7} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k6, %k6
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k5, %k6
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k5, %k6
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k5, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k4, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k4, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k4, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k3, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1280(%rsi), %zmm20 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1344(%rsi), %zmm21 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1408(%rsi), %zmm22 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1472(%rsi), %zmm23 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm23, 1472(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm22, 1408(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm21, 1344(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm20, 1280(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor6_vf64:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [53,53,53,53,54,54,54,54,54,54,55,55,55,55,55,55,56,56,56,56,56,56,57,57,57,57,57,57,58,58,58,58,58,58,59,59,59,59,59,59,60,60,60,60,60,60,61,61,61,61,61,61,62,62,62,62,62,62,63,63,63,63,63,63]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [42,42,43,43,43,43,43,43,44,44,44,44,44,44,45,45,45,45,45,45,46,46,46,46,46,46,47,47,47,47,47,47,48,48,48,48,48,48,49,49,49,49,49,49,50,50,50,50,50,50,51,51,51,51,51,51,52,52,52,52,52,52,53,53]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [32,32,32,32,32,32,33,33,33,33,33,33,34,34,34,34,34,34,35,35,35,35,35,35,36,36,36,36,36,36,37,37,37,37,37,37,38,38,38,38,38,38,39,39,39,39,39,39,40,40,40,40,40,40,41,41,41,41,41,41,42,42,42,42]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [21,21,21,21,22,22,22,22,22,22,23,23,23,23,23,23,24,24,24,24,24,24,25,25,25,25,25,25,26,26,26,26,26,26,27,27,27,27,27,27,28,28,28,28,28,28,29,29,29,29,29,29,30,30,30,30,30,30,31,31,31,31,31,31]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [10,10,11,11,11,11,11,11,12,12,12,12,12,12,13,13,13,13,13,13,14,14,14,14,14,14,15,15,15,15,15,15,16,16,16,16,16,16,17,17,17,17,17,17,18,18,18,18,18,18,19,19,19,19,19,19,20,20,20,20,20,20,21,21]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,0,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,5,5,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,8,8,8,8,8,8,9,9,9,9,9,9,10,10,10,10]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k6, %k7
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k7} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k6, %k7
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k7} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k6, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k5, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k5, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k5, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k4, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k4, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k4, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k3, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1280(%rsi), %zmm20 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1344(%rsi), %zmm21 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1408(%rsi), %zmm22 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1472(%rsi), %zmm23 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm23, 1472(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm22, 1408(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm21, 1344(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm20, 1280(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask = load <64 x i1>, ptr %in.maskvec, align 64
   %tgt.mask = shufflevector <64 x i1> %src.mask, <64 x i1> poison, <384 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 31, i32 31, i32 31, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 33, i32 33, i32 33, i32 33, i32 33, i32 33, i32 34, i32 34, i32 34, i32 34, i32 34, i32 34, i32 35, i32 35, i32 35, i32 35, i32 35, i32 35, i32 36, i32 36, i32 36, i32 36, i32 36, i32 36, i32 37, i32 37, i32 37, i32 37, i32 37, i32 37, i32 38, i32 38, i32 38, i32 38, i32 38, i32 38, i32 39, i32 39, i32 39, i32 39, i32 39, i32 39, i32 40, i32 40, i32 40, i32 40, i32 40, i32 40, i32 41, i32 41, i32 41, i32 41, i32 41, i32 41, i32 42, i32 42, i32 42, i32 42, i32 42, i32 42, i32 43, i32 43, i32 43, i32 43, i32 43, i32 43, i32 44, i32 44, i32 44, i32 44, i32 44, i32 44, i32 45, i32 45, i32 45, i32 45, i32 45, i32 45, i32 46, i32 46, i32 46, i32 46, i32 46, i32 46, i32 47, i32 47, i32 47, i32 47, i32 47, i32 47, i32 48, i32 48, i32 48, i32 48, i32 48, i32 48, i32 49, i32 49, i32 49, i32 49, i32 49, i32 49, i32 50, i32 50, i32 50, i32 50, i32 50, i32 50, i32 51, i32 51, i32 51, i32 51, i32 51, i32 51, i32 52, i32 52, i32 52, i32 52, i32 52, i32 52, i32 53, i32 53, i32 53, i32 53, i32 53, i32 53, i32 54, i32 54, i32 54, i32 54, i32 54, i32 54, i32 55, i32 55, i32 55, i32 55, i32 55, i32 55, i32 56, i32 56, i32 56, i32 56, i32 56, i32 56, i32 57, i32 57, i32 57, i32 57, i32 57, i32 57, i32 58, i32 58, i32 58, i32 58, i32 58, i32 58, i32 59, i32 59, i32 59, i32 59, i32 59, i32 59, i32 60, i32 60, i32 60, i32 60, i32 60, i32 60, i32 61, i32 61, i32 61, i32 61, i32 61, i32 61, i32 62, i32 62, i32 62, i32 62, i32 62, i32 62, i32 63, i32 63, i32 63, i32 63, i32 63, i32 63>
   %data = call <384 x i32> @llvm.masked.load.v384i32.p0(ptr %in.vec, i32 64, <384 x i1> %tgt.mask, <384 x i32> poison)
@@ -9415,43 +4369,38 @@ define void @mask_replication_factor7_vf16(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ;
 ; AVX512BW-LABEL: mask_replication_factor7_vf16:
 ; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    kmovw (%rdi), %k1
-; AVX512BW-NEXT:    vpternlogd {{.*#+}} zmm0 {%k1} {z} = -1
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm1 = [0,0,0,0,0,0,0,1,1,1,1,1,1,1,2,2]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm1, %zmm1
-; AVX512BW-NEXT:    vptestmd %zmm1, %zmm1, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm2 = [13,13,14,14,14,14,14,14,14,15,15,15,15,15,15,15]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm2, %zmm2
-; AVX512BW-NEXT:    vptestmd %zmm2, %zmm2, %k1
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm3 = [11,11,11,11,12,12,12,12,12,12,12,13,13,13,13,13]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm3, %zmm3
-; AVX512BW-NEXT:    vptestmd %zmm3, %zmm3, %k1
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm4 = [9,9,9,9,9,9,10,10,10,10,10,10,10,11,11,11]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm4, %zmm4
-; AVX512BW-NEXT:    vptestmd %zmm4, %zmm4, %k1
+; AVX512BW-NEXT:    kmovw (%rdi), %k2
+; AVX512BW-NEXT:    vpmovm2b %k2, %zmm0
+; AVX512BW-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-NEXT:    vpshufb {{.*#+}} zmm1 = zmm0[9,9,9,9,9,9,10,10,10,10,10,10,10,11,11,11,27,27,27,27,28,28,28,28,28,28,28,29,29,29,29,29,45,45,46,46,46,46,46,46,46,47,47,47,47,47,47,47,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
+; AVX512BW-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512BW-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,0,0,1,1,1,1,1,1,1,2,2,18,18,18,18,18,19,19,19,19,19,19,19,20,20,20,20,36,36,36,37,37,37,37,37,37,37,38,38,38,38,38,38,54,55,55,55,55,55,55,55,56,56,56,56,56,56,56,57]
+; AVX512BW-NEXT:    vpmovb2m %zmm0, %k0
+; AVX512BW-NEXT:    vpmovm2w %k2, %zmm0
+; AVX512BW-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512BW-NEXT:    movl $1, %eax
+; AVX512BW-NEXT:    kmovd %eax, %k2
+; AVX512BW-NEXT:    vmovdqu16 %zmm0, %zmm1 {%k2}
+; AVX512BW-NEXT:    vpmovw2m %zmm1, %k2
+; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k2} {z}
+; AVX512BW-NEXT:    kshiftrd $16, %k2, %k2
+; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k2} {z}
+; AVX512BW-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm2 {%k2} {z}
+; AVX512BW-NEXT:    kshiftrq $16, %k1, %k2
+; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm3 {%k2} {z}
 ; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm5 = [6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,9]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm5, %zmm5
-; AVX512BW-NEXT:    vptestmd %zmm5, %zmm5, %k1
+; AVX512BW-NEXT:    kshiftrq $48, %k0, %k1
 ; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm6 = [4,4,4,5,5,5,5,5,5,5,6,6,6,6,6,6]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm6, %zmm6
-; AVX512BW-NEXT:    vptestmd %zmm6, %zmm6, %k1
+; AVX512BW-NEXT:    kshiftrq $32, %k0, %k1
 ; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm6 {%k1} {z}
-; AVX512BW-NEXT:    vpmovsxbd {{.*#+}} zmm7 = [2,2,2,2,2,3,3,3,3,3,3,3,4,4,4,4]
-; AVX512BW-NEXT:    vpermd %zmm0, %zmm7, %zmm0
-; AVX512BW-NEXT:    vptestmd %zmm0, %zmm0, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, 64(%rdx)
+; AVX512BW-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm6, 128(%rdx)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm5, 192(%rdx)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm3, 320(%rdx)
 ; AVX512BW-NEXT:    vmovdqa64 %zmm2, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, (%rdx)
+; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
 ; AVX512BW-NEXT:    vzeroupper
 ; AVX512BW-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
@@ -9617,978 +4566,121 @@ define void @mask_replication_factor7_vf32(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor7_vf32:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw (%rdi), %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k2, %k3
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovq %k2, %k4
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovd (%rdi), %k6
-; AVX512BW-NEXT:    kshiftrd $1, %k6, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovq %k2, %k7
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k5
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrd $2, %k6, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
-; AVX512BW-NEXT:    kmovq %k6, %k2
-; AVX512BW-NEXT:    kshiftrd $29, %k6, %k1
-; AVX512BW-NEXT:    kmovd %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kandw %k3, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k4, %k6
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrd $30, %k2, %k1
-; AVX512BW-NEXT:    kmovq %k2, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k0, %k0
-; AVX512BW-NEXT:    kandw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k3
-; AVX512BW-NEXT:    kshiftrd $31, %k4, %k0
-; AVX512BW-NEXT:    kmovd %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k3, %k3
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k3, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 832(%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrd $27, %k4, %k1
-; AVX512BW-NEXT:    kmovd %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k3
-; AVX512BW-NEXT:    kmovw %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k3, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k3, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k7
-; AVX512BW-NEXT:    kshiftrd $28, %k4, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k7, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k5, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k6, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $4, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k2, %k4
-; AVX512BW-NEXT:    kshiftrw $3, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k5
-; AVX512BW-NEXT:    korw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    korw %k7, %k0, %k2
-; AVX512BW-NEXT:    vmovdqa32 768(%rsi), %zmm2 {%k2} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $25, %k6, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k5
-; AVX512BW-NEXT:    kshiftrd $26, %k6, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k6, %k2, %k1
-; AVX512BW-NEXT:    vmovdqa32 704(%rsi), %zmm3 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $23, %k6, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k3
-; AVX512BW-NEXT:    kshiftrd $22, %k6, %k5
-; AVX512BW-NEXT:    kmovd %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $24, %k6, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k5
-; AVX512BW-NEXT:    kshiftrw $7, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k0, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 640(%rsi), %zmm4 {%k2} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $20, %k3, %k5
-; AVX512BW-NEXT:    kmovd %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k6
-; AVX512BW-NEXT:    kmovw %k6, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k1, %k2, %k5
-; AVX512BW-NEXT:    kshiftrd $21, %k3, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k2, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $15, %k7, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kshiftlw $14, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm5 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $18, %k2, %k4
-; AVX512BW-NEXT:    kmovd %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k4, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k4, %k4
-; AVX512BW-NEXT:    kmovw %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $13, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $12, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k6
-; AVX512BW-NEXT:    kshiftrd $19, %k2, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $9, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $8, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $6, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k6, %k5
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $3, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k7, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k5, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    korw %k7, %k3, %k3
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm6 {%k3} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $16, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k3, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k3
-; AVX512BW-NEXT:    kshiftrd $17, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k3, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k2
-; AVX512BW-NEXT:    korw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    korw %k1, %k0, %k1
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $13, %k0, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kandw %k6, %k2, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $14, %k2, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kandw %k7, %k1, %k3
-; AVX512BW-NEXT:    kshiftrd $14, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k0, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $12, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $11, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k5
-; AVX512BW-NEXT:    korw %k5, %k3, %k3
-; AVX512BW-NEXT:    kandw %k4, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k5
-; AVX512BW-NEXT:    kshiftrd $15, %k6, %k3
-; AVX512BW-NEXT:    kmovq %k6, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k5, %k5
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k5, %k3
-; AVX512BW-NEXT:    kshiftlw $1, %k3, %k3
-; AVX512BW-NEXT:    kshiftrw $1, %k3, %k3
-; AVX512BW-NEXT:    korw %k1, %k3, %k1
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm8 {%k1} {z}
-; AVX512BW-NEXT:    kmovq %k0, %k3
-; AVX512BW-NEXT:    kshiftrd $11, %k0, %k0
-; AVX512BW-NEXT:    kmovd %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kmovw %k0, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k6
-; AVX512BW-NEXT:    kshiftrd $12, %k3, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $10, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $9, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $8, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $6, %k5, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k6, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $4, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k3, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k2, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k3, %k6
-; AVX512BW-NEXT:    kmovq %k3, %k0
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k0, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm9 {%k2} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $9, %k6, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k5
-; AVX512BW-NEXT:    kshiftrd $10, %k6, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k4, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $2, %k4, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm10 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $7, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k3
-; AVX512BW-NEXT:    kshiftrd $6, %k4, %k2
-; AVX512BW-NEXT:    kmovd %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $14, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $11, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $10, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k3, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrd $8, %k4, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k5
-; AVX512BW-NEXT:    kshiftrw $7, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $3, %k5, %k6
-; AVX512BW-NEXT:    korw %k6, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $2, %k5, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $14, %k3, %k3
-; AVX512BW-NEXT:    korw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftlw $1, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $1, %k2, %k2
-; AVX512BW-NEXT:    korw %k0, %k2, %k2
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm11 {%k2} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $4, %k6, %k3
-; AVX512BW-NEXT:    kmovd %k3, {{[-0-9]+}}(%r{{[sb]}}p) # 4-byte Spill
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k3, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k3, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k5
-; AVX512BW-NEXT:    korw %k5, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k2, %k5
-; AVX512BW-NEXT:    kshiftrd $5, %k6, %k2
-; AVX512BW-NEXT:    kshiftlw $15, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $12, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $11, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $10, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $9, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $8, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $7, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k1, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $6, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k5, %k2
-; AVX512BW-NEXT:    kandw %k4, %k2, %k5
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $4, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $3, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k5, %k5
-; AVX512BW-NEXT:    kshiftrw $2, %k2, %k6
-; AVX512BW-NEXT:    korw %k6, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k5, %k5
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm12 {%k1} {z}
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kshiftrw $14, %k4, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k4, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k4, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k4, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k2
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftrd $3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $9, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $8, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $7, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $6, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k4
-; AVX512BW-NEXT:    korw %k4, %k2, %k2
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k2, %k2
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k2, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovd {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 4-byte Reload
-; AVX512BW-NEXT:    kshiftlw $14, %k2, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm13 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm13, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm12, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm11, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm10, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 640(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 704(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 768(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 832(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor7_vf32:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovd (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[0,1,0,1,0,1,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[9,9,9,9,9,9,10,10,10,10,10,10,10,11,11,11,27,27,27,27,28,28,28,28,28,28,28,29,29,29,29,29,45,45,46,46,46,46,46,46,46,47,47,47,47,47,47,47,48,48,48,48,48,48,48,49,49,49,49,49,49,49,50,50]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[2,2,2,2,2,3,3,3,3,3,3,3,4,4,4,4,20,20,20,21,21,21,21,21,21,21,22,22,22,22,22,22,38,39,39,39,39,39,39,39,40,40,40,40,40,40,40,41,57,57,57,57,57,57,58,58,58,58,58,58,58,59,59,59]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,0,0,1,1,1,1,1,1,1,2,2,18,18,18,18,18,19,19,19,19,19,19,19,20,20,20,20,36,36,36,37,37,37,37,37,37,37,38,38,38,38,38,38,54,55,55,55,55,55,55,55,56,56,56,56,56,56,56,57]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [27,27,27,27,28,28,28,28,28,28,28,29,29,29,29,29,29,29,30,30,30,30,30,30,30,31,31,31,31,31,31,31]
+; AVX512BW-ONLY-NEXT:    vpermw %zmm1, %zmm2, %zmm1
+; AVX512BW-ONLY-NEXT:    vpmovw2m %zmm1, %k4
+; AVX512BW-ONLY-NEXT:    kshiftrd $16, %k4, %k5
+; AVX512BW-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm1 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm2 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm3 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm4 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm5 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm6 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm8 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm9 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm10 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm11 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm12 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm13 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm13, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm12, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm11, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm10, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 640(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 704(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 768(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 832(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor7_vf32:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovd (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [9,9,9,9,9,9,10,10,10,10,10,10,10,11,11,11,11,11,11,11,12,12,12,12,12,12,12,13,13,13,13,13,13,13,14,14,14,14,14,14,14,15,15,15,15,15,15,15,16,16,16,16,16,16,16,17,17,17,17,17,17,17,18,18]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [18,18,18,18,18,19,19,19,19,19,19,19,20,20,20,20,20,20,20,21,21,21,21,21,21,21,22,22,22,22,22,22,22,23,23,23,23,23,23,23,24,24,24,24,24,24,24,25,25,25,25,25,25,25,26,26,26,26,26,26,26,27,27,27]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,0,0,1,1,1,1,1,1,1,2,2,2,2,2,2,2,3,3,3,3,3,3,3,4,4,4,4,4,4,4,5,5,5,5,5,5,5,6,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,9]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vpmovm2w %k0, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [27,27,27,27,28,28,28,28,28,28,28,29,29,29,29,29,29,29,30,30,30,30,30,30,30,31,31,31,31,31,31,31]
+; AVX512VBMI-ONLY-NEXT:    vpermw %zmm1, %zmm2, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovw2m %zmm1, %k4
+; AVX512VBMI-ONLY-NEXT:    kshiftrd $16, %k4, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm1 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm2 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm3 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm4 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k3, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm5 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm6 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm8 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm9 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm10 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm11 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm12 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k1, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm13 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm13, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm12, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm11, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm10, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 640(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 704(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 768(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 832(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask.padded = load <64 x i1>, ptr %in.maskvec, align 64
   %src.mask = shufflevector <64 x i1> %src.mask.padded, <64 x i1> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
   %tgt.mask = shufflevector <32 x i1> %src.mask, <32 x i1> poison, <224 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 17, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 18, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 19, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 20, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 21, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 22, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 23, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 24, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 25, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 26, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 28, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 29, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 30, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 31, i32 31, i32 31, i32 31>
@@ -10872,1836 +4964,219 @@ define void @mask_replication_factor7_vf64(ptr %in.maskvec, ptr %in.vec, ptr %ou
 ; AVX512DQ-NEXT:    vzeroupper
 ; AVX512DQ-NEXT:    retq
 ;
-; AVX512BW-LABEL: mask_replication_factor7_vf64:
-; AVX512BW:       # %bb.0:
-; AVX512BW-NEXT:    movw $-3, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kmovw (%rdi), %k0
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-5, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kmovq %k2, %k3
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-9, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-17, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-33, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-65, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    movw $-129, %ax
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq (%rdi), %k4
-; AVX512BW-NEXT:    kshiftrq $1, %k4, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-257, %ax # imm = 0xFEFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-513, %ax # imm = 0xFDFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-1025, %ax # imm = 0xFBFF
-; AVX512BW-NEXT:    kmovd %eax, %k5
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kmovw %k5, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-2049, %ax # imm = 0xF7FF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-4097, %ax # imm = 0xEFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    movw $-8193, %ax # imm = 0xDFFF
-; AVX512BW-NEXT:    kmovd %eax, %k2
-; AVX512BW-NEXT:    kmovw %k2, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    movw $-16385, %ax # imm = 0xBFFF
-; AVX512BW-NEXT:    kmovd %eax, %k1
-; AVX512BW-NEXT:    kmovw %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 2-byte Spill
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $2, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k0, %k6
-; AVX512BW-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k7, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kmovq %k4, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
-; AVX512BW-NEXT:    kshiftrq $3, %k4, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $4, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k1} {z}
-; AVX512BW-NEXT:    kandw %k2, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $5, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $6, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k5, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $7, %k4, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $8, %k4, %k0
-; AVX512BW-NEXT:    kmovq %k4, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $9, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $10, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $11, %k5, %k6
-; AVX512BW-NEXT:    kmovq %k5, %k4
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kshiftrq $12, %k4, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $13, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k5, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k6
-; AVX512BW-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $14, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $15, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $16, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $17, %k5, %k0
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $18, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $19, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $20, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k1} {z}
-; AVX512BW-NEXT:    kandw %k5, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $21, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $22, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k1} {z}
-; AVX512BW-NEXT:    kandw %k5, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $23, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $24, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $25, %k2, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k7} {z}
-; AVX512BW-NEXT:    kandw %k5, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k2, %k7
-; AVX512BW-NEXT:    kshiftrq $26, %k2, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $27, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $28, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $29, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k5, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k6
-; AVX512BW-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $30, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $31, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $32, %k5, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $33, %k5, %k0
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kmovq %k7, %k3
-; AVX512BW-NEXT:    kshiftrq $34, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $35, %k3, %k0
-; AVX512BW-NEXT:    kmovq %k3, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $36, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $37, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k5, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $38, %k7, %k0
-; AVX512BW-NEXT:    kmovq %k7, %k5
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftrq $39, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $40, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $41, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $42, %k4, %k0
-; AVX512BW-NEXT:    kmovq %k4, %k3
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $43, %k3, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k3, %k7
-; AVX512BW-NEXT:    kshiftrq $44, %k3, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $45, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k6
-; AVX512BW-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k6} {z}
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $46, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $47, %k5, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1280(%rsi), %zmm20 {%k1} {z}
-; AVX512BW-NEXT:    kshiftrq $48, %k5, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $49, %k5, %k0
-; AVX512BW-NEXT:    kmovq %k5, %k7
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrq $50, %k7, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1344(%rsi), %zmm21 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k4, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $51, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $52, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1408(%rsi), %zmm22 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $53, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $54, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k1
-; AVX512BW-NEXT:    vmovdqa32 1472(%rsi), %zmm23 {%k1} {z}
-; AVX512BW-NEXT:    kandw %k3, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $55, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $56, %k7, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k6
-; AVX512BW-NEXT:    kshiftrw $7, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k6, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftlw $1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $1, %k0, %k0
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $57, %k4, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k1, %k6
-; AVX512BW-NEXT:    korw %k6, %k0, %k7
-; AVX512BW-NEXT:    vmovdqa32 1536(%rsi), %zmm24 {%k7} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k0 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $12, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $10, %k6, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k0, %k1
-; AVX512BW-NEXT:    kmovq %k4, %k7
-; AVX512BW-NEXT:    kshiftrq $58, %k4, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $59, %k7, %k6
-; AVX512BW-NEXT:    kshiftlw $15, %k6, %k0
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k6, %k7
-; AVX512BW-NEXT:    korw %k7, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1600(%rsi), %zmm25 {%k1} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k6, %k1
-; AVX512BW-NEXT:    kshiftrw $14, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k5, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k5 # 8-byte Reload
-; AVX512BW-NEXT:    kshiftrq $60, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k3 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k4 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k4, %k0, %k6
-; AVX512BW-NEXT:    kshiftrq $61, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $3, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $2, %k1, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k7 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $14, %k0, %k7
-; AVX512BW-NEXT:    korw %k7, %k6, %k6
-; AVX512BW-NEXT:    kshiftlw $1, %k6, %k6
-; AVX512BW-NEXT:    kshiftrw $1, %k6, %k6
-; AVX512BW-NEXT:    korw %k1, %k6, %k6
-; AVX512BW-NEXT:    vmovdqa32 1664(%rsi), %zmm26 {%k6} {z}
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $14, %k1, %k1
-; AVX512BW-NEXT:    korw %k1, %k0, %k0
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftrq $62, %k5, %k0
-; AVX512BW-NEXT:    kshiftlw $15, %k0, %k0
-; AVX512BW-NEXT:    kshiftrw $13, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $12, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $11, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $10, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $9, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $8, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k6 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k6, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $7, %k0, %k0
-; AVX512BW-NEXT:    korw %k0, %k1, %k0
-; AVX512BW-NEXT:    kshiftrq $63, %k5, %k5
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k1 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k1, %k0, %k1
-; AVX512BW-NEXT:    kshiftlw $15, %k5, %k0
-; AVX512BW-NEXT:    kshiftrw $6, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k3, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $5, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k4, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $4, %k0, %k6
-; AVX512BW-NEXT:    korw %k6, %k1, %k1
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $3, %k0, %k4
-; AVX512BW-NEXT:    korw %k4, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $2, %k0, %k3
-; AVX512BW-NEXT:    korw %k3, %k1, %k1
-; AVX512BW-NEXT:    kmovw {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 2-byte Reload
-; AVX512BW-NEXT:    kandw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $14, %k5, %k2
-; AVX512BW-NEXT:    korw %k2, %k1, %k1
-; AVX512BW-NEXT:    kshiftlw $1, %k1, %k1
-; AVX512BW-NEXT:    kshiftrw $1, %k1, %k1
-; AVX512BW-NEXT:    korw %k0, %k1, %k1
-; AVX512BW-NEXT:    vmovdqa32 1728(%rsi), %zmm27 {%k1} {z}
-; AVX512BW-NEXT:    vmovdqa64 %zmm27, 1728(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm26, 1664(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm25, 1600(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm24, 1536(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm23, 1472(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm22, 1408(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm21, 1344(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm20, 1280(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
-; AVX512BW-NEXT:    vmovdqa64 %zmm0, (%rdx)
-; AVX512BW-NEXT:    vzeroupper
-; AVX512BW-NEXT:    retq
+; AVX512BW-ONLY-LABEL: mask_replication_factor7_vf64:
+; AVX512BW-ONLY:       # %bb.0:
+; AVX512BW-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512BW-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[6,7,6,7,6,7,6,7]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,9,25,25,25,25,25,25,26,26,26,26,26,26,26,27,27,27,43,43,43,43,44,44,44,44,44,44,44,45,45,45,45,45,61,61,62,62,62,62,62,62,62,63,63,63,63,63,63,63]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512BW-ONLY-NEXT:    kmovq %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[4,5,6,7,6,7,6,7]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[13,13,14,14,14,14,14,14,14,15,15,15,15,15,15,15,16,16,16,16,16,16,16,17,17,17,17,17,17,17,18,18,34,34,34,34,34,35,35,35,35,35,35,35,36,36,36,36,52,52,52,53,53,53,53,53,53,53,54,54,54,54,54,54]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[4,5,4,5,4,5,4,5]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[4,4,4,5,5,5,5,5,5,5,6,6,6,6,6,6,22,23,23,23,23,23,23,23,24,24,24,24,24,24,24,25,41,41,41,41,41,41,42,42,42,42,42,42,42,43,43,43,59,59,59,59,60,60,60,60,60,60,60,61,61,61,61,61]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,4,5,4,5]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[11,11,11,11,12,12,12,12,12,12,12,13,13,13,13,13,29,29,30,30,30,30,30,30,30,31,31,31,31,31,31,31,32,32,32,32,32,32,32,33,33,33,33,33,33,33,34,34,50,50,50,50,50,51,51,51,51,51,51,51,52,52,52,52]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k4
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[2,3,2,3,2,3,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[2,2,2,2,2,3,3,3,3,3,3,3,4,4,4,4,20,20,20,21,21,21,21,21,21,21,22,22,22,22,22,22,38,39,39,39,39,39,39,39,40,40,40,40,40,40,40,41,57,57,57,57,57,57,58,58,58,58,58,58,58,59,59,59]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k5
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm1 = zmm0[0,1,0,1,0,1,2,3]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[9,9,9,9,9,9,10,10,10,10,10,10,10,11,11,11,27,27,27,27,28,28,28,28,28,28,28,29,29,29,29,29,45,45,46,46,46,46,46,46,46,47,47,47,47,47,47,47,48,48,48,48,48,48,48,49,49,49,49,49,49,49,50,50]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm1, %k6
+; AVX512BW-ONLY-NEXT:    vshufi64x2 {{.*#+}} zmm0 = zmm0[0,1,0,1,0,1,0,1]
+; AVX512BW-ONLY-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,0,0,0,0,0,0,1,1,1,1,1,1,1,2,2,18,18,18,18,18,19,19,19,19,19,19,19,20,20,20,20,36,36,36,37,37,37,37,37,37,37,38,38,38,38,38,38,54,55,55,55,55,55,55,55,56,56,56,56,56,56,56,57]
+; AVX512BW-ONLY-NEXT:    vpmovb2m %zmm0, %k7
+; AVX512BW-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k7} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k7, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k7, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k7, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k6} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k6, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k6, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k6, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k5} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k5, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k5, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k5, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k4} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k4, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k4, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k4, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k3} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k3, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k3, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k3, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1280(%rsi), %zmm20 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1344(%rsi), %zmm21 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1408(%rsi), %zmm22 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1472(%rsi), %zmm23 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 8-byte Reload
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1536(%rsi), %zmm24 {%k2} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $16, %k2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1600(%rsi), %zmm25 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $32, %k2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1664(%rsi), %zmm26 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    kshiftrq $48, %k2, %k1
+; AVX512BW-ONLY-NEXT:    vmovdqa32 1728(%rsi), %zmm27 {%k1} {z}
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm27, 1728(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm26, 1664(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm25, 1600(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm24, 1536(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm23, 1472(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm22, 1408(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm21, 1344(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm20, 1280(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512BW-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512BW-ONLY-NEXT:    vzeroupper
+; AVX512BW-ONLY-NEXT:    retq
+;
+; AVX512VBMI-ONLY-LABEL: mask_replication_factor7_vf64:
+; AVX512VBMI-ONLY:       # %bb.0:
+; AVX512VBMI-ONLY-NEXT:    kmovq (%rdi), %k0
+; AVX512VBMI-ONLY-NEXT:    vpmovm2b %k0, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [54,55,55,55,55,55,55,55,56,56,56,56,56,56,56,57,57,57,57,57,57,57,58,58,58,58,58,58,58,59,59,59,59,59,59,59,60,60,60,60,60,60,60,61,61,61,61,61,61,61,62,62,62,62,62,62,62,63,63,63,63,63,63,63]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k1
+; AVX512VBMI-ONLY-NEXT:    kmovq %k1, {{[-0-9]+}}(%r{{[sb]}}p) # 8-byte Spill
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [45,45,46,46,46,46,46,46,46,47,47,47,47,47,47,47,48,48,48,48,48,48,48,49,49,49,49,49,49,49,50,50,50,50,50,50,50,51,51,51,51,51,51,51,52,52,52,52,52,52,52,53,53,53,53,53,53,53,54,54,54,54,54,54]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k2
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [36,36,36,37,37,37,37,37,37,37,38,38,38,38,38,38,38,39,39,39,39,39,39,39,40,40,40,40,40,40,40,41,41,41,41,41,41,41,42,42,42,42,42,42,42,43,43,43,43,43,43,43,44,44,44,44,44,44,44,45,45,45,45,45]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k3
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [27,27,27,27,28,28,28,28,28,28,28,29,29,29,29,29,29,29,30,30,30,30,30,30,30,31,31,31,31,31,31,31,32,32,32,32,32,32,32,33,33,33,33,33,33,33,34,34,34,34,34,34,34,35,35,35,35,35,35,35,36,36,36,36]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k4
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [18,18,18,18,18,19,19,19,19,19,19,19,20,20,20,20,20,20,20,21,21,21,21,21,21,21,22,22,22,22,22,22,22,23,23,23,23,23,23,23,24,24,24,24,24,24,24,25,25,25,25,25,25,25,26,26,26,26,26,26,26,27,27,27]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k5
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [9,9,9,9,9,9,10,10,10,10,10,10,10,11,11,11,11,11,11,11,12,12,12,12,12,12,12,13,13,13,13,13,13,13,14,14,14,14,14,14,14,15,15,15,15,15,15,15,16,16,16,16,16,16,16,17,17,17,17,17,17,17,18,18]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm1
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm1, %k6
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 {{.*#+}} zmm1 = [0,0,0,0,0,0,0,1,1,1,1,1,1,1,2,2,2,2,2,2,2,3,3,3,3,3,3,3,4,4,4,4,4,4,4,5,5,5,5,5,5,5,6,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,9]
+; AVX512VBMI-ONLY-NEXT:    vpermb %zmm0, %zmm1, %zmm0
+; AVX512VBMI-ONLY-NEXT:    vpmovb2m %zmm0, %k7
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 (%rsi), %zmm0 {%k7} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k7, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 64(%rsi), %zmm1 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k7, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 128(%rsi), %zmm2 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k7, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 192(%rsi), %zmm3 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 256(%rsi), %zmm4 {%k6} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k6, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 320(%rsi), %zmm5 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k6, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 384(%rsi), %zmm6 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k6, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 448(%rsi), %zmm7 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 512(%rsi), %zmm8 {%k5} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k5, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 576(%rsi), %zmm9 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k5, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 640(%rsi), %zmm10 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k5, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 704(%rsi), %zmm11 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 768(%rsi), %zmm12 {%k4} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k4, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 832(%rsi), %zmm13 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k4, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 896(%rsi), %zmm14 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k4, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 960(%rsi), %zmm15 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1024(%rsi), %zmm16 {%k3} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k3, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1088(%rsi), %zmm17 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k3, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1152(%rsi), %zmm18 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k3, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1216(%rsi), %zmm19 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1280(%rsi), %zmm20 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1344(%rsi), %zmm21 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1408(%rsi), %zmm22 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1472(%rsi), %zmm23 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kmovq {{[-0-9]+}}(%r{{[sb]}}p), %k2 # 8-byte Reload
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1536(%rsi), %zmm24 {%k2} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $16, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1600(%rsi), %zmm25 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $32, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1664(%rsi), %zmm26 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    kshiftrq $48, %k2, %k1
+; AVX512VBMI-ONLY-NEXT:    vmovdqa32 1728(%rsi), %zmm27 {%k1} {z}
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm27, 1728(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm26, 1664(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm25, 1600(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm24, 1536(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm23, 1472(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm22, 1408(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm21, 1344(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm20, 1280(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm19, 1216(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm18, 1152(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm17, 1088(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm16, 1024(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm15, 960(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm14, 896(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm13, 832(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm12, 768(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm11, 704(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm10, 640(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm9, 576(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm8, 512(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm7, 448(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm6, 384(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm5, 320(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm4, 256(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm3, 192(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm2, 128(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm1, 64(%rdx)
+; AVX512VBMI-ONLY-NEXT:    vmovdqa64 %zmm0, (%rdx)
+; AVX512VBMI-ONLY-NEXT:    vzeroupper
+; AVX512VBMI-ONLY-NEXT:    retq
   %src.mask = load <64 x i1>, ptr %in.maskvec, align 64
   %tgt.mask = shufflevector <64 x i1> %src.mask, <64 x i1> poison, <448 x i32> <i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 2, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 3, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 4, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 5, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 6, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 7, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 8, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 10, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 11, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 12, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 13, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 14, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15, i32 15, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 16, i32 17, i32 17, i32 17, i32 17, i32 17, i32 17, i32 17, i32 18, i32 18, i32 18, i32 18, i32 18, i32 18, i32 18, i32 19, i32 19, i32 19, i32 19, i32 19, i32 19, i32 19, i32 20, i32 20, i32 20, i32 20, i32 20, i32 20, i32 20, i32 21, i32 21, i32 21, i32 21, i32 21, i32 21, i32 21, i32 22, i32 22, i32 22, i32 22, i32 22, i32 22, i32 22, i32 23, i32 23, i32 23, i32 23, i32 23, i32 23, i32 23, i32 24, i32 24, i32 24, i32 24, i32 24, i32 24, i32 24, i32 25, i32 25, i32 25, i32 25, i32 25, i32 25, i32 25, i32 26, i32 26, i32 26, i32 26, i32 26, i32 26, i32 26, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 27, i32 28, i32 28, i32 28, i32 28, i32 28, i32 28, i32 28, i32 29, i32 29, i32 29, i32 29, i32 29, i32 29, i32 29, i32 30, i32 30, i32 30, i32 30, i32 30, i32 30, i32 30, i32 31, i32 31, i32 31, i32 31, i32 31, i32 31, i32 31, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 32, i32 33, i32 33, i32 33, i32 33, i32 33, i32 33, i32 33, i32 34, i32 34, i32 34, i32 34, i32 34, i32 34, i32 34, i32 35, i32 35, i32 35, i32 35, i32 35, i32 35, i32 35, i32 36, i32 36, i32 36, i32 36, i32 36, i32 36, i32 36, i32 37, i32 37, i32 37, i32 37, i32 37, i32 37, i32 37, i32 38, i32 38, i32 38, i32 38, i32 38, i32 38, i32 38, i32 39, i32 39, i32 39, i32 39, i32 39, i32 39, i32 39, i32 40, i32 40, i32 40, i32 40, i32 40, i32 40, i32 40, i32 41, i32 41, i32 41, i32 41, i32 41, i32 41, i32 41, i32 42, i32 42, i32 42, i32 42, i32 42, i32 42, i32 42, i32 43, i32 43, i32 43, i32 43, i32 43, i32 43, i32 43, i32 44, i32 44, i32 44, i32 44, i32 44, i32 44, i32 44, i32 45, i32 45, i32 45, i32 45, i32 45, i32 45, i32 45, i32 46, i32 46, i32 46, i32 46, i32 46, i32 46, i32 46, i32 47, i32 47, i32 47, i32 47, i32 47, i32 47, i32 47, i32 48, i32 48, i32 48, i32 48, i32 48, i32 48, i32 48, i32 49, i32 49, i32 49, i32 49, i32 49, i32 49, i32 49, i32 50, i32 50, i32 50, i32 50, i32 50, i32 50, i32 50, i32 51, i32 51, i32 51, i32 51, i32 51, i32 51, i32 51, i32 52, i32 52, i32 52, i32 52, i32 52, i32 52, i32 52, i32 53, i32 53, i32 53, i32 53, i32 53, i32 53, i32 53, i32 54, i32 54, i32 54, i32 54, i32 54, i32 54, i32 54, i32 55, i32 55, i32 55, i32 55, i32 55, i32 55, i32 55, i32 56, i32 56, i32 56, i32 56, i32 56, i32 56, i32 56, i32 57, i32 57, i32 57, i32 57, i32 57, i32 57, i32 57, i32 58, i32 58, i32 58, i32 58, i32 58, i32 58, i32 58, i32 59, i32 59, i32 59, i32 59, i32 59, i32 59, i32 59, i32 60, i32 60, i32 60, i32 60, i32 60, i32 60, i32 60, i32 61, i32 61, i32 61, i32 61, i32 61, i32 61, i32 61, i32 62, i32 62, i32 62, i32 62, i32 62, i32 62, i32 62, i32 63, i32 63, i32 63, i32 63, i32 63, i32 63, i32 63>
   %data = call <448 x i32> @llvm.masked.load.v448i32.p0(ptr %in.vec, i32 64, <448 x i1> %tgt.mask, <448 x i32> poison)


### PR DESCRIPTION
Fix typo in check for ResVT subvector being half the size of the SrcVT vector

Fixes #195695