### PR TITLE
[flang-rt][NFC] Clean up warnings when building flang-rt

### DIFF
--- a/flang-rt/include/flang-rt/runtime/numeric-templates.h
+++ b/flang-rt/include/flang-rt/runtime/numeric-templates.h
@@ -67,7 +67,7 @@ struct MaxOrMinIdentity<TypeCategory::Real, 16, IS_MAXVAL,
     // Create a buffer to store binary representation of __float128 constant.
     constexpr std::size_t alignment =
         std::max(alignof(Type), alignof(std::uint64_t));
-    alignas(alignment) char data[sizeof(Type)];
+    alignas(alignment) char data[sizeof(Type)]{};
 
     // First, verify that our interpretation of __float128 format is correct,
     // e.g. by checking at least one known constant.
@@ -104,7 +104,7 @@ template <> struct MinValue<113, CppTypeFor<TypeCategory::Real, 16>> {
     // Create a buffer to store binary representation of __float128 constant.
     constexpr std::size_t alignment =
         std::max(alignof(Type), alignof(std::uint64_t));
-    alignas(alignment) char data[sizeof(Type)];
+    alignas(alignment) char data[sizeof(Type)]{};
 
     // First, verify that our interpretation of __float128 format is correct,
     // e.g. by checking at least one known constant.

--- a/flang-rt/lib/runtime/character.cpp
+++ b/flang-rt/lib/runtime/character.cpp
@@ -159,7 +159,7 @@ template <typename CHAR, bool ADJUSTR>
 static RT_API_ATTRS void AdjustLRHelper(Descriptor &result,
     const Descriptor &string, const Terminator &terminator) {
   int rank{string.rank()};
-  SubscriptValue ub[maxRank], stringAt[maxRank];
+  SubscriptValue ub[maxRank]{}, stringAt[maxRank]{};
   SubscriptValue elements{1};
   for (int j{0}; j < rank; ++j) {
     ub[j] = string.GetDimension(j).Extent();
@@ -215,7 +215,7 @@ template <typename INT, typename CHAR>
 static RT_API_ATTRS void LenTrim(Descriptor &result, const Descriptor &string,
     const Terminator &terminator) {
   int rank{string.rank()};
-  SubscriptValue ub[maxRank], stringAt[maxRank];
+  SubscriptValue ub[maxRank]{}, stringAt[maxRank]{};
   SubscriptValue elements{1};
   for (int j{0}; j < rank; ++j) {
     ub[j] = string.GetDimension(j).Extent();
@@ -407,8 +407,8 @@ static RT_API_ATTRS void GeneralCharFunc(Descriptor &result,
           : arg.rank()   ? arg.rank()
           : back         ? back->rank()
                          : 0};
-  SubscriptValue ub[maxRank], stringAt[maxRank], argAt[maxRank],
-      backAt[maxRank];
+  SubscriptValue ub[maxRank]{}, stringAt[maxRank]{}, argAt[maxRank]{},
+      backAt[maxRank]{};
   SubscriptValue elements{1};
   for (int j{0}; j < rank; ++j) {
     ub[j] = string.rank() ? string.GetDimension(j).Extent()

--- a/libc/shared/rpc_dispatch.h
+++ b/libc/shared/rpc_dispatch.h
@@ -253,7 +253,7 @@ RPC_ATTRS constexpr void invoke(rpc::Server::Port &port, FnTy fn) {
   port.recv_n(arg_buf);
 
   // Convert the received arguments into an invocable argument list.
-  TupleTy args[NUM_LANES];
+  TupleTy args[NUM_LANES]{};
   for (uint32_t id = 0; id < NUM_LANES; ++id) {
     if (port.get_lane_mask() & (uint64_t(1) << id))
       args[id] = Bytes::unpack(arg_buf[id]);


### PR DESCRIPTION
Summary:
Trivial warning fixes around uninitialized values.
