### PR TITLE
[CI] Build/test LLVM/Clang/libcxx on shared libc changes

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -40,6 +40,7 @@ PROJECT_DEPENDENCIES = {
 # just invert the dependencies list to give more control over what exactly is
 # tested.
 DEPENDENTS_TO_TEST = {
+    "libc-shared": {"llvm", "clang"},
     "llvm": {
         "bolt",
         "clang",
@@ -83,6 +84,7 @@ DEPENDENT_RUNTIMES_TO_TEST = {
     "clang": {"compiler-rt", "libc"},
     "clang-tools-extra": {"libc"},
     "libc": {"libc"},
+    "libc-shared": {"libcxx", "libcxxabi", "libunwind"},
     "libclc": {"libclc"},
     "compiler-rt": {"compiler-rt"},
     "flang": {"flang-rt"},
@@ -183,10 +185,12 @@ META_PROJECTS = {
     (".github", "workflows", "premerge.yaml"): ".ci",
     ("third-party",): ".ci",
     ("llvm", "utils", "lit"): "lit",
+    ("libc", "shared"): "libc-shared",
+    ("libc", "src", "__support", "math"): "libc-shared",
 }
 
 # Projects that should run tests but cannot be explicitly built.
-SKIP_BUILD_PROJECTS = ["CIR", "lit"]
+SKIP_BUILD_PROJECTS = ["CIR", "lit", "libc-shared"]
 
 # Projects that should not run any tests. These need to be metaprojects.
 SKIP_PROJECTS = ["docs", "gn"]

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -482,9 +482,16 @@ class TestComputeProjects(unittest.TestCase):
             ["libc/shared/math/acos.h"], "Linux"
         )
         self.assertEqual(env_variables["projects_to_build"], "clang;lld;llvm")
-        self.assertEqual(env_variables["project_check_targets"], "check-clang check-llvm")
-        self.assertEqual(env_variables["runtimes_to_build"], "libc;libcxx;libcxxabi;libunwind")
-        self.assertEqual(env_variables["runtimes_check_targets"], "check-cxx check-cxxabi check-libc check-unwind")
+        self.assertEqual(
+            env_variables["project_check_targets"], "check-clang check-llvm"
+        )
+        self.assertEqual(
+            env_variables["runtimes_to_build"], "libc;libcxx;libcxxabi;libunwind"
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets"],
+            "check-cxx check-cxxabi check-libc check-unwind",
+        )
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
 
 

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -477,6 +477,16 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
 
+    def test_libc_shared(self):
+        env_variables = compute_projects.get_env_variables(
+            ["libc/shared/math/acos.h"], "Linux"
+        )
+        self.assertEqual(env_variables["projects_to_build"], "clang;lld;llvm")
+        self.assertEqual(env_variables["project_check_targets"], "check-clang check-llvm")
+        self.assertEqual(env_variables["runtimes_to_build"], "libc;libcxx;libcxxabi;libunwind")
+        self.assertEqual(env_variables["runtimes_check_targets"], "check-cxx check-cxxabi check-libc check-unwind")
+        self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
libc is now being used/planned on being used in more places around the repo, particularly inside of APFloat, for constexpr evaluation, and inside of libc++. Setup premerge to handle this. I'm only aware of the APFloat planned usage that should reland soon, but running the clang tests should not hurt.