### PR TITLE
Add __builtin_bswap128

### DIFF
--- a/clang/include/clang/Basic/Builtins.h
+++ b/clang/include/clang/Basic/Builtins.h
@@ -466,6 +466,11 @@ public:
     return strchr(getAttributesString(ID), 'G') != nullptr;
   }
 
+  /// Returns true if this builtin requires target support for __int128.
+  bool requiresInt128Type(unsigned ID) const {
+    return strchr(getAttributesString(ID), 'H') != nullptr;
+  }
+
 private:
   std::pair<const InfosShard &, const Info &>
   getShardAndInfo(unsigned ID) const;

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -760,6 +760,12 @@ def BSwap : Builtin, Template<["unsigned short", "uint32_t", "uint64_t"],
   let Prototype = "T(T)";
 }
 
+def BSwap128 : Builtin {
+  let Spellings = ["__builtin_bswap128"];
+  let Attributes = [NoThrow, Const, Constexpr, RequireInt128];
+  let Prototype = "__uint128_t(__uint128_t)";
+}
+
 def BSwapg : Builtin {
   let Spellings = ["__builtin_bswapg"];
   let Attributes = [NoThrow, Const, Constexpr, CustomTypeChecking];

--- a/clang/include/clang/Basic/BuiltinsBase.td
+++ b/clang/include/clang/Basic/BuiltinsBase.td
@@ -95,6 +95,8 @@ class VScanfFormat<int I> : IndexedAttribute<"S", I>;
 def Constexpr : Attribute<"E">;
 // Builtin is immediate and must be constant evaluated. Implies Constexpr, and will only be supported in C++20 mode.
 def Consteval : Attribute<"EG">;
+// Builtin requires the target to support __int128.
+def RequireInt128 : Attribute<"H">;
 
 // Callback behavior: the first index argument is called with the arguments
 // indicated by the remaining indices.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12916,6 +12916,11 @@ QualType ASTContext::GetBuiltinType(unsigned Id,
     return {};
   }
 
+  if (BuiltinInfo.requiresInt128Type(Id) && !getTargetInfo().hasInt128Type()) {
+    Error = GE_Missing_type;
+    return {};
+  }
+
   SmallVector<QualType, 8> ArgTypes;
 
   bool RequiresICE = false;

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -4953,6 +4953,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const CallExpr *Call,
   case Builtin::BI__builtin_bswap16:
   case Builtin::BI__builtin_bswap32:
   case Builtin::BI__builtin_bswap64:
+  case Builtin::BI__builtin_bswap128:
     return interp__builtin_bswap(S, OpPC, Frame, Call);
 
   case Builtin::BI__atomic_always_lock_free:

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -16519,7 +16519,8 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
   case Builtin::BI__builtin_bswapg:
   case Builtin::BI__builtin_bswap16:
   case Builtin::BI__builtin_bswap32:
