### PR TITLE
[libc++] Use __in_out_result in the remaining appropriate algorithms

### DIFF
--- a/libcxx/include/__algorithm/copy_if.h
+++ b/libcxx/include/__algorithm/copy_if.h
@@ -9,6 +9,7 @@
 #ifndef _LIBCPP___ALGORITHM_COPY_IF_H
 #define _LIBCPP___ALGORITHM_COPY_IF_H
 
+#include <__algorithm/in_out_result.h>
 #include <__config>
 #include <__functional/identity.h>
 #include <__type_traits/invoke.h>
@@ -25,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _InIter, class _Sent, class _OutIter, class _Proj, class _Pred>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 pair<_InIter, _OutIter>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __in_out_result<_InIter, _OutIter>
 __copy_if(_InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, _Proj& __proj) {
   for (; __first != __last; ++__first) {
     if (std::__invoke(__pred, std::__invoke(__proj, *__first))) {
@@ -33,14 +34,14 @@ __copy_if(_InIter __first, _Sent __last, _OutIter __result, _Pred& __pred, _Proj
       ++__result;
     }
   }
-  return std::make_pair(std::move(__first), std::move(__result));
+  return {std::move(__first), std::move(__result)};
 }
 
 template <class _InputIterator, class _OutputIterator, class _Predicate>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _OutputIterator
 copy_if(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _Predicate __pred) {
   __identity __proj;
-  return std::__copy_if(__first, __last, __result, __pred, __proj).second;
+  return std::__copy_if(__first, __last, __result, __pred, __proj).__out_;
 }
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__algorithm/partial_sort_copy.h
+++ b/libcxx/include/__algorithm/partial_sort_copy.h
@@ -11,6 +11,7 @@
 
 #include <__algorithm/comp.h>
 #include <__algorithm/comp_ref_type.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/iterator_operations.h>
 #include <__algorithm/make_heap.h>
 #include <__algorithm/make_projected.h>
@@ -41,7 +42,8 @@ template <class _AlgPolicy,
           class _Sentinel2,
           class _Proj1,
           class _Proj2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator, _RandomAccessIterator> __partial_sort_copy(
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __in_out_result<_InputIterator, _RandomAccessIterator>
+__partial_sort_copy(
     _InputIterator __first,
     _Sentinel1 __last,
     _RandomAccessIterator __result_first,
@@ -65,8 +67,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 pair<_InputIterator, _Random
     std::__sort_heap<_AlgPolicy>(__result_first, __r, __projected_comp);
   }
 
-  return pair<_InputIterator, _RandomAccessIterator>(
-      _IterOps<_AlgPolicy>::next(std::move(__first), std::move(__last)), std::move(__r));
+  return {_IterOps<_AlgPolicy>::next(std::move(__first), std::move(__last)), std::move(__r)};
 }
 
 template <class _InputIterator, class _RandomAccessIterator, class _Compare>
@@ -87,7 +88,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _RandomAccessIterator
       static_cast<__comp_ref_type<_Compare> >(__comp),
       __identity(),
       __identity());
-  return __result.second;
+  return __result.__out_;
 }
 
 template <class _InputIterator, class _RandomAccessIterator>

