### PR TITLE
[CFG] Assume enum switch default to be reachable

### DIFF
--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -4582,6 +4582,15 @@ CFGBlock *CFGBuilder::VisitSwitchStmt(SwitchStmt *Terminator) {
       return nullptr;
   }
 
+  bool HasDefaultCase = false;
+  for (const SwitchCase *SC = Terminator->getSwitchCaseList(); SC;
+       SC = SC->getNextSwitchCase()) {
+    if (isa<DefaultStmt>(SC)) {
+      HasDefaultCase = true;
+      break;
+    }
+  }
+
   // If we have no "default:" case, the default transition is to the code
   // following the switch body.  Moreover, take into account if all the
   // cases of a switch are covered (e.g., switching on an enum value).
@@ -4593,7 +4602,7 @@ CFGBlock *CFGBuilder::VisitSwitchStmt(SwitchStmt *Terminator) {
   bool SwitchAlwaysHasSuccessor = false;
   SwitchAlwaysHasSuccessor |= switchExclusivelyCovered;
   SwitchAlwaysHasSuccessor |=
-      !BuildOpts.AssumeReachableDefaultInSwitchStatements &&
+      !HasDefaultCase && !BuildOpts.AssumeReachableDefaultInSwitchStatements &&
       Terminator->isAllEnumCasesCovered() && Terminator->getSwitchCaseList();
   addSuccessor(SwitchTerminatedBlock, DefaultCaseBlock,
                !SwitchAlwaysHasSuccessor);
@@ -5609,12 +5618,12 @@ bool CFGBlock::FilterEdge(const CFGBlock::FilterOptions &F,
 
   if (To && From && F.IgnoreDefaultsWithCoveredEnums) {
     // If the 'To' has no label or is labeled but the label isn't a
-    // CaseStmt then filter this edge.
+    // CaseStmt or DefaultStmt then filter this edge.
     if (const SwitchStmt *S =
         dyn_cast_or_null<SwitchStmt>(From->getTerminatorStmt())) {
       if (S->isAllEnumCasesCovered()) {
         const Stmt *L = To->getLabel();
-        if (!L || !isa<CaseStmt>(L))
+        if (!L || (!isa<CaseStmt>(L) && !isa<DefaultStmt>(L)))
           return true;
       }
     }

--- a/clang/test/Analysis/cfg.cpp
+++ b/clang/test/Analysis/cfg.cpp
@@ -254,14 +254,14 @@ int test_enum_with_extension(enum MyEnum value) {
 // CHECK-NEXT:    5: [B2.4] (ImplicitCastExpr, IntegralCast, int)
 // CHECK-NEXT:    T: switch [B2.5]
 // CHECK-NEXT:    Preds (1): B7
-// CHECK-NEXT:    Succs (4): B4 B5 B6 B3(Unreachable)
+// CHECK-NEXT: Succs (4): B4 B5 B6 B3
 // CHECK:  [B3]
 // CHECK-NEXT:   default:
 // CHECK-NEXT:    1: 4
 // CHECK-NEXT:    2: x
 // CHECK-NEXT:    3: [B3.2] = [B3.1]
 // CHECK-NEXT:    T: break;
-// CHECK-NEXT:    Preds (1): B2(Unreachable)
+// CHECK-NEXT: Preds (1): B2
 // CHECK-NEXT:    Succs (1): B1
 // CHECK:  [B4]
 // CHECK-NEXT:   case C:

--- a/clang/test/Analysis/cfg.cpp
+++ b/clang/test/Analysis/cfg.cpp
@@ -254,14 +254,14 @@ int test_enum_with_extension(enum MyEnum value) {
 // CHECK-NEXT:    5: [B2.4] (ImplicitCastExpr, IntegralCast, int)
 // CHECK-NEXT:    T: switch [B2.5]
 // CHECK-NEXT:    Preds (1): B7
-// CHECK-NEXT: Succs (4): B4 B5 B6 B3
+// CHECK-NEXT:    Succs (4): B4 B5 B6 B3
 // CHECK:  [B3]
 // CHECK-NEXT:   default:
 // CHECK-NEXT:    1: 4
 // CHECK-NEXT:    2: x
 // CHECK-NEXT:    3: [B3.2] = [B3.1]
 // CHECK-NEXT:    T: break;
-// CHECK-NEXT: Preds (1): B2
+// CHECK-NEXT:    Preds (1): B2
 // CHECK-NEXT:    Succs (1): B1
 // CHECK:  [B4]
 // CHECK-NEXT:   case C:

--- a/clang/test/SemaCXX/switch-enum-default.cpp
+++ b/clang/test/SemaCXX/switch-enum-default.cpp
@@ -1,0 +1,73 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wreturn-type -Wuninitialized -Wno-switch-bool %s
+
+enum E { A, B };
+
+int f(E e) {
+  switch (e) {
+    case A: return 1;
+    case B: return 2;
+    default: ;
+  }
+} // expected-warning {{non-void function does not return a value in all control paths}}
+
+int g(E e) {
+  int x; // expected-note {{initialize the variable 'x' to silence this warning}}
+  switch (e) {
+    case A: x = 1; break;
+    case B: x = 2; break;
+    default: break; // expected-warning {{variable 'x' is used uninitialized whenever switch default is taken}}
+  }
+  return x; // expected-note {{uninitialized use occurs here}}
+}
+
+int h(E e) {
+  switch (e) {
+    case A: return 1;
+    case B: return 2;
+  }
+} // no warning expected
+
+int i(E e) {
+  int x;
+  switch (e) {
+    case A: x = 1; break;
+    case B: x = 2; break;
+  }
+  return x; // no warning expected
+}
+
+enum class BoolEnum : bool { False = false, True = true };
+
+int test_bool_f(BoolEnum b) {
+  switch (b) {
+    case BoolEnum::True: return 1;
+    case BoolEnum::False: return 2;
+    default: ;
+  }
+} // expected-warning {{non-void function does not return a value in all control paths}}
+
+int test_bool_g(BoolEnum b) {
+  int x; // expected-note {{initialize the variable 'x' to silence this warning}}
+  switch (b) {
+    case BoolEnum::True: x = 1; break;
+    case BoolEnum::False: x = 2; break;
+    default: break; // expected-warning {{variable 'x' is used uninitialized whenever switch default is taken}}
+  }
+  return x; // expected-note {{uninitialized use occurs here}}
+}
+
+int test_bool_h(BoolEnum b) {
+  switch (b) {
+    case BoolEnum::True: return 1;
+    case BoolEnum::False: return 2;
+  }
+} // no warning expected
+
+int test_bool_i(BoolEnum b) {
+  int x;
+  switch (b) {
+    case BoolEnum::True: x = 1; break;
+    case BoolEnum::False: x = 2; break;
+  }
+  return x; // no warning expected
+}

--- a/clang/unittests/Analysis/CFGTest.cpp
+++ b/clang/unittests/Analysis/CFGTest.cpp
@@ -243,7 +243,7 @@ TEST(CFG, SwitchCoveredEnumWithDefault) {
   CFGBlock *SwitchBlock2 = *Entry2.succ_begin();
   ASSERT_EQ(3u, SwitchBlock2->succ_size());
   auto defaultBlock2 = SwitchBlock2->succ_rbegin();
-  EXPECT_FALSE(defaultBlock2->isReachable());
+  EXPECT_TRUE(defaultBlock2->isReachable());
 }
 
 TEST(CFG, IsLinear) {


### PR DESCRIPTION
Assume that when a "default:" is present in a "switch", it's reachable for the purpose of the analysis - even if the "case"s handle all named enum values.

This allows to catch scenarios where the enum has a value that has no name assigned.

Assisted-by: Gemini