### PR TITLE
[analyzer] Fix false positive in CStringChecker for offset buffer arg…

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -437,8 +437,8 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   if (!State)
     return nullptr;
 
-  const MemRegion *R = Element.getAsRegion();
-  const auto *ER = dyn_cast_or_null<ElementRegion>(R);
+  SVal BufVal = C.getSVal(Buffer.Expression);
+  const auto *ER = dyn_cast_or_null<ElementRegion>(BufVal.getAsRegion());
   if (!ER)
     return State;
 
@@ -456,11 +456,8 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
 
   const QualType ElemTy = Ctx.getBaseElementType(SuperR->getValueType());
 
-  const NonLoc StartIdx = ER->getIndex();
-
   std::optional<Loc> FirstElementVal =
-      State->getLValue(ElemTy, StartIdx, loc::MemRegionVal(SuperR))
-          .getAs<Loc>();
+      State->getLValue(ElemTy, SVB.makeZeroArrayIndex(), BufVal).getAs<Loc>();
   if (!FirstElementVal)
     return State;
 
@@ -512,15 +509,11 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   if (!Offset)
     return State;
 
-  // Retrieve the index of the last element.
+  // Retrieve the index of the last element relative to the buffer pointer.
   const NonLoc One = SVB.makeIntVal(1, IdxTy).castAs<NonLoc>();
   SVal LastIdx = SVB.evalBinOpNN(State, BO_Sub, *Offset, One, IdxTy);
 
-  const SVal AbsLastIdx =
-      SVB.evalBinOp(State, BO_Add, StartIdx, LastIdx, IdxTy);
-
-  SVal LastElementVal =
-      State->getLValue(ElemTy, AbsLastIdx, loc::MemRegionVal(SuperR));
+  SVal LastElementVal = State->getLValue(ElemTy, LastIdx, BufVal);
   if (!isa<Loc>(LastElementVal))
     return State;
 

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -455,10 +455,11 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   ASTContext &Ctx = SVB.getContext();
 
   const QualType ElemTy = Ctx.getBaseElementType(SuperR->getValueType());
-  const NonLoc Zero = SVB.makeZeroArrayIndex();
+
+  const NonLoc StartIdx = ER->getIndex();
 
   std::optional<Loc> FirstElementVal =
-      State->getLValue(ElemTy, Zero, loc::MemRegionVal(SuperR)).getAs<Loc>();
+      State->getLValue(ElemTy, StartIdx, loc::MemRegionVal(SuperR)).getAs<Loc>();
   if (!FirstElementVal)
     return State;
 
@@ -478,8 +479,8 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   // We won't check whether the entire region is fully initialized -- let's just
   // check that the first and the last element is. So, onto checking the last
   // element:
-  const QualType IdxTy = SVB.getArrayIndexType();
 
+  const QualType IdxTy = SVB.getArrayIndexType();
   NonLoc ElemSize =
       SVB.makeIntVal(Ctx.getTypeSizeInChars(ElemTy).getQuantity(), IdxTy)
           .castAs<NonLoc>();
@@ -514,8 +515,11 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   const NonLoc One = SVB.makeIntVal(1, IdxTy).castAs<NonLoc>();
   SVal LastIdx = SVB.evalBinOpNN(State, BO_Sub, *Offset, One, IdxTy);
 
+  const SVal AbsLastIdx =
+      SVB.evalBinOp(State, BO_Add, StartIdx, LastIdx, IdxTy);
+
   SVal LastElementVal =
-      State->getLValue(ElemTy, LastIdx, loc::MemRegionVal(SuperR));
+      State->getLValue(ElemTy, AbsLastIdx, loc::MemRegionVal(SuperR));
   if (!isa<Loc>(LastElementVal))
     return State;
 
