### PR TITLE
[libc][NFC] Fix #endif comments in hdr/ proxy headers

### DIFF
--- a/libc/hdr/elf_macros.h
+++ b/libc/hdr/elf_macros.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_ELF_MACROS_H

--- a/libc/hdr/errno_macros.h
+++ b/libc/hdr/errno_macros.h
@@ -25,6 +25,6 @@
 
 #include <errno.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_ERRNO_MACROS_H

--- a/libc/hdr/fcntl_macros.h
+++ b/libc/hdr/fcntl_macros.h
@@ -17,6 +17,6 @@
 
 #include "hdr/fcntl_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_FCNTL_MACROS_H

--- a/libc/hdr/fenv_macros.h
+++ b/libc/hdr/fenv_macros.h
@@ -56,6 +56,6 @@
 #define FE_UPWARD 0x800
 #endif // FE_UPWARD
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_FENV_MACROS_H

--- a/libc/hdr/float_macros.h
+++ b/libc/hdr/float_macros.h
@@ -17,6 +17,6 @@
 
 #include <float.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_FLOAT_MACROS_H

--- a/libc/hdr/limits_macros.h
+++ b/libc/hdr/limits_macros.h
@@ -17,6 +17,6 @@
 
 #include <limits.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_LIMITS_MACROS_H

--- a/libc/hdr/link_macros.h
+++ b/libc/hdr/link_macros.h
@@ -17,6 +17,6 @@
 
 #include <link.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_LINK_MACROS_H

--- a/libc/hdr/locale_macros.h
+++ b/libc/hdr/locale_macros.h
@@ -17,6 +17,6 @@
 
 #error "macros not available in overlay mode"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_LOCALE_MACROS_H

--- a/libc/hdr/math_function_macros.h
+++ b/libc/hdr/math_function_macros.h
@@ -22,6 +22,6 @@
 #endif
 #include <math.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_MATH_FUNCTION_MACROS_H

--- a/libc/hdr/math_macros.h
+++ b/libc/hdr/math_macros.h
@@ -43,6 +43,6 @@
 #define FP_INT_TONEAREST 4
 #endif // FP_INT_TONEAREST
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_MATH_MACROS_H

--- a/libc/hdr/offsetof_macros.h
+++ b/libc/hdr/offsetof_macros.h
@@ -18,6 +18,6 @@
 #define __need_offsetof
 #include <stddef.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_OFFSETOF_MACROS_H

--- a/libc/hdr/pthread_macros.h
+++ b/libc/hdr/pthread_macros.h
@@ -17,6 +17,6 @@
 
 #include <pthread.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_PTHREAD_MACROS_H

--- a/libc/hdr/sched_macros.h
+++ b/libc/hdr/sched_macros.h
@@ -17,6 +17,6 @@
 
 #include <sched.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SCHED_MACROS_H

--- a/libc/hdr/signal_macros.h
+++ b/libc/hdr/signal_macros.h
@@ -17,6 +17,6 @@
 
 #include <signal.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SIGNAL_MACROS_H

--- a/libc/hdr/stdio_macros.h
+++ b/libc/hdr/stdio_macros.h
@@ -18,6 +18,6 @@
 
 #include "stdio_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_STDIO_MACROS_H

--- a/libc/hdr/stdlib_macros.h
+++ b/libc/hdr/stdlib_macros.h
@@ -17,6 +17,6 @@
 
 #include "stdlib_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_STDLIB_MACROS_H

--- a/libc/hdr/sys_auxv_macros.h
+++ b/libc/hdr/sys_auxv_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/auxv.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_AUXV_MACROS_H

--- a/libc/hdr/sys_epoll_macros.h
+++ b/libc/hdr/sys_epoll_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/epoll.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_EPOLL_MACROS_H

--- a/libc/hdr/sys_ioctl_macros.h
+++ b/libc/hdr/sys_ioctl_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/ioctl.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_IOCTL_MACROS_H

--- a/libc/hdr/sys_ipc_macros.h
+++ b/libc/hdr/sys_ipc_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/ipc.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_IPC_MACROS_H

--- a/libc/hdr/sys_mman_macros.h
+++ b/libc/hdr/sys_mman_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/mman.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_MMAN_MACROS_H

