### PR TITLE
[libclc][CMake] Add depedency on CMAKE_CLC_COMPILER to each source file

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -37,6 +37,9 @@ function(libclc_add_sources target)
     endforeach()
     list(REMOVE_DUPLICATES inc_dirs)
     target_include_directories(${target} PRIVATE ${inc_dirs})
+    set_property(SOURCE ${new_sources}
+      TARGET_DIRECTORY ${target}
+      APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CLC_COMPILER}")
   endif()
 endfunction()
 


### PR DESCRIPTION
This fixes libclc is not rebuilt when clang is updated.

CMake add_library by design doesn't add compiler executable as dependency for source file change.