### PR TITLE
[lldb/Interpreter] Plumb ScriptedMetadata through scripted plugin CreatePluginObject (NFC)

### DIFF
--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedBreakpointInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedBreakpointInterface.h
@@ -18,8 +18,8 @@ namespace lldb_private {
 class ScriptedBreakpointInterface : public ScriptedInterface {
 public:
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, lldb::BreakpointSP break_sp,
-                     const StructuredDataImpl &args_sp) = 0;
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::BreakpointSP break_sp) = 0;
 
   /// "ResolverCallback" will get called when a new module is loaded.  The
   /// new module information is passed in sym_ctx.  The Resolver will add

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedFrameProviderInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedFrameProviderInterface.h
@@ -22,9 +22,8 @@ public:
   }
 
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name,
-                     lldb::StackFrameListSP input_frames,
-                     StructuredData::DictionarySP args_sp) = 0;
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::StackFrameListSP input_frames) = 0;
 
   /// Get a description string for the frame provider.
   ///

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedHookInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedHookInterface.h
@@ -28,7 +28,8 @@ public:
   };
 
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, lldb::TargetSP target_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::TargetSP target_sp,
                      const StructuredDataImpl &args_sp) = 0;
 
   /// Check which hook callback methods the Python class implements.

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedInterface.h
@@ -14,11 +14,13 @@
 #include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/ScriptedMetadata.h"
 #include "lldb/Utility/UnimplementedError.h"
 #include "lldb/lldb-private.h"
 
 #include "llvm/Support/Compiler.h"
 