--- a/libc/hdr/sys_sem_macros.h
+++ b/libc/hdr/sys_sem_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/sem.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_SEM_MACROS_H

--- a/libc/hdr/sys_socket_macros.h
+++ b/libc/hdr/sys_socket_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/socket.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_SOCKET_MACROS_H

--- a/libc/hdr/sys_stat_macros.h
+++ b/libc/hdr/sys_stat_macros.h
@@ -17,6 +17,6 @@
 
 #include <sys/stat.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_SYS_STAT_MACROS_H

--- a/libc/hdr/time_macros.h
+++ b/libc/hdr/time_macros.h
@@ -17,7 +17,7 @@
 
 #include <time.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 // TODO: For now, on windows, let's always include the extension header.
 // We will need to decide how to export this header.

--- a/libc/hdr/types/ACTION.h
+++ b/libc/hdr/types/ACTION.h
@@ -17,6 +17,6 @@
 
 #include <search.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ACTION_H

--- a/libc/hdr/types/ENTRY.h
+++ b/libc/hdr/types/ENTRY.h
@@ -17,6 +17,6 @@
 
 #include <search.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ENTRY_H

--- a/libc/hdr/types/Elf32_Addr.h
+++ b/libc/hdr/types/Elf32_Addr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_ADDR_H

--- a/libc/hdr/types/Elf32_Chdr.h
+++ b/libc/hdr/types/Elf32_Chdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_CHDR_H

--- a/libc/hdr/types/Elf32_Dyn.h
+++ b/libc/hdr/types/Elf32_Dyn.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_DYN_H

--- a/libc/hdr/types/Elf32_Ehdr.h
+++ b/libc/hdr/types/Elf32_Ehdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_EHDR_H

--- a/libc/hdr/types/Elf32_Half.h
+++ b/libc/hdr/types/Elf32_Half.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_HALF_H

--- a/libc/hdr/types/Elf32_Lword.h
+++ b/libc/hdr/types/Elf32_Lword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_LWORD_H

--- a/libc/hdr/types/Elf32_Nhdr.h
+++ b/libc/hdr/types/Elf32_Nhdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_NHDR_H

--- a/libc/hdr/types/Elf32_Off.h
+++ b/libc/hdr/types/Elf32_Off.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_OFF_H

--- a/libc/hdr/types/Elf32_Phdr.h
+++ b/libc/hdr/types/Elf32_Phdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_PHDR_H

--- a/libc/hdr/types/Elf32_Rel.h
+++ b/libc/hdr/types/Elf32_Rel.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_REL_H

--- a/libc/hdr/types/Elf32_Rela.h
+++ b/libc/hdr/types/Elf32_Rela.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_RELA_H

--- a/libc/hdr/types/Elf32_Shdr.h
+++ b/libc/hdr/types/Elf32_Shdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_SHDR_H

--- a/libc/hdr/types/Elf32_Sword.h
+++ b/libc/hdr/types/Elf32_Sword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_SWORD_H

--- a/libc/hdr/types/Elf32_Sym.h
+++ b/libc/hdr/types/Elf32_Sym.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_SYM_H

--- a/libc/hdr/types/Elf32_Verdaux.h
+++ b/libc/hdr/types/Elf32_Verdaux.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_VERDAUX_H

--- a/libc/hdr/types/Elf32_Verdef.h
+++ b/libc/hdr/types/Elf32_Verdef.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_VERDEF_H

--- a/libc/hdr/types/Elf32_Vernaux.h
+++ b/libc/hdr/types/Elf32_Vernaux.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_VERNAUX_H

--- a/libc/hdr/types/Elf32_Verneed.h
+++ b/libc/hdr/types/Elf32_Verneed.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_VERNEED_H

--- a/libc/hdr/types/Elf32_Versym.h
+++ b/libc/hdr/types/Elf32_Versym.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_VERSYM_H

--- a/libc/hdr/types/Elf32_Word.h
+++ b/libc/hdr/types/Elf32_Word.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_WORD_H

--- a/libc/hdr/types/Elf32_Xword.h
+++ b/libc/hdr/types/Elf32_Xword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_XWORD_H

--- a/libc/hdr/types/Elf32_auxv_t.h
+++ b/libc/hdr/types/Elf32_auxv_t.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF32_AUXV_T_H

--- a/libc/hdr/types/Elf64_Addr.h
+++ b/libc/hdr/types/Elf64_Addr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_ADDR_H

