### PR TITLE
[Docs] Add Formal Semantics WG to Community Syncups List

### DIFF
--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -246,6 +246,10 @@ what to add to your calendar invite.
      - `ics <https://calendar.google.com/calendar/ical/2d77f9a2624d18cd46e5299d15cc0fa0c90dca53fd68802261d52121d21a0573%40group.calendar.google.com/public/basic.ics>`__
        `gcal <https://calendar.google.com/calendar/u/0?cid=MmQ3N2Y5YTI2MjRkMThjZDQ2ZTUyOTlkMTVjYzBmYTBjOTBkY2E1M2ZkNjg4MDIyNjFkNTIxMjFkMjFhMDU3M0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t>`__
      - `Meeting notes <https://docs.google.com/document/d/1DkCik6BTnO-cox_9y_BTKzPaJJOo_hBxiNFP3lInvOM/edit?tab=t.nvvd6cfloi81>`__
+   * - Formal Semantics Working Group
+     - Every 2 weeks on Mondays
+     - `gcal <https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=NW1wdXBhOGw1ajZwa2JtMG9oMTd1ZG5mZmlfMjAyNjA1MThUMTUzMDAwWiBhaWRlbmdyb3NzbWFuQGdvb2dsZS5jb20>`
+     - `Meeting notes <https://docs.google.com/document/d/1muS2gZ7PUhbypbl0bmjb2J-UUzY7K8AO9a8RHVw_Mjo/edit?usp=sharing>`
 
 For event owners, our Discord bot also supports sending automated announcements
 of upcoming sync-ups. Please see the :ref:`discord-bot-event-pings` section for


### PR DESCRIPTION
Per a suggestion from Aaron Ballman in the discord channel a while back.