### PR TITLE
[AArch64][DAG] Use getSetCCResultType in PromoteSETCC

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -657,9 +657,12 @@ void VectorLegalizer::PromoteSETCC(SDNode *Node,
     Operands[4] = Node->getOperand(4); // evl
   }
 
-  SDValue Res = DAG.getNode(Node->getOpcode(), DL, Node->getSimpleValueType(0),
-                            Operands, Node->getFlags());
-
+  EVT ResVT =
+      TLI.getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), NewVecVT);
+  SDValue Res =
+      DAG.getNode(Node->getOpcode(), DL, ResVT, Operands, Node->getFlags());
+  if (ResVT != Node->getSimpleValueType(0))
+    Res = DAG.getSExtOrTrunc(Res, DL, Node->getSimpleValueType(0));
   Results.push_back(Res);
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -662,7 +662,7 @@ void VectorLegalizer::PromoteSETCC(SDNode *Node,
   SDValue Res =
       DAG.getNode(Node->getOpcode(), DL, ResVT, Operands, Node->getFlags());
   if (ResVT != Node->getSimpleValueType(0))
-    Res = DAG.getSExtOrTrunc(Res, DL, Node->getSimpleValueType(0));
+    Res = DAG.getBoolExtOrTrunc(Res, DL, Node->getValueType(0), NewVecVT);
   Results.push_back(Res);
 }
 

--- a/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/LegalizeVectorOps.cpp
@@ -661,7 +661,7 @@ void VectorLegalizer::PromoteSETCC(SDNode *Node,
       TLI.getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(), NewVecVT);
   SDValue Res =
       DAG.getNode(Node->getOpcode(), DL, ResVT, Operands, Node->getFlags());
-  if (ResVT != Node->getSimpleValueType(0))
+  if (ResVT != Node->getValueType(0))
     Res = DAG.getBoolExtOrTrunc(Res, DL, Node->getValueType(0), NewVecVT);
   Results.push_back(Res);
 }

