### PR TITLE
[cmake][runtimes] Remove obsolete LLVM_RUNTIMES_PREFIX

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -719,7 +719,6 @@ if(build_runtimes)
         runtime_register_target(${name}+${multilib}
           DEPENDS runtimes-${name}
           CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name}
-                     -DLLVM_RUNTIMES_PREFIX=${name}/
                      -DLLVM_RUNTIMES_LIBDIR_SUBDIR=${multilib}
                      ${extra_cmake_args}
           BASE_NAME ${name}
@@ -822,7 +821,7 @@ ${_flag_values}\
 endif()
 
 if(LIBOMP_ENABLE_ARM64X)
-  # TODO: This only needs to depend on openmp-arm64ec-pc-windows-msvc, but the 
+  # TODO: This only needs to depend on openmp-arm64ec-pc-windows-msvc, but the
   # openmp targets set up for cross build runtimes don't currently work correctly.
   add_dependencies(runtimes-configure runtimes-arm64ec-pc-windows-msvc-build)
 endif()


### PR DESCRIPTION
Hasn't been used by anything for close to 8 years.

Fixes: 887f26d4703616934fd7a11b6649f605e1c7b4e3