@@ -653,7 +657,7 @@ CStringChecker::CheckBufferAccess(CheckerContext &C, ProgramStateRef State,
         svalBuilder.evalBinOpLN(State, BO_Add, *BufLoc, LastOffset, PtrTy);
     State = CheckLocation(C, State, Buffer, BufEnd, Access, CK);
     if (Access == AccessKind::read)
-      State = checkInit(C, State, Buffer, BufEnd, *Length);
+      State = checkInit(C, State, Buffer, BufStart, *Length);
 
     // If the buffer isn't large enough, abort.
     if (!State)

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -459,7 +459,8 @@ ProgramStateRef CStringChecker::checkInit(CheckerContext &C,
   const NonLoc StartIdx = ER->getIndex();
 
   std::optional<Loc> FirstElementVal =
-      State->getLValue(ElemTy, StartIdx, loc::MemRegionVal(SuperR)).getAs<Loc>();
+      State->getLValue(ElemTy, StartIdx, loc::MemRegionVal(SuperR))
+          .getAs<Loc>();
   if (!FirstElementVal)
     return State;
 

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -69,7 +69,6 @@ void memcpy_offset_no_false_positive(char *dst) {
   memcpy(dst, &buf[5], 3); // no-warning
 }
 
-
 // The interesting case here is that the portion we're copying is initialized,
 // but not the whole matrix. We need to be careful to extract buf[1], and not
 // buf when trying to peel region layers off from the source argument.

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -111,6 +111,32 @@ void mempcpy_struct_fully_uninit() {
   mempcpy(&s2, &s1, sizeof(struct st));
 }
 
+void memcpy_offset_uninit(char *dst) {
+  char buf[10];
+  buf[0] = 'a';
+  // buf[5] is never written.
+  memcpy(dst, &buf[5], 3); // expected-warning{{The first element of the 2nd argument is undefined}}
+                           // expected-note@-1{{Other elements might also be undefined}}
+}
+
+void memcpy_offset_uninit_boundary(char *dst) {
+  char buf[10];
+  buf[5] = 'a';
+  // buf[6] and buf[7] are never written.
+  memcpy(dst, &buf[5], 3); // expected-warning{{The last accessed element (at index 2) in the 2nd argument is undefined}}
+                           // expected-note@-1{{Other elements might also be undefined}}
+}
+
+// Reduced false positive: memcpy from an offset into a partially initialized
+// buffer should not warn if the accessed range is initialized.
+void memcpy_offset_no_false_positive(char *dst) {
+  char buf[10];
+  buf[5] = 'a';
+  buf[6] = 'b';
+  buf[7] = 'c';
+  memcpy(dst, &buf[5], 3); // no-warning
+}
+
 // Creduced crash. In this case, an symbolicregion is wrapped in an
 // elementregion for the src argument.
 void *ga_copy_strings_from_0;

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -50,11 +50,7 @@ void memcpy_array_from_matrix(char *dst) {
   char buf[2][2];
   buf[1][0] = 'i';
   buf[1][1] = 'j';
-  // FIXME: This is a FP -- we mistakenly retrieve the first element of buf,
-  // instead of the first element of buf[1]. getLValueElement simply peels off
-  // another ElementRegion layer, when in this case it really shouldn't.
-  memcpy(dst, buf[1], 2); // expected-warning{{The first element of the 2nd argument is undefined}}
-                          // expected-note@-1{{Other elements might also be undefined}}
+  memcpy(dst, buf[1], 2); // no-warning
   (void)buf;
 }
 

--- a/clang/test/Analysis/bstring_UninitRead.c
+++ b/clang/test/Analysis/bstring_UninitRead.c
@@ -43,6 +43,33 @@ void memcpy_array_partially_init_error(char *dst) {
   (void)buf;
 }
 
+void memcpy_offset_uninit(char *dst) {
+  char buf[10];
+  buf[0] = 'a';
+  // buf[5] is never written.
+  memcpy(dst, &buf[5], 3); // expected-warning{{The first element of the 2nd argument is undefined}}
+                           // expected-note@-1{{Other elements might also be undefined}}
+}
+
+void memcpy_offset_uninit_boundary(char *dst) {
+  char buf[10];
+  buf[5] = 'a';
+  // buf[6] and buf[7] are never written.
+  memcpy(dst, &buf[5], 3); // expected-warning{{The last accessed element (at index 2) in the 2nd argument is undefined}}
+                           // expected-note@-1{{Other elements might also be undefined}}
+}
+
+// Reduced false positive: memcpy from an offset into a partially initialized
+// buffer should not warn if the accessed range is initialized.
+void memcpy_offset_no_false_positive(char *dst) {
+  char buf[10];
+  buf[5] = 'a';
+  buf[6] = 'b';
+  buf[7] = 'c';
+  memcpy(dst, &buf[5], 3); // no-warning
+}
+
+
 // The interesting case here is that the portion we're copying is initialized,
 // but not the whole matrix. We need to be careful to extract buf[1], and not
 // buf when trying to peel region layers off from the source argument.
@@ -105,32 +132,6 @@ void mempcpy_struct_fully_uninit() {
   // FIXME: Maybe ask UninitializedObjectChecker whether s1 is fully
   // initialized?
   mempcpy(&s2, &s1, sizeof(struct st));
-}
-
-void memcpy_offset_uninit(char *dst) {
-  char buf[10];
-  buf[0] = 'a';
-  // buf[5] is never written.
-  memcpy(dst, &buf[5], 3); // expected-warning{{The first element of the 2nd argument is undefined}}
-                           // expected-note@-1{{Other elements might also be undefined}}
-}
-
-void memcpy_offset_uninit_boundary(char *dst) {
-  char buf[10];
-  buf[5] = 'a';
-  // buf[6] and buf[7] are never written.
-  memcpy(dst, &buf[5], 3); // expected-warning{{The last accessed element (at index 2) in the 2nd argument is undefined}}
-                           // expected-note@-1{{Other elements might also be undefined}}
-}
-
-// Reduced false positive: memcpy from an offset into a partially initialized
-// buffer should not warn if the accessed range is initialized.
-void memcpy_offset_no_false_positive(char *dst) {
-  char buf[10];
-  buf[5] = 'a';
-  buf[6] = 'b';
-  buf[7] = 'c';
-  memcpy(dst, &buf[5], 3); // no-warning
 }
 
 // Creduced crash. In this case, an symbolicregion is wrapped in an


### PR DESCRIPTION
…uments

CStringChecker::checkInit() was checking the wrong array elements when the buffer argument pointed into the middle of an array (e.g., memcpy(dst, &arr[i], size)). It was called with BufEnd instead of BufStart, making the ElementRegion index off by (size-1), and the element lookups were relative to array index 0 instead of the actual buffer start offset.