### PR TITLE
[llvm-pdbutil] Add DXContainer support for pdb2yaml

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBFile.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBFile.h
@@ -11,6 +11,7 @@
 
 #include "llvm/DebugInfo/MSF/IMSFFile.h"
 #include "llvm/DebugInfo/MSF/MSFCommon.h"
+#include "llvm/Object/DXContainer.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BinaryStreamRef.h"
 #include "llvm/Support/Compiler.h"
@@ -105,6 +106,7 @@ public:
   Expected<SymbolStream &> getPDBSymbolStream();
   Expected<PDBStringTable &> getStringTable();
   Expected<InjectedSourceStream &> getInjectedSourceStream();
+  Expected<object::DXContainer &> getDXContainerStream();
 
   BumpPtrAllocator &getAllocator() { return Allocator; }
 
@@ -133,6 +135,7 @@ private:
   std::unique_ptr<DbiStream> Dbi;
   std::unique_ptr<TpiStream> Tpi;
   std::unique_ptr<TpiStream> Ipi;
+  std::unique_ptr<object::DXContainer> Dxc;
   std::unique_ptr<PublicsStream> Publics;
   std::unique_ptr<SymbolStream> Symbols;
   std::unique_ptr<msf::MappedBlockStream> DirectoryStream;

--- a/llvm/include/llvm/DebugInfo/PDB/Native/RawConstants.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/RawConstants.h
@@ -80,7 +80,10 @@ enum SpecialStream : uint32_t {
   StreamDBI = 3,
   StreamIPI = 4,
 
-  kSpecialStreamCount
+  kSpecialStreamCount = 5,
+  // Fixed index of DXContainer stream, but it's not one of the special
+  // streams and is produced only by DirectX tools.
+  StreamDXContainer = 5
 };
 
 enum class DbgHeaderType : uint16_t {

--- a/llvm/lib/DebugInfo/PDB/Native/PDBFile.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/PDBFile.cpp
@@ -398,6 +398,28 @@ Expected<InjectedSourceStream &> PDBFile::getInjectedSourceStream() {
   return *InjectedSources;
 }
 
+llvm::Expected<object::DXContainer &> PDBFile::getDXContainerStream() {
+  if (!Dxc) {
+    auto MBS = safelyCreateIndexedStream(StreamDXContainer);
+    if (!MBS)
+      return MBS.takeError();
+    auto StreamSize = getStreamByteSize(StreamDXContainer);
+    ArrayRef<uint8_t> StreamData;
+    auto Error = MBS->get()->readBytes(0, StreamSize, StreamData);
+    if (Error)
+      return Error;
+
+    StringRef Ref(reinterpret_cast<const char *>(StreamData.data()),
+                  StreamSize);
+    MemoryBufferRef MemBuf(Ref, "DXContainerStream");
+    auto DXC = object::DXContainer::create(MemBuf);
+    if (!DXC)
+      return DXC.takeError();
+    Dxc = std::make_unique<object::DXContainer>(std::move(*DXC));
+  }
+  return *Dxc;
+}
+
 uint32_t PDBFile::getPointerSize() {
   auto DbiS = getPDBDbiStream();
   if (!DbiS)
@@ -451,7 +473,9 @@ bool PDBFile::hasPDBSymbolStream() {
   return DbiS->getSymRecordStreamIndex() < getNumStreams();
 }
 
-bool PDBFile::hasPDBTpiStream() const { return StreamTPI < getNumStreams(); }
+bool PDBFile::hasPDBTpiStream() const {
+  return StreamTPI < getNumStreams() && getStreamByteSize(StreamTPI) != 0;
+}
 
 bool PDBFile::hasPDBStringTable() {
   auto IS = getPDBInfoStream();

--- a/llvm/test/tools/llvm-pdbutil/dxcontainer.test
+++ b/llvm/test/tools/llvm-pdbutil/dxcontainer.test
@@ -1,0 +1,145 @@
+## Check DXContainer support within a PDB file.
+## Disable the test until yaml2pdb and pdb2yaml are implemented.
+# UNSUPPORTED: target={{.*}}
+
+# RUN: llvm-pdbutil yaml2pdb %s --pdb=%t.pdb
+# RUN: llvm-pdbutil pdb2yaml --all %t.pdb > %t.yaml
+# RUN: llvm-pdbutil yaml2pdb %t.yaml --pdb=%t.yaml.pdb
+
+## Check that converting YAML to PDB and back results in the same YAML.
+# RUN: FileCheck -input-file=%t.yaml %s
+
+## Check that converting PDB to YAML and back results in the same binary.
+# RUN: diff %t.pdb %t.yaml.pdb
+
+# CHECK: ---
+# CHECK: MSF:
+# CHECK:   SuperBlock:
+# CHECK:     BlockSize:       512
+# CHECK:     FreeBlockMap:    2
+# CHECK:     NumBlocks:       7
+# CHECK:     NumDirectoryBytes: 36
+# CHECK:     Unknown1:        0
+# CHECK:     BlockMapAddr:    3
+# CHECK:   NumDirectoryBlocks: 1
+# CHECK:   DirectoryBlocks: [ 6 ]
+# CHECK:   NumStreams:      6
+# CHECK:   FileSize:        3584
+# CHECK: StreamSizes:     [ 0, 52, 0, 0, 0, 140 ]
+# CHECK: StreamMap:
+# CHECK:   - Stream:          [  ]
+# CHECK:   - Stream:          [ 5 ]
+# CHECK:   - Stream:          [  ]
+# CHECK:   - Stream:          [  ]
+# CHECK:   - Stream:          [  ]
+# CHECK:   - Stream:          [ 4 ]
+# CHECK: PdbStream:
+# CHECK:   Age:             1
+# CHECK:   Guid:            '{15C920AB-F953-7F22-4045-454D275D98D6}'
+# CHECK:   Signature:       0
+# CHECK:   Version:         VC70
+# CHECK: PublicsStream:
+# CHECK:   Records:         []
+# CHECK: DXContainerStream:
+# CHECK:   DXContainer: !dxcontainer
+# CHECK:     Header:
+# CHECK:       Hash:            [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+# CHECK:                          0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+# CHECK:       Version:
+# CHECK:         Major:           1
+# CHECK:         Minor:           0
+# CHECK:       FileSize:        140
+# CHECK:       PartCount:       3
+# CHECK:       PartOffsets:     [ 52, 76, 104 ]
+# CHECK:     Parts:
+# CHECK:       - Name:            ILDN
+# CHECK:         Size:            16
+# CHECK:         DebugName:
+# CHECK:           Flags:           0
+# CHECK:           NameLength:      10
+# CHECK:           DebugName:       simple.pdb
+# CHECK:       - Name:            HASH
+# CHECK:         Size:            20
+# CHECK:         Hash:
+# CHECK:           IncludesSource:  false
+# CHECK:           Digest:          [ 0xAB, 0x20, 0xC9, 0x15, 0x53, 0xF9, 0x22,
+# CHECK:                              0x7F, 0x40, 0x45, 0x45, 0x4D, 0x27, 0x5D,
+# CHECK:                              0x98, 0xD6 ]
+# CHECK:       - Name:            ILDB
+# CHECK:         Size:            28
+# CHECK:         Program:
+# CHECK:           MajorVersion:    6
+# CHECK:           MinorVersion:    5
+# CHECK:           ShaderKind:      6
+# CHECK:           Size:            8
+# CHECK:           DXILMajorVersion: 1
+# CHECK:           DXILMinorVersion: 5
+# CHECK:           DXILSize:        4
+# CHECK:           DXIL:            [ 0x42, 0x43, 0xC0, 0xDE ]
+# CHECK: ...
+
+---
+MSF:
+  SuperBlock:
+    BlockSize:       512
+    FreeBlockMap:    2
+    NumBlocks:       7
+    NumDirectoryBytes: 36
+    Unknown1:        0
+    BlockMapAddr:    3
+  NumDirectoryBlocks: 1
+  DirectoryBlocks: [ 6 ]
+  NumStreams:      6
+  FileSize:        3584
+StreamSizes:     [ 0, 52, 0, 0, 0, 140 ]
+StreamMap:
+  - Stream:          [  ]
+  - Stream:          [ 5 ]
+  - Stream:          [  ]
+  - Stream:          [  ]
+  - Stream:          [  ]
+  - Stream:          [ 4 ]
+PdbStream:
+  Age:             1
+  Guid:            '{15C920AB-F953-7F22-4045-454D275D98D6}'
+  Signature:       0
+  Version:         VC70
+PublicsStream:
+  Records:         []
+DXContainerStream:
+  DXContainer: !dxcontainer
+    Header:
+      Hash:            [ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0 ]
+      Version:
+        Major:           1
+        Minor:           0
+      FileSize:        140
+      PartCount:       3
+      PartOffsets:     [ 52, 76, 104 ]
+    Parts:
+      - Name:            ILDN
+        Size:            16
+        DebugName:
+          Flags:           0
+          NameLength:      10
+          DebugName:       simple.pdb
+      - Name:            HASH
+        Size:            20
+        Hash:
+          IncludesSource:  false
+          Digest:          [ 0xAB, 0x20, 0xC9, 0x15, 0x53, 0xF9, 0x22,
+                             0x7F, 0x40, 0x45, 0x45, 0x4D, 0x27, 0x5D,
+                             0x98, 0xD6 ]
+      - Name:            ILDB
+        Size:            28
+        Program:
+          MajorVersion:    6
+          MinorVersion:    5
+          ShaderKind:      6
+          Size:            8
+          DXILMajorVersion: 1
+          DXILMinorVersion: 5
+          DXILSize:        4
+          DXIL:            [ 0x42, 0x43, 0xC0, 0xDE ]
+...

--- a/llvm/tools/llvm-pdbutil/PdbYaml.cpp
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.cpp
@@ -112,6 +112,7 @@ void MappingTraits<PdbObject>::mapping(IO &IO, PdbObject &Obj) {
   IO.mapOptional("TpiStream", Obj.TpiStream);
   IO.mapOptional("IpiStream", Obj.IpiStream);
   IO.mapOptional("PublicsStream", Obj.PublicsStream);
+  IO.mapOptional("DXContainerStream", Obj.DXContainerStream);
 }
 
 void MappingTraits<MSFHeaders>::mapping(IO &IO, MSFHeaders &Obj) {
@@ -238,4 +239,9 @@ void MappingTraits<PdbDbiModuleInfo>::mapping(IO &IO, PdbDbiModuleInfo &Obj) {
   IO.mapOptional("SourceFiles", Obj.SourceFiles);
   IO.mapOptional("Subsections", Obj.Subsections);
   IO.mapOptional("Modi", Obj.Modi);
+}
+
+void MappingTraits<DXContainerStream>::mapping(
+    IO &IO, pdb::yaml::DXContainerStream &Obj) {
+  IO.mapRequired("DXContainer", Obj.DXC);
 }

--- a/llvm/tools/llvm-pdbutil/PdbYaml.h
+++ b/llvm/tools/llvm-pdbutil/PdbYaml.h
@@ -22,6 +22,7 @@
 #include "llvm/ObjectYAML/CodeViewYAMLDebugSections.h"
 #include "llvm/ObjectYAML/CodeViewYAMLSymbols.h"
 #include "llvm/ObjectYAML/CodeViewYAMLTypes.h"
+#include "llvm/ObjectYAML/DXContainerYAML.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/YAMLTraits.h"
 
@@ -109,6 +110,10 @@ struct PdbTpiStream {
   std::vector<CodeViewYAML::LeafRecord> Records;
 };
 
+struct DXContainerStream {
+  DXContainerYAML::Object DXC;
+};
+
 struct PdbPublicsStream {
   std::vector<CodeViewYAML::SymbolRecord> PubSyms;
 };
@@ -123,6 +128,7 @@ struct PdbObject {
   std::optional<PdbDbiStream> DbiStream;
   std::optional<PdbTpiStream> TpiStream;
   std::optional<PdbTpiStream> IpiStream;
+  std::optional<DXContainerStream> DXContainerStream;
   std::optional<PdbPublicsStream> PublicsStream;
 
   std::optional<std::vector<StringRef>> StringTable;
@@ -145,5 +151,6 @@ LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbPublicsStream)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::NamedStreamMapping)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbModiStream)
 LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::PdbDbiModuleInfo)
+LLVM_YAML_DECLARE_MAPPING_TRAITS_PRIVATE(pdb::yaml::DXContainerStream)
 
 #endif // LLVM_TOOLS_LLVMPDBDUMP_PDBYAML_H

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.cpp
@@ -74,6 +74,9 @@ Error YAMLOutputStyle::dump() {
   if (auto EC = dumpPublics())
     return EC;
 
+  if (auto EC = dumpDXContainer())
+    return EC;
+
   // Fake Coff header for dumping register enumerations.
   COFF::header Header;
   auto MachineType =
@@ -114,6 +117,9 @@ Error YAMLOutputStyle::dumpStringTable() {
                              !opts::pdb2yaml::DumpModuleSubsections.empty();
   bool RequestedStringTable = opts::pdb2yaml::StringTable;
   if (!RequiresStringTable && !RequestedStringTable)
+    return Error::success();
+
+  if (!File.hasPDBStringTable())
     return Error::success();
 
   auto ExpectedST = File.getStringTable();
@@ -310,6 +316,9 @@ Error YAMLOutputStyle::dumpTpiStream() {
   if (!opts::pdb2yaml::TpiStream)
     return Error::success();
 
+  if (!File.hasPDBTpiStream())
+    return Error::success();
+
   auto TpiS = File.getPDBTpiStream();
   if (!TpiS)
     return TpiS.takeError();
@@ -329,6 +338,9 @@ Error YAMLOutputStyle::dumpTpiStream() {
 
 Error YAMLOutputStyle::dumpIpiStream() {
   if (!opts::pdb2yaml::IpiStream)
+    return Error::success();
+
+  if (!File.hasPDBIpiStream())
     return Error::success();
 
   auto InfoS = File.getPDBInfoStream();
@@ -388,6 +400,25 @@ Error YAMLOutputStyle::dumpPublics() {
     Obj.PublicsStream->PubSyms.push_back(*ES);
   }
 
+  return Error::success();
+}
+
+Error YAMLOutputStyle::dumpDXContainer() {
+  if (!opts::pdb2yaml::DXContainerStream)
+    return Error::success();
+
+  auto DxcS = File.getDXContainerStream();
+  if (!DxcS) {
+    // Not finding a DXContainer is not an error.
+    consumeError(DxcS.takeError());
+    return Error::success();
+  }
+
+  auto DXCYaml = DXContainerYAML::fromDXContainer(*DxcS);
+  if (!DXCYaml)
+    return DXCYaml.takeError();
+  Obj.DXContainerStream.emplace();
+  Obj.DXContainerStream->DXC = *DXCYaml->get();
   return Error::success();
 }
 

--- a/llvm/tools/llvm-pdbutil/YAMLOutputStyle.h
+++ b/llvm/tools/llvm-pdbutil/YAMLOutputStyle.h
@@ -33,6 +33,7 @@ private:
   Error dumpDbiStream();
   Error dumpTpiStream();
   Error dumpIpiStream();
+  Error dumpDXContainer();
   Error dumpPublics();
 
   void flush();

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -700,6 +700,10 @@ cl::opt<bool> IpiStream("ipi-stream",
                         cl::desc("Dump the IPI Stream (Stream 5)"),
                         cl::sub(PdbToYamlSubcommand), cl::init(false));
 
+cl::opt<bool> DXContainerStream("dxcontainer",
+                                cl::desc("Dump the DXContainer Stream"),
+                                cl::sub(PdbToYamlSubcommand), cl::init(false));
+
 cl::opt<bool> PublicsStream("publics-stream",
                             cl::desc("Dump the Publics Stream"),
                             cl::sub(PdbToYamlSubcommand), cl::init(false));
@@ -1560,6 +1564,7 @@ int main(int Argc, const char **Argv) {
       opts::pdb2yaml::DbiStream = true;
       opts::pdb2yaml::TpiStream = true;
       opts::pdb2yaml::IpiStream = true;
+      opts::pdb2yaml::DXContainerStream = true;
       opts::pdb2yaml::PublicsStream = true;
       opts::pdb2yaml::DumpModules = true;
       opts::pdb2yaml::DumpModuleFiles = true;

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.h
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.h
@@ -202,6 +202,7 @@ extern llvm::cl::opt<bool> DumpModuleFiles;
 extern llvm::cl::list<ModuleSubsection> DumpModuleSubsections;
 extern llvm::cl::opt<bool> DumpModuleSyms;
 extern llvm::cl::opt<bool> DumpSectionHeaders;
+extern llvm::cl::opt<bool> DXContainerStream;
 } // namespace pdb2yaml
 
 namespace explain {


### PR DESCRIPTION
This enables outputting a PDB file with a built in `DXContainer` as YAML.
Existing DirectX tools form a PDB container with empty DBI, TPI and IPI streams, so this patch also allows them to be empty when dumping a PDB file as YAML.