### PR TITLE
[PDB][llvm-pdbutil] Add DXContainer support for yaml2pdb

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBFileBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBFileBuilder.h
@@ -53,6 +53,7 @@ public:
   LLVM_ABI TpiStreamBuilder &getIpiBuilder();
   LLVM_ABI PDBStringTableBuilder &getStringTableBuilder();
   LLVM_ABI GSIStreamBuilder &getGsiBuilder();
+  LLVM_ABI std::unique_ptr<SmallVector<char>> &getDXContainerData();
 
   // If HashPDBContentsToGUID is true on the InfoStreamBuilder, Guid is filled
   // with the computed PDB GUID on return.
@@ -96,8 +97,9 @@ private:
   std::unique_ptr<GSIStreamBuilder> Gsi;
   std::unique_ptr<TpiStreamBuilder> Tpi;
   std::unique_ptr<TpiStreamBuilder> Ipi;
+  std::unique_ptr<SmallVector<char>> Dxc;
 
-  PDBStringTableBuilder Strings;
+  std::unique_ptr<PDBStringTableBuilder> Strings;
   StringTableHashTraits InjectedSourceHashTraits;
   HashTable<SrcHeaderBlockEntry> InjectedSourceTable;
 

--- a/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h
+++ b/llvm/include/llvm/DebugInfo/PDB/Native/PDBStringTableBuilder.h
@@ -35,6 +35,7 @@ class PDBStringTableBuilder;
 struct StringTableHashTraits {
   PDBStringTableBuilder *Table;
 
+  LLVM_ABI StringTableHashTraits() = default;
   LLVM_ABI explicit StringTableHashTraits(PDBStringTableBuilder &Table);
   LLVM_ABI uint32_t hashLookupKey(StringRef S) const;
   LLVM_ABI StringRef storageKeyToLookupKey(uint32_t Offset) const;

--- a/llvm/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
@@ -40,8 +40,8 @@ class WritableBinaryStream;
 }
 
 PDBFileBuilder::PDBFileBuilder(BumpPtrAllocator &Allocator)
-    : Allocator(Allocator), InjectedSourceHashTraits(*Strings),
-      InjectedSourceTable(2) {}
+    : Allocator(Allocator), Strings(std::make_unique<PDBStringTableBuilder>()),
+      InjectedSourceHashTraits(*Strings), InjectedSourceTable(2) {}
 
 PDBFileBuilder::~PDBFileBuilder() = default;
 

--- a/llvm/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
@@ -40,7 +40,7 @@ class WritableBinaryStream;
 }
 
 PDBFileBuilder::PDBFileBuilder(BumpPtrAllocator &Allocator)
-    : Allocator(Allocator), InjectedSourceHashTraits(Strings),
+    : Allocator(Allocator), InjectedSourceHashTraits(*Strings),
       InjectedSourceTable(2) {}
 
 PDBFileBuilder::~PDBFileBuilder() = default;
