### PR TITLE
[AMDGPU] Add Pierre-vh and ritter-x2a as memory model code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -197,12 +197,16 @@
 /clang/bindings/python @DeinAlptraum
 
 # AMDGPU assembler and disassembler
-/llvm-project/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp @jwanggit86 
-/llvm-project/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp @jwanggit86 
- 
+/llvm-project/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp @jwanggit86
+/llvm-project/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp @jwanggit86
+
 # Clang Driver
 /clang/lib/Driver/ToolChains/AMDGPU.cpp @lamb-j
 /clang/lib/Driver/OffloadBundler.cpp @lamb-j @david-salinas
 
 # GlobalIsel
 /llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize* @vangthao95
+
+# AMDGPU Memory Model
+/llvm/lib/Target/AMDGPU/SIMemoryLegalizer* @Pierre-vh @ritter-x2a
+/llvm/lib/Target/AMDGPU/SIInsertWaitcnts* @Pierre-vh @ritter-x2a


### PR DESCRIPTION
Covers both SIMemoryLegalizer (code sequence lowering) and InsertWaitcnt.