### PR TITLE
[CIR] Lower pointer const_array globals without insertvalue chains

### DIFF
--- a/clang/include/clang/CIR/LoweringHelpers.h
+++ b/clang/include/clang/CIR/LoweringHelpers.h
@@ -35,7 +35,8 @@ convertToDenseElementsAttr(cir::ConstArrayAttr attr,
 
 std::optional<mlir::Attribute>
 lowerConstArrayAttr(cir::ConstArrayAttr constArr,
-                    const mlir::TypeConverter *converter);
+                    const mlir::TypeConverter *converter,
+                    mlir::ModuleOp moduleOp = {});
 
 mlir::Value getConstAPInt(mlir::OpBuilder &bld, mlir::Location loc,
                           mlir::Type typ, const llvm::APInt &val);

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -320,7 +320,6 @@ struct MissingFeatures {
   static bool unsizedTypes() { return false; }
   static bool vectorType() { return false; }
   static bool fixedPointType() { return false; }
-  static bool stringTypeWithDifferentArraySize() { return false; }
 
   // Future CIR operations
   static bool callOp() { return false; }

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2014,7 +2014,7 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
     if (constArr &&
         (denseAttr = lowerConstArrayAttr(constArr, typeConverter))) {
       attr = denseAttr.value();
-    } else if (constArr) {
+    } else {
       const mlir::Value initVal =
           lowerCirAttrAsValue(op, op.getValue(), rewriter, typeConverter);
       rewriter.replaceOp(op, initVal);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -484,6 +484,7 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
   // Iteratively lower each constant element of the array.
   if (auto arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts())) {
     for (auto [idx, elt] : llvm::enumerate(arrayAttr)) {
+      mlir::DataLayout dataLayout(parentOp->getParentOfType<mlir::ModuleOp>());
       mlir::Value init = visit(elt);
       result =
           mlir::LLVM::InsertValueOp::create(rewriter, loc, result, init, idx);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1932,13 +1932,33 @@ mlir::LogicalResult CIRToLLVMStoreOpLowering::matchAndRewrite(
   return mlir::LogicalResult::success();
 }
 
+static mlir::Type getConstArrayLeafType(mlir::Type ty) {
+  while (auto arrTy = mlir::dyn_cast<cir::ArrayType>(ty))
+    ty = arrTy.getElementType();
+  return ty;
+}
+
+static bool isBulkLowerableConstArrayLeaf(mlir::Type leafTy) {
+  return mlir::isa<cir::PointerType, cir::IntType, cir::FPTypeInterface>(
+      leafTy);
+}
+
 bool hasTrailingZeros(cir::ConstArrayAttr attr) {
-  auto array = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts());
-  return attr.hasTrailingZeros() ||
-         (array && std::count_if(array.begin(), array.end(), [](auto elt) {
-            auto ar = dyn_cast<cir::ConstArrayAttr>(elt);
-            return ar && hasTrailingZeros(ar);
-          }));
+  if (attr.hasTrailingZeros())
+    return true;
+
+  auto elts = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts());
+  if (!elts)
+    return false;
+
+  auto cirArrTy = mlir::dyn_cast<cir::ArrayType>(attr.getType());
+  if (!cirArrTy || !mlir::isa<cir::ArrayType>(cirArrTy.getElementType()))
+    return false;
+
+  return llvm::any_of(elts, [](mlir::Attribute elt) {
+    auto nested = mlir::dyn_cast<cir::ConstArrayAttr>(elt);
+    return nested && hasTrailingZeros(nested);
+  });
 }
 
 mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
@@ -2490,30 +2510,33 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
         op.emitError() << "unsupported initializer '" << init.value() << "'";
         return mlir::failure();
       }
-    } else if (mlir::isa<cir::ConstArrayAttr, cir::ConstVectorAttr,
-                         cir::ConstRecordAttr, cir::ConstPtrAttr,
-                         cir::ConstComplexAttr, cir::GlobalViewAttr,
-                         cir::TypeInfoAttr, cir::UndefAttr, cir::PoisonAttr,
-                         cir::VTableAttr, cir::ZeroAttr>(init.value())) {
-      if (auto constArr = mlir::dyn_cast<cir::ConstArrayAttr>(init.value())) {
-        if (!hasTrailingZeros(constArr)) {
-          mlir::Type elTy = constArr.getType();
-          while (auto arrTy = mlir::dyn_cast<cir::ArrayType>(elTy))
-            elTy = arrTy.getElementType();
-          if (mlir::isa<cir::PointerType>(elTy)) {
-            mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
-            if (std::optional<mlir::Attribute> bulkInit =
-                    lowerConstArrayAttr(constArr, typeConverter, module)) {
-              mlir::SymbolRefAttr comdatAttr = getComdatAttr(op, rewriter);
-              rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
-                  op, llvmType, isConst, linkage, symbol, bulkInit.value(),
-                  alignment, addrSpace, isDsoLocal, isThreadLocal, comdatAttr,
-                  attributes);
-              return mlir::success();
-            }
-          }
+    } else if (auto constArr =
+                   mlir::dyn_cast<cir::ConstArrayAttr>(init.value())) {
+      // Bulk-emit llvm.mlir.global when lowerConstArrayAttr can build the
+      // whole initializer as one aggregate attribute (no insertvalue
+      // region). Skip arrays with trailing-zero compression: those need
+      // per-element zero/undef setup. Leaf type must match what
+      // lowerConstArrayAttr handles (pointers, integers, floats today).
+      if (!hasTrailingZeros(constArr) &&
+          isBulkLowerableConstArrayLeaf(
+              getConstArrayLeafType(constArr.getType()))) {
+        mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
+        if (std::optional<mlir::Attribute> bulkInit =
+                lowerConstArrayAttr(constArr, typeConverter, module)) {
+          mlir::SymbolRefAttr comdatAttr = getComdatAttr(op, rewriter);
+          rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
+              op, llvmType, isConst, linkage, symbol, bulkInit.value(),
+              alignment, addrSpace, isDsoLocal, isThreadLocal, comdatAttr,
+              attributes);
+          return mlir::success();
         }
       }
+      return matchAndRewriteRegionInitializedGlobal(op, init.value(), rewriter);
+    } else if (mlir::isa<cir::ConstVectorAttr, cir::ConstRecordAttr,
+                         cir::ConstPtrAttr, cir::ConstComplexAttr,
+                         cir::GlobalViewAttr, cir::TypeInfoAttr, cir::UndefAttr,
+                         cir::PoisonAttr, cir::VTableAttr, cir::ZeroAttr>(
+                   init.value())) {
       // TODO(cir): once LLVM's dialect has proper equivalent attributes this
       // should be updated. For now, we use a custom op to initialize globals
       // to the appropriate value.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1932,15 +1932,15 @@ mlir::LogicalResult CIRToLLVMStoreOpLowering::matchAndRewrite(
   return mlir::LogicalResult::success();
 }
 
