### PR TITLE
[CIR] Include union tail pad in getTypeSizeInBits

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -738,6 +738,11 @@ def CIR_RecordType : CIR_Type<"Record", "record", [
     bool isIncomplete() const;
 
     mlir::Type getLargestMember(const mlir::DataLayout &dataLayout) const;
+
+    /// Tail-padding member for a padded union (last member appended by
+    /// lowerUnion).  Empty type when the record is not padded.
+    mlir::Type getPadding() const;
+
     size_t getNumElements() const { return getMembers().size(); };
     std::string getKindAsStr() {
       switch (getKind()) {

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -345,6 +345,15 @@ Type RecordType::getLargestMember(const ::mlir::DataLayout &dataLayout) const {
   });
 }
 
+mlir::Type RecordType::getPadding() const {
+  if (!getPadded())
+    return {};
+  llvm::ArrayRef<mlir::Type> members = getMembers();
+  if (members.empty())
+    return {};
+  return members.back();
+}
+
 bool RecordType::isLayoutIdentical(const RecordType &other) {
   if (getImpl() == other.getImpl())
     return true;
@@ -396,8 +405,8 @@ RecordType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
     // by `insertPadding`, making `sizeof(parent)` and array GEPs off by the
     // missing bytes.
     llvm::TypeSize size = dataLayout.getTypeSizeInBits(largest);
-    if (getPadded())
-      size += dataLayout.getTypeSizeInBits(*getMembers().rbegin());
+    if (mlir::Type tailPad = getPadding())
+      size += dataLayout.getTypeSizeInBits(tailPad);
     return size;
   }
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -382,7 +382,23 @@ RecordType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
     mlir::Type largest = getLargestMember(dataLayout);
     if (!largest)
       return llvm::TypeSize::getFixed(0);
-    return dataLayout.getTypeSizeInBits(largest);
+    // `getLargestMember` returns the highest-aligned variant (which dictates
+    // the union's alignment), not necessarily the largest by size.  When the
+    // union is `padded` -- i.e., its highest-aligned variant is strictly
+    // smaller than its layout size, as happens for any union containing both
+    // a small high-alignment scalar and a larger low-alignment array (e.g.,
+    // `union { char[16]; size_t; }`) -- `lowerUnion` appended a trailing
+    // byte-array member to extend the highest-aligned variant up to the
+    // layout size, and `LowerToLLVM` mirrors this by emitting the union as
+    // `{largest, padding}`.  Include that padding here so `getTypeSize`
+    // reports the same size `LowerToLLVM` produces; otherwise a parent
+    // record containing the union gets a spurious tail-padding member added
+    // by `insertPadding`, making `sizeof(parent)` and array GEPs off by the
+    // missing bytes.
+    llvm::TypeSize size = dataLayout.getTypeSizeInBits(largest);
+    if (getPadded())
+      size += dataLayout.getTypeSizeInBits(*getMembers().rbegin());
+    return size;
   }
 
   auto recordSize = static_cast<uint64_t>(computeStructSize(dataLayout));

--- a/clang/test/CIR/CodeGen/record-with-padded-union.cpp
+++ b/clang/test/CIR/CodeGen/record-with-padded-union.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct SSO {
+  char *p;
+  unsigned long len;
+  union {
+    char local[16];
+    unsigned long capacity;
+  };
+};
+
+// Inner union's tail padding must not bleed into the outer record.
+// CIR: !rec_anon{{.*}} = !cir.record<union "anon{{.*}}" padded {!cir.array<!s8i x 16>, !u64i, !cir.array<!u8i x 8>}>
+// CIR: !rec_SSO = !cir.record<struct "SSO" {!cir.ptr<!s8i>, !u64i, !rec_anon{{.*}}}>
+
+// LLVM: %struct.SSO = type { ptr, i64, %union.anon{{.*}} }
+// LLVM: %union.anon{{.*}} = type { i64, [8 x i8] }
+
+// OGCG: %struct.SSO = type { ptr, i64, %union.anon }
+// OGCG: %union.anon = type { i64, [8 x i8] }
+
+extern "C" SSO *last_of_three() {
+  SSO *p = new SSO[3];
+  return &p[2];
+}
+
+// Allocation is 3*sizeof(SSO)=96; per-element stride comes from struct size.
+// LLVM-LABEL: define {{.*}}@last_of_three
+// LLVM: call {{.*}}@_Znam(i64 noundef 96)
+// LLVM: getelementptr %struct.SSO, ptr %{{.+}}, i64 2
+
+// OGCG-LABEL: define {{.*}}@last_of_three
+// OGCG: call {{.*}}@_Znam(i64 noundef 96)
+// OGCG: getelementptr {{.*}}%struct.SSO, ptr %{{.+}}, i64 2

--- a/clang/test/CIR/CodeGen/record-with-padded-union.cpp
+++ b/clang/test/CIR/CodeGen/record-with-padded-union.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 struct SSO {
   char *p;
@@ -21,9 +21,6 @@ struct SSO {
 // LLVM: %struct.SSO = type { ptr, i64, %union.anon{{.*}} }
 // LLVM: %union.anon{{.*}} = type { i64, [8 x i8] }
 
-// OGCG: %struct.SSO = type { ptr, i64, %union.anon }
-// OGCG: %union.anon = type { i64, [8 x i8] }
-
 extern "C" SSO *last_of_three() {
   SSO *p = new SSO[3];
   return &p[2];
@@ -32,8 +29,4 @@ extern "C" SSO *last_of_three() {
 // Allocation is 3*sizeof(SSO)=96; per-element stride comes from struct size.
 // LLVM-LABEL: define {{.*}}@last_of_three
 // LLVM: call {{.*}}@_Znam(i64 noundef 96)
-// LLVM: getelementptr %struct.SSO, ptr %{{.+}}, i64 2
-
-// OGCG-LABEL: define {{.*}}@last_of_three
-// OGCG: call {{.*}}@_Znam(i64 noundef 96)
-// OGCG: getelementptr {{.*}}%struct.SSO, ptr %{{.+}}, i64 2
+// LLVM: getelementptr{{.*}}%struct.SSO, ptr %{{.+}}, i64 2


### PR DESCRIPTION
Padded CIR unions (e.g. libstdc++ `std::string` SSO layout) carry a
trailing byte-array member so the record matches the AST layout size.
`RecordType::getTypeSizeInBits` was returning only the largest-aligned
member and ignored that tail, so the CIR view of the union was 8 bytes
smaller than what `LowerToLLVM` emits.  Parent structs then picked up
a spurious trailing pad via `insertPadding`, arrays of those structs
used the wrong stride, and heap allocations could be overrun (Eigen's
`array_of_string` hits this directly).

The fix adds the padding member's size when the union is marked
`padded`, so struct size, GEP strides, and `new T[n]` allocation sizes
match OGCG.  Regression test models the SSO-shaped record and checks
the 96-byte `new` for three elements.