### PR TITLE
[CodeGen] Mark operator delete as captures(address)

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3207,17 +3207,15 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
   }
 
   if (const FunctionDecl *Fn = dyn_cast_or_null<FunctionDecl>(TargetDecl)) {
-    if (Fn->isReplaceableGlobalAllocationFunction()) {
-      auto Kind = Fn->getDeclName().getCXXOverloadedOperator();
-      if (Kind == OO_Delete || Kind == OO_Array_Delete) {
-        auto [IRArg, NumIRArgs] = IRFunctionArgs.getIRArgs(0);
-        assert(NumIRArgs == 1 && "Pointer should be a single argument");
-        (void)NumIRArgs;
-        // Add captures(address) to deleted pointer. The provenance is not
-        // captured, because delete destroy the provenane of the pointer. The
-        // address may be captured, as the allocator is replaceable.
-        ArgAttrs[IRArg].addCapturesAttr(llvm::CaptureComponents::Address);
-      }
+    if (Fn->isReplaceableGlobalAllocationFunction() &&
+        Fn->getDeclName().isAnyOperatorDelete()) {
+      auto [IRArg, NumIRArgs] = IRFunctionArgs.getIRArgs(0);
+      assert(NumIRArgs == 1 && "Pointer should be a single argument");
+      (void)NumIRArgs;
+      // Add captures(address) to deleted pointer. The provenance is not
+      // captured, because delete destroy the provenance of the pointer. The
+      // address may be captured, as the allocator is replaceable.
+      ArgAttrs[IRArg].addCapturesAttr(llvm::CaptureComponents::Address);
     }
   }
 

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3207,7 +3207,8 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
   }
 
   if (const FunctionDecl *Fn = dyn_cast_or_null<FunctionDecl>(TargetDecl)) {
-    if (Fn->isReplaceableGlobalAllocationFunction() &&
+    if (getCodeGenOpts().AssumeSaneOperatorNew &&
+        Fn->isReplaceableGlobalAllocationFunction() &&
         Fn->getDeclName().isAnyOperatorDelete()) {
       auto [IRArg, NumIRArgs] = IRFunctionArgs.getIRArgs(0);
       assert(NumIRArgs == 1 && "Pointer should be a single argument");

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3206,6 +3206,21 @@ void CodeGenModule::ConstructAttributeList(StringRef Name,
     }
   }
 
+  if (const FunctionDecl *Fn = dyn_cast_or_null<FunctionDecl>(TargetDecl)) {
+    if (Fn->isReplaceableGlobalAllocationFunction()) {
+      auto Kind = Fn->getDeclName().getCXXOverloadedOperator();
+      if (Kind == OO_Delete || Kind == OO_Array_Delete) {
+        auto [IRArg, NumIRArgs] = IRFunctionArgs.getIRArgs(0);
+        assert(NumIRArgs == 1 && "Pointer should be a single argument");
+        (void)NumIRArgs;
+        // Add captures(address) to deleted pointer. The provenance is not
+        // captured, because delete destroy the provenane of the pointer. The
+        // address may be captured, as the allocator is replaceable.
+        ArgAttrs[IRArg].addCapturesAttr(llvm::CaptureComponents::Address);
+      }
+    }
+  }
+
   SmallVector<llvm::AttributeSet, 4> ArgAttrSets;
   for (const llvm::AttrBuilder &Attrs : ArgAttrs)
     ArgAttrSets.push_back(llvm::AttributeSet::get(getLLVMContext(), Attrs));

--- a/clang/test/CodeGen/pr53127.cpp
+++ b/clang/test/CodeGen/pr53127.cpp
@@ -8,8 +8,8 @@ void operator delete(void*);
 // CHECK-LABEL: @_Z1fPiz(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[P_ADDR:%.*]] = alloca ptr, align 8
-// CHECK-NEXT:    [[L:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
-// CHECK-NEXT:    [[L2:%.*]] = alloca [1 x %struct.__va_list_tag], align 16
+// CHECK-NEXT:    [[L:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG:%.*]]], align 16
+// CHECK-NEXT:    [[L2:%.*]] = alloca [1 x [[STRUCT___VA_LIST_TAG]]], align 16
 // CHECK-NEXT:    store ptr [[P:%.*]], ptr [[P_ADDR]], align 8
 // CHECK-NEXT:    [[CALL:%.*]] = call noundef zeroext i1 @_Z1ev()
 // CHECK-NEXT:    br i1 [[CALL]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
@@ -33,7 +33,7 @@ void operator delete(void*);
 // CHECK-NEXT:    [[CALL6:%.*]] = call noundef zeroext i1 @_Z1ev()
 // CHECK-NEXT:    br i1 [[CALL6]], label [[COND_TRUE7:%.*]], label [[COND_FALSE8:%.*]]
 // CHECK:       cond.true7:
-// CHECK-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [1 x %struct.__va_list_tag], ptr [[L]], i64 0, i64 0
+// CHECK-NEXT:    [[ARRAYDECAY:%.*]] = getelementptr inbounds [1 x [[STRUCT___VA_LIST_TAG]]], ptr [[L]], i64 0, i64 0
 // CHECK-NEXT:    call void @llvm.va_start.p0(ptr [[ARRAYDECAY]])
 // CHECK-NEXT:    br label [[COND_END9:%.*]]
 // CHECK:       cond.false8:
@@ -42,8 +42,8 @@ void operator delete(void*);
 // CHECK-NEXT:    [[CALL10:%.*]] = call noundef zeroext i1 @_Z1ev()
 // CHECK-NEXT:    br i1 [[CALL10]], label [[COND_TRUE11:%.*]], label [[COND_FALSE14:%.*]]
 // CHECK:       cond.true11:
-// CHECK-NEXT:    [[ARRAYDECAY12:%.*]] = getelementptr inbounds [1 x %struct.__va_list_tag], ptr [[L]], i64 0, i64 0
-// CHECK-NEXT:    [[ARRAYDECAY13:%.*]] = getelementptr inbounds [1 x %struct.__va_list_tag], ptr [[L2]], i64 0, i64 0
+// CHECK-NEXT:    [[ARRAYDECAY12:%.*]] = getelementptr inbounds [1 x [[STRUCT___VA_LIST_TAG]]], ptr [[L]], i64 0, i64 0
+// CHECK-NEXT:    [[ARRAYDECAY13:%.*]] = getelementptr inbounds [1 x [[STRUCT___VA_LIST_TAG]]], ptr [[L2]], i64 0, i64 0
 // CHECK-NEXT:    call void @llvm.va_copy.p0(ptr [[ARRAYDECAY12]], ptr [[ARRAYDECAY13]])
 // CHECK-NEXT:    br label [[COND_END15:%.*]]
 // CHECK:       cond.false14:
@@ -69,7 +69,7 @@ void operator delete(void*);
 // CHECK-NEXT:    [[CALL24:%.*]] = call noundef zeroext i1 @_Z1ev()
 // CHECK-NEXT:    [[TMP2:%.*]] = zext i1 [[CALL24]] to i64
 // CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[P_ADDR]], align 8
-// CHECK-NEXT:    call void @_ZdlPv(ptr noundef [[TMP3]]) #[[ATTR8:[0-9]+]]
+// CHECK-NEXT:    call void @_ZdlPv(ptr noundef captures(address) [[TMP3]]) #[[ATTR8:[0-9]+]]
 // CHECK-NEXT:    ret void
 //
 void f(int* p, ...)

--- a/clang/test/CodeGenCXX/builtin-operator-new-delete.cpp
+++ b/clang/test/CodeGenCXX/builtin-operator-new-delete.cpp
@@ -43,7 +43,7 @@ extern "C" void test_basic() {
   __builtin_operator_delete(__builtin_operator_new(4));
 }
 // CHECK: declare noundef nonnull ptr @_Znwm(i64 noundef) [[ATTR_NOBUILTIN:#[^ ]*]]
-// CHECK: declare void @_ZdlPv(ptr noundef) [[ATTR_NOBUILTIN_NOUNWIND:#[^ ]*]]
+// CHECK: declare void @_ZdlPv(ptr noundef captures(address)) [[ATTR_NOBUILTIN_NOUNWIND:#[^ ]*]]
 
 // CHECK-LABEL: define{{.*}} void @test_aligned_alloc(
 extern "C" void test_aligned_alloc() {
@@ -52,7 +52,7 @@ extern "C" void test_aligned_alloc() {
   __builtin_operator_delete(__builtin_operator_new(4, std::align_val_t(4)), std::align_val_t(4));
 }
 // CHECK: declare noundef nonnull ptr @_ZnwmSt11align_val_t(i64 noundef, i64 noundef) [[ATTR_NOBUILTIN:#[^ ]*]]
-// CHECK: declare void @_ZdlPvSt11align_val_t(ptr noundef, i64 noundef) [[ATTR_NOBUILTIN_NOUNWIND:#[^ ]*]]
+// CHECK: declare void @_ZdlPvSt11align_val_t(ptr noundef captures(address), i64 noundef) [[ATTR_NOBUILTIN_NOUNWIND:#[^ ]*]]
 
 // CHECK-LABEL: define{{.*}} void @test_sized_delete(
 extern "C" void test_sized_delete() {
@@ -60,7 +60,7 @@ extern "C" void test_sized_delete() {
   // CHECK: call void @_ZdlPvm({{.*}}, i64 noundef 4) [[ATTR_BUILTIN_DELETE:#[^ ]*]]
   __builtin_operator_delete(__builtin_operator_new(4), 4);
 }
-// CHECK: declare void @_ZdlPvm(ptr noundef, i64 noundef) [[ATTR_NOBUILTIN_UNWIND:#[^ ]*]]
+// CHECK: declare void @_ZdlPvm(ptr noundef captures(address), i64 noundef) [[ATTR_NOBUILTIN_UNWIND:#[^ ]*]]
 
 
 // CHECK-DAG: attributes [[ATTR_NOBUILTIN]] = {{[{].*}} nobuiltin {{.*[}]}}

--- a/clang/test/CodeGenCXX/cxx1y-sized-deallocation.cpp
+++ b/clang/test/CodeGenCXX/cxx1y-sized-deallocation.cpp
@@ -50,59 +50,59 @@ template void del<F>();
 D::D() {}
 
 // CHECK-LABEL: define weak_odr void @_Z3delIiEvv()
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 4)
-// CHECK: call void @_ZdaPv(ptr noundef %{{[^ ]*}})
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 4)
+// CHECK: call void @_ZdaPv(ptr noundef captures(address) %{{[^ ]*}})
 //
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 4)
-// CHECK: call void @_ZdaPv(ptr noundef %{{[^ ]*}})
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 4)
+// CHECK: call void @_ZdaPv(ptr noundef captures(address) %{{[^ ]*}})
 
 // CHECK-LABEL: declare void @_ZdlPvm(ptr
 
 // CHECK-LABEL: define weak_odr void @_Z3delI1BEvv()
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 4)
-// CHECK: call void @_ZdaPv(ptr noundef %{{[^ ]*}})
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 4)
+// CHECK: call void @_ZdaPv(ptr noundef captures(address) %{{[^ ]*}})
 //
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 4)
-// CHECK: call void @_ZdaPv(ptr noundef %{{[^ ]*}})
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 4)
+// CHECK: call void @_ZdaPv(ptr noundef captures(address) %{{[^ ]*}})
 
 // CHECK-LABEL: define weak_odr void @_Z3delI1CEvv()
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 1)
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 1)
 // CHECK: mul i64 1, %{{[^ ]*}}
 // CHECK: add i64 %{{[^ ]*}}, 8
