### PR TITLE
[clangd] Fix remark diagnostics without a prior main diagnostic

### DIFF
--- a/clang-tools-extra/clangd/Diagnostics.cpp
+++ b/clang-tools-extra/clangd/Diagnostics.cpp
@@ -236,9 +236,7 @@ bool tryMoveToMainFile(Diag &D, FullSourceLoc DiagLoc) {
   return true;
 }
 
-bool isNote(DiagnosticsEngine::Level L) {
-  return L == DiagnosticsEngine::Note || L == DiagnosticsEngine::Remark;
-}
+bool isNote(DiagnosticsEngine::Level L) { return L == DiagnosticsEngine::Note; }
 
 llvm::StringRef diagLeveltoString(DiagnosticsEngine::Level Lvl) {
   switch (Lvl) {

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -1168,6 +1168,11 @@ TEST(DiagnosticsTest, PragmaSystemHeader) {
   EXPECT_THAT(TU.build().getDiagnostics(), IsEmpty());
 }
 
+TEST(DiagnosticsTest, PragmaDebugSlocUsage) {
+  auto TU = TestTU::withCode("#pragma clang __debug sloc_usage\n");
+  (void)TU.build().getDiagnostics();
+}
+
 TEST(ClangdTest, MSAsm) {
   // Parsing MS assembly tries to use the target MCAsmInfo, which we don't link.
   // We used to crash here. Now clang emits a diagnostic, which we filter out.


### PR DESCRIPTION
`isNote()` was treating remarks as notes, so when #pragma clang __debug sloc_usage emitted a remark as the first diagnostic, clangd crashed with "Adding a note without main diagnostic" because there was no `LastDiag` to attach to.

Fix: remove `Remark` from `isNote()`. Remarks are standalone diagnostics, not attachments — they should create a new `LastDiag` like warnings and errors do.

Fixes #197681 