### PR TITLE
[InstCombine] Handle "trunc nuw to i1" as "icmp ne,0" in foldSelectValueEquivalence

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1772,36 +1772,32 @@ Instruction *InstCombinerImpl::foldSelectValueEquivalence(SelectInst &Sel,
   // We have an 'EQ' comparison, so the select's false value will propagate.
   // Example:
   // (X == 42) ? 43 : (X + 1) --> (X == 42) ? (X + 1) : (X + 1) --> X + 1
-  auto Simpilfies = [&](Value *FalseValue) -> bool {
-    SmallVector<Instruction *> DropFlags;
-    if ((CanReplaceCmpLHSWithRHS &&
-         simplifyWithOpReplaced(FalseValue, CmpLHS, CmpRHS, SQ,
-                                /* AllowRefinement */ false,
-                                &DropFlags) == TrueVal) ||
-        (CanReplaceCmpRHSWithLHS &&
-         simplifyWithOpReplaced(FalseValue, CmpRHS, CmpLHS, SQ,
-                                /* AllowRefinement */ false,
-                                &DropFlags) == TrueVal)) {
-      for (Instruction *I : DropFlags) {
-        I->dropPoisonGeneratingAnnotations();
-        Worklist.add(I);
-      }
-      return true;
+  SmallVector<Instruction *> DropFlags;
+  if ((CanReplaceCmpLHSWithRHS &&
+       simplifyWithOpReplaced(FalseVal, CmpLHS, CmpRHS, SQ,
+                              /* AllowRefinement */ false,
+                              &DropFlags) == TrueVal) ||
+      (CanReplaceCmpRHSWithLHS &&
+       simplifyWithOpReplaced(FalseVal, CmpRHS, CmpLHS, SQ,
+                              /* AllowRefinement */ false,
+                              &DropFlags) == TrueVal)) {
+    for (Instruction *I : DropFlags) {
+      I->dropPoisonGeneratingAnnotations();
+      Worklist.add(I);
     }
-    return false;
-  };
 
-  Value *A;
+    return replaceInstUsesWith(Sel, FalseVal);
+  }
+
+  Constant *CmpC;
   if (FalseVal->getType()->isIntOrIntVectorTy(1) &&
-      match(FalseVal, m_NUWTrunc(m_Value(A)))) {
-    auto *NewICmp = new ICmpInst(CmpInst::Predicate::ICMP_NE, A,
-                                 ConstantInt::getNullValue(A->getType()));
-    if (Simpilfies(NewICmp)) {
-      return NewICmp;
-    }
-    delete NewICmp;
-  } else if (Simpilfies(FalseInst)) {
-    return replaceInstUsesWith(Sel, FalseInst);
+      match(FalseVal, m_NUWTrunc(m_Specific(CmpLHS))) &&
+      match(CmpRHS, m_ImmConstant(CmpC)) &&
+      ConstantFoldCompareInstOperands(
+          ICmpInst::Predicate::ICMP_NE, CmpC,
+          ConstantInt::getNullValue(CmpLHS->getType()), DL) == TrueVal) {
+    return new ICmpInst(CmpInst::Predicate::ICMP_NE, CmpLHS,
+                        ConstantInt::getNullValue(CmpLHS->getType()));
   }
 
   return nullptr;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -1772,21 +1772,36 @@ Instruction *InstCombinerImpl::foldSelectValueEquivalence(SelectInst &Sel,
   // We have an 'EQ' comparison, so the select's false value will propagate.
   // Example:
   // (X == 42) ? 43 : (X + 1) --> (X == 42) ? (X + 1) : (X + 1) --> X + 1
-  SmallVector<Instruction *> DropFlags;
-  if ((CanReplaceCmpLHSWithRHS &&
-       simplifyWithOpReplaced(FalseVal, CmpLHS, CmpRHS, SQ,
-                              /* AllowRefinement */ false,
-                              &DropFlags) == TrueVal) ||
-      (CanReplaceCmpRHSWithLHS &&
-       simplifyWithOpReplaced(FalseVal, CmpRHS, CmpLHS, SQ,
-                              /* AllowRefinement */ false,
-                              &DropFlags) == TrueVal)) {
-    for (Instruction *I : DropFlags) {
-      I->dropPoisonGeneratingAnnotations();
-      Worklist.add(I);
+  auto Simpilfies = [&](Value *FalseValue) -> bool {
+    SmallVector<Instruction *> DropFlags;
+    if ((CanReplaceCmpLHSWithRHS &&
+         simplifyWithOpReplaced(FalseValue, CmpLHS, CmpRHS, SQ,
+                                /* AllowRefinement */ false,
+                                &DropFlags) == TrueVal) ||
+        (CanReplaceCmpRHSWithLHS &&
+         simplifyWithOpReplaced(FalseValue, CmpRHS, CmpLHS, SQ,
+                                /* AllowRefinement */ false,
+                                &DropFlags) == TrueVal)) {
+      for (Instruction *I : DropFlags) {
+        I->dropPoisonGeneratingAnnotations();
+        Worklist.add(I);
+      }
+      return true;
     }
+    return false;
+  };
 
-    return replaceInstUsesWith(Sel, FalseVal);
+  Value *A;
+  if (FalseVal->getType()->isIntOrIntVectorTy(1) &&
+      match(FalseVal, m_NUWTrunc(m_Value(A)))) {
+    auto *NewICmp = new ICmpInst(CmpInst::Predicate::ICMP_NE, A,
+                                 ConstantInt::getNullValue(A->getType()));
+    if (Simpilfies(NewICmp)) {
+      return NewICmp;
+    }
+    delete NewICmp;
+  } else if (Simpilfies(FalseInst)) {
+    return replaceInstUsesWith(Sel, FalseInst);
   }
 
   return nullptr;

--- a/llvm/test/Transforms/InstCombine/select.ll
+++ b/llvm/test/Transforms/InstCombine/select.ll
@@ -3966,7 +3966,7 @@ define i32 @pr61361(i32 %arg) {
 
 define i32 @pr62088() {
 ; CHECK-LABEL: define i32 @pr62088() {
-; CHECK-NEXT:  entry:
+; CHECK-NEXT:  [[ENTRY:.*:]]
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
 ; CHECK-NEXT:    br i1 true, label %[[LOOP]], label %[[EXIT:.*]]
@@ -5420,6 +5420,74 @@ loop:
 exit:
   store i8 %res, ptr %out, align 1
   ret void
+}
+
+define i1 @select_replacement_trunc_nuw_i1(i8 %x) {
+; CHECK-LABEL: define i1 @select_replacement_trunc_nuw_i1(
+; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[X]], 2
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i8 [[X]] to i1
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[ICMP]], i1 true, i1 [[TRUNC]]
+; CHECK-NEXT:    ret i1 [[SELECT]]
+;
+  %icmp = icmp eq i8 %x, 2
+  %trunc = trunc nuw i8 %x to i1
+  %select = select i1 %icmp, i1 true, i1 %trunc
+  ret i1 %select
+}
+
+define <2 x i1> @select_replacement_trunc_nuw_i1_vec(<2 x i8> %x) {
+; CHECK-LABEL: define <2 x i1> @select_replacement_trunc_nuw_i1_vec(
+; CHECK-SAME: <2 x i8> [[X:%.*]]) {
+; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <2 x i8> [[X]], splat (i8 2)
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw <2 x i8> [[X]] to <2 x i1>
+; CHECK-NEXT:    [[SELECT:%.*]] = select <2 x i1> [[ICMP]], <2 x i1> splat (i1 true), <2 x i1> [[TRUNC]]
+; CHECK-NEXT:    ret <2 x i1> [[SELECT]]
+;
+  %icmp = icmp eq <2 x i8> %x, <i8 2, i8 2>
+  %trunc = trunc nuw <2 x i8> %x to <2 x i1>
+  %select = select <2 x i1> %icmp, <2 x i1> <i1 true, i1 true>, <2 x i1> %trunc
+  ret <2 x i1> %select
+}
+
+define i1 @neg_select_replacement_trunc_nuw_i1(i8 %x, i8 %y) {
+; CHECK-LABEL: define i1 @neg_select_replacement_trunc_nuw_i1(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[Y:%.*]]) {
+; CHECK-NEXT:    [[ICMP_NOT:%.*]] = icmp eq i8 [[Y]], 2
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i8 [[X]] to i1
+; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[ICMP_NOT]], i1 true, i1 [[TRUNC]]
+; CHECK-NEXT:    ret i1 [[SELECT]]
+;
+  %icmp = icmp eq i8 %y, 2
+  %trunc = trunc nuw i8 %x to i1
+  %select = select i1 %icmp, i1 true, i1 %trunc
+  ret i1 %select
+}
+
+define i1 @neg_select_replacement_trunc_i1(i8 %x) {
+; CHECK-LABEL: define i1 @neg_select_replacement_trunc_i1(
+; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[X]], 2
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[X]] to i1
+; CHECK-NEXT:    [[SELECT:%.*]] = or i1 [[ICMP]], [[TRUNC]]
+; CHECK-NEXT:    ret i1 [[SELECT]]
+;
+  %icmp = icmp eq i8 %x, 2
+  %trunc = trunc i8 %x to i1
+  %select = select i1 %icmp, i1 true, i1 %trunc
+  ret i1 %select
+}
+
+define i2 @neg_select_replacement_trunc_nuw_i2(i8 %x) {
+; CHECK-LABEL: define i2 @neg_select_replacement_trunc_nuw_i2(
+; CHECK-SAME: i8 [[X:%.*]]) {
+; CHECK-NEXT:    [[TRUNC:%.*]] = trunc i8 [[X]] to i2
+; CHECK-NEXT:    ret i2 [[TRUNC]]
+;
+  %icmp = icmp eq i8 %x, 2
+  %trunc = trunc nuw i8 %x to i2
+  %select = select i1 %icmp, i2 2, i2 %trunc
+  ret i2 %select
 }
 
 define i64 @fold_select_neg_not_eq(i64 %lo, i64 %hi) {

--- a/llvm/test/Transforms/InstCombine/select.ll
+++ b/llvm/test/Transforms/InstCombine/select.ll
@@ -5425,9 +5425,7 @@ exit:
 define i1 @select_replacement_trunc_nuw_i1(i8 %x) {
 ; CHECK-LABEL: define i1 @select_replacement_trunc_nuw_i1(
 ; CHECK-SAME: i8 [[X:%.*]]) {
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq i8 [[X]], 2
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw i8 [[X]] to i1
-; CHECK-NEXT:    [[SELECT:%.*]] = select i1 [[ICMP]], i1 true, i1 [[TRUNC]]
+; CHECK-NEXT:    [[SELECT:%.*]] = icmp ne i8 [[X]], 0
 ; CHECK-NEXT:    ret i1 [[SELECT]]
 ;
   %icmp = icmp eq i8 %x, 2
@@ -5439,9 +5437,7 @@ define i1 @select_replacement_trunc_nuw_i1(i8 %x) {
 define <2 x i1> @select_replacement_trunc_nuw_i1_vec(<2 x i8> %x) {
 ; CHECK-LABEL: define <2 x i1> @select_replacement_trunc_nuw_i1_vec(
 ; CHECK-SAME: <2 x i8> [[X:%.*]]) {
-; CHECK-NEXT:    [[ICMP:%.*]] = icmp eq <2 x i8> [[X]], splat (i8 2)
-; CHECK-NEXT:    [[TRUNC:%.*]] = trunc nuw <2 x i8> [[X]] to <2 x i1>
-; CHECK-NEXT:    [[SELECT:%.*]] = select <2 x i1> [[ICMP]], <2 x i1> splat (i1 true), <2 x i1> [[TRUNC]]
+; CHECK-NEXT:    [[SELECT:%.*]] = icmp ne <2 x i8> [[X]], zeroinitializer
 ; CHECK-NEXT:    ret <2 x i1> [[SELECT]]
 ;
   %icmp = icmp eq <2 x i8> %x, <i8 2, i8 2>


### PR DESCRIPTION
regression seen in https://github.com/dtcxzyw/llvm-opt-benchmark/pull/3528/changes/BASE..4dc27803d5fd3fdf03c6b423dff6235f557da692#r2874274598 from https://github.com/llvm/llvm-project/pull/184182
seen in 49 rust files in llvm-opt-benchmark with https://github.com/llvm/llvm-project/pull/184182

proof: https://alive2.llvm.org/ce/z/MGhWgE