--- a/libc/hdr/types/Elf64_Chdr.h
+++ b/libc/hdr/types/Elf64_Chdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_CHDR_H

--- a/libc/hdr/types/Elf64_Dyn.h
+++ b/libc/hdr/types/Elf64_Dyn.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_DYN_H

--- a/libc/hdr/types/Elf64_Ehdr.h
+++ b/libc/hdr/types/Elf64_Ehdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_EHDR_H

--- a/libc/hdr/types/Elf64_Half.h
+++ b/libc/hdr/types/Elf64_Half.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_HALF_H

--- a/libc/hdr/types/Elf64_Lword.h
+++ b/libc/hdr/types/Elf64_Lword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_LWORD_H

--- a/libc/hdr/types/Elf64_Nhdr.h
+++ b/libc/hdr/types/Elf64_Nhdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_NHDR_H

--- a/libc/hdr/types/Elf64_Off.h
+++ b/libc/hdr/types/Elf64_Off.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_OFF_H

--- a/libc/hdr/types/Elf64_Phdr.h
+++ b/libc/hdr/types/Elf64_Phdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_PHDR_H

--- a/libc/hdr/types/Elf64_Rel.h
+++ b/libc/hdr/types/Elf64_Rel.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_REL_H

--- a/libc/hdr/types/Elf64_Rela.h
+++ b/libc/hdr/types/Elf64_Rela.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_RELA_H

--- a/libc/hdr/types/Elf64_Shdr.h
+++ b/libc/hdr/types/Elf64_Shdr.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_SHDR_H

--- a/libc/hdr/types/Elf64_Sword.h
+++ b/libc/hdr/types/Elf64_Sword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_SWORD_H

--- a/libc/hdr/types/Elf64_Sxword.h
+++ b/libc/hdr/types/Elf64_Sxword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_SXWORD_H

--- a/libc/hdr/types/Elf64_Sym.h
+++ b/libc/hdr/types/Elf64_Sym.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_SYM_H

--- a/libc/hdr/types/Elf64_Verdaux.h
+++ b/libc/hdr/types/Elf64_Verdaux.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_VERDAUX_H

--- a/libc/hdr/types/Elf64_Verdef.h
+++ b/libc/hdr/types/Elf64_Verdef.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_VERDEF_H

--- a/libc/hdr/types/Elf64_Vernaux.h
+++ b/libc/hdr/types/Elf64_Vernaux.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_VERNAUX_H

--- a/libc/hdr/types/Elf64_Verneed.h
+++ b/libc/hdr/types/Elf64_Verneed.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_VERNEED_H

--- a/libc/hdr/types/Elf64_Versym.h
+++ b/libc/hdr/types/Elf64_Versym.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_VERSYM_H

--- a/libc/hdr/types/Elf64_Word.h
+++ b/libc/hdr/types/Elf64_Word.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_WORD_H

--- a/libc/hdr/types/Elf64_Xword.h
+++ b/libc/hdr/types/Elf64_Xword.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_XWORD_H

--- a/libc/hdr/types/Elf64_auxv_t.h
+++ b/libc/hdr/types/Elf64_auxv_t.h
@@ -17,6 +17,6 @@
 
 #include <elf.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ELF64_AUXV_T_H

--- a/libc/hdr/types/FILE.h
+++ b/libc/hdr/types/FILE.h
@@ -17,6 +17,6 @@
 
 #include "hdr/stdio_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_FILE_H

--- a/libc/hdr/types/VISIT.h
+++ b/libc/hdr/types/VISIT.h
@@ -17,6 +17,6 @@
 
 #include <search.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_VISIT_H

--- a/libc/hdr/types/atexithandler_t.h
+++ b/libc/hdr/types/atexithandler_t.h
@@ -17,6 +17,6 @@
 
 #error // type not available in overlay mode
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_ATEXITHANDLER_T_H

--- a/libc/hdr/types/clock_t.h
+++ b/libc/hdr/types/clock_t.h
@@ -17,6 +17,6 @@
 
 #include <sys/types.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_CLOCK_T_H

--- a/libc/hdr/types/clockid_t.h
+++ b/libc/hdr/types/clockid_t.h
@@ -18,6 +18,6 @@
 
 #include <sys/types.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_CLOCKID_T_H