+#include <optional>
 #include <string>
 
 namespace lldb_private {
@@ -29,6 +31,10 @@ public:
 
   StructuredData::GenericSP GetScriptObjectInstance() {
     return m_object_instance_sp;
+  }
+
+  const std::optional<ScriptedMetadata> &GetScriptedMetadata() const {
+    return m_scripted_metadata;
   }
 
   struct AbstractMethodRequirement {
@@ -96,6 +102,7 @@ public:
 
 protected:
   StructuredData::GenericSP m_object_instance_sp;
+  std::optional<ScriptedMetadata> m_scripted_metadata;
 };
 } // namespace lldb_private
 #endif // LLDB_INTERPRETER_INTERFACES_SCRIPTEDINTERFACE_H

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedProcessInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedProcessInterface.h
@@ -22,8 +22,8 @@ namespace lldb_private {
 class ScriptedProcessInterface : virtual public ScriptedInterface {
 public:
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
-                     StructuredData::DictionarySP args_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     ExecutionContext &exe_ctx,
                      StructuredData::Generic *script_obj = nullptr) = 0;
 
   virtual StructuredData::DictionarySP GetCapabilities() { return {}; }

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedStopHookInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedStopHookInterface.h
@@ -17,7 +17,8 @@ namespace lldb_private {
 class ScriptedStopHookInterface : public ScriptedInterface {
 public:
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, lldb::TargetSP target_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::TargetSP target_sp,
                      const StructuredDataImpl &args_sp) = 0;
 
   /// "handle_stop" will return a bool with the meaning "should_stop"...

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadInterface.h
@@ -21,8 +21,8 @@ namespace lldb_private {
 class ScriptedThreadInterface : virtual public ScriptedInterface {
 public:
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
-                     StructuredData::DictionarySP args_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     ExecutionContext &exe_ctx,
                      StructuredData::Generic *script_obj = nullptr) = 0;
 
   virtual lldb::tid_t GetThreadID() { return LLDB_INVALID_THREAD_ID; }

--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadPlanInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadPlanInterface.h
@@ -17,7 +17,7 @@ namespace lldb_private {
 class ScriptedThreadPlanInterface : public ScriptedInterface {
 public:
   virtual llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
                      lldb::ThreadPlanSP thread_plan_sp,
                      const StructuredDataImpl &args_sp) = 0;
 

--- a/lldb/include/lldb/Utility/ScriptedMetadata.h
+++ b/lldb/include/lldb/Utility/ScriptedMetadata.h
@@ -19,7 +19,7 @@ class ScriptedMetadata {
 public:
   ScriptedMetadata(llvm::StringRef class_name,
                    StructuredData::DictionarySP dict_sp)
-      : m_class_name(class_name.data()), m_args_sp(dict_sp) {}
+      : m_class_name(class_name.str()), m_args_sp(dict_sp) {}
 
   ScriptedMetadata(const ProcessInfo &process_info) {
     lldb::ScriptedMetadataSP metadata_sp = process_info.GetScriptedMetadata();
@@ -29,8 +29,8 @@ public:
     }
   }
 
-  ScriptedMetadata(const ScriptedMetadata &other)
-      : m_class_name(other.m_class_name), m_args_sp(other.m_args_sp) {}
+  ScriptedMetadata(const ScriptedMetadata &other) = default;
+  ScriptedMetadata &operator=(const ScriptedMetadata &other) = default;
 
   explicit operator bool() const { return !m_class_name.empty(); }
 

--- a/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverScripted.cpp
@@ -84,8 +84,14 @@ void BreakpointResolverScripted::CreateImplementationIfNeeded(
     return;
   }
 
+  StructuredData::ObjectSP args_obj = m_args.GetObjectSP();
+  StructuredData::DictionarySP args_dict_sp;
+  if (args_obj && args_obj->GetType() == lldb::eStructuredDataTypeDictionary)
+    args_dict_sp =
+        std::static_pointer_cast<StructuredData::Dictionary>(args_obj);
+  ScriptedMetadata scripted_metadata(m_class_name, args_dict_sp);
   auto obj_or_err =
-      m_interface_sp->CreatePluginObject(m_class_name, breakpoint_sp, m_args);
+      m_interface_sp->CreatePluginObject(scripted_metadata, breakpoint_sp);
   if (!obj_or_err) {
     m_interface_sp.reset();
     m_error = Status::FromError(obj_or_err.takeError());

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -116,8 +116,9 @@ OperatingSystemPython::OperatingSystemPython(lldb_private::Process *process,
     return;
 
   ExecutionContext exe_ctx(process);
+  ScriptedMetadata scripted_metadata(os_plugin_class_name, nullptr);
   auto obj_or_err = operating_system_interface->CreatePluginObject(
-      os_plugin_class_name, exe_ctx, nullptr);
+      scripted_metadata, exe_ctx, nullptr);
 
   if (!obj_or_err) {
     llvm::consumeError(obj_or_err.takeError());

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -108,9 +108,8 @@ ScriptedProcess::ScriptedProcess(lldb::TargetSP target_sp,
   ExecutionContext exe_ctx(target_sp, /*get_process=*/false);
 
   // Create process script object
-  auto obj_or_err = GetInterface().CreatePluginObject(
-      m_scripted_metadata.GetClassName(), exe_ctx,
-      m_scripted_metadata.GetArgsSP());
+  auto obj_or_err =
+      GetInterface().CreatePluginObject(m_scripted_metadata, exe_ctx);
 
   if (!obj_or_err) {
     llvm::consumeError(obj_or_err.takeError());

--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -57,9 +57,17 @@ ScriptedThread::Create(ScriptedProcess &process,
   }
 
   ExecutionContext exe_ctx(process);
+  // The legacy thread-spawn path (no script_object) needs to instantiate a
+  // *thread* Python class whose name comes from the process plugin, not the
+  // process's own class name. Build a thread-specific metadata for that case;
+  // when script_object is non-null the class name is unused so we just forward
+  // the process's metadata.
+  ScriptedMetadata thread_metadata =
+      script_object ? process.m_scripted_metadata
+                    : ScriptedMetadata(thread_class_name,
+                                       process.m_scripted_metadata.GetArgsSP());
   auto obj_or_err = scripted_thread_interface->CreatePluginObject(
-      thread_class_name, exe_ctx, process.m_scripted_metadata.GetArgsSP(),
-      script_object);
+      thread_metadata, exe_ctx, script_object);
 
   if (!obj_or_err) {
     llvm::consumeError(obj_or_err.takeError());

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
@@ -28,9 +28,9 @@ OperatingSystemPythonInterface::OperatingSystemPythonInterface(
 
 llvm::Expected<StructuredData::GenericSP>
 OperatingSystemPythonInterface::CreatePluginObject(
-    llvm::StringRef class_name, ExecutionContext &exe_ctx,
-    StructuredData::DictionarySP args_sp, StructuredData::Generic *script_obj) {
-  return ScriptedPythonInterface::CreatePluginObject(class_name, nullptr,
+    const ScriptedMetadata &scripted_metadata, ExecutionContext &exe_ctx,
+    StructuredData::Generic *script_obj) {
+  return ScriptedPythonInterface::CreatePluginObject(scripted_metadata, nullptr,
                                                      exe_ctx.GetProcessSP());
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.h
@@ -24,8 +24,8 @@ public:
   OperatingSystemPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
-                     StructuredData::DictionarySP args_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     ExecutionContext &exe_ctx,
                      StructuredData::Generic *script_obj = nullptr) override;
 
   llvm::SmallVector<AbstractMethodRequirement>

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.cpp
@@ -30,10 +30,9 @@ ScriptedBreakpointPythonInterface::ScriptedBreakpointPythonInterface(
 
 llvm::Expected<StructuredData::GenericSP>
 ScriptedBreakpointPythonInterface::CreatePluginObject(
-    llvm::StringRef class_name, lldb::BreakpointSP break_sp,
-    const StructuredDataImpl &args_sp) {
-  return ScriptedPythonInterface::CreatePluginObject(class_name, nullptr,
-                                                     break_sp, args_sp);
+    const ScriptedMetadata &scripted_metadata, lldb::BreakpointSP break_sp) {
+  return ScriptedPythonInterface::CreatePluginObject(
+      scripted_metadata, nullptr, break_sp, scripted_metadata.GetArgsSP());
 }
 
 bool ScriptedBreakpointPythonInterface::OverridesResolver(

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedBreakpointPythonInterface.h
@@ -22,8 +22,8 @@ public:
   ScriptedBreakpointPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, lldb::BreakpointSP break_sp,
-                     const StructuredDataImpl &args_sp) override;
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::BreakpointSP break_sp) override;
 
   llvm::SmallVector<AbstractMethodRequirement>
   GetAbstractMethodRequirements() const override {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.cpp
@@ -44,14 +44,13 @@ bool ScriptedFrameProviderPythonInterface::AppliesToThread(
 
 llvm::Expected<StructuredData::GenericSP>
 ScriptedFrameProviderPythonInterface::CreatePluginObject(
-    const llvm::StringRef class_name, lldb::StackFrameListSP input_frames,
-    StructuredData::DictionarySP args_sp) {
+    const ScriptedMetadata &scripted_metadata,
+    lldb::StackFrameListSP input_frames) {
   if (!input_frames)
     return llvm::createStringError("invalid frame list");
 
-  StructuredDataImpl sd_impl(args_sp);
-  return ScriptedPythonInterface::CreatePluginObject(class_name, nullptr,
-                                                     input_frames, sd_impl);
+  return ScriptedPythonInterface::CreatePluginObject(
+      scripted_metadata, nullptr, input_frames, scripted_metadata.GetArgsSP());
 }
 
 std::string ScriptedFrameProviderPythonInterface::GetDescription(

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFrameProviderPythonInterface.h
@@ -27,9 +27,8 @@ public:
                        lldb::ThreadSP thread_sp) override;
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name,
-                     lldb::StackFrameListSP input_frames,
-                     StructuredData::DictionarySP args_sp) override;
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::StackFrameListSP input_frames) override;
 
   llvm::SmallVector<AbstractMethodRequirement>
   GetAbstractMethodRequirements() const override {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedFramePythonInterface.cpp
@@ -33,9 +33,9 @@ ScriptedFramePythonInterface::CreatePluginObject(
     StructuredData::DictionarySP args_sp, StructuredData::Generic *script_obj) {
   ExecutionContextRefSP exe_ctx_ref_sp =
       std::make_shared<ExecutionContextRef>(exe_ctx);
-  StructuredDataImpl sd_impl(args_sp);
-  return ScriptedPythonInterface::CreatePluginObject(class_name, script_obj,
-                                                     exe_ctx_ref_sp, sd_impl);
+  ScriptedMetadata scripted_metadata(class_name, args_sp);
+  return ScriptedPythonInterface::CreatePluginObject(
+      scripted_metadata, script_obj, exe_ctx_ref_sp, args_sp);
 }
 
 lldb::user_id_t ScriptedFramePythonInterface::GetID() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.cpp
@@ -53,9 +53,9 @@ ScriptedHookPythonInterface::GetSupportedMethods() {
 
 llvm::Expected<StructuredData::GenericSP>
 ScriptedHookPythonInterface::CreatePluginObject(
-    llvm::StringRef class_name, lldb::TargetSP target_sp,
+    const ScriptedMetadata &scripted_metadata, lldb::TargetSP target_sp,
     const StructuredDataImpl &args_sp) {
-  return ScriptedPythonInterface::CreatePluginObject(class_name, nullptr,
+  return ScriptedPythonInterface::CreatePluginObject(scripted_metadata, nullptr,
                                                      target_sp, args_sp);
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedHookPythonInterface.h
@@ -21,7 +21,8 @@ public:
   ScriptedHookPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, lldb::TargetSP target_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::TargetSP target_sp,
                      const StructuredDataImpl &args_sp) override;
 
   /// A hook class must implement at least one callback. All three are

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPlatformPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPlatformPythonInterface.cpp
@@ -33,9 +33,9 @@ ScriptedPlatformPythonInterface::CreatePluginObject(
     StructuredData::DictionarySP args_sp, StructuredData::Generic *script_obj) {
   ExecutionContextRefSP exe_ctx_ref_sp =
       std::make_shared<ExecutionContextRef>(exe_ctx);
-  StructuredDataImpl sd_impl(args_sp);
-  return ScriptedPythonInterface::CreatePluginObject(class_name, script_obj,
-                                                     exe_ctx_ref_sp, sd_impl);
+  ScriptedMetadata scripted_metadata(class_name, args_sp);
+  return ScriptedPythonInterface::CreatePluginObject(
+      scripted_metadata, script_obj, exe_ctx_ref_sp, args_sp);
 }
 
 StructuredData::DictionarySP ScriptedPlatformPythonInterface::ListProcesses() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.cpp
@@ -32,13 +32,13 @@ ScriptedProcessPythonInterface::ScriptedProcessPythonInterface(
 
 llvm::Expected<StructuredData::GenericSP>
 ScriptedProcessPythonInterface::CreatePluginObject(
-    llvm::StringRef class_name, ExecutionContext &exe_ctx,
-    StructuredData::DictionarySP args_sp, StructuredData::Generic *script_obj) {
+    const ScriptedMetadata &scripted_metadata, ExecutionContext &exe_ctx,
+    StructuredData::Generic *script_obj) {
   ExecutionContextRefSP exe_ctx_ref_sp =
       std::make_shared<ExecutionContextRef>(exe_ctx);
-  StructuredDataImpl sd_impl(args_sp);
-  return ScriptedPythonInterface::CreatePluginObject(class_name, script_obj,
-                                                     exe_ctx_ref_sp, sd_impl);
+  return ScriptedPythonInterface::CreatePluginObject(
+      scripted_metadata, script_obj, exe_ctx_ref_sp,
+      scripted_metadata.GetArgsSP());
 }
 
 StructuredData::DictionarySP ScriptedProcessPythonInterface::GetCapabilities() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedProcessPythonInterface.h
@@ -23,9 +23,8 @@ public:
   ScriptedProcessPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(const llvm::StringRef class_name,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
                      ExecutionContext &exe_ctx,
-                     StructuredData::DictionarySP args_sp,
                      StructuredData::Generic *script_obj = nullptr) override;
 
   llvm::SmallVector<AbstractMethodRequirement>

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedPythonInterface.h
@@ -168,7 +168,7 @@ public:
 
   template <typename... Args>
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
                      StructuredData::Generic *script_obj, Args... args) {
     using namespace python;
     using Locker = ScriptInterpreterPythonImpl::Locker;
@@ -180,6 +180,8 @@ public:
               .str());
     };
 
+    m_scripted_metadata = scripted_metadata;
+    llvm::StringRef class_name = scripted_metadata.GetClassName();
     bool has_class_name = !class_name.empty();
     bool has_interpreter_dict =
         !(llvm::StringRef(m_interpreter.GetDictionaryName()).empty());
@@ -585,6 +587,12 @@ protected:
 
   python::PythonObject Transform(const StructuredDataImpl &arg) {
     return python::SWIGBridge::ToSWIGWrapper(arg);
+  }
+
+  template <typename T, typename = std::enable_if_t<
+                            std::is_base_of_v<StructuredData::Object, T>>>
+  python::PythonObject Transform(std::shared_ptr<T> arg) {
+    return Transform(StructuredDataImpl(arg));
   }
 
   python::PythonObject Transform(lldb::ExecutionContextRefSP arg) {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedStopHookPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedStopHookPythonInterface.cpp
@@ -26,10 +26,10 @@ ScriptedStopHookPythonInterface::ScriptedStopHookPythonInterface(
     : ScriptedStopHookInterface(), ScriptedPythonInterface(interpreter) {}
 
 llvm::Expected<StructuredData::GenericSP>
-ScriptedStopHookPythonInterface::CreatePluginObject(llvm::StringRef class_name,
-                                                    lldb::TargetSP target_sp,
-                                                    const StructuredDataImpl &args_sp) {
-  return ScriptedPythonInterface::CreatePluginObject(class_name, nullptr,
+ScriptedStopHookPythonInterface::CreatePluginObject(
+    const ScriptedMetadata &scripted_metadata, lldb::TargetSP target_sp,
+    const StructuredDataImpl &args_sp) {
+  return ScriptedPythonInterface::CreatePluginObject(scripted_metadata, nullptr,
                                                      target_sp, args_sp);
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedStopHookPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedStopHookPythonInterface.h
@@ -21,7 +21,8 @@ public:
   ScriptedStopHookPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, lldb::TargetSP target_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     lldb::TargetSP target_sp,
                      const StructuredDataImpl &args_sp) override;
 
   llvm::SmallVector<AbstractMethodRequirement>

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
@@ -26,9 +26,9 @@ ScriptedThreadPlanPythonInterface::ScriptedThreadPlanPythonInterface(
 
 llvm::Expected<StructuredData::GenericSP>
 ScriptedThreadPlanPythonInterface::CreatePluginObject(
-    const llvm::StringRef class_name, lldb::ThreadPlanSP thread_plan_sp,
-    const StructuredDataImpl &args_sp) {
-  return ScriptedPythonInterface::CreatePluginObject(class_name, nullptr,
+    const ScriptedMetadata &scripted_metadata,
+    lldb::ThreadPlanSP thread_plan_sp, const StructuredDataImpl &args_sp) {
+  return ScriptedPythonInterface::CreatePluginObject(scripted_metadata, nullptr,
                                                      thread_plan_sp, args_sp);
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.h
@@ -23,7 +23,7 @@ public:
   ScriptedThreadPlanPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(const llvm::StringRef class_name,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
                      lldb::ThreadPlanSP thread_plan_sp,
                      const StructuredDataImpl &args_sp) override;
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.cpp
@@ -29,13 +29,13 @@ ScriptedThreadPythonInterface::ScriptedThreadPythonInterface(
 
 llvm::Expected<StructuredData::GenericSP>
 ScriptedThreadPythonInterface::CreatePluginObject(
-    const llvm::StringRef class_name, ExecutionContext &exe_ctx,
-    StructuredData::DictionarySP args_sp, StructuredData::Generic *script_obj) {
+    const ScriptedMetadata &scripted_metadata, ExecutionContext &exe_ctx,
+    StructuredData::Generic *script_obj) {
   ExecutionContextRefSP exe_ctx_ref_sp =
       std::make_shared<ExecutionContextRef>(exe_ctx);
-  StructuredDataImpl sd_impl(args_sp);
-  return ScriptedPythonInterface::CreatePluginObject(class_name, script_obj,
-                                                     exe_ctx_ref_sp, sd_impl);
+  return ScriptedPythonInterface::CreatePluginObject(
+      scripted_metadata, script_obj, exe_ctx_ref_sp,
+      scripted_metadata.GetArgsSP());
 }
 
 lldb::tid_t ScriptedThreadPythonInterface::GetThreadID() {

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPythonInterface.h
@@ -20,8 +20,8 @@ public:
   ScriptedThreadPythonInterface(ScriptInterpreterPythonImpl &interpreter);
 
   llvm::Expected<StructuredData::GenericSP>
-  CreatePluginObject(llvm::StringRef class_name, ExecutionContext &exe_ctx,
-                     StructuredData::DictionarySP args_sp,
+  CreatePluginObject(const ScriptedMetadata &scripted_metadata,
+                     ExecutionContext &exe_ctx,
                      StructuredData::Generic *script_obj = nullptr) override;
 
   llvm::SmallVector<AbstractMethodRequirement>

--- a/lldb/source/Plugins/SyntheticFrameProvider/ScriptedFrameProvider/ScriptedFrameProvider.cpp
+++ b/lldb/source/Plugins/SyntheticFrameProvider/ScriptedFrameProvider/ScriptedFrameProvider.cpp
@@ -76,9 +76,8 @@ ScriptedFrameProvider::CreateInstance(
                                      thread.shared_from_this()))
     return nullptr;
 
-  auto obj_or_err = interface_sp->CreatePluginObject(
-      scripted_metadata->GetClassName(), input_frames,
-      scripted_metadata->GetArgsSP());
+  auto obj_or_err =
+      interface_sp->CreatePluginObject(*scripted_metadata, input_frames);
   if (!obj_or_err)
     return obj_or_err.takeError();
 

--- a/lldb/source/Target/ScriptedThreadPlan.cpp
+++ b/lldb/source/Target/ScriptedThreadPlan.cpp
@@ -79,8 +79,9 @@ void ScriptedThreadPlan::DidPush() {
   // the constructor, and doesn't have to care about the details of DidPush.
   m_did_push = true;
   if (m_interface) {
+    ScriptedMetadata scripted_metadata(m_class_name, {});
     auto obj_or_err = m_interface->CreatePluginObject(
-        m_class_name, this->shared_from_this(), m_args_data);
+        scripted_metadata, this->shared_from_this(), m_args_data);
     if (!obj_or_err) {
       m_error_str = llvm::toString(obj_or_err.takeError());
       SetPlanComplete(false);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4303,8 +4303,9 @@ Status Target::StopHookScripted::SetScriptCallback(
   m_class_name = class_name;
   m_extra_args.SetObjectSP(extra_args_sp);
 
+  ScriptedMetadata scripted_metadata(m_class_name, {});
   auto obj_or_err = m_interface_sp->CreatePluginObject(
-      m_class_name, GetTarget(), m_extra_args);
+      scripted_metadata, GetTarget(), m_extra_args);
   if (!obj_or_err) {
     return Status::FromError(obj_or_err.takeError());
   }
@@ -4610,8 +4611,9 @@ Status Target::HookScripted::SetScriptCallback(
   m_class_name = std::move(class_name);
   m_extra_args.SetObjectSP(extra_args_sp);
 
+  ScriptedMetadata scripted_metadata(m_class_name, {});
   auto obj_or_err = m_interface_sp->CreatePluginObject(
-      m_class_name, GetTarget(), m_extra_args);
+      scripted_metadata, GetTarget(), m_extra_args);
   if (!obj_or_err)
     return Status::FromError(obj_or_err.takeError());
 


### PR DESCRIPTION
Replace the (class_name, args_sp) parameter pair on CreatePluginObject across the scripted plugin interfaces (ScriptedThread, OperatingSystem, ScriptedBreakpoint, ScriptedFrameProvider, ScriptedProcess, and the underlying ScriptedPythonInterface template) with a single `const ScriptedMetadata &`. Callers (OperatingSystemPython, ScriptedThread, ScriptedProcess, BreakpointResolverScripted, ScriptedFrameProvider) pass their existing ScriptedMetadata directly, removing the need to re-bundle class_name and args at every call site.

ScriptedBreakpoint, ScriptedFrameProvider and ScriptedProcess no longer carry a redundant `args_sp` parameter; their callers fold those args into the metadata, and the Python overrides reconstruct a StructuredDataImpl from the metadata's args dict for the dispatched call.

ScriptedInterface gains an `m_scripted_metadata` member and a `GetScriptedMetadata()` accessor; ScriptedPythonInterface populates it when CreatePluginObject is invoked so subclasses can later report which script class is in play.

Hook/StopHook/ThreadPlan public interfaces keep their existing `args_sp` parameter for now; subsequent commits consolidate that.