### PR TITLE
[lldb] Remove FileAction::Clear

### DIFF
--- a/lldb/include/lldb/Host/FileAction.h
+++ b/lldb/include/lldb/Host/FileAction.h
@@ -29,9 +29,6 @@ public:
 
   FileAction();
 
-  /// Reset this FileAction to its default state.
-  void Clear();
-
   /// Configure this action to close a file descriptor.
   bool Close(int fd);
 

--- a/lldb/include/lldb/Host/windows/WindowsFileAction.h
+++ b/lldb/include/lldb/Host/windows/WindowsFileAction.h
@@ -26,13 +26,6 @@ public:
   /// handle fields default to INVALID_HANDLE_VALUE.
   WindowsFileAction(const FileAction &fa) : FileAction(fa) {}
 
-  /// Reset this WindowsFileAction to its default state.
-  void Clear() {
-    FileAction::Clear();
-    m_handle = LLDB_INVALID_PIPE;
-    m_arg_handle = LLDB_INVALID_PIPE;
-  }
-
   /// Configure this action to duplicate a Windows file handle.
   ///
   /// \param[in] fh

--- a/lldb/source/Host/common/FileAction.cpp
+++ b/lldb/source/Host/common/FileAction.cpp
@@ -18,13 +18,6 @@ using namespace lldb_private;
 
 FileAction::FileAction() : m_file_spec() {}
 
-void FileAction::Clear() {
-  m_action = eFileActionNone;
-  m_fd = -1;
-  m_arg = -1;
-  m_file_spec.Clear();
-}
-
 const FileSpec &FileAction::GetFileSpec() const { return m_file_spec; }
 
 bool FileAction::Open(int fd, const FileSpec &file_spec, bool read,
@@ -40,14 +33,13 @@ bool FileAction::Open(int fd, const FileSpec &file_spec, bool read,
       m_arg = O_NOCTTY | O_CREAT | O_WRONLY | O_TRUNC;
     m_file_spec = file_spec;
     return true;
-  } else {
-    Clear();
   }
+  *this = FileAction();
   return false;
 }
 
 bool FileAction::Close(int fd) {
-  Clear();
+  *this = FileAction();
   if (fd >= 0) {
     m_action = eFileActionClose;
     m_fd = fd;
@@ -56,7 +48,7 @@ bool FileAction::Close(int fd) {
 }
 
 bool FileAction::Duplicate(int fd, int dup_fd) {
-  Clear();
+  *this = FileAction();
   if (fd >= 0 && dup_fd >= 0) {
     m_action = eFileActionDuplicate;
     m_fd = fd;

--- a/lldb/source/Host/windows/WindowsFileAction.cpp
+++ b/lldb/source/Host/windows/WindowsFileAction.cpp
@@ -15,7 +15,7 @@
 using namespace lldb_private;
 
 bool WindowsFileAction::Duplicate(HANDLE fh, HANDLE dup_fh) {
-  Clear();
+  *this = WindowsFileAction();
   if (fh != INVALID_HANDLE_VALUE && dup_fh != INVALID_HANDLE_VALUE) {
     m_action = eFileActionDuplicate;
     m_handle = fh;
@@ -38,9 +38,8 @@ bool WindowsFileAction::Open(HANDLE fh, const FileSpec &file_spec, bool read,
       m_arg = O_NOCTTY | O_CREAT | O_WRONLY | O_TRUNC;
     m_file_spec = file_spec;
     return true;
-  } else {
-    Clear();
   }
+  *this = WindowsFileAction();
   return false;
 }
 


### PR DESCRIPTION
lldb is moving away from the `Clear()` pattern. This patch removes the method from the `FileAction` class.

This is a follow up to https://github.com/llvm/llvm-project/pull/179274.

rdar://177078239
