### PR TITLE
[flang][Semantics] Enforce IMPLICIT NONE(EXTERNAL) for dummy procedures

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -9702,7 +9702,8 @@ void ResolveNamesVisitor::HandleProcedureName(
 bool ResolveNamesVisitor::CheckImplicitNoneExternal(
     const SourceName &name, const Symbol &symbol) {
   if (symbol.has<ProcEntityDetails>() && isImplicitNoneExternal() &&
-      !symbol.attrs().test(Attr::EXTERNAL) &&
+      (!symbol.attrs().test(Attr::EXTERNAL) ||
+          symbol.implicitAttrs().test(Attr::EXTERNAL)) &&
       !symbol.attrs().test(Attr::INTRINSIC) && !symbol.HasExplicitInterface()) {
     Say(name,
         "'%s' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)"_err_en_US);
@@ -9728,7 +9729,7 @@ void ResolveNamesVisitor::NoteExecutablePartCall(
       ConvertToProcEntity(*symbol, name);
       if (auto *details{symbol->detailsIf<ProcEntityDetails>()}) {
         symbol->set(flag);
-        if (IsDummy(*symbol)) {
+        if (IsDummy(*symbol) && !symbol->attrs().test(Attr::EXTERNAL)) {
           SetImplicitAttr(*symbol, Attr::EXTERNAL);
         }
         ApplyImplicitRules(*symbol);

--- a/flang/test/Semantics/implicit07.f90
+++ b/flang/test/Semantics/implicit07.f90
@@ -13,3 +13,11 @@ block
 end block
 print *, arr(1) ! no error
 end
+
+subroutine sub(func_arg, n)
+  implicit none(external)
+  integer :: func_arg
+  integer :: n
+  !ERROR: 'func_arg' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
+  n = func_arg(n)
+end subroutine

--- a/flang/test/Semantics/implicit07.f90
+++ b/flang/test/Semantics/implicit07.f90
@@ -14,6 +14,7 @@ end block
 print *, arr(1) ! no error
 end
 
+! Function dummy argument without external
 subroutine sub(func_arg, n)
   implicit none(external)
   integer :: func_arg
@@ -21,3 +22,60 @@ subroutine sub(func_arg, n)
   !ERROR: 'func_arg' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
   n = func_arg(n)
 end subroutine
+
+! Subroutine dummy arguments with/without external specified
+subroutine sub_call(p, q)
+  implicit none(external)
+  ! error without external, no error with
+  external p
+  call p
+  !ERROR: 'q' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
+  call q
+end subroutine
+
+! Case that works because EXTERNAL is explicitly specified
+subroutine sub_works(func_arg, n)
+  implicit none(external)
+  integer, external :: func_arg
+  integer :: n
+  n = func_arg(n)
+end subroutine
+
+! Case that works because interface is specified
+subroutine sub_interface(func_arg, n)
+  implicit none(external)
+  interface
+    function func_arg(x)
+      integer, intent(in) :: x
+      integer :: func_arg
+    end function
+  end interface
+  integer :: n
+  n = func_arg(n)
+end subroutine
+
+! Inherited implicit none(external) into contains routine.
+subroutine sub_host(func_arg, n)
+  implicit none(external)
+  integer, external :: func_arg
+  integer :: n
+  n = func_arg(n)
+contains
+  subroutine inner(g)
+    integer :: g
+    !ERROR: 'g' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
+    n = g(n)
+  end subroutine
+end subroutine
+
+! Tests module scope for implicit none(external)
+module m
+  implicit none(external)
+contains
+  subroutine mod_sub(func_arg, n)
+    integer :: func_arg
+    integer :: n
+    !ERROR: 'func_arg' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
+    n = func_arg(n)
+  end subroutine
+end module


### PR DESCRIPTION
## Summary

Fix `CheckImplicitNoneExternal()` to correctly diagnose dummy arguments used as procedures that lack an explicit `EXTERNAL` attribute when `IMPLICIT NONE(EXTERNAL)` is in effect.

Fixes #198395 

## Problem

Flang silently accepted code where a dummy argument was called as a procedure under `IMPLICIT NONE(EXTERNAL)` without the required explicit `EXTERNAL` attribute. The Fortran 2018 standard C895 requires that each dummy procedure used as a procedure shall explicitly have the `EXTERNAL` attribute when `IMPLICIT NONE(EXTERNAL)` is specified.

## Changes

**`flang/lib/Semantics/resolve-names.cpp`:**

1. In `NoteExecutablePartCall()`: Guard the `SetImplicitAttr(*symbol, Attr::EXTERNAL)` call with a check that EXTERNAL is not already explicitly set. This prevents clobbering the explicit/implicit distinction when a dummy argument already has an explicit `EXTERNAL` attribute.

2. In `CheckImplicitNoneExternal()`: Change the EXTERNAL attribute test from `!symbol.attrs().test(Attr::EXTERNAL)` to `(!symbol.attrs().test(Attr::EXTERNAL) || symbol.implicitAttrs().test(Attr::EXTERNAL))`. This catches both the case where EXTERNAL has not yet been set (non-dummy externals) and the case where it was set only implicitly (dummy arguments used as procedures).

**`flang/test/Semantics/implicit07.f90`:**

Added test case for dummy arguments under `IMPLICIT NONE(EXTERNAL)`:
- A dummy used as a procedure without `EXTERNAL` (expects error)

Assisted by Claude Opus.