### PR TITLE
[BPF] Remove getMaxNumArgs() from BPFTargetTransformInfo

### DIFF
--- a/llvm/lib/Target/BPF/BPFTargetTransformInfo.h
+++ b/llvm/lib/Target/BPF/BPFTargetTransformInfo.h
@@ -79,8 +79,6 @@ public:
     Options.MaxNumLoads = TLI->getMaxExpandSizeMemcmp(OptSize);
     return Options;
   }
-
-  unsigned getMaxNumArgs() const override { return 5; }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
The function getMaxNumArgs() hardcoded the maximum number of function arguments to 5. LLVM now supports more than 5 arguments with stack argument support. Remove this leftover.