### PR TITLE
Fix MAKE_DWP on Linux: set DSYM so the DWP packaging step runs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -693,6 +693,9 @@ include $(wildcard $(PREREQS) $(DYLIB_PREREQS))
 .PHONY: clean
 dsym:	$(DSYM)
 all:	$(EXE) $(DSYM)
+ifeq "$(MAKE_DWP)" "YES"
+all:	$(DWP_NAME)
+endif
 clean::
 ifeq "$(findstring lldb-test-build.noindex, $(BUILDDIR))" ""
 	$(error Trying to invoke the clean rule, but not using the default build tree layout)

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -564,28 +564,37 @@ ifneq "$(CODESIGN)" ""
 endif
 endif
 
-#----------------------------------------------------------------------
-# Make the dSYM file from the executable if $(MAKE_DSYM) != "NO"
-#----------------------------------------------------------------------
 $(DSYM) : $(EXE)
 ifeq "$(OS)" "Darwin"
 ifneq "$(MAKE_DSYM)" "NO"
 	"$(DS)" $(DSFLAGS) -o "$(DSYM)" "$(EXE)"
 else
 endif
-else
+endif
+
 ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
+ifeq "$(DBG_SYMBOL_FILE)" ""
+        DBG_SYMBOL_FILE = $(EXE).debug
+endif
 ifeq "$(SAVE_FULL_DEBUG_BINARY)" "YES"
 	cp "$(EXE)" "$(EXE).unstripped"
 endif
-	$(OBJCOPY) --only-keep-debug "$(EXE)" "$(DSYM)"
-	$(OBJCOPY) --strip-debug --add-gnu-debuglink="$(DSYM)" "$(EXE)" "$(EXE)"
+	$(OBJCOPY) --only-keep-debug "$(EXE)" "$(DBG_SYMBOL_FILE)"
+	$(OBJCOPY) --strip-debug --add-gnu-debuglink="$(DBG_SYMBOL_FILE)" "$(EXE)" "$(EXE)"
 endif
+
 ifeq "$(MAKE_DWP)" "YES"
-	$(DWP) -o "$(DWP_NAME)" $(DWOS)
+ifeq "$(DWP_NAME)" ""
+ifeq "$(DBG_SYMBOL_FILE)" ""
+            DWP_NAME = $(EXE).dwp
+else
+            DWP_NAME = $(DBG_SYMBOL_FILE).dwp
 endif
 endif
 
+$(DWP_NAME): $(EXE)
+	$(DWP) -o "$(DWP_NAME)" $(DWOS)
+endif
 
 #----------------------------------------------------------------------
 # Make the dylib

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -218,6 +218,7 @@ else
 		MAKE_DWO := YES
 		DWP_NAME = $(EXE).dwp
 		DYLIB_DWP_NAME = $(DYLIB_NAME).dwp
+		DSYM = $(DWP_NAME)
 	endif
 endif
 


### PR DESCRIPTION
On non-Darwin platforms, `MAKE_DWP=YES` sets `DWP_NAME` but never sets `DSYM`. Since the `DWP` packaging step is inside the `$(DSYM)` recipe and the `all` target depends on `$(DSYM)`, the step is skipped when `DSYM` is empty. Set `DSYM = $(DWP_NAME)` so the recipe is invoked. I understand "DSYM" sounds like "dSYM" which is a Darwin concept - this is a possible fix to make `self.build(debug_info="dwp")` work (without having to manually call `llvm-dwp` after `debug_info="dwo"`, for example).

cc: @clayborg @JDevlieghere @jimingham