### PR TITLE
[flang-rt] Add -Wno-fenv-access to flang-rt compile options

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -151,6 +151,18 @@ if (FLANG_RT_INCLUDE_CUF)
   find_package(CUDAToolkit REQUIRED)
 endif()
 
+# A recently added check in clang emits warnings for feclearexcept and fesetround:
+#   'fesetround' used without enabling floating-point exception behavior; use
+#         'pragma STDC FENV_ACCESS ON' or compile with
+#         '-ffp-exception-behavior=maytrap' [-Werror,-Wfenv-access]
+# This breaks the CI build (because of -Werror).
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  check_cxx_compiler_flag("-Werror -Wno-fenv-access" CXX_SUPPORTS_NO_FENV_ACCESS_FLAG)
+  if (CXX_SUPPORTS_NO_FENV_ACCESS_FLAG)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-fenv-access")
+  endif()
+endif()  # Clang
+
 
 ########################
 # System Introspection #


### PR DESCRIPTION
A check recently added to clang will now flag uses of floating-point exception routines. There are some calls to these functions in the flang runtime. Since the flang runtime is compiled with the freshly built clang, it now shows these warnings.

Since the CI build uses -Werror, this breaks the flang-rt build even though no changes to the flang-rt have been made:
```
flang-rt/lib/runtime/main.cpp:20:3: error:
      'feclearexcept' used without enabling floating-point exception behavior;
      use 'pragma STDC FENV_ACCESS ON' or compile with
      '-ffp-exception-behavior=maytrap' [-Werror,-Wfenv-access]
   20 |   std::feclearexcept(FE_ALL_EXCEPT);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
flang-rt/lib/runtime/main.cpp:25:3: error:
      'fesetround' used without enabling floating-point exception behavior; use
      'pragma STDC FENV_ACCESS ON' or compile with
      '-ffp-exception-behavior=maytrap' [-Werror,-Wfenv-access]
   25 |   std::fesetround(FE_TONEAREST);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

This PR will add a flag to turn off the warning as a means to restore the flang-rt build.