### PR TITLE
[lit] Add timeout-config.py test case

### DIFF
--- a/llvm/utils/lit/tests/Inputs/timeout-config/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/timeout-config/lit.cfg
@@ -1,0 +1,13 @@
+# -*- Python -*-
+import os
+import sys
+import lit.formats
+
+config.name = "timeout-config"
+config.test_format = lit.formats.ShTest()
+config.suffixes = [".py"]
+config.test_source_root = os.path.dirname(__file__)
+config.test_exec_root = config.test_source_root
+lit_config.maxIndividualTestTime = 1
+
+config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/timeout-config/test.py
+++ b/llvm/utils/lit/tests/Inputs/timeout-config/test.py
@@ -1,0 +1,1 @@
+# RUN: %{python} -c "import time; time.sleep(10)"

--- a/llvm/utils/lit/tests/timeout-config.py
+++ b/llvm/utils/lit/tests/timeout-config.py
@@ -1,0 +1,9 @@
+# REQUIRES: lit-max-individual-test-time
+# UNSUPPORTED: system-windows
+
+# RUN: not %{lit} \
+# RUN:   %{inputs}/timeout-config \
+# RUN:   -j 1 -v > %t.out 2> %t.err
+# RUN: FileCheck < %t.out %s
+
+# CHECK: TIMEOUT: timeout-config :: test.py


### PR DESCRIPTION
Add an integration test case under Inputs/timeout-config to verify suite-local timeout behavior. This initial commit uses the pre-change syntax (lit_config.maxIndividualTestTime = 1) to establish a baseline.

Assisted-by: Gemini
