### PR TITLE
[flang][acc] Handle Fortran do loops as acc loops in acc routine

### DIFF
--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -124,6 +124,14 @@ void clearCollapsedDoConstructs();
 /// construct.
 bool isInsideOpenACCComputeConstruct(fir::FirOpBuilder &);
 
+/// Checks whether the current insertion point is inside an explicit
+/// `!$acc routine` function.
+bool isInsideOpenACCRoutine(fir::FirOpBuilder &);
+
+/// True when Fortran DO loops should be lowered as `acc.loop` for IV
+/// privatization.
+bool shouldLowerDoConstructAsAccLoop(fir::FirOpBuilder &);
+
 void setInsertionPointAfterOpenACCLoopIfInside(fir::FirOpBuilder &);
 
 void genEarlyReturnInOpenACCLoop(fir::FirOpBuilder &, mlir::Location);

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2539,9 +2539,10 @@ private:
       return;
     }
 
-    // Loops with induction variables inside OpenACC compute constructs
-    // need special handling to ensure that the IVs are privatized.
-    if (Fortran::lower::isInsideOpenACCComputeConstruct(*builder)) {
+    // Loops with induction variables inside OpenACC compute constructs or
+    // explicit `!$acc routine` procedures need special handling to ensure that
+    // the IVs are privatized.
+    if (Fortran::lower::shouldLowerDoConstructAsAccLoop(*builder)) {
       // Open up a new scope for the loop variables.
       localSymbols.pushScope();
       llvm::scope_exit scopeGuard([&]() { localSymbols.popScope(); });

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -67,8 +67,9 @@ static llvm::cl::opt<bool> strideIncludeLowerExtent(
 
 static llvm::cl::opt<bool> lowerDoLoopToAccLoop(
     "openacc-do-loop-to-acc-loop",
-    llvm::cl::desc("Whether to lower do loops inside OpenACC compute constructs "
-                   "as `acc.loop` operations."),
+    llvm::cl::desc(
+        "Whether to lower do loops inside OpenACC compute constructs "
+        "as `acc.loop` operations."),
     llvm::cl::init(true));
 
 static llvm::cl::opt<bool> lowerDoLoopToAccLoopInAccRoutine(
@@ -4861,10 +4862,8 @@ static bool isInsideSeqOpenACCRoutine(fir::FirOpBuilder &builder) {
 
 bool Fortran::lower::shouldLowerDoConstructAsAccLoop(
     fir::FirOpBuilder &builder) {
-  return (lowerDoLoopToAccLoop &&
-          isInsideOpenACCComputeConstruct(builder)) ||
-         (lowerDoLoopToAccLoopInAccRoutine &&
-          isInsideOpenACCRoutine(builder));
+  return (lowerDoLoopToAccLoop && isInsideOpenACCComputeConstruct(builder)) ||
+         (lowerDoLoopToAccLoopInAccRoutine && isInsideOpenACCRoutine(builder));
 }
 
 void Fortran::lower::setInsertionPointAfterOpenACCLoopIfInside(

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -15,6 +15,7 @@
 #include "flang/Common/idioms.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/ConvertType.h"
+#include "flang/Lower/ConvertVariable.h"
 #include "flang/Lower/DirectivesCommon.h"
 #include "flang/Lower/Mangler.h"
 #include "flang/Lower/PFTBuilder.h"
@@ -39,6 +40,7 @@
 #include "flang/Semantics/tools.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
 #include "mlir/Dialect/OpenACC/OpenACCUtils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/MLIRContext.h"
@@ -65,7 +67,14 @@ static llvm::cl::opt<bool> strideIncludeLowerExtent(
 
 static llvm::cl::opt<bool> lowerDoLoopToAccLoop(
     "openacc-do-loop-to-acc-loop",
-    llvm::cl::desc("Whether to lower do loops as `acc.loop` operations."),
+    llvm::cl::desc("Whether to lower do loops inside OpenACC compute constructs "
+                   "as `acc.loop` operations."),
+    llvm::cl::init(true));
+
+static llvm::cl::opt<bool> lowerDoLoopToAccLoopInAccRoutine(
+    "openacc-do-loop-to-acc-loop-in-acc-routine",
+    llvm::cl::desc("Whether to lower do loops inside explicit `!$acc routine` "
+                   "procedures as `acc.loop` operations."),
     llvm::cl::init(true));
 
 static llvm::cl::opt<bool> enableSymbolRemapping(
@@ -1439,6 +1448,8 @@ static void privatizeIv(
                          Fortran::semantics::SymbolRef(sym));
 }
 
+static bool isInsideSeqOpenACCRoutine(fir::FirOpBuilder &builder);
+
 static void determineDefaultLoopParMode(
     Fortran::lower::AbstractConverter &converter, mlir::acc::LoopOp &loopOp,
     llvm::SmallVector<mlir::Attribute> &seqDeviceTypes,
@@ -1455,22 +1466,23 @@ static void determineDefaultLoopParMode(
   if (hasDefaultSeq || hasDefaultIndependent || hasDefaultAuto)
     return; // Default loop par mode is already specified.
 
-  mlir::Region *currentRegion =
-      converter.getFirOpBuilder().getBlock()->getParent();
+  fir::FirOpBuilder &builder = converter.getFirOpBuilder();
+  mlir::Region *currentRegion = builder.getBlock()->getParent();
   mlir::Operation *parentOp = mlir::acc::getEnclosingComputeOp(*currentRegion);
   const bool isOrphanedLoop = !parentOp;
-  if (isOrphanedLoop ||
+  if ((isOrphanedLoop && !isInsideSeqOpenACCRoutine(builder)) ||
       mlir::isa_and_present<mlir::acc::ParallelOp>(parentOp)) {
     // As per OpenACC 3.3 standard section 2.9.6 independent clause:
     // A loop construct with no auto or seq clause is treated as if it has the
     // independent clause when it is an orphaned loop construct or its parent
     // compute construct is a parallel construct.
     independentDeviceTypes.push_back(mlir::acc::DeviceTypeAttr::get(
-        converter.getFirOpBuilder().getContext(), mlir::acc::DeviceType::None));
-  } else if (mlir::isa_and_present<mlir::acc::SerialOp>(parentOp)) {
-    // Serial construct implies `seq` clause on loop. However, this
-    // conflicts with parallelism assignment if already set. Therefore check
-    // that first.
+        builder.getContext(), mlir::acc::DeviceType::None));
+  } else if (mlir::isa_and_present<mlir::acc::SerialOp>(parentOp) ||
+             isInsideSeqOpenACCRoutine(builder)) {
+    // Serial construct or seq accelerator routine implies `seq` clause on loop.
+    // However, this conflicts with parallelism assignment if already set.
+    // Therefore check that first.
     bool hasDefaultGangWorkerOrVector =
         loopOp.hasVector() || loopOp.getVectorValue() || loopOp.hasWorker() ||
         loopOp.getWorkerValue() || loopOp.hasGang() ||
@@ -1479,8 +1491,7 @@ static void determineDefaultLoopParMode(
         loopOp.getGangValue(mlir::acc::GangArgType::Static);
     if (!hasDefaultGangWorkerOrVector)
       seqDeviceTypes.push_back(mlir::acc::DeviceTypeAttr::get(
-          converter.getFirOpBuilder().getContext(),
-          mlir::acc::DeviceType::None));
+          builder.getContext(), mlir::acc::DeviceType::None));
     // Since the loop has some parallelism assigned - we cannot assign `seq`.
     // However, the `acc.loop` verifier will check that one of seq, independent,
     // or auto is marked. Seems reasonable to mark as auto since the OpenACC
@@ -1489,8 +1500,7 @@ static void determineDefaultLoopParMode(
     // ignore any gang, worker, or vector clauses on the loop construct"
     else
       autoDeviceTypes.push_back(mlir::acc::DeviceTypeAttr::get(
-          converter.getFirOpBuilder().getContext(),
-          mlir::acc::DeviceType::None));
+          builder.getContext(), mlir::acc::DeviceType::None));
   } else {
     // As per OpenACC 3.3 standard section 2.9.7 auto clause:
     // When the parent compute construct is a kernels construct, a loop
@@ -1499,7 +1509,7 @@ static void determineDefaultLoopParMode(
     assert(mlir::isa_and_present<mlir::acc::KernelsOp>(parentOp) &&
            "Expected kernels construct");
     autoDeviceTypes.push_back(mlir::acc::DeviceTypeAttr::get(
-        converter.getFirOpBuilder().getContext(), mlir::acc::DeviceType::None));
+        builder.getContext(), mlir::acc::DeviceType::None));
   }
 }
 
@@ -1841,8 +1851,21 @@ void AccDataMap::remapDataOperandSymbols(
     }
     std::optional<fir::FortranVariableOpInterface> hostDef =
         symbolMap.lookupVariableDefinition(symbol);
-    assert(hostDef.has_value() && llvm::isa<hlfir::DeclareOp>(*hostDef) &&
-           "expected symbol to be mapped to hlfir.declare");
+    if (!hostDef.has_value() || !llvm::isa<hlfir::DeclareOp>(*hostDef)) {
+      // Privatized loop induction variables in explicit acc routine functions
+      // may not have a host hlfir.declare to clone. Bind the symbol directly
+      // to a declare of the acc.private result.
+      std::string uniqName = converter.mangleName(symbol.get());
+      fir::FortranVariableFlagsAttr attributes =
+          Fortran::lower::translateSymbolAttributes(builder.getContext(),
+                                                    symbol->GetUltimate());
+      auto declare = hlfir::DeclareOp::create(
+          builder, loc, value, uniqName, /*shape=*/nullptr,
+          /*typeparams=*/{}, /*dummyScope=*/nullptr, /*storage=*/nullptr,
+          /*storage_offset=*/0, attributes);
+      symbolMap.addVariableDefinition(symbol, declare, /*force=*/true);
+      continue;
+    }
     auto hostDeclare = llvm::cast<hlfir::DeclareOp>(*hostDef);
     // Replace base input and DummyScope inputs.
     mlir::Value hostInput = hostDeclare.getMemref();
@@ -4814,6 +4837,36 @@ bool Fortran::lower::isInsideOpenACCComputeConstruct(
       mlir::acc::getEnclosingComputeOp(builder.getRegion()));
 }
 
+bool Fortran::lower::isInsideOpenACCRoutine(fir::FirOpBuilder &builder) {
+  return mlir::acc::isAccRoutine(builder.getFunction().getOperation());
+}
+
+static bool isInsideSeqOpenACCRoutine(fir::FirOpBuilder &builder) {
+  mlir::func::FuncOp funcOp = builder.getFunction();
+  if (!mlir::acc::isAccRoutine(funcOp.getOperation()))
+    return false;
+  auto routineInfo = funcOp->getAttrOfType<mlir::acc::RoutineInfoAttr>(
+      mlir::acc::getRoutineInfoAttrName());
+  if (!routineInfo)
+    return false;
+  for (mlir::SymbolRefAttr routineRef : routineInfo.getAccRoutines()) {
+    auto routineOp =
+        mlir::SymbolTable::lookupNearestSymbolFrom<mlir::acc::RoutineOp>(
+            funcOp, routineRef.getLeafReference());
+    if (routineOp && routineOp.hasSeq())
+      return true;
+  }
+  return false;
+}
+
+bool Fortran::lower::shouldLowerDoConstructAsAccLoop(
+    fir::FirOpBuilder &builder) {
+  return (lowerDoLoopToAccLoop &&
+          isInsideOpenACCComputeConstruct(builder)) ||
+         (lowerDoLoopToAccLoopInAccRoutine &&
+          isInsideOpenACCRoutine(builder));
+}
+
 void Fortran::lower::setInsertionPointAfterOpenACCLoopIfInside(
     fir::FirOpBuilder &builder) {
   if (auto loopOp =
@@ -4897,7 +4950,8 @@ mlir::Operation *Fortran::lower::genOpenACCLoopFromDoConstruct(
     Fortran::semantics::SemanticsContext &semanticsContext,
     Fortran::lower::SymMap &localSymbols,
     const Fortran::parser::DoConstruct &doConstruct, pft::Evaluation &eval) {
-  if (!lowerDoLoopToAccLoop)
+  if (!Fortran::lower::shouldLowerDoConstructAsAccLoop(
+          converter.getFirOpBuilder()))
     return nullptr;
 
   // Only convert loops which have induction variables that need privatized.
@@ -4956,13 +5010,17 @@ mlir::Operation *Fortran::lower::genOpenACCLoopFromDoConstruct(
   fir::FirOpBuilder &builder = converter.getFirOpBuilder();
   mlir::Operation *accRegionOp =
       mlir::acc::getEnclosingComputeOp(builder.getRegion());
-  mlir::acc::LoopParMode parMode =
-      mlir::isa_and_present<mlir::acc::ParallelOp>(accRegionOp) &&
-              doConstruct.IsDoConcurrent()
-          ? mlir::acc::LoopParMode::loop_independent
-      : mlir::isa_and_present<mlir::acc::SerialOp>(accRegionOp)
-          ? mlir::acc::LoopParMode::loop_seq
-          : mlir::acc::LoopParMode::loop_auto;
+  mlir::acc::LoopParMode parMode;
+  if (mlir::isa_and_present<mlir::acc::SerialOp>(accRegionOp) ||
+      isInsideSeqOpenACCRoutine(builder)) {
+    parMode = mlir::acc::LoopParMode::loop_seq;
+  } else if (doConstruct.IsDoConcurrent() &&
+             (mlir::isa_and_present<mlir::acc::ParallelOp>(accRegionOp) ||
+              isInsideOpenACCRoutine(builder))) {
+    parMode = mlir::acc::LoopParMode::loop_independent;
+  } else {
+    parMode = mlir::acc::LoopParMode::loop_auto;
+  }
 
   // Set the parallel mode based on the computed parMode
   auto deviceNoneAttr = mlir::acc::DeviceTypeAttr::get(

--- a/flang/test/Lower/OpenACC/do-loops-to-acc-loops.f90
+++ b/flang/test/Lower/OpenACC/do-loops-to-acc-loops.f90
@@ -2,7 +2,7 @@
 ! Tests the new functionality that converts Fortran iteration constructs to acc.loop with proper IV handling.
 
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
-! RUN: bbc -fopenacc -emit-hlfir --openacc-do-loop-to-acc-loop=false %s -o - | FileCheck %s --check-prefix=CHECK-NOACCLOOP
+! RUN: bbc -fopenacc -emit-hlfir --openacc-do-loop-to-acc-loop=false --openacc-do-loop-to-acc-loop-in-acc-routine=false %s -o - | FileCheck %s --check-prefix=CHECK-NOACCLOOP
 
 ! CHECK-LABEL: func.func @_QPbasic_do_loop
 subroutine basic_do_loop()
@@ -426,5 +426,112 @@ subroutine while_like_loop()
 
 ! CHECK: acc.kernels {
 ! CHECK-NOT: acc.loop
+
+end subroutine
+
+! CHECK-LABEL: func.func @_QProutine_do_loop
+! CHECK-NOACCLOOP-LABEL: func.func @_QProutine_do_loop
+! CHECK-SAME: attributes {acc.routine_info
+! CHECK-NOACCLOOP-NOT: acc.loop
+subroutine routine_do_loop()
+  !$acc routine seq
+  integer :: i
+  integer, parameter :: n = 10
+  real, dimension(n) :: a, b
+
+  do i = 1, n
+    a(i) = b(i) + 1.0
+  end do
+
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
+! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_loopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: acc.yield
+! CHECK: attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK-NOT: auto_ = [#acc.device_type
+! CHECK-NOT: independent = [#acc.device_type
+
+end subroutine
+
+! CHECK-LABEL: func.func @_QProutine_do_concurrent
+! CHECK-NOACCLOOP-LABEL: func.func @_QProutine_do_concurrent
+! CHECK-SAME: attributes {acc.routine_info
+! CHECK-NOACCLOOP-NOT: acc.loop
+subroutine routine_do_concurrent()
+  !$acc routine seq
+  integer :: i
+  integer, parameter :: n = 10
+  real, dimension(n) :: a, b
+
+  do concurrent (i = 1:n)
+    a(i) = b(i) + 1.0
+  end do
+
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
+! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_concurrentEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: acc.yield
+! CHECK: attributes {inclusiveUpperbound = array<i1: true>, seq = [#acc.device_type<none>]}
+! CHECK-NOT: independent = [#acc.device_type
+
+end subroutine
+
+! CHECK-LABEL: func.func @_QProutine_do_loop_nonseq
+! CHECK-NOACCLOOP-LABEL: func.func @_QProutine_do_loop_nonseq
+! CHECK-SAME: attributes {acc.routine_info
+! CHECK-NOACCLOOP-NOT: acc.loop
+subroutine routine_do_loop_nonseq()
+  !$acc routine
+  integer :: i
+  integer, parameter :: n = 10
+  real, dimension(n) :: a, b
+
+  do i = 1, n
+    a(i) = b(i) + 1.0
+  end do
+
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
+! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_loop_nonseqEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: acc.yield
+! CHECK: attributes {auto_ = [#acc.device_type<none>], inclusiveUpperbound = array<i1: true>}
+! CHECK-NOT: seq = [#acc.device_type
+! CHECK-NOT: independent = [#acc.device_type
+
+end subroutine
+
+! CHECK-LABEL: func.func @_QProutine_do_concurrent_nonseq
+! CHECK-NOACCLOOP-LABEL: func.func @_QProutine_do_concurrent_nonseq
+! CHECK-SAME: attributes {acc.routine_info
+! CHECK-NOACCLOOP-NOT: acc.loop
+subroutine routine_do_concurrent_nonseq()
+  !$acc routine
+  integer :: i
+  integer, parameter :: n = 10
+  real, dimension(n) :: a, b
+
+  do concurrent (i = 1:n)
+    a(i) = b(i) + 1.0
+  end do
+
+! CHECK: %[[PRIVATE_IV:.*]] = acc.private varPtr(%{{.*}} : !fir.ref<i32>) recipe(@privatization_ref_i32) -> !fir.ref<i32> {implicit = true, name = "i"}
+! CHECK: acc.loop private(%[[PRIVATE_IV]] : !fir.ref<i32>) control(%{{.*}} : i32) = (%{{.*}} : i32) to (%{{.*}} : i32) step (%{{.*}} : i32)
+! CHECK: %[[PRIVATE_DECLARE:.*]]:2 = hlfir.declare %[[PRIVATE_IV]] {uniq_name = "_QFroutine_do_concurrent_nonseqEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: fir.store %{{.*}} to %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: %{{.*}} = fir.load %[[PRIVATE_DECLARE]]#0 : !fir.ref<i32>
+! CHECK: acc.yield
+! CHECK: attributes {inclusiveUpperbound = array<i1: true>, independent = [#acc.device_type<none>]}
+! CHECK-NOT: seq = [#acc.device_type
+! CHECK-NOT: auto_ = [#acc.device_type
 
 end subroutine


### PR DESCRIPTION
As was previously done for do loops in acc compute constructs in https://github.com/llvm/llvm-project/issues/149614 , this PR does the same for do loops in `acc routine`. The rules are follows:
- Do loops not marked with `acc loop` are considered `auto`
- Do concurrent loops are considered `independent`
- Any loops in an `acc routine seq` are considered `seq`

This ensures that the IV is correctly privatized and attached to acc loop.