-// CHECK: call void @_ZdaPvm(ptr noundef %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
+// CHECK: call void @_ZdaPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
 //
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 1)
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 1)
 // CHECK: mul i64 1, %{{[^ ]*}}
 // CHECK: add i64 %{{[^ ]*}}, 8
-// CHECK: call void @_ZdaPvm(ptr noundef %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
+// CHECK: call void @_ZdaPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
 
 // CHECK-LABEL: declare void @_ZdaPvm(ptr
 
 // CHECK-LABEL: define weak_odr void @_Z3delI1DEvv()
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 8)
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 8)
 // CHECK: mul i64 8, %{{[^ ]*}}
 // CHECK: add i64 %{{[^ ]*}}, 8
-// CHECK: call void @_ZdaPvm(ptr noundef %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
+// CHECK: call void @_ZdaPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
 //
 // CHECK-NOT: Zdl
 // CHECK: call void %{{.*}}
 // CHECK-NOT: Zdl
 // CHECK: mul i64 8, %{{[^ ]*}}
 // CHECK: add i64 %{{[^ ]*}}, 8
-// CHECK: call void @_ZdaPvm(ptr noundef %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
+// CHECK: call void @_ZdaPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
 
 // CHECK-LABEL: define weak_odr void @_Z3delI1EEvv()
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 1)
-// CHECK: call void @_ZdaPv(ptr noundef %{{[^ ]*}})
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 1)
+// CHECK: call void @_ZdaPv(ptr noundef captures(address) %{{[^ ]*}})
 //
 // CHECK: call void @_ZN1EdlEPv(ptr noundef %{{[^ ]*}})
 // CHECK: call void @_ZN1EdaEPv(ptr noundef %{{[^ ]*}})
 
 // CHECK-LABEL: define weak_odr void @_Z3delI1FEvv()
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 1)
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 1)
 // CHECK: mul i64 1, %{{[^ ]*}}
 // CHECK: add i64 %{{[^ ]*}}, 8
-// CHECK: call void @_ZdaPvm(ptr noundef %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
+// CHECK: call void @_ZdaPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef %{{[^ ]*}})
 //
 // CHECK: call void @_ZN1FdlEPvm(ptr noundef %{{[^ ]*}}, i64 noundef 1)
 // CHECK: mul i64 1, %{{[^ ]*}}
@@ -111,4 +111,4 @@ D::D() {}
 
 
 // CHECK-LABEL: define linkonce_odr void @_ZN1DD0Ev(ptr {{[^,]*}} %this)
-// CHECK: call void @_ZdlPvm(ptr noundef %{{[^ ]*}}, i64 noundef 8)
+// CHECK: call void @_ZdlPvm(ptr noundef captures(address) %{{[^ ]*}}, i64 noundef 8)

--- a/clang/test/CodeGenCXX/cxx1z-aligned-allocation.cpp
+++ b/clang/test/CodeGenCXX/cxx1z-aligned-allocation.cpp
@@ -28,11 +28,11 @@ struct OVERALIGNED A { A(); int n[128]; };
 
 // CHECK-LABEL: define {{.*}} @_Z2a0v()
 // CHECK: %[[ALLOC:.*]] = call noalias noundef nonnull align 32 ptr @_ZnwmSt11align_val_t(i64 noundef 512, i64 noundef 32)
-// CHECK: call void @_ZdlPvSt11align_val_t(ptr noundef %[[ALLOC]], i64 noundef 32)
+// CHECK: call void @_ZdlPvSt11align_val_t(ptr noundef captures(address) %[[ALLOC]], i64 noundef 32)
 // CHECK-MS-LABEL: define {{.*}} @"?a0@@YAPEAXXZ"()
 // CHECK-MS: %[[ALLOC:.*]] = call noalias noundef nonnull align 32 ptr @"??2@YAPEAX_KW4align_val_t@std@@@Z"(i64 noundef 512, i64 noundef 32)
 // CHECK-MS: cleanuppad
-// CHECK-MS: call void @"??3@YAXPEAXW4align_val_t@std@@@Z"(ptr noundef %[[ALLOC]], i64 noundef 32)
+// CHECK-MS: call void @"??3@YAXPEAXW4align_val_t@std@@@Z"(ptr noundef captures(address) %[[ALLOC]], i64 noundef 32)
 void *a0() { return new A; }
 
 // FIXME: Why don't we call the sized array deallocation overload in this case?
