### PR TITLE
[AArch64][BOLT] Document AArch64 optimization flag support

### DIFF
--- a/bolt/docs/BOLTAArch64OptimizationStatus.rst
+++ b/bolt/docs/BOLTAArch64OptimizationStatus.rst
@@ -11,9 +11,11 @@ explicitly enable when optimizing AArch64 binaries.
 BOLT is to be used with binaries linked with
 relocations (``--emit-relocs`` or ``-Wl,-q``) and representative profile data.
 
-Supported Flags
----------------
-The following flags are supported for AArch64.
+Main Code-Layout Optimizations
+------------------------------
+The following code-layout optimizations are typically the first options to
+consider when optimizing AArch64 binaries with representative profile data.
+They typically provide the largest performance gains among BOLT optimizations.
 
 .. list-table::
      :header-rows: 1
@@ -32,6 +34,19 @@ The following flags are supported for AArch64.
          | ``--split-all-cold``
          | ``--split-eh``
        - Split hot and cold code
+
+
+Other Supported Optimizations
+-----------------------------
+The following optimizations are also supported for AArch64.
+
+.. list-table::
+     :header-rows: 1
+     :widths: 34 42
+     :align: left
+
+     * - Flag
+       - Optimization
      * - | ``--align-blocks``
          | ``--block-alignment=<uint>``
        - Align basic blocks

--- a/bolt/docs/BOLTAArch64OptimizationStatus.rst
+++ b/bolt/docs/BOLTAArch64OptimizationStatus.rst
@@ -8,7 +8,7 @@ Overview
 This page summarizes default-off BOLT optimization flags that users may
 explicitly enable when optimizing AArch64 binaries.
 
-Ideally, BOLT is to be used with binaries linked with
+BOLT is to be used with binaries linked with
 relocations (``--emit-relocs`` or ``-Wl,-q``) and representative profile data.
 
 Supported Flags
@@ -22,15 +22,23 @@ The following flags are supported for AArch64.
 
      * - Flag
        - Optimization
+     * - | ``--reorder-functions=exec-count|hfsort|cdsort|pettis-hansen|random|user``
+         | ``--function-order=<file>``
+       - Reorder functions
+     * - ``--reorder-blocks=normal|ext-tsp|cache|branch-predictor|reverse|cluster-shuffle``
+       - Reorder basic blocks
+     * - | ``--split-functions``
+         | ``--split-strategy=profile2|random2|randomN|all``
+         | ``--split-all-cold``
+         | ``--split-eh``
+       - Split hot and cold code
+     * - | ``--align-blocks``
+         | ``--block-alignment=<uint>``
+       - Align basic blocks
      * - ``--tail-duplication=aggressive|moderate|cache``
        - Duplicate branch tails
      * - ``--peepholes=double-jumps|tailcall-traps|useless-branches|all``
        - Run peephole optimizations
-     * - ``--reorder-blocks=normal|ext-tsp|cache|branch-predictor|reverse|cluster-shuffle``
-       - Reorder basic blocks
-     * - | ``--align-blocks``
-         | ``--block-alignment=<uint>``
-       - Align basic blocks
      * - | ``--inline-all``
          | ``--inline-small-functions``
          | Related options:
@@ -40,9 +48,6 @@ The following flags are supported for AArch64.
        - Inline functions
      * - ``--icf=safe|all``
        - Fold identical functions
-     * - | ``--reorder-functions=exec-count|hfsort|cdsort|pettis-hansen|random|user``
-         | ``--function-order=<file>``
-       - Reorder functions
 
 Supported Flags With Limitations
 --------------------------------
@@ -71,12 +76,9 @@ an error or perform no transformation.
          | ``--reorder-data-algo=count|funcs``
        - Reorder data sections
        - ``move``, ``split`` and ``aggressive`` disable data reordering.
-     * - | ``--split-functions``
-         | ``--split-strategy=profile2|cdsplit|random2|randomN|all``
-         | ``--split-all-cold``
-         | ``--split-eh``
-       - Split hot and cold code
-       - ``--split-strategy=cdsplit`` requires ``--compact-code-model`` on AArch64.
+     * - ``--split-strategy=cdsplit``
+       - Split functions using cache-directed splitting
+       - Requires ``--compact-code-model`` on AArch64.
 
 Unsupported Flags
 -----------------
