### PR TITLE
[Clang] [NFC] Use `unique_ptr<Lexer>` everywhere

### DIFF
--- a/clang/include/clang/Lex/Lexer.h
+++ b/clang/include/clang/Lex/Lexer.h
@@ -23,6 +23,7 @@
 #include "llvm/ADT/StringRef.h"
 #include <cassert>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -186,11 +187,10 @@ public:
 
   /// Create_PragmaLexer: Lexer constructor - Create a new lexer object for
   /// _Pragma expansion.  This has a variety of magic semantics that this method
-  /// sets up.  It returns a new'd Lexer that must be delete'd when done.
-  static Lexer *Create_PragmaLexer(SourceLocation SpellingLoc,
-                                   SourceLocation ExpansionLocStart,
-                                   SourceLocation ExpansionLocEnd,
-                                   unsigned TokLen, Preprocessor &PP);
+  /// sets up.
+  static std::unique_ptr<Lexer> Create_PragmaLexer(
+      SourceLocation SpellingLoc, SourceLocation ExpansionLocStart,
+      SourceLocation ExpansionLocEnd, unsigned TokLen, Preprocessor &PP);
 
   /// getFileLoc - Return the File Location for the file we are lexing out of.
   /// The physical location encodes the location where the characters come from,

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -2780,7 +2780,8 @@ private:
 
   /// Add a lexer to the top of the include stack and
   /// start lexing tokens from it instead of the current buffer.