@@ -43,22 +43,22 @@ void *a0() { return new A; }
 // No array cookie.
 // CHECK-NOT: store
 // CHECK: invoke void @_ZN1AC1Ev(
-// CHECK: call void @_ZdaPvSt11align_val_t(ptr noundef %[[ALLOC]], i64 noundef 32)
+// CHECK: call void @_ZdaPvSt11align_val_t(ptr noundef captures(address) %[[ALLOC]], i64 noundef 32)
 // CHECK-MS-LABEL: define {{.*}} @"?a1@@YAPEAXJ@Z"(
 // CHECK-MS: %[[ALLOC:.*]] = call noalias noundef nonnull align 32 ptr @"??_U@YAPEAX_KW4align_val_t@std@@@Z"(i64 noundef %{{.*}}, i64 noundef 32)
 // No array cookie.
 // CHECK-MS-NOT: store
 // CHECK-MS: invoke noundef ptr @"??0A@@QEAA@XZ"(
 // CHECK-MS: cleanuppad
-// CHECK-MS: call void @"??_V@YAXPEAXW4align_val_t@std@@@Z"(ptr noundef %[[ALLOC]], i64 noundef 32)
+// CHECK-MS: call void @"??_V@YAXPEAXW4align_val_t@std@@@Z"(ptr noundef captures(address) %[[ALLOC]], i64 noundef 32)
 void *a1(long n) { return new A[n]; }
 
 // CHECK-LABEL: define {{.*}} @_Z2a2P1A(
-// CHECK: call void @_ZdlPvmSt11align_val_t(ptr noundef %{{.*}}, i64 noundef 512, i64 noundef 32) #9
+// CHECK: call void @_ZdlPvmSt11align_val_t(ptr noundef captures(address) %{{.*}}, i64 noundef 512, i64 noundef 32) #9
 void a2(A *p) { delete p; }
 
 // CHECK-LABEL: define {{.*}} @_Z2a3P1A(
-// CHECK: call void @_ZdaPvSt11align_val_t(ptr noundef %{{.*}}, i64 noundef 32) #9
+// CHECK: call void @_ZdaPvSt11align_val_t(ptr noundef captures(address) %{{.*}}, i64 noundef 32) #9
 void a3(A *p) { delete[] p; }
 
 
@@ -170,7 +170,7 @@ void *d0() { return new (q) D; }
 #ifndef UNALIGNED
 // CHECK-LABEL: define {{.*}} @_Z2e0v(
 // CHECK: %[[ALLOC:.*]] = call noalias noundef nonnull align 4 ptr @_ZnwmSt11align_val_t(i64 noundef 512, i64 noundef 4)
-// CHECK: call void @_ZdlPvSt11align_val_t(ptr noundef %[[ALLOC]], i64 noundef 4)
+// CHECK: call void @_ZdlPvSt11align_val_t(ptr noundef captures(address) %[[ALLOC]], i64 noundef 4)
 void *e0() { return new (std::align_val_t(4)) A; }
 
 // CHECK-LABEL: define {{.*}} @_Z2e1v(

--- a/clang/test/CodeGenCXX/cxx2a-destroying-delete.cpp
+++ b/clang/test/CodeGenCXX/cxx2a-destroying-delete.cpp
@@ -42,11 +42,11 @@ void glob_delete_A(A *a) { ::delete a; }
 // CHECK: br i1
 
 // CHECK-ITANIUM: call void @_ZN1AD1Ev(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) %[[a]])
-// CHECK-ITANIUM-NEXT: call void @_ZdlPvm(ptr noundef %[[a]], i64 noundef 8)
+// CHECK-ITANIUM-NEXT: call void @_ZdlPvm(ptr noundef captures(address) %[[a]], i64 noundef 8)
 // CHECK-MSABI64: call void @"??1A@@QEAA@XZ"(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) %[[a]])
-// CHECK-MSABI64-NEXT: call void @"??3@YAXPEAX_K@Z"(ptr noundef %[[a]], i64 noundef 8)
+// CHECK-MSABI64-NEXT: call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %[[a]], i64 noundef 8)
 // CHECK-MSABI32: call x86_thiscallcc void @"??1A@@QAE@XZ"(ptr noundef nonnull align 4 dead_on_return(4) dereferenceable(4) %[[a]])
-// CHECK-MSABI32-NEXT: call void @"??3@YAXPAXI@Z"(ptr noundef %[[a]], i32 noundef 4)
+// CHECK-MSABI32-NEXT: call void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %[[a]], i32 noundef 4)
 
 struct B {
   virtual ~B();
@@ -229,8 +229,8 @@ H::~H() { call_in_dtor(); }
 // CLANG22-MSABI-NEXT: br i1 %[[CHCK2]], label %dtor.call_class_delete, label %dtor.call_glob_delete
 //
 // CLANG22-MSABI-LABEL: dtor.call_glob_delete:
-// CLANG22-MSABI64: call void @"??3@YAXPEAX_K@Z"(ptr noundef %{{.*}}, i64 noundef 48)
-// CLANG22-MSABI32: call void @"??3@YAXPAXIW4align_val_t@std@@@Z"(ptr noundef %{{.*}}, i32 noundef 32, i32 noundef 16)
+// CLANG22-MSABI64: call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %{{.*}}, i64 noundef 48)
+// CLANG22-MSABI32: call void @"??3@YAXPAXIW4align_val_t@std@@@Z"(ptr noundef captures(address) %{{.*}}, i32 noundef 32, i32 noundef 16)
 // CLANG22-MSABI-NEXT: br label %[[RETURN:.*]]
 //
 // CLANG21-MSABI: dtor.call_delete:
@@ -284,8 +284,8 @@ I::~I() { call_in_dtor(); }
 // CLANG22-MSABI-NEXT: br i1 %[[CHCK2]], label %dtor.call_class_delete, label %dtor.call_glob_delete
 //
 // CLANG22-MSABI: dtor.call_glob_delete:
-// CLANG22-MSABI64: call void @"??3@YAXPEAX_KW4align_val_t@std@@@Z"(ptr noundef %{{.*}}, i64 noundef 96, i64 noundef 32)
-// CLANG22-MSABI32: call void @"??3@YAXPAXIW4align_val_t@std@@@Z"(ptr noundef %{{.*}}, i32 noundef 64, i32 noundef 32)
+// CLANG22-MSABI64: call void @"??3@YAXPEAX_KW4align_val_t@std@@@Z"(ptr noundef captures(address) %{{.*}}, i64 noundef 96, i64 noundef 32)
+// CLANG22-MSABI32: call void @"??3@YAXPAXIW4align_val_t@std@@@Z"(ptr noundef captures(address) %{{.*}}, i32 noundef 64, i32 noundef 32)
 // CLANG22-MSABI-NEXT: br label %[[RETURN:.*]]
 //
 // CLANG21-MSABI: dtor.call_delete:

--- a/clang/test/CodeGenCXX/delete-two-arg.cpp
+++ b/clang/test/CodeGenCXX/delete-two-arg.cpp
@@ -45,7 +45,7 @@ namespace test2 {
     // CHECK-NEXT: [[T5:%.*]] = load i32, ptr [[T3]]
     // CHECK-NEXT: [[T6:%.*]] = mul i32 4, [[T5]]
     // CHECK-NEXT: [[T7:%.*]] = add i32 [[T6]], 4
-    // CHECK-NEXT: call void @_ZdaPvj(ptr noundef [[T3]], i32 noundef [[T7]])
+    // CHECK-NEXT: call void @_ZdaPvj(ptr noundef captures(address) [[T3]], i32 noundef [[T7]])
     // CHECK-NEXT: br label
     ::delete[] p;
   }

--- a/clang/test/CodeGenCXX/delete.cpp
+++ b/clang/test/CodeGenCXX/delete.cpp
@@ -94,7 +94,7 @@ namespace test1 {
     // CHECK-NEXT: br i1 [[ISDONE]]
     // CHECK:      [[MUL:%.*]] = mul i64 4, [[COUNT]]
     // CHECK-NEXT: [[SIZE:%.*]] = add i64 [[MUL]], 8
-    // CHECK-NEXT: call void @_ZdaPvm(ptr noundef [[ALLOC]], i64 noundef [[SIZE]])
+    // CHECK-NEXT: call void @_ZdaPvm(ptr noundef captures(address) [[ALLOC]], i64 noundef [[SIZE]])
   }
 
   // CHECK-LABEL: define{{.*}} void @_ZN5test11gEPA_NS_1AE(
@@ -113,7 +113,7 @@ namespace test1 {
     // CHECK-NEXT: call void @_ZN5test11AD1Ev(ptr {{[^,]*}} [[CUR]])
     // CHECK-NEXT: [[ISDONE:%.*]] = icmp eq ptr [[CUR]], [[PTR]]
     // CHECK-NEXT: br i1 [[ISDONE]]
-    // CHECK:      call void @_ZdaPv(ptr noundef [[ALLOC]])
+    // CHECK:      call void @_ZdaPv(ptr noundef captures(address) [[ALLOC]])
   }
 }
 