--- a/libcxx/include/__algorithm/ranges_copy_if.h
+++ b/libcxx/include/__algorithm/ranges_copy_if.h
@@ -46,8 +46,7 @@ struct __copy_if {
     requires indirectly_copyable<_Iter, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_if_result<_Iter, _OutIter>
   operator()(_Iter __first, _Sent __last, _OutIter __result, _Pred __pred, _Proj __proj = {}) const {
-    auto __res = std::__copy_if(std::move(__first), std::move(__last), std::move(__result), __pred, __proj);
-    return {std::move(__res.first), std::move(__res.second)};
+    return std::__copy_if(std::move(__first), std::move(__last), std::move(__result), __pred, __proj);
   }
 
   template <input_range _Range,
@@ -57,8 +56,7 @@ struct __copy_if {
     requires indirectly_copyable<iterator_t<_Range>, _OutIter>
   _LIBCPP_HIDE_FROM_ABI constexpr copy_if_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __r, _OutIter __result, _Pred __pred, _Proj __proj = {}) const {
-    auto __res = std::__copy_if(ranges::begin(__r), ranges::end(__r), std::move(__result), __pred, __proj);
-    return {std::move(__res.first), std::move(__res.second)};
+    return std::__copy_if(ranges::begin(__r), ranges::end(__r), std::move(__result), __pred, __proj);
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_partial_sort_copy.h
+++ b/libcxx/include/__algorithm/ranges_partial_sort_copy.h
@@ -60,7 +60,7 @@ struct __partial_sort_copy {
       _Comp __comp   = {},
       _Proj1 __proj1 = {},
       _Proj2 __proj2 = {}) const {
-    auto __result = std::__partial_sort_copy<_RangeAlgPolicy>(
+    return std::__partial_sort_copy<_RangeAlgPolicy>(
         std::move(__first),
         std::move(__last),
         std::move(__result_first),
@@ -68,7 +68,6 @@ struct __partial_sort_copy {
         __comp,
         __proj1,
         __proj2);
-    return {std::move(__result.first), std::move(__result.second)};
   }
 
   template <input_range _Range1,
@@ -84,7 +83,7 @@ struct __partial_sort_copy {
   _LIBCPP_HIDE_FROM_ABI constexpr partial_sort_copy_result<borrowed_iterator_t<_Range1>, borrowed_iterator_t<_Range2>>
   operator()(
       _Range1&& __range, _Range2&& __result_range, _Comp __comp = {}, _Proj1 __proj1 = {}, _Proj2 __proj2 = {}) const {
-    auto __result = std::__partial_sort_copy<_RangeAlgPolicy>(
+    return std::__partial_sort_copy<_RangeAlgPolicy>(
         ranges::begin(__range),
         ranges::end(__range),
         ranges::begin(__result_range),
@@ -92,7 +91,6 @@ struct __partial_sort_copy {
         __comp,
         __proj1,
         __proj2);
-    return {std::move(__result.first), std::move(__result.second)};
   }
 };
 

--- a/libcxx/include/__algorithm/ranges_unique_copy.h
+++ b/libcxx/include/__algorithm/ranges_unique_copy.h
@@ -26,7 +26,6 @@
 #include <__ranges/dangling.h>
 #include <__utility/forward.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -73,13 +72,12 @@ struct __unique_copy {
               indirectly_copyable_storable<_InIter, _OutIter>)
   _LIBCPP_HIDE_FROM_ABI constexpr unique_copy_result<_InIter, _OutIter>
   operator()(_InIter __first, _Sent __last, _OutIter __result, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __ret = std::__unique_copy<_RangeAlgPolicy>(
+    return std::__unique_copy<_RangeAlgPolicy>(
         std::move(__first),
         std::move(__last),
         std::move(__result),
         std::__make_projected(__comp, __proj),
         __algo_tag_t<_InIter, _OutIter>());
-    return {std::move(__ret.first), std::move(__ret.second)};
   }
 
   template <input_range _Range,
@@ -92,13 +90,12 @@ struct __unique_copy {
               indirectly_copyable_storable<iterator_t<_Range>, _OutIter>)
   _LIBCPP_HIDE_FROM_ABI constexpr unique_copy_result<borrowed_iterator_t<_Range>, _OutIter>
   operator()(_Range&& __range, _OutIter __result, _Comp __comp = {}, _Proj __proj = {}) const {
-    auto __ret = std::__unique_copy<_RangeAlgPolicy>(
+    return std::__unique_copy<_RangeAlgPolicy>(
         ranges::begin(__range),
         ranges::end(__range),
         std::move(__result),
         std::__make_projected(__comp, __proj),
         __algo_tag_t<iterator_t<_Range>, _OutIter>());
-    return {std::move(__ret.first), std::move(__ret.second)};
   }
 };
 

--- a/libcxx/include/__algorithm/unique_copy.h
+++ b/libcxx/include/__algorithm/unique_copy.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___ALGORITHM_UNIQUE_COPY_H
 
 #include <__algorithm/comp.h>
+#include <__algorithm/in_out_result.h>
 #include <__algorithm/iterator_operations.h>
 #include <__config>
 #include <__iterator/iterator_traits.h>
@@ -17,7 +18,6 @@
 #include <__type_traits/is_base_of.h>
 #include <__type_traits/is_same.h>
 #include <__utility/move.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -37,7 +37,7 @@ struct __read_from_tmp_value_tag {};
 } // namespace __unique_copy_tags
 
 template <class _AlgPolicy, class _BinaryPredicate, class _InputIterator, class _Sent, class _OutputIterator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _OutputIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _OutputIterator>
 __unique_copy(_InputIterator __first,
               _Sent __last,
               _OutputIterator __result,
@@ -55,11 +55,11 @@ __unique_copy(_InputIterator __first,
       }
     }
   }
-  return pair<_InputIterator, _OutputIterator>(std::move(__first), std::move(__result));
+  return {std::move(__first), std::move(__result)};
 }
 
 template <class _AlgPolicy, class _BinaryPredicate, class _ForwardIterator, class _Sent, class _OutputIterator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI pair<_ForwardIterator, _OutputIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __in_out_result<_ForwardIterator, _OutputIterator>
 __unique_copy(_ForwardIterator __first,
               _Sent __last,
               _OutputIterator __result,
@@ -77,11 +77,11 @@ __unique_copy(_ForwardIterator __first,
       }
     }
   }
-  return pair<_ForwardIterator, _OutputIterator>(std::move(__first), std::move(__result));
+  return {std::move(__first), std::move(__result)};
 }
 
 template <class _AlgPolicy, class _BinaryPredicate, class _InputIterator, class _Sent, class _InputAndOutputIterator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _InputAndOutputIterator>
+_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _InputAndOutputIterator>
 __unique_copy(_InputIterator __first,
               _Sent __last,
               _InputAndOutputIterator __result,
@@ -94,7 +94,7 @@ __unique_copy(_InputIterator __first,
         *++__result = *__first;
     ++__result;
   }
-  return pair<_InputIterator, _InputAndOutputIterator>(std::move(__first), std::move(__result));
+  return {std::move(__first), std::move(__result)};
 }
 
 template <class _InputIterator, class _OutputIterator, class _BinaryPredicate>
@@ -111,7 +111,7 @@ unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __res
           __unique_copy_tags::__read_from_tmp_value_tag> >;
   return std::__unique_copy<_ClassicAlgPolicy>(
              std::move(__first), std::move(__last), std::move(__result), __pred, __algo_tag())
-      .second;
+      .__out_;
 }
 
 template <class _InputIterator, class _OutputIterator>