@@ -101,21 +103,24 @@ target.
      * - ``--three-way-branch``
        - Reorder three-way branches
        - Not implemented for AArch64.
-     * - ``--cmov-conversion``
-       - Convert branches to conditional moves
-       - Not applicable to AArch64.
+     * - ``--simplify-rodata-loads``
+       - Replace read-only data loads with constants
+       - Not implemented for AArch64.
      * - ``--frame-opt=hot|all``
        - Optimize stack-frame accesses
        - Not implemented for AArch64.
      * - ``--indirect-call-promotion=calls|jump-tables|all``
        - Promote indirect calls
        - Not implemented for AArch64.
+     * - ``--memcpy1-spec=<func1,func2:cs1:cs2,...>``
+       - Specialize one-byte ``memcpy`` calls
+       - Not implemented for AArch64.
      * - ``--reg-reassign``
        - Reassign registers to reduce encoding size
        - Not applicable to AArch64.
-     * - ``--simplify-rodata-loads``
-       - Replace read-only data loads with constants
-       - Not implemented for AArch64.
+     * - ``--cmov-conversion``
+       - Convert branches to conditional moves
+       - Not applicable to AArch64.
      * - | ``--stoke``
          | ``--stoke-out``
        - Emit STOKE optimization data
@@ -123,6 +128,3 @@ target.
      * - ``--insert-retpolines``
        - Insert retpolines
        - Not applicable to AArch64.
-     * - ``--memcpy1-spec=<func1,func2:cs1:cs2,...>``
-       - Specialize one-byte ``memcpy`` calls
-       - Not implemented for AArch64.

--- a/bolt/docs/BOLTAArch64OptimizationStatus.rst
+++ b/bolt/docs/BOLTAArch64OptimizationStatus.rst
@@ -1,0 +1,125 @@
+=====================================
+AArch64 Optimization and Flags Status
+=====================================
+
+Overview
+--------
+
+This page summarizes default-off BOLT optimization flags that users may
+explicitly enable when optimizing AArch64 binaries.
+
+Ideally, BOLT is to be used with binaries linked with
+relocations (``--emit-relocs`` or ``-Wl,-q``) and representative profile data.
+
+Supported Flags
+---------------
+The following flags are supported for AArch64.
+
+.. list-table::
+     :header-rows: 1
+     :widths: 34 42
+
+     * - Flag
+       - Optimization
+     * - ``--tail-duplication=aggressive|moderate|cache``
+       - Duplicate branch tails
+     * - ``--peepholes=double-jumps|tailcall-traps|useless-branches|all``
+       - Run peephole optimizations
+     * - ``--reorder-blocks=normal|ext-tsp|cache|branch-predictor|reverse|cluster-shuffle``
+       - Reorder basic blocks
+     * - | ``--align-blocks``
+         | ``--block-alignment=<uint>``
+       - Align basic blocks
+     * - | ``--inline-all``
+         | ``--inline-small-functions``
+         | Related options:
+         | ``--inline-ap``
+         | ``--inline-limit=<uint>``
+         | ``--inline-small-functions-bytes=<uint>``
+       - Inline functions
+     * - ``--icf=safe|all``
+       - Fold identical functions
+     * - | ``--reorder-functions=exec-count|hfsort|cdsort|pettis-hansen|random|user``
+         | ``--function-order=<file>``
+       - Reorder functions
+
+Supported Flags With Limitations
+--------------------------------
+The following flags are implemented for AArch64, but require specific runtime
+or option conditions. Enabling them without the required conditions may report
+an error or perform no transformation.
+
+.. list-table::
+     :header-rows: 1
+     :widths: 30 28 44
+
+     * - Flag
+       - Optimization
+       - Notes
+     * - ``--inline-memcpy``
+       - Inline fixed-size ``memcpy`` calls
+       - Only applies when the copy size is a known constant; AArch64 skips sizes over 64 bytes.
+     * - ``--plt=hot|all``
+       - Optimize PLT calls
+       - Requires immediate binding. If BOLT cannot update the binary, relink with ``-znow``.
+     * - ``--hugify``
+       - Place hot code on huge pages
+       - Applies to binaries with a recognized entry point; skipped when ``--instrument`` is used.
+     * - | ``--reorder-data=<section1,section2,...>``
+         | ``--reorder-data-algo=count|funcs``
+       - Reorder data sections
+       - ``move``, ``split`` and ``aggressive`` disable data reordering.
+     * - | ``--split-functions``
+         | ``--split-strategy=profile2|cdsplit|random2|randomN|all``
+         | ``--split-all-cold``
+         | ``--split-eh``
+       - Split hot and cold code
+       - ``--split-strategy=cdsplit`` requires ``--compact-code-model`` on AArch64.
+
+Unsupported Flags
+-----------------
+
+The following flags are not available for AArch64. ``Not applicable to
+AArch64`` means the optimization targets architectural features or mechanisms
+that do not apply to AArch64. ``Not implemented for AArch64`` means the
+optimization could be relevant, but is not currently implemented for this
+target.
+
+.. list-table::
+     :header-rows: 1
+     :widths: 30 28 42
+
+     * - Flag
+       - Optimization
+       - Notes
+     * - ``--jt-footprint-reduction``
+       - Reduce jump-table footprint
+       - Not implemented for AArch64.
+     * - ``--three-way-branch``
+       - Reorder three-way branches
+       - Not implemented for AArch64.
+     * - ``--cmov-conversion``
+       - Convert branches to conditional moves
+       - Not applicable to AArch64.
+     * - ``--frame-opt=hot|all``
+       - Optimize stack-frame accesses
+       - Not implemented for AArch64.
+     * - ``--indirect-call-promotion=calls|jump-tables|all``
+       - Promote indirect calls
+       - Not implemented for AArch64.
+     * - ``--reg-reassign``
+       - Reassign registers to reduce encoding size
+       - Not applicable to AArch64.
+     * - ``--simplify-rodata-loads``
+       - Replace read-only data loads with constants
+       - Not implemented for AArch64.
+     * - | ``--stoke``
+         | ``--stoke-out``
+       - Emit STOKE optimization data
+       - Not applicable to AArch64.
+     * - ``--insert-retpolines``
+       - Insert retpolines
+       - Not applicable to AArch64.
+     * - ``--memcpy1-spec=<func1,func2:cs1:cs2,...>``
+       - Specialize one-byte ``memcpy`` calls
+       - Not implemented for AArch64.

