### PR TITLE
[lldb][windows] Make skipUnlessMSVC tolerate cl.exe not in PATH

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1132,11 +1132,14 @@ def skipUnlessMSVC(func):
     """Decorate the item to skip test unless msvc is available."""
 
     def is_msvc_in_path():
-        result = subprocess.run(
-            ["cl.exe"],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["cl.exe"],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return f"Test requires MSVC to be in the Path."
         if result.returncode != 0:
             return f"Test requires MSVC to be in the Path."
         return None


### PR DESCRIPTION
If `cl.exe` is not in the PATH, `subprocess.run([\"cl.exe\"])` raises `FileNotFoundError`. This marks the test as `UNRESOLVED` instead of `SKIPPED`.

This patch makes sure lit catches `FileNotFoundError` so the test is skipped cleanly.