--- a/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
@@ -603,8 +603,8 @@ define <4 x i1> @test_fcmp_ueq(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    fcmgt v2.4s, v0.4s, v1.4s
 ; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-SD-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-BF16-SD-LABEL: test_fcmp_ueq:
@@ -614,8 +614,8 @@ define <4 x i1> @test_fcmp_ueq(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-BF16-SD-NEXT:    fcmgt v2.4s, v0.4s, v1.4s
 ; CHECK-BF16-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-BF16-SD-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-BF16-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-BF16-SD-NEXT:    ret
 ;
 ; CHECK-CVT-GI-LABEL: test_fcmp_ueq:
@@ -644,81 +644,27 @@ define <4 x i1> @test_fcmp_ueq(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 }
 
 define <4 x i1> @test_fcmp_ugt(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
-; CHECK-CVT-SD-LABEL: test_fcmp_ugt:
-; CHECK-CVT-SD:       // %bb.0:
-; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-SD-NEXT:    fcmge v0.4s, v1.4s, v0.4s
-; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
-; CHECK-CVT-SD-NEXT:    ret
-;
-; CHECK-BF16-SD-LABEL: test_fcmp_ugt:
-; CHECK-BF16-SD:       // %bb.0:
-; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-BF16-SD-NEXT:    fcmge v0.4s, v1.4s, v0.4s
-; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-SD-NEXT:    mvn v0.8b, v0.8b
-; CHECK-BF16-SD-NEXT:    ret
-;
-; CHECK-CVT-GI-LABEL: test_fcmp_ugt:
-; CHECK-CVT-GI:       // %bb.0:
-; CHECK-CVT-GI-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-GI-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-GI-NEXT:    fcmge v0.4s, v1.4s, v0.4s
-; CHECK-CVT-GI-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-GI-NEXT:    ret
-;
-; CHECK-BF16-GI-LABEL: test_fcmp_ugt:
-; CHECK-BF16-GI:       // %bb.0:
-; CHECK-BF16-GI-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-BF16-GI-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-BF16-GI-NEXT:    fcmge v0.4s, v1.4s, v0.4s
-; CHECK-BF16-GI-NEXT:    mvn v0.16b, v0.16b
-; CHECK-BF16-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-GI-NEXT:    ret
+; CHECK-LABEL: test_fcmp_ugt:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-NEXT:    fcmge v0.4s, v1.4s, v0.4s
+; CHECK-NEXT:    mvn v0.16b, v0.16b
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
   %1 = fcmp ugt <4 x bfloat> %a, %b
   ret <4 x i1> %1
 }
 
 define <4 x i1> @test_fcmp_uge(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
-; CHECK-CVT-SD-LABEL: test_fcmp_uge:
-; CHECK-CVT-SD:       // %bb.0:
-; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
-; CHECK-CVT-SD-NEXT:    ret
-;
-; CHECK-BF16-SD-LABEL: test_fcmp_uge:
-; CHECK-BF16-SD:       // %bb.0:
-; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-BF16-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-SD-NEXT:    mvn v0.8b, v0.8b
-; CHECK-BF16-SD-NEXT:    ret
-;
-; CHECK-CVT-GI-LABEL: test_fcmp_uge:
-; CHECK-CVT-GI:       // %bb.0:
-; CHECK-CVT-GI-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-CVT-GI-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-CVT-GI-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-CVT-GI-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-GI-NEXT:    ret
-;
-; CHECK-BF16-GI-LABEL: test_fcmp_uge:
-; CHECK-BF16-GI:       // %bb.0:
-; CHECK-BF16-GI-NEXT:    shll v0.4s, v0.4h, #16
-; CHECK-BF16-GI-NEXT:    shll v1.4s, v1.4h, #16
-; CHECK-BF16-GI-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-BF16-GI-NEXT:    mvn v0.16b, v0.16b
-; CHECK-BF16-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-GI-NEXT:    ret
+; CHECK-LABEL: test_fcmp_uge:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
+; CHECK-NEXT:    mvn v0.16b, v0.16b
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
   %1 = fcmp uge <4 x bfloat> %a, %b
   ret <4 x i1> %1
 }
@@ -729,8 +675,8 @@ define <4 x i1> @test_fcmp_ult(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
 ; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
 ; CHECK-CVT-SD-NEXT:    fcmge v0.4s, v0.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-BF16-SD-LABEL: test_fcmp_ult:
@@ -738,8 +684,8 @@ define <4 x i1> @test_fcmp_ult(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
 ; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
 ; CHECK-BF16-SD-NEXT:    fcmge v0.4s, v0.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-BF16-SD-NEXT:    ret
 ;
 ; CHECK-CVT-GI-LABEL: test_fcmp_ult:
@@ -769,8 +715,8 @@ define <4 x i1> @test_fcmp_ule(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    shll v1.4s, v1.4h, #16
 ; CHECK-CVT-SD-NEXT:    shll v0.4s, v0.4h, #16
 ; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-BF16-SD-LABEL: test_fcmp_ule:
@@ -778,8 +724,8 @@ define <4 x i1> @test_fcmp_ule(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-BF16-SD-NEXT:    shll v1.4s, v1.4h, #16
 ; CHECK-BF16-SD-NEXT:    shll v0.4s, v0.4h, #16
 ; CHECK-BF16-SD-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
+; CHECK-BF16-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-BF16-SD-NEXT:    ret
 ;
 ; CHECK-CVT-GI-LABEL: test_fcmp_ule:
@@ -811,8 +757,8 @@ define <4 x i1> @test_fcmp_uno(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    fcmge v2.4s, v0.4s, v1.4s
 ; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-SD-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-BF16-SD-LABEL: test_fcmp_uno:
@@ -822,8 +768,8 @@ define <4 x i1> @test_fcmp_uno(<4 x bfloat> %a, <4 x bfloat> %b) #0 {
 ; CHECK-BF16-SD-NEXT:    fcmge v2.4s, v0.4s, v1.4s
 ; CHECK-BF16-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-BF16-SD-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-BF16-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-BF16-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-BF16-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-BF16-SD-NEXT:    ret
 ;
 ; CHECK-CVT-GI-LABEL: test_fcmp_uno:

--- a/llvm/test/CodeGen/AArch64/fp16-v4-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/fp16-v4-instructions.ll
@@ -510,8 +510,8 @@ define <4 x i1> @test_fcmp_ueq(<4 x half> %a, <4 x half> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    fcmgt v2.4s, v0.4s, v1.4s
 ; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-SD-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_fcmp_ueq:
@@ -538,58 +538,40 @@ define <4 x i1> @test_fcmp_ueq(<4 x half> %a, <4 x half> %b) #0 {
 }
 
 define <4 x i1> @test_fcmp_ugt(<4 x half> %a, <4 x half> %b) #0 {
-; CHECK-CVT-SD-LABEL: test_fcmp_ugt:
-; CHECK-CVT-SD:       // %bb.0:
-; CHECK-CVT-SD-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-CVT-SD-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-CVT-SD-NEXT:    fcmge v0.4s, v1.4s, v0.4s
-; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
-; CHECK-CVT-SD-NEXT:    ret
+; CHECK-CVT-LABEL: test_fcmp_ugt:
+; CHECK-CVT:       // %bb.0:
+; CHECK-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-CVT-NEXT:    fcvtl v1.4s, v1.4h
+; CHECK-CVT-NEXT:    fcmge v0.4s, v1.4s, v0.4s
+; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
+; CHECK-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_fcmp_ugt:
 ; CHECK-FP16:       // %bb.0:
 ; CHECK-FP16-NEXT:    fcmge v0.4h, v1.4h, v0.4h
 ; CHECK-FP16-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-FP16-NEXT:    ret
-;
-; CHECK-CVT-GI-LABEL: test_fcmp_ugt:
-; CHECK-CVT-GI:       // %bb.0:
-; CHECK-CVT-GI-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-CVT-GI-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-CVT-GI-NEXT:    fcmge v0.4s, v1.4s, v0.4s
-; CHECK-CVT-GI-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-GI-NEXT:    ret
 
   %1 = fcmp ugt <4 x half> %a, %b
   ret <4 x i1> %1
 }
 
 define <4 x i1> @test_fcmp_uge(<4 x half> %a, <4 x half> %b) #0 {
-; CHECK-CVT-SD-LABEL: test_fcmp_uge:
-; CHECK-CVT-SD:       // %bb.0:
-; CHECK-CVT-SD-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-CVT-SD-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
-; CHECK-CVT-SD-NEXT:    ret
+; CHECK-CVT-LABEL: test_fcmp_uge:
+; CHECK-CVT:       // %bb.0:
+; CHECK-CVT-NEXT:    fcvtl v0.4s, v0.4h
+; CHECK-CVT-NEXT:    fcvtl v1.4s, v1.4h
+; CHECK-CVT-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
+; CHECK-CVT-NEXT:    mvn v0.16b, v0.16b
+; CHECK-CVT-NEXT:    xtn v0.4h, v0.4s
+; CHECK-CVT-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_fcmp_uge:
 ; CHECK-FP16:       // %bb.0:
 ; CHECK-FP16-NEXT:    fcmgt v0.4h, v1.4h, v0.4h
 ; CHECK-FP16-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-FP16-NEXT:    ret
-;
-; CHECK-CVT-GI-LABEL: test_fcmp_uge:
-; CHECK-CVT-GI:       // %bb.0:
-; CHECK-CVT-GI-NEXT:    fcvtl v0.4s, v0.4h
-; CHECK-CVT-GI-NEXT:    fcvtl v1.4s, v1.4h
-; CHECK-CVT-GI-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
-; CHECK-CVT-GI-NEXT:    mvn v0.16b, v0.16b
-; CHECK-CVT-GI-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-GI-NEXT:    ret
 
   %1 = fcmp uge <4 x half> %a, %b
   ret <4 x i1> %1
@@ -601,8 +583,8 @@ define <4 x i1> @test_fcmp_ult(<4 x half> %a, <4 x half> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    fcvtl v1.4s, v1.4h
 ; CHECK-CVT-SD-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-CVT-SD-NEXT:    fcmge v0.4s, v0.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_fcmp_ult:
@@ -630,8 +612,8 @@ define <4 x i1> @test_fcmp_ule(<4 x half> %a, <4 x half> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    fcvtl v1.4s, v1.4h
 ; CHECK-CVT-SD-NEXT:    fcvtl v0.4s, v0.4h
 ; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v0.4s, v1.4s
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_fcmp_ule:
@@ -661,8 +643,8 @@ define <4 x i1> @test_fcmp_uno(<4 x half> %a, <4 x half> %b) #0 {
 ; CHECK-CVT-SD-NEXT:    fcmge v2.4s, v0.4s, v1.4s
 ; CHECK-CVT-SD-NEXT:    fcmgt v0.4s, v1.4s, v0.4s
 ; CHECK-CVT-SD-NEXT:    orr v0.16b, v0.16b, v2.16b
+; CHECK-CVT-SD-NEXT:    mvn v0.16b, v0.16b
 ; CHECK-CVT-SD-NEXT:    xtn v0.4h, v0.4s
-; CHECK-CVT-SD-NEXT:    mvn v0.8b, v0.8b
 ; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: test_fcmp_uno:

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-fp-compares.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-fp-compares.ll
@@ -339,6 +339,257 @@ define void @fcmp_oeq_v32f64(ptr %a, ptr %b, ptr %c) vscale_range(16,0) #0 {
   ret void
 }
 
+define <4 x i16> @fcmp_oeq_v4bf16(<4 x bfloat> %op1, <4 x bfloat> %op2) vscale_range(2,0) #0 {
+; CHECK-LABEL: fcmp_oeq_v4bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    shll v1.4s, v1.4h, #16
+; CHECK-NEXT:    shll v0.4s, v0.4h, #16
+; CHECK-NEXT:    fcmeq v0.4s, v0.4s, v1.4s
+; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    ret
+  %cmp = fcmp oeq <4 x bfloat> %op1, %op2
+  %sext = sext <4 x i1> %cmp to <4 x i16>
+  ret <4 x i16> %sext
+}
+
+define <8 x i16> @fcmp_oeq_v8bf16(<8 x bfloat> %op1, <8 x bfloat> %op2) vscale_range(2,0) #0 {
+; CHECK-LABEL: fcmp_oeq_v8bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $q1 killed $q1 def $z1
+; CHECK-NEXT:    // kill: def $q0 killed $q0 def $z0
+; CHECK-NEXT:    ptrue p0.s, vl8
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    lsl z1.s, z1.s, #16
+; CHECK-NEXT:    lsl z0.s, z0.s, #16
+; CHECK-NEXT:    fcmeq p0.s, p0/z, z0.s, z1.s
+; CHECK-NEXT:    mov z0.s, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    uzp1 z0.h, z0.h, z0.h
+; CHECK-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; CHECK-NEXT:    ret
+  %cmp = fcmp oeq <8 x bfloat> %op1, %op2
+  %sext = sext <8 x i1> %cmp to <8 x i16>
+  ret <8 x i16> %sext
+}
+
+define void @fcmp_oeq_v16bf16(ptr %a, ptr %b, ptr %c) vscale_range(2,0) #0 {
+; CHECK-LABEL: fcmp_oeq_v16bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ldp q3, q0, [x1]
+; CHECK-NEXT:    ptrue p0.s, vl8
+; CHECK-NEXT:    ldp q2, q1, [x0]
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    uunpklo z3.s, z3.h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    uunpklo z2.s, z2.h
+; CHECK-NEXT:    lsl z0.s, z0.s, #16
+; CHECK-NEXT:    lsl z3.s, z3.s, #16
+; CHECK-NEXT:    lsl z1.s, z1.s, #16
+; CHECK-NEXT:    lsl z2.s, z2.s, #16
+; CHECK-NEXT:    fcmeq p1.s, p0/z, z1.s, z0.s
+; CHECK-NEXT:    fcmeq p0.s, p0/z, z2.s, z3.s
+; CHECK-NEXT:    mov z0.s, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z1.s, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    ptrue p0.h, vl8
+; CHECK-NEXT:    uzp1 z0.h, z0.h, z0.h
+; CHECK-NEXT:    uzp1 z1.h, z1.h, z1.h
+; CHECK-NEXT:    splice z1.h, p0, z1.h, z0.h
+; CHECK-NEXT:    ptrue p0.h, vl16
+; CHECK-NEXT:    st1h { z1.h }, p0, [x2]
+; CHECK-NEXT:    ret
+  %op1 = load <16 x bfloat>, ptr %a
+  %op2 = load <16 x bfloat>, ptr %b
+  %cmp = fcmp oeq <16 x bfloat> %op1, %op2
+  %sext = sext <16 x i1> %cmp to <16 x i16>
+  store <16 x i16> %sext, ptr %c
+  ret void
+}
+
+define void @fcmp_oeq_v32bf16(ptr %a, ptr %b, ptr %c) #0 {
+; VBITS_GE_256-LABEL: fcmp_oeq_v32bf16:
+; VBITS_GE_256:       // %bb.0:
+; VBITS_GE_256-NEXT:    ldp q0, q1, [x0]
+; VBITS_GE_256-NEXT:    ptrue p0.s, vl8
+; VBITS_GE_256-NEXT:    ldp q2, q3, [x1]
+; VBITS_GE_256-NEXT:    mov x8, #16 // =0x10
+; VBITS_GE_256-NEXT:    ldp q4, q5, [x0, #32]
+; VBITS_GE_256-NEXT:    ldp q7, q6, [x1, #32]
+; VBITS_GE_256-NEXT:    uunpklo z1.s, z1.h
+; VBITS_GE_256-NEXT:    uunpklo z3.s, z3.h
+; VBITS_GE_256-NEXT:    uunpklo z2.s, z2.h
+; VBITS_GE_256-NEXT:    uunpklo z0.s, z0.h
+; VBITS_GE_256-NEXT:    uunpklo z5.s, z5.h
+; VBITS_GE_256-NEXT:    uunpklo z4.s, z4.h
+; VBITS_GE_256-NEXT:    uunpklo z6.s, z6.h
+; VBITS_GE_256-NEXT:    uunpklo z7.s, z7.h
+; VBITS_GE_256-NEXT:    lsl z1.s, z1.s, #16
+; VBITS_GE_256-NEXT:    lsl z3.s, z3.s, #16
+; VBITS_GE_256-NEXT:    lsl z2.s, z2.s, #16
+; VBITS_GE_256-NEXT:    lsl z0.s, z0.s, #16
+; VBITS_GE_256-NEXT:    lsl z5.s, z5.s, #16
+; VBITS_GE_256-NEXT:    lsl z4.s, z4.s, #16
+; VBITS_GE_256-NEXT:    lsl z6.s, z6.s, #16
+; VBITS_GE_256-NEXT:    lsl z7.s, z7.s, #16
+; VBITS_GE_256-NEXT:    fcmeq p1.s, p0/z, z1.s, z3.s
+; VBITS_GE_256-NEXT:    fcmeq p2.s, p0/z, z5.s, z6.s
+; VBITS_GE_256-NEXT:    fcmeq p3.s, p0/z, z4.s, z7.s
+; VBITS_GE_256-NEXT:    fcmeq p0.s, p0/z, z0.s, z2.s
+; VBITS_GE_256-NEXT:    mov z2.s, p1/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_256-NEXT:    mov z0.s, p2/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_256-NEXT:    mov z1.s, p3/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_256-NEXT:    uzp1 z2.h, z2.h, z2.h
+; VBITS_GE_256-NEXT:    mov z3.s, p0/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_256-NEXT:    ptrue p0.h, vl8
+; VBITS_GE_256-NEXT:    uzp1 z0.h, z0.h, z0.h
+; VBITS_GE_256-NEXT:    uzp1 z1.h, z1.h, z1.h
+; VBITS_GE_256-NEXT:    uzp1 z3.h, z3.h, z3.h
+; VBITS_GE_256-NEXT:    splice z1.h, p0, z1.h, z0.h
+; VBITS_GE_256-NEXT:    splice z3.h, p0, z3.h, z2.h
+; VBITS_GE_256-NEXT:    ptrue p0.h, vl16
+; VBITS_GE_256-NEXT:    st1h { z1.h }, p0, [x2, x8, lsl #1]
+; VBITS_GE_256-NEXT:    st1h { z3.h }, p0, [x2]
+; VBITS_GE_256-NEXT:    ret
+;
+; VBITS_GE_512-LABEL: fcmp_oeq_v32bf16:
+; VBITS_GE_512:       // %bb.0:
+; VBITS_GE_512-NEXT:    ldp q0, q1, [x0, #32]
+; VBITS_GE_512-NEXT:    ptrue p0.s, vl8
+; VBITS_GE_512-NEXT:    ldp q2, q3, [x1, #32]
+; VBITS_GE_512-NEXT:    ldp q4, q5, [x1]
+; VBITS_GE_512-NEXT:    ldp q6, q7, [x0]
+; VBITS_GE_512-NEXT:    uunpklo z1.s, z1.h
+; VBITS_GE_512-NEXT:    uunpklo z3.s, z3.h
+; VBITS_GE_512-NEXT:    uunpklo z2.s, z2.h
+; VBITS_GE_512-NEXT:    uunpklo z0.s, z0.h
+; VBITS_GE_512-NEXT:    uunpklo z5.s, z5.h
+; VBITS_GE_512-NEXT:    uunpklo z4.s, z4.h
+; VBITS_GE_512-NEXT:    uunpklo z7.s, z7.h
+; VBITS_GE_512-NEXT:    uunpklo z6.s, z6.h
+; VBITS_GE_512-NEXT:    lsl z1.s, z1.s, #16
+; VBITS_GE_512-NEXT:    lsl z3.s, z3.s, #16
+; VBITS_GE_512-NEXT:    lsl z2.s, z2.s, #16
+; VBITS_GE_512-NEXT:    lsl z0.s, z0.s, #16
+; VBITS_GE_512-NEXT:    lsl z5.s, z5.s, #16
+; VBITS_GE_512-NEXT:    lsl z4.s, z4.s, #16
+; VBITS_GE_512-NEXT:    lsl z7.s, z7.s, #16
+; VBITS_GE_512-NEXT:    lsl z6.s, z6.s, #16
+; VBITS_GE_512-NEXT:    fcmeq p1.s, p0/z, z1.s, z3.s
+; VBITS_GE_512-NEXT:    fcmeq p2.s, p0/z, z0.s, z2.s
+; VBITS_GE_512-NEXT:    fcmeq p3.s, p0/z, z7.s, z5.s
+; VBITS_GE_512-NEXT:    fcmeq p0.s, p0/z, z6.s, z4.s
+; VBITS_GE_512-NEXT:    mov z0.s, p1/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_512-NEXT:    mov z1.s, p2/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_512-NEXT:    mov z2.s, p3/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_512-NEXT:    mov z3.s, p0/z, #-1 // =0xffffffffffffffff
+; VBITS_GE_512-NEXT:    uzp1 z0.h, z0.h, z0.h
+; VBITS_GE_512-NEXT:    ptrue p0.h, vl8
+; VBITS_GE_512-NEXT:    uzp1 z1.h, z1.h, z1.h
+; VBITS_GE_512-NEXT:    uzp1 z2.h, z2.h, z2.h
+; VBITS_GE_512-NEXT:    uzp1 z3.h, z3.h, z3.h
+; VBITS_GE_512-NEXT:    splice z1.h, p0, z1.h, z0.h
+; VBITS_GE_512-NEXT:    splice z3.h, p0, z3.h, z2.h
+; VBITS_GE_512-NEXT:    ptrue p0.h, vl16
+; VBITS_GE_512-NEXT:    splice z3.h, p0, z3.h, z1.h
+; VBITS_GE_512-NEXT:    ptrue p0.h, vl32
+; VBITS_GE_512-NEXT:    st1h { z3.h }, p0, [x2]
+; VBITS_GE_512-NEXT:    ret
+  %op1 = load <32 x bfloat>, ptr %a
+  %op2 = load <32 x bfloat>, ptr %b
+  %cmp = fcmp oeq <32 x bfloat> %op1, %op2
+  %sext = sext <32 x i1> %cmp to <32 x i16>
+  store <32 x i16> %sext, ptr %c
+  ret void
+}
+
+define void @fcmp_oeq_v64bf16(ptr %a, ptr %b, ptr %c) vscale_range(8,0) #0 {
+; CHECK-LABEL: fcmp_oeq_v64bf16:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    ldp q3, q2, [x1, #96]
+; CHECK-NEXT:    ptrue p0.s, vl8
+; CHECK-NEXT:    ldp q4, q5, [x0, #96]
+; CHECK-NEXT:    ldp q18, q19, [x0, #64]
+; CHECK-NEXT:    uunpklo z6.s, z2.h
+; CHECK-NEXT:    ldp q2, q17, [x0, #32]
+; CHECK-NEXT:    uunpklo z5.s, z5.h
+; CHECK-NEXT:    uunpklo z3.s, z3.h
+; CHECK-NEXT:    uunpklo z4.s, z4.h
+; CHECK-NEXT:    ldp q22, q23, [x1, #32]
+; CHECK-NEXT:    uunpklo z19.s, z19.h
+; CHECK-NEXT:    ldp q0, q1, [x0]
+; CHECK-NEXT:    uunpklo z18.s, z18.h
+; CHECK-NEXT:    lsl z6.s, z6.s, #16
+; CHECK-NEXT:    ldp q7, q16, [x1, #64]
+; CHECK-NEXT:    lsl z5.s, z5.s, #16
+; CHECK-NEXT:    ldp q20, q21, [x1]
+; CHECK-NEXT:    lsl z3.s, z3.s, #16
+; CHECK-NEXT:    lsl z4.s, z4.s, #16
+; CHECK-NEXT:    uunpklo z2.s, z2.h
+; CHECK-NEXT:    uunpklo z16.s, z16.h
+; CHECK-NEXT:    uunpklo z7.s, z7.h
+; CHECK-NEXT:    uunpklo z1.s, z1.h
+; CHECK-NEXT:    fcmeq p1.s, p0/z, z5.s, z6.s
+; CHECK-NEXT:    uunpklo z5.s, z23.h
+; CHECK-NEXT:    uunpklo z6.s, z17.h
+; CHECK-NEXT:    lsl z17.s, z19.s, #16
+; CHECK-NEXT:    uunpklo z19.s, z22.h
+; CHECK-NEXT:    uunpklo z21.s, z21.h
+; CHECK-NEXT:    uunpklo z20.s, z20.h
+; CHECK-NEXT:    uunpklo z0.s, z0.h
+; CHECK-NEXT:    lsl z18.s, z18.s, #16
+; CHECK-NEXT:    fcmeq p2.s, p0/z, z4.s, z3.s
+; CHECK-NEXT:    lsl z16.s, z16.s, #16
+; CHECK-NEXT:    lsl z7.s, z7.s, #16
+; CHECK-NEXT:    lsl z3.s, z5.s, #16
+; CHECK-NEXT:    lsl z4.s, z6.s, #16
+; CHECK-NEXT:    lsl z2.s, z2.s, #16
+; CHECK-NEXT:    lsl z5.s, z19.s, #16
+; CHECK-NEXT:    lsl z6.s, z21.s, #16
+; CHECK-NEXT:    lsl z1.s, z1.s, #16
+; CHECK-NEXT:    lsl z0.s, z0.s, #16
+; CHECK-NEXT:    fcmeq p5.s, p0/z, z4.s, z3.s
+; CHECK-NEXT:    lsl z3.s, z20.s, #16
+; CHECK-NEXT:    fcmeq p3.s, p0/z, z17.s, z16.s
+; CHECK-NEXT:    fcmeq p4.s, p0/z, z18.s, z7.s
+; CHECK-NEXT:    fcmeq p6.s, p0/z, z2.s, z5.s
+; CHECK-NEXT:    fcmeq p7.s, p0/z, z1.s, z6.s
+; CHECK-NEXT:    mov z1.s, p2/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z4.s, p5/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z2.s, p3/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    fcmeq p0.s, p0/z, z0.s, z3.s
+; CHECK-NEXT:    mov z0.s, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z3.s, p4/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    mov z5.s, p6/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    uzp1 z1.h, z1.h, z1.h
+; CHECK-NEXT:    uzp1 z4.h, z4.h, z4.h
+; CHECK-NEXT:    mov z6.s, p7/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    uzp1 z2.h, z2.h, z2.h
+; CHECK-NEXT:    uzp1 z0.h, z0.h, z0.h
+; CHECK-NEXT:    uzp1 z3.h, z3.h, z3.h
+; CHECK-NEXT:    mov z7.s, p0/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    uzp1 z5.h, z5.h, z5.h
+; CHECK-NEXT:    ptrue p0.h, vl8
+; CHECK-NEXT:    uzp1 z6.h, z6.h, z6.h
+; CHECK-NEXT:    splice z1.h, p0, z1.h, z0.h
+; CHECK-NEXT:    splice z3.h, p0, z3.h, z2.h
+; CHECK-NEXT:    uzp1 z7.h, z7.h, z7.h
+; CHECK-NEXT:    splice z5.h, p0, z5.h, z4.h
+; CHECK-NEXT:    splice z7.h, p0, z7.h, z6.h
+; CHECK-NEXT:    ptrue p0.h, vl16
+; CHECK-NEXT:    splice z3.h, p0, z3.h, z1.h
+; CHECK-NEXT:    splice z7.h, p0, z7.h, z5.h
+; CHECK-NEXT:    ptrue p0.h, vl32
+; CHECK-NEXT:    splice z7.h, p0, z7.h, z3.h
+; CHECK-NEXT:    ptrue p0.h, vl64
+; CHECK-NEXT:    st1h { z7.h }, p0, [x2]
+; CHECK-NEXT:    ret
+  %op1 = load <64 x bfloat>, ptr %a
+  %op2 = load <64 x bfloat>, ptr %b
+  %cmp = fcmp oeq <64 x bfloat> %op1, %op2
+  %sext = sext <64 x i1> %cmp to <64 x i16>
+  store <64 x i16> %sext, ptr %c
+  ret void
+}
+
 ;
 ; FCMP UEQ
 ;


### PR DESCRIPTION
During the promotion of a v16bf16 vector setcc with 256 bit sve, a v16i16 setcc(v16f32) is created, that gets legalized to a v8i16 setcc(v8f32), which trips up an assert in the aarch64 custom lowering to vector registers. It could be solved elsewhere but this addresses it by making sure that when the f32 setcc is created, the result type matches getSetCCResultType.

The mvn+xtn vs xtn+mvn is mostly benign, and should both probably be a subhn if it can be done without causing regressions.