@@ -80,13 +80,21 @@ TpiStreamBuilder &PDBFileBuilder::getIpiBuilder() {
 }
 
 PDBStringTableBuilder &PDBFileBuilder::getStringTableBuilder() {
-  return Strings;
+  if (!Strings)
+    Strings = std::make_unique<PDBStringTableBuilder>();
+  return *Strings;
 }
 
 GSIStreamBuilder &PDBFileBuilder::getGsiBuilder() {
   if (!Gsi)
     Gsi = std::make_unique<GSIStreamBuilder>(*Msf);
   return *Gsi;
+}
+
+std::unique_ptr<SmallVector<char>> &PDBFileBuilder::getDXContainerData() {
+  if (!Dxc)
+    Dxc = std::make_unique<SmallVector<char>>();
+  return Dxc;
 }
 
 Expected<uint32_t> PDBFileBuilder::allocateNamedStream(StringRef Name,
@@ -140,11 +148,14 @@ Error PDBFileBuilder::finalizeMsfLayout() {
     Info.addFeature(PdbRaw_FeatureSig::VC140);
   }
 
-  uint32_t StringsLen = Strings.calculateSerializedSize();
-
-  Expected<uint32_t> SN = allocateNamedStream("/LinkInfo", 0);
-  if (!SN)
-    return SN.takeError();
+  if (Dxc) {
+    if (auto EC = Msf->setStreamSize(StreamDXContainer, Dxc->size()))
+      return EC;
+  } else {
+    Expected<uint32_t> SN = allocateNamedStream("/LinkInfo", 0);
+    if (!SN)
+      return SN.takeError();
+  }
 
   if (Gsi) {
     if (auto EC = Gsi->finalizeMsfLayout())
@@ -163,10 +174,12 @@ Error PDBFileBuilder::finalizeMsfLayout() {
     if (auto EC = Dbi->finalizeMsfLayout())
       return EC;
   }
-  SN = allocateNamedStream("/names", StringsLen);
-  if (!SN)
-    return SN.takeError();
-
+  if (Strings) {
+    uint32_t StringsLen = Strings->calculateSerializedSize();
+    Expected<uint32_t> SN = allocateNamedStream("/names", StringsLen);
+    if (!SN)
+      return SN.takeError();
+  }
   if (Ipi) {
     if (auto EC = Ipi->finalizeMsfLayout())
       return EC;
@@ -203,7 +216,8 @@ Error PDBFileBuilder::finalizeMsfLayout() {
     uint32_t SrcHeaderBlockSize =
         sizeof(SrcHeaderBlockHeader) +
         InjectedSourceTable.calculateSerializedLength();
-    SN = allocateNamedStream("/src/headerblock", SrcHeaderBlockSize);
+    Expected<uint32_t> SN =
+        allocateNamedStream("/src/headerblock", SrcHeaderBlockSize);
     if (!SN)
       return SN.takeError();
     for (const auto &IS : InjectedSources) {
@@ -282,16 +296,17 @@ Error PDBFileBuilder::commit(StringRef Filename, codeview::GUID *Guid) {
     return ExpectedMsfBuffer.takeError();
   FileBufferByteStream Buffer = std::move(*ExpectedMsfBuffer);
 
-  auto ExpectedSN = getNamedStreamIndex("/names");
-  if (!ExpectedSN)
-    return ExpectedSN.takeError();
+  if (Strings) {
+    auto ExpectedSN = getNamedStreamIndex("/names");
+    if (!ExpectedSN)
+      return ExpectedSN.takeError();
 
-  auto NS = WritableMappedBlockStream::createIndexedStream(
-      Layout, Buffer, *ExpectedSN, Allocator);
-  BinaryStreamWriter NSWriter(*NS);
-  if (auto EC = Strings.commit(NSWriter))
-    return EC;
-
+    auto NS = WritableMappedBlockStream::createIndexedStream(
+        Layout, Buffer, *ExpectedSN, Allocator);
+    BinaryStreamWriter NSWriter(*NS);
+    if (auto EC = Strings->commit(NSWriter))
+      return EC;
+  }
   {
     llvm::TimeTraceScope timeScope("Named stream data");
     for (const auto &NSE : NamedStreamData) {
@@ -328,6 +343,17 @@ Error PDBFileBuilder::commit(StringRef Filename, codeview::GUID *Guid) {
 
   if (Gsi) {
     if (auto EC = Gsi->commit(Layout, Buffer))
+      return EC;
+  }
+
+  if (Dxc) {
+    llvm::TimeTraceScope timeScope("DXContainer stream");
+    auto DxcS = WritableMappedBlockStream::createIndexedStream(
+        Layout, Buffer, StreamDXContainer, Allocator);
+    BinaryStreamWriter Writer(*DxcS);
+    llvm::ArrayRef<uint8_t> DataRef(reinterpret_cast<uint8_t *>(Dxc->data()),
+                                    Dxc->size());
+    if (auto EC = Writer.writeBytes(DataRef))
       return EC;
   }
 

--- a/llvm/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
+++ b/llvm/lib/DebugInfo/PDB/Native/PDBFileBuilder.cpp
@@ -40,8 +40,7 @@ class WritableBinaryStream;
 }
 
 PDBFileBuilder::PDBFileBuilder(BumpPtrAllocator &Allocator)
-    : Allocator(Allocator), Strings(std::make_unique<PDBStringTableBuilder>()),
-      InjectedSourceHashTraits(*Strings), InjectedSourceTable(2) {}
+    : Allocator(Allocator), InjectedSourceTable(2) {}
 
 PDBFileBuilder::~PDBFileBuilder() = default;
 
@@ -80,8 +79,10 @@ TpiStreamBuilder &PDBFileBuilder::getIpiBuilder() {
 }
 
 PDBStringTableBuilder &PDBFileBuilder::getStringTableBuilder() {
-  if (!Strings)
+  if (!Strings) {
     Strings = std::make_unique<PDBStringTableBuilder>();
+    InjectedSourceHashTraits = StringTableHashTraits(*Strings);
+  }
   return *Strings;
 }
 

--- a/llvm/test/tools/llvm-pdbutil/dxcontainer.test
+++ b/llvm/test/tools/llvm-pdbutil/dxcontainer.test
@@ -1,6 +1,4 @@
 ## Check DXContainer support within a PDB file.
-## Disable the test until yaml2pdb and pdb2yaml are implemented.
-# UNSUPPORTED: target={{.*}}
 
 # RUN: llvm-pdbutil yaml2pdb %s --pdb=%t.pdb
 # RUN: llvm-pdbutil pdb2yaml --all %t.pdb > %t.yaml

--- a/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
+++ b/llvm/tools/llvm-pdbutil/llvm-pdbutil.cpp
@@ -76,6 +76,7 @@
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeFunctionSig.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeTypedef.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h"
+#include "llvm/ObjectYAML/yaml2obj.h"
 #include "llvm/Support/BinaryByteStream.h"
 #include "llvm/Support/COM.h"
 #include "llvm/Support/CommandLine.h"
@@ -817,19 +818,13 @@ static void yamlToPdb(StringRef Path) {
   for (uint32_t I = 0; I < kSpecialStreamCount; ++I)
     ExitOnErr(Builder.getMsfBuilder().addStream(0));
 
-  StringsAndChecksums Strings;
-  Strings.setStrings(std::make_shared<DebugStringTableSubsection>());
-
-  if (YamlObj.StringTable) {
-    for (auto S : *YamlObj.StringTable)
-      Strings.strings()->insert(S);
+  auto &Dxc = YamlObj.DXContainerStream;
+  if (Dxc) {
+    // If there is a DXContainer, add add it as a stream #5.
+    ExitOnErr(Builder.getMsfBuilder().addStream(0));
   }
 
   pdb::yaml::PdbInfoStream DefaultInfoStream;
-  pdb::yaml::PdbDbiStream DefaultDbiStream;
-  pdb::yaml::PdbTpiStream DefaultTpiStream;
-  pdb::yaml::PdbTpiStream DefaultIpiStream;
-
   const auto &Info = YamlObj.PdbStream.value_or(DefaultInfoStream);
 
   auto &InfoBuilder = Builder.getInfoBuilder();
@@ -839,6 +834,36 @@ static void yamlToPdb(StringRef Path) {
   InfoBuilder.setVersion(Info.Version);
   for (auto F : Info.Features)
     InfoBuilder.addFeature(F);
+
+  if (Dxc) {
+    auto &Data = Builder.getDXContainerData();
+    llvm::raw_svector_ostream DataStream(*Data);
+    std::string ErrorMsg;
+    llvm::yaml::yaml2dxcontainer(
+        Dxc->DXC, DataStream, [&ErrorMsg](const Twine &Msg) {
+          ErrorMsg = (Twine("DXContainer error: ") + Msg).str();
+        });
+    if (!ErrorMsg.empty())
+      ExitOnErr(createStringError(ErrorMsg));
+
+    codeview::GUID IgnoredOutGuid;
+    ExitOnErr(
+        Builder.commit(opts::yaml2pdb::YamlPdbOutputFile, &IgnoredOutGuid));
+    // Leave all other streams empty if there is a DXContainer.
+    return;
+  }
+
+  StringsAndChecksums Strings;
+  Strings.setStrings(std::make_shared<DebugStringTableSubsection>());
+
+  if (YamlObj.StringTable) {
+    for (auto S : *YamlObj.StringTable)
+      Strings.strings()->insert(S);
+  }
+
+  pdb::yaml::PdbDbiStream DefaultDbiStream;
+  pdb::yaml::PdbTpiStream DefaultTpiStream;
+  pdb::yaml::PdbTpiStream DefaultIpiStream;
 
   const auto &Dbi = YamlObj.DbiStream.value_or(DefaultDbiStream);
   auto &DbiBuilder = Builder.getDbiBuilder();


### PR DESCRIPTION
Create a PDB file from YAML with an built in `DXContainer`.
When creating a PDB with a `DXContainer`, streams DBI, TPI and IPI can be completely empty, so this patch also includes adjustments to allow forming such a PDB file. This is done to maintain compatibility with other DirectX tools.
This patch enables `dxcontainer.test` introduced in #198351.