### PR TITLE
[CIR] Set ExternalWeakLinkage on weak/weak_import function declarations

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -976,12 +976,21 @@ static void setLinkageForGV(cir::GlobalOp &gv, const NamedDecl *nd) {
     gv.setLinkage(cir::GlobalLinkageKind::ExternalWeakLinkage);
 }
 
-static void setLinkageForFunction(cir::FuncOp &func, const NamedDecl *nd) {
+static void setLinkageForFunction(CIRGenModule &cgm, cir::FuncOp &func,
+                                  const NamedDecl *nd) {
   // Mirrors CodeGenModule::setLinkageForGV for function declarations.
   LinkageInfo lv = nd->getLinkageAndVisibility();
   if (isExternallyVisible(lv.getLinkage()) &&
-      (nd->hasAttr<WeakAttr>() || nd->isWeakImported()))
-    func.setLinkage(cir::GlobalLinkageKind::ExternalWeakLinkage);
+      (nd->hasAttr<WeakAttr>() || nd->isWeakImported())) {
+    auto linkage = cir::GlobalLinkageKind::ExternalWeakLinkage;
+    func.setLinkage(linkage);
+    func.setLinkageAttr(
+        cir::GlobalLinkageKindAttr::get(&cgm.getMLIRContext(), linkage));
+    // Declarations must keep 'private' MLIR visibility; only update for defs.
+    if (!func.isDeclaration())
+      mlir::SymbolTable::setSymbolVisibility(
+          func, cgm.getMLIRVisibilityFromCIRLinkage(linkage));
+  }
 }
 
 static llvm::SmallVector<int64_t> indexesOfArrayAttr(mlir::ArrayAttr indexes) {
@@ -3002,24 +3011,7 @@ void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
     getTargetCIRGenInfo().setTargetAttributes(funcDecl, func, *this);
 
   // Mirrors setLinkageForGV in CodeGenModule::SetFunctionAttributes.
-  setLinkageForFunction(func, funcDecl);
-
-  // GetGVALinkageForFunction requires a definition (or willHaveBody) and
-  // asserts via isInlineDefinitionExternallyVisible on bare declarations.
-  const bool isDeclWithoutBody =
-      func.isDeclaration() && !funcDecl->doesThisDeclarationHaveABody();
-  if (!isIncompleteFunction && !isDeclWithoutBody) {
-    // TODO(cir): This needs a lot of work to better match CodeGen. That
-    // ultimately ends up in setGlobalVisibility, which already has the linkage
-    // of the LLVM GV (corresponding to our FuncOp) computed, so it doesn't have
-    // to recompute it here. This is a minimal fix for now.
-    if (!isLocalLinkage(getFunctionLinkage(globalDecl))) {
-      const Decl *decl = globalDecl.getDecl();
-      func.setGlobalVisibility(
-          getGlobalVisibilityAttrFromDecl(decl).getValue());
-    }
-  }
-
+  setLinkageForFunction(*this, func, funcDecl);
 
   // If we plan on emitting this inline builtin, we can't treat it as a builtin.
   if (funcDecl->isInlineBuiltinDeclaration()) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -976,6 +976,14 @@ static void setLinkageForGV(cir::GlobalOp &gv, const NamedDecl *nd) {
     gv.setLinkage(cir::GlobalLinkageKind::ExternalWeakLinkage);
 }
 
+static void setLinkageForFunction(cir::FuncOp &func, const NamedDecl *nd) {
+  // Mirrors CodeGenModule::setLinkageForGV for function declarations.
+  LinkageInfo lv = nd->getLinkageAndVisibility();
+  if (isExternallyVisible(lv.getLinkage()) &&
+      (nd->hasAttr<WeakAttr>() || nd->isWeakImported()))
+    func.setLinkage(cir::GlobalLinkageKind::ExternalWeakLinkage);
+}
+
 static llvm::SmallVector<int64_t> indexesOfArrayAttr(mlir::ArrayAttr indexes) {
   llvm::SmallVector<int64_t> inds;
   for (mlir::Attribute i : indexes) {
@@ -2992,6 +3000,26 @@ void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
 
   if (!isIncompleteFunction && func.isDeclaration())
     getTargetCIRGenInfo().setTargetAttributes(funcDecl, func, *this);
+
+  // Mirrors setLinkageForGV in CodeGenModule::SetFunctionAttributes.
+  setLinkageForFunction(func, funcDecl);
+
+  // GetGVALinkageForFunction requires a definition (or willHaveBody) and
+  // asserts via isInlineDefinitionExternallyVisible on bare declarations.
+  const bool isDeclWithoutBody =
+      func.isDeclaration() && !funcDecl->doesThisDeclarationHaveABody();
+  if (!isIncompleteFunction && !isDeclWithoutBody) {
+    // TODO(cir): This needs a lot of work to better match CodeGen. That
+    // ultimately ends up in setGlobalVisibility, which already has the linkage
+    // of the LLVM GV (corresponding to our FuncOp) computed, so it doesn't have
+    // to recompute it here. This is a minimal fix for now.
+    if (!isLocalLinkage(getFunctionLinkage(globalDecl))) {
+      const Decl *decl = globalDecl.getDecl();
+      func.setGlobalVisibility(
+          getGlobalVisibilityAttrFromDecl(decl).getValue());
+    }
+  }
+
 
   // If we plan on emitting this inline builtin, we can't treat it as a builtin.
   if (funcDecl->isInlineBuiltinDeclaration()) {

--- a/clang/test/CIR/CodeGen/func-linkage-weak-import.c
+++ b/clang/test/CIR/CodeGen/func-linkage-weak-import.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+extern void weak_import_fn(void) __attribute__((weak_import));
+void user(void) {
+  weak_import_fn();
+}
+
+// CIR-DAG: cir.func{{.*}}extern_weak{{.*}}@weak_import_fn
+// CIR-DAG: cir.func{{.*}}@user
+// CIR: cir.call @weak_import_fn
+
+// LLVM-DAG: declare extern_weak void @weak_import_fn()
+// LLVM-DAG: define{{.*}}@user
+// LLVM-DAG: call{{.*}}@weak_import_fn

--- a/clang/test/CIR/CodeGen/inline-forward-decl.c
+++ b/clang/test/CIR/CodeGen/inline-forward-decl.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=gnu17 -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=gnu17 -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 inline int helper(int);
 void user(void) {
@@ -13,12 +13,13 @@ inline int helper(int x) {
   return x;
 }
 
+__attribute__((weak)) void weak_fn(void) {}
+
 // CIR-DAG: cir.func{{.*}}@helper
 // CIR-DAG: cir.func{{.*}}@user
-// CIR: cir.call @helper
+// CIR-DAG: cir.func{{.*}}weak @weak_fn
+// CIR-DAG: cir.call @helper
 
 // LLVM: define{{.*}}@user
 // LLVM: call{{.*}}@helper
-
-// OGCG: define{{.*}}@user
-// OGCG: call{{.*}}@helper
+// LLVM: define weak void @weak_fn()

--- a/clang/test/CIR/CodeGen/inline-forward-decl.c
+++ b/clang/test/CIR/CodeGen/inline-forward-decl.c
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=gnu17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=gnu17 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=gnu17 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+inline int helper(int);
+void user(void) {
+  helper(1);
+}
+inline int helper(int x) {
+  return x;
+}
+
+// CIR-DAG: cir.func{{.*}}@helper
+// CIR-DAG: cir.func{{.*}}@user
+// CIR: cir.call @helper
+
+// LLVM: define{{.*}}@user
+// LLVM: call{{.*}}@helper
+
+// OGCG: define{{.*}}@user
+// OGCG: call{{.*}}@helper


### PR DESCRIPTION
Classic CodeGen's `SetFunctionAttributes` calls `setLinkageForGV` to force `ExternalWeakLinkage` on `__attribute__((weak))` and Darwin `weak_import` declarations.  CIR had no equivalent: weak function declarations were emitted with `ExternalLinkage` instead of `ExternalWeakLinkage`.

This adds `setLinkageForFunction` — the same weak/external-weak logic as `setLinkageForGV` — and calls it from `setFunctionAttributes`.  The underlying crash on inline forward declarations (the original motivation) is already fixed by [#195257](https://github.com/llvm/llvm-project/pull/195257); what remains is this linkage gap.

`inline-forward-decl.c` covers `__attribute__((weak))` on an inline forward declaration; `func-linkage-weak-import.c` covers Darwin `weak_import` (→ `extern_weak` in CIR and LLVM).