### PR TITLE
[SPIR-V] Fix legalized load of single-element vector from array

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizePointerCast.cpp
@@ -237,6 +237,16 @@ class SPIRVLegalizePointerCastImpl {
   Value *
   buildVectorFromLoadedElements(IRBuilder<> &B, FixedVectorType *TargetType,
                                 SmallVector<Value *, 4> &LoadedElements) {
+    // <1 x T> shares the SPIR-V type with T, so emitting OpCompositeInsert on
+    // a scalar would be invalid. Bridge with spv_bitcast instead.
+    if (TargetType->getNumElements() == 1) {
+      Value *Scalar = LoadedElements[0];
+      Value *NewVector = B.CreateIntrinsic(
+          Intrinsic::spv_bitcast, {TargetType, Scalar->getType()}, {Scalar});
+      buildAssignType(B, TargetType, NewVector);
+      return NewVector;
+    }
+
     // Build the vector from the loaded elements.
     Value *NewVector = PoisonValue::get(TargetType);
     buildAssignType(B, TargetType, NewVector);

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-transpose.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/matrix-transpose.ll
@@ -93,13 +93,17 @@ define internal void @test_transpose_f32_4x1_to_1x4() {
 }
 
 ; Test Transpose 1x1 float (Result is 1x1 float), should be a copy (scalar float)
-; TODO(171175): The SPIR-V backend does not seem to be legalizing single element vectors.
-; define internal void @test_transpose_f32_1x1() {
-;   %1 = load <1 x float>, ptr addrspace(10) @private_v1f32
-;   %2 = call <1 x float> @llvm.matrix.transpose.v1f32.i32(<1 x float> %1, i32 1, i32 1)
-;   store <1 x float> %2, ptr addrspace(10) @private_v1f32
-;   ret void
-; }
+; CHECK-LABEL: ; -- Begin function test_transpose_f32_1x1
+; CHECK: %[[AccessChain1x1:[0-9]+]] = OpAccessChain %[[_ptr_Float_ID]] %{{[0-9]+}} %{{[0-9]+}}
+; CHECK: %[[Load1x1:[0-9]+]] = OpLoad %[[Float_ID]] %[[AccessChain1x1]]
+; CHECK: %[[AccessChain1x1Store:[0-9]+]] = OpAccessChain %[[_ptr_Float_ID]] %{{[0-9]+}} %{{[0-9]+}}
+; CHECK: OpStore %[[AccessChain1x1Store]] %[[Load1x1]]
+define internal void @test_transpose_f32_1x1() {
+  %1 = load <1 x float>, ptr addrspace(10) @private_v1f32
+  %2 = call <1 x float> @llvm.matrix.transpose.v1f32.i32(<1 x float> %1, i32 1, i32 1)
+  store <1 x float> %2, ptr addrspace(10) @private_v1f32
+  ret void
+}
 
 define void @main() #0 {
   ret void
@@ -107,6 +111,6 @@ define void @main() #0 {
 
 declare <4 x float> @llvm.matrix.transpose.v4f32.i32(<4 x float>, i32, i32)
 declare <6 x float> @llvm.matrix.transpose.v6f32.i32(<6 x float>, i32, i32)
-; declare <1 x float> @llvm.matrix.transpose.v1f32.i32(<1 x float>, i32, i32)
+declare <1 x float> @llvm.matrix.transpose.v1f32.i32(<1 x float>, i32, i32)
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }


### PR DESCRIPTION
OpCompositeInsert into a scalar is invalid SPIR-V, and `<1 x T>` is collapsed to `T` in the global registry. Emit `spv_bitcast` in place of `spv_insertelt` for the `N == 1` case so the wrapper lowers to a simple copy

Enable the previously-disabled 1x1 matrix transpose test