### PR TITLE
[clang-tidy] Fix crash in misc-static-initialization-cycle

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/StaticInitializationCycleCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/StaticInitializationCycleCheck.cpp
@@ -193,7 +193,7 @@ public:
   }
   bool TraverseAttr(Attr *At) override { return true; }
   bool TraverseDecl(Decl *D) override {
-    if (DC && DC->containsDecl(D))
+    if (D && DC && DC->containsDecl(D))
       return DynamicRecursiveASTVisitor::TraverseDecl(D);
     return true;
   }

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/static-initialization-cycle.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/static-initialization-cycle.cpp
@@ -120,6 +120,14 @@ int f1() {
 int S::A = f1();
 }
 
+namespace catch_all_handler {
+void f() {
+  try {
+  } catch (...) {
+  }
+}
+}
+
 namespace recursive_calls {
 int f2();
 int f1() {

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/static-initialization-cycle.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/static-initialization-cycle.cpp
@@ -126,7 +126,7 @@ void f() {
   } catch (...) {
   }
 }
-}
+} // catch_all_handler
 
 namespace recursive_calls {
 int f2();


### PR DESCRIPTION
This commit fixes `misc-static-initialization-cycle` crashing on `catch (...)`.

Catch-all handlers have no exception declaration, so traversal of `CXXCatchStmt` can call `TraverseDecl(nullptr)`. The check previously passed that null pointer to `DeclContext::containsDecl`. This commit fixes the problem by adding a null guard.

Closes #198150