### PR TITLE
[llvm] Fix DEMANGLE_ABI for MinGW

### DIFF
--- a/llvm/include/llvm/Demangle/DemangleConfig.h
+++ b/llvm/include/llvm/Demangle/DemangleConfig.h
@@ -102,7 +102,7 @@
 #if defined(LLVM_BUILD_STATIC) || !defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS)
 #define DEMANGLE_ABI
 #else
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #if defined(LLVM_EXPORTS)
 #define DEMANGLE_ABI __declspec(dllexport)
 #else


### PR DESCRIPTION
Exclude MinGW from __declspec(dllimport) like LLVM_ABI in llvm/include/llvm/Support/Compiler.h does. MinGW auto-exports all DLL symbols, so __declspec is not needed and causes undefined __imp__ references when linking static libraries.