### PR TITLE
[CIR] Guard union ABI alignment when getLargestMember is empty

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -392,8 +392,12 @@ RecordType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
 uint64_t
 RecordType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                             ::mlir::DataLayoutEntryListRef params) const {
-  if (isUnion())
-    return dataLayout.getTypeABIAlignment(getLargestMember(dataLayout));
+  if (isUnion()) {
+    mlir::Type largest = getLargestMember(dataLayout);
+    if (!largest)
+      return 1;
+    return dataLayout.getTypeABIAlignment(largest);
+  }
 
   // Packed structures always have an ABI alignment of 1.
   if (getPacked())

--- a/clang/test/CIR/CodeGen/empty-union.cpp
+++ b/clang/test/CIR/CodeGen/empty-union.cpp
@@ -2,7 +2,9 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=OGCG
 
-// Empty union (should be padded to size 1)
+// Padding-only union: CIR keeps only a tail pad member, so
+// getLargestMember() is null and getABIAlignment must not call
+// getTypeABIAlignment on null.
 union Empty {};
 // CIR: !rec_Empty = !cir.record<union "Empty" padded {!u8i}>
 // LLVM-DAG: %union.Empty = type { i8 }
@@ -14,6 +16,8 @@ union alignas(16) EmptyAligned {};
 // LLVM-DAG: %union.EmptyAligned = type { [16 x i8] }
 // OGCG-DAG: %union.EmptyAligned = type { [16 x i8] }
 
+// Struct holding a padding-only union member: layout queries !rec_Empty
+// alignment (null largest), not OuterWithEmpty's int x.
 union OuterWithEmpty {
   Empty e;
   int x;

--- a/clang/test/CIR/CodeGen/empty-union.cpp
+++ b/clang/test/CIR/CodeGen/empty-union.cpp
@@ -5,14 +5,33 @@
 // Empty union (should be padded to size 1)
 union Empty {};
 // CIR: !rec_Empty = !cir.record<union "Empty" padded {!u8i}>
-// LLVM: %union.Empty = type { i8 }
-// OGCG: %union.Empty = type { i8 }
+// LLVM-DAG: %union.Empty = type { i8 }
+// OGCG-DAG: %union.Empty = type { i8 }
 
 // Aligned empty union (should have aligned integer member in CIR)
 union alignas(16) EmptyAligned {};
 // CIR: !rec_EmptyAligned = !cir.record<union "EmptyAligned" padded {!cir.array<!u8i x 16>}>
-// LLVM: %union.EmptyAligned = type { [16 x i8] }
-// OGCG: %union.EmptyAligned = type { [16 x i8] }
+// LLVM-DAG: %union.EmptyAligned = type { [16 x i8] }
+// OGCG-DAG: %union.EmptyAligned = type { [16 x i8] }
+
+union OuterWithEmpty {
+  Empty e;
+  int x;
+};
+struct WrapEmpty {
+  OuterWithEmpty o;
+  int s;
+};
+WrapEmpty w;
+// CIR:      !rec_OuterWithEmpty = !cir.record<union "OuterWithEmpty" {!rec_Empty, !s32i}>
+// CIR:      !rec_WrapEmpty = !cir.record<struct "WrapEmpty" {!rec_OuterWithEmpty, !s32i}>
+// CIR:      cir.global external @w = #cir.zero : !rec_WrapEmpty {alignment = 4 : i64}
+// LLVM-DAG: %struct.WrapEmpty = type { %union.OuterWithEmpty, i32 }
+// LLVM-DAG: %union.OuterWithEmpty = type { i32 }
+// LLVM:     @w = global %struct.WrapEmpty zeroinitializer, align 4
+// OGCG-DAG: %struct.WrapEmpty = type { %union.OuterWithEmpty, i32 }
+// OGCG-DAG: %union.OuterWithEmpty = type { i32 }
+// OGCG:     @w = global %struct.WrapEmpty zeroinitializer, align 4
 
 void useEmpty() {
   Empty e;


### PR DESCRIPTION
Padding-only unions (an empty union lowered as a single `!u8i`
padding member) leave `getLargestMember()` null when CIRGen walks
record layout through MLIR's DataLayout API.  `RecordType::getABIAlignment`
then passed that null `Type` into `getTypeABIAlignment` and crashed.
This showed up compiling libc++ types such as
`std::__variant_detail::__union` nested under `common_iterator`.

Return ABI alignment `1` when there is no largest member, matching a
byte-padded empty union.  This parallels how empty unions are already
handled for size (`getTypeSizeInBits` uses zero size in that situation).

Regression coverage adds a nested-union global in `empty-union.cpp`.