@@ -157,7 +157,7 @@ namespace test4 {
     // CHECK-NEXT: [[DTOR:%.*]] = load ptr, ptr [[T0]]
     // CHECK-NEXT: call void [[DTOR]](ptr {{[^,]*}} [[OBJ:%.*]])
     //   Call the global operator delete.
-    // CHECK-NEXT: call void @_ZdlPvm(ptr noundef [[ALLOCATED]], i64 noundef 8) [[NUW:#[0-9]+]]
+    // CHECK-NEXT: call void @_ZdlPvm(ptr noundef captures(address) [[ALLOCATED]], i64 noundef 8) [[NUW:#[0-9]+]]
     ::delete xp;
   }
 }

--- a/clang/test/CodeGenCXX/dllimport.cpp
+++ b/clang/test/CodeGenCXX/dllimport.cpp
@@ -208,7 +208,7 @@ USEVAR(VarTmpl<ExplicitSpec_Imported>)
 // Functions
 //===----------------------------------------------------------------------===//
 
-// GNU-DAG: declare dso_local void @_ZdlPv{{[jym]}}(ptr, i{{32|64}})
+// GNU-DAG: declare dso_local void @_ZdlPv{{[jym]}}(ptr captures(address), i{{32|64}})
 
 // Import function declaration.
 // MSC-DAG: declare dllimport void @"?decl@@YAXXZ"()

--- a/clang/test/CodeGenCXX/exceptions.cpp
+++ b/clang/test/CodeGenCXX/exceptions.cpp
@@ -37,7 +37,7 @@ namespace test1 {
     // CHECK:      [[NEW:%.*]] = call noalias nonnull ptr @_Znwm(i64 8)
     // CHECK-NEXT: invoke void @_ZN5test11AC1Ei(ptr {{[^,]*}} [[NEW]], i32 5)
     // CHECK:      ret ptr [[NEW]]
-    // CHECK:      call void @_ZdlPv(ptr [[NEW]])
+    // CHECK:      call void @_ZdlPv(ptr captures(address) [[NEW]])
     return new A(5);
   }
 
@@ -47,7 +47,7 @@ namespace test1 {
     // CHECK-NEXT: [[FOO:%.*]] = invoke i32 @_ZN5test13fooEv()
     // CHECK:      invoke void @_ZN5test11AC1Ei(ptr {{[^,]*}} [[NEW]], i32 [[FOO]])
     // CHECK:      ret ptr [[NEW]]
-    // CHECK:      call void @_ZdlPv(ptr [[NEW]])
+    // CHECK:      call void @_ZdlPv(ptr captures(address) [[NEW]])
     extern int foo();
     return new A(foo());
   }
@@ -72,7 +72,7 @@ namespace test1 {
     // CHECK:      ret ptr [[NEW]]
     // CHECK:      [[ISACTIVE:%.*]] = load i1, ptr [[ACTIVE]]
     // CHECK-NEXT: br i1 [[ISACTIVE]]
-    // CHECK:      call void @_ZdlPv(ptr [[NEW]])
+    // CHECK:      call void @_ZdlPv(ptr captures(address) [[NEW]])
     return new A(B().x);
   }
 
@@ -98,7 +98,7 @@ namespace test1 {
     // CHECK:      ret ptr [[NEW]]
     // CHECK:      [[ISACTIVE:%.*]] = load i1, ptr [[ACTIVE]]
     // CHECK-NEXT: br i1 [[ISACTIVE]]
-    // CHECK:      call void @_ZdlPv(ptr [[NEW]])
+    // CHECK:      call void @_ZdlPv(ptr captures(address) [[NEW]])
     return new A(B());
   }
 
@@ -123,7 +123,7 @@ namespace test1 {
     // CHECK:      ret ptr [[NEW]]
     // CHECK:      [[ISACTIVE:%.*]] = load i1, ptr [[ACTIVE]]
     // CHECK-NEXT: br i1 [[ISACTIVE]]
-    // CHECK:      call void @_ZdlPv(ptr [[NEW]])
+    // CHECK:      call void @_ZdlPv(ptr captures(address) [[NEW]])
     return new A(B(), B());
   }
   A *f() {
@@ -159,7 +159,7 @@ namespace test1 {
     // CHECK:      ret ptr [[RET]]
     // CHECK:      [[ISACTIVE:%.*]] = load i1, ptr [[ACTIVE]]
     // CHECK-NEXT: br i1 [[ISACTIVE]]
-    // CHECK:      call void @_ZdlPv(ptr [[NEW]])
+    // CHECK:      call void @_ZdlPv(ptr captures(address) [[NEW]])
     A *x;
     return (x = new A(makeB()), makeB(), x);
   }
@@ -444,7 +444,7 @@ namespace test9 {
   }
   // CHECK: define{{.*}} ptr @_ZN5test94testEv
   // CHECK: [[TEST9_NEW:%.*]] = call noalias nonnull ptr @_Znam
-  // CHECK: call void @_ZdaPv(ptr [[TEST9_NEW]])
+  // CHECK: call void @_ZdaPv(ptr captures(address) [[TEST9_NEW]])
 }
 
 // In a destructor with a function-try-block, a return statement in a

