### PR TITLE
[lldb] Fix "Debugger::Initialize called more than once!"

### DIFF
--- a/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/DWARFASTParserClangTests.cpp
@@ -11,6 +11,7 @@
 #include "Plugins/SymbolFile/DWARF/DWARFDIE.h"
 #include "TestingSupport/Symbol/ClangTestUtils.h"
 #include "TestingSupport/Symbol/YAMLModuleTester.h"
+#include "TestingSupport/TestUtilities.h"
 #include "lldb/Core/Debugger.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -21,11 +22,10 @@ using namespace lldb_private::plugin::dwarf;
 using namespace llvm::dwarf;
 
 namespace {
-static std::once_flag debugger_initialize_flag;
 
 class DWARFASTParserClangTests : public testing::Test {
   void SetUp() override {
-    std::call_once(debugger_initialize_flag,
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
                    []() { Debugger::Initialize(nullptr); });
   }
 };


### PR DESCRIPTION
When multiple tests from the same binary, 1bac9410365260e250ab9483f096a411da5936b0 caused debugger_initialize_flag to be called more than once. 

We use the shared location: TestUtilities::g_debugger_initialize_flag to ensure that the flag is initialized only once, following what is done in other tests.