### PR TITLE
[BPF] Emit ABI-accurate BTF prototypes for DW_CC_nocall

### DIFF
--- a/llvm/lib/Target/BPF/BTFDebug.cpp
+++ b/llvm/lib/Target/BPF/BTFDebug.cpp
@@ -119,7 +119,7 @@ static bool sourceArgMatchesIRType(const DIType *SourceTy, Type *IRTy) {
 /// registers to stack frame objects during the entry-block walk (using
 /// MachineMemOperands to identify the target frame index), then match them
 /// against VariableDbgInfo entries after the scan.
-static SmallDenseMap<uint32_t, Register>
+static SmallVector<std::pair<uint32_t, Register>, 8>
 collectNocallEntryArgRegs(const MachineFunction &MF) {
   SmallDenseMap<uint32_t, Register> EntryRegMap;
   const DISubprogram *SP = MF.getFunction().getSubprogram();
@@ -203,7 +203,10 @@ collectNocallEntryArgRegs(const MachineFunction &MF) {
       EntryRegMap[Arg] = It->second;
   }
 
-  return EntryRegMap;
+  SmallVector<std::pair<uint32_t, Register>, 8> AliveArgs(EntryRegMap.begin(),
+                                                          EntryRegMap.end());
+  llvm::sort(AliveArgs, llvm::less_first());
+  return AliveArgs;
 }
 
 /// Check whether the optimized IR signature matches the surviving source
@@ -212,19 +215,18 @@ collectNocallEntryArgRegs(const MachineFunction &MF) {
 /// BPF register order (R1..R5) for register args.
 static bool canUseNocallOptimizedSignature(
     const MachineFunction &MF, DITypeArray Elements,
-    ArrayRef<uint32_t> SortedAlive,
-    const SmallDenseMap<uint32_t, Register> &EntryRegMap,
+    ArrayRef<std::pair<uint32_t, Register>> AliveArgs,
     const TargetRegisterInfo &TRI) {
-  if (MF.getFunction().arg_size() != SortedAlive.size()) {
+  if (MF.getFunction().arg_size() != AliveArgs.size()) {
     LLVM_DEBUG(dbgs() << "BTF skip " << MF.getName() << ": IR arg count ("
                       << MF.getFunction().arg_size() << ") != alive arg count ("
-                      << SortedAlive.size() << ")\n");
+                      << AliveArgs.size() << ")\n");
     return false;
   }
 
   auto ArgIt = MF.getFunction().arg_begin();
-  for (unsigned I = 0, N = SortedAlive.size(); I < N; ++I, ++ArgIt) {
-    uint32_t ArgNo = SortedAlive[I];
+  for (unsigned I = 0, N = AliveArgs.size(); I < N; ++I, ++ArgIt) {
+    auto [ArgNo, Reg] = AliveArgs[I];
     if (!sourceArgMatchesIRType(Elements[ArgNo], ArgIt->getType())) {
       LLVM_DEBUG(dbgs() << "BTF skip " << MF.getName()
                         << ": type mismatch for source arg " << ArgNo
@@ -235,10 +237,7 @@ static bool canUseNocallOptimizedSignature(
     if (I >= std::size(CC_BPF64_ArgRegs))
       continue;
 
-    auto It = EntryRegMap.find(ArgNo);
-    assert(It != EntryRegMap.end() &&
-           "register arg must have entry-block DBG_VALUE");
-    int DwarfReg = TRI.getDwarfRegNum(It->second, false);
+    int DwarfReg = TRI.getDwarfRegNum(Reg, false);
     if (DwarfReg != static_cast<int>(I + 1)) {
       LLVM_DEBUG(dbgs() << "BTF skip " << MF.getName() << ": arg " << ArgNo
                         << " in DWARF reg " << DwarfReg << ", expected "
@@ -1590,30 +1589,28 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
     const TargetRegisterInfo *TRI = MF->getSubtarget().getRegisterInfo();
     DITypeArray Elements = SP->getType()->getTypeArray();
 
-    SmallDenseMap<uint32_t, Register> EntryRegMap =
+    SmallVector<std::pair<uint32_t, Register>, 8> AliveArgs =
         collectNocallEntryArgRegs(*MF);
 
-    SmallVector<uint32_t, 8> SortedAlive;
-    for (const auto &[ArgNo, Reg] : EntryRegMap)
-      SortedAlive.push_back(ArgNo);
-    llvm::sort(SortedAlive);
-
-    UseFilteredParams = canUseNocallOptimizedSignature(
-        *MF, Elements, SortedAlive, EntryRegMap, *TRI);
+    UseFilteredParams =
+        canUseNocallOptimizedSignature(*MF, Elements, AliveArgs, *TRI);
 
     if (UseFilteredParams) {
+      SmallVector<uint32_t, 8> AliveParamIndices;
       SmallDenseMap<uint32_t, uint32_t> ArgIndexMap;
-      for (uint32_t I = 0; I < SortedAlive.size(); ++I)
-        ArgIndexMap[SortedAlive[I]] = I;
+      for (auto [I, ArgReg] : llvm::enumerate(AliveArgs)) {
+        AliveParamIndices.push_back(ArgReg.first);
+        ArgIndexMap[ArgReg.first] = I;
+      }
 
       if (!VoidReturn)
         visitTypeEntry(Elements[0]);
-      for (uint32_t ArgNo : SortedAlive)
+      for (uint32_t ArgNo : AliveParamIndices)
         visitTypeEntry(Elements[ArgNo]);
 
       auto TypeEntry = std::make_unique<BTFTypeFuncProto>(
-          SP->getType(), SortedAlive.size(), FuncArgNames, true, SortedAlive,
-          VoidReturn);
+          SP->getType(), AliveParamIndices.size(), FuncArgNames, true,
+          AliveParamIndices, VoidReturn);
       ProtoTypeId = addType(std::move(TypeEntry));
       FuncTypeId = processDISubprogram(SP, ProtoTypeId, Scope, &ArgIndexMap);
     }

--- a/llvm/lib/Target/BPF/BTFDebug.cpp
+++ b/llvm/lib/Target/BPF/BTFDebug.cpp
@@ -19,11 +19,14 @@
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineOperand.h"
+#include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/LineIterator.h"
@@ -32,6 +35,11 @@
 #include <optional>
 
 using namespace llvm;
+
+#define DEBUG_TYPE "btf-debug"
+
+#define GET_CC_REGISTER_LISTS
+#include "BPFGenCallingConv.inc"
 
 static const char *BTFKindStr[] = {
 #define HANDLE_BTF_KIND(ID, NAME) "BTF_KIND_" #NAME,
@@ -45,6 +53,145 @@ static const DIType *tryRemoveAtomicType(const DIType *Ty) {
   if (DerivedTy && DerivedTy->getTag() == dwarf::DW_TAG_atomic_type)
     return DerivedTy->getBaseType();
   return Ty;
+}
+
+static const DIType *stripDITypeAttributes(const DIType *Ty) {
+  while (const auto *DTy = dyn_cast_or_null<DIDerivedType>(Ty)) {
+    switch (DTy->getTag()) {
+    case dwarf::DW_TAG_atomic_type:
+    case dwarf::DW_TAG_const_type:
+    case dwarf::DW_TAG_restrict_type:
+    case dwarf::DW_TAG_typedef:
+    case dwarf::DW_TAG_volatile_type:
+      Ty = DTy->getBaseType();
+      break;
+    default:
+      return Ty;
+    }
+  }
+  return Ty;
+}
+
+static bool sourceArgMatchesIRType(const DIType *SourceTy, Type *IRTy) {
+  SourceTy = stripDITypeAttributes(SourceTy);
+
+  // All pointers are opaque in LLVM IR, so any source-level pointer matches any
+  // IR pointer regardless of pointee type.
+  if (const auto *DTy = dyn_cast<DIDerivedType>(SourceTy))
+    return DTy->getTag() == dwarf::DW_TAG_pointer_type && IRTy->isPointerTy();
+
+  if (const auto *BTy = dyn_cast<DIBasicType>(SourceTy)) {
+    uint64_t SizeInBits = BTy->getSizeInBits();
+    if (BTy->getEncoding() == dwarf::DW_ATE_float)
+      return IRTy->isFloatingPointTy() &&
+             IRTy->getPrimitiveSizeInBits() == SizeInBits;
+    // _Bool is 8 bits in DWARF/source but lowered to i1 in LLVM IR.
+    if (BTy->getEncoding() == dwarf::DW_ATE_boolean && IRTy->isIntegerTy(1))
+      return true;
+    return IRTy->isIntegerTy(SizeInBits);
+  }
+
+  const auto *CTy = dyn_cast<DICompositeType>(SourceTy);
+  if (!CTy)
+    return false;
+
+  switch (CTy->getTag()) {
+  case dwarf::DW_TAG_enumeration_type:
+    return IRTy->isIntegerTy(CTy->getSizeInBits());
+  default:
+    return false;
+  }
+}
+
+/// Collect the physical register each source argument lives in by scanning
+/// DBG_VALUE instructions in the entry block.  A DBG_VALUE is only recorded
+/// when its register either (a) has not been redefined by any preceding
+/// non-debug instruction (i.e. it still holds the caller-passed value), or
+/// (b) was most recently loaded from the stack via $r11 (a stack-passed
+/// argument beyond the first five register args).
+static SmallDenseMap<uint32_t, Register>
+collectNocallEntryArgRegs(const MachineFunction &MF) {
+  SmallDenseMap<uint32_t, Register> EntryRegMap;
+  const DISubprogram *SP = MF.getFunction().getSubprogram();
+  SmallDenseSet<Register> DefinedRegs, StackLoadRegs;
+
+  for (const MachineInstr &MI : MF.front()) {
+    if (MI.isDebugValue()) {
+      // Skip indirect DBG_VALUEs — the register is a base address for a
+      // memory location, not the argument value itself.
+      if (MI.isIndirectDebugValue())
+        continue;
+
+      const DILocalVariable *DV = MI.getDebugVariable();
+      if (!DV || !DV->getArg() || DV->getScope()->getSubprogram() != SP)
+        continue;
+
+      uint32_t Arg = DV->getArg();
+      const MachineOperand &MO = MI.getDebugOperand(0);
+      if (!MO.isReg() || !MO.getReg().isPhysical())
+        continue;
+
+      if (!DefinedRegs.contains(MO.getReg()) ||
+          StackLoadRegs.contains(MO.getReg()))
+        EntryRegMap[Arg] = MO.getReg();
+      continue;
+    }
+
+    for (const MachineOperand &MO : MI.operands())
+      if (MO.isReg() && MO.isDef() && MO.getReg().isPhysical()) {
+        DefinedRegs.insert(MO.getReg());
+        StackLoadRegs.erase(MO.getReg());
+      }
+
+    // Detect stack argument loads: $rX = LDD $r11, offset.
+    if (MI.getOpcode() == BPF::LDD && MI.getOperand(1).getReg() == BPF::R11)
+      StackLoadRegs.insert(MI.getOperand(0).getReg());
+  }
+  return EntryRegMap;
+}
+
+/// Check whether the optimized IR signature matches the surviving source
+/// arguments precisely enough to emit a filtered BTF prototype.
+/// Requires exact IR/source arg count match, matching types, and correct
+/// BPF register order (R1..R5) for register args.
+static bool canUseNocallOptimizedSignature(
+    const MachineFunction &MF, DITypeArray Elements,
+    ArrayRef<uint32_t> SortedAlive,
+    const SmallDenseMap<uint32_t, Register> &EntryRegMap,
+    const TargetRegisterInfo &TRI) {
+  if (MF.getFunction().arg_size() != SortedAlive.size()) {
+    LLVM_DEBUG(dbgs() << "BTF skip " << MF.getName() << ": IR arg count ("
+                      << MF.getFunction().arg_size() << ") != alive arg count ("
+                      << SortedAlive.size() << ")\n");
+    return false;
+  }
+
+  auto ArgIt = MF.getFunction().arg_begin();
+  for (unsigned I = 0, N = SortedAlive.size(); I < N; ++I, ++ArgIt) {
+    uint32_t ArgNo = SortedAlive[I];
+    if (!sourceArgMatchesIRType(Elements[ArgNo], ArgIt->getType())) {
+      LLVM_DEBUG(dbgs() << "BTF skip " << MF.getName()
+                        << ": type mismatch for source arg " << ArgNo
+                        << " at IR position " << I << "\n");
+      return false;
+    }
+
+    if (I >= std::size(CC_BPF64_ArgRegs))
+      continue;
+
+    auto It = EntryRegMap.find(ArgNo);
+    assert(It != EntryRegMap.end() &&
+           "register arg must have entry-block DBG_VALUE");
+    int DwarfReg = TRI.getDwarfRegNum(It->second, false);
+    if (DwarfReg != static_cast<int>(I + 1)) {
+      LLVM_DEBUG(dbgs() << "BTF skip " << MF.getName() << ": arg " << ArgNo
+                        << " in DWARF reg " << DwarfReg << ", expected "
+                        << (I + 1) << "\n");
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /// Emit a BTF common type.
@@ -398,8 +545,12 @@ std::string BTFTypeStruct::getName() { return std::string(STy->getName()); }
 /// for subprogram.
 BTFTypeFuncProto::BTFTypeFuncProto(
     const DISubroutineType *STy, uint32_t VLen,
-    const std::unordered_map<uint32_t, StringRef> &FuncArgNames)
-    : STy(STy), FuncArgNames(FuncArgNames) {
+    const SmallDenseMap<uint32_t, StringRef> &FuncArgNames,
+    bool UseFilteredParams, ArrayRef<uint32_t> AliveParamIndices,
+    bool ChangedToVoid)
+    : STy(STy), FuncArgNames(FuncArgNames),
+      AliveParamIndices(AliveParamIndices),
+      UseFilteredParams(UseFilteredParams), ChangedToVoid(ChangedToVoid) {
   Kind = BTF::BTF_KIND_FUNC_PROTO;
   BTFType.Info = (Kind << 24) | VLen;
 }
@@ -410,24 +561,37 @@ void BTFTypeFuncProto::completeType(BTFDebug &BDebug) {
   IsCompleted = true;
 
   DITypeArray Elements = STy->getTypeArray();
-  auto RetType = tryRemoveAtomicType(Elements[0]);
-  BTFType.Type = RetType ? BDebug.getTypeId(RetType) : 0;
+  if (ChangedToVoid) {
+    BTFType.Type = 0;
+  } else {
+    auto RetType = tryRemoveAtomicType(Elements[0]);
+    BTFType.Type = RetType ? BDebug.getTypeId(RetType) : 0;
+  }
   BTFType.NameOff = 0;
 
-  // For null parameter which is typically the last one
-  // to represent the vararg, encode the NameOff/Type to be 0.
-  for (unsigned I = 1, N = Elements.size(); I < N; ++I) {
+  auto EmitParam = [&](uint32_t I) {
     struct BTF::BTFParam Param;
     auto Element = tryRemoveAtomicType(Elements[I]);
     if (Element) {
-      Param.NameOff = BDebug.addString(FuncArgNames[I]);
+      auto It = FuncArgNames.find(I);
+      Param.NameOff =
+          It != FuncArgNames.end() ? BDebug.addString(It->second) : 0;
       Param.Type = BDebug.getTypeId(Element);
     } else {
       Param.NameOff = 0;
       Param.Type = 0;
     }
     Parameters.push_back(Param);
+  };
+
+  if (UseFilteredParams) {
+    for (uint32_t I : AliveParamIndices)
+      EmitParam(I);
+    return;
   }
+
+  for (unsigned I = 1, N = Elements.size(); I < N; ++I)
+    EmitParam(I);
 }
 
 void BTFTypeFuncProto::emitType(MCStreamer &OS) {
@@ -626,8 +790,8 @@ void BTFDebug::visitBasicType(const DIBasicType *BTy, uint32_t &TypeId) {
 /// Handle subprogram or subroutine types.
 void BTFDebug::visitSubroutineType(
     const DISubroutineType *STy, bool ForSubprog,
-    const std::unordered_map<uint32_t, StringRef> &FuncArgNames,
-    uint32_t &TypeId) {
+    const SmallDenseMap<uint32_t, StringRef> &FuncArgNames, uint32_t &TypeId,
+    bool ChangedToVoid) {
   DITypeArray Elements = STy->getTypeArray();
   uint32_t VLen = Elements.size() - 1;
   if (VLen > BTF::MAX_VLEN)
@@ -637,15 +801,20 @@ void BTFDebug::visitSubroutineType(
   // a function pointer has an empty name. The subprogram type will
   // not be added to DIToIdMap as it should not be referenced by
   // any other types.
-  auto TypeEntry = std::make_unique<BTFTypeFuncProto>(STy, VLen, FuncArgNames);
+  auto TypeEntry = std::make_unique<BTFTypeFuncProto>(
+      STy, VLen, FuncArgNames, false, ArrayRef<uint32_t>(), ChangedToVoid);
   if (ForSubprog)
     TypeId = addType(std::move(TypeEntry)); // For subprogram
   else
     TypeId = addType(std::move(TypeEntry), STy); // For func ptr
 
   // Visit return type and func arg types.
-  for (const auto Element : Elements) {
-    visitTypeEntry(Element);
+  if (!ChangedToVoid) {
+    for (const auto Element : Elements)
+      visitTypeEntry(Element);
+  } else {
+    for (unsigned I = 1, N = Elements.size(); I < N; ++I)
+      visitTypeEntry(Elements[I]);
   }
 }
 
@@ -668,8 +837,9 @@ void BTFDebug::processDeclAnnotations(DINodeArray Annotations,
   }
 }
 
-uint32_t BTFDebug::processDISubprogram(const DISubprogram *SP,
-                                       uint32_t ProtoTypeId, uint8_t Scope) {
+uint32_t BTFDebug::processDISubprogram(
+    const DISubprogram *SP, uint32_t ProtoTypeId, uint8_t Scope,
+    const SmallDenseMap<uint32_t, uint32_t> *ArgIndexMap) {
   auto FuncTypeEntry =
       std::make_unique<BTFTypeFunc>(SP->getName(), ProtoTypeId, Scope);
   uint32_t FuncId = addType(std::move(FuncTypeEntry));
@@ -678,8 +848,15 @@ uint32_t BTFDebug::processDISubprogram(const DISubprogram *SP,
   for (const DINode *DN : SP->getRetainedNodes()) {
     if (const auto *DV = dyn_cast<DILocalVariable>(DN)) {
       uint32_t Arg = DV->getArg();
-      if (Arg)
-        processDeclAnnotations(DV->getAnnotations(), FuncId, Arg - 1);
+      if (Arg) {
+        if (ArgIndexMap) {
+          auto It = ArgIndexMap->find(Arg);
+          if (It != ArgIndexMap->end())
+            processDeclAnnotations(DV->getAnnotations(), FuncId, It->second);
+        } else {
+          processDeclAnnotations(DV->getAnnotations(), FuncId, Arg - 1);
+        }
+      }
     }
   }
   processDeclAnnotations(SP->getAnnotations(), FuncId, -1);
@@ -1036,7 +1213,7 @@ void BTFDebug::visitTypeEntry(const DIType *Ty, uint32_t &TypeId,
   if (const auto *BTy = dyn_cast<DIBasicType>(Ty))
     visitBasicType(BTy, TypeId);
   else if (const auto *STy = dyn_cast<DISubroutineType>(Ty))
-    visitSubroutineType(STy, false, std::unordered_map<uint32_t, StringRef>(),
+    visitSubroutineType(STy, false, SmallDenseMap<uint32_t, StringRef>(),
                         TypeId);
   else if (const auto *CTy = dyn_cast<DICompositeType>(Ty))
     visitCompositeType(CTy, TypeId);
@@ -1331,7 +1508,7 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
   // Collect all types locally referenced in this function.
   // Use RetainedNodes so we can collect all argument names
   // even if the argument is not used.
-  std::unordered_map<uint32_t, StringRef> FuncArgNames;
+  SmallDenseMap<uint32_t, StringRef> FuncArgNames;
   for (const DINode *DN : SP->getRetainedNodes()) {
     if (const auto *DV = dyn_cast<DILocalVariable>(DN)) {
       // Collect function arguments for subprogram func type.
@@ -1344,12 +1521,59 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
   }
 
   // Construct subprogram func proto type.
-  uint32_t ProtoTypeId;
-  visitSubroutineType(SP->getType(), true, FuncArgNames, ProtoTypeId);
-
-  // Construct subprogram func type
+  uint32_t ProtoTypeId, FuncTypeId;
   uint8_t Scope = SP->isLocalToUnit() ? BTF::FUNC_STATIC : BTF::FUNC_GLOBAL;
-  uint32_t FuncTypeId = processDISubprogram(SP, ProtoTypeId, Scope);
+  bool IsNocall = SP->getType()->getCC() == dwarf::DW_CC_nocall;
+  bool UseFilteredParams = false;
+  bool ChangedToVoid = false;
+
+  if (IsNocall) {
+    // For DW_CC_nocall functions, try to build a FUNC_PROTO reflecting
+    // the true ABI: only parameters that survived optimization and whose
+    // first 5 arguments map to the correct BPF registers (R1-R5).
+    const TargetRegisterInfo *TRI = MF->getSubtarget().getRegisterInfo();
+    DITypeArray Elements = SP->getType()->getTypeArray();
+
+    // Check if DeadArgumentElimination changed the return type to void.
+    ChangedToVoid =
+        MF->getFunction().getReturnType()->isVoidTy() && Elements[0] != nullptr;
+
+    SmallDenseMap<uint32_t, Register> EntryRegMap =
+        collectNocallEntryArgRegs(*MF);
+
+    SmallVector<uint32_t, 8> SortedAlive;
+    for (const auto &[ArgNo, Reg] : EntryRegMap)
+      SortedAlive.push_back(ArgNo);
+    llvm::sort(SortedAlive);
+
+    UseFilteredParams = canUseNocallOptimizedSignature(
+        *MF, Elements, SortedAlive, EntryRegMap, *TRI);
+
+    if (UseFilteredParams) {
+      SmallDenseMap<uint32_t, uint32_t> ArgIndexMap;
+      for (uint32_t I = 0; I < SortedAlive.size(); ++I)
+        ArgIndexMap[SortedAlive[I]] = I;
+
+      if (!ChangedToVoid)
+        visitTypeEntry(Elements[0]);
+      for (uint32_t ArgNo : SortedAlive)
+        visitTypeEntry(Elements[ArgNo]);
+
+      auto TypeEntry = std::make_unique<BTFTypeFuncProto>(
+          SP->getType(), SortedAlive.size(), FuncArgNames, true, SortedAlive,
+          ChangedToVoid);
+      ProtoTypeId = addType(std::move(TypeEntry));
+      FuncTypeId = processDISubprogram(SP, ProtoTypeId, Scope, &ArgIndexMap);
+    }
+  }
+
+  if (!UseFilteredParams) {
+    // Fall back to the full source prototype, still voiding the return
+    // type if compiler removed it.
+    visitSubroutineType(SP->getType(), true, FuncArgNames, ProtoTypeId,
+                        ChangedToVoid);
+    FuncTypeId = processDISubprogram(SP, ProtoTypeId, Scope);
+  }
 
   for (const auto &TypeEntry : TypeEntries)
     TypeEntry->completeType(*this);
@@ -1713,7 +1937,7 @@ void BTFDebug::processFuncPrototypes(const Function *F) {
     return;
 
   uint32_t ProtoTypeId;
-  const std::unordered_map<uint32_t, StringRef> FuncArgNames;
+  const SmallDenseMap<uint32_t, StringRef> FuncArgNames;
   visitSubroutineType(SP->getType(), false, FuncArgNames, ProtoTypeId);
   uint32_t FuncId = processDISubprogram(SP, ProtoTypeId, BTF::FUNC_EXTERN);
 

--- a/llvm/lib/Target/BPF/BTFDebug.cpp
+++ b/llvm/lib/Target/BPF/BTFDebug.cpp
@@ -603,10 +603,10 @@ BTFTypeFuncProto::BTFTypeFuncProto(
     const DISubroutineType *STy, uint32_t VLen,
     const SmallDenseMap<uint32_t, StringRef> &FuncArgNames,
     bool UseFilteredParams, ArrayRef<uint32_t> AliveParamIndices,
-    bool ChangedToVoid)
+    bool VoidReturn)
     : STy(STy), FuncArgNames(FuncArgNames),
       AliveParamIndices(AliveParamIndices),
-      UseFilteredParams(UseFilteredParams), ChangedToVoid(ChangedToVoid) {
+      UseFilteredParams(UseFilteredParams), VoidReturn(VoidReturn) {
   Kind = BTF::BTF_KIND_FUNC_PROTO;
   BTFType.Info = (Kind << 24) | VLen;
 }
@@ -617,7 +617,7 @@ void BTFTypeFuncProto::completeType(BTFDebug &BDebug) {
   IsCompleted = true;
 
   DITypeArray Elements = STy->getTypeArray();
-  if (ChangedToVoid) {
+  if (VoidReturn) {
     BTFType.Type = 0;
   } else {
     auto RetType = tryRemoveAtomicType(Elements[0]);
@@ -847,7 +847,7 @@ void BTFDebug::visitBasicType(const DIBasicType *BTy, uint32_t &TypeId) {
 void BTFDebug::visitSubroutineType(
     const DISubroutineType *STy, bool ForSubprog,
     const SmallDenseMap<uint32_t, StringRef> &FuncArgNames, uint32_t &TypeId,
-    bool ChangedToVoid) {
+    bool VoidReturn) {
   DITypeArray Elements = STy->getTypeArray();
   uint32_t VLen = Elements.size() - 1;
   if (VLen > BTF::MAX_VLEN)
@@ -858,14 +858,14 @@ void BTFDebug::visitSubroutineType(
   // not be added to DIToIdMap as it should not be referenced by
   // any other types.
   auto TypeEntry = std::make_unique<BTFTypeFuncProto>(
-      STy, VLen, FuncArgNames, false, ArrayRef<uint32_t>(), ChangedToVoid);
+      STy, VLen, FuncArgNames, false, ArrayRef<uint32_t>(), VoidReturn);
   if (ForSubprog)
     TypeId = addType(std::move(TypeEntry)); // For subprogram
   else
     TypeId = addType(std::move(TypeEntry), STy); // For func ptr
 
   // Visit return type and func arg types.
-  if (!ChangedToVoid) {
+  if (!VoidReturn) {
     for (const auto Element : Elements)
       visitTypeEntry(Element);
   } else {
@@ -1581,7 +1581,7 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
   uint8_t Scope = SP->isLocalToUnit() ? BTF::FUNC_STATIC : BTF::FUNC_GLOBAL;
   bool IsNocall = SP->getType()->getCC() == dwarf::DW_CC_nocall;
   bool UseFilteredParams = false;
-  bool ChangedToVoid = false;
+  bool VoidReturn = MF->getFunction().getReturnType()->isVoidTy();
 
   if (IsNocall) {
     // For DW_CC_nocall functions, try to build a FUNC_PROTO reflecting
@@ -1589,10 +1589,6 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
     // first 5 arguments map to the correct BPF registers (R1-R5).
     const TargetRegisterInfo *TRI = MF->getSubtarget().getRegisterInfo();
     DITypeArray Elements = SP->getType()->getTypeArray();
-
-    // Check if DeadArgumentElimination changed the return type to void.
-    ChangedToVoid =
-        MF->getFunction().getReturnType()->isVoidTy() && Elements[0] != nullptr;
 
     SmallDenseMap<uint32_t, Register> EntryRegMap =
         collectNocallEntryArgRegs(*MF);
@@ -1610,14 +1606,14 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
       for (uint32_t I = 0; I < SortedAlive.size(); ++I)
         ArgIndexMap[SortedAlive[I]] = I;
 
-      if (!ChangedToVoid)
+      if (!VoidReturn)
         visitTypeEntry(Elements[0]);
       for (uint32_t ArgNo : SortedAlive)
         visitTypeEntry(Elements[ArgNo]);
 
       auto TypeEntry = std::make_unique<BTFTypeFuncProto>(
           SP->getType(), SortedAlive.size(), FuncArgNames, true, SortedAlive,
-          ChangedToVoid);
+          VoidReturn);
       ProtoTypeId = addType(std::move(TypeEntry));
       FuncTypeId = processDISubprogram(SP, ProtoTypeId, Scope, &ArgIndexMap);
     }
@@ -1627,7 +1623,7 @@ void BTFDebug::beginFunctionImpl(const MachineFunction *MF) {
     // Fall back to the full source prototype, still voiding the return
     // type if compiler removed it.
     visitSubroutineType(SP->getType(), true, FuncArgNames, ProtoTypeId,
-                        ChangedToVoid);
+                        VoidReturn);
     FuncTypeId = processDISubprogram(SP, ProtoTypeId, Scope);
   }
 

--- a/llvm/lib/Target/BPF/BTFDebug.cpp
+++ b/llvm/lib/Target/BPF/BTFDebug.cpp
@@ -17,6 +17,7 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/CodeGen/AsmPrinter.h"
+#include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
@@ -109,11 +110,32 @@ static bool sourceArgMatchesIRType(const DIType *SourceTy, Type *IRTy) {
 /// non-debug instruction (i.e. it still holds the caller-passed value), or
 /// (b) was most recently loaded from the stack via $r11 (a stack-passed
 /// argument beyond the first five register args).
+///
+/// There is another case where DBG_VALUE is not emitted due to
+/// AssignmentTrackingAnalysis which determines that a variable is
+/// always stack-homed, and describes the variable via MachineFunction's
+/// VariableDbgInfo (setVariableDbgInfo with a frame index). To recover the
+/// register for those arguments, we also track stores of un-redefined physical
+/// registers to stack frame objects during the entry-block walk (using
+/// MachineMemOperands to identify the target frame index), then match them
+/// against VariableDbgInfo entries after the scan.
 static SmallDenseMap<uint32_t, Register>
 collectNocallEntryArgRegs(const MachineFunction &MF) {
   SmallDenseMap<uint32_t, Register> EntryRegMap;
   const DISubprogram *SP = MF.getFunction().getSubprogram();
   SmallDenseSet<Register> DefinedRegs, StackLoadRegs;
+
+  // Build a reverse map from IR alloca to frame index so we can
+  // identify which frame object a store targets via its MachineMemOperand.
+  const MachineFrameInfo &MFI = MF.getFrameInfo();
+  SmallDenseMap<const Value *, int> AllocaToFI;
+  for (int I = 0, N = MFI.getObjectIndexEnd(); I < N; ++I)
+    if (const AllocaInst *AI = MFI.getObjectAllocation(I))
+      AllocaToFI[AI] = I;
+
+  // Maps frame index → first physical register stored there before
+  // that register is redefined.
+  SmallDenseMap<int, Register> FrameIndexToReg;
 
   for (const MachineInstr &MI : MF.front()) {
     if (MI.isDebugValue()) {
@@ -137,6 +159,23 @@ collectNocallEntryArgRegs(const MachineFunction &MF) {
       continue;
     }
 
+    // Track stores of unredefined physical registers to stack frame
+    // objects.  Use MachineMemOperands to identify the target frame
+    // index rather than assuming a particular addressing mode.
+    if (MI.mayStore() && !MI.isCall() && MI.getOperand(0).isReg()) {
+      Register SrcReg = MI.getOperand(0).getReg();
+      if (SrcReg.isPhysical() && !DefinedRegs.contains(SrcReg)) {
+        for (const MachineMemOperand *MMO : MI.memoperands()) {
+          const Value *V = MMO->getValue();
+          if (!V)
+            continue;
+          auto It = AllocaToFI.find(V);
+          if (It != AllocaToFI.end())
+            FrameIndexToReg.try_emplace(It->second, SrcReg);
+        }
+      }
+    }
+
     for (const MachineOperand &MO : MI.operands())
       if (MO.isReg() && MO.isDef() && MO.getReg().isPhysical()) {
         DefinedRegs.insert(MO.getReg());
@@ -147,6 +186,23 @@ collectNocallEntryArgRegs(const MachineFunction &MF) {
     if (MI.getOpcode() == BPF::LDD && MI.getOperand(1).getReg() == BPF::R11)
       StackLoadRegs.insert(MI.getOperand(0).getReg());
   }
+
+  // Check VariableDbgInfo for args that AssignmentTrackingAnalysis described
+  // via setVariableDbgInfo (single-loc stack-homed variables) rather than
+  // DBG_VALUE instructions.
+  for (const auto &VI : MF.getVariableDbgInfo()) {
+    if (!VI.Var || !VI.Var->getArg() || !VI.inStackSlot())
+      continue;
+    if (VI.Var->getScope()->getSubprogram() != SP)
+      continue;
+    uint32_t Arg = VI.Var->getArg();
+    if (EntryRegMap.count(Arg))
+      continue;
+    auto It = FrameIndexToReg.find(VI.getStackSlot());
+    if (It != FrameIndexToReg.end())
+      EntryRegMap[Arg] = It->second;
+  }
+
   return EntryRegMap;
 }
 

--- a/llvm/lib/Target/BPF/BTFDebug.h
+++ b/llvm/lib/Target/BPF/BTFDebug.h
@@ -146,14 +146,14 @@ class BTFTypeFuncProto : public BTFTypeBase {
   SmallVector<uint32_t, 8> AliveParamIndices;
   bool UseFilteredParams = false;
   std::vector<struct BTF::BTFParam> Parameters;
-  bool ChangedToVoid = false;
+  bool VoidReturn = false;
 
 public:
   BTFTypeFuncProto(const DISubroutineType *STy, uint32_t NumParams,
                    const SmallDenseMap<uint32_t, StringRef> &FuncArgNames,
                    bool UseFilteredParams = false,
                    ArrayRef<uint32_t> AliveParamIndices = {},
-                   bool ChangedToVoid = false);
+                   bool VoidReturn = false);
   uint32_t getSize() override {
     return BTFTypeBase::getSize() + Parameters.size() * BTF::BTFParamSize;
   }
@@ -332,7 +332,7 @@ class BTFDebug : public DebugHandlerBase {
   void
   visitSubroutineType(const DISubroutineType *STy, bool ForSubprog,
                       const SmallDenseMap<uint32_t, StringRef> &FuncArgNames,
-                      uint32_t &TypeId, bool ChangedToVoid = false);
+                      uint32_t &TypeId, bool VoidReturn = false);
   void visitFwdDeclType(const DICompositeType *CTy, bool IsUnion,
                         uint32_t &TypeId);
   void visitCompositeType(const DICompositeType *CTy, uint32_t &TypeId);

--- a/llvm/lib/Target/BPF/BTFDebug.h
+++ b/llvm/lib/Target/BPF/BTFDebug.h
@@ -142,12 +142,18 @@ public:
 /// Handle function pointer.
 class BTFTypeFuncProto : public BTFTypeBase {
   const DISubroutineType *STy;
-  std::unordered_map<uint32_t, StringRef> FuncArgNames;
+  SmallDenseMap<uint32_t, StringRef> FuncArgNames;
+  SmallVector<uint32_t, 8> AliveParamIndices;
+  bool UseFilteredParams = false;
   std::vector<struct BTF::BTFParam> Parameters;
+  bool ChangedToVoid = false;
 
 public:
   BTFTypeFuncProto(const DISubroutineType *STy, uint32_t NumParams,
-                   const std::unordered_map<uint32_t, StringRef> &FuncArgNames);
+                   const SmallDenseMap<uint32_t, StringRef> &FuncArgNames,
+                   bool UseFilteredParams = false,
+                   ArrayRef<uint32_t> AliveParamIndices = {},
+                   bool ChangedToVoid = false);
   uint32_t getSize() override {
     return BTFTypeBase::getSize() + Parameters.size() * BTF::BTFParamSize;
   }
@@ -323,10 +329,10 @@ class BTFDebug : public DebugHandlerBase {
   void visitTypeEntry(const DIType *Ty, uint32_t &TypeId, bool CheckPointer,
                       bool SeenPointer);
   void visitBasicType(const DIBasicType *BTy, uint32_t &TypeId);
-  void visitSubroutineType(
-      const DISubroutineType *STy, bool ForSubprog,
-      const std::unordered_map<uint32_t, StringRef> &FuncArgNames,
-      uint32_t &TypeId);
+  void
+  visitSubroutineType(const DISubroutineType *STy, bool ForSubprog,
+                      const SmallDenseMap<uint32_t, StringRef> &FuncArgNames,
+                      uint32_t &TypeId, bool ChangedToVoid = false);
   void visitFwdDeclType(const DICompositeType *CTy, bool IsUnion,
                         uint32_t &TypeId);
   void visitCompositeType(const DICompositeType *CTy, uint32_t &TypeId);
@@ -365,8 +371,9 @@ class BTFDebug : public DebugHandlerBase {
                               int ComponentId);
 
   /// Generate types for DISubprogram and it's arguments.
-  uint32_t processDISubprogram(const DISubprogram *SP, uint32_t ProtoTypeId,
-                               uint8_t Scope);
+  uint32_t processDISubprogram(
+      const DISubprogram *SP, uint32_t ProtoTypeId, uint8_t Scope,
+      const SmallDenseMap<uint32_t, uint32_t> *ArgIndexMap = nullptr);
 
   /// Generate BTF type_tag's. If BaseTypeId is nonnegative, the last
   /// BTF type_tag in the chain points to BaseTypeId. Otherwise, it points to

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-all-dead.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-all-dead.ll
@@ -1,0 +1,36 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; DeadArgElimination removing all arguments:
+;   static __noinline int sub(int dead1, int dead2) { return 42; }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=0 vlen=0
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal void @sub() #0 !dbg !7 {
+  ret void, !dbg !14
+}
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13}
+!12 = !DILocalVariable(name: "dead1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "dead2", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-bool-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-bool-arg.ll
@@ -1,0 +1,53 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; DeadArgElimination on a function with a bool parameter:
+;   static __noinline int sub(int dead, _Bool flag, int a) {
+;     return flag ? a : 0;
+;   }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] TYPEDEF 'bool' type_id=3
+; CHECK-NEXT: [3] INT '_Bool' size=1 bits_offset=0 nr_bits=8 encoding=BOOL
+; CHECK-NEXT: [4] FUNC_PROTO '(anon)' ret_type_id=1 vlen=2
+; CHECK-NEXT: 	'flag' type_id=2
+; CHECK-NEXT: 	'a' type_id=1
+; CHECK-NEXT: [5] FUNC 'sub' type_id=4 linkage=static
+
+define internal i32 @sub(i1 zeroext %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i1 %0, metadata !15,
+                            metadata !DIExpression(DW_OP_LLVM_convert, 1, DW_ATE_unsigned, DW_OP_LLVM_convert, 8, DW_ATE_unsigned, DW_OP_stack_value)), !dbg !17
+  call void @llvm.dbg.value(metadata i32 %1, metadata !16, metadata !DIExpression()), !dbg !17
+  %3 = select i1 %0, i32 %1, i32 0, !dbg !18
+  ret i32 %3, !dbg !19
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !13, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!14, !15, !16}
+!12 = !DIBasicType(name: "_Bool", size: 8, encoding: DW_ATE_boolean)
+!13 = !DIDerivedType(tag: DW_TAG_typedef, name: "bool", file: !1, line: 1, baseType: !12)
+!14 = !DILocalVariable(name: "dead", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "flag", arg: 2, scope: !7, file: !1, line: 1, type: !13)
+!16 = !DILocalVariable(name: "a", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!17 = !DILocation(line: 1, column: 1, scope: !7)
+!18 = !DILocation(line: 2, column: 10, scope: !7)
+!19 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-const-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-const-arg.ll
@@ -1,0 +1,54 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; DeadArgElimination on a function where arg 3 was
+; constant-propagated and removed from the IR:
+;   static __noinline int sub(int a1, int a2, int constarg, int a4) {
+;     return a1 + a2 + a4;
+;   }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=3
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a2' type_id=1
+; CHECK-NEXT: 	'a4' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i32 @sub(i32 %0, i32 %1, i32 %2) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !12, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 %1, metadata !13, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 42, metadata !14, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 %2, metadata !15, metadata !DIExpression()), !dbg !16
+  %4 = add i32 %0, %1, !dbg !17
+  %5 = add i32 %4, %2, !dbg !17
+  ret i32 %5, !dbg !18
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14, !15}
+!12 = !DILocalVariable(name: "a1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "a2", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "constarg", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "a4", arg: 4, scope: !7, file: !1, line: 1, type: !10)
+!16 = !DILocation(line: 1, column: 1, scope: !7)
+!17 = !DILocation(line: 2, column: 10, scope: !7)
+!18 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-const-no-shift.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-const-no-shift.ll
@@ -1,0 +1,59 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates a case where arg 3 is constant-propagated but still occupies
+; a calling convention slot (arg4 remains in R4, not shifted to R3):
+;   static __noinline int sub(int a1, int a2, int constarg, int a4) {
+;     return a1 + a2 + a4;
+;   }
+; The IR still has 4 args (constarg not removed), but constarg has only
+; an immediate DBG_VALUE. SortedAlive = {1,2,4} (3 alive) but
+; arg_size() = 4, so the mismatch causes fallback to the original
+; source signature.
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=4
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a2' type_id=1
+; CHECK-NEXT: 	'constarg' type_id=1
+; CHECK-NEXT: 	'a4' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i32 @sub(i32 %0, i32 %1, i32 %2, i32 %3) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !12, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 %1, metadata !13, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 42, metadata !14, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 %3, metadata !15, metadata !DIExpression()), !dbg !16
+  %5 = add i32 %0, %1, !dbg !17
+  %6 = add i32 %5, %3, !dbg !17
+  ret i32 %6, !dbg !18
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14, !15}
+!12 = !DILocalVariable(name: "a1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "a2", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "constarg", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "a4", arg: 4, scope: !7, file: !1, line: 1, type: !10)
+!16 = !DILocation(line: 1, column: 1, scope: !7)
+!17 = !DILocation(line: 2, column: 10, scope: !7)
+!18 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-dead-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-dead-arg.ll
@@ -1,0 +1,48 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates the output of DeadArgElimination on:
+;   static __noinline int sub(int unused, int a1, int a2) {
+;     return a1 + a2;
+;   }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=2
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a2' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i32 @sub(i32 %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !13, metadata !DIExpression()), !dbg !15
+  call void @llvm.dbg.value(metadata i32 %1, metadata !14, metadata !DIExpression()), !dbg !15
+  %3 = add i32 %0, %1, !dbg !16
+  ret i32 %3, !dbg !17
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14}
+!12 = !DILocalVariable(name: "unused", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "a1", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "a2", arg: 3, file: !1, line: 1, type: !10, scope: !7)
+!15 = !DILocation(line: 1, column: 1, scope: !7)
+!16 = !DILocation(line: 2, column: 10, scope: !7)
+!17 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-dead-type-mismatch.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-dead-type-mismatch.ll
@@ -1,0 +1,52 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates DeadArgElimination removing a dead first arg while a surviving
+; pointer arg has been changed to i64 in the optimized function type:
+;   static __noinline int foo(int dead, int *p, int a) {
+;     return a;
+;   }
+; Since a surviving arg has a type-only change, fall back to the original
+; source prototype instead of emitting the filtered ABI signature.
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] PTR '(anon)' type_id=1
+; CHECK-NEXT: [3] FUNC_PROTO '(anon)' ret_type_id=1 vlen=3
+; CHECK-NEXT: 	'dead' type_id=1
+; CHECK-NEXT: 	'p' type_id=2
+; CHECK-NEXT: 	'a' type_id=1
+; CHECK-NEXT: [4] FUNC 'foo' type_id=3 linkage=static
+
+define internal i32 @foo(i64 %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i64 %0, metadata !14, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 %1, metadata !15, metadata !DIExpression()), !dbg !16
+  ret i32 %1, !dbg !17
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !13, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !14, !15}
+!12 = !DILocalVariable(name: "dead", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !10, size: 64)
+!14 = !DILocalVariable(name: "p", arg: 2, scope: !7, file: !1, line: 1, type: !13)
+!15 = !DILocalVariable(name: "a", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!16 = !DILocation(line: 1, column: 1, scope: !7)
+!17 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-decl-tag.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-decl-tag.ll
@@ -1,0 +1,61 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates DeadArgElimination on a function with btf_decl_tag annotations:
+;   static __noinline int sub(int dead __attribute__((btf_decl_tag("dead_tag"))),
+;                             int a1 __attribute__((btf_decl_tag("a1_tag"))),
+;                             int a2 __attribute__((btf_decl_tag("a2_tag")))) {
+;     return a1 + a2;
+;   }
+; DAE removes 'dead' (arg 1). BTF should emit FUNC_PROTO with (a1, a2)
+; and remap decl_tag component indices: a1 becomes param 0, a2 becomes param 1.
+; The dead arg's annotation should be dropped.
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=2
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a2' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+; CHECK-NEXT: [4] DECL_TAG 'a1_tag' type_id=3 component_idx=0
+; CHECK-NEXT: [5] DECL_TAG 'a2_tag' type_id=3 component_idx=1
+
+define internal i32 @sub(i32 %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !15, metadata !DIExpression()), !dbg !17
+  call void @llvm.dbg.value(metadata i32 %1, metadata !16, metadata !DIExpression()), !dbg !17
+  %3 = add i32 %0, %1, !dbg !18
+  ret i32 %3, !dbg !19
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !15, !16}
+!12 = !DILocalVariable(name: "dead", arg: 1, scope: !7, file: !1, line: 1, type: !10, annotations: !13)
+!13 = !{!14}
+!14 = !{!"btf_decl_tag", !"dead_tag"}
+!15 = !DILocalVariable(name: "a1", arg: 2, scope: !7, file: !1, line: 1, type: !10, annotations: !20)
+!16 = !DILocalVariable(name: "a2", arg: 3, file: !1, line: 1, type: !10, scope: !7, annotations: !22)
+!17 = !DILocation(line: 1, column: 1, scope: !7)
+!18 = !DILocation(line: 2, column: 10, scope: !7)
+!19 = !DILocation(line: 2, column: 3, scope: !7)
+!20 = !{!21}
+!21 = !{!"btf_decl_tag", !"a1_tag"}
+!22 = !{!23}
+!23 = !{!"btf_decl_tag", !"a2_tag"}

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-mixed-types.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-mixed-types.ll
@@ -1,0 +1,60 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates DeadArgElimination on a function with mixed parameter types:
+;   enum color { RED };
+;   static __noinline int sub(int dead, int *p, enum color c) {
+;     return *p + c;
+;   }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] PTR '(anon)' type_id=1
+; CHECK-NEXT: [3] ENUM 'color' encoding=UNSIGNED size=4 vlen=1
+; CHECK-NEXT: 	'RED' val=0
+; CHECK-NEXT: [4] FUNC_PROTO '(anon)' ret_type_id=1 vlen=2
+; CHECK-NEXT: 	'p' type_id=2
+; CHECK-NEXT: 	'c' type_id=3
+; CHECK-NEXT: [5] FUNC 'sub' type_id=4 linkage=static
+
+define internal i32 @sub(ptr %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata ptr %0, metadata !18, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i32 %1, metadata !19, metadata !DIExpression()), !dbg !20
+  %3 = load i32, ptr %0, !dbg !21
+  %4 = add i32 %3, %1, !dbg !22
+  ret i32 %4, !dbg !23
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !13, !14}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !18, !19}
+!12 = !DILocalVariable(name: "dead", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !10, size: 64)
+; enum color { RED = 0 }
+!14 = !DICompositeType(tag: DW_TAG_enumeration_type, name: "color", file: !1, line: 1, baseType: !15, size: 32, elements: !16)
+!15 = !DIBasicType(name: "unsigned int", size: 32, encoding: DW_ATE_unsigned)
+!16 = !{!17}
+!17 = !DIEnumerator(name: "RED", value: 0)
+!18 = !DILocalVariable(name: "p", arg: 2, scope: !7, file: !1, line: 1, type: !13)
+!19 = !DILocalVariable(name: "c", arg: 3, scope: !7, file: !1, line: 1, type: !14)
+!20 = !DILocation(line: 1, column: 1, scope: !7)
+!21 = !DILocation(line: 2, column: 10, scope: !7)
+!22 = !DILocation(line: 2, column: 15, scope: !7)
+!23 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-multi-dead.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-multi-dead.ll
@@ -1,0 +1,49 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates DeadArgElimination on:
+;   static __noinline int sub(int dead1, int a1, int dead2, int a2) {
+;     return a1 + a2;
+;   }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=2
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a2' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i32 @sub(i32 %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !13, metadata !DIExpression()), !dbg !16
+  call void @llvm.dbg.value(metadata i32 %1, metadata !15, metadata !DIExpression()), !dbg !16
+  %3 = add i32 %0, %1, !dbg !17
+  ret i32 %3, !dbg !18
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14, !15}
+!12 = !DILocalVariable(name: "dead1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "a1", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "dead2", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "a2", arg: 4, scope: !7, file: !1, line: 1, type: !10)
+!16 = !DILocation(line: 1, column: 1, scope: !7)
+!17 = !DILocation(line: 2, column: 10, scope: !7)
+!18 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-no-dead-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-no-dead-arg.ll
@@ -1,0 +1,61 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; DW_CC_nocall function where no arguments were removed (ArgumentPromotion
+; changed struct big to i64 but all source args survived). Since no args
+; were eliminated, there is nothing to optimize — fall back to the original
+; source prototype.
+
+; CHECK:      [1] STRUCT 'big' size=16 vlen=2
+; CHECK-NEXT: 	'x' type_id=2 bits_offset=0
+; CHECK-NEXT: 	'y' type_id=2 bits_offset=64
+; CHECK-NEXT: [2] INT 'long' size=8 bits_offset=0 nr_bits=64 encoding=SIGNED
+; CHECK-NEXT: [3] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [4] FUNC_PROTO '(anon)' ret_type_id=3 vlen=2
+; CHECK-NEXT: 	's' type_id=1
+; CHECK-NEXT: 	'a' type_id=3
+; CHECK-NEXT: [5] FUNC 'foo' type_id=4 linkage=static
+
+define internal i32 @foo(i64 %0, i32 %1) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i64 %0, metadata !17,
+                            metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg !19
+  call void @llvm.dbg.value(metadata i64 poison, metadata !17,
+                            metadata !DIExpression(DW_OP_LLVM_fragment, 64, 64)), !dbg !19
+  call void @llvm.dbg.value(metadata i32 %1, metadata !18, metadata !DIExpression()), !dbg !19
+  %3 = trunc i64 %0 to i32, !dbg !20
+  %4 = add i32 %3, %1, !dbg !21
+  ret i32 %4, !dbg !22
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 3, type: !8, scopeLine: 3, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !12, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!17, !18}
+!12 = !DICompositeType(tag: DW_TAG_structure_type, name: "big", file: !1, line: 1, size: 128, elements: !13)
+!13 = !{!14, !15}
+!14 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !12, file: !1, line: 1, baseType: !16, size: 64)
+!15 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !12, file: !1, line: 1, baseType: !16, size: 64, offset: 64)
+!16 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!17 = !DILocalVariable(name: "s", arg: 1, scope: !7, file: !1, line: 3, type: !12)
+!18 = !DILocalVariable(name: "a", arg: 2, scope: !7, file: !1, line: 3, type: !10)
+!19 = !DILocation(line: 3, column: 1, scope: !7)
+!20 = !DILocation(line: 4, column: 10, scope: !7)
+!21 = !DILocation(line: 4, column: 15, scope: !7)
+!22 = !DILocation(line: 4, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-stack-arg-i64.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-stack-arg-i64.ll
@@ -1,0 +1,72 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Like func-nocall-stack-arg.ll but with i64 arguments so that
+; stack-arg loads (LDD $r11, offset) and their DBG_VALUEs both use
+; the 64-bit register ($r1), exercising the StackLoadRegs path in
+; collectNocallEntryArgRegs rather than falling through on a
+; sub-register mismatch.
+;
+; Source (after DAE removes dead2 and dead7):
+;   static __noinline long sub(long a1, long dead2, long a3, long a4,
+;                              long a5, long a6, long dead7, long a8) {
+;     return a1 + a3 + a4 + a5 + a6 + a8;
+;   }
+
+; CHECK:      [1] INT 'long' size=8 bits_offset=0 nr_bits=64 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=6
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a3' type_id=1
+; CHECK-NEXT: 	'a4' type_id=1
+; CHECK-NEXT: 	'a5' type_id=1
+; CHECK-NEXT: 	'a6' type_id=1
+; CHECK-NEXT: 	'a8' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i64 @sub(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i64 %0, metadata !12, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i64 %1, metadata !14, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i64 %2, metadata !15, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i64 %3, metadata !16, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i64 %4, metadata !17, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i64 %5, metadata !19, metadata !DIExpression()), !dbg !20
+  %7 = add i64 %0, %1, !dbg !21
+  %8 = add i64 %7, %2, !dbg !21
+  %9 = add i64 %8, %3, !dbg !21
+  %10 = add i64 %9, %4, !dbg !21
+  %11 = add i64 %10, %5, !dbg !21
+  ret i64 %11, !dbg !22
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10, !10, !10, !10, !10, !10}
+!10 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14, !15, !16, !17, !18, !19}
+!12 = !DILocalVariable(name: "a1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "dead2", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "a3", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "a4", arg: 4, scope: !7, file: !1, line: 1, type: !10)
+!16 = !DILocalVariable(name: "a5", arg: 5, scope: !7, file: !1, line: 1, type: !10)
+!17 = !DILocalVariable(name: "a6", arg: 6, scope: !7, file: !1, line: 1, type: !10)
+!18 = !DILocalVariable(name: "dead7", arg: 7, scope: !7, file: !1, line: 1, type: !10)
+!19 = !DILocalVariable(name: "a8", arg: 8, scope: !7, file: !1, line: 1, type: !10)
+!20 = !DILocation(line: 1, column: 1, scope: !7)
+!21 = !DILocation(line: 2, column: 10, scope: !7)
+!22 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-stack-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-stack-arg.ll
@@ -1,0 +1,69 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates DeadArgElimination on a function with 8 args (5 reg + 3 stack):
+;   static __noinline int sub(int a1, int dead2, int a3, int a4,
+;                             int a5, int a6, int dead7, int a8) {
+;     return a1 + a3 + a4 + a5 + a6 + a8;
+;   }
+; DAE removes 'dead2' (register arg 2) and 'dead7' (stack arg 7).
+; The remaining 6 args use R1-R5 + stack. BTF should emit FUNC_PROTO
+; with (a1, a3, a4, a5, a6, a8).
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=6
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: 	'a3' type_id=1
+; CHECK-NEXT: 	'a4' type_id=1
+; CHECK-NEXT: 	'a5' type_id=1
+; CHECK-NEXT: 	'a6' type_id=1
+; CHECK-NEXT: 	'a8' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i32 @sub(i32 %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !12, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i32 %1, metadata !14, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i32 %2, metadata !15, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i32 %3, metadata !16, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i32 %4, metadata !17, metadata !DIExpression()), !dbg !20
+  call void @llvm.dbg.value(metadata i32 %5, metadata !19, metadata !DIExpression()), !dbg !20
+  %7 = add i32 %0, %1, !dbg !21
+  %8 = add i32 %7, %2, !dbg !21
+  %9 = add i32 %8, %3, !dbg !21
+  %10 = add i32 %9, %4, !dbg !21
+  %11 = add i32 %10, %5, !dbg !21
+  ret i32 %11, !dbg !22
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10, !10, !10, !10, !10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14, !15, !16, !17, !18, !19}
+!12 = !DILocalVariable(name: "a1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "dead2", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "a3", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DILocalVariable(name: "a4", arg: 4, scope: !7, file: !1, line: 1, type: !10)
+!16 = !DILocalVariable(name: "a5", arg: 5, scope: !7, file: !1, line: 1, type: !10)
+!17 = !DILocalVariable(name: "a6", arg: 6, scope: !7, file: !1, line: 1, type: !10)
+!18 = !DILocalVariable(name: "dead7", arg: 7, scope: !7, file: !1, line: 1, type: !10)
+!19 = !DILocalVariable(name: "a8", arg: 8, scope: !7, file: !1, line: 1, type: !10)
+!20 = !DILocation(line: 1, column: 1, scope: !7)
+!21 = !DILocation(line: 2, column: 10, scope: !7)
+!22 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-stack-homed-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-stack-homed-arg.ll
@@ -1,0 +1,57 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates a nocall function after DeadArgElimination removed 'ctx':
+;   static __noinline void func(void *ctx, int key, int sig) { ... }
+; 'ctx' is dead.  'key' is stack-homed (address passed to helper),
+; described via #dbg_assign.  'sig' is register-only, described via
+; #dbg_value.  BTF FUNC_PROTO should list both key and sig.
+
+; CHECK:      [2] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [3] FUNC_PROTO '(anon)' ret_type_id=0 vlen=2
+; CHECK-NEXT: 	'key' type_id=2
+; CHECK-NEXT: 	'sig' type_id=2
+; CHECK-NEXT: [4] FUNC 'func' type_id=3 linkage=static
+
+@map = external global i64
+
+define internal void @func(i32 noundef %key, i32 noundef %sig) #0 !dbg !7 {
+entry:
+  %key.addr = alloca i32, align 4, !DIAssignID !20
+    #dbg_assign(i1 poison, !13, !DIExpression(), !20, ptr %key.addr, !DIExpression(), !19)
+  store i32 %key, ptr %key.addr, align 4, !DIAssignID !21
+    #dbg_assign(i32 %key, !13, !DIExpression(), !21, ptr %key.addr, !DIExpression(), !19)
+    #dbg_value(i32 %sig, !14, !DIExpression(), !19)
+  %call = call ptr inttoptr (i64 1 to ptr)(ptr noundef @map, ptr noundef %key.addr) #1
+  ret void, !dbg !22
+}
+
+attributes #0 = { noinline nounwind }
+attributes #1 = { nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5, !23}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "func", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{null, !15, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13, !14}
+!12 = !DILocalVariable(name: "ctx", arg: 1, scope: !7, file: !1, line: 1, type: !15)
+!13 = !DILocalVariable(name: "key", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "sig", arg: 3, scope: !7, file: !1, line: 1, type: !10)
+!15 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: null, size: 64)
+!19 = !DILocation(line: 1, column: 1, scope: !7)
+!20 = distinct !DIAssignID()
+!21 = distinct !DIAssignID()
+!22 = !DILocation(line: 2, column: 1, scope: !7)
+!23 = !{i32 7, !"debug-info-assignment-tracking", i1 true}

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-undef-dead-arg.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-undef-dead-arg.ll
@@ -1,0 +1,50 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -stop-after=prologepilog -o - %s | FileCheck -check-prefixes=MIR %s
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=BTF %s
+
+; Reproducer for nocall BTF signature filtering with a dead source argument
+; described by dbg.value(poison, ...). During lowering that dead parameter
+; becomes DBG_VALUE $noreg, which should not count as an alive argument when
+; building the filtered BTF FUNC_PROTO.
+
+; MIR: ![[DEAD:[0-9]+]] = !DILocalVariable(name: "dead", arg: 1, scope:
+; MIR: DBG_VALUE $noreg, $noreg, ![[DEAD]], !DIExpression()
+
+; BTF:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; BTF-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=1 vlen=1
+; BTF-NEXT: 	'a1' type_id=1
+; BTF-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal i32 @sub(i32 %0) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 poison, metadata !12,
+                            metadata !DIExpression()), !dbg !14
+  call void @llvm.dbg.value(metadata i32 %0, metadata !13,
+                            metadata !DIExpression()), !dbg !14
+  ret i32 %0, !dbg !15
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13}
+!12 = !DILocalVariable(name: "dead", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "a1", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocation(line: 1, column: 1, scope: !7)
+!15 = !DILocation(line: 2, column: 3, scope: !7)

--- a/llvm/test/CodeGen/BPF/BTF/func-nocall-void-return.ll
+++ b/llvm/test/CodeGen/BPF/BTF/func-nocall-void-return.ll
@@ -1,0 +1,42 @@
+; RUN: llc -mtriple=bpfel -mcpu=v3 -filetype=obj -o %t1 %s
+; RUN: llvm-objcopy --dump-section='.BTF'=%t2 %t1
+; RUN: %python %p/print_btf.py %t2 | FileCheck -check-prefixes=CHECK %s
+
+; Simulates DeadArgElimination on a function where both an argument and the
+; return value are dead:
+;   static __noinline int sub(int dead, int a1) { return a1; }
+
+; CHECK:      [1] INT 'int' size=4 bits_offset=0 nr_bits=32 encoding=SIGNED
+; CHECK-NEXT: [2] FUNC_PROTO '(anon)' ret_type_id=0 vlen=1
+; CHECK-NEXT: 	'a1' type_id=1
+; CHECK-NEXT: [3] FUNC 'sub' type_id=2 linkage=static
+
+define internal void @sub(i32 %0) #0 !dbg !7 {
+  call void @llvm.dbg.value(metadata i32 %0, metadata !13, metadata !DIExpression()), !dbg !14
+  ret void, !dbg !15
+}
+
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+attributes #0 = { noinline }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/DNE")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang"}
+!7 = distinct !DISubprogram(name: "sub", scope: !1, file: !1, line: 1, type: !8, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !11)
+!8 = !DISubroutineType(cc: DW_CC_nocall, types: !9)
+!9 = !{!10, !10, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !{!12, !13}
+!12 = !DILocalVariable(name: "dead", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!13 = !DILocalVariable(name: "a1", arg: 2, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocation(line: 1, column: 1, scope: !7)
+!15 = !DILocation(line: 2, column: 3, scope: !7)


### PR DESCRIPTION
DW_CC_nocall subprograms can end up with an optimized IR signature that no
longer matches the original source-level DISubroutineType. Dead argument
elimination may drop source parameters, and the return value may be
removed entirely, while the debug type still describes the original
prototype. In that case BTFDebug emits a FUNC_PROTO that no longer matches
the real BPF ABI.

Teach BTFDebug to derive a filtered FUNC_PROTO for nocall functions.

Detecting surviving arguments (collectNocallEntryArgRegs):

Scan all DBG_VALUE instructions in the entry block while tracking which
registers have been redefined by non-debug instructions:

- A DBG_VALUE whose register has not been redefined records a
  register-passed argument (R1-R5 at function entry).
- A DBG_VALUE whose register was most recently loaded via LDD $r11,
  offset records a stack-passed argument (beyond the first five).
  LowerFormalArguments always places stack argument loads in the entry
  block, so scanning MF.front() is sufficient.
- Indirect DBG_VALUEs (describing memory locations, e.g. spills to
  [$r10 + offset]) are skipped -- the register is a base address,
  not the argument value.
- DBG_VALUEs with immediate operands (constant-propagated args) are
  skipped because MO.isReg() returns false.

Emitting a filtered prototype:

A filtered prototype (true ABI signature) is emitted when all of the
following hold:
  - The number of surviving source arguments equals the number of
    optimized IR arguments (no merging or splitting).
  - Every surviving source argument matches the corresponding IR type
    (pointer, same-width integer/boolean/float, or same-width enum).
  - For up to the first std::size(CC_BPF64_ArgRegs) surviving
    arguments, entry-block DBG_VALUEs assign BPF registers in order
    R1..R5.

The original source prototype is used as fallback when:
  - The surviving source arg count differs from the IR arg count.
  - Any surviving source type does not match its IR type (e.g. structs).
  - The register assignment does not follow R1..R5 order.

Independently, if the IR return type is void but the debug info declares a
non-void return, the emitted BTF return type becomes void. This applies
regardless of whether the parameter list is filtered.

When using the filtered prototype, decl_tag component indices are remapped
to the filtered parameter list.

Add coverage for dead register and stack args, all-dead args, unchanged
signatures, const/bool/mixed types, type mismatches, decl_tags, poisoned
DBG_VALUE inputs, and voided returns.