### PR TITLE
[DirectX] Update intrinsic test with more precise error message

### DIFF
--- a/llvm/test/CodeGen/DirectX/discard_error.ll
+++ b/llvm/test/CodeGen/DirectX/discard_error.ll
@@ -2,7 +2,7 @@
 
 ; DXIL operation discard does not support no bool overload type
 
-; CHECK: intrinsic has incorrect argument type
+; CHECK: intrinsic argument 0 type expected i1, but got double
 ; CHECK: call void @llvm.dx.discard(double %p)
 ;
 define void @discard_double(double noundef %p) {


### PR DESCRIPTION
Error messages for bad intrinsic signatures were improved in #196802, update this test to match.