### PR TITLE
[NVPTX] Autoupgrade atom.load intrinsics to device scope

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -2725,16 +2725,22 @@ static Value *upgradeNVVMIntrinsicCall(StringRef Name, CallBase *CI,
              Name.starts_with("atomic.load.add.f64.p")) {
     Value *Ptr = CI->getArgOperand(0);
     Value *Val = CI->getArgOperand(1);
-    Rep = Builder.CreateAtomicRMW(AtomicRMWInst::FAdd, Ptr, Val, MaybeAlign(),
-                                  AtomicOrdering::Monotonic);
+    Rep = Builder.CreateAtomicRMW(
+        AtomicRMWInst::FAdd, Ptr, Val, MaybeAlign(), AtomicOrdering::Monotonic,
+        CI->getContext().getOrInsertSyncScopeID("device"));
+    // The default scope for atomic.load.* intrinsics is device
+    // (= gpu scope in ptx), but the default LLVM atomic scope is
+    // "system"
   } else if (Name.starts_with("atomic.load.inc.32.p") ||
              Name.starts_with("atomic.load.dec.32.p")) {
     Value *Ptr = CI->getArgOperand(0);
     Value *Val = CI->getArgOperand(1);
     auto Op = Name.starts_with("atomic.load.inc") ? AtomicRMWInst::UIncWrap
                                                   : AtomicRMWInst::UDecWrap;
-    Rep = Builder.CreateAtomicRMW(Op, Ptr, Val, MaybeAlign(),
-                                  AtomicOrdering::Monotonic);
+    Rep = Builder.CreateAtomicRMW(
+        Op, Ptr, Val, MaybeAlign(), AtomicOrdering::Monotonic,
+        CI->getContext().getOrInsertSyncScopeID("device"));
+    // See comment above.
   } else if (Name == "clz.ll") {
     // llvm.nvvm.clz.ll returns an i32, but llvm.ctlz.i64 returns an i64.
     Value *Arg = CI->getArgOperand(0);

--- a/llvm/test/Assembler/auto_upgrade_nvvm_intrinsics.ll
+++ b/llvm/test/Assembler/auto_upgrade_nvvm_intrinsics.ll
@@ -284,10 +284,10 @@ define void @ldg(ptr %p0, ptr addrspace(1) %p1) {
 
 ; CHECK-LABEL: @atomics
 define i32 @atomics(ptr %p0, i32 %a, float %b, double %c) {
-; CHECK: %1 = atomicrmw uinc_wrap ptr %p0, i32 %a monotonic
-; CHECK: %2 = atomicrmw udec_wrap ptr %p0, i32 %a monotonic
-; CHECK: %3 = atomicrmw fadd ptr %p0, float %b monotonic
-; CHECK: %4 = atomicrmw fadd ptr %p0, double %c monotonic
+; CHECK: %1 = atomicrmw uinc_wrap ptr %p0, i32 %a syncscope("device") monotonic
+; CHECK: %2 = atomicrmw udec_wrap ptr %p0, i32 %a syncscope("device") monotonic
+; CHECK: %3 = atomicrmw fadd ptr %p0, float %b syncscope("device") monotonic
+; CHECK: %4 = atomicrmw fadd ptr %p0, double %c syncscope("device") monotonic
 
   %r1 = call i32 @llvm.nvvm.atomic.load.inc.32.p0(ptr %p0, i32 %a)
   %r2 = call i32 @llvm.nvvm.atomic.load.dec.32.p0(ptr %p0, i32 %a)

--- a/llvm/test/CodeGen/NVPTX/atomics-sm60.ll
+++ b/llvm/test/CodeGen/NVPTX/atomics-sm60.ll
@@ -5,11 +5,11 @@
 
 ; CHECK-LABEL: .func test(
 define void @test(ptr %dp0, ptr addrspace(1) %dp1, ptr addrspace(3) %dp3, double %d) {
-; CHECK: atom.sys.add.f64
+; CHECK: atom.gpu.add.f64
   %r1 = call double @llvm.nvvm.atomic.load.add.f64.p0(ptr %dp0, double %d)
-; CHECK: atom.sys.global.add.f64
+; CHECK: atom.gpu.global.add.f64
   %r2 = call double @llvm.nvvm.atomic.load.add.f64.p1(ptr addrspace(1) %dp1, double %d)
-; CHECK: atom.sys.shared.add.f64
+; CHECK: atom.gpu.shared.add.f64
   %ret = call double @llvm.nvvm.atomic.load.add.f64.p3(ptr addrspace(3) %dp3, double %d)
   ret void
 }


### PR DESCRIPTION
The default scope for the "atom" instruction in PTX is "gpu" (corresponds to "device" in LLVM). The default LLVM scope is "system". 

When scopes were not supported, the "system" scope was silently dropped, and the default device scope was desired behavior. 

This patch fixes the discrepancy introduced by https://github.com/llvm/llvm-project/pull/179553. 