### PR TITLE
[libc++] Revert changes to locale_base_api.h accidentally committed in f5b6e4f

### DIFF
--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -33,7 +33,6 @@
 // -----------------
 // namespace __locale {
 //  using __locale_t = implementation-defined;  // required by the headers
-//  using __mbstate_t = implementation-defined; // required by the headers
 //  using __lconv_t  = implementation-defined;
 //  __locale_t  __newlocale(int, const char*, __locale_t);
 //  void        __freelocale(__locale_t);
@@ -113,8 +112,6 @@
 #    include <__locale_dir/support/freebsd.h>
 #  elif defined(__NetBSD__)
 #    include <__locale_dir/support/netbsd.h>
-#  elif defined(__OpenBSD__)
-#    include <__locale_dir/support/bsd_like.h>
 #  elif defined(_LIBCPP_MSVCRT_LIKE)
 #    include <__locale_dir/support/windows.h>
 #  elif defined(__Fuchsia__)


### PR DESCRIPTION
These changes weren't intended to be in the patch and don't make sense as-is, so this reverts them.
