### PR TITLE
Fix MAKE_DWP on Linux: set DSYM so the DWP packaging step runs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -237,6 +237,7 @@ else
 		MAKE_DWO := YES
 		DWP_NAME = $(EXE).dwp
 		DYLIB_DWP_NAME = $(DYLIB_NAME).dwp
+		DSYM = $(DWP_NAME)
 	endif
 endif
 


### PR DESCRIPTION
On non-Darwin platforms, MAKE_DWP=YES sets DWP_NAME but never sets DSYM. Since the DWP packaging step is inside the `$(DSYM)` recipe and the all target depends on $(DSYM), the step is skipped when DSYM is empty. Set `DSYM = $(DWP_NAME)` so the recipe is invoked. I understand "DSYM" sounds like "dSYM" which is a Darwin concept - this is a possible fix to make `self.build(debug_info="dwp")` work (without having to manually call `llvm-dwp` after debug_info="dwo", for example). 

cc: @clayborg @jimingham @JDevlieghere 