### PR TITLE
[lldb] Do not include argv[0] to the process info arguments.

### DIFF
--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -614,9 +614,14 @@ static bool GetMacOSXProcessArgs(const ProcessInstanceInfoMatch *match_info_ptr,
               break;
             ++offset;
           }
-          // Now extract all arguments
+
+          // Skip argv[0] as we already have the file name from the executable path.
+          if (argc > 0 )
+            data.GetCStr(&offset);
+
+          // Now extract the rest of the arguments.
           Args &proc_args = process_info.GetArguments();
-          for (int i = 0; i < static_cast<int>(argc); ++i) {
+          for (int i = 1; i < static_cast<int>(argc); ++i) {
             cstr = data.GetCStr(&offset);
             if (cstr)
               proc_args.AppendArgument(llvm::StringRef(cstr));

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -616,8 +616,8 @@ static bool GetMacOSXProcessArgs(const ProcessInstanceInfoMatch *match_info_ptr,
           }
 
           // Skip argv[0] as we already have the file name from the executable path.
-          if (argc > 0 )
-            data.GetCStr(&offset);
+          if (argc > 0)
+            process_info.SetArg0(data.GetCStr(&offset));
 
           // Now extract the rest of the arguments.
           Args &proc_args = process_info.GetArguments();

--- a/lldb/test/API/commands/platform/process/list/TestProcessList.py
+++ b/lldb/test/API/commands/platform/process/list/TestProcessList.py
@@ -26,5 +26,5 @@ class ProcessListTestCase(TestBase):
         popen = self.spawnSubprocess(exe, args=[sync_file, "arg1", "--arg2", "arg3"])
         lldbutil.wait_for_file_on_target(self, sync_file)
 
-        substrs = [str(popen.pid), "TestProcess", "arg1 --arg2 arg3"]
+        substrs = [str(popen.pid), "TestProcess", sync_file, "arg1 --arg2 arg3"]
         self.expect("platform process list -v", substrs=substrs)

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -445,7 +445,7 @@ class ProcessAPITestCase(TestBase):
 
         process_info.GetParentProcessID()
 
-    @expectedFailureWindows # Not yet implemented.
+    @expectedFailureWindows  # Not yet implemented.
     def test_get_process_info_arguments(self):
         """Test SBProcessInfo Arguments returns the correct values."""
         self.build()

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -445,7 +445,7 @@ class ProcessAPITestCase(TestBase):
 
         process_info.GetParentProcessID()
 
-    @skipUnlessPlatform(["linux"])
+    @expectedFailureWindows # Not yet implemented.
     def test_get_process_info_arguments(self):
         """Test SBProcessInfo Arguments returns the correct values."""
         self.build()


### PR DESCRIPTION
The process file name is stored separately from other command line args. and argv[0] may differ from the executable path if process was created using the `exec*()` variants.