### PR TITLE
[ELF] Remove redundant memset in SymbolTable::insert. NFC

### DIFF
--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -85,8 +85,8 @@ Symbol *SymbolTable::insert(StringRef name) {
   Symbol *sym = reinterpret_cast<Symbol *>(make<SymbolUnion>());
   symVector.push_back(sym);
 
-  // *sym was not initialized by a constructor. Initialize all Symbol fields.
-  memset(static_cast<void *>(sym), 0, sizeof(Symbol));
+  // make<SymbolUnion>() value-initializes the storage, so the Symbol fields
+  // are zero. Set the ones that need a non-zero value.
   sym->setName(name);
   sym->partition = 1;
   sym->versionId = VER_NDX_GLOBAL;


### PR DESCRIPTION
make<SymbolUnion>() value-initializes the union, zero-initializing all
sizeof(SymbolUnion) bytes. The following memset(sym, 0, sizeof(Symbol))
is therefore redundant.

This placeholder path runs no Symbol constructor, so it was not covered
by the constructor initialization in 905a88b923433eb8cd83677ea55bee82eb9ba498.