### PR TITLE
[lldb][PECOFF] Recognise truncated .lldb{summaries,formatters} section names

### DIFF
--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -998,11 +998,14 @@ SectionType ObjectFilePECOFF::GetSectionType(llvm::StringRef sect_name,
           .Case(".debug", eSectionTypeDebug)
           .Case(".stabstr", eSectionTypeDataCString)
           .Case(".reloc", eSectionTypeOther)
-          // .eh_frame can be truncated to 8 chars.
+          // PE/COFF image-file section names are limited to 8 characters,
+          // so the linker truncates the longer source names. Match both.
           .Cases({".eh_frame", ".eh_fram"}, eSectionTypeEHFrame)
           .Case(".gosymtab", eSectionTypeGoSymtab)
-          .Case(".lldbsummaries", lldb::eSectionTypeLLDBTypeSummaries)
-          .Case(".lldbformatters", lldb::eSectionTypeLLDBFormatters)
+          .Cases({".lldbsummaries", ".lldbsum"},
+                 lldb::eSectionTypeLLDBTypeSummaries)
+          .Cases({".lldbformatters", ".lldbfor"},
+                 lldb::eSectionTypeLLDBFormatters)
           .Case("swiftast", eSectionTypeSwiftModules)
           .Default(eSectionTypeInvalid);
   if (section_type != eSectionTypeInvalid)

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -995,17 +995,17 @@ SectionType ObjectFilePECOFF::GetSectionType(llvm::StringRef sect_name,
 
   SectionType section_type =
       llvm::StringSwitch<SectionType>(sect_name)
-          .Case(".debug", eSectionTypeDebug)
-          .Case(".stabstr", eSectionTypeDataCString)
-          .Case(".reloc", eSectionTypeOther)
           // PE/COFF image-file section names are limited to 8 characters,
           // so the linker truncates the longer source names. Match both.
           .Cases({".eh_frame", ".eh_fram"}, eSectionTypeEHFrame)
-          .Case(".gosymtab", eSectionTypeGoSymtab)
+          .Cases({".gosymtab", ".gosymta"}, eSectionTypeGoSymtab)
           .Cases({".lldbsummaries", ".lldbsum"},
                  lldb::eSectionTypeLLDBTypeSummaries)
           .Cases({".lldbformatters", ".lldbfor"},
                  lldb::eSectionTypeLLDBFormatters)
+          .Case(".debug", eSectionTypeDebug)
+          .Case(".stabstr", eSectionTypeDataCString)
+          .Case(".reloc", eSectionTypeOther)
           .Case("swiftast", eSectionTypeSwiftModules)
           .Default(eSectionTypeInvalid);
   if (section_type != eSectionTypeInvalid)

--- a/lldb/test/API/functionalities/data-formatter/bytecode-summary/TestBytecodeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-summary/TestBytecodeSummary.py
@@ -5,7 +5,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipIfWindows
     def test(self):
         self.build()
         if self.TraceOn():

--- a/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/bytecode-synthetic/TestBytecodeSynthetic.py
@@ -5,7 +5,6 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @skipIfWindows
     def test_synthetic(self):
         self.build()
         if self.TraceOn():
@@ -22,7 +21,6 @@ class TestCase(TestBase):
 
         self.expect("v acc", matching=False, substrs=["password"])
 
-    @skipIfWindows
     def test_update_reuse(self):
         self.build()
 


### PR DESCRIPTION
PE/COFF image-file section names are limited to 8 characters, so the linker truncates the longer source names. This patch matches both.

See the specs for more details: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers

This is a follow up to https://github.com/llvm/llvm-project/pull/197955.

rdar://177420528