--- a/libc/hdr/types/cookie_io_functions_t.h
+++ b/libc/hdr/types/cookie_io_functions_t.h
@@ -17,6 +17,6 @@
 
 #include "hdr/stdio_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_COOKIE_IO_FUNCTIONS_T_H

--- a/libc/hdr/types/cpu_set_t.h
+++ b/libc/hdr/types/cpu_set_t.h
@@ -17,6 +17,6 @@
 
 #include <sched.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_CPU_SET_T_H

--- a/libc/hdr/types/div_t.h
+++ b/libc/hdr/types/div_t.h
@@ -17,6 +17,6 @@
 
 #include "hdr/stdlib_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_DIV_T_H

--- a/libc/hdr/types/fenv_t.h
+++ b/libc/hdr/types/fenv_t.h
@@ -17,6 +17,6 @@
 
 #include <fenv.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_FENV_T_H

--- a/libc/hdr/types/fexcept_t.h
+++ b/libc/hdr/types/fexcept_t.h
@@ -17,6 +17,6 @@
 
 #include <fenv.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_FEXCEPT_T_H

--- a/libc/hdr/types/gid_t.h
+++ b/libc/hdr/types/gid_t.h
@@ -17,6 +17,6 @@
 
 #include <sys/types.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_GID_T_H

--- a/libc/hdr/types/jmp_buf.h
+++ b/libc/hdr/types/jmp_buf.h
@@ -17,6 +17,6 @@
 
 #include <setjmp.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_JMP_BUF_H

--- a/libc/hdr/types/key_t.h
+++ b/libc/hdr/types/key_t.h
@@ -17,6 +17,6 @@
 
 #include <sys/ipc.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_KEY_T_H

--- a/libc/hdr/types/ldiv_t.h
+++ b/libc/hdr/types/ldiv_t.h
@@ -17,6 +17,6 @@
 
 #include "hdr/stdlib_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_LDIV_T_H

--- a/libc/hdr/types/lldiv_t.h
+++ b/libc/hdr/types/lldiv_t.h
@@ -17,6 +17,6 @@
 
 #include "hdr/stdlib_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_LLDIV_T_H

--- a/libc/hdr/types/locale_t.h
+++ b/libc/hdr/types/locale_t.h
@@ -17,6 +17,6 @@
 
 #error "type not available in overlay mode"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_LOCALE_T_H

--- a/libc/hdr/types/mbstate_t.h
+++ b/libc/hdr/types/mbstate_t.h
@@ -17,6 +17,6 @@
 
 #error "Cannot overlay mbstate_t"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_MBSTATE_T_H

--- a/libc/hdr/types/mode_t.h
+++ b/libc/hdr/types/mode_t.h
@@ -17,6 +17,6 @@
 
 #include "hdr/fcntl_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_MODE_T_H

--- a/libc/hdr/types/nfds_t.h
+++ b/libc/hdr/types/nfds_t.h
@@ -18,6 +18,6 @@
 
 #include <poll.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_NFDS_T_H

--- a/libc/hdr/types/off_t.h
+++ b/libc/hdr/types/off_t.h
@@ -17,6 +17,6 @@
 
 #include "hdr/stdio_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_OFF_T_H

--- a/libc/hdr/types/pid_t.h
+++ b/libc/hdr/types/pid_t.h
@@ -17,6 +17,6 @@
 
 #include <sys/types.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_PID_T_H

--- a/libc/hdr/types/posix_tnode.h
+++ b/libc/hdr/types/posix_tnode.h
@@ -23,6 +23,6 @@
 #include <search.h>
 typedef void __llvm_libc_tnode;
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_POSIX_TNODE_H

--- a/libc/hdr/types/pthread_barrier_t.h
+++ b/libc/hdr/types/pthread_barrier_t.h
@@ -17,6 +17,6 @@
 
 #error "Cannot overlay pthread_barrier_t"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_PTHREAD_BARRIER_T_H

--- a/libc/hdr/types/pthread_barrierattr_t.h
+++ b/libc/hdr/types/pthread_barrierattr_t.h
@@ -17,6 +17,6 @@
 
 #error "Cannot overlay pthread_barrierattr_t"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_PTHREAD_BARRIERATTR_T_H

