### PR TITLE
[IR] Drop hash map for ValueHandleBase

### DIFF
--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -52,6 +52,7 @@ class raw_ostream;
 template<typename ValueTy> class StringMapEntry;
 class Twine;
 class User;
+class ValueHandleBase;
 
 using ValueName = StringMapEntry<Value *>;
 
@@ -73,8 +74,7 @@ using ValueName = StringMapEntry<Value *>;
 /// objects that watch it and listen to RAUW and Destroy events.  See
 /// llvm/IR/ValueHandle.h for details.
 class Value {
-  const unsigned char SubclassID;   // Subclass identifier (for isa/dyn_cast)
-  unsigned char HasValueHandle : 1; // Has a ValueHandle pointing to this?
+  const unsigned char SubclassID; // Subclass identifier (for isa/dyn_cast)
 
 protected:
   /// Hold subclass data that can be dropped.
@@ -82,7 +82,7 @@ protected:
   /// This member is similar to SubclassData, however it is for holding
   /// information which may be used to aid optimization, but which may be
   /// cleared to zero without affecting conservative interpretation.
-  unsigned char SubclassOptionalData : 7;
+  unsigned char SubclassOptionalData;
 
 private:
   /// Hold arbitrary subclass data.
@@ -117,9 +117,10 @@ protected:
 private:
   Type *VTy;
   Use *UseList = nullptr;
+  ValueHandleBase *ValueHandle = nullptr;
 
   friend class ValueAsMetadata; // Allow access to IsUsedByMD.
-  friend class ValueHandleBase; // Allow access to HasValueHandle.
+  friend class ValueHandleBase; // Allow access to ValueHandle.
 
   template <typename UseT> // UseT == 'Use' or 'const Use'
   class use_iterator_impl {
@@ -562,7 +563,7 @@ public:
   }
 
   /// Return true if there is a value handle associated with this value.
-  bool hasValueHandle() const { return HasValueHandle; }
+  bool hasValueHandle() const { return ValueHandle != nullptr; }
 
   /// Return true if there is metadata referencing this value.
   bool isUsedByMetadata() const { return IsUsedByMD; }

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -1760,12 +1760,6 @@ public:
   DenseMap<unsigned, PointerType *> PointerTypes;
   DenseMap<std::pair<Type *, unsigned>, TypedPointerType *> ASTypedPointerTypes;
 
-  /// ValueHandles - This map keeps track of all of the value handles that are
-  /// watching a Value*.  The Value::HasValueHandle bit is used to know
-  /// whether or not a value has an entry in this map.
-  using ValueHandlesTy = DenseMap<Value *, ValueHandleBase *>;
-  ValueHandlesTy ValueHandles;
-
   /// CustomMDKindNames - Map to hold the metadata string to ID mapping.
   StringMap<unsigned> CustomMDKindNames;
 

--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -51,9 +51,9 @@ static inline Type *checkType(Type *Ty) {
 }
 
 Value::Value(Type *ty, unsigned scid)
-    : SubclassID(scid), HasValueHandle(0), SubclassOptionalData(0),
-      SubclassData(0), NumUserOperands(0), IsUsedByMD(false), HasName(false),
-      VTy(checkType(ty)) {
+    : SubclassID(scid), SubclassOptionalData(0), SubclassData(0),
+      NumUserOperands(0), IsUsedByMD(false), HasName(false), VTy(checkType(ty)),
+      ValueHandle(nullptr) {
   static_assert(ConstantFirstVal == 0, "!(SubclassID < ConstantFirstVal)");
   // FIXME: Why isn't this in the subclass gunk??
   // Note, we cannot call isa<CallInst> before the CallInst has been
@@ -69,13 +69,13 @@ Value::Value(Type *ty, unsigned scid)
            (/*SubclassID < ConstantFirstVal ||*/ SubclassID > ConstantLastVal))
     assert((VTy->isFirstClassType() || VTy->isVoidTy()) &&
            "Cannot create non-first-class values except for constants!");
-  static_assert(sizeof(Value) == 2 * sizeof(void *) + 2 * sizeof(unsigned),
+  static_assert(sizeof(Value) == 3 * sizeof(void *) + 2 * sizeof(unsigned),
                 "Value too big");
 }
 
 Value::~Value() {
   // Notify all ValueHandles (if present) that this value is going away.
-  if (HasValueHandle)
+  if (ValueHandle)
     ValueHandleBase::ValueIsDeleted(this);
   if (isUsedByMetadata())
     ValueAsMetadata::handleDeletion(this);
@@ -523,7 +523,7 @@ void Value::doRAUW(Value *New, ReplaceMetadataUses ReplaceMetaUses) {
          "replaceAllUses of value with new value of different type!");
 
   // Notify all ValueHandles (if present) that this value is going away.
-  if (HasValueHandle)
+  if (ValueHandle)
     ValueHandleBase::ValueIsRAUWd(this, New);
   if (ReplaceMetaUses == ReplaceMetadataUses::Yes && isUsedByMetadata())
     ValueAsMetadata::handleRAUW(this, New);
@@ -1163,47 +1163,11 @@ void ValueHandleBase::AddToExistingUseListAfter(ValueHandleBase *List) {
 void ValueHandleBase::AddToUseList() {
   assert(getValPtr() && "Null pointer doesn't have a use list!");
 
-  LLVMContextImpl *pImpl = getValPtr()->getContext().pImpl;
-
-  if (getValPtr()->HasValueHandle) {
-    // If this value already has a ValueHandle, then it must be in the
-    // ValueHandles map already.
-    ValueHandleBase *&Entry = pImpl->ValueHandles[getValPtr()];
-    assert(Entry && "Value doesn't have any handles?");
-    AddToExistingUseList(&Entry);
-    return;
-  }
-
-  // Ok, it doesn't have any handles yet, so we must insert it into the
-  // DenseMap.  However, doing this insertion could cause the DenseMap to
-  // reallocate itself, which would invalidate all of the PrevP pointers that
-  // point into the old table.  Handle this by checking for reallocation and
-  // updating the stale pointers only if needed.
-  DenseMap<Value*, ValueHandleBase*> &Handles = pImpl->ValueHandles;
-  const void *OldBucketPtr = Handles.getPointerIntoBucketsArray();
-
-  ValueHandleBase *&Entry = Handles[getValPtr()];
-  assert(!Entry && "Value really did already have handles?");
-  AddToExistingUseList(&Entry);
-  getValPtr()->HasValueHandle = true;
-
-  // If reallocation didn't happen or if this was the first insertion, don't
-  // walk the table.
-  if (Handles.isPointerIntoBucketsArray(OldBucketPtr) ||
-      Handles.size() == 1) {
-    return;
-  }
-
-  // Okay, reallocation did happen.  Fix the Prev Pointers.
-  for (auto I = Handles.begin(), E = Handles.end(); I != E; ++I) {
-    assert(I->second && I->first == I->second->getValPtr() &&
-           "List invariant broken!");
-    I->second->setPrevPtr(&I->second);
-  }
+  AddToExistingUseList(&getValPtr()->ValueHandle);
 }
 
 void ValueHandleBase::RemoveFromUseList() {
-  assert(getValPtr() && getValPtr()->HasValueHandle &&
+  assert(getValPtr() && getValPtr()->ValueHandle &&
          "Pointer doesn't have a use list!");
 
   // Unlink this from its use list.
@@ -1217,24 +1181,16 @@ void ValueHandleBase::RemoveFromUseList() {
     return;
   }
 
-  // If the Next pointer was null, then it is possible that this was the last
-  // ValueHandle watching VP.  If so, delete its entry from the ValueHandles
-  // map.
-  LLVMContextImpl *pImpl = getValPtr()->getContext().pImpl;
-  DenseMap<Value*, ValueHandleBase*> &Handles = pImpl->ValueHandles;
-  if (Handles.isPointerIntoBucketsArray(PrevPtr)) {
-    Handles.erase(getValPtr());
-    getValPtr()->HasValueHandle = false;
-  }
+  if (PrevPtr == &getValPtr()->ValueHandle)
+    getValPtr()->ValueHandle = nullptr;
 }
 
 void ValueHandleBase::ValueIsDeleted(Value *V) {
-  assert(V->HasValueHandle && "Should only be called if ValueHandles present");
+  assert(V->ValueHandle && "Should only be called if ValueHandles present");
 
   // Get the linked list base, which is guaranteed to exist since the
-  // HasValueHandle flag is set.
-  LLVMContextImpl *pImpl = V->getContext().pImpl;
-  ValueHandleBase *Entry = pImpl->ValueHandles[V];
+  // ValueHandle flag is set.
+  ValueHandleBase *Entry = V->ValueHandle;
   assert(Entry && "Value bit set but no entries exist");
 
   // We use a local ValueHandleBase as an iterator so that ValueHandles can add
@@ -1268,11 +1224,11 @@ void ValueHandleBase::ValueIsDeleted(Value *V) {
   }
 
   // All callbacks, weak references, and assertingVHs should be dropped by now.
-  if (V->HasValueHandle) {
+  if (V->ValueHandle) {
 #ifndef NDEBUG      // Only in +Asserts mode...
     dbgs() << "While deleting: " << *V->getType() << " %" << V->getName()
            << "\n";
-    if (pImpl->ValueHandles[V]->getKind() == Assert)
+    if (V->ValueHandle->getKind() == Assert)
       llvm_unreachable("An asserting value handle still pointed to this"
                        " value!");
 
@@ -1282,15 +1238,14 @@ void ValueHandleBase::ValueIsDeleted(Value *V) {
 }
 
 void ValueHandleBase::ValueIsRAUWd(Value *Old, Value *New) {
-  assert(Old->HasValueHandle &&"Should only be called if ValueHandles present");
+  assert(Old->ValueHandle && "Should only be called if ValueHandles present");
   assert(Old != New && "Changing value into itself!");
   assert(Old->getType() == New->getType() &&
          "replaceAllUses of value with new value of different type!");
 
   // Get the linked list base, which is guaranteed to exist since the
-  // HasValueHandle flag is set.
-  LLVMContextImpl *pImpl = Old->getContext().pImpl;
-  ValueHandleBase *Entry = pImpl->ValueHandles[Old];
+  // ValueHandle flag is set.
+  ValueHandleBase *Entry = Old->ValueHandle;
 
   assert(Entry && "Value bit set but no entries exist");
 
@@ -1322,18 +1277,16 @@ void ValueHandleBase::ValueIsRAUWd(Value *Old, Value *New) {
 #ifndef NDEBUG
   // If any new weak value handles were added while processing the
   // list, then complain about it now.
-  if (Old->HasValueHandle)
-    for (Entry = pImpl->ValueHandles[Old]; Entry; Entry = Entry->Next)
-      switch (Entry->getKind()) {
-      case WeakTracking:
-        dbgs() << "After RAUW from " << *Old->getType() << " %"
-               << Old->getName() << " to " << *New->getType() << " %"
-               << New->getName() << "\n";
-        llvm_unreachable(
-            "A weak tracking value handle still pointed to the old value!\n");
-      default:
-        break;
-      }
+  for (Entry = Old->ValueHandle; Entry; Entry = Entry->Next)
+    switch (Entry->getKind()) {
+    case WeakTracking:
+      dbgs() << "After RAUW from " << *Old->getType() << " %" << Old->getName()
+             << " to " << *New->getType() << " %" << New->getName() << "\n";
+      llvm_unreachable(
+          "A weak tracking value handle still pointed to the old value!\n");
+    default:
+      break;
+    }
 #endif
 }
 


### PR DESCRIPTION
I accidentally found that the DenseMap lookup of ValueHandleBase takes up about ~2.7% of the compilation time: https://dtcxzyw.github.io/llvm-opt-benchmark-nightly/

This patch drops the hash map for value handles. Instead, it stores the head of use chain in the Value class. This change saves about 1% compilation time, at the cost of adding one pointer to each Value instance.

Some benchmark measurements:
https://github.com/dtcxzyw/llvm-opt-benchmark-nightly/pull/324
https://llvm-compile-time-tracker.com/compare.php?from=d90baa054dfc7d9f53148e4739effbf9fd7ac27a&to=431a99496947e997049ef465f5a6ba69fccb8552&stat=instructions:u
Memory usage (the worst case is +1.5%): https://llvm-compile-time-tracker.com/compare.php?from=d90baa054dfc7d9f53148e4739effbf9fd7ac27a&to=431a99496947e997049ef465f5a6ba69fccb8552&stat=max-rss

I am not clear about the historical reason for keeping the Value class compacted. But I believe it is a win. As a bonus, this also frees up 1 bit for SubclassOptionalData.
