### PR TITLE
[clang][test] Use `FileCheck` in `Driver/modules-driver-incompatible-options.cpp`

### DIFF
--- a/clang/test/Driver/modules-driver-incompatible-options.cpp
+++ b/clang/test/Driver/modules-driver-incompatible-options.cpp
@@ -2,7 +2,7 @@
 // -fmodules-driver and other options.
 
 // RUN: split-file %s %t
-// RUN: not %clang -std=c++20 -fmodules-driver -fno-modules-reduced-bmi main.cpp -###
+// RUN: not %clang -std=c++20 -fmodules-driver -fno-modules-reduced-bmi %t/main.cpp -### 2>&1 | FileCheck %s
 
 // CHECK: clang: error: '-fmodules-driver' is currently incompatible with '-fno-modules-reduced-bmi'
 


### PR DESCRIPTION
The test had `CHECK` directives that were never executed because the `RUN` line did not pipe output to `FileCheck`.

This also includes `2>&1` before the pipe to `FileCheck`, since Clang's driver error messages are written to `stderr`.

This also adds `%t/` prefix to `main.cpp`, which should be the intended directory.