--- a/libc/hdr/types/sigjmp_buf.h
+++ b/libc/hdr/types/sigjmp_buf.h
@@ -17,6 +17,6 @@
 
 #include <setjmp.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_SIGJMP_BUF_H

--- a/libc/hdr/types/stack_t.h
+++ b/libc/hdr/types/stack_t.h
@@ -18,6 +18,6 @@
 
 #include <signal.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STACK_T_H

--- a/libc/hdr/types/struct_pollfd.h
+++ b/libc/hdr/types/struct_pollfd.h
@@ -18,6 +18,6 @@
 
 #include <poll.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_POLLFD_H

--- a/libc/hdr/types/struct_rlimit.h
+++ b/libc/hdr/types/struct_rlimit.h
@@ -17,6 +17,6 @@
 
 #include <sys/resource.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_RLIMIT_H

--- a/libc/hdr/types/struct_sched_param.h
+++ b/libc/hdr/types/struct_sched_param.h
@@ -17,6 +17,6 @@
 
 #include <sched.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_SCHED_PARAM_H

--- a/libc/hdr/types/struct_sembuf.h
+++ b/libc/hdr/types/struct_sembuf.h
@@ -17,6 +17,6 @@
 
 #include <sys/sem.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_SEMBUF_H

--- a/libc/hdr/types/struct_semid_ds.h
+++ b/libc/hdr/types/struct_semid_ds.h
@@ -17,6 +17,6 @@
 
 #include <sys/sem.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_SEMID_DS_H

--- a/libc/hdr/types/struct_seminfo.h
+++ b/libc/hdr/types/struct_seminfo.h
@@ -17,6 +17,6 @@
 
 #include <sys/sem.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_SEMINFO_H

--- a/libc/hdr/types/struct_stat.h
+++ b/libc/hdr/types/struct_stat.h
@@ -22,6 +22,6 @@
 
 #include <sys/stat.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_STRUCT_STAT_H

--- a/libc/hdr/types/suseconds_t.h
+++ b/libc/hdr/types/suseconds_t.h
@@ -17,6 +17,6 @@
 
 #include <sys/types.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_SUSECONDS_T_H

--- a/libc/hdr/types/time_t.h
+++ b/libc/hdr/types/time_t.h
@@ -17,6 +17,6 @@
 
 #include <time.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_TIME_T_H

--- a/libc/hdr/types/uid_t.h
+++ b/libc/hdr/types/uid_t.h
@@ -17,6 +17,6 @@
 
 #include <sys/types.h>
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_UID_T_H

--- a/libc/hdr/types/wchar_t.h
+++ b/libc/hdr/types/wchar_t.h
@@ -18,6 +18,6 @@
 
 #include "hdr/wchar_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_WCHAR_T_H

--- a/libc/hdr/types/wctype_t.h
+++ b/libc/hdr/types/wctype_t.h
@@ -18,6 +18,6 @@
 
 #include "hdr/wctype_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_WCTYPE_T_H

--- a/libc/hdr/types/wint_t.h
+++ b/libc/hdr/types/wint_t.h
@@ -18,6 +18,6 @@
 
 #include "hdr/wchar_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_TYPES_WINT_T_H

--- a/libc/hdr/unistd_macros.h
+++ b/libc/hdr/unistd_macros.h
@@ -17,6 +17,6 @@
 
 #include "unistd_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_UNISTD_MACROS_H

--- a/libc/hdr/wchar_macros.h
+++ b/libc/hdr/wchar_macros.h
@@ -17,6 +17,6 @@
 
 #include "hdr/wchar_overlay.h"
 
-#endif // LLVM_LIBC_FULL_BUILD
+#endif // LIBC_FULL_BUILD
 
 #endif // LLVM_LIBC_HDR_WCHAR_MACROS_H


### PR DESCRIPTION
The #endif closing the LIBC_FULL_BUILD guard used the CMake variable name LLVM_LIBC_FULL_BUILD in its comment rather than the preprocessor macro LIBC_FULL_BUILD that the #ifdef above references. These are distinct: LLVM_LIBC_FULL_BUILD is the CMake option; LIBC_FULL_BUILD is the C macro defined via -DLIBC_FULL_BUILD when that option is ON.

Fixed 113 files under libc/hdr/ with a mechanical substitution.

Assisted-by: Automated tooling, human reviewed.