-  void EnterSourceFileWithLexer(Lexer *TheLexer, ConstSearchDirIterator Dir);
+  void EnterSourceFileWithLexer(std::unique_ptr<Lexer> TheLexer,
+                                ConstSearchDirIterator Dir);
 
   /// Set the FileID for the preprocessor predefines.
   void setPredefinesFileID(FileID FID) {

--- a/clang/lib/Format/FormatTokenLexer.cpp
+++ b/clang/lib/Format/FormatTokenLexer.cpp
@@ -36,7 +36,8 @@ FormatTokenLexer::FormatTokenLexer(
       FormattingDisabled(false), FormatOffRegex(Style.OneLineFormatOffRegex),
       MacroBlockBeginRegex(Style.MacroBlockBegin),
       MacroBlockEndRegex(Style.MacroBlockEnd), VerilogProtectedBlock(false) {
-  Lex.reset(new Lexer(ID, SourceMgr.getBufferOrFake(ID), SourceMgr, LangOpts));
+  Lex = std::make_unique<Lexer>(ID, SourceMgr.getBufferOrFake(ID), SourceMgr,
+                                LangOpts);
   Lex->SetKeepWhitespaceMode(true);
 
   for (const std::string &ForEachMacro : Style.ForEachMacros) {
@@ -1608,8 +1609,9 @@ void FormatTokenLexer::readRawToken(FormatToken &Tok) {
 
 void FormatTokenLexer::resetLexer(unsigned Offset) {
   StringRef Buffer = SourceMgr.getBufferData(ID);
-  Lex.reset(new Lexer(SourceMgr.getLocForStartOfFile(ID), LangOpts,
-                      Buffer.begin(), Buffer.begin() + Offset, Buffer.end()));
+  Lex = std::make_unique<Lexer>(SourceMgr.getLocForStartOfFile(ID), LangOpts,
+                                Buffer.begin(), Buffer.begin() + Offset,
+                                Buffer.end());
   Lex->SetKeepWhitespaceMode(true);
   TrailingWhitespace = 0;
 }

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -497,8 +497,8 @@ static SourceLocation ReadOriginalFileName(CompilerInstance &CI,
   if (!MainFileBuf)
     return SourceLocation();
 
-  std::unique_ptr<Lexer> RawLexer(
-      new Lexer(MainFileID, *MainFileBuf, SourceMgr, CI.getLangOpts()));
+  auto RawLexer = std::make_unique<Lexer>(MainFileID, *MainFileBuf, SourceMgr,
+                                          CI.getLangOpts());
 
   // If the first line has the syntax of
   //

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -237,7 +237,7 @@ void Lexer::resetExtendedTokenMode() {
 
 /// Create_PragmaLexer: Lexer constructor - Create a new lexer object for
 /// _Pragma expansion.  This has a variety of magic semantics that this method
-/// sets up.  It returns a new'd Lexer that must be delete'd when done.
+/// sets up.
 ///
 /// On entrance to this routine, TokStartLoc is a macro location which has a
 /// spelling loc that indicates the bytes to be lexed for the token and an
@@ -250,16 +250,15 @@ void Lexer::resetExtendedTokenMode() {
 /// interface that could handle this stuff.  This would pull GetMappedTokenLoc
 /// out of the critical path of the lexer!
 ///
-Lexer *Lexer::Create_PragmaLexer(SourceLocation SpellingLoc,
-                                 SourceLocation ExpansionLocStart,
-                                 SourceLocation ExpansionLocEnd,
-                                 unsigned TokLen, Preprocessor &PP) {
+std::unique_ptr<Lexer> Lexer::Create_PragmaLexer(
+    SourceLocation SpellingLoc, SourceLocation ExpansionLocStart,
+    SourceLocation ExpansionLocEnd, unsigned TokLen, Preprocessor &PP) {
   SourceManager &SM = PP.getSourceManager();
 
   // Create the lexer as if we were going to lex the file normally.
   FileID SpellingFID = SM.getFileID(SpellingLoc);
   llvm::MemoryBufferRef InputFile = SM.getBufferOrFake(SpellingFID);
-  Lexer *L = new Lexer(SpellingFID, InputFile, PP);
+  auto L = std::make_unique<Lexer>(SpellingFID, InputFile, PP);
 
   // Now that the lexer is created, change the start/end locations so that we
   // just lex the subsection of the file that we want.  This is lexing from a

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -91,19 +91,20 @@ bool Preprocessor::EnterSourceFile(FileID FID, ConstSearchDirIterator CurDir,
         CodeCompletionFileLoc.getLocWithOffset(CodeCompletionOffset);
   }
 
-  Lexer *TheLexer = new Lexer(FID, *InputFile, *this, IsFirstIncludeOfFile);
+  auto TheLexer =
+      std::make_unique<Lexer>(FID, *InputFile, *this, IsFirstIncludeOfFile);
   if (GetDependencyDirectives && FID != PredefinesFileID)
     if (OptionalFileEntryRef File = SourceMgr.getFileEntryRefForID(FID))
       if (auto MaybeDepDirectives = (*GetDependencyDirectives)(*File))
         TheLexer->DepDirectives = *MaybeDepDirectives;
 
-  EnterSourceFileWithLexer(TheLexer, CurDir);
+  EnterSourceFileWithLexer(std::move(TheLexer), CurDir);
   return false;
 }
 
 /// EnterSourceFileWithLexer - Add a source file to the top of the include stack
 ///  and start lexing tokens from it instead of the current buffer.
-void Preprocessor::EnterSourceFileWithLexer(Lexer *TheLexer,
+void Preprocessor::EnterSourceFileWithLexer(std::unique_ptr<Lexer> TheLexer,
                                             ConstSearchDirIterator CurDir) {
   PreprocessorLexer *PrevPPLexer = CurPPLexer;
 
@@ -111,11 +112,11 @@ void Preprocessor::EnterSourceFileWithLexer(Lexer *TheLexer,
   if (CurPPLexer || CurTokenLexer)
     PushIncludeMacroStack();
 
-  CurLexer.reset(TheLexer);
-  CurPPLexer = TheLexer;
+  CurLexer = std::move(TheLexer);
+  CurPPLexer = CurLexer.get();
   CurDirLookup = CurDir;
   CurLexerSubmodule = nullptr;
-  CurLexerCallback = TheLexer->isDependencyDirectivesLexer()
+  CurLexerCallback = CurLexer->isDependencyDirectivesLexer()
                          ? CLK_DependencyDirectivesLexer
                          : CLK_Lexer;
 

--- a/clang/lib/Lex/Pragma.cpp
+++ b/clang/lib/Lex/Pragma.cpp
@@ -288,10 +288,10 @@ void Preprocessor::Handle_Pragma(Token &Tok) {
 
   // Make and enter a lexer object so that we lex and expand the tokens just
   // like any others.
-  Lexer *TL = Lexer::Create_PragmaLexer(TokLoc, PragmaLoc, RParenLoc,
-                                        StrVal.size(), *this);
+  std::unique_ptr<Lexer> TL = Lexer::Create_PragmaLexer(
+      TokLoc, PragmaLoc, RParenLoc, StrVal.size(), *this);
 
-  EnterSourceFileWithLexer(TL, nullptr);
+  EnterSourceFileWithLexer(std::move(TL), nullptr);
 
   // With everything set up, lex this as a #pragma directive.
   HandlePragmaDirective({PIK__Pragma, PragmaLoc});


### PR DESCRIPTION
Replace every instance of `new Lexer` with `make_unique<Lexer>` and adjust `Lexer::Create_PragmaLexer()` to return a `std::unique_ptr<Lexer>` instead.