### PR TITLE
[libc][math] Fix pow() subnormal base exponent computation

### DIFF
--- a/libc/src/__support/math/pow.h
+++ b/libc/src/__support/math/pow.h
@@ -340,8 +340,9 @@ LIBC_INLINE double pow(double x, double y) {
 
     // Normalize denormal inputs.
     if (x_a < FPBits::min_normal().uintval()) {
-      e_x -= 64.0;
-      x_mant = FPBits(x * 0x1.0p64).get_mantissa();
+      FPBits x_norm(x * 0x1.0p64);
+      e_x = static_cast<double>(x_norm.get_exponent()) - 64.0;
+      x_mant = x_norm.get_mantissa();
     }
 
     // x is finite and negative, and y is a finite integer.

--- a/libc/test/src/math/smoke/pow_test.cpp
+++ b/libc/test/src/math/smoke/pow_test.cpp
@@ -229,6 +229,12 @@ TEST_F(LlvmLibcPowTest, SpecialNumbers) {
   }
 }
 
+TEST_F(LlvmLibcPowTest, SubnormalBase) {
+  EXPECT_FP_EQ(0x1.0p825, LIBC_NAMESPACE::pow(0x1.0p-1024, -0x1.9c8p-1));
+  EXPECT_FP_EQ(0x1.0p-512, LIBC_NAMESPACE::pow(0x1.0p-1024, 0.5));
+  EXPECT_FP_EQ(0x1.0p512, LIBC_NAMESPACE::pow(0x1.0p-1024, -0.5));
+}
+
 #ifdef LIBC_TEST_FTZ_DAZ
 
 using namespace LIBC_NAMESPACE::testing;

--- a/libc/test/src/math/smoke/powf_test.cpp
+++ b/libc/test/src/math/smoke/powf_test.cpp
@@ -236,6 +236,13 @@ TEST_F(LlvmLibcPowfTest, SpecialNumbers) {
   EXPECT_FP_EQ(0.0f, LIBC_NAMESPACE::powf(-0.015625f, 26.0f));
 }
 
+TEST_F(LlvmLibcPowfTest, SubnormalBase) {
+  EXPECT_FP_EQ(0x1.0p-32f, LIBC_NAMESPACE::powf(0x1.0p-128f, 0.25f));
+  EXPECT_FP_EQ(0x1.0p96f, LIBC_NAMESPACE::powf(0x1.0p-128f, -0.75f));
+  EXPECT_FP_EQ(0x1.90a962p-33f, LIBC_NAMESPACE::powf(0x1.8p-130f, 0.25f));
+  EXPECT_FP_EQ(0x1.47238cp+32f, LIBC_NAMESPACE::powf(0x1.8p-130f, -0.25f));
+}
+
 #ifdef LIBC_TEST_FTZ_DAZ
 
 using namespace LIBC_NAMESPACE::testing;


### PR DESCRIPTION
For subnormal inputs, get_exponent() returns -1023. The code subtracted 64 after normalizing but didn't recompute e_x from the normalized value. This set e_x to -1087 for every subnormal.

To fix, compute e_x from the normalized value.

powf() doesn't have this bug because it adds
`x_u >> FloatBits::FRACTION_LEN` to ex, where x_u is `x_u = FloatBits(x).uintval();` with `x` being the normalized value. Added subnormal base tests for powf to show that it works fine as-is.

Fixes #197212.