### PR TITLE
[mlir][emitc] Support struct and union definition

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -1772,7 +1772,9 @@ def EmitC_ClassOp
     ```
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name, UnitAttr:$final_specifier);
+  let arguments = (ins SymbolNameAttr:$sym_name, UnitAttr:$final_specifier,
+                   DefaultValuedAttr<EmitC_ClassTypeAttr,
+                                     "ClassType::class_">:$class_type);
 
   let regions = (region AnyRegion:$body);
 
@@ -1782,7 +1784,7 @@ def EmitC_ClassOp
   }];
 
   let assemblyFormat =
-      [{ (`final` $final_specifier^)? $sym_name attr-dict-with-keyword $body }];
+      [{ ($class_type^)? (`final` $final_specifier^)? $sym_name attr-dict-with-keyword $body }];
 }
 
 def EmitC_FieldOp : EmitC_Op<"field", [Symbol]> {

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitCAttributes.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitCAttributes.td
@@ -41,6 +41,16 @@ def EmitC_CmpPredicateAttr : I64EnumAttr<
   let cppNamespace = "::mlir::emitc";
 }
 
+def EmitC_ClassTypeAttr : I32EnumAttr<
+    "ClassType", "C++ aggregate type keyword",
+    [
+      I32EnumAttrCase<"class_",  0, "class">,
+      I32EnumAttrCase<"struct_", 1, "struct">,
+      I32EnumAttrCase<"union_",  2, "union">,
+    ]> {
+  let cppNamespace = "::mlir::emitc";
+}
+
 def EmitC_OpaqueAttr : EmitC_Attr<"Opaque", "opaque"> {
   let summary = "An opaque attribute";
 

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1225,11 +1225,15 @@ static LogicalResult printOperation(CppEmitter &emitter, ModuleOp moduleOp) {
 
 static LogicalResult printOperation(CppEmitter &emitter, ClassOp classOp) {
   raw_indented_ostream &os = emitter.ostream();
-  os << "struct " << classOp.getSymName();
+  ClassType classType = classOp.getClassType();
+  os << stringifyClassType(classType) << " " << classOp.getSymName();
   if (classOp.getFinalSpecifier())
     os << " final";
   os << " {\n";
   os.indent();
+
+  if (classType == ClassType::class_)
+    os << "public:\n";
 
   for (Operation &op : classOp) {
     if (failed(emitter.emitOperation(op, /*trailingSemicolon=*/false)))

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1230,10 +1230,11 @@ static LogicalResult printOperation(CppEmitter &emitter, ClassOp classOp) {
   if (classOp.getFinalSpecifier())
     os << " final";
   os << " {\n";
-  os.indent();
 
   if (classType == ClassType::class_)
-    os << "public:\n";
+    os << " public:\n";
+
+  os.indent();
 
   for (Operation &op : classOp) {
     if (failed(emitter.emitOperation(op, /*trailingSemicolon=*/false)))

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1225,10 +1225,10 @@ static LogicalResult printOperation(CppEmitter &emitter, ModuleOp moduleOp) {
 
 static LogicalResult printOperation(CppEmitter &emitter, ClassOp classOp) {
   raw_indented_ostream &os = emitter.ostream();
-  os << "class " << classOp.getSymName();
+  os << "struct " << classOp.getSymName();
   if (classOp.getFinalSpecifier())
     os << " final";
-  os << " {\n public:\n";
+  os << " {\n";
   os.indent();
 
   for (Operation &op : classOp) {

--- a/mlir/test/Target/Cpp/class.mlir
+++ b/mlir/test/Target/Cpp/class.mlir
@@ -12,7 +12,8 @@ emitc.class @modelClass {
   }
 }
 
-// CHECK-LABEL: struct modelClass {
+// CHECK-LABEL: class modelClass {
+// CHECK-NEXT:    public:
 // CHECK-NEXT:    float fieldName0[1];
 // CHECK-NEXT:    float fieldName1[1];
 // CHECK-NEXT:    void execute() {
@@ -33,7 +34,8 @@ emitc.class final @finalClass {
   }
 }
 
-// CHECK-LABEL: struct finalClass final {
+// CHECK-LABEL: class finalClass final {
+// CHECK-NEXT:    public:
 // CHECK-NEXT:    float fieldName0[1];
 // CHECK-NEXT:    float fieldName1[1];
 // CHECK-NEXT:    void execute() {
@@ -50,7 +52,8 @@ emitc.class @mainClass {
   }
 }
 
-// CHECK-LABEL: struct mainClass {
+// CHECK-LABEL: class mainClass {
+// CHECK-NEXT:    public:
 // CHECK-NEXT:    float fieldName0[2] = {0.0e+00f, 0.0e+00f};
 // CHECK-NEXT:    void get_fieldName0() {
 // CHECK-NEXT:     return;
@@ -65,10 +68,33 @@ emitc.class @reflectionClass {
   }
 }
 
-// CHECK-LABEL: struct reflectionClass {
+// CHECK-LABEL: class reflectionClass {
+// CHECK-NEXT:    public:
 // CHECK-NEXT:    const std::map<std::string, std::string> reflectionMap = { { "another_feature", "fieldName0" } };
 // CHECK-NEXT:    void get_reflectionMap() {
 // CHECK-NEXT:     return;
 // CHECK-NEXT:    }
+// CHECK-NEXT:  };
+
+// struct does not emit a public: section.
+emitc.class struct @structClass {
+  emitc.field @x : i32
+  emitc.field @y : i32
+}
+
+// CHECK-LABEL: struct structClass {
+// CHECK-NEXT:    int32_t x;
+// CHECK-NEXT:    int32_t y;
+// CHECK-NEXT:  };
+
+// union does not emit a public: section.
+emitc.class union @unionClass {
+  emitc.field @asInt : i32
+  emitc.field @asFloat : f32
+}
+
+// CHECK-LABEL: union unionClass {
+// CHECK-NEXT:    int32_t asInt;
+// CHECK-NEXT:    float asFloat;
 // CHECK-NEXT:  };
 

--- a/mlir/test/Target/Cpp/class.mlir
+++ b/mlir/test/Target/Cpp/class.mlir
@@ -13,7 +13,7 @@ emitc.class @modelClass {
 }
 
 // CHECK-LABEL: class modelClass {
-// CHECK-NEXT:    public:
+// CHECK-NEXT:   public:
 // CHECK-NEXT:    float fieldName0[1];
 // CHECK-NEXT:    float fieldName1[1];
 // CHECK-NEXT:    void execute() {
@@ -35,7 +35,7 @@ emitc.class final @finalClass {
 }
 
 // CHECK-LABEL: class finalClass final {
-// CHECK-NEXT:    public:
+// CHECK-NEXT:   public:
 // CHECK-NEXT:    float fieldName0[1];
 // CHECK-NEXT:    float fieldName1[1];
 // CHECK-NEXT:    void execute() {
@@ -53,7 +53,7 @@ emitc.class @mainClass {
 }
 
 // CHECK-LABEL: class mainClass {
-// CHECK-NEXT:    public:
+// CHECK-NEXT:   public:
 // CHECK-NEXT:    float fieldName0[2] = {0.0e+00f, 0.0e+00f};
 // CHECK-NEXT:    void get_fieldName0() {
 // CHECK-NEXT:     return;
@@ -69,7 +69,7 @@ emitc.class @reflectionClass {
 }
 
 // CHECK-LABEL: class reflectionClass {
-// CHECK-NEXT:    public:
+// CHECK-NEXT:   public:
 // CHECK-NEXT:    const std::map<std::string, std::string> reflectionMap = { { "another_feature", "fieldName0" } };
 // CHECK-NEXT:    void get_reflectionMap() {
 // CHECK-NEXT:     return;

--- a/mlir/test/Target/Cpp/class.mlir
+++ b/mlir/test/Target/Cpp/class.mlir
@@ -12,8 +12,7 @@ emitc.class @modelClass {
   }
 }
 
-// CHECK-LABEL: class modelClass {
-// CHECK-NEXT:   public:
+// CHECK-LABEL: struct modelClass {
 // CHECK-NEXT:    float fieldName0[1];
 // CHECK-NEXT:    float fieldName1[1];
 // CHECK-NEXT:    void execute() {
@@ -34,8 +33,7 @@ emitc.class final @finalClass {
   }
 }
 
-// CHECK-LABEL: class finalClass final {
-// CHECK-NEXT:   public:
+// CHECK-LABEL: struct finalClass final {
 // CHECK-NEXT:    float fieldName0[1];
 // CHECK-NEXT:    float fieldName1[1];
 // CHECK-NEXT:    void execute() {
@@ -52,8 +50,7 @@ emitc.class @mainClass {
   }
 }
 
-// CHECK-LABEL: class mainClass {
-// CHECK-NEXT:   public:
+// CHECK-LABEL: struct mainClass {
 // CHECK-NEXT:    float fieldName0[2] = {0.0e+00f, 0.0e+00f};
 // CHECK-NEXT:    void get_fieldName0() {
 // CHECK-NEXT:     return;
@@ -68,8 +65,7 @@ emitc.class @reflectionClass {
   }
 }
 
-// CHECK-LABEL: class reflectionClass {
-// CHECK-NEXT:   public:
+// CHECK-LABEL: struct reflectionClass {
 // CHECK-NEXT:    const std::map<std::string, std::string> reflectionMap = { { "another_feature", "fieldName0" } };
 // CHECK-NEXT:    void get_reflectionMap() {
 // CHECK-NEXT:     return;


### PR DESCRIPTION
This patch extends the `emitc.class` op to define structs and unions in addition to classes using a new enum attribute with the values:
- class_  (class,  value 0) -- default
- struct_ (struct, value 1)
- union_  (union,  value 2)
    
Class op now takes an optional class_type, defaulting to `class`. The attribute is printed to the assembly only when it differs from the default, retaining current semantics, e.g.:

      emitc.class @Foo { ... }          // class (default, omitted)
      emitc.class struct @Foo { ... }   // struct
      emitc.class union @Foo { ... }    // union
      emitc.class struct final @Foo {}  // struct + final

The translator emits the class_type instead of the previously hard-coded `class`, and for `class` types also emits `public:` inside the body, retaining the current 'all-public classes' behavior of `emitc.class`.

Assisted-by: Copilot