--- a/bolt/docs/BOLTAArch64OptimizationStatus.rst
+++ b/bolt/docs/BOLTAArch64OptimizationStatus.rst
@@ -18,6 +18,7 @@ The following flags are supported for AArch64.
 .. list-table::
      :header-rows: 1
      :widths: 34 42
+     :align: left
 
      * - Flag
        - Optimization
@@ -52,6 +53,7 @@ an error or perform no transformation.
 .. list-table::
      :header-rows: 1
      :widths: 30 28 44
+     :align: left
 
      * - Flag
        - Optimization
@@ -88,6 +90,7 @@ target.
 .. list-table::
      :header-rows: 1
      :widths: 30 28 42
+     :align: left
 
      * - Flag
        - Optimization

--- a/bolt/docs/index.rst
+++ b/bolt/docs/index.rst
@@ -256,17 +256,6 @@ Profile Formats
 See `Profile Formats <profiles.md>`__ for comprehensive documentation of all
 profile formats accepted by BOLT: perf.data, fdata, YAML, and pre-aggregated.
 
-Additional Documentation
-------------------------
-
-.. toctree::
-   :hidden:
-
-   BOLTAArch64OptimizationStatus
-
-:doc:`BOLTAArch64OptimizationStatus`
-  Status of default-off BOLT optimization flags on AArch64.
-
 License
 -------
 

--- a/bolt/docs/index.rst
+++ b/bolt/docs/index.rst
@@ -256,6 +256,17 @@ Profile Formats
 See `Profile Formats <profiles.md>`__ for comprehensive documentation of all
 profile formats accepted by BOLT: perf.data, fdata, YAML, and pre-aggregated.
 
+Additional Documentation
+------------------------
+
+.. toctree::
+   :hidden:
+
+   BOLTAArch64OptimizationStatus
+
+:doc:`BOLTAArch64OptimizationStatus`
+  Status of default-off BOLT optimization flags on AArch64.
+
 License
 -------
 


### PR DESCRIPTION
BOLTAArch64OptimizationStatus.rst aims to document default-off, user-enabled passes and their status (supported/unsupported) on AArch64.

``--simplify-rodata-loads`` has a patch in review, so I have documented its current status.

Discussion on RST/MD: https://discourse.llvm.org/t/rfc-make-myst-markdown-the-llvm-docs-format-rip-rest/90840