### PR TITLE
[CI] Fix GH PR Greeter

### DIFF
--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -47,12 +47,16 @@ jobs:
 
       - name: Greet Author
         working-directory: ./llvm/utils/git/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           python3 ./github-automation.py \
-            --token '${{ secrets.GITHUB_TOKEN }}' \
+            --token "$GH_TOKEN" \
             pr-greeter \
-            --issue-number "${{ github.event.pull_request.number }}" \
-            --author "${{ github.event.pull_request.user.login }}"
+            --issue-number "$ISSUE_NUMBER" \
+            --author "$PR_AUTHOR"
 
   automate-prs-labels:
     # Greet first so that only the author gets that notification.

--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -51,7 +51,8 @@ jobs:
           python3 ./github-automation.py \
             --token '${{ secrets.GITHUB_TOKEN }}' \
             pr-greeter \
-            --issue-number "${{ github.event.pull_request.number }}"
+            --issue-number "${{ github.event.pull_request.number }}" \
+            --author "${{ github.event.pull_request.user.login }}"
 
   automate-prs-labels:
     # Greet first so that only the author gets that notification.

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -891,6 +891,7 @@ pr_subscriber_parser.add_argument("--issue-number", type=int, required=True)
 
 pr_greeter_parser = subparsers.add_parser("pr-greeter")
 pr_greeter_parser.add_argument("--issue-number", type=int, required=True)
+pr_greeter_parser.add_argument("--author", type=str, required=True)
 
 commit_request_greeter = subparsers.add_parser("commit-request-greeter")
 commit_request_greeter.add_argument("--issue-number", type=int, required=True)


### PR DESCRIPTION
Add missing argument in the PR Greeter invocation. Follow-up for #197140. Issue reported here: https://discourse.llvm.org/t/ci-failure-prgreeter-on-my-first-pr


Also, as per https://docs.github.com/en/actions/concepts/security/script-injections + https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable, make sure that that greeter relies on ENV variables for input arguments.