### PR TITLE
[flang-rt][test] Fix write01.f90 missing LD_LIBRARY_PATH (introduced in #187662)

### DIFF
--- a/flang-rt/test/Driver/write01.f90
+++ b/flang-rt/test/Driver/write01.f90
@@ -3,7 +3,8 @@
 ! reallocations as the size increases geometrically when certain
 ! threshold is reached
 
-! RUN: %flang %isysroot -L"%libdir" -O3 -g %s -o %t && %t | FileCheck %s
+! RUN: %flang %isysroot -L"%libdir" -O3 -g %s -o %t
+! RUN: env LD_LIBRARY_PATH="$LD_LIBRARY_PATH:%libdir" %t | FileCheck %s
 ! CHECK: PASS
 
 program test_array_write


### PR DESCRIPTION
The test binary was run without setting LD_LIBRARY_PATH, causing libflang_rt.runtime.so to not be found at runtime. Match the pattern used other tests in the same directory.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>