### PR TITLE
[Clang][Sema] Store constraints-not-satisfied deduction info as ASTConstraintSatisfaction

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15075,6 +15075,9 @@ public:
   void DiagnoseUnsatisfiedConstraint(const ConstraintSatisfaction &Satisfaction,
                                      SourceLocation Loc = {},
                                      bool First = true);
+  void
+  DiagnoseUnsatisfiedConstraint(const ASTConstraintSatisfaction &Satisfaction,
+                                SourceLocation Loc = {}, bool First = true);
 
   /// \brief Emit diagnostics explaining why a constraint expression was deemed
   /// unsatisfied.

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -2007,16 +2007,18 @@ void Sema::DiagnoseUnsatisfiedConstraint(
 }
 
 void Sema::DiagnoseUnsatisfiedConstraint(
-    const ConceptSpecializationExpr *ConstraintExpr, bool First) {
-
-  const ASTConstraintSatisfaction &Satisfaction =
-      ConstraintExpr->getSatisfaction();
+    const ASTConstraintSatisfaction &Satisfaction, SourceLocation Loc,
+    bool First) {
 
   assert(!Satisfaction.IsSatisfied &&
          "Attempted to diagnose a satisfied constraint");
+  ::DiagnoseUnsatisfiedConstraint(*this, Satisfaction.records(), Loc, First);
+}
 
