### PR TITLE
[sanitizer][test] Fix coverage-module-unloaded.cpp etc. on Solaris

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/coverage-module-unloaded.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage-module-unloaded.cpp
@@ -1,8 +1,8 @@
 // Check that unloading a module doesn't break coverage dumping for remaining
 // modules.
 // RUN: mkdir -p %t.dir && cd %t.dir
-// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib1 -fPIC
-// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib2 -fPIC
+// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED_LIB %s -shared -o %dynamiclib1 -fPIC
+// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED_LIB %s -shared -o %dynamiclib2 -fPIC
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %libdl -o %t.dir/exe
 // RUN: mkdir -p %t.tmp/coverage-module-unloaded && cd %t.tmp/coverage-module-unloaded
 // RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t.dir/exe %dynamiclib1 %dynamiclib2 2>&1        | FileCheck %s
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#ifdef SHARED
+#ifdef SHARED_LIB
 extern "C" {
 void bar() { printf("bar\n"); }
 }

--- a/compiler-rt/test/sanitizer_common/TestCases/get_module_and_offset_for_pc.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/get_module_and_offset_for_pc.cpp
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t-dir
-// RUN: %clangxx -DSHARED %s -shared -o %t-dir/get_module_and_offset_for_pc.so -fPIC
+// RUN: %clangxx -DSHARED_LIB %s -shared -o %t-dir/get_module_and_offset_for_pc.so -fPIC
 // RUN: %clangxx -DSO_DIR=\"%t-dir\" -O0 %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s
 
@@ -13,7 +13,7 @@
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
 
-#ifdef SHARED
+#ifdef SHARED_LIB
 extern "C" {
 int foo() { return 1; }
 }


### PR DESCRIPTION
When switching `clang++` to the default Solaris 11.4 compilation environment, XPG7 + extensions, two tests `FAIL`:

```
  AddressSanitizer-i386-sunos :: TestCases/Posix/coverage-module-unloaded.cpp
  AddressSanitizer-i386-sunos-dynamic :: TestCases/Posix/coverage-module-unloaded.cpp

  SanitizerCommon-asan-i386-SunOS :: get_module_and_offset_for_pc.cpp
  SanitizerCommon-ubsan-i386-SunOS :: get_module_and_offset_for_pc.cpp
  SanitizerCommon-ubsan-x86_64-SunOS :: get_module_and_offset_for_pc.cpp
```

The failure mode is the same in both cases: the tests fail to link with `main` undefined.  This happens because `<sys/mman.h>` defines

```
#define	SHARED		0x10
```

for the benefit of the Solaris-specific `memcntl(2)`.  This was previously hidden since `clang++` defined `_XOPEN_SOURCE=600`.  This interferes with the use of `SHARED` in the tests.

While I'm the first to admit that such a generic identifier is highly unfortunate, this is also true for the tests.  The interface goes all the way back to Solaris 1.0/SunOS 4, thus isn't going to change.

This patch fixes this by following the lead of other tests that use `SHARED_LIB` instead of `SHARED` for this purpose.

Tested on `amd64-pc-solaris2.11` and `sparcv9-sun-solaris2.11`. 