### PR TITLE
[TableGen] Fix getting weights of register classes

### DIFF
--- a/llvm/test/TableGen/ArtificialRegs.td
+++ b/llvm/test/TableGen/ArtificialRegs.td
@@ -36,6 +36,7 @@ def DA : RegisterClass<"D", [i64], 64, (add D0, A)>;
 // CHECK-NEXT: CoveredBySubRegs:
 // CHECK-NEXT: Allocatable:
 // CHECK-NEXT: AllocationPriority:
+// CHECK-NEXT: Weight: 1
 // CHECK-NEXT: BaseClassOrder:
 // CHECK-NEXT: Regs: A R0 R1{{$}}
 // CHECK-NEXT: SubClasses: RA{{$}}
@@ -49,6 +50,7 @@ def DA : RegisterClass<"D", [i64], 64, (add D0, A)>;
 // CHECK-NEXT: CoveredBySubRegs:
 // CHECK-NEXT: Allocatable:
 // CHECK-NEXT: AllocationPriority:
+// CHECK-NEXT: Weight: 2
 // CHECK-NEXT: BaseClassOrder:
 // CHECK-NEXT: Regs: A D0{{$}}
 // CHECK-NEXT: SubClasses: DA{{$}}

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -833,10 +833,15 @@ unsigned CodeGenRegisterClass::getWeight(const CodeGenRegBank &RegBank) const {
   if (TheDef && !TheDef->isValueUnset("Weight"))
     return TheDef->getValueAsInt("Weight");
 
-  if (Members.empty() || Artificial)
+  if (Artificial)
     return 0;
 
-  return (*Members.begin())->getWeight(RegBank);
+  for (const CodeGenRegister *Reg : Members) {
+    if (!Reg->Artificial)
+      return Reg->getWeight(RegBank);
+  }
+
+  return 0;
 }
 
 // This is a simple lexicographical order that can be used to search for sets.

--- a/llvm/utils/TableGen/RegisterInfoEmitter.cpp
+++ b/llvm/utils/TableGen/RegisterInfoEmitter.cpp
@@ -2007,6 +2007,7 @@ void RegisterInfoEmitter::debugDump(raw_ostream &OS) {
     OS << "\tCoveredBySubRegs: " << RC.CoveredBySubRegs << '\n';
     OS << "\tAllocatable: " << RC.Allocatable << '\n';
     OS << "\tAllocationPriority: " << unsigned(RC.AllocationPriority) << '\n';
+    OS << "\tWeight: " << RC.getWeight(RegBank) << '\n';
     OS << "\tBaseClassOrder: " << RC.getBaseClassOrder() << '\n';
     OS << "\tRegs:";
     for (const CodeGenRegister *R : RC.getMembers()) {


### PR DESCRIPTION
The first member can be an aritifical register, so we have to find a non-artificial one to query its weight.