--- a/clang/test/CodeGenCXX/microsoft-abi-structors.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-structors.cpp
@@ -58,7 +58,7 @@ struct C {
 // DTORS-NEXT:   br i1 %[[CONDITION]], label %[[CONTINUE_LABEL:[0-9a-z._]+]], label %[[CALL_DELETE_LABEL:[0-9a-z._]+]]
 //
 // DTORS:      [[CALL_DELETE_LABEL]]
-// DTORS-NEXT:   call void @"??3@YAXPAX@Z"(ptr %[[THIS]])
+// DTORS-NEXT:   call void @"??3@YAXPAX@Z"(ptr captures(address) %[[THIS]])
 // DTORS-NEXT:   br label %[[CONTINUE_LABEL]]
 //
 // DTORS:      [[CONTINUE_LABEL]]
@@ -117,7 +117,7 @@ void call_deleting_dtor_and_global_delete(C *obj_ptr) {
 // CHECK-NEXT:   %[[VDTOR:.*]] = load ptr, ptr %[[PVDTOR]]
 // CLANG22-NEXT:   %[[CALL:.*]] = call x86_thiscallcc ptr %[[VDTOR]](ptr {{[^,]*}} %[[OBJ_PTR_VALUE]], i32 5)
 // CLANG21-NEXT:   %[[CALL:.*]] = call x86_thiscallcc ptr %[[VDTOR]](ptr {{[^,]*}} %[[OBJ_PTR_VALUE]], i32 0)
-// CLANG21-NEXT: call void @"??3@YAXPAX@Z"(ptr %[[CALL]])
+// CLANG21-NEXT: call void @"??3@YAXPAX@Z"(ptr captures(address) %[[CALL]])
 // CHECK:      ret void
 }
 
@@ -487,7 +487,7 @@ void checkH() {
 // DTORS-NEXT:   br i1 %[[CONDITION1]], label %[[CALL_CLASS_DELETE:[0-9a-z._]+]], label %[[CALL_GLOB_DELETE:[0-9a-z._]+]]
 //
 // DTORS:      [[CALL_GLOB_DELETE]]
-// DTORS-NEXT:   call void @"??3@YAXPAX@Z"(ptr %[[THIS]])
+// DTORS-NEXT:   call void @"??3@YAXPAX@Z"(ptr captures(address) %[[THIS]])
 // DTORS-NEXT:   br label %[[CONTINUE_LABEL]]
 //
 // DTORS:      [[CALL_CLASS_DELETE]]

--- a/clang/test/CodeGenCXX/microsoft-vector-deleting-dtors.cpp
+++ b/clang/test/CodeGenCXX/microsoft-vector-deleting-dtors.cpp
@@ -104,8 +104,8 @@ void bar() {
 // X86-NEXT:   %[[HOWMANYBYTES:.*]] = mul i32 4, %[[HOWMANY]]
 // X64-NEXT:   %[[ADDCOOKIESIZE:.*]] = add i64 %[[HOWMANYBYTES]], 8
 // X86-NEXT:   %[[ADDCOOKIESIZE:.*]] = add i32 %[[HOWMANYBYTES]], 4
-// X64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef %[[COOKIEGEP]], i64 noundef %[[ADDCOOKIESIZE]])
-// X86-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef %[[COOKIEGEP]], i32 noundef %[[ADDCOOKIESIZE]])
+// X64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %[[COOKIEGEP]], i64 noundef %[[ADDCOOKIESIZE]])
+// X86-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %[[COOKIEGEP]], i32 noundef %[[ADDCOOKIESIZE]])
 // CHECK-NEXT:   br label %delete.end
 // CHECK: vdtor.call:
 // CHECK-NEXT:   %[[VTABLE:.*]] = load ptr, ptr %[[LPTR]]
@@ -139,7 +139,7 @@ void bar() {
 // CLANG21: arraydestroy.done1:
 // CLANG21-NEXT:   %3 = mul i64 8, %2
 // CLANG21-NEXT:   %4 = add i64 %3, 8
-// CLANG21-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef %1, i64 noundef %4)
+// CLANG21-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %1, i64 noundef %4)
 // CLANG21-NEXT:   br label %delete.end2
 
 // Definition of S::foo, check that it has vector deleting destructor call
@@ -164,8 +164,8 @@ void bar() {
 // X86-NEXT:   %[[HOWMANYBYTES:.*]] = mul i32 4, %[[HOWMANY]]
 // X64-NEXT:   %[[ADDCOOKIESIZE:.*]] = add i64 %[[HOWMANYBYTES]], 8
 // X86-NEXT:   %[[ADDCOOKIESIZE:.*]] = add i32 %[[HOWMANYBYTES]], 4
-// X64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef %[[COOKIEGEP]], i64 noundef %[[ADDCOOKIESIZE]])
-// X86-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef %[[COOKIEGEP]], i32 noundef %[[ADDCOOKIESIZE]])
+// X64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %[[COOKIEGEP]], i64 noundef %[[ADDCOOKIESIZE]])
+// X86-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %[[COOKIEGEP]], i32 noundef %[[ADDCOOKIESIZE]])
 // CHECK-NEXT:   br label %delete.end
 // CHECK: vdtor.call:                                       ; preds = %delete.notnull
 // CHECK-NEXT:   %[[VTABLE:.*]] = load ptr, ptr %[[DEL_PTR]]
@@ -221,8 +221,8 @@ void bar() {
 // X86-NEXT:  %[[ARRSZ:.*]] = mul i32 4, %[[HOWMANY]]
 // X64-NEXT:  %[[TOTALSZ:.*]] = add i64 %[[ARRSZ]], 8
 // X86-NEXT:  %[[TOTALSZ:.*]] = add i32 %[[ARRSZ]], 4
-// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef %[[COOKIEGEP]], i64 noundef %[[TOTALSZ]])
-// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef %[[COOKIEGEP]], i32 noundef %[[TOTALSZ]])
+// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %[[COOKIEGEP]], i64 noundef %[[TOTALSZ]])
+// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %[[COOKIEGEP]], i32 noundef %[[TOTALSZ]])
 // CHECK-NEXT:  br label %dtor.continue
 // CHECK: dtor.scalar:
 // X64-NEXT:   call void @"??1Parrot@@UEAA@XZ"(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) %[[LTHIS]])
@@ -231,8 +231,8 @@ void bar() {
 // CHECK-NEXT:   %[[ISFIRSTBITZERO:.*]] = icmp eq i32 %[[FIRSTBIT]], 0
 // CHECK-NEXT:   br i1 %[[ISFIRSTBITZERO]], label %dtor.continue, label %dtor.call_delete
 // CHECK: dtor.call_delete:
-// X64-NEXT:     call void @"??3@YAXPEAX_K@Z"(ptr noundef %[[LTHIS]], i64 noundef 8)
-// X86-NEXT:     call void @"??3@YAXPAXI@Z"(ptr noundef %[[LTHIS]], i32 noundef 4)
+// X64-NEXT:     call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %[[LTHIS]], i64 noundef 8)
+// X86-NEXT:     call void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %[[LTHIS]], i32 noundef 4)
 // CHECK-NEXT:   br label %dtor.continue
 // CHECK: dtor.continue:
 // CHECK-NEXT:   %[[LOADRET:.*]] = load ptr, ptr %[[RET]]
@@ -260,8 +260,8 @@ void bar() {
 // X86-NEXT: %[[ARRSZ:.*]] = mul i32 4, %[[COOKIE:.*]]
 // X64-NEXT: %[[TOTALSZ:.*]] = add i64 %[[ARRSZ]], 8
 // X86-NEXT: %[[TOTALSZ:.*]] = add i32 %[[ARRSZ]], 4
-// X64-NEXT: call void @"??_V@YAXPEAX_K@Z"(ptr noundef %2, i64 noundef %[[TOTALSZ]])
-// X86-NEXT: call void @"??_V@YAXPAXI@Z"(ptr noundef %2, i32 noundef %[[TOTALSZ]])
+// X64-NEXT: call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %2, i64 noundef %[[TOTALSZ]])
+// X86-NEXT: call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %2, i32 noundef %[[TOTALSZ]])
 // CHECK-NEXT:   br label %dtor.continue
 
 
@@ -326,8 +326,8 @@ void foobartest() {
 // X86-NEXT: %[[ARRSZ:.*]] = mul i32 8, %[[COOKIE:.*]]
 // X64-NEXT: %[[TOTALSZ:.*]] = add i64 %[[ARRSZ]], 8
 // X86-NEXT: %[[TOTALSZ:.*]] = add i32 %[[ARRSZ]], 4
-// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef %2, i64 noundef %[[TOTALSZ]])
-// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef %2, i32 noundef %[[TOTALSZ]])
+// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %2, i64 noundef %[[TOTALSZ]])
+// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %2, i32 noundef %[[TOTALSZ]])
 // CHECK-NEXT:  br label %dtor.continue
 // CHECK: dtor.scalar:
 // X64-NEXT:  call void @"??1Derived@@UEAA@XZ"(ptr noundef nonnull align 8 dead_on_return(16) dereferenceable(16) %this1)
@@ -336,8 +336,8 @@ void foobartest() {
 // CHECK-NEXT:  %9 = icmp eq i32 %8, 0
 // CHECK-NEXT:  br i1 %9, label %dtor.continue, label %dtor.call_delete
 // CHECK: dtor.call_delete:
-// X64-NEXT:  call void @"??3@YAXPEAX_K@Z"(ptr noundef %this1, i64 noundef 16)
-// X86-NEXT:  call void @"??3@YAXPAXI@Z"(ptr noundef %this1, i32 noundef 8)
+// X64-NEXT:  call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %this1, i64 noundef 16)
+// X86-NEXT:  call void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %this1, i32 noundef 8)
 // CHECK-NEXT:  br label %dtor.continue
 // CHECK: dtor.continue:
 // CHECK-NEXT:  %10 = load ptr, ptr %retval

--- a/clang/test/CodeGenCXX/microsoft-vector-deleting-dtors2.cpp
+++ b/clang/test/CodeGenCXX/microsoft-vector-deleting-dtors2.cpp
@@ -52,27 +52,27 @@ void TesttheTest() {
   Test *a = new Test[30];
 }
 
-// X64: define dso_local void @"??3@YAXPEAX_K@Z"(ptr noundef %0, i64 noundef %1)
-// X64: define dso_local void @"??_V@YAXPEAX_K@Z"(ptr noundef %0, i64 noundef %1)
+// X64: define dso_local void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %0, i64 noundef %1)
+// X64: define dso_local void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %0, i64 noundef %1)
 // X64: define dso_local dllexport void @"??1DrawingBuffer@@UEAA@XZ"(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) %this)
 
 // X64: define weak dso_local noundef ptr @"??_EDrawingBuffer@@UEAAPEAXI@Z"
 // X64: call void @"??1DrawingBuffer@@UEAA@XZ"(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) %arraydestroy.element)
 // X64: call void @"??_V?$RefCounted@UDrawingBuffer@@@@SAXPEAX@Z"(ptr noundef %2)
-// X64: call void @"??_V@YAXPEAX_K@Z"(ptr noundef %2, i64 noundef %{{.*}})
+// X64: call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %2, i64 noundef %{{.*}})
 // X64: call void @"??1DrawingBuffer@@UEAA@XZ"(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) %this1)
-// X64: call void @"??3@YAXPEAX_K@Z"(ptr noundef %this1, i64 noundef {{.*}})
+// X64: call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %this1, i64 noundef {{.*}})
 
 
-// X86: define dso_local void @"??3@YAXPAXI@Z"(ptr noundef %0, i32 noundef %1)
-// X86: define dso_local void @"??_V@YAXPAXI@Z"(ptr noundef %0, i32 noundef %1)
+// X86: define dso_local void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %0, i32 noundef %1)
+// X86: define dso_local void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %0, i32 noundef %1)
 
 // X86: define weak dso_local x86_thiscallcc noundef ptr @"??_EDrawingBuffer@@UAEPAXI@Z"
 // X86: call x86_thiscallcc void @"??1DrawingBuffer@@UAE@XZ"(ptr noundef nonnull align 4 dead_on_return(4) dereferenceable(4) %arraydestroy.element)
 // X86: call void @"??_V?$RefCounted@UDrawingBuffer@@@@SAXPAX@Z"(ptr noundef %2)
-// X86: call void @"??_V@YAXPAXI@Z"(ptr noundef %2, i32 noundef {{.*}})
+// X86: call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %2, i32 noundef {{.*}})
 // X86  call x86_thiscallcc void @"??1DrawingBuffer@@UAE@XZ"(ptr noundef nonnull align 4 dereferenceable(4) %this1)
-// X86: call void @"??3@YAXPAXI@Z"(ptr noundef %this1, i32 noundef {{.*}})
+// X86: call void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %this1, i32 noundef {{.*}})
 
 
 // X64: define weak dso_local noundef ptr @"??_ETest@@UEAAPEAXI@Z"(ptr noundef nonnull align 8 dereferenceable(8) %this, i32 noundef %should_call_delete)

--- a/clang/test/CodeGenCXX/ms-vdtors-devirtualization.cpp
+++ b/clang/test/CodeGenCXX/ms-vdtors-devirtualization.cpp
@@ -48,8 +48,8 @@ void case1(A *arg) {
 // X86-NEXT:  %[[HOWMANYELEMS:.*]] = mul i32 4, %[[COOKIE]]
 // X64-NEXT:  %[[SIZEPLUSCOOKIE:.*]] = add i64 %[[HOWMANYELEMS]], 8
 // X86-NEXT:  %[[SIZEPLUSCOOKIE:.*]] = add i32 %[[HOWMANYELEMS]], 4
-// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef %[[COOKIEADDR]], i64 noundef %[[SIZEPLUSCOOKIE]])
-// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef %[[COOKIEADDR]], i32 noundef %[[SIZEPLUSCOOKIE]])
+// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %[[COOKIEADDR]], i64 noundef %[[SIZEPLUSCOOKIE]])
+// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %[[COOKIEADDR]], i32 noundef %[[SIZEPLUSCOOKIE]])
 // CHECK-NEXT:  br label %delete.end2
 
 void case2(B *arg) {
@@ -88,8 +88,8 @@ void case2(B *arg) {
 // X86-NEXT:  %[[HOWMANYELEMS:.*]] = mul i32 4, %[[COOKIE]]
 // X64-NEXT:  %[[SIZEPLUSCOOKIE:.*]] = add i64 %[[HOWMANYELEMS]], 8
 // X86-NEXT:  %[[SIZEPLUSCOOKIE:.*]] = add i32 %[[HOWMANYELEMS]], 4
-// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef %[[COOKIEADDR]], i64 noundef %[[SIZEPLUSCOOKIE]])
-// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef %[[COOKIEADDR]], i32 noundef %[[SIZEPLUSCOOKIE]])
+// X64-NEXT:  call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %[[COOKIEADDR]], i64 noundef %[[SIZEPLUSCOOKIE]])
+// X86-NEXT:  call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %[[COOKIEADDR]], i32 noundef %[[SIZEPLUSCOOKIE]])
 // CHECK-NEXT:  br label %delete.end2
 
 

--- a/clang/test/CodeGenCXX/msvc-vector-deleting-dtors-sized-delete.cpp
+++ b/clang/test/CodeGenCXX/msvc-vector-deleting-dtors-sized-delete.cpp
@@ -50,5 +50,5 @@ void test() {
 // X86-NEXT:  %[[ARRSZ1:.*]] = mul i32 12, %[[HOWMANY]]
 // X64-NEXT:  %[[TOTALSZ1:.*]] = add i64 %[[ARRSZ1]], 8
 // X86-NEXT:  %[[TOTALSZ1:.*]] = add i32 %[[ARRSZ1]], 4
-// X64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef %2, i64 noundef %[[TOTALSZ1]])
-// X86-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef %2, i32 noundef %[[TOTALSZ1]])
+// X64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %2, i64 noundef %[[TOTALSZ1]])
+// X86-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %2, i32 noundef %[[TOTALSZ1]])

--- a/clang/test/CodeGenCXX/new.cpp
+++ b/clang/test/CodeGenCXX/new.cpp
@@ -15,9 +15,9 @@ void t1() {
 }
 
 // CHECK: declare noundef nonnull ptr @_Znwm(i64 noundef) [[ATTR_NOBUILTIN:#[^ ]*]]
-// CHECK: declare void @_ZdlPvm(ptr noundef, i64 noundef) [[ATTR_NOBUILTIN_NOUNWIND:#[^ ]*]]
+// CHECK: declare void @_ZdlPvm(ptr noundef captures(address), i64 noundef) [[ATTR_NOBUILTIN_NOUNWIND:#[^ ]*]]
 // CHECK: declare noundef nonnull ptr @_Znam(i64 noundef) [[ATTR_NOBUILTIN]]
-// CHECK: declare void @_ZdaPv(ptr noundef) [[ATTR_NOBUILTIN_NOUNWIND]]
+// CHECK: declare void @_ZdaPv(ptr noundef captures(address)) [[ATTR_NOBUILTIN_NOUNWIND]]
 
 namespace std {
   struct nothrow_t {};
@@ -192,7 +192,7 @@ void f() {
   // CHECK: store i64 200
   delete[] new (nothrow) Alloc[10][20];
   // CHECK: call noalias noundef nonnull ptr @_Znwm
-  // CHECK: call void @_ZdlPvm(ptr noundef {{%.*}}, i64 noundef 1)
+  // CHECK: call void @_ZdlPvm(ptr noundef captures(address) {{%.*}}, i64 noundef 1)
   delete new bool;
   // CHECK: ret void
 }
@@ -357,7 +357,7 @@ namespace builtins {
   // CHECK-LABEL: define{{.*}} void @_ZN8builtins1fEv
   void f() {
     // CHECK: call noalias noundef nonnull ptr @_Znwm(i64 noundef 4) [[ATTR_BUILTIN_NEW]]
-    // CHECK: call void @_ZdlPv({{.*}}) [[ATTR_BUILTIN_DELETE]]
+    // CHECK: call void @_ZdlPv(ptr noundef captures(address) {{.*}}) [[ATTR_BUILTIN_DELETE]]
     __builtin_operator_delete(__builtin_operator_new(4));
   }
 }

--- a/clang/test/CodeGenCXX/operator-new.cpp
+++ b/clang/test/CodeGenCXX/operator-new.cpp
@@ -27,3 +27,9 @@ void *f2(long N) {
 }
 
 // ALL: declare noundef nonnull ptr @_Znaj(
+
+void f3(int *p) {
+  // SANE: call void @_ZdlPvj(ptr noundef captures(address) %{{.*}}, i32 noundef 4)
+  // SANENOT: call void @_ZdlPvj(ptr noundef %{{.*}}, i32 noundef 4)
+  delete p;
+}

--- a/clang/test/CodeGenCXX/ptrauth-virtual-function.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-virtual-function.cpp
@@ -496,7 +496,7 @@ void testD3Destructor0(D3 *a) {
 // CHECK: %[[T14:[0-9]+]] = call i64 @llvm.ptrauth.blend(i64 %[[T13]], i64 57279)
 // DARWIN: %call = call noundef ptr %[[T12]](ptr noundef nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T14]]) ]
 // ELF:    call void %[[T12]](ptr noundef nonnull align {{[0-9]+}} dereferenceable(32) %{{.*}}) #{{.*}} [ "ptrauth"(i32 0, i64 %[[T14]]) ]
-// CHECK: call void @_ZdlPv(ptr noundef %[[T7]])
+// CHECK: call void @_ZdlPv(ptr noundef captures(address) %[[T7]])
 
 void testD3Destructor1(D3 *a) {
   ::delete a;

--- a/clang/test/CodeGenCoroutines/coro-alloc.cpp
+++ b/clang/test/CodeGenCoroutines/coro-alloc.cpp
@@ -71,7 +71,7 @@ extern "C" void f0(global_new_delete_tag) {
 
   // CHECK: [[FreeBB]]:
   // CHECK: %[[SIZE:.+]] = call i64 @llvm.coro.size.i64()
-  // CHECK: call void @_ZdlPvm(ptr noundef %[[MEM]], i64 noundef %[[SIZE]])
+  // CHECK: call void @_ZdlPvm(ptr noundef captures(address) %[[MEM]], i64 noundef %[[SIZE]])
   // CHECK: br label %[[Afterwards]]
 
   // CHECK: [[Afterwards]]:
@@ -101,7 +101,7 @@ extern "C" void f1(promise_new_tag ) {
   // CHECK: %[[FRAME:.+]] = call ptr @llvm.coro.begin(
   // CHECK: %[[MEM:.+]] = call ptr @llvm.coro.free(token %[[ID]], ptr %[[FRAME]])
   // CHECK: %[[SIZE:.+]] = call i64 @llvm.coro.size.i64()
-  // CHECK: call void @_ZdlPvm(ptr noundef %[[MEM]], i64 noundef %[[SIZE]])
+  // CHECK: call void @_ZdlPvm(ptr noundef captures(address) %[[MEM]], i64 noundef %[[SIZE]])
   co_return;
 }
 

--- a/clang/test/CodeGenCoroutines/coro-cleanup.cpp
+++ b/clang/test/CodeGenCoroutines/coro-cleanup.cpp
@@ -85,12 +85,12 @@ void f() {
   // CHECK: call void @_ZNSt16coroutine_traitsIJvEE12promise_typeD1Ev(
   // CHECK: %[[Mem0:.+]] = call ptr @llvm.coro.free(
   // CHECK: %[[SIZE:.+]] = call i64 @llvm.coro.size.i64()
-  // CHECK: call void @_ZdlPvm(ptr noundef %[[Mem0]], i64 noundef %[[SIZE]])
+  // CHECK: call void @_ZdlPvm(ptr noundef captures(address) %[[Mem0]], i64 noundef %[[SIZE]])
 
   // CHECK: [[Dealloc]]:
   // THROWEND:   %[[Mem:.+]] = call ptr @llvm.coro.free(
   // THROWEND:   %[[SIZE:.+]] = call i64 @llvm.coro.size.i64()
-  // THROWEND:   call void @_ZdlPvm(ptr noundef %[[Mem]], i64 noundef %[[SIZE]])
+  // THROWEND:   call void @_ZdlPvm(ptr noundef captures(address) %[[Mem]], i64 noundef %[[SIZE]])
 
   co_return;
 }

--- a/clang/test/CodeGenCoroutines/coro-gro.cpp
+++ b/clang/test/CodeGenCoroutines/coro-gro.cpp
@@ -85,7 +85,7 @@ int f() {
   // CHECK-NEXT: %[[Mem:.+]] = call ptr @llvm.coro.free(
 
   // CHECK: %[[SIZE:.+]] = call i64 @llvm.coro.size.i64()
-  // CHECK-NEXT: call void @_ZdlPvm(ptr noundef %[[Mem]], i64 noundef %[[SIZE]])
+  // CHECK-NEXT: call void @_ZdlPvm(ptr noundef captures(address) %[[Mem]], i64 noundef %[[SIZE]])
 
   // CHECK: [[CoroRet]]:
   // CHECK-NEXT: call void @llvm.coro.end(

--- a/clang/test/Headers/openmp_new_nothrow.cpp
+++ b/clang/test/Headers/openmp_new_nothrow.cpp
@@ -78,7 +78,7 @@ int* new_array_stuff_nothrow() {
 // NVPTX-CXX03-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
 // NVPTX-CXX03-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR]], align 8
 // NVPTX-CXX03-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
-// NVPTX-CXX03-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR6:[0-9]+]]
+// NVPTX-CXX03-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR6:[0-9]+]]
 // NVPTX-CXX03-NEXT:    ret void
 //
 // NVPTX-NVPTX-CXX11-LABEL: define hidden void @_Z20delete_stuff_nothrowPi
@@ -87,7 +87,7 @@ int* new_array_stuff_nothrow() {
 // NVPTX-NVPTX-CXX11-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
 // NVPTX-NVPTX-CXX11-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR]], align 8
 // NVPTX-NVPTX-CXX11-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
-// NVPTX-NVPTX-CXX11-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR8:[0-9]+]]
+// NVPTX-NVPTX-CXX11-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR8:[0-9]+]]
 // NVPTX-NVPTX-CXX11-NEXT:    ret void
 //
 // AMDGPU-CXX03-LABEL: define hidden void @_Z20delete_stuff_nothrowPi
@@ -97,7 +97,7 @@ int* new_array_stuff_nothrow() {
 // AMDGPU-CXX03-NEXT:    [[PTR_ADDR_ASCAST:%.*]] = addrspacecast ptr addrspace(5) [[PTR_ADDR]] to ptr
 // AMDGPU-CXX03-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR_ASCAST]], align 8
 // AMDGPU-CXX03-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR_ASCAST]], align 8
-// AMDGPU-CXX03-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR6:[0-9]+]]
+// AMDGPU-CXX03-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR6:[0-9]+]]
 // AMDGPU-CXX03-NEXT:    ret void
 //
 // AMDGPU-CXX11-LABEL: define hidden void @_Z20delete_stuff_nothrowPi
@@ -107,7 +107,7 @@ int* new_array_stuff_nothrow() {
 // AMDGPU-CXX11-NEXT:    [[PTR_ADDR_ASCAST:%.*]] = addrspacecast ptr addrspace(5) [[PTR_ADDR]] to ptr
 // AMDGPU-CXX11-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR_ASCAST]], align 8
 // AMDGPU-CXX11-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR_ASCAST]], align 8
-// AMDGPU-CXX11-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR8:[0-9]+]]
+// AMDGPU-CXX11-NEXT:    call void @_ZdlPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR8:[0-9]+]]
 // AMDGPU-CXX11-NEXT:    ret void
 //
 void delete_stuff_nothrow(int* ptr) {
@@ -129,7 +129,7 @@ void delete_stuff_nothrow(int* ptr) {
 // NVPTX-CXX03-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
 // NVPTX-CXX03-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR]], align 8
 // NVPTX-CXX03-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
-// NVPTX-CXX03-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR6]]
+// NVPTX-CXX03-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR6]]
 // NVPTX-CXX03-NEXT:    ret void
 //
 // NVPTX-NVPTX-CXX11-LABEL: define hidden void @_Z26delete_array_stuff_nothrowPi
@@ -138,7 +138,7 @@ void delete_stuff_nothrow(int* ptr) {
 // NVPTX-NVPTX-CXX11-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
 // NVPTX-NVPTX-CXX11-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR]], align 8
 // NVPTX-NVPTX-CXX11-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
-// NVPTX-NVPTX-CXX11-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR8]]
+// NVPTX-NVPTX-CXX11-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) @nothrow) #[[ATTR8]]
 // NVPTX-NVPTX-CXX11-NEXT:    ret void
 //
 // AMDGPU-CXX03-LABEL: define hidden void @_Z26delete_array_stuff_nothrowPi
@@ -148,7 +148,7 @@ void delete_stuff_nothrow(int* ptr) {
 // AMDGPU-CXX03-NEXT:    [[PTR_ADDR_ASCAST:%.*]] = addrspacecast ptr addrspace(5) [[PTR_ADDR]] to ptr
 // AMDGPU-CXX03-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR_ASCAST]], align 8
 // AMDGPU-CXX03-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR_ASCAST]], align 8
-// AMDGPU-CXX03-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR6]]
+// AMDGPU-CXX03-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR6]]
 // AMDGPU-CXX03-NEXT:    ret void
 //
 // AMDGPU-CXX11-LABEL: define hidden void @_Z26delete_array_stuff_nothrowPi
@@ -158,7 +158,7 @@ void delete_stuff_nothrow(int* ptr) {
 // AMDGPU-CXX11-NEXT:    [[PTR_ADDR_ASCAST:%.*]] = addrspacecast ptr addrspace(5) [[PTR_ADDR]] to ptr
 // AMDGPU-CXX11-NEXT:    store ptr [[PTR]], ptr [[PTR_ADDR_ASCAST]], align 8
 // AMDGPU-CXX11-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR_ASCAST]], align 8
-// AMDGPU-CXX11-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR8]]
+// AMDGPU-CXX11-NEXT:    call void @_ZdaPvRKSt9nothrow_t(ptr noundef captures(address) [[TMP0]], ptr noundef nonnull align 1 dereferenceable(1) addrspacecast (ptr addrspace(1) @nothrow to ptr)) #[[ATTR8]]
 // AMDGPU-CXX11-NEXT:    ret void
 //
 void delete_array_stuff_nothrow(int* ptr) {

--- a/clang/test/Modules/msvc-vector-deleting-destructors.cpp
+++ b/clang/test/Modules/msvc-vector-deleting-destructors.cpp
@@ -24,11 +24,11 @@ void out_of_module_tests(Derived *p, Derived *p1) {
 // CHECK32-NEXT: %[[ARRSZ:.*]] = mul i32 8, %[[COOKIE:.*]]
 // CHECK64-NEXT: %[[TOTALSZ:.*]] = add i64 %[[ARRSZ]], 8
 // CHECK32-NEXT: %[[TOTALSZ:.*]] = add i32 %[[ARRSZ]], 4
-// CHECK32-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef %2, i32 noundef %[[TOTALSZ]])
-// CHECK64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef %2, i64 noundef %[[TOTALSZ]])
+// CHECK32-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %2, i32 noundef %[[TOTALSZ]])
+// CHECK64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %2, i64 noundef %[[TOTALSZ]])
 // CHECK: dtor.call_glob_delete:
-// CHECK32-NEXT:   call void @"??3@YAXPAXI@Z"(ptr noundef %this1, i32 noundef 8)
-// CHECK64-NEXT:   call void @"??3@YAXPEAX_K@Z"(ptr noundef %this1, i64 noundef 16)
+// CHECK32-NEXT:   call void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %this1, i32 noundef 8)
+// CHECK64-NEXT:   call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %this1, i64 noundef 16)
 // CHECK: dtor.call_class_delete:
 // CHECK32-NEXT:   call void @"??3Base2@@SAXPAX@Z"(ptr noundef %this1)
 // CHECK64-NEXT:   call void @"??3Base2@@SAXPEAX@Z"(ptr noundef %this1)

--- a/clang/test/PCH/msvc-vector-deleting-destructors.cpp
+++ b/clang/test/PCH/msvc-vector-deleting-destructors.cpp
@@ -28,11 +28,11 @@ void out_of_module_tests(Derived *p, Derived *p1) {
 // CHECK32-NEXT: %[[ARRSZ:.*]] = mul i32 8, %[[COOKIE:.*]]
 // CHECK64-NEXT: %[[TOTALSZ:.*]] = add i64 %[[ARRSZ]], 8
 // CHECK32-NEXT: %[[TOTALSZ:.*]] = add i32 %[[ARRSZ]], 4
-// CHECK32-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef %2, i32 noundef %[[TOTALSZ]])
-// CHECK64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef %2, i64 noundef %[[TOTALSZ]])
+// CHECK32-NEXT:   call void @"??_V@YAXPAXI@Z"(ptr noundef captures(address) %2, i32 noundef %[[TOTALSZ]])
+// CHECK64-NEXT:   call void @"??_V@YAXPEAX_K@Z"(ptr noundef captures(address) %2, i64 noundef %[[TOTALSZ]])
 // CHECK: dtor.call_glob_delete:
-// CHECK32-NEXT:   call void @"??3@YAXPAXI@Z"(ptr noundef %this1, i32 noundef 8)
-// CHECK64-NEXT:   call void @"??3@YAXPEAX_K@Z"(ptr noundef %this1, i64 noundef 16)
+// CHECK32-NEXT:   call void @"??3@YAXPAXI@Z"(ptr noundef captures(address) %this1, i32 noundef 8)
+// CHECK64-NEXT:   call void @"??3@YAXPEAX_K@Z"(ptr noundef captures(address) %this1, i64 noundef 16)
 // CHECK: dtor.call_class_delete:
 // CHECK32-NEXT:   call void @"??3Base2@@SAXPAX@Z"(ptr noundef %this1)
 // CHECK64-NEXT:   call void @"??3Base2@@SAXPEAX@Z"(ptr noundef %this1)


### PR DESCRIPTION
The pointer passed to operator delete cannot be used after the call, which means that its provenance is not captured. As such, we can mark the pointer as `captures(address)`. We allow address capture, because operator delete is replaceable, and a replacement allocator could observe the address.

I'm applying the attribute independently of `-fassume-sane-operator-new`, as I don't believe this makes any assumptions on the underlying allocator implementation. (It might make sense to upgrade to `captures(none)` under `-fassume-sane-operator-new`, but I'm not sure there is much benefit to that.)

This makes sure that pointers produced by operator new and only passed to operator delete are considered "never escaped".

AI disclosure: Claude assisted with test updates.