### PR TITLE
[ArgumentPromotion][BPF] Regenerate check lines (NFC)

### DIFF
--- a/llvm/test/Transforms/ArgumentPromotion/BPF/argpromotion.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/BPF/argpromotion.ll
@@ -59,10 +59,7 @@ entry:
   ret i32 %add4
 }
 
-; Without number-of-argument constraint, argpromotion will create a function signature with 6 arguments. Since
-; bpf target only supports maximum 5 arguments, so no argpromotion here.
-;
-; CHECK:  i32 @foo1(ptr noundef readonly captures(none) %p1, ptr noundef readonly captures(none) %p2, ptr noundef readonly captures(none) %p3)
+; CHECK:  i32 @foo1(i32 %p1.0.val, i32 %p1.4.val, i32 %p2.8.val, i32 %p2.16.val, i32 %p3.20.val, i32 %p3.24.val)
 
 define internal i32 @foo2(ptr noundef %p1, ptr noundef %p2, ptr noundef %p3) {
 entry:
@@ -82,7 +79,4 @@ entry:
   ret i32 %add3
 }
 
-; Without number-of-argument constraint, argpromotion will create a function signature with 5 arguments, which equals
-; the maximum number of argument permitted by bpf backend, so argpromotion result code does work.
-;
 ; CHECK:  i32 @foo2(i32 %p1.0.val, i32 %p1.4.val, i32 %p2.8.val, i32 %p2.16.val, i32 %p3.20.val)


### PR DESCRIPTION
Test update after 7f396dbc9cdcf33e85dd857945dd8f1e921f887c, previously missing.

Fixes: https://github.com/llvm/llvm-project/issues/198264.