### PR TITLE
[IR][PrintPasses] Disable IO Sandbox in doSystemDiff

### DIFF
--- a/llvm/lib/IR/PrintPasses.cpp
+++ b/llvm/lib/IR/PrintPasses.cpp
@@ -216,7 +216,7 @@ std::error_code llvm::cleanUpTempFiles(ArrayRef<std::string> FileName) {
 std::string llvm::doSystemDiff(StringRef Before, StringRef After,
                                StringRef OldLineFormat, StringRef NewLineFormat,
                                StringRef UnchangedLineFormat) {
-  [[maybe_unused]] auto BypassSandbox = sys::sandbox::scopedDisable();
+  auto BypassSandbox = sys::sandbox::scopedDisable();
 
   // Store the 2 bodies into temporary files and call diff on them
   // to get the body of the node.

--- a/llvm/lib/IR/PrintPasses.cpp
+++ b/llvm/lib/IR/PrintPasses.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Program.h"
 #include <unordered_set>
@@ -215,6 +216,8 @@ std::error_code llvm::cleanUpTempFiles(ArrayRef<std::string> FileName) {
 std::string llvm::doSystemDiff(StringRef Before, StringRef After,
                                StringRef OldLineFormat, StringRef NewLineFormat,
                                StringRef UnchangedLineFormat) {
+  [[maybe_unused]] auto BypassSandbox = sys::sandbox::scopedDisable();
+
   // Store the 2 bodies into temporary files and call diff on them
   // to get the body of the node.
   static SmallVector<int> FD{-1, -1, -1};


### PR DESCRIPTION
Fix `fatal error: error in backend: IO sandbox violation` when executing `clang -cc1 -print-after-all -print-changed=diff`.

doSystemDiff does temporary file I/O and executes external diff program. This conflicts with IO sandbox.