--- a/libcxx/include/__memory/ranges_uninitialized_algorithms.h
+++ b/libcxx/include/__memory/ranges_uninitialized_algorithms.h
@@ -166,9 +166,8 @@ struct __uninitialized_copy {
     using _ValueType = remove_reference_t<iter_reference_t<_OutputIterator>>;
 
     auto __stop_copying = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
-    auto __result       = std::__uninitialized_copy<_ValueType>(
+    return std::__uninitialized_copy<_ValueType>(
         std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __stop_copying);
-    return {std::move(__result.first), std::move(__result.second)};
   }
 
   template <input_range _InputRange, __nothrow_forward_range _OutputRange>
@@ -201,9 +200,7 @@ struct __uninitialized_copy_n {
              _Sentinel __olast) const {
     using _ValueType    = remove_reference_t<iter_reference_t<_OutputIterator>>;
     auto __stop_copying = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
-    auto __result =
-        std::__uninitialized_copy_n<_ValueType>(std::move(__ifirst), __n, std::move(__ofirst), __stop_copying);
-    return {std::move(__result.first), std::move(__result.second)};
+    return std::__uninitialized_copy_n<_ValueType>(std::move(__ifirst), __n, std::move(__ofirst), __stop_copying);
   }
 };
 
@@ -227,9 +224,8 @@ struct __uninitialized_move {
     using _ValueType   = remove_reference_t<iter_reference_t<_OutputIterator>>;
     auto __iter_move   = [](auto&& __iter) -> decltype(auto) { return ranges::iter_move(__iter); };
     auto __stop_moving = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
-    auto __result      = std::__uninitialized_move<_ValueType>(
+    return std::__uninitialized_move<_ValueType>(
         std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __stop_moving, __iter_move);
-    return {std::move(__result.first), std::move(__result.second)};
   }
 
   template <input_range _InputRange, __nothrow_forward_range _OutputRange>
@@ -263,9 +259,8 @@ struct __uninitialized_move_n {
     using _ValueType   = remove_reference_t<iter_reference_t<_OutputIterator>>;
     auto __iter_move   = [](auto&& __iter) -> decltype(auto) { return ranges::iter_move(__iter); };
     auto __stop_moving = [&__olast](auto&& __out_iter) -> bool { return __out_iter == __olast; };
-    auto __result      = std::__uninitialized_move_n<_ValueType>(
+    return std::__uninitialized_move_n<_ValueType>(
         std::move(__ifirst), __n, std::move(__ofirst), __stop_moving, __iter_move);
-    return {std::move(__result.first), std::move(__result.second)};
   }
 };
 

--- a/libcxx/include/__memory/uninitialized_algorithms.h
+++ b/libcxx/include/__memory/uninitialized_algorithms.h
@@ -57,7 +57,7 @@ struct __always_false {
 // uninitialized_copy
 
 template <class _ValueType, class _InputIterator, class _Sentinel1, class _ForwardIterator, class _EndPredicate>
-inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitialized_copy(
+inline _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _ForwardIterator> __uninitialized_copy(
     _InputIterator __ifirst, _Sentinel1 __ilast, _ForwardIterator __ofirst, _EndPredicate __stop_copying) {
   _ForwardIterator __idx = __ofirst;
   auto __guard           = std::__make_exception_guard([&] { std::__destroy(__ofirst, __idx); });
@@ -65,7 +65,7 @@ inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitiali
     ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(*__ifirst);
   __guard.__complete();
 
-  return pair<_InputIterator, _ForwardIterator>(std::move(__ifirst), std::move(__idx));
+  return {std::move(__ifirst), std::move(__idx)};
 }
 
 template <class _InputIterator, class _ForwardIterator>
@@ -74,13 +74,13 @@ uninitialized_copy(_InputIterator __ifirst, _InputIterator __ilast, _ForwardIter
   typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
   auto __result = std::__uninitialized_copy<_ValueType>(
       std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __always_false());
-  return std::move(__result.second);
+  return std::move(__result.__out_);
 }
 
 // uninitialized_copy_n
 
 template <class _ValueType, class _InputIterator, class _Size, class _ForwardIterator, class _EndPredicate>
-inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator>
+inline _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _ForwardIterator>
 __uninitialized_copy_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofirst, _EndPredicate __stop_copying) {
   _ForwardIterator __idx = __ofirst;
   auto __guard           = std::__make_exception_guard([&] { std::__destroy(__ofirst, __idx); });
@@ -88,7 +88,7 @@ __uninitialized_copy_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __of
     ::new (static_cast<void*>(std::addressof(*__idx))) _ValueType(*__ifirst);
   __guard.__complete();
 
-  return pair<_InputIterator, _ForwardIterator>(std::move(__ifirst), std::move(__idx));
+  return {std::move(__ifirst), std::move(__idx)};
 }
 
 template <class _InputIterator, class _Size, class _ForwardIterator>
@@ -97,7 +97,7 @@ uninitialized_copy_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofir
   typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
   auto __result =
       std::__uninitialized_copy_n<_ValueType>(std::move(__ifirst), __n, std::move(__ofirst), __always_false());
-  return std::move(__result.second);
+  return std::move(__result.__out_);
 }
 
 // uninitialized_fill
@@ -230,7 +230,7 @@ template <class _ValueType,
           class _ForwardIterator,
           class _EndPredicate,
           class _IterMove>
-inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitialized_move(
+inline _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _ForwardIterator> __uninitialized_move(
     _InputIterator __ifirst,
     _Sentinel1 __ilast,
     _ForwardIterator __ofirst,
@@ -254,7 +254,7 @@ uninitialized_move(_InputIterator __ifirst, _InputIterator __ilast, _ForwardIter
 
   auto __result = std::__uninitialized_move<_ValueType>(
       std::move(__ifirst), std::move(__ilast), std::move(__ofirst), __always_false(), __iter_move);
-  return std::move(__result.second);
+  return std::move(__result.__out_);
 }
 
 // uninitialized_move_n
@@ -265,7 +265,7 @@ template <class _ValueType,
           class _ForwardIterator,
           class _EndPredicate,
           class _IterMove>
-inline _LIBCPP_HIDE_FROM_ABI pair<_InputIterator, _ForwardIterator> __uninitialized_move_n(
+inline _LIBCPP_HIDE_FROM_ABI __in_out_result<_InputIterator, _ForwardIterator> __uninitialized_move_n(
     _InputIterator __ifirst, _Size __n, _ForwardIterator __ofirst, _EndPredicate __stop_moving, _IterMove __iter_move) {
   auto __idx   = __ofirst;
   auto __guard = std::__make_exception_guard([&] { std::__destroy(__ofirst, __idx); });
@@ -282,8 +282,9 @@ uninitialized_move_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofir
   using _ValueType = typename iterator_traits<_ForwardIterator>::value_type;
   auto __iter_move = [](auto&& __iter) -> decltype(auto) { return std::move(*__iter); };
 
-  return std::__uninitialized_move_n<_ValueType>(
+  auto __result = std::__uninitialized_move_n<_ValueType>(
       std::move(__ifirst), __n, std::move(__ofirst), __always_false(), __iter_move);
+  return {std::move(__result.__in_), std::move(__result.__out_)};
 }
 
 // TODO: Rewrite this to iterate left to right and use reverse_iterators when calling


### PR DESCRIPTION
We've already switched some algorithms to use `__in_out_result` instead of `pair` as the return type. This updates the remaining appropriate algorithms.