-static mlir::Type getConstArrayLeafType(mlir::Type ty) {
+static mlir::Type getConstArrayBaseElementType(mlir::Type ty) {
   while (auto arrTy = mlir::dyn_cast<cir::ArrayType>(ty))
     ty = arrTy.getElementType();
   return ty;
 }
 
-static bool isBulkLowerableConstArrayLeaf(mlir::Type leafTy) {
+static bool isBulkLowerableConstArrayBaseElement(mlir::Type baseElemTy) {
   return mlir::isa<cir::PointerType, cir::IntType, cir::BoolType,
-                   cir::FPTypeInterface>(leafTy);
+                   cir::FPTypeInterface>(baseElemTy);
 }
 
 mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
@@ -2494,11 +2494,11 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
       // region). Leaf type must match what lowerConstArrayAttr handles
       // (pointers, integers, bools, floats, and string literals with
       // trailing_zeros).
-      if (isBulkLowerableConstArrayLeaf(
-              getConstArrayLeafType(constArr.getType()))) {
-        mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
+      if (isBulkLowerableConstArrayBaseElement(
+              getConstArrayBaseElementType(constArr.getType()))) {
+        mlir::ModuleOp modOp = op->getParentOfType<mlir::ModuleOp>();
         if (std::optional<mlir::Attribute> bulkInit =
-                lowerConstArrayAttr(constArr, typeConverter, module)) {
+                lowerConstArrayAttr(constArr, typeConverter, modOp)) {
           mlir::SymbolRefAttr comdatAttr = getComdatAttr(op, rewriter);
           rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
               op, llvmType, isConst, linkage, symbol, bulkInit.value(),
@@ -2539,13 +2539,13 @@ CIRToLLVMGlobalOpLowering::getComdatAttr(cir::GlobalOp &op,
   if (!op.getComdat())
     return mlir::SymbolRefAttr{};
 
-  mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
+  mlir::ModuleOp modOp = op->getParentOfType<mlir::ModuleOp>();
   mlir::OpBuilder::InsertionGuard guard(builder);
   StringRef comdatName("__llvm_comdat_globals");
   if (!comdatOp) {
-    builder.setInsertionPointToStart(module.getBody());
+    builder.setInsertionPointToStart(modOp.getBody());
     comdatOp =
-        mlir::LLVM::ComdatOp::create(builder, module.getLoc(), comdatName);
+        mlir::LLVM::ComdatOp::create(builder, modOp.getLoc(), comdatName);
   }
 
   if (auto comdatSelector = comdatOp.lookupSymbol<mlir::LLVM::ComdatSelectorOp>(

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1939,8 +1939,8 @@ static mlir::Type getConstArrayLeafType(mlir::Type ty) {
 }
 
 static bool isBulkLowerableConstArrayLeaf(mlir::Type leafTy) {
-  return mlir::isa<cir::PointerType, cir::IntType, cir::FPTypeInterface>(
-      leafTy);
+  return mlir::isa<cir::PointerType, cir::IntType, cir::BoolType,
+                   cir::FPTypeInterface>(leafTy);
 }
 
 bool hasTrailingZeros(cir::ConstArrayAttr attr) {
@@ -2516,7 +2516,7 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
       // whole initializer as one aggregate attribute (no insertvalue
       // region). Skip arrays with trailing-zero compression: those need
       // per-element zero/undef setup. Leaf type must match what
-      // lowerConstArrayAttr handles (pointers, integers, floats today).
+      // lowerConstArrayAttr handles (pointers, integers, bools, floats).
       if (!hasTrailingZeros(constArr) &&
           isBulkLowerableConstArrayLeaf(
               getConstArrayLeafType(constArr.getType()))) {

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -484,7 +484,6 @@ mlir::Value CIRAttrToValue::visitCirAttr(cir::ConstArrayAttr attr) {
   // Iteratively lower each constant element of the array.
   if (auto arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts())) {
     for (auto [idx, elt] : llvm::enumerate(arrayAttr)) {
-      mlir::DataLayout dataLayout(parentOp->getParentOfType<mlir::ModuleOp>());
       mlir::Value init = visit(elt);
       result =
           mlir::LLVM::InsertValueOp::create(rewriter, loc, result, init, idx);
@@ -2496,6 +2495,25 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
                          cir::ConstComplexAttr, cir::GlobalViewAttr,
                          cir::TypeInfoAttr, cir::UndefAttr, cir::PoisonAttr,
                          cir::VTableAttr, cir::ZeroAttr>(init.value())) {
+      if (auto constArr = mlir::dyn_cast<cir::ConstArrayAttr>(init.value())) {
+        if (!hasTrailingZeros(constArr)) {
+          mlir::Type elTy = constArr.getType();
+          while (auto arrTy = mlir::dyn_cast<cir::ArrayType>(elTy))
+            elTy = arrTy.getElementType();
+          if (mlir::isa<cir::PointerType>(elTy)) {
+            mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
+            if (std::optional<mlir::Attribute> bulkInit =
+                    lowerConstArrayAttr(constArr, typeConverter, module)) {
+              mlir::SymbolRefAttr comdatAttr = getComdatAttr(op, rewriter);
+              rewriter.replaceOpWithNewOp<mlir::LLVM::GlobalOp>(
+                  op, llvmType, isConst, linkage, symbol, bulkInit.value(),
+                  alignment, addrSpace, isDsoLocal, isThreadLocal, comdatAttr,
+                  attributes);
+              return mlir::success();
+            }
+          }
+        }
+      }
       // TODO(cir): once LLVM's dialect has proper equivalent attributes this
       // should be updated. For now, we use a custom op to initialize globals
       // to the appropriate value.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1943,24 +1943,6 @@ static bool isBulkLowerableConstArrayLeaf(mlir::Type leafTy) {
                    cir::FPTypeInterface>(leafTy);
 }
 
-bool hasTrailingZeros(cir::ConstArrayAttr attr) {
-  if (attr.hasTrailingZeros())
-    return true;
-
-  auto elts = mlir::dyn_cast<mlir::ArrayAttr>(attr.getElts());
-  if (!elts)
-    return false;
-
-  auto cirArrTy = mlir::dyn_cast<cir::ArrayType>(attr.getType());
-  if (!cirArrTy || !mlir::isa<cir::ArrayType>(cirArrTy.getElementType()))
-    return false;
-
-  return llvm::any_of(elts, [](mlir::Attribute elt) {
-    auto nested = mlir::dyn_cast<cir::ConstArrayAttr>(elt);
-    return nested && hasTrailingZeros(nested);
-  });
-}
-
 mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
     cir::ConstantOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
@@ -2029,15 +2011,10 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
       return op.emitError() << "array does not have a constant initializer";
 
     std::optional<mlir::Attribute> denseAttr;
-    if (constArr && hasTrailingZeros(constArr)) {
-      const mlir::Value newOp =
-          lowerCirAttrAsValue(op, constArr, rewriter, getTypeConverter());
-      rewriter.replaceOp(op, newOp);
-      return mlir::success();
-    } else if (constArr &&
-               (denseAttr = lowerConstArrayAttr(constArr, typeConverter))) {
+    if (constArr &&
+        (denseAttr = lowerConstArrayAttr(constArr, typeConverter))) {
       attr = denseAttr.value();
-    } else {
+    } else if (constArr) {
       const mlir::Value initVal =
           lowerCirAttrAsValue(op, op.getValue(), rewriter, typeConverter);
       rewriter.replaceOp(op, initVal);
@@ -2514,11 +2491,10 @@ mlir::LogicalResult CIRToLLVMGlobalOpLowering::matchAndRewrite(
                    mlir::dyn_cast<cir::ConstArrayAttr>(init.value())) {
       // Bulk-emit llvm.mlir.global when lowerConstArrayAttr can build the
       // whole initializer as one aggregate attribute (no insertvalue
-      // region). Skip arrays with trailing-zero compression: those need
-      // per-element zero/undef setup. Leaf type must match what
-      // lowerConstArrayAttr handles (pointers, integers, bools, floats).
-      if (!hasTrailingZeros(constArr) &&
-          isBulkLowerableConstArrayLeaf(
+      // region). Leaf type must match what lowerConstArrayAttr handles
+      // (pointers, integers, bools, floats, and string literals with
+      // trailing_zeros).
+      if (isBulkLowerableConstArrayLeaf(
               getConstArrayLeafType(constArr.getType()))) {
         mlir::ModuleOp module = op->getParentOfType<mlir::ModuleOp>();
         if (std::optional<mlir::Attribute> bulkInit =

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -14,7 +14,6 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/SymbolTable.h"
-#include "clang/CIR/MissingFeatures.h"
 
 static unsigned getIntOrBoolBitWidth(mlir::Type ty) {
   if (auto intTy = mlir::dyn_cast<cir::IntType>(ty))

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -101,7 +101,8 @@ void convertToDenseElementsAttrImpl(
   for (auto eltAttr : arrayAttr) {
     if (auto boolAttr = mlir::dyn_cast<cir::BoolAttr>(eltAttr)) {
       if constexpr (std::is_same_v<StorageTy, mlir::APInt>) {
-        values[currentIndex++] = mlir::APInt(1, (uint64_t)boolAttr.getValue());
+        values[currentIndex++] =
+          llvm::APInt(1, static_cast<uint64_t>(boolAttr.getValue()));
         continue;
       }
     }
@@ -256,6 +257,13 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
         constArr, dims, type, converter->convertType(type));
 
   if (mlir::isa<cir::PointerType>(type)) {
+    // Pointer arrays with trailing_zeros (null-sentinel tables) fall through
+    // to the insertvalue path for now.
+    // FIXME: extend this to cover trailing null pointers via explicit null
+    // elements so long sentinel-terminated pointer tables also benefit from
+    // the bulk path.
+    if (constArr.getTrailingZerosNum() > 0)
+      return std::nullopt;
     auto eltsArr = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts());
     if (!eltsArr)
       return std::nullopt;

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -35,7 +35,8 @@ convertStringAttrToDenseElementsAttr(cir::ConstArrayAttr attr,
 }
 
 template <> mlir::APInt getZeroInitFromType(mlir::Type ty) {
-  assert(mlir::isa<cir::IntType>(ty) && "expected int type");
+  if (mlir::isa<cir::BoolType>(ty))
+    return mlir::APInt::getZero(1);
   const auto intTy = mlir::cast<cir::IntType>(ty);
   return mlir::APInt::getZero(intTy.getWidth());
 }
@@ -80,6 +81,12 @@ void convertToDenseElementsAttrImpl(
 
   auto arrayAttr = mlir::cast<mlir::ArrayAttr>(attr.getElts());
   for (auto eltAttr : arrayAttr) {
+    if (auto boolAttr = mlir::dyn_cast<cir::BoolAttr>(eltAttr)) {
+      if constexpr (std::is_same_v<StorageTy, mlir::APInt>) {
+        values[currentIndex++] = mlir::APInt(1, (uint64_t)boolAttr.getValue());
+        continue;
+      }
+    }
     if (auto valueAttr = mlir::dyn_cast<AttrTy>(eltAttr)) {
       values[currentIndex++] = valueAttr.getValue();
       continue;
@@ -219,6 +226,10 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
     return convertStringAttrToDenseElementsAttr(constArr,
                                                 converter->convertType(type));
   if (mlir::isa<cir::IntType>(type))
+    return convertToDenseElementsAttr<cir::IntAttr, mlir::APInt>(
+        constArr, dims, type, converter->convertType(type));
+
+  if (mlir::isa<cir::BoolType>(type))
     return convertToDenseElementsAttr<cir::IntAttr, mlir::APInt>(
         constArr, dims, type, converter->convertType(type));
 

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -12,6 +12,8 @@
 
 #include "clang/CIR/LoweringHelpers.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/SymbolTable.h"
 #include "clang/CIR/MissingFeatures.h"
 
 mlir::DenseElementsAttr
@@ -115,9 +117,71 @@ mlir::DenseElementsAttr convertToDenseElementsAttr(
       llvm::ArrayRef(values));
 }
 
+/// Return true when \p gv can be lowered to a \c FlatSymbolRefAttr leaf without
+/// addrspacecast or bitcast (mirrors \c CIRAttrToValue::visitCirAttr).
+static bool globalViewMatchesPointerLeaf(cir::GlobalViewAttr gv,
+                                         mlir::ModuleOp moduleOp,
+                                         const mlir::TypeConverter *converter) {
+  if (gv.getIndices() || mlir::isa<cir::IntType, cir::VPtrType>(gv.getType()))
+    return false;
+
+  auto ptrTy = mlir::dyn_cast<cir::PointerType>(gv.getType());
+  if (!ptrTy)
+    return false;
+
+  unsigned sourceAddrSpace = 0;
+  mlir::Type sourceType;
+  auto sourceSymbol =
+      mlir::SymbolTable::lookupSymbolIn(moduleOp, gv.getSymbol());
+  if (auto llvmSymbol = mlir::dyn_cast<mlir::LLVM::GlobalOp>(sourceSymbol)) {
+    sourceType = llvmSymbol.getType();
+    sourceAddrSpace = llvmSymbol.getAddrSpace();
+  } else if (auto cirSymbol = mlir::dyn_cast<cir::GlobalOp>(sourceSymbol)) {
+    sourceType = converter->convertType(cirSymbol.getSymType());
+    if (auto targetAS = mlir::dyn_cast_if_present<cir::TargetAddressSpaceAttr>(
+            cirSymbol.getAddrSpaceAttr()))
+      sourceAddrSpace = targetAS.getValue();
+  } else {
+    return false;
+  }
+
+  auto llvmDstTy = converter->convertType<mlir::LLVM::LLVMPointerType>(ptrTy);
+  if (llvmDstTy.getAddressSpace() != sourceAddrSpace)
+    return false;
+
+  mlir::Type llvmEltTy = converter->convertType(ptrTy.getPointee());
+  if (llvmEltTy == sourceType)
+    return true;
+  if (auto arrTy = mlir::dyn_cast<mlir::LLVM::LLVMArrayType>(sourceType))
+    return llvmEltTy == arrTy.getElementType();
+  return false;
+}
+
+/// Lower a single pointer-element of a \c cir.const_array to an LLVM-dialect
+/// constant leaf suitable for a bulk \c llvm.mlir.constant.  Only handles
+/// address-of-global without indices and null pointers; indexed global views
+/// must use the per-element \c llvm.insertvalue fallback.
+static std::optional<mlir::Attribute>
+lowerPointerElementAttr(mlir::Attribute elt, mlir::MLIRContext *ctx,
+                        mlir::ModuleOp moduleOp,
+                        const mlir::TypeConverter *converter) {
+  if (auto gv = mlir::dyn_cast<cir::GlobalViewAttr>(elt)) {
+    if (!moduleOp || !globalViewMatchesPointerLeaf(gv, moduleOp, converter))
+      return std::nullopt;
+    return gv.getSymbol();
+  }
+  if (auto nullPtr = mlir::dyn_cast<cir::ConstPtrAttr>(elt)) {
+    if (nullPtr.isNullValue())
+      return mlir::LLVM::ZeroAttr::get(ctx);
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
 std::optional<mlir::Attribute>
 lowerConstArrayAttr(cir::ConstArrayAttr constArr,
-                    const mlir::TypeConverter *converter) {
+                    const mlir::TypeConverter *converter,
+                    mlir::ModuleOp moduleOp) {
   // Ensure ConstArrayAttr has a type.
   const auto typedConstArr = mlir::cast<mlir::TypedAttr>(constArr);
 
@@ -132,6 +196,13 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
     type = arrayType.getElementType();
   }
 
+  if (auto eltsArr = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts())) {
+    for (mlir::Attribute elt : eltsArr) {
+      if (mlir::isa<cir::PoisonAttr>(elt))
+        return std::nullopt;
+    }
+  }
+
   if (mlir::isa<mlir::StringAttr>(constArr.getElts()))
     return convertStringAttrToDenseElementsAttr(constArr,
                                                 converter->convertType(type));
@@ -142,6 +213,23 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
   if (mlir::isa<cir::FPTypeInterface>(type))
     return convertToDenseElementsAttr<cir::FPAttr, mlir::APFloat>(
         constArr, dims, type, converter->convertType(type));
+
+  if (mlir::isa<cir::PointerType>(type)) {
+    auto eltsArr = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts());
+    if (!eltsArr)
+      return std::nullopt;
+    llvm::SmallVector<mlir::Attribute> lowered;
+    lowered.reserve(eltsArr.size());
+    mlir::MLIRContext *ctx = constArr.getContext();
+    for (mlir::Attribute elt : eltsArr) {
+      std::optional<mlir::Attribute> llvmElt =
+          lowerPointerElementAttr(elt, ctx, moduleOp, converter);
+      if (!llvmElt)
+        return std::nullopt;
+      lowered.push_back(*llvmElt);
+    }
+    return mlir::ArrayAttr::get(ctx, lowered);
+  }
 
   return std::nullopt;
 }

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -97,8 +97,8 @@ void convertToDenseElementsAttrImpl(
 
   auto arrayAttr = mlir::cast<mlir::ArrayAttr>(attr.getElts());
   for (auto eltAttr : arrayAttr) {
-    if (auto boolAttr = mlir::dyn_cast<cir::BoolAttr>(eltAttr)) {
-      if constexpr (std::is_same_v<StorageTy, mlir::APInt>) {
+    if constexpr (std::is_same_v<StorageTy, mlir::APInt>) {
+      if (auto boolAttr = mlir::dyn_cast<cir::BoolAttr>(eltAttr)) {
         values[currentIndex++] =
             llvm::APInt(1, static_cast<uint64_t>(boolAttr.getValue()));
         continue;

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -142,6 +142,8 @@ static bool globalViewMatchesPointerLeaf(cir::GlobalViewAttr gv,
             cirSymbol.getAddrSpaceAttr()))
       sourceAddrSpace = targetAS.getValue();
   } else {
+    // cir.func and other symbols not yet lowered to globals cannot be used as
+    // bulk constant leaves; those cases keep the insertvalue fallback.
     return false;
   }
 
@@ -178,6 +180,20 @@ lowerPointerElementAttr(mlir::Attribute elt, mlir::MLIRContext *ctx,
   return std::nullopt;
 }
 
+static bool containsPoison(mlir::Attribute attr) {
+  if (mlir::isa<cir::PoisonAttr>(attr))
+    return true;
+  if (auto elts = mlir::dyn_cast<mlir::ArrayAttr>(attr))
+    return llvm::any_of(elts, containsPoison);
+  if (auto constArr = mlir::dyn_cast<cir::ConstArrayAttr>(attr)) {
+    if (mlir::isa<mlir::StringAttr>(constArr.getElts()))
+      return false;
+    if (auto elts = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts()))
+      return llvm::any_of(elts, containsPoison);
+  }
+  return false;
+}
+
 std::optional<mlir::Attribute>
 lowerConstArrayAttr(cir::ConstArrayAttr constArr,
                     const mlir::TypeConverter *converter,
@@ -196,12 +212,8 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
     type = arrayType.getElementType();
   }
 
-  if (auto eltsArr = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts())) {
-    for (mlir::Attribute elt : eltsArr) {
-      if (mlir::isa<cir::PoisonAttr>(elt))
-        return std::nullopt;
-    }
-  }
+  if (containsPoison(constArr))
+    return std::nullopt;
 
   if (mlir::isa<mlir::StringAttr>(constArr.getElts()))
     return convertStringAttrToDenseElementsAttr(constArr,

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -36,7 +36,7 @@ convertStringAttrToDenseElementsAttr(cir::ConstArrayAttr attr,
          "trailing_zeros");
 
   const unsigned bitWidth = getIntOrBoolBitWidth(arrayTy.getElementType());
-  auto values = llvm::SmallVector<mlir::APInt, 8>{};
+  llvm::SmallVector<mlir::APInt> values;
   values.reserve(totalSize);
 
   for (const char element : stringAttr)
@@ -102,7 +102,7 @@ void convertToDenseElementsAttrImpl(
     if (auto boolAttr = mlir::dyn_cast<cir::BoolAttr>(eltAttr)) {
       if constexpr (std::is_same_v<StorageTy, mlir::APInt>) {
         values[currentIndex++] =
-          llvm::APInt(1, static_cast<uint64_t>(boolAttr.getValue()));
+            llvm::APInt(1, static_cast<uint64_t>(boolAttr.getValue()));
         continue;
       }
     }
@@ -257,11 +257,8 @@ lowerConstArrayAttr(cir::ConstArrayAttr constArr,
         constArr, dims, type, converter->convertType(type));
 
   if (mlir::isa<cir::PointerType>(type)) {
-    // Pointer arrays with trailing_zeros (null-sentinel tables) fall through
-    // to the insertvalue path for now.
-    // FIXME: extend this to cover trailing null pointers via explicit null
-    // elements so long sentinel-terminated pointer tables also benefit from
-    // the bulk path.
+    // FIXME: Pointer arrays with trailing_zeros (null-sentinel tables) fall
+    // through to the insertvalue path for now.
     if (constArr.getTrailingZerosNum() > 0)
       return std::nullopt;
     auto eltsArr = mlir::dyn_cast<mlir::ArrayAttr>(constArr.getElts());

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -19,9 +19,9 @@
 static unsigned getIntOrBoolBitWidth(mlir::Type ty) {
   if (auto intTy = mlir::dyn_cast<cir::IntType>(ty))
     return intTy.getWidth();
-  if (mlir::isa<cir::BoolType>(ty))
-    return 1;
-  llvm_unreachable("expected CIR integer or bool element type");
+  assert(mlir::isa<cir::BoolType>(ty) &&
+         "expected CIR integer or bool element type");
+  return 1;
 }
 
 mlir::DenseElementsAttr
@@ -40,14 +40,12 @@ convertStringAttrToDenseElementsAttr(cir::ConstArrayAttr attr,
   values.reserve(totalSize);
 
   for (const char element : stringAttr)
-    values.emplace_back(bitWidth, (uint64_t)(unsigned char)element);
+    values.emplace_back(bitWidth, element);
 
-  for (unsigned i = 0; i < trailingZeros; ++i)
-    values.push_back(mlir::APInt::getZero(bitWidth));
+  values.insert(values.end(), trailingZeros, mlir::APInt::getZero(bitWidth));
 
   return mlir::DenseElementsAttr::get(
-      mlir::RankedTensorType::get({(int64_t)totalSize}, type),
-      llvm::ArrayRef(values));
+      mlir::RankedTensorType::get({totalSize}, type), llvm::ArrayRef(values));
 }
 
 template <> mlir::APInt getZeroInitFromType(mlir::Type ty) {

--- a/clang/lib/CIR/Lowering/LoweringHelpers.cpp
+++ b/clang/lib/CIR/Lowering/LoweringHelpers.cpp
@@ -16,21 +16,37 @@
 #include "mlir/IR/SymbolTable.h"
 #include "clang/CIR/MissingFeatures.h"
 
+static unsigned getIntOrBoolBitWidth(mlir::Type ty) {
+  if (auto intTy = mlir::dyn_cast<cir::IntType>(ty))
+    return intTy.getWidth();
+  if (mlir::isa<cir::BoolType>(ty))
+    return 1;
+  llvm_unreachable("expected CIR integer or bool element type");
+}
+
 mlir::DenseElementsAttr
 convertStringAttrToDenseElementsAttr(cir::ConstArrayAttr attr,
                                      mlir::Type type) {
-  auto values = llvm::SmallVector<mlir::APInt, 8>{};
   const auto stringAttr = mlir::cast<mlir::StringAttr>(attr.getElts());
+  const auto arrayTy = mlir::cast<cir::ArrayType>(attr.getType());
+  const unsigned totalSize = arrayTy.getSize();
+  const unsigned trailingZeros = attr.getTrailingZerosNum();
+  assert(stringAttr.size() + trailingZeros == totalSize &&
+         "string const_array size must match explicit elements plus "
+         "trailing_zeros");
+
+  const unsigned bitWidth = getIntOrBoolBitWidth(arrayTy.getElementType());
+  auto values = llvm::SmallVector<mlir::APInt, 8>{};
+  values.reserve(totalSize);
 
   for (const char element : stringAttr)
-    values.push_back({8, (uint64_t)element});
+    values.emplace_back(bitWidth, (uint64_t)(unsigned char)element);
 
-  const auto arrayTy = mlir::cast<cir::ArrayType>(attr.getType());
-  if (arrayTy.getSize() != stringAttr.size())
-    assert(!cir::MissingFeatures::stringTypeWithDifferentArraySize());
+  for (unsigned i = 0; i < trailingZeros; ++i)
+    values.push_back(mlir::APInt::getZero(bitWidth));
 
   return mlir::DenseElementsAttr::get(
-      mlir::RankedTensorType::get({(int64_t)values.size()}, type),
+      mlir::RankedTensorType::get({(int64_t)totalSize}, type),
       llvm::ArrayRef(values));
 }
 
@@ -70,6 +86,8 @@ void convertToDenseElementsAttrImpl(
         auto intAttr = cir::IntAttr::get(arrayType.getElementType(), element);
         values[currentIndex++] = mlir::dyn_cast<AttrTy>(intAttr).getValue();
       }
+      // Remaining slots are trailing zeros; values was zero-initialized.
+      currentIndex += attr.getTrailingZerosNum();
       return;
     }
   }

--- a/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
+++ b/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
@@ -5,6 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
+const char *foo = "asdf";
 const char *names[] = { "a", "b", "c" };
 const int table[] = { 0, 1, 2, 3 };
 const int matrix[2][2] = { { 1, 2 }, { 3, 4 } };
@@ -14,7 +15,13 @@ int len() {
          flags[2];
 }
 
-// CIR: cir.global {{.*}}@names = #cir.const_array<[#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.global_view<@".str.1"> : !cir.ptr<!s8i>, #cir.global_view<@".str.2"> : !cir.ptr<!s8i>]>
+// CIR: cir.global {{.*}}@".str" = #cir.const_array<"asdf" : !cir.array<!s8i x 4>, trailing_zeros>
+
+// LLVM:       @.str = {{.*}}constant [5 x i8]
+// LLVM-NOT:   insertvalue
+// OGCG:       @.str = {{.*}}constant [5 x i8]
+
+// CIR: cir.global {{.*}}@names = #cir.const_array<[#cir.global_view<@".str.1"> : !cir.ptr<!s8i>, #cir.global_view<@".str.2"> : !cir.ptr<!s8i>, #cir.global_view<@".str.3"> : !cir.ptr<!s8i>]>
 
 // LLVM:       @names = {{.*}}global [3 x ptr] [ptr @.str{{.*}}, ptr @.str{{.*}}, ptr @.str{{.*}}]
 // LLVM-NOT:   insertvalue

--- a/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
+++ b/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+const char *names[] = { "a", "b", "c" };
+int len() { return sizeof(names)/sizeof(*names); }
+
+// CIR: cir.global {{.*}}@names = #cir.const_array<[#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.global_view<@".str.1"> : !cir.ptr<!s8i>, #cir.global_view<@".str.2"> : !cir.ptr<!s8i>]>
+
+// LLVM:       @names = {{.*}}global [3 x ptr] [ptr @.str{{.*}}, ptr @.str{{.*}}, ptr @.str{{.*}}]
+// LLVM-NOT:   insertvalue
+
+// OGCG:       @names = {{.*}}global [3 x ptr] [ptr @.str{{.*}}, ptr @.str{{.*}}, ptr @.str{{.*}}]

--- a/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
+++ b/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
@@ -1,3 +1,8 @@
+// Verify that const_array globals with leaf types handled by lowerConstArrayAttr
+// (pointers, integers, bools, floats, and string literals with trailing_zeros)
+// are lowered via a single llvm.mlir.global aggregate constant rather than a
+// chain of insertvalue operations.
+//
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll

--- a/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
+++ b/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
@@ -1,14 +1,9 @@
-// Verify that const_array globals with leaf types handled by lowerConstArrayAttr
-// (pointers, integers, bools, floats, and string literals with trailing_zeros)
-// are lowered via a single llvm.mlir.global aggregate constant rather than a
-// chain of insertvalue operations.
-//
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 const char *foo = "asdf";
 const char *names[] = { "a", "b", "c" };
@@ -24,26 +19,20 @@ int len() {
 
 // LLVM:       @.str = {{.*}}constant [5 x i8]
 // LLVM-NOT:   insertvalue
-// OGCG:       @.str = {{.*}}constant [5 x i8]
 
 // CIR: cir.global {{.*}}@names = #cir.const_array<[#cir.global_view<@".str.1"> : !cir.ptr<!s8i>, #cir.global_view<@".str.2"> : !cir.ptr<!s8i>, #cir.global_view<@".str.3"> : !cir.ptr<!s8i>]>
 
 // LLVM:       @names = {{.*}}global [3 x ptr] [ptr @.str{{.*}}, ptr @.str{{.*}}, ptr @.str{{.*}}]
 // LLVM-NOT:   insertvalue
 
-// OGCG:       @names = {{.*}}global [3 x ptr] [ptr @.str{{.*}}, ptr @.str{{.*}}, ptr @.str{{.*}}]
-
 // CIR: cir.global {{.*}}table = #cir.const_array<[#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]>
 // LLVM:       {{.*}}table{{.*}} = {{.*}}constant [4 x i32] [i32 0, i32 1, i32 2, i32 3]
 // LLVM-NOT:   insertvalue
-// OGCG:       {{.*}}table{{.*}} = {{.*}}constant [4 x i32] [i32 0, i32 1, i32 2, i32 3]
 
 // CIR: cir.global {{.*}}matrix = #cir.const_array<
 // LLVM:       {{.*}}matrix{{.*}} = {{.*}}constant [2 x [2 x i32]]
 // LLVM-NOT:   insertvalue
-// OGCG:       {{.*}}matrix{{.*}} = {{.*}}constant [2 x [2 x i32]]
 
 // CIR: cir.global {{.*}}flags = #cir.const_array<[#true, #false, #true]> : !cir.array<!cir.bool x 3>
 // LLVM:       {{.*}}flags{{.*}} = {{.*}}constant [3 x i8]
 // LLVM-NOT:   insertvalue
-// OGCG:       {{.*}}flags{{.*}} = {{.*}}constant [3 x i8]

--- a/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
+++ b/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
@@ -6,7 +6,11 @@
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
 const char *names[] = { "a", "b", "c" };
-int len() { return sizeof(names)/sizeof(*names); }
+const int table[] = { 0, 1, 2, 3 };
+const int matrix[2][2] = { { 1, 2 }, { 3, 4 } };
+int len() {
+  return sizeof(names) / sizeof(*names) + table[0] + matrix[1][1];
+}
 
 // CIR: cir.global {{.*}}@names = #cir.const_array<[#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.global_view<@".str.1"> : !cir.ptr<!s8i>, #cir.global_view<@".str.2"> : !cir.ptr<!s8i>]>
 
@@ -14,3 +18,13 @@ int len() { return sizeof(names)/sizeof(*names); }
 // LLVM-NOT:   insertvalue
 
 // OGCG:       @names = {{.*}}global [3 x ptr] [ptr @.str{{.*}}, ptr @.str{{.*}}, ptr @.str{{.*}}]
+
+// CIR: cir.global {{.*}}table = #cir.const_array<[#cir.int<0> : !s32i, #cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]>
+// LLVM:       {{.*}}table{{.*}} = {{.*}}constant [4 x i32] [i32 0, i32 1, i32 2, i32 3]
+// LLVM-NOT:   insertvalue
+// OGCG:       {{.*}}table{{.*}} = {{.*}}constant [4 x i32] [i32 0, i32 1, i32 2, i32 3]
+
+// CIR: cir.global {{.*}}matrix = #cir.const_array<
+// LLVM:       {{.*}}matrix{{.*}} = {{.*}}constant [2 x [2 x i32]]
+// LLVM-NOT:   insertvalue
+// OGCG:       {{.*}}matrix{{.*}} = {{.*}}constant [2 x [2 x i32]]

--- a/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
+++ b/clang/test/CIR/CodeGen/global-pointer-array-fast-lowering.cpp
@@ -8,8 +8,10 @@
 const char *names[] = { "a", "b", "c" };
 const int table[] = { 0, 1, 2, 3 };
 const int matrix[2][2] = { { 1, 2 }, { 3, 4 } };
+const bool flags[] = { true, false, true };
 int len() {
-  return sizeof(names) / sizeof(*names) + table[0] + matrix[1][1];
+  return sizeof(names) / sizeof(*names) + table[0] + matrix[1][1] +
+         flags[2];
 }
 
 // CIR: cir.global {{.*}}@names = #cir.const_array<[#cir.global_view<@".str"> : !cir.ptr<!s8i>, #cir.global_view<@".str.1"> : !cir.ptr<!s8i>, #cir.global_view<@".str.2"> : !cir.ptr<!s8i>]>
@@ -28,3 +30,8 @@ int len() {
 // LLVM:       {{.*}}matrix{{.*}} = {{.*}}constant [2 x [2 x i32]]
 // LLVM-NOT:   insertvalue
 // OGCG:       {{.*}}matrix{{.*}} = {{.*}}constant [2 x [2 x i32]]
+
+// CIR: cir.global {{.*}}flags = #cir.const_array<[#true, #false, #true]> : !cir.array<!cir.bool x 3>
+// LLVM:       {{.*}}flags{{.*}} = {{.*}}constant [3 x i8]
+// LLVM-NOT:   insertvalue
+// OGCG:       {{.*}}flags{{.*}} = {{.*}}constant [3 x i8]

--- a/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
+++ b/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
@@ -36,13 +36,19 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   ]> : !cir.array<!cir.array<!cir.ptr<!s8i> x 2> x 2>
 }
 
-// CHECK-LABEL: llvm.mlir.global external @tz_arr
-// CHECK:       llvm.insertvalue
+// CHECK-LABEL: llvm.mlir.global external @tz_arr(
+// CHECK-SAME:    dense<
 
 // CHECK-LABEL: llvm.mlir.global external @as_mismatch
 // CHECK:       llvm.insertvalue
 
 // CHECK-LABEL: llvm.mlir.global external @matrix(
+// CHECK-SAME:    dense<
+
+// CHECK-LABEL: llvm.mlir.global private constant @s0(
+// CHECK-SAME:    dense<
+
+// CHECK-LABEL: llvm.mlir.global private constant @s1(
 // CHECK-SAME:    dense<
 
 // CHECK-LABEL: llvm.mlir.global external @ptr2d

--- a/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
+++ b/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
@@ -17,6 +17,23 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
       #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>,
       #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>
   ]> : !cir.array<!cir.array<!s32i x 2> x 2>
+
+  cir.global "private" constant cir_private dso_local @s0 =
+      #cir.const_array<"x" : !cir.array<!s8i x 1>, trailing_zeros> :
+      !cir.array<!s8i x 2>
+  cir.global "private" constant cir_private dso_local @s1 =
+      #cir.const_array<"y" : !cir.array<!s8i x 1>, trailing_zeros> :
+      !cir.array<!s8i x 2>
+  cir.global external @ptr2d = #cir.const_array<[
+      #cir.const_array<[
+          #cir.global_view<@s0> : !cir.ptr<!s8i>,
+          #cir.global_view<@s1> : !cir.ptr<!s8i>
+      ]> : !cir.array<!cir.ptr<!s8i> x 2>,
+      #cir.const_array<[
+          #cir.global_view<@s0> : !cir.ptr<!s8i>,
+          #cir.global_view<@s1> : !cir.ptr<!s8i>
+      ]> : !cir.array<!cir.ptr<!s8i> x 2>
+  ]> : !cir.array<!cir.array<!cir.ptr<!s8i> x 2> x 2>
 }
 
 // CHECK-LABEL: llvm.mlir.global external @tz_arr
@@ -27,3 +44,6 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 
 // CHECK-LABEL: llvm.mlir.global external @matrix(
 // CHECK-SAME:    dense<
+
+// CHECK-LABEL: llvm.mlir.global external @ptr2d
+// CHECK:       llvm.insertvalue

--- a/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
+++ b/clang/test/CIR/Lowering/const-array-bulk-lowering-fallbacks.cir
@@ -1,0 +1,29 @@
+// RUN: cir-opt %s --cir-to-llvm -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s8i = !cir.int<s, 8>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
+  cir.global external @tz_arr =
+      #cir.const_array<"ab" : !cir.array<!s8i x 2>, trailing_zeros> :
+      !cir.array<!s8i x 8>
+
+  cir.global external target_address_space(1) @as1 = #cir.int<1> : !s32i
+  cir.global external @as_mismatch =
+      #cir.const_array<[#cir.global_view<@as1> : !cir.ptr<!s32i>]> :
+      !cir.array<!cir.ptr<!s32i> x 1>
+
+  cir.global external @matrix = #cir.const_array<[
+      #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>,
+      #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>
+  ]> : !cir.array<!cir.array<!s32i x 2> x 2>
+}
+
+// CHECK-LABEL: llvm.mlir.global external @tz_arr
+// CHECK:       llvm.insertvalue
+
+// CHECK-LABEL: llvm.mlir.global external @as_mismatch
+// CHECK:       llvm.insertvalue
+
+// CHECK-LABEL: llvm.mlir.global external @matrix(
+// CHECK-SAME:    dense<

--- a/clang/test/CIR/Lowering/const-array-of-pointers.cir
+++ b/clang/test/CIR/Lowering/const-array-of-pointers.cir
@@ -1,0 +1,18 @@
+// RUN: cir-opt %s --cir-to-llvm -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
+  cir.global "private" constant cir_private dso_local @g0 = #cir.int<0> : !s32i
+  cir.global "private" constant cir_private dso_local @g1 = #cir.int<1> : !s32i
+  cir.global "private" constant cir_private dso_local @g2 = #cir.int<2> : !s32i
+
+  cir.global constant external dso_local @ptrs = #cir.const_array<[
+      #cir.global_view<@g0> : !cir.ptr<!s32i>,
+      #cir.global_view<@g1> : !cir.ptr<!s32i>,
+      #cir.global_view<@g2> : !cir.ptr<!s32i>
+  ]> : !cir.array<!cir.ptr<!s32i> x 3>
+}
+
+// CHECK-LABEL: llvm.mlir.global external constant @ptrs(
+// CHECK-NOT:   llvm.insertvalue


### PR DESCRIPTION
`cir.global` initializers that are `const_array` of `global_view` (no
indices) or null pointers were lowered through an initializer region
full of `llvm.insertvalue` ops even though the elements are all
attribute-representable.  That forced the O(N²) MLIR-to-LLVM IR path
on large tables (SPEC CPU 2026 `gcc/insn-automata.cc`).

When `lowerConstArrayAttr` can build the whole initializer, emit the
global with one aggregate attribute instead.  String literals with
`trailing_zeros` are padded into `DenseElementsAttr` so C string tables
take the same bulk path.  Indexed `global_view`, `#cir.zero` arrays, and
other non-bulk cases still use the insertvalue path.

MLIR prerequisite [#198424](https://github.com/llvm/llvm-project/pull/198424) is merged on `main`; this branch is rebased and CIR-only.