-  ::DiagnoseUnsatisfiedConstraint(*this, Satisfaction.records(),
-                                  ConstraintExpr->getBeginLoc(), First);
+void Sema::DiagnoseUnsatisfiedConstraint(
+    const ConceptSpecializationExpr *ConstraintExpr, bool First) {
+  DiagnoseUnsatisfiedConstraint(ConstraintExpr->getSatisfaction(),
+                                ConstraintExpr->getBeginLoc(), First);
 }
 
 namespace {

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -874,8 +874,6 @@ void DeductionFailureInfo::Destroy() {
 
   case TemplateDeductionResult::ConstraintsNotSatisfied:
     // FIXME: Destroy the template argument list?
-    // CNSInfo and ASTConstraintSatisfaction are ASTContext-allocated and do
-    // not own non-arena resources.
     Data = nullptr;
     if (PartialDiagnosticAt *Diag = getSFINAEDiagnostic()) {
       Diag->~PartialDiagnosticAt();

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CheckExprLifetime.h"
+#include "clang/AST/ASTConcept.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
@@ -741,7 +742,7 @@ namespace {
   // unsatisfied constraints.
   struct CNSInfo {
     TemplateArgumentList *TemplateArgs;
-    ConstraintSatisfaction Satisfaction;
+    const ASTConstraintSatisfaction *Satisfaction;
   };
 }
 
@@ -822,9 +823,10 @@ clang::MakeDeductionFailureInfo(ASTContext &Context,
     break;
 
   case TemplateDeductionResult::ConstraintsNotSatisfied: {
-    CNSInfo *Saved = new (Context) CNSInfo;
-    Saved->TemplateArgs = Info.takeSugared();
-    Saved->Satisfaction = std::move(Info.AssociatedConstraintsSatisfaction);
+    auto *Saved = new (Context)
+        CNSInfo{Info.takeSugared(),
+                ASTConstraintSatisfaction::Create(
+                    Context, Info.AssociatedConstraintsSatisfaction)};
     Result.Data = Saved;
     break;
   }
@@ -872,7 +874,8 @@ void DeductionFailureInfo::Destroy() {
 
   case TemplateDeductionResult::ConstraintsNotSatisfied:
     // FIXME: Destroy the template argument list?
-    static_cast<CNSInfo *>(Data)->Satisfaction.~ConstraintSatisfaction();
+    // CNSInfo and ASTConstraintSatisfaction are ASTContext-allocated and do
+    // not own non-arena resources.
     Data = nullptr;
     if (PartialDiagnosticAt *Diag = getSFINAEDiagnostic()) {
       Diag->~PartialDiagnosticAt();
@@ -11386,7 +11389,7 @@ bool OverloadCandidate::NotValidBecauseConstraintExprHasError() const {
          static_cast<TemplateDeductionResult>(DeductionFailure.Result) ==
              TemplateDeductionResult::ConstraintsNotSatisfied &&
          static_cast<CNSInfo *>(DeductionFailure.Data)
-             ->Satisfaction.ContainsErrors;
+             ->Satisfaction->ContainsErrors;
 }
 
 void OverloadCandidateSet::AddDeferredTemplateCandidate(
@@ -12523,7 +12526,7 @@ static void DiagnoseBadDeduction(Sema &S, NamedDecl *Found, Decl *Templated,
         << TemplateArgString;
 
     S.DiagnoseUnsatisfiedConstraint(
-        static_cast<CNSInfo*>(DeductionFailure.Data)->Satisfaction);
+        *static_cast<CNSInfo *>(DeductionFailure.Data)->Satisfaction);
     return;
   }
   case TemplateDeductionResult::TooManyArguments:


### PR DESCRIPTION
When I checked #143129, I found that the issue had been fixed. My manual experiment revealed that` static_cast<CNSInfo *>(Data)->Satisfaction.~ConstraintSatisfaction();` fixed the problem. Removing this line of code reproduced the ASan/LSan leak report. But the explicit destructor call here feels too much like manual memory management: it works, but it is easy to miss and makes the lifetime model more fragile. That is why I proposed this alternative solution in this PR.

Using ASTConstraintSatisfaction might cause an increase in RSS because ASTContext arena storage is released when the ASTContext is destroyed. To check for this potential memory increase, I constructed some highly specific synthetic tests, but further testing using llvm-test-suite showed that max-rss did not increase or decrease significantly. This indicates that my previous synthetic tests were too narrow and not general enough. I also added test data from llvm-test-suite.

### Memory Impact

I removed the synthetic stress-case numbers and kept only llvm-test-suite CTMark results.

I ran CTMark with fresh build directories, -j1, and TEST_SUITE_REPORT_COMPILE_MAX_RSS=ON. Each configuration was run 5 times.


| Config | Metric | Mean | Median | Min | Max |
|---|---:|---:|---:|---:|---:|
| O0-g | compile_time | -1.667% | -1.708% | -3.918% | +1.809% |
| O0-g | compile_maxrss | -0.016% | -0.066% | -0.211% | +0.234% |
| O0-g | link_maxrss | -0.024% | -0.069% | -0.256% | +0.299% |
| O0-g | size | -0.001% | -0.001% | -0.001% | -0.001% |
| O3 | compile_time | -0.551% | -1.365% | -10.463% | +10.017% |
| O3 | compile_maxrss | +0.065% | -0.006% | -0.355% | +0.534% |
| O3 | link_time | +2.076% | +1.157% | -19.125% | +26.917% |
| O3 | link_maxrss | +0.040% | -0.032% | -0.383% | +0.607% |
| O3 | size | +0.000% | +0.000% | +0.000% | +0.000% |

The baseline compiler was built from commit `bae540bde882aa1911ccffb0fe7691cb16831017`, and the patched compiler was built from the same commit plus this PR.

## AI Usage Report:

Assisted-by: ChatGPT 5.5

1. Used ChatGPT 5.5 to assist with translating my Chinese draft into English.


2. Used ChatGPT 5.5 to help locate and update source locations affected by changing

```cpp
ConstraintSatisfaction Satisfaction;
```
to
```cpp
const ASTConstraintSatisfaction *Satisfaction;
```
including places that needed to be changed to use Satisfaction as a pointer.

3. Used ChatGPT 5.5 to draft scripts to generate synthetic stress test cases.

I carefully reviewed and edited the AI-assisted text to the best of my ability before posting, and I am responsible for the final contents of this PR.

[archived_synthetic_stress_results.txt](https://github.com/user-attachments/files/27947894/archived_synthetic_stress_results_unreliable.txt)
[archived_synthetic_stress_reproducer.py](https://github.com/user-attachments/files/27947893/archived_synthetic_stress_reproducer.py)
[llvm-test-suite-result.txt](https://github.com/user-attachments/files/27947895/llvm-test-suite.txt)
[llvm-test-suite-result-summary.txt](https://github.com/user-attachments/files/27953366/llvm-test-suite-result-summary.txt)

