### PR TITLE
Update `QualType::get{Split,Atomic,}UnqualifiedType` with `const ASTContext &` parameter (NFC).

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/DerivedMethodShadowingBaseMethodCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/DerivedMethodShadowingBaseMethodCheck.cpp
@@ -19,10 +19,11 @@ static bool sameBasicType(const ParmVarDecl *Lhs, const ParmVarDecl *Rhs) {
          Lhs->getType()
                  .getCanonicalType()
                  .getNonReferenceType()
-                 .getUnqualifiedType() == Rhs->getType()
-                                              .getCanonicalType()
-                                              .getNonReferenceType()
-                                              .getUnqualifiedType();
+                 .getUnqualifiedType(Lhs->getASTContext()) ==
+             Rhs->getType()
+                 .getCanonicalType()
+                 .getNonReferenceType()
+                 .getUnqualifiedType(Rhs->getASTContext());
 }
 
 static bool namesCollide(const CXXMethodDecl &Lhs, const CXXMethodDecl &Rhs) {

--- a/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.cpp
@@ -27,12 +27,12 @@ AST_MATCHER(ImplicitCastExpr, isMultiLevelPointerConversion) {
   const QualType TargetType = Node.getType()
                                   .getCanonicalType()
                                   .getNonReferenceType()
-                                  .getUnqualifiedType();
+                                  .getUnqualifiedType(Finder->getASTContext());
   const QualType SourceType = Node.getSubExpr()
                                   ->getType()
                                   .getCanonicalType()
                                   .getNonReferenceType()
-                                  .getUnqualifiedType();
+                                  .getUnqualifiedType(Finder->getASTContext());
 
   if (TargetType == SourceType)
     return false;
@@ -50,7 +50,8 @@ AST_MATCHER(ImplicitCastExpr, isMultiLevelPointerConversion) {
 
 AST_MATCHER(QualType, isPointerType) {
   const QualType Type =
-      Node.getCanonicalType().getNonReferenceType().getUnqualifiedType();
+      Node.getCanonicalType().getNonReferenceType().getUnqualifiedType(
+          Finder->getASTContext());
 
   return !Type.isNull() && Type->isPointerType();
 }

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.cpp
@@ -190,8 +190,8 @@ static const BuiltinType *getBuiltinType(const Expr &E) {
   return E.getType().getCanonicalType().getTypePtr()->getAs<BuiltinType>();
 }
 
-static QualType getUnqualifiedType(const Expr &E) {
-  return E.getType().getUnqualifiedType();
+static QualType getUnqualifiedType(const ASTContext &Ctx, const Expr &E) {
+  return E.getType().getUnqualifiedType(Ctx);
 }
 
 static APValue getConstantExprValue(const ASTContext &Ctx, const Expr &E) {
@@ -329,50 +329,54 @@ bool NarrowingConversionsCheck::isWarningInhibitedByEquivalentSize(
   return false;
 }
 
-void NarrowingConversionsCheck::diagNarrowType(SourceLocation SourceLoc,
+void NarrowingConversionsCheck::diagNarrowType(const ASTContext &Context,
+                                               SourceLocation SourceLoc,
                                                const Expr &Lhs,
                                                const Expr &Rhs) {
   diag(SourceLoc, "narrowing conversion from %0 to %1")
-      << getUnqualifiedType(Rhs) << getUnqualifiedType(Lhs);
+      << getUnqualifiedType(Context, Rhs) << getUnqualifiedType(Context, Lhs);
 }
 
 void NarrowingConversionsCheck::diagNarrowTypeToSignedInt(
-    SourceLocation SourceLoc, const Expr &Lhs, const Expr &Rhs) {
+    const ASTContext &Context, SourceLocation SourceLoc, const Expr &Lhs,
+    const Expr &Rhs) {
   diag(SourceLoc, "narrowing conversion from %0 to signed type %1 is "
                   "implementation-defined")
-      << getUnqualifiedType(Rhs) << getUnqualifiedType(Lhs);
+      << getUnqualifiedType(Context, Rhs) << getUnqualifiedType(Context, Lhs);
 }
 
 void NarrowingConversionsCheck::diagNarrowIntegerConstant(
-    SourceLocation SourceLoc, const Expr &Lhs, const Expr &Rhs,
-    const llvm::APSInt &Value) {
+    const ASTContext &Context, SourceLocation SourceLoc, const Expr &Lhs,
+    const Expr &Rhs, const llvm::APSInt &Value) {
   diag(SourceLoc,
        "narrowing conversion from constant value %0 of type %1 to %2")
-      << getValueAsString(Value, /*NoHex*/ 0) << getUnqualifiedType(Rhs)
-      << getUnqualifiedType(Lhs);
+      << getValueAsString(Value, /*NoHex*/ 0)
+      << getUnqualifiedType(Context, Rhs) << getUnqualifiedType(Context, Lhs);
 }
 
 void NarrowingConversionsCheck::diagNarrowIntegerConstantToSignedInt(
-    SourceLocation SourceLoc, const Expr &Lhs, const Expr &Rhs,
-    const llvm::APSInt &Value, const uint64_t HexBits) {
+    const ASTContext &Context, SourceLocation SourceLoc, const Expr &Lhs,
+    const Expr &Rhs, const llvm::APSInt &Value, const uint64_t HexBits) {
   diag(SourceLoc, "narrowing conversion from constant value %0 of type %1 "
                   "to signed type %2 is implementation-defined")
-      << getValueAsString(Value, HexBits) << getUnqualifiedType(Rhs)
-      << getUnqualifiedType(Lhs);
+      << getValueAsString(Value, HexBits) << getUnqualifiedType(Context, Rhs)
+      << getUnqualifiedType(Context, Lhs);
 }
 
-void NarrowingConversionsCheck::diagNarrowConstant(SourceLocation SourceLoc,
+void NarrowingConversionsCheck::diagNarrowConstant(const ASTContext &Context,
+                                                   SourceLocation SourceLoc,
                                                    const Expr &Lhs,
                                                    const Expr &Rhs) {
   diag(SourceLoc, "narrowing conversion from constant %0 to %1")
-      << getUnqualifiedType(Rhs) << getUnqualifiedType(Lhs);
+      << getUnqualifiedType(Context, Rhs) << getUnqualifiedType(Context, Lhs);
 }
 
-void NarrowingConversionsCheck::diagConstantCast(SourceLocation SourceLoc,
+void NarrowingConversionsCheck::diagConstantCast(const ASTContext &Context,
+                                                 SourceLocation SourceLoc,
                                                  const Expr &Lhs,
                                                  const Expr &Rhs) {
   diag(SourceLoc, "constant value should be of type of type %0 instead of %1")
-      << getUnqualifiedType(Lhs) << getUnqualifiedType(Rhs);
+      << getUnqualifiedType(Context, Lhs) << getUnqualifiedType(Context, Rhs);
 }
 
 void NarrowingConversionsCheck::diagNarrowTypeOrConstant(
@@ -380,11 +384,11 @@ void NarrowingConversionsCheck::diagNarrowTypeOrConstant(
     const Expr &Rhs) {
   APValue Constant = getConstantExprValue(Context, Rhs);
   if (Constant.isInt())
-    diagNarrowIntegerConstant(SourceLoc, Lhs, Rhs, Constant.getInt());
+    diagNarrowIntegerConstant(Context, SourceLoc, Lhs, Rhs, Constant.getInt());
   else if (Constant.isFloat())
-    diagNarrowConstant(SourceLoc, Lhs, Rhs);
+    diagNarrowConstant(Context, SourceLoc, Lhs, Rhs);
   else
-    diagNarrowType(SourceLoc, Lhs, Rhs);
+    diagNarrowType(Context, SourceLoc, Lhs, Rhs);
 }
 
 void NarrowingConversionsCheck::handleIntegralCast(const ASTContext &Context,
@@ -414,13 +418,13 @@ void NarrowingConversionsCheck::handleIntegralCast(const ASTContext &Context,
     llvm::APSInt IntegerConstant;
     if (getIntegerConstantExprValue(Context, Rhs, IntegerConstant)) {
       if (!isWideEnoughToHold(Context, IntegerConstant, *ToType))
-        diagNarrowIntegerConstantToSignedInt(SourceLoc, Lhs, Rhs,
+        diagNarrowIntegerConstantToSignedInt(Context, SourceLoc, Lhs, Rhs,
                                              IntegerConstant,
                                              Context.getTypeSize(FromType));
       return;
     }
     if (!isWideEnoughToHold(Context, *FromType, *ToType))
-      diagNarrowTypeToSignedInt(SourceLoc, Lhs, Rhs);
+      diagNarrowTypeToSignedInt(Context, SourceLoc, Lhs, Rhs);
   }
 }
 
@@ -442,7 +446,8 @@ void NarrowingConversionsCheck::handleIntegralToFloating(
     llvm::APSInt IntegerConstant;
     if (getIntegerConstantExprValue(Context, Rhs, IntegerConstant)) {
       if (!isWideEnoughToHold(Context, IntegerConstant, *ToType))
-        diagNarrowIntegerConstant(SourceLoc, Lhs, Rhs, IntegerConstant);
+        diagNarrowIntegerConstant(Context, SourceLoc, Lhs, Rhs,
+                                  IntegerConstant);
       return;
     }
 
@@ -450,7 +455,7 @@ void NarrowingConversionsCheck::handleIntegralToFloating(
     if (isWarningInhibitedByEquivalentSize(Context, *FromType, *ToType))
       return;
     if (!isWideEnoughToHold(Context, *FromType, *ToType))
-      diagNarrowType(SourceLoc, Lhs, Rhs);
+      diagNarrowType(Context, SourceLoc, Lhs, Rhs);
   }
 }
 
@@ -460,10 +465,10 @@ void NarrowingConversionsCheck::handleFloatingToIntegral(
   llvm::APFloat FloatConstant(0.0);
   if (getFloatingConstantExprValue(Context, Rhs, FloatConstant)) {
     if (!isFloatExactlyRepresentable(Context, FloatConstant, Lhs.getType()))
-      diagNarrowConstant(SourceLoc, Lhs, Rhs);
+      diagNarrowConstant(Context, SourceLoc, Lhs, Rhs);
 
     else if (PedanticMode)
-      diagConstantCast(SourceLoc, Lhs, Rhs);
+      diagConstantCast(Context, SourceLoc, Lhs, Rhs);
 
     return;
   }
@@ -472,7 +477,7 @@ void NarrowingConversionsCheck::handleFloatingToIntegral(
   const BuiltinType *ToType = getBuiltinType(Lhs);
   if (isWarningInhibitedByEquivalentSize(Context, *FromType, *ToType))
     return;
-  diagNarrowType(SourceLoc, Lhs, Rhs); // Assumed always lossy.
+  diagNarrowType(Context, SourceLoc, Lhs, Rhs); // Assumed always lossy.
 }
 
 void NarrowingConversionsCheck::handleFloatingToBoolean(
@@ -508,14 +513,14 @@ void NarrowingConversionsCheck::handleFloatingCast(const ASTContext &Context,
       Tmp.convert(Context.getFloatTypeSemantics(ToType->desugar()),
                   llvm::APFloatBase::rmNearestTiesToEven, &UnusedLosesInfo);
       if (Tmp.isInfinity())
-        diagNarrowConstant(SourceLoc, Lhs, Rhs);
+        diagNarrowConstant(Context, SourceLoc, Lhs, Rhs);
       return;
     }
     const BuiltinType *FromType = getBuiltinType(Rhs);
     if (!llvm::APFloatBase::isRepresentableBy(
             Context.getFloatTypeSemantics(FromType->desugar()),
             Context.getFloatTypeSemantics(ToType->desugar())))
-      diagNarrowType(SourceLoc, Lhs, Rhs);
+      diagNarrowType(Context, SourceLoc, Lhs, Rhs);
   }
 }
 

--- a/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/NarrowingConversionsCheck.h
@@ -29,25 +29,28 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  void diagNarrowType(SourceLocation SourceLoc, const Expr &Lhs,
-                      const Expr &Rhs);
+  void diagNarrowType(const ASTContext &Context, SourceLocation SourceLoc,
+                      const Expr &Lhs, const Expr &Rhs);
 
-  void diagNarrowTypeToSignedInt(SourceLocation SourceLoc, const Expr &Lhs,
+  void diagNarrowTypeToSignedInt(const ASTContext &Context,
+                                 SourceLocation SourceLoc, const Expr &Lhs,
                                  const Expr &Rhs);
 
-  void diagNarrowIntegerConstant(SourceLocation SourceLoc, const Expr &Lhs,
+  void diagNarrowIntegerConstant(const ASTContext &Context,
+                                 SourceLocation SourceLoc, const Expr &Lhs,
                                  const Expr &Rhs, const llvm::APSInt &Value);
 
-  void diagNarrowIntegerConstantToSignedInt(SourceLocation SourceLoc,
+  void diagNarrowIntegerConstantToSignedInt(const ASTContext &Context,
+                                            SourceLocation SourceLoc,
                                             const Expr &Lhs, const Expr &Rhs,
                                             const llvm::APSInt &Value,
                                             uint64_t HexBits);
 
-  void diagNarrowConstant(SourceLocation SourceLoc, const Expr &Lhs,
-                          const Expr &Rhs);
+  void diagNarrowConstant(const ASTContext &Context, SourceLocation SourceLoc,
+                          const Expr &Lhs, const Expr &Rhs);
 
-  void diagConstantCast(SourceLocation SourceLoc, const Expr &Lhs,
-                        const Expr &Rhs);
+  void diagConstantCast(const ASTContext &Context, SourceLocation SourceLoc,
+                        const Expr &Lhs, const Expr &Rhs);
 
   void diagNarrowTypeOrConstant(const ASTContext &Context,
                                 SourceLocation SourceLoc, const Expr &Lhs,

--- a/clang-tools-extra/clang-tidy/bugprone/OptionalValueConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/OptionalValueConversionCheck.cpp
@@ -23,9 +23,10 @@ namespace clang::tidy::bugprone {
 namespace {
 
 AST_MATCHER_P(QualType, hasCleanType, Matcher<QualType>, InnerMatcher) {
-  return InnerMatcher.matches(
-      Node.getNonReferenceType().getUnqualifiedType().getCanonicalType(),
-      Finder, Builder);
+  return InnerMatcher.matches(Node.getNonReferenceType()
+                                  .getUnqualifiedType(Finder->getASTContext())
+                                  .getCanonicalType(),
+                              Finder, Builder);
 }
 
 constexpr std::array<StringRef, 2> MakeSmartPtrList{
@@ -129,7 +130,7 @@ void OptionalValueConversionCheck::check(
   diag(MatchedExpr->getExprLoc(),
        "conversion from %0 into %1 and back into %0, remove potentially "
        "error-prone optional dereference")
-      << *OptionalType << ValueType->getUnqualifiedType();
+      << *OptionalType << ValueType->getUnqualifiedType(*Result.Context);
 
   if (const auto *OperatorExpr =
           Result.Nodes.getNodeAs<CXXOperatorCallExpr>("op-call")) {

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeVarargCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/ProTypeVarargCheck.cpp
@@ -67,7 +67,7 @@ namespace {
 AST_MATCHER(QualType, isVAList) {
   const ASTContext &Context = Finder->getASTContext();
   const QualType Desugar = Node.getDesugaredType(Context);
-  const QualType NodeTy = Node.getUnqualifiedType();
+  const QualType NodeTy = Node.getUnqualifiedType(Context);
 
   auto CheckVaList = [](QualType NodeTy, QualType Expected,
                         const ASTContext &Context) {

--- a/clang-tools-extra/clang-tidy/modernize/AvoidCStyleCastCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/AvoidCStyleCastCheck.cpp
@@ -49,13 +49,14 @@ static bool needsConstCast(QualType SourceType, QualType DestType) {
   return false;
 }
 
-static bool pointedUnqualifiedTypesAreEqual(QualType T1, QualType T2) {
+static bool pointedUnqualifiedTypesAreEqual(QualType T1, QualType T2,
+                                            const ASTContext &Ctx) {
   while ((T1->isPointerType() && T2->isPointerType()) ||
          (T1->isReferenceType() && T2->isReferenceType())) {
     T1 = T1->getPointeeType();
     T2 = T2->getPointeeType();
   }
-  return T1.getUnqualifiedType() == T2.getUnqualifiedType();
+  return T1.getUnqualifiedType(Ctx) == T2.getUnqualifiedType(Ctx);
 }
 
 static CharSourceRange getReplaceRange(const ExplicitCastExpr *Expr) {
@@ -132,9 +133,10 @@ void AvoidCStyleCastCheck::check(const MatchFinder::MatchResult &Result) {
   };
 
   const QualType DestTypeAsWritten =
-      CastExpr->getTypeAsWritten().getUnqualifiedType();
+      CastExpr->getTypeAsWritten().getUnqualifiedType(*Result.Context);
   const QualType SourceTypeAsWritten =
-      CastExpr->getSubExprAsWritten()->getType().getUnqualifiedType();
+      CastExpr->getSubExprAsWritten()->getType().getUnqualifiedType(
+          *Result.Context);
   const QualType SourceType = SourceTypeAsWritten.getCanonicalType();
   const QualType DestType = DestTypeAsWritten.getCanonicalType();
 
@@ -229,7 +231,8 @@ void AvoidCStyleCastCheck::check(const MatchFinder::MatchResult &Result) {
       return;
     }
     if (needsConstCast(SourceType, DestType) &&
-        pointedUnqualifiedTypesAreEqual(SourceType, DestType)) {
+        pointedUnqualifiedTypesAreEqual(SourceType, DestType,
+                                        *Result.Context)) {
       ReplaceWithNamedCast("const_cast");
       return;
     }

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.cpp
@@ -745,7 +745,7 @@ void LoopConvertCheck::doConversion(
 
   QualType Type = Context->getAutoDeductType();
   if (!Descriptor.ElemType.isNull() && Descriptor.ElemType->isFundamentalType())
-    Type = Descriptor.ElemType.getUnqualifiedType();
+    Type = Descriptor.ElemType.getUnqualifiedType(*Context);
   Type = Type.getDesugaredType(*Context);
 
   // If the new variable name is from the aliased variable, then the reference

--- a/clang-tools-extra/clang-tidy/modernize/MinMaxUseInitializerListCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/MinMaxUseInitializerListCheck.cpp
@@ -87,7 +87,7 @@ generateReplacements(const MatchFinder::MatchResult &Match,
                                   ->getReturnType()
                                   .getCanonicalType()
                                   .getNonReferenceType()
-                                  .getUnqualifiedType();
+                                  .getUnqualifiedType(*Match.Context);
 
   // check if the type is trivial
   const bool IsResultTypeTrivial = ResultType.isTrivialType(*Match.Context);
@@ -112,7 +112,7 @@ generateReplacements(const MatchFinder::MatchResult &Match,
       const QualType ArgType = Arg->IgnoreParenImpCasts()
                                    ->getType()
                                    .getCanonicalType()
-                                   .getUnqualifiedType();
+                                   .getUnqualifiedType(*Match.Context);
 
       if (ArgType == ResultType)
         continue;

--- a/clang-tools-extra/clang-tidy/modernize/ReturnBracedInitListCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ReturnBracedInitListCheck.cpp
@@ -83,8 +83,8 @@ void ReturnBracedInitListCheck::check(const MatchFinder::MatchResult &Result) {
             MatchedConstructExpr->getConstructor()->getParamDecl(I))) {
       const auto ArgType = MatchedConstructExpr->getArg(I)->getType();
       const auto ParamType = VD->getType().getNonReferenceType();
-      if (ArgType.getCanonicalType().getUnqualifiedType() !=
-          ParamType.getCanonicalType().getUnqualifiedType())
+      if (ArgType.getCanonicalType().getUnqualifiedType(*Result.Context) !=
+          ParamType.getCanonicalType().getUnqualifiedType(*Result.Context))
         return;
     }
   }

--- a/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
@@ -45,8 +45,8 @@ static SmallVector<const VarDecl *> getLockGuardsFromDecl(const DeclStmt *DS) {
 
   for (const Decl *Decl : DS->decls()) {
     if (const auto *VD = dyn_cast<VarDecl>(Decl)) {
-      const QualType Type =
-          VD->getType().getCanonicalType().getUnqualifiedType();
+      const QualType Type = VD->getType().getCanonicalType().getUnqualifiedType(
+          VD->getASTContext());
       if (isLockGuard(Type))
         LockGuards.push_back(VD);
     }

--- a/clang-tools-extra/clang-tidy/performance/InefficientAlgorithmCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/InefficientAlgorithmCheck.cpp
@@ -80,11 +80,11 @@ void InefficientAlgorithmCheck::check(const MatchFinder::MatchResult &Result) {
   if (AlgCall->getNumArgs() == 4 && !Unordered) {
     const Expr *Arg = AlgCall->getArg(3);
     const QualType AlgCmp =
-        Arg->getType().getUnqualifiedType().getCanonicalType();
+        Arg->getType().getUnqualifiedType(*Result.Context).getCanonicalType();
     const unsigned CmpPosition = IneffContName.contains("map") ? 2 : 1;
     const QualType ContainerCmp = IneffCont->getTemplateArgs()[CmpPosition]
                                       .getAsType()
-                                      .getUnqualifiedType()
+                                      .getUnqualifiedType(*Result.Context)
                                       .getCanonicalType();
     if (AlgCmp != ContainerCmp) {
       diag(Arg->getBeginLoc(),

--- a/clang-tools-extra/clang-tidy/readability/QualifiedAutoCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/QualifiedAutoCheck.cpp
@@ -23,7 +23,8 @@ namespace {
 // FIXME move to ASTMatchers
 AST_MATCHER_P(QualType, hasUnqualifiedType,
               ast_matchers::internal::Matcher<QualType>, InnerMatcher) {
-  return InnerMatcher.matches(Node.getUnqualifiedType(), Finder, Builder);
+  return InnerMatcher.matches(Node.getUnqualifiedType(Finder->getASTContext()),
+                              Finder, Builder);
 }
 
 enum class Qualifier { Const, Volatile, Restrict };

--- a/clang-tools-extra/clang-tidy/readability/StaticAccessedThroughInstanceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/StaticAccessedThroughInstanceCheck.cpp
@@ -65,12 +65,13 @@ void StaticAccessedThroughInstanceCheck::check(
 
   const Expr *BaseExpr = MemberExpression->getBase();
 
+  const ASTContext *AstContext = Result.Context;
   const QualType BaseType =
       BaseExpr->getType()->isPointerType()
-          ? BaseExpr->getType()->getPointeeType().getUnqualifiedType()
-          : BaseExpr->getType().getUnqualifiedType();
+          ? BaseExpr->getType()->getPointeeType().getUnqualifiedType(
+                *AstContext)
+          : BaseExpr->getType().getUnqualifiedType(*AstContext);
 
-  const ASTContext *AstContext = Result.Context;
   PrintingPolicy PrintingPolicyWithSuppressedTag(AstContext->getLangOpts());
   PrintingPolicyWithSuppressedTag.SuppressTagKeyword = true;
   PrintingPolicyWithSuppressedTag.SuppressUnwrittenScope = true;

--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -319,7 +319,7 @@ static bool isCompatibleWithArrayReference(QualType ArgType, QualType ParamType,
   if (!ParamType.isAtLeastAsQualifiedAs(ArgType, Ctx))
     return false;
 
-  return ParamType.getUnqualifiedType() == ArgType.getUnqualifiedType();
+  return ParamType.getUnqualifiedType(Ctx) == ArgType.getUnqualifiedType(Ctx);
 }
 
 static QualType convertToPointeeOrArrayElementQualType(QualType TypeToConvert) {
@@ -377,7 +377,7 @@ static bool arePointerTypesCompatible(QualType ArgType, QualType ParamType,
                                         IsParamContinuouslyConst, Ctx))
       return false;
 
-    if (ParamType.getUnqualifiedType() == ArgType.getUnqualifiedType())
+    if (ParamType.getUnqualifiedType(Ctx) == ArgType.getUnqualifiedType(Ctx))
       return true;
 
   } while (ParamType->isPointerType() && ArgType->isPointerType());
@@ -408,7 +408,7 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
   ArgType = ArgType.getNonReferenceType();
   ParamType = ParamType.getNonReferenceType();
 
-  if (ParamType.getUnqualifiedType() == ArgType.getUnqualifiedType())
+  if (ParamType.getUnqualifiedType(Ctx) == ArgType.getUnqualifiedType(Ctx))
     return true;
 
   // Arithmetic types are interconvertible, except scoped enums.
@@ -449,7 +449,7 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
   if (!ParamType.isAtLeastAsQualifiedAs(ArgType, Ctx))
     return false;
 
-  if (ParamType.getUnqualifiedType() == ArgType.getUnqualifiedType())
+  if (ParamType.getUnqualifiedType(Ctx) == ArgType.getUnqualifiedType(Ctx))
     return true;
 
   // At this point, all possible C language implicit conversion were checked.

--- a/clang-tools-extra/clang-tidy/readability/UseStdMinMaxCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UseStdMinMaxCheck.cpp
@@ -76,13 +76,14 @@ static QualType getNonTemplateAlias(QualType QT) {
 }
 
 static QualType getReplacementCastType(const Expr *CondLhs, const Expr *CondRhs,
-                                       QualType ComparedType) {
+                                       QualType ComparedType,
+                                       const ASTContext &Ctx) {
   const QualType LhsType = CondLhs->getType();
   const QualType RhsType = CondRhs->getType();
   const QualType LhsCanonicalType =
-      LhsType.getCanonicalType().getNonReferenceType().getUnqualifiedType();
+      LhsType.getCanonicalType().getNonReferenceType().getUnqualifiedType(Ctx);
   const QualType RhsCanonicalType =
-      RhsType.getCanonicalType().getNonReferenceType().getUnqualifiedType();
+      RhsType.getCanonicalType().getNonReferenceType().getUnqualifiedType(Ctx);
   QualType GlobalImplicitCastType;
   if (LhsCanonicalType != RhsCanonicalType) {
     if (isa<IntegerLiteral>(CondRhs))
@@ -95,11 +96,10 @@ static QualType getReplacementCastType(const Expr *CondLhs, const Expr *CondRhs,
   return GlobalImplicitCastType;
 }
 
-static std::string
-createReplacement(const Expr *CondLhs, const Expr *CondRhs,
-                  const Expr *AssignLhs, const SourceManager &Source,
-                  const LangOptions &LO, StringRef FunctionName,
-                  const BinaryOperator *BO, StringRef Comment = "") {
+static std::string createReplacement(
+    const Expr *CondLhs, const Expr *CondRhs, const Expr *AssignLhs,
+    const SourceManager &Source, const LangOptions &LO, const ASTContext &Ctx,
+    StringRef FunctionName, const BinaryOperator *BO, StringRef Comment = "") {
   const StringRef CondLhsStr = Lexer::getSourceText(
       Source.getExpansionRange(CondLhs->getSourceRange()), Source, LO);
   const StringRef CondRhsStr = Lexer::getSourceText(
@@ -108,7 +108,7 @@ createReplacement(const Expr *CondLhs, const Expr *CondRhs,
       Source.getExpansionRange(AssignLhs->getSourceRange()), Source, LO);
 
   const QualType GlobalImplicitCastType =
-      getReplacementCastType(CondLhs, CondRhs, BO->getLHS()->getType());
+      getReplacementCastType(CondLhs, CondRhs, BO->getLHS()->getType(), Ctx);
 
   return (AssignLhsStr + " = " + FunctionName +
           (!GlobalImplicitCastType.isNull()
@@ -226,7 +226,8 @@ void UseStdMinMaxCheck::check(const MatchFinder::MatchResult &Result) {
                SourceRange(IfLocation, Lexer::getLocForEndOfToken(
                                            ThenLocation, 0, Source, LO)),
                createReplacement(CondLhs, CondRhs, AssignLhs, Source, LO,
-                                 FunctionName, BinaryOp, Comment))
+                                 *Result.Context, FunctionName, BinaryOp,
+                                 Comment))
         << IncludeInserter.createIncludeInsertion(
                Source.getFileID(If->getBeginLoc()), AlgorithmHeader);
   };

--- a/clang-tools-extra/clang-tidy/utils/FormatStringConverter.cpp
+++ b/clang-tools-extra/clang-tidy/utils/FormatStringConverter.cpp
@@ -45,9 +45,9 @@ static bool isRealCharType(const QualType &Ty) {
 /// passed integer type. If the passed type is already signed then its name is
 /// just returned. Only supports BuiltinTypes.
 static std::optional<std::string>
-getCorrespondingSignedTypeName(const QualType &QT) {
+getCorrespondingSignedTypeName(const QualType &QT, const ASTContext &Ctx) {
   using namespace clang;
-  const auto UQT = QT.getUnqualifiedType();
+  const auto UQT = QT.getUnqualifiedType(Ctx);
   if (const auto *BT = dyn_cast<BuiltinType>(UQT)) {
     switch (BT->getKind()) {
     case BuiltinType::UChar:
@@ -97,9 +97,9 @@ getCorrespondingSignedTypeName(const QualType &QT) {
 /// the passed integer type. If the passed type is already unsigned then its
 /// name is just returned. Only supports BuiltinTypes.
 static std::optional<std::string>
-getCorrespondingUnsignedTypeName(const QualType &QT) {
+getCorrespondingUnsignedTypeName(const QualType &QT, const ASTContext &Ctx) {
   using namespace clang;
-  const auto UQT = QT.getUnqualifiedType();
+  const auto UQT = QT.getUnqualifiedType(Ctx);
   if (const auto *BT = dyn_cast<BuiltinType>(UQT)) {
     switch (BT->getKind()) {
     case BuiltinType::SChar:
@@ -148,10 +148,11 @@ getCorrespondingUnsignedTypeName(const QualType &QT) {
 }
 
 static std::optional<std::string>
-castTypeForArgument(ConversionSpecifier::Kind ArgKind, const QualType &QT) {
+castTypeForArgument(ConversionSpecifier::Kind ArgKind, const QualType &QT,
+                    const ASTContext &Ctx) {
   if (ArgKind == ConversionSpecifier::Kind::uArg)
-    return getCorrespondingUnsignedTypeName(QT);
-  return getCorrespondingSignedTypeName(QT);
+    return getCorrespondingUnsignedTypeName(QT, Ctx);
+  return getCorrespondingSignedTypeName(QT, Ctx);
 }
 
 static bool isMatchingSignedness(ConversionSpecifier::Kind ArgKind,
@@ -461,7 +462,7 @@ bool FormatStringConverter::emitIntegerArgument(
     // same.
     if (const auto *ED = ArgType->getAsEnumDecl()) {
       if (const std::optional<std::string> MaybeCastType =
-              castTypeForArgument(ArgKind, ED->getIntegerType()))
+              castTypeForArgument(ArgKind, ED->getIntegerType(), *Context))
         ArgFixes.emplace_back(
             ArgIndex, (Twine("static_cast<") + *MaybeCastType + ">(").str());
       else
@@ -475,7 +476,7 @@ bool FormatStringConverter::emitIntegerArgument(
     // Even -Wformat doesn't warn for this. std::format will format as
     // unsigned unless we cast it.
     if (const std::optional<std::string> MaybeCastType =
-            castTypeForArgument(ArgKind, ArgType))
+            castTypeForArgument(ArgKind, ArgType, *Context))
       ArgFixes.emplace_back(
           ArgIndex, (Twine("static_cast<") + *MaybeCastType + ">(").str());
     else

--- a/clang-tools-extra/clang-tidy/utils/Matchers.cpp
+++ b/clang-tools-extra/clang-tidy/utils/Matchers.cpp
@@ -37,8 +37,8 @@ bool MatchesAnyListedTypeNameMatcher::matches(
   PrintingPolicyWithSuppressedTag.SuppressScope = false;
   PrintingPolicyWithSuppressedTag.SuppressTagKeyword = true;
   PrintingPolicyWithSuppressedTag.SuppressUnwrittenScope = true;
-  std::string TypeName =
-      Node.getUnqualifiedType().getAsString(PrintingPolicyWithSuppressedTag);
+  std::string TypeName = Node.getUnqualifiedType(Finder->getASTContext())
+                             .getAsString(PrintingPolicyWithSuppressedTag);
 
   return llvm::any_of(NameMatchers, [&TypeName](const llvm::Regex &NM) {
     return NM.isValid() && NM.match(TypeName);

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -2574,7 +2574,7 @@ public:
       return type;
     Qualifiers Qs = type.getQualifiers();
     Qs.removeObjCLifetime();
-    return getQualifiedType(type.getUnqualifiedType(), Qs);
+    return getQualifiedType(type.getUnqualifiedType(*this), Qs);
   }
 
   /// \brief Return a type with the given __ptrauth qualifier.

--- a/clang/include/clang/AST/CanonicalType.h
+++ b/clang/include/clang/AST/CanonicalType.h
@@ -214,7 +214,7 @@ using CanQualType = CanQual<Type>;
 
 inline CanQualType Type::getCanonicalTypeUnqualified() const {
   return CanQualType::CreateUnsafe(
-      getCanonicalTypeInternal().getUnqualifiedType());
+      getCanonicalTypeInternal().getLocalUnqualifiedType());
 }
 
 inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,

--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -4208,7 +4208,9 @@ public:
       return QualType();
     if (const Type *T = dyn_cast<const Type *>(IntegerType))
       return QualType(T, 0);
-    return cast<TypeSourceInfo *>(IntegerType)->getType().getUnqualifiedType();
+    return cast<TypeSourceInfo *>(IntegerType)
+        ->getType()
+        .getUnqualifiedType(getASTContext());
   }
 
   /// Set the underlying integer type.

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -182,12 +182,15 @@ class CXXBaseSpecifier {
   /// range does not include the \c virtual or the access specifier.
   TypeSourceInfo *BaseTypeInfo;
 
+  const ASTContext *Ctx;
+
 public:
   CXXBaseSpecifier() = default;
-  CXXBaseSpecifier(SourceRange R, bool V, bool BC, AccessSpecifier A,
-                   TypeSourceInfo *TInfo, SourceLocation EllipsisLoc)
-    : Range(R), EllipsisLoc(EllipsisLoc), Virtual(V), BaseOfClass(BC),
-      Access(A), InheritConstructors(false), BaseTypeInfo(TInfo) {}
+  CXXBaseSpecifier(const ASTContext &Ctx, SourceRange R, bool V, bool BC,
+                   AccessSpecifier A, TypeSourceInfo *TInfo,
+                   SourceLocation EllipsisLoc)
+      : Range(R), EllipsisLoc(EllipsisLoc), Virtual(V), BaseOfClass(BC),
+        Access(A), InheritConstructors(false), BaseTypeInfo(TInfo), Ctx(&Ctx) {}
 
   /// Retrieves the source range that contains the entire base specifier.
   SourceRange getSourceRange() const LLVM_READONLY { return Range; }
@@ -247,7 +250,7 @@ public:
   ///
   /// This type will always be an unqualified class type.
   QualType getType() const {
-    return BaseTypeInfo->getType().getUnqualifiedType();
+    return BaseTypeInfo->getType().getUnqualifiedType(*Ctx);
   }
 
   /// Retrieves the type and source location of the base class.

--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -2285,13 +2285,13 @@ inline SizedDeallocationMode sizedDeallocationModeFromBool(bool IsSized) {
 }
 
 struct ImplicitAllocationParameters {
-  ImplicitAllocationParameters(QualType AllocType,
+  ImplicitAllocationParameters(const ASTContext &Ctx, QualType AllocType,
                                TypeAwareAllocationMode PassTypeIdentity,
                                AlignedAllocationMode PassAlignment)
       : Type(AllocType), PassTypeIdentity(PassTypeIdentity),
         PassAlignment(PassAlignment) {
     if (!Type.isNull())
-      Type = Type.getUnqualifiedType();
+      Type = Type.getUnqualifiedType(Ctx);
   }
   explicit ImplicitAllocationParameters(AlignedAllocationMode PassAlignment)
       : PassTypeIdentity(TypeAwareAllocationMode::No),
@@ -2312,14 +2312,14 @@ struct ImplicitAllocationParameters {
 };
 
 struct ImplicitDeallocationParameters {
-  ImplicitDeallocationParameters(QualType DeallocType,
+  ImplicitDeallocationParameters(const ASTContext &Ctx, QualType DeallocType,
                                  TypeAwareAllocationMode PassTypeIdentity,
                                  AlignedAllocationMode PassAlignment,
                                  SizedDeallocationMode PassSize)
       : Type(DeallocType), PassTypeIdentity(PassTypeIdentity),
         PassAlignment(PassAlignment), PassSize(PassSize) {
     if (!Type.isNull())
-      Type = Type.getUnqualifiedType();
+      Type = Type.getUnqualifiedType(Ctx);
   }
 
   ImplicitDeallocationParameters(AlignedAllocationMode PassAlignment,
@@ -2512,8 +2512,8 @@ public:
     return const_cast<CXXNewExpr *>(this)->getPlacementArg(I);
   }
 
-  unsigned getNumImplicitArgs() const {
-    return implicitAllocationParameters().getNumImplicitArgs();
+  unsigned getNumImplicitArgs(const ASTContext &Ctx) const {
+    return implicitAllocationParameters(Ctx).getNumImplicitArgs();
   }
 
   bool isParenTypeId() const { return CXXNewExprBits.IsParenTypeId; }
@@ -2563,9 +2563,10 @@ public:
 
   /// Provides the full set of information about expected implicit
   /// parameters in this call
-  ImplicitAllocationParameters implicitAllocationParameters() const {
+  ImplicitAllocationParameters
+  implicitAllocationParameters(const ASTContext &Ctx) const {
     return ImplicitAllocationParameters{
-        getAllocatedType(),
+        Ctx, getAllocatedType(),
         typeAwareAllocationModeFromBool(CXXNewExprBits.ShouldPassTypeIdentity),
         alignedAllocationModeFromBool(CXXNewExprBits.ShouldPassAlignment)};
   }

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -1261,7 +1261,7 @@ public:
   /// Note: In C, the _Atomic qualifier is special (see C23 6.2.5p32 for
   /// details), and it is not stripped by this function. Use
   /// getAtomicUnqualifiedType() to strip qualifiers including _Atomic.
-  inline QualType getUnqualifiedType() const;
+  inline QualType getUnqualifiedType(const ASTContext &Ctx) const;
 
   /// Retrieve the unqualified variant of the given type, removing as little
   /// sugar as possible.
@@ -1272,7 +1272,7 @@ public:
   /// The resulting type might still be qualified if it's sugar for an array
   /// type.  To strip qualifiers even from within a sugared array type, use
   /// ASTContext::getUnqualifiedArrayType.
-  inline SplitQualType getSplitUnqualifiedType() const;
+  inline SplitQualType getSplitUnqualifiedType(const ASTContext &Ctx) const;
 
   /// Determine whether this type is more qualified than the other
   /// given type, requiring exact equality for non-CVR qualifiers.
@@ -1639,7 +1639,7 @@ public:
   /// Like getUnqualifiedType(), the type may still be qualified if it is a
   /// sugared array type.  To strip qualifiers even from within a sugared array
   /// type, use in conjunction with ASTContext::getUnqualifiedArrayType.
-  QualType getAtomicUnqualifiedType() const;
+  QualType getAtomicUnqualifiedType(const ASTContext &Ctx) const;
 
 private:
   // These methods are implemented in a separate translation unit;
@@ -1648,7 +1648,8 @@ private:
   static bool isConstant(QualType T, const ASTContext& Ctx);
   static QualType getDesugaredType(QualType T, const ASTContext &Context);
   static SplitQualType getSplitDesugaredType(QualType T);
-  static SplitQualType getSplitUnqualifiedTypeImpl(QualType type);
+  static SplitQualType getSplitUnqualifiedTypeImpl(QualType type,
+                                                   const ASTContext &Ctx);
   static QualType getSingleStepDesugaredTypeImpl(QualType type,
                                                  const ASTContext &C);
   static QualType IgnoreParens(QualType T);
@@ -8536,18 +8537,19 @@ inline bool QualType::hasQualifiers() const {
          getCommonPtr()->CanonicalType.hasLocalQualifiers();
 }
 
-inline QualType QualType::getUnqualifiedType() const {
+inline QualType QualType::getUnqualifiedType(const ASTContext &Ctx) const {
   if (!getTypePtr()->getCanonicalTypeInternal().hasLocalQualifiers())
     return QualType(getTypePtr(), 0);
 
-  return QualType(getSplitUnqualifiedTypeImpl(*this).Ty, 0);
+  return QualType(getSplitUnqualifiedTypeImpl(*this, Ctx).Ty, 0);
 }
 
-inline SplitQualType QualType::getSplitUnqualifiedType() const {
+inline SplitQualType
+QualType::getSplitUnqualifiedType(const ASTContext &Ctx) const {
   if (!getTypePtr()->getCanonicalTypeInternal().hasLocalQualifiers())
     return split();
 
-  return getSplitUnqualifiedTypeImpl(*this);
+  return getSplitUnqualifiedTypeImpl(*this, Ctx);
 }
 
 inline void QualType::removeLocalConst() {
@@ -8612,7 +8614,7 @@ inline bool QualType::isAtLeastAsQualifiedAs(QualType other,
   Qualifiers OtherQuals = other.getQualifiers();
 
   // Ignore __unaligned qualifier if this type is a void.
-  if (getUnqualifiedType()->isVoidType())
+  if (getUnqualifiedType(Ctx)->isVoidType())
     OtherQuals.removeUnaligned();
 
   return getQualifiers().compatiblyIncludes(OtherQuals, Ctx);

--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -291,7 +291,7 @@ public:
     InitializedEntity Entity;
     Entity.Kind = EK_Parameter;
     Entity.Type =
-      Context.getVariableArrayDecayedType(Type.getUnqualifiedType());
+        Context.getVariableArrayDecayedType(Type.getUnqualifiedType(Context));
     Entity.Parent = nullptr;
     Entity.Parameter = {Parm, Consumed};
     return Entity;

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -445,7 +445,7 @@ class Sema;
               N && N->isMemberFunctionPointer())
             T = C.getDecayedType(N->getPointeeType());
 
-          return T.getAtomicUnqualifiedType();
+          return T.getAtomicUnqualifiedType(C);
         };
         // The types might differ if there is an array-to-pointer conversion
         // an function-to-pointer conversion, or lvalue-to-rvalue conversion.

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CallEvent.h
@@ -1150,7 +1150,7 @@ public:
   /// C++17 aligned operator new() calls that have alignment implicitly
   /// passed as the second argument, and to 1 for other operator new() calls.
   unsigned getNumImplicitArgs() const {
-    return getOriginExpr()->getNumImplicitArgs();
+    return getOriginExpr()->getNumImplicitArgs(getASTContext());
   }
 
   unsigned getNumArgs() const override {

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -871,7 +871,8 @@ bool ASTContext::isUnaryOverflowPatternExcluded(const UnaryOperator *UO) {
 /// presence within an ignorelist.
 bool ASTContext::isTypeIgnoredBySanitizer(const SanitizerMask &Mask,
                                           const QualType &Ty) const {
-  std::string TyName = Ty.getUnqualifiedType().getAsString(getPrintingPolicy());
+  std::string TyName =
+      Ty.getUnqualifiedType(*this).getAsString(getPrintingPolicy());
   return NoSanitizeL->containsType(Mask, TyName);
 }
 
@@ -3649,7 +3650,7 @@ uint16_t ASTContext::getPointerAuthTypeDiscriminator(QualType T) {
   if (T->isFunctionType()) {
     encodeTypeForFunctionPointerAuth(*this, Out, T);
   } else {
-    T = T.getUnqualifiedType();
+    T = T.getUnqualifiedType(*this);
     // Calls to member function pointers don't need to worry about
     // language interop or the laxness of the C type compatibility rules.
     // We just mangle the member pointer type directly, which is
@@ -7130,7 +7131,7 @@ CanQualType ASTContext::getCanonicalParamType(QualType T) const {
 
 QualType ASTContext::getUnqualifiedArrayType(QualType type,
                                              Qualifiers &quals) const {
-  SplitQualType splitType = type.getSplitUnqualifiedType();
+  SplitQualType splitType = type.getSplitUnqualifiedType(*this);
 
   // FIXME: getSplitUnqualifiedType() actually walks all the way to
   // the unqualified desugared type and then drops it on the floor.
@@ -8127,7 +8128,7 @@ QualType ASTContext::getAdjustedParameterType(QualType T) const {
 QualType ASTContext::getSignatureParameterType(QualType T) const {
   T = getVariableArrayDecayedType(T);
   T = getAdjustedParameterType(T);
-  return T.getUnqualifiedType();
+  return T.getUnqualifiedType(*this);
 }
 
 QualType ASTContext::getExceptionObjectType(QualType T) const {
@@ -8140,7 +8141,7 @@ QualType ASTContext::getExceptionObjectType(QualType T) const {
   T = getVariableArrayDecayedType(T);
   if (T->isArrayType() || T->isFunctionType())
     T = getDecayedType(T);
-  return T.getUnqualifiedType();
+  return T.getUnqualifiedType(*this);
 }
 
 /// getArrayDecayedType - Return the properly qualified result of decaying the
@@ -11519,7 +11520,7 @@ QualType ASTContext::mergeTransparentUnionType(QualType T, QualType SubType,
     RecordDecl *UD = UT->getDecl()->getMostRecentDecl();
     if (UD->hasAttr<TransparentUnionAttr>()) {
       for (const auto *I : UD->fields()) {
-        QualType ET = I->getType().getUnqualifiedType();
+        QualType ET = I->getType().getUnqualifiedType(*this);
         QualType MT = mergeTypes(ET, SubType, OfBlockPointer, Unqualified);
         if (!MT.isNull())
           return MT;
@@ -11579,7 +11580,7 @@ QualType ASTContext::mergeFunctionTypes(QualType lhs, QualType rhs,
     return {};
 
   if (Unqualified)
-    retType = retType.getUnqualifiedType();
+    retType = retType.getUnqualifiedType(*this);
 
   CanQualType LRetType = getCanonicalType(lbase->getReturnType());
   CanQualType RRetType = getCanonicalType(rbase->getReturnType());
@@ -11700,20 +11701,20 @@ QualType ASTContext::mergeFunctionTypes(QualType lhs, QualType rhs,
     // Check parameter type compatibility
     SmallVector<QualType, 10> types;
     for (unsigned i = 0, n = lproto->getNumParams(); i < n; i++) {
-      QualType lParamType = lproto->getParamType(i).getUnqualifiedType();
-      QualType rParamType = rproto->getParamType(i).getUnqualifiedType();
+      QualType lParamType = lproto->getParamType(i).getUnqualifiedType(*this);
+      QualType rParamType = rproto->getParamType(i).getUnqualifiedType(*this);
       QualType paramType = mergeFunctionParameterTypes(
           lParamType, rParamType, OfBlockPointer, Unqualified);
       if (paramType.isNull())
         return {};
 
       if (Unqualified)
-        paramType = paramType.getUnqualifiedType();
+        paramType = paramType.getUnqualifiedType(*this);
 
       types.push_back(paramType);
       if (Unqualified) {
-        lParamType = lParamType.getUnqualifiedType();
-        rParamType = rParamType.getUnqualifiedType();
+        lParamType = lParamType.getUnqualifiedType(*this);
+        rParamType = rParamType.getUnqualifiedType(*this);
       }
 
       if (getCanonicalType(paramType) != getCanonicalType(lParamType))
@@ -11891,8 +11892,8 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS, bool OfBlockPointer,
     return *MergedOBT;
 
   if (Unqualified) {
-    LHS = LHS.getUnqualifiedType();
-    RHS = RHS.getUnqualifiedType();
+    LHS = LHS.getUnqualifiedType(*this);
+    RHS = RHS.getUnqualifiedType(*this);
   }
 
   QualType LHSCan = getCanonicalType(LHS),
@@ -12021,8 +12022,8 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS, bool OfBlockPointer,
     QualType LHSPointee = LHS->castAs<PointerType>()->getPointeeType();
     QualType RHSPointee = RHS->castAs<PointerType>()->getPointeeType();
     if (Unqualified) {
-      LHSPointee = LHSPointee.getUnqualifiedType();
-      RHSPointee = RHSPointee.getUnqualifiedType();
+      LHSPointee = LHSPointee.getUnqualifiedType(*this);
+      RHSPointee = RHSPointee.getUnqualifiedType(*this);
     }
     QualType ResultType = mergeTypes(LHSPointee, RHSPointee, false,
                                      Unqualified);
@@ -12040,8 +12041,8 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS, bool OfBlockPointer,
     QualType LHSPointee = LHS->castAs<BlockPointerType>()->getPointeeType();
     QualType RHSPointee = RHS->castAs<BlockPointerType>()->getPointeeType();
     if (Unqualified) {
-      LHSPointee = LHSPointee.getUnqualifiedType();
-      RHSPointee = RHSPointee.getUnqualifiedType();
+      LHSPointee = LHSPointee.getUnqualifiedType(*this);
+      RHSPointee = RHSPointee.getUnqualifiedType(*this);
     }
     if (getLangOpts().OpenCL) {
       Qualifiers LHSPteeQual = LHSPointee.getQualifiers();
@@ -12073,8 +12074,8 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS, bool OfBlockPointer,
     QualType LHSValue = LHS->castAs<AtomicType>()->getValueType();
     QualType RHSValue = RHS->castAs<AtomicType>()->getValueType();
     if (Unqualified) {
-      LHSValue = LHSValue.getUnqualifiedType();
-      RHSValue = RHSValue.getUnqualifiedType();
+      LHSValue = LHSValue.getUnqualifiedType(*this);
+      RHSValue = RHSValue.getUnqualifiedType(*this);
     }
     QualType ResultType = mergeTypes(LHSValue, RHSValue, false,
                                      Unqualified);
@@ -12096,8 +12097,8 @@ QualType ASTContext::mergeTypes(QualType LHS, QualType RHS, bool OfBlockPointer,
     QualType LHSElem = getAsArrayType(LHS)->getElementType();
     QualType RHSElem = getAsArrayType(RHS)->getElementType();
     if (Unqualified) {
-      LHSElem = LHSElem.getUnqualifiedType();
-      RHSElem = RHSElem.getUnqualifiedType();
+      LHSElem = LHSElem.getUnqualifiedType(*this);
+      RHSElem = RHSElem.getUnqualifiedType(*this);
     }
 
     QualType ResultType = mergeTypes(LHSElem, RHSElem, false, Unqualified);

--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -1934,7 +1934,7 @@ class TemplateDiff {
         // FIXME: Diffing the APValue would be neat.
         // FIXME: Suppress this and use the full name of the declaration if the
         // parameter is a pointer or reference.
-        TPO->getType().getUnqualifiedType().print(OS, Policy);
+        TPO->getType().getUnqualifiedType(Context).print(OS, Policy);
         TPO->printAsInit(OS, Policy);
         return;
       }

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -2612,14 +2612,10 @@ Error ASTNodeImporter::ImportDefinition(
       if (!TSIOrErr)
         return TSIOrErr.takeError();
 
-      Bases.push_back(
-          new (Importer.getToContext()) CXXBaseSpecifier(
-              *RangeOrErr,
-              Base1.isVirtual(),
-              Base1.isBaseOfClass(),
-              Base1.getAccessSpecifierAsWritten(),
-              *TSIOrErr,
-              EllipsisLoc));
+      Bases.push_back(new (Importer.getToContext()) CXXBaseSpecifier(
+          Importer.getToContext(), *RangeOrErr, Base1.isVirtual(),
+          Base1.isBaseOfClass(), Base1.getAccessSpecifierAsWritten(), *TSIOrErr,
+          EllipsisLoc));
     }
     if (!Bases.empty())
       ToCXX->setBases(Bases.data(), Bases.size());
@@ -8615,7 +8611,8 @@ ExpectedStmt ASTNodeImporter::VisitCXXNewExpr(CXXNewExpr *E) {
 
   return CXXNewExpr::Create(
       Importer.getToContext(), E->isGlobalNew(), ToOperatorNew,
-      ToOperatorDelete, E->implicitAllocationParameters(),
+      ToOperatorDelete,
+      E->implicitAllocationParameters(Importer.getToContext()),
       E->doesUsualArrayDeleteWantSize(), ToPlacementArgs, ToTypeIdParens,
       ToArraySize, E->getInitializationStyle(), ToInitializer, ToType,
       ToAllocatedTypeSourceInfo, ToSourceRange, ToDirectInitRange);
@@ -10485,8 +10482,9 @@ ASTImporter::Import(const CXXBaseSpecifier *BaseSpec) {
   if (!ToEllipsisLoc)
     return ToEllipsisLoc.takeError();
   CXXBaseSpecifier *Imported = new (ToContext) CXXBaseSpecifier(
-      *ToSourceRange, BaseSpec->isVirtual(), BaseSpec->isBaseOfClass(),
-      BaseSpec->getAccessSpecifierAsWritten(), *ToTSI, *ToEllipsisLoc);
+      ToContext, *ToSourceRange, BaseSpec->isVirtual(),
+      BaseSpec->isBaseOfClass(), BaseSpec->getAccessSpecifierAsWritten(),
+      *ToTSI, *ToEllipsisLoc);
   ImportedCXXBaseSpecifiers[BaseSpec] = Imported;
   return Imported;
 }

--- a/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltinBitCast.cpp
@@ -214,7 +214,8 @@ static bool CheckBitcastType(InterpState &S, CodePtr OpPC, QualType T,
   auto note = [&](int Construct, QualType NoteType,
                   SourceRange NoteRange) -> bool {
     S.Note(NoteRange.getBegin(), diag::note_constexpr_bit_cast_invalid_subtype)
-        << NoteType << Construct << T.getUnqualifiedType() << NoteRange;
+        << NoteType << Construct << T.getUnqualifiedType(S.getASTContext())
+        << NoteRange;
     return false;
   };
   auto unsupported = [&](QualType T) -> bool {

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -1642,7 +1642,7 @@ void TemplateParamObjectDecl::printAsExpr(llvm::raw_ostream &OS) const {
 
 void TemplateParamObjectDecl::printAsExpr(llvm::raw_ostream &OS,
                                           const PrintingPolicy &Policy) const {
-  getType().getUnqualifiedType().print(OS, Policy);
+  getType().getUnqualifiedType(getASTContext()).print(OS, Policy);
   printAsInit(OS, Policy);
 }
 

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -6713,7 +6713,7 @@ static bool HandleDynamicCast(EvalInfo &Info, const ExplicitCastExpr *E,
     Info.FFDiag(E, diag::note_constexpr_dynamic_cast_to_reference_failed)
         << DiagKind << Ptr.Designator.getType(Info.Ctx)
         << Info.Ctx.getCanonicalTagType(DynType->Type)
-        << E->getType().getUnqualifiedType();
+        << E->getType().getUnqualifiedType(Info.Ctx);
     return false;
   };
 
@@ -21108,7 +21108,7 @@ static bool Evaluate(APValue &Result, EvalInfo &Info, const Expr *E) {
     if (!EvaluateVoid(E, Info))
       return false;
   } else if (T->isAtomicType()) {
-    QualType Unqual = T.getAtomicUnqualifiedType();
+    QualType Unqual = T.getAtomicUnqualifiedType(Info.Ctx);
     if (Unqual->isArrayType() || Unqual->isRecordType()) {
       LValue LV;
       APValue &Value = Info.CurrentCall->createTemporary(
@@ -21156,7 +21156,7 @@ static bool EvaluateInPlace(APValue &Result, EvalInfo &Info, const LValue &This,
     else if (T->isRecordType())
       return EvaluateRecord(E, This, Result, Info);
     else if (T->isAtomicType()) {
-      QualType Unqual = T.getAtomicUnqualifiedType();
+      QualType Unqual = T.getAtomicUnqualifiedType(Info.Ctx);
       if (Unqual->isArrayType() || Unqual->isRecordType())
         return EvaluateAtomic(E, &This, Result, Info);
     }

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -1520,8 +1520,9 @@ void CXXNameMangler::mangleUnqualifiedName(
     if (auto *TPO = dyn_cast<TemplateParamObjectDecl>(ND)) {
       // Proposed in https://github.com/itanium-cxx-abi/cxx-abi/issues/63.
       Out << "TA";
-      mangleValueInTemplateArg(TPO->getType().getUnqualifiedType(),
-                               TPO->getValue(), /*TopLevel=*/true);
+      mangleValueInTemplateArg(
+          TPO->getType().getUnqualifiedType(getASTContext()), TPO->getValue(),
+          /*TopLevel=*/true);
       break;
     }
 
@@ -6370,17 +6371,18 @@ void CXXNameMangler::mangleTemplateArg(TemplateArgument A, bool NeedExactType) {
     //  <expr-primary> ::= L <mangled-name> E # external name
     ValueDecl *D = A.getAsDecl();
 
+    ASTContext &Ctx = getASTContext();
+
     // Template parameter objects are modeled by reproducing a source form
     // produced as if by aggregate initialization.
     if (A.getParamTypeForDecl()->isRecordType()) {
       auto *TPO = cast<TemplateParamObjectDecl>(D);
-      mangleValueInTemplateArg(TPO->getType().getUnqualifiedType(),
+      mangleValueInTemplateArg(TPO->getType().getUnqualifiedType(Ctx),
                                TPO->getValue(), /*TopLevel=*/true,
                                NeedExactType);
       break;
     }
 
-    ASTContext &Ctx = Context.getASTContext();
     APValue Value;
     if (D->isCXXInstanceMember())
       // Simple pointer-to-member with no conversion.
@@ -6850,7 +6852,7 @@ void CXXNameMangler::mangleValueInTemplateArg(QualType T, const APValue &V,
           Out << "ad";
         Out << "so";
         mangleType(T->isVoidPointerType()
-                       ? getLValueType(Ctx, V).getUnqualifiedType()
+                       ? getLValueType(Ctx, V).getUnqualifiedType(Ctx)
                        : T->getPointeeType());
         Kind = Path;
       } else {

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -1220,8 +1220,9 @@ void MicrosoftCXXNameMangler::mangleUnqualifiedName(GlobalDecl GD,
 
       if (const auto *TPO = dyn_cast<TemplateParamObjectDecl>(ND)) {
         Out << "?__N";
-        mangleTemplateArgValue(TPO->getType().getUnqualifiedType(),
-                               TPO->getValue(), TplArgKind::ClassNTTP);
+        mangleTemplateArgValue(
+            TPO->getType().getUnqualifiedType(getASTContext()), TPO->getValue(),
+            TplArgKind::ClassNTTP);
         break;
       }
 
@@ -1820,7 +1821,7 @@ void MicrosoftCXXNameMangler::mangleTemplateArg(const TemplateDecl *TD,
     } else if (TA.getParamTypeForDecl()->isRecordType()) {
       Out << "$";
       auto *TPO = cast<TemplateParamObjectDecl>(ND);
-      mangleTemplateArgValue(TPO->getType().getUnqualifiedType(),
+      mangleTemplateArgValue(TPO->getType().getUnqualifiedType(getASTContext()),
                              TPO->getValue(), TplArgKind::ClassNTTP);
     } else if (const VarDecl *VD = dyn_cast<VarDecl>(ND)) {
       mangleVarDecl(VD, cast<NonTypeTemplateParmDecl>(Parm),
@@ -3208,7 +3209,7 @@ void MicrosoftCXXNameMangler::mangleFunctionType(const FunctionType *T,
       }
     } else {
       if (ResultType->isVoidType())
-        ResultType = ResultType.getUnqualifiedType();
+        ResultType = ResultType.getUnqualifiedType(getASTContext());
       mangleType(ResultType, Range, QMM_Result);
     }
   }

--- a/clang/lib/AST/TemplateBase.cpp
+++ b/clang/lib/AST/TemplateBase.cpp
@@ -536,7 +536,9 @@ void TemplateArgument::print(const PrintingPolicy &Policy, raw_ostream &Out,
     ValueDecl *VD = getAsDecl();
     if (getParamTypeForDecl()->isRecordType()) {
       if (auto *TPO = dyn_cast<TemplateParamObjectDecl>(VD)) {
-        TPO->getType().getUnqualifiedType().print(Out, Policy);
+        TPO->getType()
+            .getUnqualifiedType(VD->getASTContext())
+            .print(Out, Policy);
         TPO->printAsInit(Out, Policy);
         break;
       }

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -591,7 +591,8 @@ SplitQualType QualType::getSplitDesugaredType(QualType T) {
   }
 }
 
-SplitQualType QualType::getSplitUnqualifiedTypeImpl(QualType type) {
+SplitQualType QualType::getSplitUnqualifiedTypeImpl(QualType type,
+                                                    const ASTContext &Ctx) {
   SplitQualType split = type.split();
 
   // All the qualifiers we've seen so far.
@@ -1716,11 +1717,11 @@ QualType QualType::stripObjCKindOfType(const ASTContext &constCtx) const {
   return visitor.recurse(*this);
 }
 
-QualType QualType::getAtomicUnqualifiedType() const {
+QualType QualType::getAtomicUnqualifiedType(const ASTContext &Ctx) const {
   QualType T = *this;
   if (const auto AT = T.getTypePtr()->getAs<AtomicType>())
     T = AT->getValueType();
-  return T.getUnqualifiedType();
+  return T.getUnqualifiedType(Ctx);
 }
 
 std::optional<ArrayRef<QualType>>
@@ -3686,7 +3687,7 @@ QualType QualType::getNonLValueExprType(const ASTContext &Context) const {
   // See also C99 6.3.2.1p2.
   if (!Context.getLangOpts().CPlusPlus ||
       (!getTypePtr()->isDependentType() && !getTypePtr()->isRecordType()))
-    return getUnqualifiedType();
+    return getUnqualifiedType(Context);
 
   return *this;
 }
@@ -4217,7 +4218,8 @@ TypeOfExprType::TypeOfExprType(const ASTContext &Context, Expr *E,
            // We have to protect against 'Can' being invalid through its
            // default argument.
            Kind == TypeOfKind::Unqualified && !Can.isNull()
-               ? Context.getUnqualifiedArrayType(Can).getAtomicUnqualifiedType()
+               ? Context.getUnqualifiedArrayType(Can).getAtomicUnqualifiedType(
+                     Context)
                : Can,
            toTypeDependence(E->getDependence()) |
                (E->getType()->getDependence() &
@@ -4232,7 +4234,8 @@ QualType TypeOfExprType::desugar() const {
   if (isSugared()) {
     QualType QT = getUnderlyingExpr()->getType();
     return getKind() == TypeOfKind::Unqualified
-               ? Context.getUnqualifiedArrayType(QT).getAtomicUnqualifiedType()
+               ? Context.getUnqualifiedArrayType(QT).getAtomicUnqualifiedType(
+                     Context)
                : QT;
   }
   return QualType(this, 0);
@@ -4249,7 +4252,8 @@ TypeOfType::TypeOfType(const ASTContext &Context, QualType T, QualType Can,
                        TypeOfKind Kind)
     : Type(TypeOf,
            Kind == TypeOfKind::Unqualified
-               ? Context.getUnqualifiedArrayType(Can).getAtomicUnqualifiedType()
+               ? Context.getUnqualifiedArrayType(Can).getAtomicUnqualifiedType(
+                     Context)
                : Can,
            T->getDependence()),
       TOType(T), Context(Context) {
@@ -4259,7 +4263,8 @@ TypeOfType::TypeOfType(const ASTContext &Context, QualType T, QualType Can,
 QualType TypeOfType::desugar() const {
   QualType QT = getUnmodifiedType();
   return getKind() == TypeOfKind::Unqualified
-             ? Context.getUnqualifiedArrayType(QT).getAtomicUnqualifiedType()
+             ? Context.getUnqualifiedArrayType(QT).getAtomicUnqualifiedType(
+                   Context)
              : QT;
 }
 

--- a/clang/lib/Analysis/BodyFarm.cpp
+++ b/clang/lib/Analysis/BodyFarm.cpp
@@ -652,9 +652,10 @@ static Stmt *create_OSAtomicCompareAndSwap(ASTContext &C, const FunctionDecl *D)
   // The synthesized body assumes that oldVaue, newValue and *theValue all
   // share the same type. When the user provided declaration uses mis-matched
   // types, refuse to model the call.
-  QualType OldCanonical = OldValueTy.getCanonicalType().getUnqualifiedType();
-  QualType NewCanonical = NewValueTy.getCanonicalType().getUnqualifiedType();
-  QualType PointeeCanonical = PointeeTy.getCanonicalType().getUnqualifiedType();
+  QualType OldCanonical = OldValueTy.getCanonicalType().getUnqualifiedType(C);
+  QualType NewCanonical = NewValueTy.getCanonicalType().getUnqualifiedType(C);
+  QualType PointeeCanonical =
+      PointeeTy.getCanonicalType().getUnqualifiedType(C);
   if (OldCanonical != NewCanonical || OldCanonical != PointeeCanonical)
     return nullptr;
 

--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -6069,7 +6069,8 @@ static void print_elem(raw_ostream &OS, StmtPrinterHelper &Helper,
       T = getReferenceInitTemporaryType(VD->getInit(), nullptr);
 
     OS << ".~";
-    T.getUnqualifiedType().print(OS, PrintingPolicy(Helper.getLangOpts()));
+    T.getUnqualifiedType(VD->getASTContext())
+        .print(OS, PrintingPolicy(Helper.getLangOpts()));
     OS << "() (Implicit destructor)";
     break;
   }

--- a/clang/lib/Analysis/CocoaConventions.cpp
+++ b/clang/lib/Analysis/CocoaConventions.cpp
@@ -38,7 +38,7 @@ bool cocoa::isRefType(QualType RetTy, StringRef Prefix,
 
   // Is the type void*?
   const PointerType* PT = RetTy->castAs<PointerType>();
-  if (!PT || !PT->getPointeeType().getUnqualifiedType()->isVoidType())
+  if (!PT || !PT->getPointeeType()->isVoidType())
     return false;
 
   // Does the name start with the prefix?

--- a/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
@@ -59,7 +59,10 @@ FieldSet DataflowAnalysisContext::computeModeledFields(QualType Type) {
 }
 
 const FieldSet &DataflowAnalysisContext::getModeledFields(QualType Type) {
-  QualType CanonicalType = Type.getCanonicalType().getUnqualifiedType();
+  const RecordDecl *RD = Type->getAsRecordDecl();
+  assert(RD != nullptr && "getModeledFields requires a record-typed QualType");
+  const ASTContext &Ctx = RD->getASTContext();
+  QualType CanonicalType = Type.getCanonicalType().getUnqualifiedType(Ctx);
   std::unique_ptr<FieldSet> &Fields = CachedModeledFields[CanonicalType];
   if (Fields == nullptr)
     Fields = std::make_unique<FieldSet>(computeModeledFields(CanonicalType));

--- a/clang/lib/Analysis/FlowSensitive/RecordOps.cpp
+++ b/clang/lib/Analysis/FlowSensitive/RecordOps.cpp
@@ -56,8 +56,9 @@ static void copySyntheticField(QualType FieldType, StorageLocation &SrcFieldLoc,
 
 void copyRecord(RecordStorageLocation &Src, RecordStorageLocation &Dst,
                 Environment &Env, const QualType TypeToCopy) {
-  auto SrcType = Src.getType().getCanonicalType().getUnqualifiedType();
-  auto DstType = Dst.getType().getCanonicalType().getUnqualifiedType();
+  const ASTContext &Ctx = Src.getType()->getAsRecordDecl()->getASTContext();
+  auto SrcType = Src.getType().getCanonicalType().getUnqualifiedType(Ctx);
+  auto DstType = Dst.getType().getCanonicalType().getUnqualifiedType(Ctx);
 
   auto SrcDecl = SrcType->getAsCXXRecordDecl();
   auto DstDecl = DstType->getAsCXXRecordDecl();
@@ -133,15 +134,16 @@ void copyRecord(RecordStorageLocation &Src, RecordStorageLocation &Dst,
 
 bool recordsEqual(const RecordStorageLocation &Loc1, const Environment &Env1,
                   const RecordStorageLocation &Loc2, const Environment &Env2) {
+  const ASTContext &Ctx = Loc1.getType()->getAsRecordDecl()->getASTContext();
   LLVM_DEBUG({
-    if (Loc2.getType().getCanonicalType().getUnqualifiedType() !=
-        Loc1.getType().getCanonicalType().getUnqualifiedType()) {
+    if (Loc2.getType().getCanonicalType().getUnqualifiedType(Ctx) !=
+        Loc1.getType().getCanonicalType().getUnqualifiedType(Ctx)) {
       llvm::dbgs() << "Loc1 type " << Loc1.getType() << "\n";
       llvm::dbgs() << "Loc2 type " << Loc2.getType() << "\n";
     }
   });
-  assert(Loc2.getType().getCanonicalType().getUnqualifiedType() ==
-         Loc1.getType().getCanonicalType().getUnqualifiedType());
+  assert(Loc2.getType().getCanonicalType().getUnqualifiedType(Ctx) ==
+         Loc1.getType().getCanonicalType().getUnqualifiedType(Ctx));
 
   for (auto [Field, FieldLoc1] : Loc1.children()) {
     StorageLocation *FieldLoc2 = Loc2.getChild(*Field);

--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -676,8 +676,9 @@ public:
       // The assignment operator can have an arbitrary return type. We model the
       // return value only if the return type is the same as or a base class of
       // the destination type.
-      if (S->getType().getCanonicalType().getUnqualifiedType() !=
-          LocDst->getType().getCanonicalType().getUnqualifiedType()) {
+      const ASTContext &Ctx = Method->getASTContext();
+      if (S->getType().getCanonicalType().getUnqualifiedType(Ctx) !=
+          LocDst->getType().getCanonicalType().getUnqualifiedType(Ctx)) {
         auto ReturnDecl = S->getType()->getAsCXXRecordDecl();
         auto DstDecl = LocDst->getType()->getAsCXXRecordDecl();
         if (ReturnDecl == nullptr || DstDecl == nullptr)
@@ -857,8 +858,9 @@ public:
         Loc.setChild(*Field, &Env.createObject(Field->getType(), Init));
         continue;
       }
-      assert(Field->getType().getCanonicalType().getUnqualifiedType() ==
-             Init->getType().getCanonicalType().getUnqualifiedType());
+      const ASTContext &Ctx = Field->getASTContext();
+      assert(Field->getType().getCanonicalType().getUnqualifiedType(Ctx) ==
+             Init->getType().getCanonicalType().getUnqualifiedType(Ctx));
       StorageLocation *FieldLoc = Loc.getChild(*Field);
       // Locations for non-reference fields must always be non-null.
       assert(FieldLoc != nullptr);

--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -260,7 +260,7 @@ Address AtomicInfo::createTempAlloca() const {
   // alloca pointer element.
   QualType tmpTy = (lvalue.isBitField() && valueSizeInBits > atomicSizeInBits)
                        ? valueTy
-                       : atomicTy.getUnqualifiedType();
+                       : atomicTy.getUnqualifiedType(cgf.getContext());
   Address tempAlloca =
       cgf.createMemTemp(tmpTy, getAtomicAlignment(), loc, "atomic-temp");
 
@@ -1248,7 +1248,7 @@ RValue CIRGenFunction::emitAtomicExpr(AtomicExpr *e) {
     break;
   }
 
-  QualType resultTy = e->getType().getUnqualifiedType();
+  QualType resultTy = e->getType().getUnqualifiedType(getContext());
 
   bool shouldCastToIntPtrTy =
       shouldCastToInt(convertTypeForMem(memTy), e->isCmpXChg());

--- a/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprCXX.cpp
@@ -923,7 +923,7 @@ static void enterNewDeleteCleanup(CIRGenFunction &cgf, const CXXNewExpr *e,
                                   Address newPtr, mlir::Value allocSize,
                                   CharUnits allocAlign,
                                   const CallArgList &newArgs) {
-  unsigned numNonPlacementArgs = e->getNumImplicitArgs();
+  unsigned numNonPlacementArgs = e->getNumImplicitArgs(cgf.getContext());
 
   // If we're not inside a conditional branch, then the cleanup will
   // dominate and we can do the easier (and more efficient) thing.
@@ -940,8 +940,8 @@ static void enterNewDeleteCleanup(CIRGenFunction &cgf, const CXXNewExpr *e,
     assert(!cir::MissingFeatures::typeAwareAllocation());
     DirectCleanup *cleanup = cgf.ehStack.pushCleanupWithExtra<DirectCleanup>(
         EHCleanup, e->getNumPlacementArgs(), e->getOperatorDelete(),
-        newPtr.getPointer(), allocSize, e->implicitAllocationParameters(),
-        allocAlign);
+        newPtr.getPointer(), allocSize,
+        e->implicitAllocationParameters(cgf.getContext()), allocAlign);
     for (auto i : llvm::seq<unsigned>(0, e->getNumPlacementArgs())) {
       const CallArg &arg = newArgs[i + numNonPlacementArgs];
       cleanup->setPlacementArg(
@@ -986,8 +986,8 @@ static void enterNewDeleteCleanup(CIRGenFunction &cgf, const CXXNewExpr *e,
   ConditionalCleanup *cleanup =
       cgf.ehStack.pushCleanupWithExtra<ConditionalCleanup>(
           EHCleanup, e->getNumPlacementArgs(), e->getOperatorDelete(),
-          savedNewPtr, savedAllocSize, e->implicitAllocationParameters(),
-          allocAlign);
+          savedNewPtr, savedAllocSize,
+          e->implicitAllocationParameters(cgf.getContext()), allocAlign);
   for (auto i : llvm::seq<unsigned>(0, e->getNumPlacementArgs())) {
     const CallArg &arg = newArgs[i + numNonPlacementArgs];
     cleanup->setPlacementArg(

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -524,7 +524,8 @@ void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
     // is set up before EmitFunctionProlog runs).
     // TODO(cir): Align prolog handling with classic codegen.
     if (fd && fd->hasImplicitReturnZero()) {
-      mlir::Type cirRetTy = convertType(returnType.getUnqualifiedType());
+      mlir::Type cirRetTy =
+          convertType(returnType.getUnqualifiedType(getContext()));
       mlir::Location bodyBeginMLIRLoc = getLoc(bodyBeginLoc);
       mlir::Value zero = builder.getNullValue(cirRetTy, bodyBeginMLIRLoc);
       builder.CIRBaseBuilderTy::createStore(bodyBeginMLIRLoc, zero,

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -983,7 +983,7 @@ static unsigned extractPBaseFlags(const ASTContext &ctx, QualType &ty) {
   if (ty.isRestrictQualified())
     flags |= PTI_Restrict;
 
-  ty = ty.getUnqualifiedType();
+  ty = ty.getUnqualifiedType(ctx);
 
   if (containsIncompleteClassType(ty))
     flags |= PTI_Incomplete;
@@ -2317,10 +2317,12 @@ static cir::DynamicCastInfoAttr emitDynamicCastInfo(CIRGenFunction &cgf,
                                                     mlir::Location loc,
                                                     QualType srcRecordTy,
                                                     QualType destRecordTy) {
-  auto srcRtti = mlir::cast<cir::GlobalViewAttr>(
-      cgf.cgm.getAddrOfRTTIDescriptor(loc, srcRecordTy.getUnqualifiedType()));
-  auto destRtti = mlir::cast<cir::GlobalViewAttr>(
-      cgf.cgm.getAddrOfRTTIDescriptor(loc, destRecordTy.getUnqualifiedType()));
+  auto srcRtti =
+      mlir::cast<cir::GlobalViewAttr>(cgf.cgm.getAddrOfRTTIDescriptor(
+          loc, srcRecordTy.getUnqualifiedType(cgf.getContext())));
+  auto destRtti =
+      mlir::cast<cir::GlobalViewAttr>(cgf.cgm.getAddrOfRTTIDescriptor(
+          loc, destRecordTy.getUnqualifiedType(cgf.getContext())));
 
   cir::FuncOp runtimeFuncOp = getItaniumDynamicCastFn(cgf);
   cir::FuncOp badCastFuncOp = getBadCastFn(cgf);

--- a/clang/lib/CIR/CodeGen/CIRGenOpenACC.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenACC.cpp
@@ -69,7 +69,8 @@ CIRGenFunction::OpenACCDataOperandInfo
 CIRGenFunction::getOpenACCDataOperandInfo(const Expr *e) {
   const Expr *curVarExpr = e->IgnoreParenImpCasts();
   QualType origType =
-      curVarExpr->getType().getNonReferenceType().getUnqualifiedType();
+      curVarExpr->getType().getNonReferenceType().getUnqualifiedType(
+          getContext());
   // Array sections are special, and we have to treat them that way.
   if (const auto *section =
           dyn_cast<ArraySectionExpr>(curVarExpr->IgnoreParenImpCasts()))
@@ -138,7 +139,8 @@ CIRGenFunction::getOpenACCDataOperandInfo(const Expr *e) {
             emitMemberExpr(memExpr).getPointer(),
             exprString,
             origType,
-            curVarExpr->getType().getNonReferenceType().getUnqualifiedType(),
+            curVarExpr->getType().getNonReferenceType().getUnqualifiedType(
+                getContext()),
             std::move(bounds),
             std::move(boundTypes)};
 
@@ -151,7 +153,8 @@ CIRGenFunction::getOpenACCDataOperandInfo(const Expr *e) {
           emitDeclRefLValue(dre).getPointer(),
           exprString,
           origType,
-          curVarExpr->getType().getNonReferenceType().getUnqualifiedType(),
+          curVarExpr->getType().getNonReferenceType().getUnqualifiedType(
+              getContext()),
           std::move(bounds),
           std::move(boundTypes)};
 }

--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -302,7 +302,7 @@ Address AtomicInfo::CreateTempAlloca() const {
   // alloca pointer element.
   QualType TmpTy = (LVal.isBitField() && ValueSizeInBits > AtomicSizeInBits)
                        ? ValueTy
-                       : AtomicTy.getUnqualifiedType();
+                       : AtomicTy.getUnqualifiedType(CGF.getContext());
   Address TempAlloca =
       CGF.CreateMemTemp(TmpTy, getAtomicAlignment(), "atomic-temp");
   // Cast to pointer to value type for bitfields.
@@ -1099,7 +1099,7 @@ RValue CodeGenFunction::EmitAtomicExpr(AtomicExpr *E) {
     break;
   }
 
-  QualType RValTy = E->getType().getUnqualifiedType();
+  QualType RValTy = E->getType().getUnqualifiedType(getContext());
   bool ShouldCastToIntPtrTy =
       shouldCastToInt(ConvertTypeForMem(MemTy), E->isCmpXChg());
 

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -2728,7 +2728,7 @@ private:
 
     if (D.Ty->isAtomicType()) {
       auto Unwrapped = D;
-      Unwrapped.Ty = D.Ty.getAtomicUnqualifiedType();
+      Unwrapped.Ty = D.Ty.getAtomicUnqualifiedType(CGF.getContext());
       Stack.push_back(Unwrapped);
       return;
     }

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3289,7 +3289,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
   // return statements.
   if (const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(CurCodeDecl)) {
     if (FD->hasImplicitReturnZero()) {
-      QualType RetTy = FD->getReturnType().getUnqualifiedType();
+      QualType RetTy = FD->getReturnType().getUnqualifiedType(getContext());
       llvm::Type *LLVMTy = CGM.getTypes().ConvertType(RetTy);
       llvm::Constant *Zero = llvm::Constant::getNullValue(LLVMTy);
       Builder.CreateStore(Zero, ReturnValue);

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1397,7 +1397,7 @@ void CodeGenFunction::EmitAndRegisterVariableArrayDimensions(
   while (getContext().getAsVariableArrayType(Type1D)) {
     auto VlaSize = getVLAElements1D(Type1D);
     if (auto *C = dyn_cast<llvm::ConstantInt>(VlaSize.NumElts))
-      Dimensions.emplace_back(C, Type1D.getUnqualifiedType());
+      Dimensions.emplace_back(C, Type1D.getUnqualifiedType(getContext()));
     else {
       // Generate a locally unique name for the size expression.
       Twine Name = Twine("__vla_expr") + Twine(VLAExprCounter++);
@@ -1409,7 +1409,7 @@ void CodeGenFunction::EmitAndRegisterVariableArrayDimensions(
           CreateDefaultAlignTempAlloca(VlaSize.NumElts->getType(), NameRef);
       Builder.CreateStore(VlaSize.NumElts, SizeExprAddr);
       Dimensions.emplace_back(SizeExprAddr.getPointer(),
-                              Type1D.getUnqualifiedType());
+                              Type1D.getUnqualifiedType(getContext()));
     }
     Type1D = VlaSize.Type;
   }

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -530,7 +530,8 @@ void CodeGenFunction::EmitStartEHSpec(const Decl *D) {
 
     for (unsigned I = 0; I != NumExceptions; ++I) {
       QualType Ty = Proto->getExceptionType(I);
-      QualType ExceptType = Ty.getNonReferenceType().getUnqualifiedType();
+      QualType ExceptType =
+          Ty.getNonReferenceType().getUnqualifiedType(getContext());
       llvm::Value *EHType = CGM.GetAddrOfRTTIDescriptor(ExceptType,
                                                         /*ForEH=*/true);
       Filter->setFilter(I, EHType);

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -911,8 +911,8 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
     // Compute a deterministic hash of the mangled name of the type.
     SmallString<64> MangledName;
     llvm::raw_svector_ostream Out(MangledName);
-    CGM.getCXXABI().getMangleContext().mangleCXXRTTI(Ty.getUnqualifiedType(),
-                                                     Out);
+    CGM.getCXXABI().getMangleContext().mangleCXXRTTI(
+        Ty.getUnqualifiedType(CGM.getContext()), Out);
 
     // Contained in NoSanitizeList based on the mangled type.
     if (!CGM.getContext().getNoSanitizeList().containsType(SanitizerKind::Vptr,
@@ -951,11 +951,9 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
       // diagnostic.
       llvm::Value *EqualHash = Builder.CreateICmpEQ(CacheVal, Hash);
       llvm::Constant *StaticData[] = {
-        EmitCheckSourceLocation(Loc),
-        EmitCheckTypeDescriptor(Ty),
-        CGM.GetAddrOfRTTIDescriptor(Ty.getUnqualifiedType()),
-        llvm::ConstantInt::get(Int8Ty, TCK)
-      };
+          EmitCheckSourceLocation(Loc), EmitCheckTypeDescriptor(Ty),
+          CGM.GetAddrOfRTTIDescriptor(Ty.getUnqualifiedType(CGM.getContext())),
+          llvm::ConstantInt::get(Int8Ty, TCK)};
       llvm::Value *DynamicData[] = { Ptr, Hash };
       EmitCheck(std::make_pair(EqualHash, SanitizerKind::SO_Vptr),
                 SanitizerHandler::DynamicTypeCacheMiss, StaticData,
@@ -1961,7 +1959,7 @@ CodeGenFunction::tryEmitAsConstant(const DeclRefExpr *RefExpr) {
   if (CEK != CEK_AsReferenceOnly &&
       RefExpr->EvaluateAsRValue(result, getContext())) {
     resultIsReference = false;
-    resultType = RefExpr->getType().getUnqualifiedType();
+    resultType = RefExpr->getType().getUnqualifiedType(getContext());
 
   // Otherwise, try to evaluate as an l-value.
   } else if (CEK != CEK_AsValueOnly &&
@@ -7365,7 +7363,7 @@ void CodeGenFunction::FlattenAccessAndTypeLValue(
 
   while (!WorkList.empty()) {
     auto [LVal, T, IdxList] = WorkList.pop_back_val();
-    T = T.getCanonicalType().getUnqualifiedType();
+    T = T.getCanonicalType().getUnqualifiedType(getContext());
     if (const auto *CAT = dyn_cast<ConstantArrayType>(T)) {
       uint64_t Size = CAT->getZExtSize();
       for (int64_t I = Size - 1; I > -1; I--) {

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -1497,7 +1497,7 @@ static void EnterNewDeleteCleanup(CodeGenFunction &CGF, const CXXNewExpr *E,
                                   RValue TypeIdentity, Address NewPtr,
                                   llvm::Value *AllocSize, CharUnits AllocAlign,
                                   const CallArgList &NewArgs) {
-  unsigned NumNonPlacementArgs = E->getNumImplicitArgs();
+  unsigned NumNonPlacementArgs = E->getNumImplicitArgs(CGF.getContext());
 
   // If we're not inside a conditional branch, then the cleanup will
   // dominate and we can do the easier (and more efficient) thing.
@@ -1514,7 +1514,7 @@ static void EnterNewDeleteCleanup(CodeGenFunction &CGF, const CXXNewExpr *E,
     DirectCleanup *Cleanup = CGF.EHStack.pushCleanupWithExtra<DirectCleanup>(
         EHCleanup, E->getNumPlacementArgs(), E->getOperatorDelete(),
         TypeIdentity, NewPtr.emitRawPointer(CGF), AllocSize,
-        E->implicitAllocationParameters(), AllocAlign);
+        E->implicitAllocationParameters(CGF.getContext()), AllocAlign);
     for (unsigned I = 0, N = E->getNumPlacementArgs(); I != N; ++I) {
       auto &Arg = NewArgs[I + NumNonPlacementArgs];
       Cleanup->setPlacementArg(I, Arg.getRValue(CGF), Arg.Ty);
@@ -1543,7 +1543,7 @@ static void EnterNewDeleteCleanup(CodeGenFunction &CGF, const CXXNewExpr *E,
       CGF.EHStack.pushCleanupWithExtra<ConditionalCleanup>(
           EHCleanup, E->getNumPlacementArgs(), E->getOperatorDelete(),
           SavedTypeIdentity, SavedNewPtr, SavedAllocSize,
-          E->implicitAllocationParameters(), AllocAlign);
+          E->implicitAllocationParameters(CGF.getContext()), AllocAlign);
   for (unsigned I = 0, N = E->getNumPlacementArgs(); I != N; ++I) {
     auto &Arg = NewArgs[I + NumNonPlacementArgs];
     Cleanup->setPlacementArg(
@@ -1614,7 +1614,8 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
   } else {
     const FunctionProtoType *allocatorType =
         allocator->getType()->castAs<FunctionProtoType>();
-    ImplicitAllocationParameters IAP = E->implicitAllocationParameters();
+    ImplicitAllocationParameters IAP =
+        E->implicitAllocationParameters(getContext());
     unsigned ParamsToSkip = 0;
     if (isTypeAwareAllocation(IAP.PassTypeIdentity)) {
       QualType SpecializedTypeIdentity = allocatorType->getParamType(0);

--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -302,7 +302,7 @@ public:
     if (llvm::APFloat::semanticsMaxExponent(ElementTypeSemantics) * 2 + 1 <=
         llvm::APFloat::semanticsMaxExponent(HigherElementTypeSemantics)) {
       if (!Ctx.getTargetInfo().hasLongDoubleType() &&
-          HigherElementType.getCanonicalType().getUnqualifiedType() ==
+          HigherElementType.getCanonicalType().getUnqualifiedType(Ctx) ==
               Ctx.LongDoubleTy)
         return QualType();
       FPHasBeenPromoted = true;
@@ -507,10 +507,10 @@ ComplexPairTy ComplexExprEmitter::EmitComplexToComplexCast(ComplexPairTy Val,
                                                            QualType DestType,
                                                            SourceLocation Loc) {
   // Get the src/dest element type.
-  SrcType = SrcType.getAtomicUnqualifiedType()
+  SrcType = SrcType.getAtomicUnqualifiedType(CGF.getContext())
                 ->castAs<ComplexType>()
                 ->getElementType();
-  DestType = DestType.getAtomicUnqualifiedType()
+  DestType = DestType.getAtomicUnqualifiedType(CGF.getContext())
                  ->castAs<ComplexType>()
                  ->getElementType();
 
@@ -538,7 +538,7 @@ ComplexPairTy ComplexExprEmitter::EmitScalarToComplexCast(llvm::Value *Val,
 
 ComplexPairTy ComplexExprEmitter::EmitCast(CastKind CK, Expr *Op,
                                            QualType DestTy) {
-  DestTy = DestTy.getAtomicUnqualifiedType();
+  DestTy = DestTy.getAtomicUnqualifiedType(CGF.getContext());
   switch (CK) {
   case CK_Dependent:
     llvm_unreachable("dependent cast kind in IR gen!");
@@ -1217,7 +1217,8 @@ LValue ComplexExprEmitter::EmitCompoundAssignLValue(
     ComplexPairTy (ComplexExprEmitter::*Func)(const BinOpInfo &), RValue &Val) {
   TestAndClearIgnoreReal();
   TestAndClearIgnoreImag();
-  QualType LHSTy = E->getLHS()->getType().getAtomicUnqualifiedType();
+  QualType LHSTy =
+      E->getLHS()->getType().getAtomicUnqualifiedType(CGF.getContext());
 
   BinOpInfo OpInfo;
   OpInfo.FPFeatures = E->getFPFeaturesInEffect(CGF.getLangOpts());

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -93,7 +93,7 @@ CodeGenFunction::EmitObjCBoxedExpr(const ObjCBoxedExpr *E) {
 
   CallArgList Args;
   const ParmVarDecl *ArgDecl = *BoxingMethod->param_begin();
-  QualType ArgQT = ArgDecl->getType().getUnqualifiedType();
+  QualType ArgQT = ArgDecl->getType().getUnqualifiedType(getContext());
 
   // ObjCBoxedExpr supports boxing of structs and unions
   // via [NSValue valueWithBytes:objCType:]
@@ -114,7 +114,8 @@ CodeGenFunction::EmitObjCBoxedExpr(const ObjCBoxedExpr *E) {
 
     // Cast type encoding to correct type
     const ParmVarDecl *EncodingDecl = BoxingMethod->parameters()[1];
-    QualType EncodingQT = EncodingDecl->getType().getUnqualifiedType();
+    QualType EncodingQT =
+        EncodingDecl->getType().getUnqualifiedType(getContext());
     llvm::Value *Cast = Builder.CreateBitCast(GV, ConvertType(EncodingQT));
 
     Args.add(RValue::get(Cast), EncodingQT);
@@ -221,15 +222,15 @@ llvm::Value *CodeGenFunction::EmitObjCCollectionLiteral(const Expr *E,
   CallArgList Args;
   ObjCMethodDecl::param_const_iterator PI = MethodWithObjects->param_begin();
   const ParmVarDecl *argDecl = *PI++;
-  QualType ArgQT = argDecl->getType().getUnqualifiedType();
+  QualType ArgQT = argDecl->getType().getUnqualifiedType(getContext());
   Args.add(RValue::get(Objects, *this), ArgQT);
   if (DLE) {
     argDecl = *PI++;
-    ArgQT = argDecl->getType().getUnqualifiedType();
+    ArgQT = argDecl->getType().getUnqualifiedType(getContext());
     Args.add(RValue::get(Keys, *this), ArgQT);
   }
   argDecl = *PI;
-  ArgQT = argDecl->getType().getUnqualifiedType();
+  ArgQT = argDecl->getType().getUnqualifiedType(getContext());
   llvm::Value *Count =
     llvm::ConstantInt::get(CGM.getTypes().ConvertType(ArgQT), NumElements);
   Args.add(RValue::get(Count), ArgQT);
@@ -1655,9 +1656,9 @@ CodeGenFunction::generateObjCSetterBody(const ObjCImplementationDecl *classImpl,
   QualType argType = argDecl->getType().getNonReferenceType();
   DeclRefExpr arg(getContext(), argDecl, false, argType, VK_LValue,
                   SourceLocation());
-  ImplicitCastExpr argLoad(ImplicitCastExpr::OnStack,
-                           argType.getUnqualifiedType(), CK_LValueToRValue,
-                           &arg, VK_PRValue, FPOptionsOverride());
+  ImplicitCastExpr argLoad(
+      ImplicitCastExpr::OnStack, argType.getUnqualifiedType(getContext()),
+      CK_LValueToRValue, &arg, VK_PRValue, FPOptionsOverride());
 
   // The property type can differ from the ivar type in some situations with
   // Objective-C pointer types, we can always bit cast the RHS in these cases.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2963,9 +2963,10 @@ public:
   AggValueSlot CreateAggTemp(QualType T, const Twine &Name = "tmp",
                              RawAddress *Alloca = nullptr) {
     return AggValueSlot::forAddr(
-        CreateMemTemp(T.getUnqualifiedType(), Name, Alloca), T.getQualifiers(),
-        AggValueSlot::IsNotDestructed, AggValueSlot::DoesNotNeedGCBarriers,
-        AggValueSlot::IsNotAliased, AggValueSlot::DoesNotOverlap);
+        CreateMemTemp(T.getUnqualifiedType(getContext()), Name, Alloca),
+        T.getQualifiers(), AggValueSlot::IsNotDestructed,
+        AggValueSlot::DoesNotNeedGCBarriers, AggValueSlot::IsNotAliased,
+        AggValueSlot::DoesNotOverlap);
   }
 
   /// EvaluateExprAsBool - Perform the usual unary conversions on the specified

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2796,7 +2796,7 @@ void CodeGenModule::GenKernelArgMetadata(llvm::Function *Fn,
         accessQuals.push_back(llvm::MDString::get(VMContext, "none"));
 
       auto getTypeSpelling = [&](QualType Ty) {
-        auto typeName = Ty.getUnqualifiedType().getAsString(Policy);
+        auto typeName = Ty.getUnqualifiedType(getContext()).getAsString(Policy);
 
         if (Ty.isCanonical()) {
           StringRef typeNameRef = typeName;
@@ -4111,7 +4111,7 @@ bool CodeGenModule::isInNoSanitizeList(SanitizerMask Kind,
     // not sanitized, we also don't instrument arrays of them.
     while (auto AT = dyn_cast<ArrayType>(Ty.getTypePtr()))
       Ty = AT->getElementType();
-    Ty = Ty.getCanonicalType().getUnqualifiedType();
+    Ty = Ty.getCanonicalType().getUnqualifiedType(getContext());
     // Only record types (classes, structs etc.) are ignored.
     if (Ty->isRecordType()) {
       std::string TypeStr = Ty.getAsString(getContext().getPrintingPolicy());

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1652,10 +1652,10 @@ llvm::Value *ItaniumCXXABI::emitDynamicCastCall(
   llvm::Type *PtrDiffLTy =
       CGF.ConvertType(CGF.getContext().getPointerDiffType());
 
-  llvm::Value *SrcRTTI =
-      CGF.CGM.GetAddrOfRTTIDescriptor(SrcRecordTy.getUnqualifiedType());
-  llvm::Value *DestRTTI =
-      CGF.CGM.GetAddrOfRTTIDescriptor(DestRecordTy.getUnqualifiedType());
+  llvm::Value *SrcRTTI = CGF.CGM.GetAddrOfRTTIDescriptor(
+      SrcRecordTy.getUnqualifiedType(CGF.getContext()));
+  llvm::Value *DestRTTI = CGF.CGM.GetAddrOfRTTIDescriptor(
+      DestRecordTy.getUnqualifiedType(CGF.getContext()));
 
   // Compute the offset hint.
   const CXXRecordDecl *SrcDecl = SrcRecordTy->getAsCXXRecordDecl();
@@ -4612,7 +4612,7 @@ static unsigned extractPBaseFlags(ASTContext &Ctx, QualType &Type) {
     Flags |= ItaniumRTTIBuilder::PTI_Volatile;
   if (Type.isRestrictQualified())
     Flags |= ItaniumRTTIBuilder::PTI_Restrict;
-  Type = Type.getUnqualifiedType();
+  Type = Type.getUnqualifiedType(Ctx);
 
   // Itanium C++ ABI 2.9.5p7:
   //   When the abi::__pbase_type_info is for a direct or indirect pointer to an

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -1039,10 +1039,10 @@ bool MicrosoftCXXABI::shouldDynamicCastCallBeNullChecked(bool SrcIsPtr,
 llvm::Value *MicrosoftCXXABI::emitDynamicCastCall(
     CodeGenFunction &CGF, Address This, QualType SrcRecordTy, QualType DestTy,
     QualType DestRecordTy, llvm::BasicBlock *CastEnd) {
-  llvm::Value *SrcRTTI =
-      CGF.CGM.GetAddrOfRTTIDescriptor(SrcRecordTy.getUnqualifiedType());
-  llvm::Value *DestRTTI =
-      CGF.CGM.GetAddrOfRTTIDescriptor(DestRecordTy.getUnqualifiedType());
+  llvm::Value *SrcRTTI = CGF.CGM.GetAddrOfRTTIDescriptor(
+      SrcRecordTy.getUnqualifiedType(CGF.getContext()));
+  llvm::Value *DestRTTI = CGF.CGM.GetAddrOfRTTIDescriptor(
+      DestRecordTy.getUnqualifiedType(CGF.getContext()));
 
   llvm::Value *Offset;
   std::tie(This, Offset, std::ignore) =
@@ -3993,14 +3993,14 @@ static QualType decomposeTypeForEH(ASTContext &Context, QualType T,
   // Member pointer types like "const int A::*" are represented by having RTTI
   // for "int A::*" and separately storing the const qualifier.
   if (const auto *MPTy = T->getAs<MemberPointerType>())
-    T = Context.getMemberPointerType(PointeeType.getUnqualifiedType(),
+    T = Context.getMemberPointerType(PointeeType.getUnqualifiedType(Context),
                                      MPTy->getQualifier(),
                                      MPTy->getMostRecentCXXRecordDecl());
 
   // Pointer types like "const int * const *" are represented by having RTTI
   // for "const int **" and separately storing the const qualifier.
   if (T->isPointerType())
-    T = Context.getPointerType(PointeeType.getUnqualifiedType());
+    T = Context.getPointerType(PointeeType.getUnqualifiedType(Context));
 
   return T;
 }

--- a/clang/lib/CodeGen/QualTypeMapper.cpp
+++ b/clang/lib/CodeGen/QualTypeMapper.cpp
@@ -48,7 +48,7 @@ const llvm::abi::Type *QualTypeMapper::convertType(QualType QT) {
   // for instance,  __attribute__((aligned(N))) are lost here. Capture the
   // effective alignment from the original QT and thread it through
   // convertTypeImpl.
-  QT = QT.getCanonicalType().getUnqualifiedType();
+  QT = QT.getCanonicalType().getUnqualifiedType(ASTCtx);
 
   // Results are cached since type conversion may be expensive.
   auto It = TypeCache.find(QT);

--- a/clang/lib/Edit/RewriteObjCFoundationAPI.cpp
+++ b/clang/lib/Edit/RewriteObjCFoundationAPI.cpp
@@ -112,7 +112,7 @@ maybeAdjustInterfaceForSubscriptingCheck(const ObjCInterfaceDecl *IFace,
   assert(IFace && Receiver);
 
   // If the receiver has type 'id'...
-  if (!Ctx.isObjCIdType(Receiver->getType().getUnqualifiedType()))
+  if (!Ctx.isObjCIdType(Receiver->getType().getUnqualifiedType(Ctx)))
     return IFace;
 
   const ObjCMessageExpr *

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -394,8 +394,8 @@ void ASTUnit::CacheCodeCompletionResults() {
         CachedResult.TypeClass = STC_Void;
         CachedResult.Type = 0;
       } else {
-        CanQualType CanUsageType
-          = Ctx->getCanonicalType(UsageType.getUnqualifiedType());
+        CanQualType CanUsageType =
+            Ctx->getCanonicalType(UsageType.getUnqualifiedType(*Ctx));
         CachedResult.TypeClass = getSimplifiedTypeClass(CanUsageType);
 
         // Determine whether we have already seen this type. If so, we save
@@ -1985,9 +1985,8 @@ void AugmentedCodeCompleteConsumer::ProcessCodeCompleteResults(Sema &S,
                                          S.getLangOpts(),
                                Context.getPreferredType()->isAnyPointerType());
       } else if (C->Type) {
-        CanQualType Expected
-          = S.Context.getCanonicalType(
-                               Context.getPreferredType().getUnqualifiedType());
+        CanQualType Expected = S.Context.getCanonicalType(
+            Context.getPreferredType().getUnqualifiedType(S.Context));
         SimplifiedTypeClass ExpectedSTC = getSimplifiedTypeClass(Expected);
         if (ExpectedSTC == C->TypeClass) {
           // We know this type is similar; check for an exact match.

--- a/clang/lib/Parse/ParseReflect.cpp
+++ b/clang/lib/Parse/ParseReflect.cpp
@@ -40,7 +40,7 @@ ExprResult Parser::ParseCXXReflectExpression() {
     if (!TSI)
       TSI = Actions.getASTContext().getTrivialTypeSourceInfo(QT, OperandLoc);
 
-    QT = QT.getCanonicalType().getUnqualifiedType();
+    QT = QT.getCanonicalType().getUnqualifiedType(Actions.getASTContext());
     if (TSI && QT.getTypePtr()->isBuiltinType()) {
       // Only supports builtin types for now
       return Actions.ActOnCXXReflectExpr(CaretCaretLoc, TSI);

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2328,7 +2328,7 @@ void Sema::checkTypeSupport(QualType Ty, SourceLocation Loc, ValueDecl *D) {
         LangOpts.CUDAIsDevice)
       CheckDeviceType(Ty);
 
-    QualType UnqualTy = Ty.getCanonicalType().getUnqualifiedType();
+    QualType UnqualTy = Ty.getCanonicalType().getUnqualifiedType(Context);
     const TargetInfo &TI = Context.getTargetInfo();
     if (!TI.hasLongDoubleType() && UnqualTy == Context.LongDoubleTy) {
       PartialDiagnostic PD = PDiag(diag::err_target_unsupported_type);

--- a/clang/lib/Sema/SemaARM.cpp
+++ b/clang/lib/Sema/SemaARM.cpp
@@ -907,7 +907,7 @@ bool SemaARM::CheckARMBuiltinExclusiveCall(const TargetInfo &TI,
   // task is to insert the appropriate casts into the AST. First work out just
   // what the appropriate type is.
   QualType ValType = pointerType->getPointeeType();
-  QualType AddrType = ValType.getUnqualifiedType().withVolatile();
+  QualType AddrType = ValType.getUnqualifiedType(Context).withVolatile();
   if (IsLdrex)
     AddrType.addConst();
 

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -78,7 +78,7 @@ namespace {
       // the qualifier.
       if (!S.Context.getLangOpts().ObjC && !DestType->isRecordType() &&
           !DestType->isArrayType() && !DestType.getPointerAuth()) {
-        DestType = DestType.getAtomicUnqualifiedType();
+        DestType = DestType.getAtomicUnqualifiedType(S.Context);
       }
 
       if (const BuiltinType *placeholder =
@@ -883,7 +883,7 @@ void CastOperation::CheckDynamicCast() {
     }
   } else {
     Self.Diag(OpRange.getBegin(), diag::err_bad_dynamic_cast_not_class)
-      << DestPointee.getUnqualifiedType() << DestRange;
+        << DestPointee.getUnqualifiedType(Self.Context) << DestRange;
     SrcExpr = ExprError();
     return;
   }
@@ -928,7 +928,8 @@ void CastOperation::CheckDynamicCast() {
     }
   } else {
     Self.Diag(OpRange.getBegin(), diag::err_bad_dynamic_cast_not_class)
-      << SrcPointee.getUnqualifiedType() << SrcExpr.get()->getSourceRange();
+        << SrcPointee.getUnqualifiedType(Self.Context)
+        << SrcExpr.get()->getSourceRange();
     SrcExpr = ExprError();
     return;
   }
@@ -974,7 +975,8 @@ void CastOperation::CheckDynamicCast() {
   assert(SrcDecl && "Definition missing");
   if (!cast<CXXRecordDecl>(SrcDecl)->isPolymorphic()) {
     Self.Diag(OpRange.getBegin(), diag::err_bad_dynamic_cast_not_polymorphic)
-      << SrcPointee.getUnqualifiedType() << SrcExpr.get()->getSourceRange();
+        << SrcPointee.getUnqualifiedType(Self.Context)
+        << SrcExpr.get()->getSourceRange();
     SrcExpr = ExprError();
   }
 
@@ -1631,8 +1633,8 @@ TryCastResult TryLValueToRValueCast(Sema &Self, Expr *SrcExpr,
   QualType FromType = SrcExpr->getType();
   QualType ToType = R->getPointeeType();
   if (CStyle) {
-    FromType = FromType.getUnqualifiedType();
-    ToType = ToType.getUnqualifiedType();
+    FromType = FromType.getUnqualifiedType(Self.Context);
+    ToType = ToType.getUnqualifiedType(Self.Context);
   }
 
   Sema::ReferenceConversions RefConv;
@@ -1807,9 +1809,9 @@ TryCastResult TryStaticDowncast(Sema &Self, CanQualType SrcType,
     }
 
     Self.Diag(OpRange.getBegin(), diag::err_ambiguous_base_to_derived_cast)
-      << QualType(SrcType).getUnqualifiedType()
-      << QualType(DestType).getUnqualifiedType()
-      << PathDisplayStr << OpRange;
+        << QualType(SrcType).getUnqualifiedType(Self.Context)
+        << QualType(DestType).getUnqualifiedType(Self.Context) << PathDisplayStr
+        << OpRange;
     msg = 0;
     return TC_Failed;
   }
@@ -2143,7 +2145,7 @@ static void DiagnoseCastOfObjCSEL(Sema &Self, const ExprResult &SrcExpr,
       QualType DT = DestType;
       if (isa<PointerType>(DestType))
         DT = DestType->getPointeeType();
-      if (!DT.getUnqualifiedType()->isVoidType())
+      if (!DT->isVoidType())
         Self.Diag(SrcExpr.get()->getExprLoc(),
                   diag::warn_cast_pointer_from_sel)
         << SrcType << DestType << SrcExpr.get()->getSourceRange();
@@ -3000,7 +3002,7 @@ static void DiagnoseBadFunctionCast(Sema &Self, const ExprResult &SrcExpr,
     return;
 
   QualType SrcType = SrcExpr.get()->getType();
-  if (DestType.getUnqualifiedType()->isVoidType())
+  if (DestType->isVoidType())
     return;
   if ((SrcType->isAnyPointerType() || SrcType->isBlockPointerType())
       && (DestType->isAnyPointerType() || DestType->isBlockPointerType()))

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1682,7 +1682,7 @@ static bool checkPointerAuthValue(Sema &S, Expr *&Arg, PointerAuthOpKind OpKind,
   // Require the value to have the right range of type.
   QualType ExpectedTy;
   if (AllowsPointer(OpKind) && Arg->getType()->isPointerType()) {
-    ExpectedTy = Arg->getType().getUnqualifiedType();
+    ExpectedTy = Arg->getType().getUnqualifiedType(S.Context);
   } else if (AllowsPointer(OpKind) && Arg->getType()->isNullPtrType()) {
     ExpectedTy = S.Context.VoidPtrTy;
   } else if (AllowsInteger(OpKind) &&
@@ -2562,7 +2562,7 @@ static bool CheckMaskedBuiltinArgs(Sema &S, Expr *MaskArg, Expr *PtrArg,
       (!AllowConst && PointeeTy.isConstQualified()) ||
       (!AllowAS && PointeeTy.hasAddressSpace())) {
     QualType Target =
-        S.Context.getPointerType(PointeeTy.getAtomicUnqualifiedType());
+        S.Context.getPointerType(PointeeTy.getAtomicUnqualifiedType(S.Context));
     return S.Diag(PtrArg->getExprLoc(),
                   diag::err_typecheck_convert_incompatible)
            << PtrTy << Target << /*different qualifiers=*/5
@@ -2610,8 +2610,8 @@ static ExprResult BuiltinMaskedLoad(Sema &S, CallExpr *TheCall) {
   QualType PointeeTy = PtrTy->getPointeeType();
   const VectorType *MaskVecTy = MaskTy->getAs<VectorType>();
 
-  QualType RetTy = S.Context.getExtVectorType(PointeeTy.getUnqualifiedType(),
-                                              MaskVecTy->getNumElements());
+  QualType RetTy = S.Context.getExtVectorType(
+      PointeeTy.getUnqualifiedType(S.Context), MaskVecTy->getNumElements());
   if (TheCall->getNumArgs() == 3) {
     Expr *PassThruArg = TheCall->getArg(2);
     QualType PassThruTy = PassThruArg->getType();
@@ -2661,8 +2661,9 @@ static ExprResult BuiltinMaskedStore(Sema &S, CallExpr *TheCall) {
         << MaskTy << ValTy);
   }
 
-  if (!S.Context.hasSameType(ValVecTy->getElementType().getUnqualifiedType(),
-                             PtrTy->getPointeeType().getUnqualifiedType()))
+  if (!S.Context.hasSameType(
+          ValVecTy->getElementType().getUnqualifiedType(S.Context),
+          PtrTy->getPointeeType().getUnqualifiedType(S.Context)))
     return ExprError(S.Diag(TheCall->getBeginLoc(),
                             diag::err_vec_builtin_incompatible_vector)
                      << TheCall->getDirectCallee() << /*isMorethantwoArgs*/ 2
@@ -2708,8 +2709,8 @@ static ExprResult BuiltinMaskedGather(Sema &S, CallExpr *TheCall) {
                TheCall->getBuiltinCallee())
         << MaskTy << IdxTy);
 
-  QualType RetTy = S.Context.getExtVectorType(PointeeTy.getUnqualifiedType(),
-                                              MaskVecTy->getNumElements());
+  QualType RetTy = S.Context.getExtVectorType(
+      PointeeTy.getUnqualifiedType(S.Context), MaskVecTy->getNumElements());
   if (TheCall->getNumArgs() == 4) {
     Expr *PassThruArg = TheCall->getArg(3);
     QualType PassThruTy = PassThruArg->getType();
@@ -2767,8 +2768,9 @@ static ExprResult BuiltinMaskedScatter(Sema &S, CallExpr *TheCall) {
                TheCall->getBuiltinCallee())
         << MaskTy << ValTy);
 
-  if (!S.Context.hasSameType(ValVecTy->getElementType().getUnqualifiedType(),
-                             PtrTy->getPointeeType().getUnqualifiedType()))
+  if (!S.Context.hasSameType(
+          ValVecTy->getElementType().getUnqualifiedType(S.Context),
+          PtrTy->getPointeeType().getUnqualifiedType(S.Context)))
     return ExprError(S.Diag(TheCall->getBeginLoc(),
                             diag::err_vec_builtin_incompatible_vector)
                      << TheCall->getDirectCallee() << /*isMoreThanTwoArgs*/ 2
@@ -5302,8 +5304,8 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
                   ValArg->getType()->getAs<PointerType>()) {
             AS = PtrTy->getPointeeType().getAddressSpace();
           }
-          Ty = Context.getPointerType(
-              Context.getAddrSpaceQualType(ValType.getUnqualifiedType(), AS));
+          Ty = Context.getPointerType(Context.getAddrSpaceQualType(
+              ValType.getUnqualifiedType(Context), AS));
         }
         break;
       case 2:
@@ -5532,7 +5534,7 @@ ExprResult Sema::BuiltinAtomicOverloaded(ExprResult TheCallResult) {
   }
 
   // Strip any qualifiers off ValType.
-  ValType = ValType.getUnqualifiedType();
+  ValType = ValType.getUnqualifiedType(Context);
 
   // The majority of builtins return a value, but a few have special return
   // types, so allow them to override appropriately below.
@@ -5880,7 +5882,7 @@ ExprResult Sema::BuiltinNontemporalOverloaded(ExprResult TheCallResult) {
   QualType ValType = pointerType->getPointeeType();
 
   // Strip any qualifiers off ValType.
-  ValType = ValType.getUnqualifiedType();
+  ValType = ValType.getUnqualifiedType(Context);
   if (!ValType->isIntegerType() && !ValType->isAnyPointerType() &&
       !ValType->isBlockPointerType() && !ValType->isFloatingType() &&
       !ValType->isVectorType()) {
@@ -12881,12 +12883,12 @@ static void DiagnoseFloatingImpCast(Sema &S, const Expr *E, QualType T,
   if (PruneWarnings) {
     S.DiagRuntimeBehavior(E->getExprLoc(), E,
                           S.PDiag(DiagID)
-                              << E->getType() << T.getUnqualifiedType()
+                              << E->getType() << T.getUnqualifiedType(S.Context)
                               << PrettySourceValue << PrettyTargetValue
                               << E->getSourceRange() << SourceRange(CContext));
   } else {
     S.Diag(E->getExprLoc(), DiagID)
-        << E->getType() << T.getUnqualifiedType() << PrettySourceValue
+        << E->getType() << T.getUnqualifiedType(S.Context) << PrettySourceValue
         << PrettyTargetValue << E->getSourceRange() << SourceRange(CContext);
   }
 }
@@ -13141,7 +13143,8 @@ static void DiagnoseMixedUnicodeImplicitConversion(Sema &S, const Type *Source,
 
       S.Diag(CC, diag::warn_impcast_unicode_char_type_constant)
           << E->getType() << T
-          << IsSingleCodeUnitCP(E->getType().getUnqualifiedType(), Value)
+          << IsSingleCodeUnitCP(E->getType().getUnqualifiedType(S.Context),
+                                Value)
           << FormatUTFCodeUnitAsCodepoint(Value.getExtValue(), E->getType());
     }
   } else {
@@ -16387,8 +16390,8 @@ static bool isLayoutCompatible(const ASTContext &C, QualType T1, QualType T2) {
   // Two types cv1 T1 and cv2 T2 are layout-compatible types
   // if T1 and T2 are the same type, layout-compatible enumerations (9.7.1),
   // or layout-compatible standard-layout class types (11.4).
-  T1 = T1.getCanonicalType().getUnqualifiedType();
-  T2 = T2.getCanonicalType().getUnqualifiedType();
+  T1 = T1.getCanonicalType().getUnqualifiedType(C);
+  T2 = T2.getCanonicalType().getUnqualifiedType(C);
 
   if (C.hasSameType(T1, T2))
     return true;
@@ -17154,7 +17157,7 @@ ExprResult Sema::BuiltinMatrixColumnMajorLoad(CallExpr *TheCall,
         << PtrExpr->getType();
     ArgError = true;
   } else {
-    ElementTy = PtrTy->getPointeeType().getUnqualifiedType();
+    ElementTy = PtrTy->getPointeeType().getUnqualifiedType(Context);
 
     if (!ConstantMatrixType::isValidElementType(ElementTy, getLangOpts())) {
       Diag(PtrExpr->getBeginLoc(), diag::err_builtin_invalid_arg_type)
@@ -17300,7 +17303,7 @@ ExprResult Sema::BuiltinMatrixColumnMajorStore(CallExpr *TheCall,
       Diag(PtrExpr->getBeginLoc(), diag::err_builtin_matrix_store_to_const);
       ArgError = true;
     }
-    ElementTy = ElementTy.getUnqualifiedType().getCanonicalType();
+    ElementTy = ElementTy.getUnqualifiedType(Context).getCanonicalType();
     if (MatrixTy &&
         !Context.hasSameType(ElementTy, MatrixTy->getElementType())) {
       Diag(PtrExpr->getBeginLoc(),

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3189,7 +3189,7 @@ static std::string FormatFunctionParameter(
     if (!ObjCMethodParam && Param->getIdentifier())
       Result = std::string(Param->getIdentifier()->deuglifiedName());
 
-    QualType Type = Param->getType().getUnqualifiedType();
+    QualType Type = Param->getType().getUnqualifiedType(Param->getASTContext());
 
     if (ObjCMethodParam) {
       Result = Type.getAsString(Policy);
@@ -9185,7 +9185,8 @@ void SemaCodeCompletion::CodeCompleteObjCPropertySynthesizeIvar(
     if (ObjCPropertyDecl *Property = Class->FindPropertyDeclaration(
             PropertyName, ObjCPropertyQueryKind::OBJC_PR_query_instance)) {
       PropertyType =
-          Property->getType().getNonReferenceType().getUnqualifiedType();
+          Property->getType().getNonReferenceType().getUnqualifiedType(
+              Property->getASTContext());
 
       // Give preference to ivars
       Results.setPreferredType(PropertyType);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9745,7 +9745,8 @@ static bool isOpenCLSizeDependentType(ASTContext &C, QualType Ty) {
   QualType DesugaredTy = Ty;
   do {
     ArrayRef<StringRef> Names(SizeTypeNames);
-    auto Match = llvm::find(Names, DesugaredTy.getUnqualifiedType().getAsString());
+    auto Match =
+        llvm::find(Names, DesugaredTy.getUnqualifiedType(C).getAsString());
     if (Names.end() != Match)
       return true;
 
@@ -13589,7 +13590,7 @@ struct DiagNonTrivalCUnionDefaultInitializeVisitor
 
     if (InNonTrivialUnion)
       S.Diag(RD->getLocation(), diag::note_non_trivial_c_union)
-          << 0 << 0 << QT.getUnqualifiedType() << "";
+          << 0 << 0 << QT.getUnqualifiedType(S.Context) << "";
 
     for (const FieldDecl *FD : RD->fields())
       if (!shouldIgnoreForRecordTriviality(FD))
@@ -13655,7 +13656,7 @@ struct DiagNonTrivalCUnionDestructedTypeVisitor
 
     if (InNonTrivialUnion)
       S.Diag(RD->getLocation(), diag::note_non_trivial_c_union)
-          << 0 << 1 << QT.getUnqualifiedType() << "";
+          << 0 << 1 << QT.getUnqualifiedType(S.Context) << "";
 
     for (const FieldDecl *FD : RD->fields())
       if (!shouldIgnoreForRecordTriviality(FD))
@@ -13720,7 +13721,7 @@ struct DiagNonTrivalCUnionCopyVisitor
 
     if (InNonTrivialUnion)
       S.Diag(RD->getLocation(), diag::note_non_trivial_c_union)
-          << 0 << 2 << QT.getUnqualifiedType() << "";
+          << 0 << 2 << QT.getUnqualifiedType(S.Context) << "";
 
     for (const FieldDecl *FD : RD->fields())
       if (!shouldIgnoreForRecordTriviality(FD))
@@ -17669,7 +17670,7 @@ bool Sema::CheckEnumUnderlyingType(TypeSourceInfo *TI) {
   if (QualSelect)
     Diag(UnderlyingLoc, diag::warn_cv_stripped_in_enum) << *QualSelect;
 
-  T = T.getAtomicUnqualifiedType();
+  T = T.getAtomicUnqualifiedType(Context);
 
   // This doesn't use 'isIntegralType' despite the error message mentioning
   // integral type because isIntegralType would also allow enum types in C.
@@ -18094,7 +18095,8 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
       // ones like _Atomic where it forms a different type.
       if (TypeSourceInfo *TI = dyn_cast<TypeSourceInfo *>(EnumUnderlying);
           TI && TI->getType()->isAtomicType())
-        EnumUnderlying = TI->getType().getAtomicUnqualifiedType().getTypePtr();
+        EnumUnderlying =
+            TI->getType().getAtomicUnqualifiedType(Context).getTypePtr();
 
     } else if (Context.getTargetInfo().getTriple().isWindowsMSVCEnvironment()) {
       // For MSVC ABI compatibility, unfixed enums must use an underlying type
@@ -18524,7 +18526,7 @@ Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK, SourceLocation KWLoc,
           QualType EnumUnderlyingTy;
           if (TypeSourceInfo *TI =
                   dyn_cast_if_present<TypeSourceInfo *>(EnumUnderlying))
-            EnumUnderlyingTy = TI->getType().getUnqualifiedType();
+            EnumUnderlyingTy = TI->getType().getUnqualifiedType(Context);
           else if (const Type *T =
                        dyn_cast_if_present<const Type *>(EnumUnderlying))
             EnumUnderlyingTy = QualType(T, 0);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -886,8 +886,8 @@ static void handleDiagnoseAsBuiltinAttr(Sema &S, Decl *D,
     QualType T1 = AttrFD->getParamDecl(I - 1)->getType();
     QualType T2 = DeclFD->getParamDecl(Index - 1)->getType();
 
-    if (T1.getCanonicalType().getUnqualifiedType() !=
-        T2.getCanonicalType().getUnqualifiedType()) {
+    if (T1.getCanonicalType().getUnqualifiedType(S.Context) !=
+        T2.getCanonicalType().getUnqualifiedType(S.Context)) {
       S.Diag(IndexExpr->getBeginLoc(), diag::err_attribute_parameter_types)
           << AL << Index << DeclFD << T2 << I << AttrFD << T1;
       return;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2879,8 +2879,8 @@ CXXBaseSpecifier *Sema::CheckBaseSpecifier(CXXRecordDecl *Class,
 
   // Create the base specifier.
   return new (Context) CXXBaseSpecifier(
-      SpecifierRange, Virtual, Class->getTagKind() == TagTypeKind::Class,
-      Access, TInfo, EllipsisLoc);
+      Context, SpecifierRange, Virtual,
+      Class->getTagKind() == TagTypeKind::Class, Access, TInfo, EllipsisLoc);
 }
 
 BaseResult Sema::ActOnBaseSpecifier(Decl *classdecl, SourceRange SpecifierRange,
@@ -4977,9 +4977,9 @@ BuildImplicitBaseInitializer(Sema &SemaRef, CXXConstructorDecl *Constructor,
     SemaRef.MarkDeclRefReferenced(cast<DeclRefExpr>(CopyCtorArg));
 
     // Cast to the base class to avoid ambiguities.
-    QualType ArgTy =
-      SemaRef.Context.getQualifiedType(BaseSpec->getType().getUnqualifiedType(),
-                                       ParamType.getQualifiers());
+    QualType ArgTy = SemaRef.Context.getQualifiedType(
+        BaseSpec->getType().getUnqualifiedType(SemaRef.Context),
+        ParamType.getQualifiers());
 
     if (Moving) {
       CopyCtorArg = CastForMoving(SemaRef, CopyCtorArg);
@@ -10074,7 +10074,7 @@ bool Sema::ShouldDeleteSpecialMember(CXXMethodDecl *MD,
     DeclarationName Name =
       Context.DeclarationNames.getCXXOperatorName(OO_Delete);
     ImplicitDeallocationParameters IDP = {
-        DeallocType, ShouldUseTypeAwareOperatorNewOrDelete(),
+        Context, DeallocType, ShouldUseTypeAwareOperatorNewOrDelete(),
         AlignedAllocationMode::No, SizedDeallocationMode::No};
     if (FindDeallocationFunction(MD->getLocation(), MD->getParent(), Name,
                                  OperatorDelete, IDP,
@@ -10321,25 +10321,25 @@ static bool checkTrivialSubobjectCall(Sema &S, SourceLocation SubobjLoc,
 
     if (!Selected && CSM == CXXSpecialMemberKind::DefaultConstructor) {
       S.Diag(SubobjLoc, diag::note_nontrivial_no_def_ctor)
-        << Kind << SubType.getUnqualifiedType();
+          << Kind << SubType.getUnqualifiedType(S.Context);
       if (CXXConstructorDecl *CD = findUserDeclaredCtor(SubRD))
         S.Diag(CD->getLocation(), diag::note_user_declared_ctor);
     } else if (!Selected)
       S.Diag(SubobjLoc, diag::note_nontrivial_no_copy)
-          << Kind << SubType.getUnqualifiedType() << CSM << SubType;
+          << Kind << SubType.getUnqualifiedType(S.Context) << CSM << SubType;
     else if (Selected->isUserProvided()) {
       if (Kind == TSK_CompleteObject)
         S.Diag(Selected->getLocation(), diag::note_nontrivial_user_provided)
-            << Kind << SubType.getUnqualifiedType() << CSM;
+            << Kind << SubType.getUnqualifiedType(S.Context) << CSM;
       else {
         S.Diag(SubobjLoc, diag::note_nontrivial_user_provided)
-            << Kind << SubType.getUnqualifiedType() << CSM;
+            << Kind << SubType.getUnqualifiedType(S.Context) << CSM;
         S.Diag(Selected->getLocation(), diag::note_declared_at);
       }
     } else {
       if (Kind != TSK_CompleteObject)
         S.Diag(SubobjLoc, diag::note_nontrivial_subobject)
-            << Kind << SubType.getUnqualifiedType() << CSM;
+            << Kind << SubType.getUnqualifiedType(S.Context) << CSM;
 
       // Explain why the defaulted or deleted special member isn't trivial.
       S.SpecialMemberIsTrivial(Selected, CSM,
@@ -12525,7 +12525,7 @@ bool Sema::isInitListConstructor(const FunctionDecl *Ctor) {
 
   QualType ArgType = Ctor->getParamDecl(0)->getType();
   if (const ReferenceType *RT = ArgType->getAs<ReferenceType>())
-    ArgType = RT->getPointeeType().getUnqualifiedType();
+    ArgType = RT->getPointeeType().getUnqualifiedType(Context);
 
   return isStdInitializerList(ArgType, nullptr);
 }
@@ -15434,7 +15434,7 @@ void Sema::DefineImplicitCopyAssignment(SourceLocation CurrentLocation,
   for (auto &Base : ClassDecl->bases()) {
     // Form the assignment:
     //   static_cast<Base*>(this)->Base::operator=(static_cast<Base&>(other));
-    QualType BaseType = Base.getType().getUnqualifiedType();
+    QualType BaseType = Base.getType().getUnqualifiedType(Context);
     if (!BaseType->isRecordType()) {
       Invalid = true;
       continue;
@@ -15823,7 +15823,7 @@ void Sema::DefineImplicitMoveAssignment(SourceLocation CurrentLocation,
 
     // Form the assignment:
     //   static_cast<Base*>(this)->Base::operator=(static_cast<Base&&>(other));
-    QualType BaseType = Base.getType().getUnqualifiedType();
+    QualType BaseType = Base.getType().getUnqualifiedType(Context);
     if (!BaseType->isRecordType()) {
       Invalid = true;
       continue;
@@ -16659,7 +16659,7 @@ static CanQualType RemoveAddressSpaceFromPtr(Sema &SemaRef,
   Qualifiers PtrQuals = PtrTy->getPointeeType().getQualifiers();
   PtrQuals.removeAddressSpace();
   return Ctx.getPointerType(Ctx.getCanonicalType(Ctx.getQualifiedType(
-      PtrTy->getPointeeType().getUnqualifiedType(), PtrQuals)));
+      PtrTy->getPointeeType().getUnqualifiedType(Ctx), PtrQuals)));
 }
 
 enum class AllocationOperatorKind { New, Delete };
@@ -16799,7 +16799,7 @@ static inline bool CheckOperatorNewDeleteTypes(
     CanQualType CanExpectedTy =
         NormalizeType(SemaRef.Context.getCanonicalType(ExpectedType));
     auto ActualParamType =
-        NormalizeType(ParamDecl->getType().getUnqualifiedType());
+        NormalizeType(ParamDecl->getType().getUnqualifiedType(SemaRef.Context));
     if (ActualParamType == CanExpectedTy)
       return false;
     unsigned Diagnostic = ActualParamType->isDependentType()
@@ -17198,7 +17198,7 @@ bool Sema::CheckLiteralOperatorDeclaration(FunctionDecl *FnDecl) {
   } else if (FnDecl->param_size() == 1) {
     const ParmVarDecl *Param = FnDecl->getParamDecl(0);
 
-    QualType ParamType = Param->getType().getUnqualifiedType();
+    QualType ParamType = Param->getType().getUnqualifiedType(Context);
 
     // Only unsigned long long int, long double, any character type, and const
     // char * are allowed as the only parameters.
@@ -17213,7 +17213,7 @@ bool Sema::CheckLiteralOperatorDeclaration(FunctionDecl *FnDecl) {
       QualType InnerType = Ptr->getPointeeType();
 
       // Pointer parameter must be a const char *.
-      if (!(Context.hasSameType(InnerType.getUnqualifiedType(),
+      if (!(Context.hasSameType(InnerType.getUnqualifiedType(Context),
                                 Context.CharTy) &&
             InnerType.isConstQualified() && !InnerType.isVolatileQualified())) {
         Diag(Param->getSourceRange().getBegin(),
@@ -17244,7 +17244,7 @@ bool Sema::CheckLiteralOperatorDeclaration(FunctionDecl *FnDecl) {
 
     // First, verify that the first parameter is correct.
 
-    QualType FirstParamType = (*Param)->getType().getUnqualifiedType();
+    QualType FirstParamType = (*Param)->getType().getUnqualifiedType(Context);
 
     // Two parameter function must have a pointer to const as a
     // first parameter; let's strip those qualifiers.
@@ -17266,7 +17266,7 @@ bool Sema::CheckLiteralOperatorDeclaration(FunctionDecl *FnDecl) {
       return true;
     }
 
-    QualType InnerType = PointeeType.getUnqualifiedType();
+    QualType InnerType = PointeeType.getUnqualifiedType(Context);
     // Only const char *, const wchar_t*, const char8_t*, const char16_t*, and
     // const char32_t* are allowed as the first parameter to a two-parameter
     // function
@@ -17285,7 +17285,7 @@ bool Sema::CheckLiteralOperatorDeclaration(FunctionDecl *FnDecl) {
     ++Param;
 
     // The second parameter must be a std::size_t.
-    QualType SecondParamType = (*Param)->getType().getUnqualifiedType();
+    QualType SecondParamType = (*Param)->getType().getUnqualifiedType(Context);
     if (!Context.hasSameType(SecondParamType, Context.getSizeType())) {
       Diag((*Param)->getSourceRange().getBegin(),
            diag::err_literal_operator_param)

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -746,8 +746,8 @@ DeclResult SemaObjC::actOnObjCTypeParam(
         Qualifiers quals = typeBound.getQualifiers();
         quals.removeCVRQualifiers();
         if (!quals.empty()) {
-          typeBoundInfo =
-             Context.getTrivialTypeSourceInfo(typeBound.getUnqualifiedType());
+          typeBoundInfo = Context.getTrivialTypeSourceInfo(
+              typeBound.getUnqualifiedType(Context));
         }
       }
     }
@@ -5587,7 +5587,7 @@ Decl *SemaObjC::ActOnIvar(Scope *S, SourceLocation DeclStart, Declarator &D,
   ASTContext &Context = getASTContext();
   if (Context.getLangOpts().PointerAuthObjcInterfaceSel &&
       !T.getPointerAuth()) {
-    if (Context.isObjCSelType(T.getUnqualifiedType())) {
+    if (Context.isObjCSelType(T.getUnqualifiedType(Context))) {
       if (auto PAQ = Context.getObjCMemberSelTypePtrAuth())
         T = Context.getPointerAuthType(T, PAQ);
     }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -715,7 +715,7 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
   //   version of the type of the lvalue; otherwise, the value has the
   //   type of the lvalue.
   if (T.hasQualifiers())
-    T = T.getUnqualifiedType();
+    T = T.getUnqualifiedType(Context);
 
   // Under the MS ABI, lock down the inheritance model now.
   if (T->isMemberPointerType() &&
@@ -748,7 +748,7 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
   //   ... if the lvalue has atomic type, the value has the non-atomic version
   //   of the type of the lvalue ...
   if (const AtomicType *Atomic = T->getAs<AtomicType>()) {
-    T = Atomic->getValueType().getUnqualifiedType();
+    T = Atomic->getValueType().getUnqualifiedType(Context);
     Res = ImplicitCastExpr::Create(Context, T, CK_AtomicToNonAtomic, Res.get(),
                                    nullptr, VK_PRValue, FPOptionsOverride());
   }
@@ -1627,8 +1627,8 @@ void Sema::checkEnumArithmeticConversions(Expr *LHS, Expr *RHS,
 static void CheckUnicodeArithmeticConversions(Sema &SemaRef, Expr *LHS,
                                               Expr *RHS, SourceLocation Loc,
                                               ArithConvKind ACK) {
-  QualType LHSType = LHS->getType().getUnqualifiedType();
-  QualType RHSType = RHS->getType().getUnqualifiedType();
+  QualType LHSType = LHS->getType().getUnqualifiedType(SemaRef.Context);
+  QualType RHSType = RHS->getType().getUnqualifiedType(SemaRef.Context);
 
   if (!SemaRef.getLangOpts().CPlusPlus || !LHSType->isUnicodeCharacterType() ||
       !RHSType->isUnicodeCharacterType())
@@ -1720,8 +1720,8 @@ QualType Sema::UsualArithmeticConversions(ExprResult &LHS, ExprResult &RHS,
 
   // For conversion purposes, we ignore any qualifiers.
   // For example, "const float" and "float" are equivalent.
-  QualType LHSType = LHS.get()->getType().getUnqualifiedType();
-  QualType RHSType = RHS.get()->getType().getUnqualifiedType();
+  QualType LHSType = LHS.get()->getType().getUnqualifiedType(Context);
+  QualType RHSType = RHS.get()->getType().getUnqualifiedType(Context);
 
   // For conversion purposes, we ignore any atomic qualifier on the LHS.
   if (const AtomicType *AtomicLHS = LHSType->getAs<AtomicType>())
@@ -3471,7 +3471,7 @@ ExprResult Sema::BuildDeclarationNameExpr(
     //   [...] The expression is an lvalue if the entity is a [...] template
     //   parameter object.
     if (type->isRecordType()) {
-      type = type.getUnqualifiedType().withConst();
+      type = type.getUnqualifiedType(Context).withConst();
       valueKind = VK_LValue;
       break;
     }
@@ -3479,7 +3479,7 @@ ExprResult Sema::BuildDeclarationNameExpr(
     // For non-references, we need to strip qualifiers just in case
     // the template parameter was declared as 'const int' or whatever.
     valueKind = VK_PRValue;
-    type = type.getUnqualifiedType();
+    type = type.getUnqualifiedType(Context);
     break;
   }
 
@@ -7003,8 +7003,8 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
         // Construct a new arg type with address space of Param
         Qualifiers ArgPtQuals = ArgPtTy.getQualifiers();
         ArgPtQuals.setAddressSpace(ParamAS);
-        auto NewArgPtTy =
-            Context.getQualifiedType(ArgPtTy.getUnqualifiedType(), ArgPtQuals);
+        auto NewArgPtTy = Context.getQualifiedType(
+            ArgPtTy.getUnqualifiedType(Context), ArgPtQuals);
         auto NewArgTy =
             Context.getQualifiedType(Context.getPointerType(NewArgPtTy),
                                      ArgTy.getQualifiers());
@@ -8512,8 +8512,10 @@ static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
   lhQual.removeAddressSpace();
   rhQual.removeAddressSpace();
 
-  lhptee = S.Context.getQualifiedType(lhptee.getUnqualifiedType(), lhQual);
-  rhptee = S.Context.getQualifiedType(rhptee.getUnqualifiedType(), rhQual);
+  lhptee =
+      S.Context.getQualifiedType(lhptee.getUnqualifiedType(S.Context), lhQual);
+  rhptee =
+      S.Context.getQualifiedType(rhptee.getUnqualifiedType(S.Context), rhQual);
 
   QualType CompositeTy = S.Context.mergeTypes(
       lhptee, rhptee, /*OfBlockPointer=*/false, /*Unqualified=*/false,
@@ -8552,7 +8554,8 @@ static QualType checkConditionalPointerCompatibility(Sema &S, ExprResult &LHS,
       Qualifiers CompositeQuals = CompositeTy.getQualifiers();
       CompositeQuals.setAddressSpace(ResultAddrSpace);
       return S.Context
-          .getQualifiedType(CompositeTy.getUnqualifiedType(), CompositeQuals)
+          .getQualifiedType(CompositeTy.getUnqualifiedType(S.Context),
+                            CompositeQuals)
           .withCVRQualifiers(MergedCVRQual);
     }
     return CompositeTy.withCVRQualifiers(MergedCVRQual);
@@ -8676,9 +8679,9 @@ static QualType OpenCLArithmeticConversions(Sema &S, ExprResult &LHS,
   // For conversion purposes, we ignore any qualifiers.
   // For example, "const float" and "float" are equivalent.
   QualType LHSType =
-    S.Context.getCanonicalType(LHS.get()->getType()).getUnqualifiedType();
+      S.Context.getCanonicalType(LHS.get()->getType()).getUnqualifiedType();
   QualType RHSType =
-    S.Context.getCanonicalType(RHS.get()->getType()).getUnqualifiedType();
+      S.Context.getCanonicalType(RHS.get()->getType()).getUnqualifiedType();
 
   if (!LHSType->isIntegerType() && !LHSType->isRealFloatingType()) {
     S.Diag(QuestionLoc, diag::err_typecheck_cond_expect_int_float)
@@ -8735,7 +8738,7 @@ OpenCLConvertScalarsToVectors(Sema &S, ExprResult &LHS, ExprResult &RHS,
       != S.Context.getTypeSize(ResTy)) {
     // Since VectorTy is created internally, it does not pretty print
     // with an OpenCL name. Instead, we just print a description.
-    std::string EleTyName = ResTy.getUnqualifiedType().getAsString();
+    std::string EleTyName = ResTy.getUnqualifiedType(S.Context).getAsString();
     SmallString<64> Str;
     llvm::raw_svector_ostream OS(Str);
     OS << "(vector of " << NumElements << " '" << EleTyName << "' values)";
@@ -8965,8 +8968,8 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
   // FIXME: Type of conditional expression must be complete in C mode.
   if (LHSTy->isRecordType() &&
       Context.hasSameUnqualifiedType(LHSTy, RHSTy)) // C99 6.5.15p3
-    return Context.getCommonSugaredType(LHSTy.getUnqualifiedType(),
-                                        RHSTy.getUnqualifiedType());
+    return Context.getCommonSugaredType(LHSTy.getUnqualifiedType(Context),
+                                        RHSTy.getUnqualifiedType(Context));
 
   // C99 6.5.15p5: "If both operands have void type, the result has void type."
   // The following || allows only one side to be void (a GCC-ism).
@@ -9580,8 +9583,10 @@ static AssignConvertType checkBlockPointerTypesForAssignment(Sema &S,
   //  * unqualified types should be compatible.
   if (S.getLangOpts().OpenCL) {
     if (!S.Context.typesAreBlockPointerCompatible(
-            S.Context.getQualifiedType(LHSType.getUnqualifiedType(), LQuals),
-            S.Context.getQualifiedType(RHSType.getUnqualifiedType(), RQuals)))
+            S.Context.getQualifiedType(LHSType.getUnqualifiedType(S.Context),
+                                       LQuals),
+            S.Context.getQualifiedType(RHSType.getUnqualifiedType(S.Context),
+                                       RQuals)))
       return AssignConvertType::IncompatibleBlockPointer;
   } else if (!S.Context.typesAreBlockPointerCompatible(LHSType, RHSType))
     return AssignConvertType::IncompatibleBlockPointer;
@@ -10177,19 +10182,20 @@ AssignConvertType Sema::CheckSingleAssignmentConstraints(QualType LHSType,
       // cv-unqualified type of the left operand.
       QualType RHSType = RHS.get()->getType();
       if (Diagnose) {
-        RHS = PerformImplicitConversion(RHS.get(), LHSType.getUnqualifiedType(),
+        RHS = PerformImplicitConversion(RHS.get(),
+                                        LHSType.getUnqualifiedType(Context),
                                         AssignmentAction::Assigning);
       } else {
-        ImplicitConversionSequence ICS =
-            TryImplicitConversion(RHS.get(), LHSType.getUnqualifiedType(),
-                                  /*SuppressUserConversions=*/false,
-                                  AllowedExplicit::None,
-                                  /*InOverloadResolution=*/false,
-                                  /*CStyle=*/false,
-                                  /*AllowObjCWritebackConversion=*/false);
+        ImplicitConversionSequence ICS = TryImplicitConversion(
+            RHS.get(), LHSType.getUnqualifiedType(Context),
+            /*SuppressUserConversions=*/false, AllowedExplicit::None,
+            /*InOverloadResolution=*/false,
+            /*CStyle=*/false,
+            /*AllowObjCWritebackConversion=*/false);
         if (ICS.isFailure())
           return AssignConvertType::Incompatible;
-        RHS = PerformImplicitConversion(RHS.get(), LHSType.getUnqualifiedType(),
+        RHS = PerformImplicitConversion(RHS.get(),
+                                        LHSType.getUnqualifiedType(Context),
                                         ICS, AssignmentAction::Assigning);
       }
       if (RHS.isInvalid())
@@ -10244,7 +10250,7 @@ AssignConvertType Sema::CheckSingleAssignmentConstraints(QualType LHSType,
 
   // The constraints are expressed in terms of the atomic, qualified, or
   // unqualified type of the LHS.
-  QualType LHSTypeAfterConversion = LHSType.getAtomicUnqualifiedType();
+  QualType LHSTypeAfterConversion = LHSType.getAtomicUnqualifiedType(Context);
 
   // C99 6.5.16.1p1: the left operand is a pointer and the right is
   // a null pointer constant <C23>or its type is nullptr_t;</C23>.
@@ -10272,8 +10278,9 @@ AssignConvertType Sema::CheckSingleAssignmentConstraints(QualType LHSType,
       if (Kind != CK_NoOp && !getLangOpts().CPlusPlus &&
           !RHS.get()->getBeginLoc().isMacroID()) {
         QualType CanRHS =
-            RHS.get()->getType().getCanonicalType().getUnqualifiedType();
-        QualType CanLHS = LHSType.getCanonicalType().getUnqualifiedType();
+            RHS.get()->getType().getCanonicalType().getUnqualifiedType(Context);
+        QualType CanLHS =
+            LHSType.getCanonicalType().getUnqualifiedType(Context);
         if (CanRHS->isVoidPointerType() && CanLHS->isPointerType()) {
           Ret = checkPointerTypesForAssignment(*this, CanLHS, CanRHS,
                                                RHS.get()->getExprLoc());
@@ -10526,7 +10533,7 @@ static bool canConvertIntToOtherIntTy(Sema &S, ExprResult *Int,
   if (E->containsErrors() || E->isInstantiationDependent())
     return false;
 
-  QualType IntTy = Int->get()->getType().getUnqualifiedType();
+  QualType IntTy = Int->get()->getType().getUnqualifiedType(S.Context);
 
   // Reject cases where the value of the Int is unknown as that would
   // possibly cause truncation, but accept cases where the scalar can be
@@ -10567,7 +10574,7 @@ static bool canConvertIntTyToFloatTy(Sema &S, ExprResult *Int,
   if (Int->get()->containsErrors())
     return false;
 
-  QualType IntTy = Int->get()->getType().getUnqualifiedType();
+  QualType IntTy = Int->get()->getType().getUnqualifiedType(S.Context);
 
   // Determine if the integer constant can be expressed as a floating point
   // number of the appropriate type.
@@ -10611,8 +10618,8 @@ static bool canConvertIntTyToFloatTy(Sema &S, ExprResult *Int,
 /// type without causing truncation of Scalar.
 static bool tryGCCVectorConvertAndSplat(Sema &S, ExprResult *Scalar,
                                         ExprResult *Vector) {
-  QualType ScalarTy = Scalar->get()->getType().getUnqualifiedType();
-  QualType VectorTy = Vector->get()->getType().getUnqualifiedType();
+  QualType ScalarTy = Scalar->get()->getType().getUnqualifiedType(S.Context);
+  QualType VectorTy = Vector->get()->getType().getUnqualifiedType(S.Context);
   QualType VectorEltTy;
 
   if (const auto *VT = VectorTy->getAs<VectorType>()) {
@@ -10718,8 +10725,8 @@ QualType Sema::CheckVectorOperands(ExprResult &LHS, ExprResult &RHS,
 
   // For conversion purposes, we ignore any qualifiers.
   // For example, "const float" and "float" are equivalent.
-  QualType LHSType = LHS.get()->getType().getUnqualifiedType();
-  QualType RHSType = RHS.get()->getType().getUnqualifiedType();
+  QualType LHSType = LHS.get()->getType().getUnqualifiedType(Context);
+  QualType RHSType = RHS.get()->getType().getUnqualifiedType(Context);
 
   const VectorType *LHSVecType = LHSType->getAs<VectorType>();
   const VectorType *RHSVecType = RHSType->getAs<VectorType>();
@@ -10982,8 +10989,8 @@ QualType Sema::CheckSizelessVectorOperands(ExprResult &LHS, ExprResult &RHS,
   if (RHS.isInvalid())
     return QualType();
 
-  QualType LHSType = LHS.get()->getType().getUnqualifiedType();
-  QualType RHSType = RHS.get()->getType().getUnqualifiedType();
+  QualType LHSType = LHS.get()->getType().getUnqualifiedType(Context);
+  QualType RHSType = RHS.get()->getType().getUnqualifiedType(Context);
 
   const BuiltinType *LHSBuiltinTy = LHSType->getAs<BuiltinType>();
   const BuiltinType *RHSBuiltinTy = RHSType->getAs<BuiltinType>();
@@ -11876,9 +11883,9 @@ QualType Sema::CheckSubtractionOperands(ExprResult &LHS, ExprResult &RHS,
       if (!rpointee->isVoidType() && !rpointee->isFunctionType()) {
         CharUnits ElementSize = Context.getTypeSizeInChars(rpointee);
         if (ElementSize.isZero()) {
-          Diag(Loc,diag::warn_sub_ptr_zero_size_types)
-            << rpointee.getUnqualifiedType()
-            << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
+          Diag(Loc, diag::warn_sub_ptr_zero_size_types)
+              << rpointee.getUnqualifiedType(Context)
+              << LHS.get()->getSourceRange() << RHS.get()->getSourceRange();
         }
       }
 
@@ -12870,7 +12877,8 @@ void Sema::CheckPtrComparisonWithNullChar(ExprResult &E, ExprResult &NullE) {
                                             NullValue ? "NULL" : "(void *)0");
     } else if (const auto *CE = dyn_cast<CStyleCastExpr>(E.get())) {
         TypeSourceInfo *TI = CE->getTypeInfoAsWritten();
-        QualType T = Context.getCanonicalType(TI->getType()).getUnqualifiedType();
+        QualType T =
+            Context.getCanonicalType(TI->getType()).getUnqualifiedType();
         if (T == Context.CharTy)
           Diag(E.get()->getExprLoc(), diag::warn_pointer_compare)
               << NullValue
@@ -13058,8 +13066,8 @@ QualType Sema::CheckCompareOperands(ExprResult &LHS, ExprResult &RHS,
       RHSType->castAs<PointerType>()->getPointeeType().getCanonicalType();
 
     // C99 6.5.9p2 and C99 6.5.8p2
-    if (Context.typesAreCompatible(LCanPointeeTy.getUnqualifiedType(),
-                                   RCanPointeeTy.getUnqualifiedType())) {
+    if (Context.typesAreCompatible(LCanPointeeTy.getUnqualifiedType(Context),
+                                   RCanPointeeTy.getUnqualifiedType(Context))) {
       if (IsRelational) {
         // Pointers both need to point to complete or incomplete types
         if ((LCanPointeeTy->isIncompleteType() !=
@@ -13725,8 +13733,8 @@ QualType Sema::CheckMatrixElementwiseOperands(ExprResult &LHS, ExprResult &RHS,
 
   // For conversion purposes, we ignore any qualifiers.
   // For example, "const float" and "float" are equivalent.
-  QualType LHSType = LHS.get()->getType().getUnqualifiedType();
-  QualType RHSType = RHS.get()->getType().getUnqualifiedType();
+  QualType LHSType = LHS.get()->getType().getUnqualifiedType(Context);
+  QualType RHSType = RHS.get()->getType().getUnqualifiedType(Context);
 
   const MatrixType *LHSMatType = LHSType->getAs<MatrixType>();
   const MatrixType *RHSMatType = RHSType->getAs<MatrixType>();
@@ -13779,8 +13787,8 @@ QualType Sema::CheckMatrixMultiplyOperands(ExprResult &LHS, ExprResult &RHS,
 
     if (Context.hasSameType(LHSMatType, RHSMatType))
       return Context.getCommonSugaredType(
-          LHS.get()->getType().getUnqualifiedType(),
-          RHS.get()->getType().getUnqualifiedType());
+          LHS.get()->getType().getUnqualifiedType(Context),
+          RHS.get()->getType().getUnqualifiedType(Context));
 
     QualType LHSELTy = LHSMatType->getElementType(),
              RHSELTy = RHSMatType->getElementType();
@@ -14495,8 +14503,8 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
   if (getLangOpts().OpenCL &&
       !getOpenCLOptions().isAvailableOption("cl_khr_fp16", getLangOpts()) &&
       LHSType->isHalfType()) {
-    Diag(Loc, diag::err_opencl_half_load_store) << 1
-        << LHSType.getUnqualifiedType();
+    Diag(Loc, diag::err_opencl_half_load_store)
+        << 1 << LHSType.getUnqualifiedType(Context);
     return QualType();
   }
 
@@ -14609,7 +14617,8 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
   // non-atomic version of the type of the lvalue.
   // C++ 5.17p1: the type of the assignment expression is that of its left
   // operand.
-  return getLangOpts().CPlusPlus ? LHSType : LHSType.getAtomicUnqualifiedType();
+  return getLangOpts().CPlusPlus ? LHSType
+                                 : LHSType.getAtomicUnqualifiedType(Context);
 }
 
 // Scenarios to ignore if expression E is:
@@ -14797,7 +14806,7 @@ static QualType CheckIncrementDecrementOperand(Sema &S, Expr *Op,
     return ResType;
   } else {
     VK = VK_PRValue;
-    return ResType.getUnqualifiedType();
+    return ResType.getUnqualifiedType(S.Context);
   }
 }
 
@@ -16135,12 +16144,12 @@ ExprResult Sema::BuildBinOp(Scope *S, SourceLocation OpLoc,
       // assignment, but is not an lvalue.
       return CompoundAssignOperator::Create(
           Context, LHSExpr, RHSExpr, Opc,
-          LHSExpr->getType().getUnqualifiedType(), VK_PRValue, OK_Ordinary,
-          OpLoc, CurFPFeatureOverrides());
+          LHSExpr->getType().getUnqualifiedType(Context), VK_PRValue,
+          OK_Ordinary, OpLoc, CurFPFeatureOverrides());
     QualType ResultType;
     switch (Opc) {
     case BO_Assign:
-      ResultType = LHSExpr->getType().getUnqualifiedType();
+      ResultType = LHSExpr->getType().getUnqualifiedType(Context);
       break;
     case BO_LT:
     case BO_GT:
@@ -16622,7 +16631,7 @@ ExprResult Sema::ActOnStmtExprResult(ExprResult ER) {
   // FIXME: Provide a better location for the initialization.
   return PerformCopyInitialization(
       InitializedEntity::InitializeStmtExprResult(
-          E->getBeginLoc(), E->getType().getAtomicUnqualifiedType()),
+          E->getBeginLoc(), E->getType().getAtomicUnqualifiedType(Context)),
       SourceLocation(), E);
 }
 
@@ -17591,8 +17600,8 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     CheckInferredResultType = DstType->isObjCObjectPointerType() &&
       SrcType->isObjCObjectPointerType();
     if (CheckInferredResultType) {
-      SrcType = SrcType.getUnqualifiedType();
-      DstType = DstType.getUnqualifiedType();
+      SrcType = SrcType.getUnqualifiedType(Context);
+      DstType = DstType.getUnqualifiedType(Context);
     } else {
       ConvHints.tryToFixConversion(SrcExpr, SrcType, DstType, *this);
     }
@@ -19507,7 +19516,7 @@ static bool captureInCapturedRegion(
     // Using an LValue reference type is consistent with Lambdas (see below).
     if (S.OpenMP().isOpenMPCapturedDecl(Var)) {
       bool HasConst = DeclRefType.isConstQualified();
-      DeclRefType = DeclRefType.getUnqualifiedType();
+      DeclRefType = DeclRefType.getUnqualifiedType(S.Context);
       // Don't lose diagnostics about assignments to const.
       if (HasConst)
         DeclRefType.addConst();
@@ -19965,7 +19974,7 @@ bool Sema::tryCaptureVariable(
               (IsGlobal && !IsGlobalCap)) {
             Nested = !IsTargetCap;
             bool HasConst = DeclRefType.isConstQualified();
-            DeclRefType = DeclRefType.getUnqualifiedType();
+            DeclRefType = DeclRefType.getUnqualifiedType(Context);
             // Don't lose diagnostics about assignments to const.
             if (HasConst)
               DeclRefType.addConst();

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -1635,11 +1635,11 @@ Sema::BuildCXXTypeConstructExpr(TypeSourceInfo *TInfo,
   if (Ty->isVoidType()) {
     if (Exprs.empty())
       return new (Context) CXXScalarValueInitExpr(
-          Ty.getUnqualifiedType(), TInfo, Kind.getRange().getEnd());
+          Ty.getUnqualifiedType(Context), TInfo, Kind.getRange().getEnd());
     if (ListInitialization &&
         cast<InitListExpr>(Exprs[0])->getNumInits() == 0) {
       return CXXFunctionalCastExpr::Create(
-          Context, Ty.getUnqualifiedType(), VK_PRValue, TInfo, CK_ToVoid,
+          Context, Ty.getUnqualifiedType(Context), VK_PRValue, TInfo, CK_ToVoid,
           Exprs[0], /*Path=*/nullptr, CurFPFeatureOverrides(),
           Exprs[0]->getBeginLoc(), Exprs[0]->getEndLoc());
     }
@@ -1768,7 +1768,7 @@ namespace {
                        SourceLocation Loc)
         : Found(Found), FD(dyn_cast<FunctionDecl>(Found->getUnderlyingDecl())),
           Destroying(false),
-          IDP({AllocType, TypeAwareAllocationMode::No,
+          IDP({S.Context, AllocType, TypeAwareAllocationMode::No,
                AlignedAllocationMode::No, SizedDeallocationMode::No}),
           CUDAPref(SemaCUDA::CFP_Native) {
       // A function template declaration is only a usual deallocation function
@@ -2014,7 +2014,7 @@ static bool doesUsualArrayDeleteWantSize(Sema &S, SourceLocation loc,
   //   If the deallocation functions have class scope, the one without a
   //   parameter of type std::size_t is selected.
   ImplicitDeallocationParameters IDP = {
-      allocType, PassType,
+      S.Context, allocType, PassType,
       alignedAllocationModeFromBool(hasNewExtendedAlignment(S, allocType)),
       SizedDeallocationMode::No};
   auto Best = resolveDeallocationOverload(S, ops, IDP, loc);
@@ -2436,7 +2436,7 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
       AllocType->isDependentType() ? 0 : Context.getTypeAlign(AllocType);
   unsigned NewAlignment = Context.getTargetInfo().getNewAlign();
   ImplicitAllocationParameters IAP = {
-      AllocType, ShouldUseTypeAwareOperatorNewOrDelete(),
+      Context, AllocType, ShouldUseTypeAwareOperatorNewOrDelete(),
       alignedAllocationModeFromBool(getLangOpts().AlignedAllocation &&
                                     Alignment > NewAlignment)};
 
@@ -2700,7 +2700,7 @@ bool Sema::CheckAllocatedType(QualType AllocType, SourceLocation Loc,
   else if (AllocType.getAddressSpace() != LangAS::Default &&
            !getLangOpts().OpenCLCPlusPlus)
     return Diag(Loc, diag::err_address_space_qualified_new)
-           << AllocType.getUnqualifiedType()
+           << AllocType.getUnqualifiedType(Context)
            << Qualifiers::getAddrSpaceAsString(AllocType.getAddressSpace());
 
   else if (getLangOpts().ObjCAutoRefCount) {
@@ -3260,7 +3260,7 @@ bool Sema::FindAllocationFunctions(
     // with a size_t where possible (which it always is in this case).
     llvm::SmallVector<UsualDeallocFnInfo, 4> BestDeallocFns;
     ImplicitDeallocationParameters IDP = {
-        AllocElemType, OriginalTypeAwareState,
+        Context, AllocElemType, OriginalTypeAwareState,
         alignedAllocationModeFromBool(
             hasNewExtendedAlignment(*this, AllocElemType)),
         sizedDeallocationModeFromBool(FoundGlobalDelete)};
@@ -3329,8 +3329,8 @@ bool Sema::FindAllocationFunctions(
       bool IsSizedDelete = isSizedDeallocation(Info.IDP.PassSize);
       if (IsSizedDelete && !FoundGlobalDelete) {
         ImplicitDeallocationParameters SizeTestingIDP = {
-            AllocElemType, Info.IDP.PassTypeIdentity, Info.IDP.PassAlignment,
-            SizedDeallocationMode::No};
+            Context, AllocElemType, Info.IDP.PassTypeIdentity,
+            Info.IDP.PassAlignment, SizedDeallocationMode::No};
         auto NonSizedDelete = resolveDeallocationOverload(
             *this, FoundDelete, SizeTestingIDP, StartLoc);
         if (NonSizedDelete &&
@@ -3667,7 +3667,7 @@ FunctionDecl *Sema::FindDeallocationFunctionForDestructor(
   FunctionDecl *OperatorDelete = nullptr;
   CanQualType DeallocType = Context.getCanonicalTagType(RD);
   ImplicitDeallocationParameters IDP = {
-      DeallocType, ShouldUseTypeAwareOperatorNewOrDelete(),
+      Context, DeallocType, ShouldUseTypeAwareOperatorNewOrDelete(),
       AlignedAllocationMode::No, SizedDeallocationMode::No};
 
   if (!LookForGlobal) {
@@ -4100,7 +4100,7 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
         !getLangOpts().OpenCLCPlusPlus)
       return Diag(Ex.get()->getBeginLoc(),
                   diag::err_address_space_qualified_delete)
-             << Pointee.getUnqualifiedType()
+             << Pointee.getUnqualifiedType(Context)
              << Qualifiers::getAddrSpaceAsString(Pointee.getAddressSpace());
 
     CXXRecordDecl *PointeeRD = nullptr;
@@ -4142,7 +4142,7 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
 
     if (PointeeRD) {
       ImplicitDeallocationParameters IDP = {
-          Pointee, ShouldUseTypeAwareOperatorNewOrDelete(),
+          Context, Pointee, ShouldUseTypeAwareOperatorNewOrDelete(),
           AlignedAllocationMode::No, SizedDeallocationMode::No};
       if (!UseGlobal &&
           FindDeallocationFunction(StartLoc, PointeeRD, DeleteName,
@@ -4198,7 +4198,7 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
 
       // Look for a global declaration.
       ImplicitDeallocationParameters IDP = {
-          Pointee, ShouldUseTypeAwareOperatorNewOrDelete(),
+          Context, Pointee, ShouldUseTypeAwareOperatorNewOrDelete(),
           alignedAllocationModeFromBool(Overaligned),
           sizedDeallocationModeFromBool(CanProvideSize)};
       OperatorDelete = FindUsualDeallocationFunction(StartLoc, IDP, DeleteName);
@@ -4247,7 +4247,7 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
         // for access and ambiguity.
         Qs.removeCVRQualifiers();
         QualType Unqual = Context.getPointerType(
-            Context.getQualifiedType(Pointee.getUnqualifiedType(), Qs));
+            Context.getQualifiedType(Pointee.getUnqualifiedType(Context), Qs));
         Ex = ImpCastExprToType(Ex.get(), Unqual, CK_NoOp);
       }
       Ex = PerformImplicitConversion(Ex.get(), ParamType,
@@ -4845,7 +4845,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
   switch (SCS.First) {
   case ICK_Identity:
     if (const AtomicType *FromAtomic = FromType->getAs<AtomicType>()) {
-      FromType = FromAtomic->getValueType().getUnqualifiedType();
+      FromType = FromAtomic->getValueType().getUnqualifiedType(Context);
       From = ImplicitCastExpr::Create(Context, FromType, CK_AtomicToNonAtomic,
                                       From, /*BasePath=*/nullptr, VK_PRValue,
                                       FPOptionsOverride());
@@ -5258,7 +5258,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
            "Invalid cast");
     CastKind Kind =
         AddrSpaceL != AddrSpaceR ? CK_AddressSpaceConversion : CK_BitCast;
-    From = ImpCastExprToType(From, ToType.getUnqualifiedType(), Kind,
+    From = ImpCastExprToType(From, ToType.getUnqualifiedType(Context), Kind,
                              VK_PRValue, /*BasePath=*/nullptr, CCK)
                .get();
     break;
@@ -5850,8 +5850,8 @@ QualType Sema::CheckVectorConditionalTypes(ExprResult &Cond, ExprResult &LHS,
       return {};
   } else {
     // Both are scalar.
-    LHSType = LHSType.getUnqualifiedType();
-    RHSType = RHSType.getUnqualifiedType();
+    LHSType = LHSType.getUnqualifiedType(Context);
+    RHSType = RHSType.getUnqualifiedType(Context);
     QualType ResultElementTy =
         Context.hasSameType(LHSType, RHSType)
             ? Context.getCommonSugaredType(LHSType, RHSType)

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -1285,7 +1285,7 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
   if (const auto *ATy = BaseType->getAs<AtomicType>()) {
     S.DiagRuntimeBehavior(OpLoc, BaseExpr.get(),
                           S.PDiag(diag::warn_atomic_member_access));
-    BaseType = ATy->getValueType().getUnqualifiedType();
+    BaseType = ATy->getValueType().getUnqualifiedType(S.Context);
     BaseExpr = ImplicitCastExpr::Create(
         S.Context, IsArrow ? S.Context.getPointerType(BaseType) : BaseType,
         CK_AtomicToNonAtomic, BaseExpr.get(), nullptr,

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -585,8 +585,9 @@ static CXXRecordDecl *createHostLayoutStruct(Sema &S,
       if (BaseDecl) {
         TypeSourceInfo *TSI =
             AST.getTrivialTypeSourceInfo(AST.getCanonicalTagType(BaseDecl));
-        Base = CXXBaseSpecifier(SourceRange(), false, StructDecl->isClass(),
-                                AS_none, TSI, SourceLocation());
+        Base =
+            CXXBaseSpecifier(AST, SourceRange(), false, StructDecl->isClass(),
+                             AS_none, TSI, SourceLocation());
       }
     }
     if (BaseDecl) {
@@ -4639,20 +4640,20 @@ bool SemaHLSL::CheckBuiltinFunctionCall(unsigned BuiltinID, CallExpr *TheCall) {
   return false;
 }
 
-static void BuildFlattenedTypeList(QualType BaseTy,
+static void BuildFlattenedTypeList(const ASTContext &Ctx, QualType BaseTy,
                                    llvm::SmallVectorImpl<QualType> &List) {
   llvm::SmallVector<QualType, 16> WorkList;
   WorkList.push_back(BaseTy);
   while (!WorkList.empty()) {
     QualType T = WorkList.pop_back_val();
-    T = T.getCanonicalType().getUnqualifiedType();
+    T = T.getCanonicalType().getUnqualifiedType(Ctx);
     if (const auto *AT = dyn_cast<ConstantArrayType>(T)) {
       llvm::SmallVector<QualType, 16> ElementFields;
       // Generally I've avoided recursion in this algorithm, but arrays of
       // structs could be time-consuming to flatten and churn through on the
       // work list. Hopefully nesting arrays of structs containing arrays
       // of structs too many levels deep is unlikely.
-      BuildFlattenedTypeList(AT->getElementType(), ElementFields);
+      BuildFlattenedTypeList(Ctx, AT->getElementType(), ElementFields);
       // Repeat the element's field list n times.
       for (uint64_t Ct = 0; Ct < AT->getZExtSize(); ++Ct)
         llvm::append_range(List, ElementFields);
@@ -4757,17 +4758,17 @@ bool SemaHLSL::IsScalarizedLayoutCompatible(QualType T1, QualType T2) const {
   if (T1.isNull() || T2.isNull())
     return false;
 
-  T1 = T1.getCanonicalType().getUnqualifiedType();
-  T2 = T2.getCanonicalType().getUnqualifiedType();
+  T1 = T1.getCanonicalType().getUnqualifiedType(SemaRef.getASTContext());
+  T2 = T2.getCanonicalType().getUnqualifiedType(SemaRef.getASTContext());
 
   // If both types are the same canonical type, they're obviously compatible.
   if (SemaRef.getASTContext().hasSameType(T1, T2))
     return true;
 
   llvm::SmallVector<QualType, 16> T1Types;
-  BuildFlattenedTypeList(T1, T1Types);
+  BuildFlattenedTypeList(SemaRef.getASTContext(), T1, T1Types);
   llvm::SmallVector<QualType, 16> T2Types;
-  BuildFlattenedTypeList(T2, T2Types);
+  BuildFlattenedTypeList(SemaRef.getASTContext(), T2, T2Types);
 
   // Check the flattened type list
   return llvm::equal(T1Types, T2Types,
@@ -4902,7 +4903,7 @@ bool SemaHLSL::CanPerformAggregateSplatCast(Expr *Src, QualType DestTy) {
     SrcTy = SrcMatTy->getElementType();
 
   llvm::SmallVector<QualType> DestTypes;
-  BuildFlattenedTypeList(DestTy, DestTypes);
+  BuildFlattenedTypeList(SemaRef.getASTContext(), DestTy, DestTypes);
 
   for (unsigned I = 0, Size = DestTypes.size(); I < Size; ++I) {
     if (DestTypes[I]->isUnionType())
@@ -4931,9 +4932,9 @@ bool SemaHLSL::CanPerformElementwiseCast(Expr *Src, QualType DestTy) {
     return false;
 
   llvm::SmallVector<QualType> DestTypes;
-  BuildFlattenedTypeList(DestTy, DestTypes);
+  BuildFlattenedTypeList(SemaRef.getASTContext(), DestTy, DestTypes);
   llvm::SmallVector<QualType> SrcTypes;
-  BuildFlattenedTypeList(SrcTy, SrcTypes);
+  BuildFlattenedTypeList(SemaRef.getASTContext(), SrcTy, SrcTypes);
 
   // Usually the size of SrcTypes must be greater than or equal to the size of
   // DestTypes.
@@ -6035,7 +6036,7 @@ public:
       const IncompleteArrayType *IAT = Ctx.getAsIncompleteArrayType(InitTy);
       InitTy = IAT->getElementType();
     }
-    BuildFlattenedTypeList(InitTy, DestTypes);
+    BuildFlattenedTypeList(SemaRef.getASTContext(), InitTy, DestTypes);
     DstIt = DestTypes.begin();
   }
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -4878,7 +4878,7 @@ ResolveOverloadedFunctionForReferenceBinding(Sema &S,
       Sequence.AddAddressOverloadResolutionStep(Fn, Found,
                                                 HadMultipleCandidates);
       SourceType = Fn->getType();
-      UnqualifiedSourceType = SourceType.getUnqualifiedType();
+      UnqualifiedSourceType = SourceType.getUnqualifiedType(S.Context);
     } else if (!UnqualifiedTargetType->isRecordType()) {
       Sequence.SetFailed(InitializationSequence::FK_AddressOfOverloadFailed);
       return true;
@@ -5269,9 +5269,9 @@ static OverloadingResult TryRefInitWithConversionFunction(
     InitializationSequence &Sequence) {
   QualType DestType = Entity.getType();
   QualType cv1T1 = DestType->castAs<ReferenceType>()->getPointeeType();
-  QualType T1 = cv1T1.getUnqualifiedType();
+  QualType T1 = cv1T1.getUnqualifiedType(S.Context);
   QualType cv2T2 = Initializer->getType();
-  QualType T2 = cv2T2.getUnqualifiedType();
+  QualType T2 = cv2T2.getUnqualifiedType(S.Context);
 
   assert(!S.CompareReferenceRelationship(Initializer->getBeginLoc(), T1, T2) &&
          "Must have incompatible references when binding via conversion");
@@ -5675,7 +5675,7 @@ static void TryReferenceInitializationCore(Sema &S,
       Qualifiers T2BaseQuals =
           T2ForQualConv.getQualifiers().withoutObjCLifetime();
       T2ForQualConv = S.Context.getQualifiedType(
-          T2ForQualConv.getUnqualifiedType(), T2BaseQuals);
+          T2ForQualConv.getUnqualifiedType(S.Context), T2BaseQuals);
     }
     QualType cv1T4 = S.Context.getQualifiedType(T2ForQualConv, T1QualsIgnoreAS);
     if (T1QualsIgnoreAS != T2QualsIgnoreAS)
@@ -6316,7 +6316,7 @@ static void TryUserDefinedConversion(Sema &S,
     // subsumed by the initialization. Per DR5, the created temporary is of the
     // cv-unqualified type of the destination.
     Sequence.AddUserConversionStep(Function, Best->FoundDecl,
-                                   DestType.getUnqualifiedType(),
+                                   DestType.getUnqualifiedType(S.Context),
                                    HadMultipleCandidates);
 
     // C++14 and before:
@@ -8695,7 +8695,7 @@ ExprResult InitializationSequence::Perform(Sema &S,
         auto InvalidType = [&] {
           S.Diag(Record->getLocation(),
                  diag::err_std_initializer_list_malformed)
-              << Step->Type.getUnqualifiedType();
+              << Step->Type.getUnqualifiedType(S.Context);
           return ExprError();
         };
 

--- a/clang/lib/Sema/SemaLambda.cpp
+++ b/clang/lib/Sema/SemaLambda.cpp
@@ -436,10 +436,11 @@ bool Sema::DiagnoseInvalidExplicitObjectParameterInLambda(
     return false;
 
   ParmVarDecl *Param = Method->getParamDecl(0);
-  QualType ExplicitObjectParameterType = Param->getType()
-                                             .getNonReferenceType()
-                                             .getUnqualifiedType()
-                                             .getDesugaredType(getASTContext());
+  QualType ExplicitObjectParameterType =
+      Param->getType()
+          .getNonReferenceType()
+          .getUnqualifiedType(getASTContext())
+          .getDesugaredType(getASTContext());
   CanQualType LambdaType = getASTContext().getCanonicalTagType(RD);
   if (LambdaType == ExplicitObjectParameterType)
     return false;
@@ -801,7 +802,7 @@ void Sema::deduceClosureReturnType(CapturingScopeInfo &CSI) {
     const Expr *RetE = RS->getRetValue();
 
     QualType ReturnType =
-        (RetE ? RetE->getType() : Context.VoidTy).getUnqualifiedType();
+        (RetE ? RetE->getType() : Context.VoidTy).getUnqualifiedType(Context);
     if (Context.getCanonicalFunctionResultType(ReturnType) ==
           Context.getCanonicalFunctionResultType(CSI.ReturnType)) {
       // Use the return type with the strictest possible nullability annotation.

--- a/clang/lib/Sema/SemaObjC.cpp
+++ b/clang/lib/Sema/SemaObjC.cpp
@@ -574,7 +574,7 @@ static QualType applyObjCTypeArgs(Sema &S, SourceLocation loc, QualType type,
     }
 
     // Remove qualifiers even if they're non-local.
-    typeArg = typeArg.getUnqualifiedType();
+    typeArg = typeArg.getUnqualifiedType(S.Context);
 
     finalTypeArgs.push_back(typeArg);
 
@@ -1352,10 +1352,10 @@ bool SemaObjC::isObjCWritebackConversion(QualType FromType, QualType ToType,
   // Remove qualifiers from the pointee type we're converting from; they
   // aren't used in the compatibility check belong, and we'll be adding back
   // qualifiers (with __autoreleasing) if the compatibility check succeeds.
-  FromPointee = FromPointee.getUnqualifiedType();
+  FromPointee = FromPointee.getUnqualifiedType(Context);
 
   // The unqualified form of the pointee types must be compatible.
-  ToPointee = ToPointee.getUnqualifiedType();
+  ToPointee = ToPointee.getUnqualifiedType(Context);
   bool IncompatibleObjC;
   if (Context.typesAreCompatible(FromPointee, ToPointee))
     FromPointee = ToPointee;

--- a/clang/lib/Sema/SemaObjCProperty.cpp
+++ b/clang/lib/Sema/SemaObjCProperty.cpp
@@ -1667,7 +1667,8 @@ bool SemaObjC::DiagnosePropertyAccessorMismatch(ObjCPropertyDecl *property,
     return false;
   QualType GetterType = GetterMethod->getReturnType().getNonReferenceType();
   QualType PropertyRValueType =
-      property->getType().getNonReferenceType().getAtomicUnqualifiedType();
+      property->getType().getNonReferenceType().getAtomicUnqualifiedType(
+          Context);
   bool compat = Context.hasSameType(PropertyRValueType, GetterType);
   if (!compat) {
     const ObjCObjectPointerType *propertyObjCPtr = nullptr;
@@ -2426,7 +2427,7 @@ void SemaObjC::ProcessPropertyDecl(ObjCPropertyDecl *property) {
 
     // The getter returns the declared property type with all qualifiers
     // removed.
-    QualType resultTy = property->getType().getAtomicUnqualifiedType();
+    QualType resultTy = property->getType().getAtomicUnqualifiedType(Context);
 
     // If the property is null_resettable, the getter returns nonnull.
     if (property->getPropertyAttributes() &
@@ -2502,8 +2503,9 @@ void SemaObjC::ProcessPropertyDecl(ObjCPropertyDecl *property) {
               : ObjCImplementationControl::Required);
 
       // Remove all qualifiers from the setter's parameter type.
-      QualType paramTy =
-          property->getType().getUnqualifiedType().getAtomicUnqualifiedType();
+      QualType paramTy = property->getType()
+                             .getUnqualifiedType(Context)
+                             .getAtomicUnqualifiedType(Context);
 
       // If the property is null_resettable, the setter accepts a
       // nullable value.

--- a/clang/lib/Sema/SemaOpenACC.cpp
+++ b/clang/lib/Sema/SemaOpenACC.cpp
@@ -509,7 +509,7 @@ bool SemaOpenACC::CheckVarIsPointerType(OpenACCClauseKind ClauseKind,
   }
 
   QualType Ty = VarExpr->getType();
-  Ty = Ty.getNonReferenceType().getUnqualifiedType();
+  Ty = Ty.getNonReferenceType().getUnqualifiedType(getASTContext());
 
   // Nothing we can do if this is a dependent type.
   if (Ty->isDependentType())
@@ -643,7 +643,7 @@ ExprResult CheckVarType(SemaOpenACC &S, OpenACCClauseKind CK, Expr *VarExpr,
   if (InnerTy.isNull() || InnerTy->isDependentType())
     return VarExpr;
 
-  InnerTy = InnerTy.getUnqualifiedType();
+  InnerTy = InnerTy.getUnqualifiedType(S.getASTContext());
   if (auto *RefTy = InnerTy->getAs<ReferenceType>())
     InnerTy = RefTy->getPointeeType();
 
@@ -2778,8 +2778,8 @@ OpenACCPrivateRecipe SemaOpenACC::CreatePrivateInitRecipe(const Expr *VarExpr) {
   if (!VarExpr || VarExpr->getType()->isDependentType())
     return OpenACCPrivateRecipe::Empty();
 
-  QualType VarTy =
-      VarExpr->getType().getNonReferenceType().getUnqualifiedType();
+  QualType VarTy = VarExpr->getType().getNonReferenceType().getUnqualifiedType(
+      getASTContext());
 
   // Array sections are special, and we have to treat them that way.
   if (const auto *ASE =
@@ -2814,8 +2814,8 @@ SemaOpenACC::CreateFirstPrivateInitRecipe(const Expr *VarExpr) {
   if (!VarExpr || VarExpr->getType()->isDependentType())
     return OpenACCFirstPrivateRecipe::Empty();
 
-  QualType VarTy =
-      VarExpr->getType().getNonReferenceType().getUnqualifiedType();
+  QualType VarTy = VarExpr->getType().getNonReferenceType().getUnqualifiedType(
+      getASTContext());
 
   // Array sections are special, and we have to treat them that way.
   if (const auto *ASE =
@@ -2916,8 +2916,8 @@ OpenACCReductionRecipeWithStorage SemaOpenACC::CreateReductionInitRecipe(
   if (!VarExpr || VarExpr->getType()->isDependentType())
     return OpenACCReductionRecipeWithStorage::Empty();
 
-  QualType VarTy =
-      VarExpr->getType().getNonReferenceType().getUnqualifiedType();
+  QualType VarTy = VarExpr->getType().getNonReferenceType().getUnqualifiedType(
+      getASTContext());
 
   // Array sections are special, and we have to treat them that way.
   if (const auto *ASE =

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -160,7 +160,8 @@ bool SemaOpenCL::checkBuiltinNDRangeAndBlock(CallExpr *TheCall) {
 
   // First argument is an ndrange_t type.
   Expr *NDRangeArg = TheCall->getArg(0);
-  if (NDRangeArg->getType().getUnqualifiedType().getAsString() != "ndrange_t") {
+  if (NDRangeArg->getType().getUnqualifiedType(getASTContext()).getAsString() !=
+      "ndrange_t") {
     Diag(NDRangeArg->getBeginLoc(), diag::err_opencl_builtin_expected_type)
         << TheCall->getDirectCallee() << "'ndrange_t'";
     return true;
@@ -268,7 +269,8 @@ bool SemaOpenCL::checkBuiltinEnqueueKernel(CallExpr *TheCall) {
   }
 
   // Third argument is always an ndrange_t type.
-  if (Arg2->getType().getUnqualifiedType().getAsString() != "ndrange_t") {
+  if (Arg2->getType().getUnqualifiedType(Context).getAsString() !=
+      "ndrange_t") {
     Diag(TheCall->getArg(2)->getBeginLoc(),
          diag::err_opencl_builtin_expected_type)
         << TheCall->getDirectCallee() << "'ndrange_t'";
@@ -570,8 +572,8 @@ bool SemaOpenCL::checkBuiltinToAddr(unsigned BuiltinID, CallExpr *Call) {
   default:
     llvm_unreachable("Invalid builtin function");
   }
-  Call->setType(getASTContext().getPointerType(
-      getASTContext().getQualifiedType(RT.getUnqualifiedType(), Qual)));
+  Call->setType(getASTContext().getPointerType(getASTContext().getQualifiedType(
+      RT.getUnqualifiedType(getASTContext()), Qual)));
 
   return false;
 }

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -2983,8 +2983,8 @@ void SemaOpenMP::EndOpenMPDSABlock(Stmt *CurDirective) {
       // variable is not added to IdResolver, so the code in the OpenMP
       // region uses original variable for proper diagnostics.
       VarDecl *VDPrivate = buildVarDecl(
-          SemaRef, DE->getExprLoc(), Type.getUnqualifiedType(), VD->getName(),
-          VD->hasAttrs() ? &VD->getAttrs() : nullptr, DRE);
+          SemaRef, DE->getExprLoc(), Type.getUnqualifiedType(SemaRef.Context),
+          VD->getName(), VD->hasAttrs() ? &VD->getAttrs() : nullptr, DRE);
       SemaRef.ActOnUninitializedDecl(VDPrivate);
       if (VDPrivate->isInvalidDecl()) {
         PrivateCopies.push_back(nullptr);
@@ -7046,7 +7046,7 @@ SemaOpenMP::DeclGroupPtrTy SemaOpenMP::ActOnOpenMPDeclareSimdDirective(
           }
           QualType QTy = PVD->getType()
                              .getNonReferenceType()
-                             .getUnqualifiedType()
+                             .getUnqualifiedType(getASTContext())
                              .getCanonicalType();
           const Type *Ty = QTy.getTypePtrOrNull();
           if (!Ty || (!Ty->isArrayType() && !Ty->isPointerType())) {
@@ -7689,9 +7689,10 @@ SemaOpenMP::checkOpenMPDeclareVariantFunction(SemaOpenMP::DeclGroupPtrTy DG,
       FnPtrType = Context.getPointerType(AdjustedFnType);
     }
     QualType VarianPtrType = Context.getPointerType(VariantRef->getType());
-    if (VarianPtrType.getUnqualifiedType() != FnPtrType.getUnqualifiedType()) {
+    if (VarianPtrType.getUnqualifiedType(Context) !=
+        FnPtrType.getUnqualifiedType(Context)) {
       ImplicitConversionSequence ICS = SemaRef.TryImplicitConversion(
-          VariantRef, FnPtrType.getUnqualifiedType(),
+          VariantRef, FnPtrType.getUnqualifiedType(Context),
           /*SuppressUserConversions=*/false, Sema::AllowedExplicit::None,
           /*InOverloadResolution=*/false,
           /*CStyle=*/false,
@@ -7705,7 +7706,7 @@ SemaOpenMP::checkOpenMPDeclareVariantFunction(SemaOpenMP::DeclGroupPtrTy DG,
         return std::nullopt;
       }
       VariantRefCast = SemaRef.PerformImplicitConversion(
-          VariantRef, FnPtrType.getUnqualifiedType(),
+          VariantRef, FnPtrType.getUnqualifiedType(Context),
           AssignmentAction::Converting);
       if (!VariantRefCast.isUsable())
         return std::nullopt;
@@ -18947,7 +18948,8 @@ static bool isValidInteropVariable(Sema &SemaRef, Expr *InteropVarExpr,
     return false;
   }
 
-  QualType VarType = InteropVarExpr->getType().getUnqualifiedType();
+  QualType VarType =
+      InteropVarExpr->getType().getUnqualifiedType(SemaRef.Context);
   if (!SemaRef.Context.hasSameType(InteropType, VarType)) {
     SemaRef.Diag(VarLoc, diag::err_omp_interop_variable_wrong_type);
     return false;
@@ -19469,7 +19471,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPPrivateClause(ArrayRef<Expr *> VarList,
     // the new private variable in CodeGen. This new variable is not added to
     // IdResolver, so the code in the OpenMP region uses original variable for
     // proper diagnostics.
-    Type = Type.getUnqualifiedType();
+    Type = Type.getUnqualifiedType(SemaRef.Context);
     VarDecl *VDPrivate =
         buildVarDecl(SemaRef, ELoc, Type, D->getName(),
                      D->hasAttrs() ? &D->getAttrs() : nullptr,
@@ -19478,7 +19480,8 @@ OMPClause *SemaOpenMP::ActOnOpenMPPrivateClause(ArrayRef<Expr *> VarList,
     if (VDPrivate->isInvalidDecl())
       continue;
     DeclRefExpr *VDPrivateRefExpr = buildDeclRefExpr(
-        SemaRef, VDPrivate, RefExpr->getType().getUnqualifiedType(), ELoc);
+        SemaRef, VDPrivate,
+        RefExpr->getType().getUnqualifiedType(SemaRef.Context), ELoc);
 
     DeclRefExpr *Ref = nullptr;
     if (!VD && !SemaRef.CurContext->isDependentContext()) {
@@ -19710,7 +19713,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPFirstprivateClause(ArrayRef<Expr *> VarList,
       continue;
     }
 
-    Type = Type.getUnqualifiedType();
+    Type = Type.getUnqualifiedType(SemaRef.Context);
     VarDecl *VDPrivate =
         buildVarDecl(SemaRef, ELoc, Type, D->getName(),
                      D->hasAttrs() ? &D->getAttrs() : nullptr,
@@ -19728,7 +19731,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPFirstprivateClause(ArrayRef<Expr *> VarList,
           buildVarDecl(SemaRef, RefExpr->getExprLoc(), ElemType, D->getName());
       VDInitRefExpr = buildDeclRefExpr(SemaRef, VDInit, ElemType, ELoc);
       Expr *Init = SemaRef.DefaultLvalueConversion(VDInitRefExpr).get();
-      ElemType = ElemType.getUnqualifiedType();
+      ElemType = ElemType.getUnqualifiedType(SemaRef.Context);
       VarDecl *VDInitTemp = buildVarDecl(SemaRef, RefExpr->getExprLoc(),
                                          ElemType, ".firstprivate.temp");
       InitializedEntity Entity =
@@ -19760,9 +19763,10 @@ OMPClause *SemaOpenMP::ActOnOpenMPFirstprivateClause(ArrayRef<Expr *> VarList,
       continue;
     }
     SemaRef.CurContext->addDecl(VDPrivate);
-    DeclRefExpr *VDPrivateRefExpr = buildDeclRefExpr(
-        SemaRef, VDPrivate, RefExpr->getType().getUnqualifiedType(),
-        RefExpr->getExprLoc());
+    DeclRefExpr *VDPrivateRefExpr =
+        buildDeclRefExpr(SemaRef, VDPrivate,
+                         RefExpr->getType().getUnqualifiedType(SemaRef.Context),
+                         RefExpr->getExprLoc());
     DeclRefExpr *Ref = nullptr;
     if (!VD && !SemaRef.CurContext->isDependentContext()) {
       if (TopDVar.CKind == OMPC_lastprivate) {
@@ -19918,11 +19922,11 @@ OMPClause *SemaOpenMP::ActOnOpenMPLastprivateClause(
     //  lastprivate clause requires an accessible, unambiguous copy assignment
     //  operator for the class type.
     Type = getASTContext().getBaseElementType(Type).getNonReferenceType();
-    VarDecl *SrcVD = buildVarDecl(SemaRef, ERange.getBegin(),
-                                  Type.getUnqualifiedType(), ".lastprivate.src",
-                                  D->hasAttrs() ? &D->getAttrs() : nullptr);
-    DeclRefExpr *PseudoSrcExpr =
-        buildDeclRefExpr(SemaRef, SrcVD, Type.getUnqualifiedType(), ELoc);
+    VarDecl *SrcVD = buildVarDecl(
+        SemaRef, ERange.getBegin(), Type.getUnqualifiedType(getASTContext()),
+        ".lastprivate.src", D->hasAttrs() ? &D->getAttrs() : nullptr);
+    DeclRefExpr *PseudoSrcExpr = buildDeclRefExpr(
+        SemaRef, SrcVD, Type.getUnqualifiedType(getASTContext()), ELoc);
     VarDecl *DstVD =
         buildVarDecl(SemaRef, ERange.getBegin(), Type, ".lastprivate.dst",
                      D->hasAttrs() ? &D->getAttrs() : nullptr);
@@ -20292,7 +20296,7 @@ buildDeclareReductionRef(Sema &SemaRef, SourceLocation Loc, SourceRange Range,
                          /*DetectVirtual=*/false);
       if (SemaRef.IsDerivedFrom(Loc, Ty, VD->getType(), Paths)) {
         if (!Paths.isAmbiguous(SemaRef.Context.getCanonicalType(
-                VD->getType().getUnqualifiedType()))) {
+                VD->getType().getUnqualifiedType(SemaRef.Context)))) {
           if (SemaRef.CheckBaseClassAccess(
                   Loc, VD->getType(), Ty, Paths.front(),
                   /*DiagID=*/0) != Sema::AR_inaccessible) {
@@ -20831,7 +20835,7 @@ static bool actOnOMPReductionKindClause(
       }
     }
 
-    Type = Type.getNonLValueExprType(Context).getUnqualifiedType();
+    Type = Type.getNonLValueExprType(Context).getUnqualifiedType(Context);
     VarDecl *LHSVD = buildVarDecl(S, ELoc, Type, ".reduction.lhs",
                                   D->hasAttrs() ? &D->getAttrs() : nullptr);
     VarDecl *RHSVD = buildVarDecl(S, ELoc, Type, D->getName(),
@@ -21370,7 +21374,7 @@ bool SemaOpenMP::CheckOpenMPLinearDecl(const ValueDecl *D, SourceLocation ELoc,
     return true;
 
   // A list item must be of integral or pointer type.
-  Type = Type.getUnqualifiedType().getCanonicalType();
+  Type = Type.getUnqualifiedType(SemaRef.Context).getCanonicalType();
   const auto *Ty = Type.getTypePtrOrNull();
   if (!Ty || (LinKind != OMPC_LINEAR_ref && !Ty->isDependentType() &&
               !Ty->isIntegralType(getASTContext()) && !Ty->isPointerType())) {
@@ -21439,7 +21443,9 @@ OMPClause *SemaOpenMP::ActOnOpenMPLinearClause(
 
     if (CheckOpenMPLinearDecl(D, ELoc, LinKind, Type))
       continue;
-    Type = Type.getNonReferenceType().getUnqualifiedType().getCanonicalType();
+    Type = Type.getNonReferenceType()
+               .getUnqualifiedType(SemaRef.Context)
+               .getCanonicalType();
 
     // Build private copy of original var.
     VarDecl *Private =
@@ -21583,10 +21589,10 @@ static bool FinishOpenMPLinearClause(OMPLinearClause &Clause, DeclRefExpr *IV,
     if (LinKind == OMPC_LINEAR_uval)
       CapturedRef = cast<VarDecl>(DE->getDecl())->getInit();
     else
-      CapturedRef =
-          buildDeclRefExpr(SemaRef, cast<VarDecl>(DE->getDecl()),
-                           DE->getType().getUnqualifiedType(), DE->getExprLoc(),
-                           /*RefersToCapture=*/true);
+      CapturedRef = buildDeclRefExpr(
+          SemaRef, cast<VarDecl>(DE->getDecl()),
+          DE->getType().getUnqualifiedType(SemaRef.Context), DE->getExprLoc(),
+          /*RefersToCapture=*/true);
 
     // Build update: Var = InitExpr + IV * Step
     ExprResult Update;
@@ -21658,7 +21664,9 @@ OMPClause *SemaOpenMP::ActOnOpenMPAlignedClause(
     // OpenMP  [2.8.1, simd construct, Restrictions]
     // The type of list items appearing in the aligned clause must be
     // array, pointer, reference to array, or reference to pointer.
-    QType = QType.getNonReferenceType().getUnqualifiedType().getCanonicalType();
+    QType = QType.getNonReferenceType()
+                .getUnqualifiedType(SemaRef.Context)
+                .getCanonicalType();
     const Type *Ty = QType.getTypePtrOrNull();
     if (!Ty || (!Ty->isArrayType() && !Ty->isPointerType())) {
       Diag(ELoc, diag::err_omp_aligned_expected_array_or_ptr)
@@ -21770,10 +21778,12 @@ OMPClause *SemaOpenMP::ActOnOpenMPCopyinClause(ArrayRef<Expr *> VarList,
     QualType ElemType =
         getASTContext().getBaseElementType(Type).getNonReferenceType();
     VarDecl *SrcVD =
-        buildVarDecl(SemaRef, DE->getBeginLoc(), ElemType.getUnqualifiedType(),
+        buildVarDecl(SemaRef, DE->getBeginLoc(),
+                     ElemType.getUnqualifiedType(getASTContext()),
                      ".copyin.src", VD->hasAttrs() ? &VD->getAttrs() : nullptr);
     DeclRefExpr *PseudoSrcExpr = buildDeclRefExpr(
-        SemaRef, SrcVD, ElemType.getUnqualifiedType(), DE->getExprLoc());
+        SemaRef, SrcVD, ElemType.getUnqualifiedType(getASTContext()),
+        DE->getExprLoc());
     VarDecl *DstVD =
         buildVarDecl(SemaRef, DE->getBeginLoc(), ElemType, ".copyin.dst",
                      VD->hasAttrs() ? &VD->getAttrs() : nullptr);
@@ -21885,7 +21895,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPCopyprivateClause(ArrayRef<Expr *> VarList,
     //  operator for the class type.
     Type = getASTContext()
                .getBaseElementType(Type.getNonReferenceType())
-               .getUnqualifiedType();
+               .getUnqualifiedType(getASTContext());
     VarDecl *SrcVD =
         buildVarDecl(SemaRef, RefExpr->getBeginLoc(), Type, ".copyprivate.src",
                      D->hasAttrs() ? &D->getAttrs() : nullptr);
@@ -23210,7 +23220,7 @@ static ExprResult buildUserDefinedMapperRef(Sema &SemaRef, Scope *S,
                        /*DetectVirtual=*/false);
     if (SemaRef.IsDerivedFrom(Loc, Type, VD->getType(), Paths)) {
       if (!Paths.isAmbiguous(SemaRef.Context.getCanonicalType(
-              VD->getType().getUnqualifiedType()))) {
+              VD->getType().getUnqualifiedType(SemaRef.Context)))) {
         if (SemaRef.CheckBaseClassAccess(
                 Loc, VD->getType(), Type, Paths.front(),
                 /*DiagID=*/0) != Sema::AR_inaccessible) {
@@ -23382,8 +23392,8 @@ static bool hasUserDefinedMapper(Sema &SemaRef, Scope *S,
   CXXBasePaths Paths(/*FindAmbiguities=*/true, /*RecordPaths=*/true,
                      /*DetectVirtual=*/false);
   if (SemaRef.IsDerivedFrom(Loc, Type, VD->getType(), Paths)) {
-    bool IsAmbiguous = !Paths.isAmbiguous(
-        SemaRef.Context.getCanonicalType(VD->getType().getUnqualifiedType()));
+    bool IsAmbiguous = !Paths.isAmbiguous(SemaRef.Context.getCanonicalType(
+        VD->getType().getUnqualifiedType(SemaRef.Context)));
     if (IsAmbiguous)
       return false;
     if (SemaRef.CheckBaseClassAccess(Loc, VD->getType(), Type, Paths.front(),
@@ -25161,7 +25171,7 @@ OMPClause *SemaOpenMP::ActOnOpenMPUseDevicePtrClause(
       continue;
 
     QualType Type = D->getType();
-    Type = Type.getNonReferenceType().getUnqualifiedType();
+    Type = Type.getNonReferenceType().getUnqualifiedType(SemaRef.Context);
 
     auto *VD = dyn_cast<VarDecl>(D);
 
@@ -25182,7 +25192,8 @@ OMPClause *SemaOpenMP::ActOnOpenMPUseDevicePtrClause(
 
     SemaRef.CurContext->addDecl(VDPrivate);
     DeclRefExpr *VDPrivateRefExpr = buildDeclRefExpr(
-        SemaRef, VDPrivate, RefExpr->getType().getUnqualifiedType(), ELoc);
+        SemaRef, VDPrivate,
+        RefExpr->getType().getUnqualifiedType(SemaRef.Context), ELoc);
 
     // Add temporary variable to initialize the private copy of the pointer.
     VarDecl *VDInit =

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1737,7 +1737,7 @@ TryUserDefinedConversion(Sema &S, Expr *From, QualType ToType,
         FromLoc = From->getBeginLoc();
       }
       QualType FromCanon =
-          S.Context.getCanonicalType(FromType.getUnqualifiedType());
+          S.Context.getCanonicalType(FromType.getUnqualifiedType(S.Context));
       QualType ToCanon
         = S.Context.getCanonicalType(ToType).getUnqualifiedType();
       if ((FromCanon == ToCanon ||
@@ -2422,8 +2422,8 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
     SCS.First = ICK_HLSL_Array_RValue;
 
     // Don't consider qualifiers, which include things like address spaces
-    if (FromType.getCanonicalType().getUnqualifiedType() !=
-        ToType.getCanonicalType().getUnqualifiedType())
+    if (FromType.getCanonicalType().getUnqualifiedType(S.Context) !=
+        ToType.getCanonicalType().getUnqualifiedType(S.Context))
       return false;
 
     SCS.setAllToTypes(ToType);
@@ -2446,7 +2446,7 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
     // cv-unqualified version of T. Otherwise, the type of the rvalue
     // is T (C++ 4.1p1). C++ can't get here with class types; in C, we
     // just strip the qualifiers because they don't matter.
-    FromType = FromType.getUnqualifiedType();
+    FromType = FromType.getUnqualifiedType(S.Context);
   } else if (FromType->isArrayType()) {
     // Array-to-pointer conversion (C++ 4.2)
     SCS.First = ICK_Array_To_Pointer;
@@ -2505,23 +2505,23 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
   } else if (S.IsIntegralPromotion(From, FromType, ToType)) {
     // Integral promotion (C++ 4.5).
     SCS.Second = ICK_Integral_Promotion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (S.IsFloatingPointPromotion(FromType, ToType)) {
     // Floating point promotion (C++ 4.6).
     SCS.Second = ICK_Floating_Promotion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (S.IsComplexPromotion(FromType, ToType)) {
     // Complex promotion (Clang extension)
     SCS.Second = ICK_Complex_Promotion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (S.IsOverflowBehaviorTypePromotion(FromType, ToType)) {
     // OverflowBehaviorType promotions
     SCS.Second = ICK_Integral_Promotion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (S.IsOverflowBehaviorTypeConversion(FromType, ToType)) {
     // OverflowBehaviorType conversions
     SCS.Second = ICK_Integral_Conversion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (ToType->isBooleanType() &&
              (FromType->isArithmeticType() || FromType->isAnyPointerType() ||
               FromType->isBlockPointerType() ||
@@ -2533,20 +2533,20 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
              ToType->isIntegralType(S.Context)) {
     // Integral conversions (C++ 4.7).
     SCS.Second = ICK_Integral_Conversion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (FromType->isAnyComplexType() && ToType->isAnyComplexType()) {
     // Complex conversions (C99 6.3.1.6)
     SCS.Second = ICK_Complex_Conversion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if ((FromType->isAnyComplexType() && ToType->isArithmeticType()) ||
              (ToType->isAnyComplexType() && FromType->isArithmeticType())) {
     // Complex-real conversions (C99 6.3.1.7)
     SCS.Second = ICK_Complex_Real;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (IsFloatingPointConversion(S, FromType, ToType)) {
     // Floating point conversions (C++ 4.8).
     SCS.Second = ICK_Floating_Conversion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if ((FromType->isRealFloatingType() &&
               ToType->isIntegralType(S.Context)) ||
              (FromType->isIntegralOrUnscopedEnumerationType() &&
@@ -2554,7 +2554,7 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
 
     // Floating-integral conversions (C++ 4.9).
     SCS.Second = ICK_Floating_Integral;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (S.IsBlockPointerConversion(FromType, ToType, FromType)) {
     SCS.Second = ICK_Block_Pointer_Conversion;
   } else if (AllowObjCWritebackConversion &&
@@ -2565,7 +2565,7 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
     // Pointer conversions (C++ 4.10).
     SCS.Second = ICK_Pointer_Conversion;
     SCS.IncompatibleObjC = IncompatibleObjC;
-    FromType = FromType.getUnqualifiedType();
+    FromType = FromType.getUnqualifiedType(S.Context);
   } else if (S.IsMemberPointerConversion(From, FromType, ToType,
                                          InOverloadResolution, FromType)) {
     // Pointer to member conversions (4.11).
@@ -2574,17 +2574,17 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
                                 From, InOverloadResolution, CStyle)) {
     SCS.Second = SecondICK;
     SCS.Dimension = DimensionICK;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (IsMatrixConversion(S, FromType, ToType, SecondICK, DimensionICK,
                                 From, InOverloadResolution, CStyle)) {
     SCS.Second = SecondICK;
     SCS.Dimension = DimensionICK;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (!S.getLangOpts().CPlusPlus &&
              S.Context.typesAreCompatible(ToType, FromType)) {
     // Compatible conversions (Clang extension for C function overloading)
     SCS.Second = ICK_Compatible_Conversion;
-    FromType = ToType.getUnqualifiedType();
+    FromType = ToType.getUnqualifiedType(S.Context);
   } else if (IsTransparentUnionStandardConversion(
                  S, From, ToType, InOverloadResolution, SCS, CStyle)) {
     SCS.Second = ICK_TransparentUnionConversion;
@@ -2997,7 +2997,7 @@ BuildSimilarlyQualifiedPointerType(const Type *FromPtr,
 
   /// Conversions to 'id' subsume cv-qualifier conversions.
   if (ToType->isObjCIdType() || ToType->isObjCQualifiedIdType())
-    return ToType.getUnqualifiedType();
+    return ToType.getUnqualifiedType(Context);
 
   QualType CanonFromPointee
     = Context.getCanonicalType(FromPtr->getPointeeType());
@@ -3011,7 +3011,7 @@ BuildSimilarlyQualifiedPointerType(const Type *FromPtr,
   if (CanonToPointee.getLocalQualifiers() == Quals) {
     // ToType is exactly what we need. Return it.
     if (!ToType.isNull())
-      return ToType.getUnqualifiedType();
+      return ToType.getUnqualifiedType(Context);
 
     // Build a pointer to ToPointee. It has the right qualifiers
     // already.
@@ -3188,7 +3188,7 @@ static QualType AdoptQualifiers(ASTContext &Context, QualType T, Qualifiers Qs){
   if (Qs.compatiblyIncludes(TQs, Context))
     return Context.getQualifiedType(T, Qs);
 
-  return Context.getQualifiedType(T.getUnqualifiedType(), Qs);
+  return Context.getQualifiedType(T.getUnqualifiedType(Context), Qs);
 }
 
 bool Sema::isObjCPointerConversion(QualType FromType, QualType ToType,
@@ -3412,7 +3412,7 @@ bool Sema::IsBlockPointerConversion(QualType FromType, QualType ToType,
     QualType LHS = ToFunctionType->getReturnType();
     if ((!getLangOpts().CPlusPlus || !RHS->isRecordType()) &&
         !RHS.hasQualifiers() && LHS.hasQualifiers())
-       LHS = LHS.getUnqualifiedType();
+      LHS = LHS.getUnqualifiedType(Context);
 
      if (Context.hasSameType(RHS,LHS)) {
        // OK exact match.
@@ -3596,9 +3596,9 @@ bool Sema::FunctionParamTypesAreEqual(ArrayRef<QualType> Old,
     // Ignore address spaces in pointee type. This is to disallow overloading
     // on __ptr32/__ptr64 address spaces.
     QualType OldType =
-        Context.removePtrSizeAddrSpace(Type.getUnqualifiedType());
-    QualType NewType =
-        Context.removePtrSizeAddrSpace((New.begin() + J)->getUnqualifiedType());
+        Context.removePtrSizeAddrSpace(Type.getUnqualifiedType(Context));
+    QualType NewType = Context.removePtrSizeAddrSpace(
+        (New.begin() + J)->getUnqualifiedType(Context));
 
     if (!Context.hasSameType(OldType, NewType)) {
       if (ArgPos)
@@ -3959,7 +3959,8 @@ Sema::IsQualificationConversion(QualType FromType, QualType ToType,
 
   // If FromType and ToType are the same type, this is not a
   // qualification conversion.
-  if (FromType.getUnqualifiedType() == ToType.getUnqualifiedType())
+  if (FromType.getUnqualifiedType(Context) ==
+      ToType.getUnqualifiedType(Context))
     return false;
 
   // (C++ 4.4p4):
@@ -4795,8 +4796,10 @@ CompareStandardConversionSequences(Sema &S, SourceLocation Loc,
     if (SCS2.First == ICK_Array_To_Pointer)
       FromType2 = S.Context.getArrayDecayedType(FromType2);
 
-    QualType FromPointee1 = FromType1->getPointeeType().getUnqualifiedType();
-    QualType FromPointee2 = FromType2->getPointeeType().getUnqualifiedType();
+    QualType FromPointee1 =
+        FromType1->getPointeeType().getUnqualifiedType(S.Context);
+    QualType FromPointee2 =
+        FromType2->getPointeeType().getUnqualifiedType(S.Context);
 
     if (S.IsDerivedFrom(Loc, FromPointee2, FromPointee1))
       return ImplicitConversionSequence::Better;
@@ -5076,13 +5079,17 @@ CompareDerivedToBaseConversions(Sema &S, SourceLocation Loc,
       FromType1->isPointerType() && FromType2->isPointerType() &&
       ToType1->isPointerType() && ToType2->isPointerType()) {
     QualType FromPointee1 =
-        FromType1->castAs<PointerType>()->getPointeeType().getUnqualifiedType();
+        FromType1->castAs<PointerType>()->getPointeeType().getUnqualifiedType(
+            S.Context);
     QualType ToPointee1 =
-        ToType1->castAs<PointerType>()->getPointeeType().getUnqualifiedType();
+        ToType1->castAs<PointerType>()->getPointeeType().getUnqualifiedType(
+            S.Context);
     QualType FromPointee2 =
-        FromType2->castAs<PointerType>()->getPointeeType().getUnqualifiedType();
+        FromType2->castAs<PointerType>()->getPointeeType().getUnqualifiedType(
+            S.Context);
     QualType ToPointee2 =
-        ToType2->castAs<PointerType>()->getPointeeType().getUnqualifiedType();
+        ToType2->castAs<PointerType>()->getPointeeType().getUnqualifiedType(
+            S.Context);
 
     //   -- conversion of C* to B* is better than conversion of C* to A*,
     if (FromPointee1 == FromPointee2 && ToPointee1 != ToPointee2) {
@@ -5385,8 +5392,8 @@ FindConversionForRefInit(Sema &S, ImplicitConversionSequence &ICS,
               DeclLoc,
               Conv->getConversionType()
                   .getNonReferenceType()
-                  .getUnqualifiedType(),
-              DeclType.getNonReferenceType().getUnqualifiedType()) ==
+                  .getUnqualifiedType(S.Context),
+              DeclType.getNonReferenceType().getUnqualifiedType(S.Context)) ==
               Sema::Ref_Incompatible)
         continue;
     } else {
@@ -7106,9 +7113,9 @@ ExprResult Sema::PerformContextualImplicitConversion(
       } else {
         if (!ConvTemplate && getLangOpts().CPlusPlus14) {
           if (ToType.isNull())
-            ToType = CurToType.getUnqualifiedType();
+            ToType = CurToType.getUnqualifiedType(Context);
           else if (HasUniqueTargetType &&
-                   (CurToType.getUnqualifiedType() != ToType))
+                   (CurToType.getUnqualifiedType(Context) != ToType))
             HasUniqueTargetType = false;
         }
         ViableConversions.addDecl(I.getDecl(), I.getAccess());
@@ -8600,8 +8607,8 @@ void Sema::AddConversionCandidate(
   // We won't go through a user-defined type conversion function to convert a
   // derived to base as such conversions are given Conversion Rank. They only
   // go through a copy constructor. 13.3.3.1.2-p4 [over.ics.user]
-  QualType FromCanon
-    = Context.getCanonicalType(From->getType().getUnqualifiedType());
+  QualType FromCanon =
+      Context.getCanonicalType(From->getType().getUnqualifiedType(Context));
   QualType ToCanon = Context.getCanonicalType(ToType).getUnqualifiedType();
   if (FromCanon == ToCanon ||
       IsDerivedFrom(CandidateSet.getLocation(), FromCanon, ToCanon)) {
@@ -9842,10 +9849,10 @@ public:
           bool Reversed = C->isReversed();
           QualType FirstParamType = C->Function->getParamDecl(Reversed ? 1 : 0)
                                         ->getType()
-                                        .getUnqualifiedType();
+                                        .getUnqualifiedType(S.Context);
           QualType SecondParamType = C->Function->getParamDecl(Reversed ? 0 : 1)
                                          ->getType()
-                                         .getUnqualifiedType();
+                                         .getUnqualifiedType(S.Context);
 
           // Skip if either parameter isn't of enumeral type.
           if (!FirstParamType->isEnumeralType() ||
@@ -13652,8 +13659,7 @@ QualType Sema::ExtractUnqualifiedFunctionType(QualType PossiblyAFunctionType) {
   else if (const MemberPointerType *MemTypePtr =
     PossiblyAFunctionType->getAs<MemberPointerType>())
     Ret = MemTypePtr->getPointeeType();
-  Ret =
-    Context.getCanonicalType(Ret).getUnqualifiedType();
+  Ret = Context.getCanonicalType(Ret).getUnqualifiedType();
   return Ret;
 }
 
@@ -16280,9 +16286,8 @@ ExprResult Sema::BuildCallToMemberFunction(Scope *S, Expr *MemExprE,
     if (difference) {
       std::string qualsString = difference.getAsString();
       Diag(LParenLoc, diag::err_pointer_to_member_call_drops_quals)
-        << fnType.getUnqualifiedType()
-        << qualsString
-        << (qualsString.find(' ') == std::string::npos ? 1 : 2);
+          << fnType.getUnqualifiedType(Context) << qualsString
+          << (qualsString.find(' ') == std::string::npos ? 1 : 2);
     }
 
     CXXMemberCallExpr *call = CXXMemberCallExpr::Create(

--- a/clang/lib/Sema/SemaPPC.cpp
+++ b/clang/lib/Sema/SemaPPC.cpp
@@ -424,7 +424,7 @@ bool SemaPPC::CheckPPCMMAType(QualType Type, SourceLocation TypeLoc) {
   if (Type->isPointerType() || Type->isArrayType())
     return false;
 
-  QualType CoreType = Type.getCanonicalType().getUnqualifiedType();
+  QualType CoreType = Type.getCanonicalType().getUnqualifiedType(Context);
 #define PPC_VECTOR_TYPE(Name, Id, Size) || CoreType == Context.Id##Ty
   if (false
 #include "clang/Basic/PPCTypes.def"
@@ -524,7 +524,8 @@ bool SemaPPC::BuiltinPPCMMACall(CallExpr *TheCall, unsigned BuiltinID,
     // Strip Restrict/Volatile qualifiers.
     if (StrippedRVType.isRestrictQualified() ||
         StrippedRVType.isVolatileQualified())
-      StrippedRVType = StrippedRVType.getCanonicalType().getUnqualifiedType();
+      StrippedRVType =
+          StrippedRVType.getCanonicalType().getUnqualifiedType(Context);
 
     // The only case where the argument type and expected type are allowed to
     // mismatch is if the argument type is a non-void pointer (or array) and

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -1495,7 +1495,7 @@ bool SemaRISCV::CheckBuiltinFunctionCall(const TargetInfo &TI,
     }
 
     QualType ValType = PtrType->getPointeeType();
-    ValType = ValType.getUnqualifiedType();
+    ValType = ValType.getUnqualifiedType(Context);
     if (!ValType->isIntegerType() && !ValType->isAnyPointerType() &&
         !ValType->isBlockPointerType() && !ValType->isFloatingType() &&
         !ValType->isVectorType() && !ValType->isRVVSizelessBuiltinType()) {

--- a/clang/lib/Sema/SemaSPIRV.cpp
+++ b/clang/lib/Sema/SemaSPIRV.cpp
@@ -175,7 +175,8 @@ static bool checkGenericCastToPtr(Sema &SemaRef, CallExpr *Call) {
   }
   Qual.setAddressSpace(AddrSpace);
   Call->setType(SemaRef.getASTContext().getPointerType(
-      SemaRef.getASTContext().getQualifiedType(RT.getUnqualifiedType(), Qual)));
+      SemaRef.getASTContext().getQualifiedType(
+          RT.getUnqualifiedType(SemaRef.getASTContext()), Qual)));
 
   return false;
 }

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -875,7 +875,8 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
     auto DoTypesMatch = [this, &PD](QualType A, QualType B,
                                     unsigned Select) -> bool {
       if (!Context.hasSimilarType(A, B)) {
-        PD << Select << A.getUnqualifiedType() << B.getUnqualifiedType();
+        PD << Select << A.getUnqualifiedType(Context)
+           << B.getUnqualifiedType(Context);
         return false;
       }
       return true;
@@ -1757,7 +1758,7 @@ Sema::DiagnoseAssignmentEnum(QualType DstType, QualType SrcType,
   if (ED->hasAttr<FlagEnumAttr>()) {
     if (!IsValueInFlagEnum(ED, *RHSVal, /*AllowMask=*/true))
       Diag(SrcExpr->getExprLoc(), diag::warn_not_in_enum_assignment)
-          << DstType.getUnqualifiedType();
+          << DstType.getUnqualifiedType(Context);
     return;
   }
 
@@ -1784,7 +1785,7 @@ Sema::DiagnoseAssignmentEnum(QualType DstType, QualType SrcType,
     return;
 
   Diag(SrcExpr->getExprLoc(), diag::warn_not_in_enum_assignment)
-      << DstType.getUnqualifiedType();
+      << DstType.getUnqualifiedType(Context);
 }
 
 StmtResult Sema::ActOnWhileStmt(SourceLocation WhileLoc,
@@ -3631,7 +3632,7 @@ StmtResult Sema::ActOnCapScopeReturnStmt(SourceLocation ReturnLoc,
       // for a block). These rules differ from the stated C++11 rules only in
       // that they remove top-level cv-qualifiers.
       if (!CurContext->isDependentContext())
-        FnRetType = RetValExp->getType().getUnqualifiedType();
+        FnRetType = RetValExp->getType().getUnqualifiedType(Context);
       else
         FnRetType = CurCap->ReturnType = Context.DependentTy;
     } else {
@@ -4285,11 +4286,12 @@ public:
   /// Used when creating a CatchHandlerType from a handler type; will determine
   /// whether the type is a pointer or reference and will strip off the top
   /// level pointer and cv-qualifiers.
-  CatchHandlerType(QualType Q) : QT(Q), IsPointer(false) {
+  CatchHandlerType(QualType Q, const ASTContext &Ctx)
+      : QT(Q), IsPointer(false) {
     if (QT->isPointerType())
       IsPointer = true;
 
-    QT = QT.getUnqualifiedType();
+    QT = QT.getUnqualifiedType(Ctx);
     if (IsPointer || QT->isReferenceType())
       QT = QT->getPointeeType();
   }
@@ -4428,7 +4430,7 @@ StmtResult Sema::ActOnCXXTryBlock(SourceLocation TryLoc, Stmt *TryBlock,
     // Walk the type hierarchy to diagnose when this type has already been
     // handled (duplication), or cannot be handled (derivation inversion). We
     // ignore top-level cv-qualifiers, per [except.handle]p3
-    CatchHandlerType HandlerCHT = H->getCaughtType().getCanonicalType();
+    CatchHandlerType HandlerCHT(H->getCaughtType().getCanonicalType(), Context);
 
     // We can ignore whether the type is a reference or a pointer; we need the
     // underlying declaration type in order to get at the underlying record
@@ -4461,13 +4463,13 @@ StmtResult Sema::ActOnCXXTryBlock(SourceLocation TryLoc, Stmt *TryBlock,
       // Strip the qualifiers here because we're going to be comparing this
       // type to the base type specifiers of a class, which are ignored in a
       // base specifier per [class.derived.general]p2.
-      HandledBaseTypes[Underlying.getUnqualifiedType()] = H;
+      HandledBaseTypes[Underlying.getUnqualifiedType(Context)] = H;
     }
 
     // Add the type the list of ones we have handled; diagnose if we've already
     // handled it.
-    auto R = HandledTypes.insert(
-        std::make_pair(H->getCaughtType().getCanonicalType(), H));
+    auto R = HandledTypes.insert(std::make_pair(
+        CatchHandlerType(H->getCaughtType().getCanonicalType(), Context), H));
     if (!R.second) {
       const CXXCatchStmt *Problem = R.first->second;
       Diag(H->getExceptionDecl()->getTypeSpecStartLoc(),

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -1472,7 +1472,7 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
       T->isUndeducedType()) {
     // C++ [temp.param]p5: The top-level cv-qualifiers on the template-parameter
     // are ignored when determining its type.
-    return T.getUnqualifiedType();
+    return T.getUnqualifiedType(Context);
   }
 
   // C++ [temp.param]p8:
@@ -1490,7 +1490,7 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
   // used during instantiation, so that should be OK. (Using the
   // qualified type is equally wrong.)
   if (T->isDependentType())
-    return T.getUnqualifiedType();
+    return T.getUnqualifiedType(Context);
 
   // C++20 [temp.param]p6:
   //   -- a structural type
@@ -1506,7 +1506,7 @@ QualType Sema::CheckNonTypeTemplateParameterType(QualType T,
   }
 
   Diag(Loc, diag::warn_cxx17_compat_template_nontype_parm_type) << T;
-  return T.getUnqualifiedType();
+  return T.getUnqualifiedType(Context);
 }
 
 NamedDecl *Sema::ActOnNonTypeTemplateParameter(Scope *S, Declarator &D,
@@ -7251,7 +7251,7 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
     // not the type of the template argument deduced from A, against the
     // template parameter type.
     Diag(StartLoc, diag::err_deduced_non_type_template_arg_type_mismatch)
-        << Arg->getType() << ParamType.getUnqualifiedType();
+        << Arg->getType() << ParamType.getUnqualifiedType(Context);
     NoteTemplateParameterLocation(*Param);
     return ExprError();
   }
@@ -7527,7 +7527,7 @@ ExprResult Sema::CheckTemplateArgument(NamedDecl *Param, QualType ParamType,
 
     // From here on out, all we care about is the unqualified form
     // of the argument type.
-    ArgType = ArgType.getUnqualifiedType();
+    ArgType = ArgType.getUnqualifiedType(Context);
 
     // Try to convert the argument to the parameter's type.
     if (Context.hasSameType(ParamType, ArgType)) {

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -1221,10 +1221,10 @@ static TemplateDeductionResult DeduceForEachType(
         return TemplateDeductionResult::MiscellaneousDeductionFailure;
       }
 
-      if (TemplateDeductionResult Result =
-              DeductFunc(S, TemplateParams, ParamIdx, ArgIdx,
-                         Params[ParamIdx].getUnqualifiedType(),
-                         Args[ArgIdx].getUnqualifiedType(), Info, Deduced, POK);
+      if (TemplateDeductionResult Result = DeductFunc(
+              S, TemplateParams, ParamIdx, ArgIdx,
+              Params[ParamIdx].getUnqualifiedType(S.Context),
+              Args[ArgIdx].getUnqualifiedType(S.Context), Info, Deduced, POK);
           Result != TemplateDeductionResult::Success)
         return Result;
 
@@ -1251,8 +1251,8 @@ static TemplateDeductionResult DeduceForEachType(
         // Deduce template arguments from the pattern.
         if (TemplateDeductionResult Result = DeductFunc(
                 S, TemplateParams, ParamIdx, ArgIdx,
-                Pattern.getUnqualifiedType(), Args[ArgIdx].getUnqualifiedType(),
-                Info, Deduced, POK);
+                Pattern.getUnqualifiedType(S.Context),
+                Args[ArgIdx].getUnqualifiedType(S.Context), Info, Deduced, POK);
             Result != TemplateDeductionResult::Success)
           return Result;
         PackScope.nextPackElement();
@@ -1765,8 +1765,8 @@ static TemplateDeductionResult DeduceTemplateArgumentsByTypeMatch(
         !DeducedQs.hasObjCLifetime())
       DeducedQs.setObjCLifetime(Qualifiers::OCL_Strong);
 
-    DeducedType =
-        S.Context.getQualifiedType(DeducedType.getUnqualifiedType(), DeducedQs);
+    DeducedType = S.Context.getQualifiedType(
+        DeducedType.getUnqualifiedType(S.Context), DeducedQs);
 
     DeducedTemplateArgument NewDeduced(DeducedType, DeducedFromArrayBound);
     DeducedTemplateArgument Result =
@@ -2193,7 +2193,7 @@ static TemplateDeductionResult DeduceTemplateArgumentsByTypeMatch(
           MPA->isSugared()
               ? S.Context.getCanonicalTagType(MPA->getMostRecentCXXRecordDecl())
               : QualType(MPA->getQualifier().getAsType(), 0)
-                    .getUnqualifiedType();
+                    .getUnqualifiedType(S.Context);
       assert(!TA.isNull() && "member pointer with non-type class");
 
       return DeduceTemplateArgumentsByTypeMatch(
@@ -3791,7 +3791,8 @@ CheckOriginalCallArgDeduction(Sema &S, TemplateDeductionInfo &Info,
       // Qualifiers are compatible, so have the argument type adopt the
       // deduced argument type's qualifiers as if we had performed the
       // qualification conversion.
-      A = Context.getQualifiedType(A.getUnqualifiedType(), DeducedAQuals);
+      A = Context.getQualifiedType(A.getUnqualifiedType(Context),
+                                   DeducedAQuals);
     }
   }
 
@@ -4264,7 +4265,7 @@ static bool AdjustFunctionParmAndArgTypesForDeduction(
   //   If P is a cv-qualified type, the top level cv-qualifiers of P's type
   //   are ignored for type deduction.
   if (ParamType.hasQualifiers())
-    ParamType = ParamType.getUnqualifiedType();
+    ParamType = ParamType.getUnqualifiedType(S.Context);
 
   //   [...] If P is a reference type, the type referred to by P is
   //   used for type deduction.
@@ -4314,7 +4315,7 @@ static bool AdjustFunctionParmAndArgTypesForDeduction(
     else {
       // - If A is a cv-qualified type, the top level cv-qualifiers of A's
       //   type are ignored for type deduction.
-      ArgType = ArgType.getUnqualifiedType();
+      ArgType = ArgType.getUnqualifiedType(S.Context);
     }
   }
 
@@ -4923,8 +4924,8 @@ TemplateDeductionResult Sema::DeduceTemplateArguments(
     // removed from P and A in this case, unless P was a reference type. This
     // seems to mostly match what other compilers are doing.
     if (!IsReferenceP) {
-      A = A.getUnqualifiedType();
-      P = P.getUnqualifiedType();
+      A = A.getUnqualifiedType(Context);
+      P = P.getUnqualifiedType(Context);
     }
 
   // C++ [temp.deduct.conv]p3:
@@ -4946,13 +4947,13 @@ TemplateDeductionResult Sema::DeduceTemplateArguments(
     //   - If P is a cv-qualified type, the top level cv-qualifiers of
     //     P's type are ignored for type deduction.
     else
-      P = P.getUnqualifiedType();
+      P = P.getUnqualifiedType(Context);
 
     // C++0x [temp.deduct.conv]p4:
     //   If A is a cv-qualified type, the top level cv-qualifiers of A's
     //   type are ignored for type deduction. If A is a reference type, the type
     //   referred to by A is used for type deduction.
-    A = A.getUnqualifiedType();
+    A = A.getUnqualifiedType(Context);
   }
 
   // Unevaluated SFINAE context.

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1159,7 +1159,7 @@ void Sema::PrintInstantiationStack(InstantiationContextDiagFuncRef DiagFunc) {
         QualType RecordType = FD->getParamDecl(0)
                                   ->getType()
                                   .getNonReferenceType()
-                                  .getUnqualifiedType();
+                                  .getUnqualifiedType(Context);
         DiagFunc(Active->PointOfInstantiation,
                  PDiag(diag::note_comparison_synthesized_at)
                      << (int)DFK.asComparison() << RecordType);
@@ -2463,8 +2463,8 @@ QualType TemplateInstantiator::BuildSubstTemplateTypeParmType(
     Qualifiers RQs;
     RQs = Replacement.getQualifiers();
     RQs.removeObjCLifetime();
-    Replacement =
-        SemaRef.Context.getQualifiedType(Replacement.getUnqualifiedType(), RQs);
+    Replacement = SemaRef.Context.getQualifiedType(
+        Replacement.getUnqualifiedType(SemaRef.Context), RQs);
   }
 
   // TODO: only do this uniquing once, at the start of instantiation.

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -2148,7 +2148,8 @@ Decl *TemplateDeclInstantiator::VisitEnumDecl(EnumDecl *D) {
         // derived TypeSourceInfo which strips qualifiers including the weird
         // ones like _Atomic where it forms a different type.
         if (NewTI->getType()->isAtomicType())
-          Enum->setIntegerType(NewTI->getType().getAtomicUnqualifiedType());
+          Enum->setIntegerType(
+              NewTI->getType().getAtomicUnqualifiedType(SemaRef.Context));
         else
           Enum->setIntegerTypeSourceInfo(NewTI);
       }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1699,7 +1699,7 @@ QualType Sema::BuildQualifiedType(QualType T, SourceLocation Loc,
     //
     // Don't need to worry about array types here, since _Atomic can't be
     // applied to such types.
-    SplitQualType Split = T.getSplitUnqualifiedType();
+    SplitQualType Split = T.getSplitUnqualifiedType(Context);
     T = BuildAtomicType(QualType(Split.Ty, 0),
                         DS ? DS->getAtomicSpecLoc() : Loc);
     if (T.isNull())
@@ -10027,7 +10027,7 @@ QualType Sema::getDecltypeForExpr(Expr *E) {
   if (const auto *DRE = dyn_cast<DeclRefExpr>(IDExpr)) {
     const ValueDecl *VD = DRE->getDecl();
     QualType T = VD->getType();
-    return isa<TemplateParamObjectDecl>(VD) ? T.getUnqualifiedType() : T;
+    return isa<TemplateParamObjectDecl>(VD) ? T.getUnqualifiedType(Context) : T;
   }
   if (const auto *ME = dyn_cast<MemberExpr>(IDExpr)) {
     if (const auto *VD = ME->getMemberDecl())
@@ -10181,7 +10181,7 @@ QualType Sema::BuiltinDecay(QualType BaseType, SourceLocation Loc) {
   if (Underlying->isFunctionType())
     return BuiltinAddPointer(BaseType, Loc);
 
-  SplitQualType Split = Underlying.getSplitUnqualifiedType();
+  SplitQualType Split = Underlying.getSplitUnqualifiedType(Context);
   // std::decay is supposed to produce 'std::remove_cv', but since 'restrict' is
   // in the same group of qualifiers as 'const' and 'volatile', we're extending
   // '__decay(T)' so that it removes all qualifiers.

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -5622,8 +5622,8 @@ QualType TreeTransform<Derived>::RebuildQualifiedType(QualType T,
         QualType Deduced = AutoTy->getDeducedType();
         Qualifiers Qs = Deduced.getQualifiers();
         Qs.removeObjCLifetime();
-        Deduced =
-            SemaRef.Context.getQualifiedType(Deduced.getUnqualifiedType(), Qs);
+        Deduced = SemaRef.Context.getQualifiedType(
+            Deduced.getUnqualifiedType(SemaRef.Context), Qs);
         T = SemaRef.Context.getAutoType(AutoTy->getDeducedKind(), Deduced,
                                         AutoTy->getKeyword(),
                                         AutoTy->getTypeConstraintConcept(),

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -10300,8 +10300,8 @@ ASTRecordReader::readCXXBaseSpecifier() {
   TypeSourceInfo *TInfo = readTypeSourceInfo();
   SourceRange Range = readSourceRange();
   SourceLocation EllipsisLoc = readSourceLocation();
-  CXXBaseSpecifier Result(Range, isVirtual, isBaseOfClass, AS, TInfo,
-                          EllipsisLoc);
+  CXXBaseSpecifier Result(getContext(), Range, isVirtual, isBaseOfClass, AS,
+                          TInfo, EllipsisLoc);
   Result.setInheritConstructors(inheritConstructors);
   return Result;
 }

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -2004,7 +2004,8 @@ void ASTStmtWriter::VisitCXXNewExpr(CXXNewExpr *E) {
   Record.push_back(E->isParenTypeId());
 
   Record.push_back(E->isGlobalNew());
-  ImplicitAllocationParameters IAP = E->implicitAllocationParameters();
+  ImplicitAllocationParameters IAP =
+      E->implicitAllocationParameters(Record.getASTContext());
   Record.push_back(isAlignedAllocation(IAP.PassAlignment));
   Record.push_back(isTypeAwareAllocation(IAP.PassTypeIdentity));
   Record.push_back(E->doesUsualArrayDeleteWantSize());

--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -2567,8 +2567,9 @@ void CStringChecker::evalStrsep(CheckerContext &C,
   SourceArgExpr SearchStrPtr = {{Call.getArgExpr(0), 0}};
 
   QualType CharPtrTy = SearchStrPtr.Expression->getType()->getPointeeType();
-  if (CharPtrTy.isNull() || Call.getResultType().getUnqualifiedType() !=
-                                CharPtrTy.getUnqualifiedType())
+  if (CharPtrTy.isNull() ||
+      Call.getResultType().getUnqualifiedType(C.getASTContext()) !=
+          CharPtrTy.getUnqualifiedType(C.getASTContext()))
     return;
 
   CurrentFunctionDescription = "strsep()";

--- a/clang/lib/StaticAnalyzer/Checkers/CheckSecuritySyntaxOnly.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CheckSecuritySyntaxOnly.cpp
@@ -371,7 +371,8 @@ void WalkAST::checkCall_bcmp(const CallExpr *CE, const FunctionDecl *FD) {
     if (!PT)
       return;
 
-    if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().VoidTy)
+    if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+        BR.getContext().VoidTy)
       return;
   }
 
@@ -413,7 +414,8 @@ void WalkAST::checkCall_bcopy(const CallExpr *CE, const FunctionDecl *FD) {
     if (!PT)
       return;
 
-    if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().VoidTy)
+    if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+        BR.getContext().VoidTy)
       return;
   }
 
@@ -455,7 +457,8 @@ void WalkAST::checkCall_bzero(const CallExpr *CE, const FunctionDecl *FD) {
   if (!PT)
     return;
 
-  if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().VoidTy)
+  if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+      BR.getContext().VoidTy)
     return;
 
   // Verify the second argument type is integer.
@@ -497,7 +500,8 @@ void WalkAST::checkCall_gets(const CallExpr *CE, const FunctionDecl *FD) {
   if (!PT)
     return;
 
-  if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().CharTy)
+  if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+      BR.getContext().CharTy)
     return;
 
   // Issue a warning.
@@ -537,7 +541,8 @@ void WalkAST::checkCall_getpw(const CallExpr *CE, const FunctionDecl *FD) {
   if (!PT)
     return;
 
-  if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().CharTy)
+  if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+      BR.getContext().CharTy)
     return;
 
   // Issue a warning.
@@ -578,7 +583,8 @@ void WalkAST::checkCall_mktemp(const CallExpr *CE, const FunctionDecl *FD) {
     return;
 
   // Verify that the argument is a 'char*'.
-  if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().CharTy)
+  if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+      BR.getContext().CharTy)
     return;
 
   // Issue a warning.
@@ -846,7 +852,8 @@ bool WalkAST::checkCall_strCommon(const CallExpr *CE, const FunctionDecl *FD) {
       return false;
 
     // Verify that the argument is a 'char*'.
-    if (PT->getPointeeType().getUnqualifiedType() != BR.getContext().CharTy)
+    if (PT->getPointeeType().getUnqualifiedType(BR.getContext()) !=
+        BR.getContext().CharTy)
       return false;
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/NumberObjectConversionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/NumberObjectConversionChecker.cpp
@@ -129,13 +129,13 @@ void Callback::run(const MatchFinder::MatchResult &Result) {
   llvm::raw_svector_ostream OS(Msg);
 
   // Remove ObjC ARC qualifiers.
-  QualType ObjT = Obj->getType().getUnqualifiedType();
+  QualType ObjT = Obj->getType().getUnqualifiedType(ACtx);
 
   // Remove consts from pointers.
   if (IsCpp) {
     assert(ObjT.getCanonicalType()->isPointerType());
     ObjT = ACtx.getPointerType(
-        ObjT->getPointeeType().getCanonicalType().getUnqualifiedType());
+        ObjT->getPointeeType().getCanonicalType().getUnqualifiedType(ACtx));
   }
 
   if (IsComparison)

--- a/clang/lib/StaticAnalyzer/Checkers/ObjCPropertyChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ObjCPropertyChecker.cpp
@@ -47,9 +47,10 @@ void ObjCPropertyChecker::checkCopyMutable(const ObjCPropertyDecl *D,
   if (!T->isObjCObjectPointerType())
     return;
 
-  const std::string &PropTypeName(T->getPointeeType().getCanonicalType()
-                                                     .getUnqualifiedType()
-                                                     .getAsString());
+  const std::string &PropTypeName(T->getPointeeType()
+                                      .getCanonicalType()
+                                      .getUnqualifiedType(BR.getContext())
+                                      .getAsString());
   if (!StringRef(PropTypeName).starts_with("NSMutable"))
     return;
 

--- a/clang/lib/StaticAnalyzer/Core/DynamicType.cpp
+++ b/clang/lib/StaticAnalyzer/Core/DynamicType.cpp
@@ -64,11 +64,11 @@ const DynamicTypeInfo *getRawDynamicTypeInfo(ProgramStateRef State,
   return State->get<DynamicTypeMap>(MR);
 }
 
-static void unbox(QualType &Ty) {
+static void unbox(QualType &Ty, const ASTContext &Ctx) {
   // FIXME: Why are we being fed references to pointers in the first place?
   while (Ty->isReferenceType() || Ty->isPointerType())
     Ty = Ty->getPointeeType();
-  Ty = Ty.getCanonicalType().getUnqualifiedType();
+  Ty = Ty.getCanonicalType().getUnqualifiedType(Ctx);
 }
 
 const DynamicCastInfo *getDynamicCastInfo(ProgramStateRef State,
@@ -79,8 +79,8 @@ const DynamicCastInfo *getDynamicCastInfo(ProgramStateRef State,
   if (!Lookup)
     return nullptr;
 
-  unbox(CastFromTy);
-  unbox(CastToTy);
+  unbox(CastFromTy, State->getStateManager().getContext());
+  unbox(CastToTy, State->getStateManager().getContext());
 
   for (const DynamicCastInfo &Cast : *Lookup)
     if (Cast.equals(CastFromTy, CastToTy))
@@ -121,8 +121,8 @@ ProgramStateRef setDynamicTypeAndCastInfo(ProgramStateRef State,
     State = State->set<DynamicTypeMap>(MR, CastToTy);
   }
 
-  unbox(CastFromTy);
-  unbox(CastToTy);
+  unbox(CastFromTy, State->getStateManager().getContext());
+  unbox(CastToTy, State->getStateManager().getContext());
 
   DynamicCastInfo::CastResult ResultKind =
       CastSucceeds ? DynamicCastInfo::CastResult::Success

--- a/clang/tools/libclang/CXType.cpp
+++ b/clang/tools/libclang/CXType.cpp
@@ -152,7 +152,7 @@ CXType cxtype::MakeCXType(QualType T, CXTranslationUnit TU) {
 
     ASTContext &Ctx = cxtu::getASTUnit(TU)->getASTContext();
     if (Ctx.getLangOpts().ObjC) {
-      QualType UnqualT = T.getUnqualifiedType();
+      QualType UnqualT = T.getUnqualifiedType(Ctx);
       if (Ctx.isObjCIdType(UnqualT))
         TK = CXType_ObjCId;
       else if (Ctx.isObjCClassType(UnqualT))
@@ -514,7 +514,8 @@ try_again:
 }
 
 CXType clang_getUnqualifiedType(CXType CT) {
-  return MakeCXType(GetQualType(CT).getUnqualifiedType(), GetTU(CT));
+  ASTContext &Ctx = cxtu::getASTUnit(GetTU(CT))->getASTContext();
+  return MakeCXType(GetQualType(CT).getUnqualifiedType(Ctx), GetTU(CT));
 }
 
 CXType clang_getNonReferenceType(CXType CT) {

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -140,8 +140,8 @@ bool isOverload(clang::CXXMethodDecl *m1, clang::CXXMethodDecl *m2) {
 
   auto compareArgTypes = [&context](const clang::QualType &m1p,
                                     const clang::QualType &m2p) {
-    return context.hasSameType(m1p.getUnqualifiedType(),
-                               m2p.getUnqualifiedType());
+    return context.hasSameType(m1p.getUnqualifiedType(context),
+                               m2p.getUnqualifiedType(context));
   };
 
   // FIXME: In C++14 and later, we can just pass m2Type->param_type_end()
@@ -1172,8 +1172,8 @@ bool TypeSystemClang::AreTypesSame(CompilerType type1, CompilerType type2,
   QualType type2_qual = ClangUtil::GetQualType(type2);
 
   if (ignore_qualifiers) {
-    type1_qual = type1_qual.getUnqualifiedType();
-    type2_qual = type2_qual.getUnqualifiedType();
+    type1_qual = type1_qual.getUnqualifiedType(ast->getASTContext());
+    type2_qual = type2_qual.getUnqualifiedType(ast->getASTContext());
   }
 
   return ast->getASTContext().hasSameType(type1_qual, type2_qual);
@@ -2948,7 +2948,7 @@ bool TypeSystemClang::IsRuntimeGeneratedType(
 }
 
 bool TypeSystemClang::IsCharType(lldb::opaque_compiler_type_t type) {
-  return GetQualType(type).getUnqualifiedType()->isCharType();
+  return GetQualType(type).getUnqualifiedType(getASTContext())->isCharType();
 }
 
 bool TypeSystemClang::IsCompleteType(lldb::opaque_compiler_type_t type) {
@@ -4285,7 +4285,7 @@ static clang::QualType GetFullyUnqualifiedType_Impl(clang::ASTContext *ast,
         arr->getSize(), arr->getSizeExpr(), arr->getSizeModifier(),
         arr->getIndexTypeQualifiers().getAsOpaqueValue());
   } else
-    qual_type = qual_type.getUnqualifiedType();
+    qual_type = qual_type.getUnqualifiedType(*ast);
   qual_type.removeLocalConst();
   qual_type.removeLocalRestrict();
   qual_type.removeLocalVolatile();
@@ -7596,11 +7596,12 @@ void TypeSystemClang::SetIntegerInitializerForVariable(
   // Bools are handled separately because the clang AST printer handles bools
   // separately from other integral types.
   if (qt->isSpecificBuiltinType(BuiltinType::Bool)) {
-    var->setInit(CXXBoolLiteralExpr::Create(
-        ast, !init_value.isZero(), qt.getUnqualifiedType(), SourceLocation()));
+    var->setInit(CXXBoolLiteralExpr::Create(ast, !init_value.isZero(),
+                                            qt.getUnqualifiedType(ast),
+                                            SourceLocation()));
   } else {
     var->setInit(IntegerLiteral::Create(
-        ast, init_value, qt.getUnqualifiedType(), SourceLocation()));
+        ast, init_value, qt.getUnqualifiedType(ast), SourceLocation()));
   }
 }
 
@@ -7612,7 +7613,7 @@ void TypeSystemClang::SetFloatingInitializerForVariable(
   QualType qt = var->getType();
   assert(qt->isFloatingType() && "only floating point types supported");
   var->setInit(FloatingLiteral::Create(
-      ast, init_value, true, qt.getUnqualifiedType(), SourceLocation()));
+      ast, init_value, true, qt.getUnqualifiedType(ast), SourceLocation()));
 }
 
 llvm::SmallVector<clang::ParmVarDecl *>
@@ -7836,7 +7837,7 @@ TypeSystemClang::CreateBaseClassSpecifier(lldb::opaque_compiler_type_t type,
     return nullptr;
 
   return std::make_unique<clang::CXXBaseSpecifier>(
-      clang::SourceRange(), is_virtual, base_of_class,
+      getASTContext(), clang::SourceRange(), is_virtual, base_of_class,
       TypeSystemClang::ConvertAccessTypeToAccessSpecifier(access),
       getASTContext().getTrivialTypeSourceInfo(GetQualType(type)),
       clang::SourceLocation());


### PR DESCRIPTION
This is in preparation for changes to handle vector types with qualified element type which will require to potentially construct new vector types in order to minimize the amount of sugar removed.