-  case Builtin::BI__builtin_bswap64: {
+  case Builtin::BI__builtin_bswap64:
+  case Builtin::BI__builtin_bswap128: {
     APSInt Val;
     if (!EvaluateInteger(E->getArg(0), Val, Info))
       return false;

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -1251,6 +1251,7 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_bswap16:
   case Builtin::BI__builtin_bswap32:
   case Builtin::BI__builtin_bswap64:
+  case Builtin::BI__builtin_bswap128:
   case Builtin::BI_byteswap_ushort:
   case Builtin::BI_byteswap_ulong:
   case Builtin::BI_byteswap_uint64: {

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3713,6 +3713,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_bswap16:
   case Builtin::BI__builtin_bswap32:
   case Builtin::BI__builtin_bswap64:
+  case Builtin::BI__builtin_bswap128:
   case Builtin::BI_byteswap_ushort:
   case Builtin::BI_byteswap_ulong:
   case Builtin::BI_byteswap_uint64: {

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -875,6 +875,9 @@ namespace bswap {
   int h3 = __builtin_bswap16(0x1234) == 0x3412 ? 1 : f();
   int h4 = __builtin_bswap32(0x1234) == 0x34120000 ? 1 : f();
   int h5 = __builtin_bswap64(0x1234) == 0x3412000000000000 ? 1 : f();
+#ifdef __SIZEOF_INT128__
+  int h5b = __builtin_bswap128(0x1234) == (((__int128)0x3412) << 112) ? 1 : f();
+#endif
   int h6 = __builtin_bswapg(0x12) == 0x12 ? 1 : f();
   int h7 = __builtin_bswapg(0x1234) == 0x3412 ? 1 : f();
   int h8 = __builtin_bswapg(0x00001234) == 0x34120000 ? 1 : f();

--- a/clang/test/CodeGen/builtin-bswap128.c
+++ b/clang/test/CodeGen/builtin-bswap128.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -no-enable-noundef-analysis -emit-llvm -o - %s | FileCheck %s
+
+#ifdef __SIZEOF_INT128__
+__uint128_t test_constexpr(void) {
+  return __builtin_bswap128(0x1234);
+}
+
+// CHECK-LABEL: define{{.*}} i128 @test_constexpr()
+// CHECK: ret i128 69213317124269252288311516068503879680
+
+__uint128_t test_non_const(__uint128_t x) {
+  return __builtin_bswap128(x);
+}
+
+// CHECK-LABEL: define{{.*}} i128 @test_non_const(i128 %x)
+// CHECK: call i128 @llvm.bswap.i128(i128 %{{.*}})
+// CHECK: ret i128
+#endif

--- a/clang/test/CodeGen/builtins.cpp
+++ b/clang/test/CodeGen/builtins.cpp
@@ -20,6 +20,10 @@ extern uint32_t bswap32;
 decltype(__builtin_bswap32(0)) bswap32 = 42;
 extern uint64_t bswap64;
 decltype(__builtin_bswap64(0)) bswap64 = 42;
+#ifdef __SIZEOF_INT128__
+extern __uint128_t bswap128;
+decltype(__builtin_bswap128(0)) bswap128 = 42;
+#endif
 
 #ifdef __clang__
 extern uint8_t bitrev8;

--- a/clang/test/Sema/builtin-bswap128.c
+++ b/clang/test/Sema/builtin-bswap128.c
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -triple i686-linux-gnu -fsyntax-only -verify %s
+
+void test(void) {
+  __builtin_bswap128(1); // expected-error {{use of unknown builtin '__builtin_bswap128'}}
+}

--- a/clang/test/Sema/constant-builtins-2.c
+++ b/clang/test/Sema/constant-builtins-2.c
@@ -479,6 +479,9 @@ int h0 = __builtin_types_compatible_p(int, float);
 int h3 = __builtin_bswap16(0x1234) == 0x3412 ? 1 : f();
 int h4 = __builtin_bswap32(0x1234) == 0x34120000 ? 1 : f();
 int h5 = __builtin_bswap64(0x1234) == 0x3412000000000000 ? 1 : f();
+#ifdef __SIZEOF_INT128__
+int h5b = __builtin_bswap128(0x1234) == (((__int128)0x3412) << 112) ? 1 : f();
+#endif
 int h5a = __builtin_bswapg((_Bool)(0x0)) == (_Bool)(0x0) ? 1 : f();
 int h6 = __builtin_bswapg((char)(0x12)) == (char)(0x12) ? 1 : f();
 int h7 = __builtin_bswapg((short)(0x1234)) == (short)(0x3412) ? 1 : f();

--- a/clang/test/Sema/constant-builtins.c
+++ b/clang/test/Sema/constant-builtins.c
@@ -25,6 +25,9 @@ int h0 = __builtin_types_compatible_p(int,float);
 int h3 = __builtin_bswap16(0x1234) == 0x3412 ? 1 : f();
 int h4 = __builtin_bswap32(0x1234) == 0x34120000 ? 1 : f();
 int h5 = __builtin_bswap64(0x1234) == 0x3412000000000000 ? 1 : f();
+#ifdef __SIZEOF_INT128__
+int h5b = __builtin_bswap128(0x1234) == (((__int128)0x3412) << 112) ? 1 : f();
+#endif
 int h5a = __builtin_bswapg((_Bool)1) == (_Bool)1 ? 1 : f();
 int h6 = __builtin_bswapg((char)0x12) == (char)0x12 ? 1 : f();
 int h7 = __builtin_bswapg((short)(0x1234)) == (short)(0x3412) ? 1 : f();


### PR DESCRIPTION
Add support for __builtin_bswap128. 
Hide the builtin on targets without __int128 support, for that purpose adds a new attribute, which in the future can also be used for __builtin_bitreverse128 which gcc now has too.

Aligns clang with gcc.

Took inspiration from https://reviews.llvm.org/D114425