### PR TITLE
[ELF] Fix imprecise --why-live message for exported symbols

### DIFF
--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -356,7 +356,7 @@ void MarkLive<ELFT, TrackWhyLive>::run() {
   // file can interpose other ELF file's symbols at runtime.
   for (Symbol *sym : ctx.symtab->getSymbols())
     if (sym->isExported && sym->partition == partition)
-      markSymbol(sym, "externally visible symbol; may interpose");
+      markSymbol(sym, "externally visible symbol");
 
   // If this isn't the main partition, that's all that we need to preserve.
   if (partition != 1) {

--- a/lld/test/ELF/why-live.test
+++ b/lld/test/ELF/why-live.test
@@ -220,6 +220,17 @@ test_eh:
 # PERSONALITY-NEXT: >>> referenced by: a.o:(.eh_frame) (exception handling frame)
 # PERSONALITY-EMPTY:
 
+## Symbols exported into the dynamic symbol table are GC roots.
+.globl test_exported
+.section .test_exported,"ax",@progbits
+test_exported:
+  jmp test_exported
+
+# RUN: ld.lld a.o a.so --gc-sections --export-dynamic --why-live=test_exported | FileCheck %s --check-prefix=EXPORTED
+
+# EXPORTED:      live symbol: a.o:(test_exported) (externally visible symbol)
+# EXPORTED-EMPTY:
+
 #--- b.s
 ## --why-live='*' skips symbol at index 0 and section symbols.
 # RUN: ld.lld b.o --threads=1 --gc-sections --why-live="*" | FileCheck %s --check-prefix=STAR --match-full-lines


### PR DESCRIPTION
The "; may interpose" suffix is imprecise: a symbol is preserved because
it is exported into the dynamic symbol table, regardless of whether it
is interposable (preemptible).

Fix #192035 and add a test (previously uncovered)