### PR TITLE
Don't warn for unknown `@Command`s in backticks in doc comments

### DIFF
--- a/clang-tools-extra/clangd/SymbolDocumentation.cpp
+++ b/clang-tools-extra/clangd/SymbolDocumentation.cpp
@@ -366,7 +366,7 @@ void SymbolDocCommentVisitor::preprocessDocumentation(StringRef Doc) {
   // which would break the parsing if we would just enclose the comment text
   // with "/** */".
 
-  // Escape doxygen commands inside markdown inline code spans.
+  // Escape doxygen commands inside multi-line markdown inline code spans.
   // This is required to not let the doxygen parser interpret them as
   // commands.
   // Note: This is a heuristic which may fail in some cases.
@@ -436,11 +436,32 @@ void SymbolDocCommentVisitor::preprocessDocumentation(StringRef Doc) {
       // command. To avoid this, we add a space before the '<'.
       OS << ' ';
 
-    for (char C : Line) {
-      if (C == '`')
-        InCodeSpan = !InCodeSpan;
-      else if (InCodeSpan && (C == '@' || C == '\\'))
+    for (size_t Idx = 0, End = Line.size(); Idx != End; ++Idx) {
+      char C = Line[Idx];
+
+      if (C == '`') {
+        if (!InCodeSpan) {
+          // Explicitly skip escaping for balanced inline code spans.
+          // If we see a backtick, find a balanced closing backtick and
+          // output the entire escaped substring. However, if we don't
+          // find an ending backtick, this is a code span that spans
+          // multiple lines and should still be escaped.
+          size_t Close = Line.find('`', Idx + 1);
+          if (Close != llvm::StringRef::npos) {
+            OS << Line.substr(Idx, Close - Idx + 1);
+            Idx = Close;
+            continue;
+          }
+
+          InCodeSpan = true;
+        } else {
+          InCodeSpan = false;
+        }
+      }
+
+      if (InCodeSpan && (C == '@' || C == '\\'))
         OS << '\\';
+
       OS << C;
     }
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -635,6 +635,7 @@ Bug Fixes to AST Handling
 - Fixed a crash when parsing Doxygen ``@param`` commands attached to invalid declarations or non-function entities. (#GH182737)
 - Fixed the SourceLocation and SourceRange of reversed rewritten CXXOperatorCallExpr. (#GH192467)
 - Fixed a assertion when ``__block`` is used on global variables in C mode. (#GH183974)
+- Fixed comment lexing to skip parsing commands in Markdown code spans. (#GH198418)
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/CommentLexer.cpp
+++ b/clang/lib/AST/CommentLexer.cpp
@@ -282,7 +282,7 @@ void Lexer::formTokenWithChars(Token &Result, const char *TokEnd,
 const char *Lexer::skipTextToken() {
   const char *TokenPtr = BufferPtr;
   assert(TokenPtr < CommentEnd);
-  StringRef TokStartSymbols = ParseCommands ? "\n\r\\@\"&<" : "\n\r";
+  StringRef TokStartSymbols = ParseCommands ? "\n\r\\@\"`&<" : "\n\r";
 
 again:
   size_t End =
@@ -290,12 +290,15 @@ again:
   if (End == StringRef::npos)
     return CommentEnd;
 
-  // Doxygen doesn't recognize any commands in a one-line double quotation.
-  // If we don't find an ending quotation mark, we pretend it never began.
-  if (*(TokenPtr + End) == '\"') {
+  // Doxygen doesn't recognize any commands in a one-line double quotation
+  // or in a backtick-delimited code span.
+  // If we don't find a balanced ending quote or backtick, we pretend it
+  // never began.
+  char StartChar = *(TokenPtr + End);
+  if (StartChar == '\"' || StartChar == '`') {
     TokenPtr += End + 1;
-    End = StringRef(TokenPtr, CommentEnd - TokenPtr).find_first_of("\n\r\"");
-    if (End != StringRef::npos && *(TokenPtr + End) == '\"')
+    End = StringRef(TokenPtr, CommentEnd - TokenPtr).find_first_of("\n\r\"`");
+    if (End != StringRef::npos && *(TokenPtr + End) == StartChar)
       TokenPtr += End + 1;
     goto again;
   }

--- a/clang/test/Lexer/comment-unknown-commands.c
+++ b/clang/test/Lexer/comment-unknown-commands.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -verify %s -fsyntax-only -Wdocumentation -Wdocumentation-unknown-command
+
+/// A test function with an `@command` in backticks
+void test(void) {}
+// ok: the command name is in backticks
+
+/// A test function with an "@command" in quotes
+void test2(void) {}
+// ok: the command name is in quotes
+
+/// A test function with an @command outside of quotes or backticks
+void test3(void) {}
+// expected-warning@-2 {{unknown command tag name}}


### PR DESCRIPTION
`-Wdocumentation-unknown-command` currently ignores doxygen commands within single quotes to match doxygen behavior. Since doxygen supports Markdown, I tried putting commands in backticks, and it ignores those too.

The impetus for this was a spurious warning in a generated `-Swift.h` header from someone referencing "an `@MainActor` function". Such a use should be totally permitted.