### PR TITLE
[sanitizer_common] Fix sanitizer_platform_limits_solaris.cpp compilation

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_solaris.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_solaris.cpp
@@ -51,6 +51,7 @@
 #include <sys/timeb.h>
 #include <sys/times.h>
 #include <sys/types.h>
+#include <sys/ucontext.h>
 #include <sys/utsname.h>
 #include <termios.h>
 #include <time.h>


### PR DESCRIPTION
When switching `clang++` to the default Solaris 11.4 compilation environment, XPG7 + extensions, `sanitizer_platform_limits_solaris.cpp` fails to compile:

```
compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_solaris.cpp:93:53: error: use of undeclared identifier 'ucontext_t'; did you mean 'ucontext_t_sz'?
   93 |   unsigned ucontext_t_sz(void *ctx) { return sizeof(ucontext_t); }
      |                                                     ^~~~~~~~~~
      |                                                     ucontext_t_sz
compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_solaris.cpp:93:12: note: 'ucontext_t_sz' declared here
   93 |   unsigned ucontext_t_sz(void *ctx) { return sizeof(ucontext_t); }
      |            ^
compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_solaris.cpp:93:52: error: invalid application of 'sizeof' to a function type
   93 |   unsigned ucontext_t_sz(void *ctx) { return sizeof(ucontext_t); }
      |                                                    ^~~~~~~~~~~~

```

Previously, `<sys/signal.h>` would include `<sys/ucontext.h>` due to a XPG4v2 requirement.  Now the latter needs to be included directly.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`.