### PR TITLE
[mlir][IR] Add SymbolUserTypeInterface

### DIFF
--- a/mlir/include/mlir/IR/CMakeLists.txt
+++ b/mlir/include/mlir/IR/CMakeLists.txt
@@ -2,6 +2,8 @@ add_mlir_interface(SymbolInterfaces)
 set(LLVM_TARGET_DEFINITIONS SymbolInterfaces.td)
 mlir_tablegen(SymbolInterfacesAttrInterface.h.inc -gen-attr-interface-decls)
 mlir_tablegen(SymbolInterfacesAttrInterface.cpp.inc -gen-attr-interface-defs)
+mlir_tablegen(SymbolInterfacesTypeInterface.h.inc -gen-type-interface-decls)
+mlir_tablegen(SymbolInterfacesTypeInterface.cpp.inc -gen-type-interface-defs)
 add_mlir_interface(RegionKindInterface)
 
 add_mlir_type_interface(QuantStorageTypeInterface)

--- a/mlir/include/mlir/IR/SymbolInterfaces.td
+++ b/mlir/include/mlir/IR/SymbolInterfaces.td
@@ -228,12 +228,31 @@ def SymbolUserAttrInterface : AttrInterface<"SymbolUserAttrInterface"> {
     interface allows for users of symbols to hook into verification and other
     symbol related utilities that are either costly or otherwise disallowed
     within an operation (e.g., recreating symbol users per op verified rather
-    than per symbol table, or querying symbols usage of sibblings).
+    than per symbol table, or querying symbols usage of siblings).
   }];
   let cppNamespace = "::mlir";
 
   let methods = [
     InterfaceMethod<"Verify the symbol uses held by this attribute of this operation.",
+      "::llvm::LogicalResult", "verifySymbolUses",
+      (ins "::mlir::Operation *":$op,
+           "::mlir::SymbolTableCollection &":$symbolTable)
+    >,
+  ];
+}
+
+def SymbolUserTypeInterface : TypeInterface<"SymbolUserTypeInterface"> {
+  let description = [{
+    This interface describes a type that may use a `Symbol`. This interface
+    allows types to hook into verification that needs a symbol table, which is
+    costly or otherwise disallowed within type construction and uniquing.
+    `op` is the operation whose verification triggered the check and should be
+    used as the anchor for symbol lookups.
+  }];
+  let cppNamespace = "::mlir";
+
+  let methods = [
+    InterfaceMethod<"Verify the symbol uses held by this type of this operation.",
       "::llvm::LogicalResult", "verifySymbolUses",
       (ins "::mlir::Operation *":$op,
            "::mlir::SymbolTableCollection &":$symbolTable)

--- a/mlir/include/mlir/IR/SymbolTable.h
+++ b/mlir/include/mlir/IR/SymbolTable.h
@@ -500,5 +500,6 @@ ParseResult parseOptionalVisibilityKeyword(OpAsmParser &parser,
 /// Include the generated symbol interfaces.
 #include "mlir/IR/SymbolInterfaces.h.inc"
 #include "mlir/IR/SymbolInterfacesAttrInterface.h.inc"
+#include "mlir/IR/SymbolInterfacesTypeInterface.h.inc"
 
 #endif // MLIR_IR_SYMBOLTABLE_H

--- a/mlir/lib/IR/SymbolTable.cpp
+++ b/mlir/lib/IR/SymbolTable.cpp
@@ -476,6 +476,51 @@ raw_ostream &mlir::operator<<(raw_ostream &os,
 // SymbolTable Trait Types
 //===----------------------------------------------------------------------===//
 
+/// Verify the symbol uses held by the types owned by `op`: its operand,
+/// result, and block-argument types, and any types nested within its
+/// attributes. `op` is the anchor used for symbol lookups. `verifiedTypes`
+/// records the types already verified within the current symbol table so that
+/// each type, which may be uniqued and shared across many positions or
+/// operations, is verified at most once. Verification fails fast on the first
+/// invalid symbol use.
+static LogicalResult verifyOpTypeSymbolUses(Operation *op,
+                                            SymbolTableCollection &symbolTable,
+                                            SetVector<Type> &verifiedTypes) {
+  // Walk `type` and any nested type parameters reachable from it, verifying
+  // each not-yet-seen type and interrupting on the first failure.
+  auto verify = [&](Type type) {
+    return type.walk<WalkOrder::PreOrder>([&](Type nestedType) {
+      if (!verifiedTypes.insert(nestedType))
+        return WalkResult::advance();
+      if (auto user = dyn_cast<SymbolUserTypeInterface>(nestedType))
+        if (failed(user.verifySymbolUses(op, symbolTable)))
+          return WalkResult::interrupt();
+      return WalkResult::advance();
+    });
+  };
+
+  for (Type type : op->getOperandTypes())
+    if (verify(type).wasInterrupted())
+      return failure();
+  for (Type type : op->getResultTypes())
+    if (verify(type).wasInterrupted())
+      return failure();
+  for (Region &region : op->getRegions())
+    for (Block &block : region)
+      for (BlockArgument argument : block.getArguments())
+        if (verify(argument.getType()).wasInterrupted())
+          return failure();
+
+  // Verify types nested within the operation's attributes.
+  WalkResult attrResult =
+      op->getAttrDictionary().walk<WalkOrder::PreOrder>([&](Type type) {
+        if (verify(type).wasInterrupted())
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      });
+  return failure(attrResult.wasInterrupted());
+}
+
 LogicalResult detail::verifySymbolTable(Operation *op) {
   if (op->getNumRegions() != 1)
     return op->emitOpError()
@@ -506,16 +551,27 @@ LogicalResult detail::verifySymbolTable(Operation *op) {
 
   // Verify any nested symbol user operations.
   SymbolTableCollection symbolTable;
+  // walkSymbolTable does not descend into nested symbol tables, so every
+  // operation visited here shares the same nearest symbol table. A uniqued
+  // attribute or type therefore resolves its symbol uses identically
+  // regardless of which operation anchors the lookup, so each is verified at
+  // most once across the whole scope.
+  SetVector<Attribute> verifiedAttrs;
+  SetVector<Type> verifiedTypes;
   auto verifySymbolUserFn = [&](Operation *op) -> std::optional<WalkResult> {
     if (SymbolUserOpInterface user = dyn_cast<SymbolUserOpInterface>(op))
       if (failed(user.verifySymbolUses(symbolTable)))
         return WalkResult::interrupt();
     for (auto &attr : op->getDiscardableAttrs()) {
       if (auto user = dyn_cast<SymbolUserAttrInterface>(attr.getValue())) {
+        if (!verifiedAttrs.insert(attr.getValue()))
+          continue;
         if (failed(user.verifySymbolUses(op, symbolTable)))
           return WalkResult::interrupt();
       }
     }
+    if (failed(verifyOpTypeSymbolUses(op, symbolTable, verifiedTypes)))
+      return WalkResult::interrupt();
     return WalkResult::advance();
   };
 
@@ -1137,3 +1193,4 @@ ParseResult impl::parseOptionalVisibilityKeyword(OpAsmParser &parser,
 /// Include the generated symbol interfaces.
 #include "mlir/IR/SymbolInterfaces.cpp.inc"
 #include "mlir/IR/SymbolInterfacesAttrInterface.cpp.inc"
+#include "mlir/IR/SymbolInterfacesTypeInterface.cpp.inc"

--- a/mlir/test/IR/test-verifiers-symbol-user-type.mlir
+++ b/mlir/test/IR/test-verifiers-symbol-user-type.mlir
@@ -1,0 +1,95 @@
+// RUN: mlir-opt %s -verify-diagnostics -split-input-file
+
+module {
+  func.func private @existing_symbol()
+
+  "test.type_producer"() : () -> !test.symbol_ref<@existing_symbol>
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.type_producer"() : () -> !test.symbol_ref<@non_existent_symbol>
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  %0 = "test.type_producer"() : () -> !test.symbol_ref<@existing_symbol>
+  "test.type_consumer"(%0) : (!test.symbol_ref<@existing_symbol>) -> ()
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  "test.type_producer"() : () -> tuple<!test.symbol_ref<@existing_symbol>>
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.type_producer"() : () -> tuple<!test.symbol_ref<@non_existent_symbol>>
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  func.func private @uses_symbol_type(%arg0: !test.symbol_ref<@existing_symbol>)
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  func.func private @uses_symbol_type(%arg0: !test.symbol_ref<@non_existent_symbol>)
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  "test.one_region_op"() ({
+  ^bb0(%arg0: !test.symbol_ref<@existing_symbol>):
+    "test.valid"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.one_region_op"() ({
+  ^bb0(%arg0: !test.symbol_ref<@non_existent_symbol>):
+    "test.valid"() : () -> ()
+  }) : () -> ()
+}
+
+// -----
+
+module {
+  func.func private @existing_symbol()
+
+  "test.typed_attr"() <{
+    type = !test.symbol_ref<@existing_symbol>,
+    attr = 0 : i32
+  }> : () -> ()
+}
+
+// -----
+
+module {
+  // expected-error@+1 {{'@non_existent_symbol' does not reference a valid symbol}}
+  "test.typed_attr"() <{
+    type = !test.symbol_ref<@non_existent_symbol>,
+    attr = 0 : i32
+  }> : () -> ()
+}

--- a/mlir/test/lib/Dialect/Test/TestTypeDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestTypeDefs.td
@@ -19,6 +19,7 @@ include "TestAttrDefs.td"
 include "TestInterfaces.td"
 include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/DataLayoutInterfaces.td"
 include "mlir/Dialect/Bufferization/IR/BufferizationTypeInterfaces.td"
 
@@ -82,6 +83,14 @@ def CompoundNestedOuterTypeQual : Test_Type<"CompoundNestedOuterQual"> {
     CompoundNestedInnerType:$inner
   );
   let assemblyFormat = "`<` `i`  qualified($inner) `>`";
+}
+
+def TestSymbolUserType : Test_Type<"TestSymbolUser",
+    [DeclareTypeInterfaceMethods<SymbolUserTypeInterface>]> {
+  let mnemonic = "symbol_ref";
+  let summary = "Test type that references a symbol";
+  let parameters = (ins "::mlir::FlatSymbolRefAttr":$symbol);
+  let assemblyFormat = "`<` $symbol `>`";
 }
 
 // An example of how one could implement a standard integer.

--- a/mlir/test/lib/Dialect/Test/TestTypes.cpp
+++ b/mlir/test/lib/Dialect/Test/TestTypes.cpp
@@ -333,6 +333,19 @@ uint64_t TestTypeWithLayoutType::extractKind(DataLayoutEntryListRef params,
 }
 
 //===----------------------------------------------------------------------===//
+// TestSymbolUserType
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+TestSymbolUserType::verifySymbolUses(Operation *op,
+                                     SymbolTableCollection &symbolTable) const {
+  if (!symbolTable.lookupNearestSymbolFrom<SymbolOpInterface>(op, getSymbol()))
+    return op->emitOpError()
+           << "'" << getSymbol() << "' does not reference a valid symbol";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Dynamic Types
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/lib/Dialect/Test/TestTypes.h
+++ b/mlir/test/lib/Dialect/Test/TestTypes.h
@@ -24,6 +24,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -79,24 +79,33 @@ filegroup(
 
 exports_files(glob(["include/**/*.td"]))
 
-[
-    gentbl_cc_library(
-        name = name + "IncGen",
-        tbl_outs = {
-            "include/mlir/IR/" + name + ".h.inc": ["-gen-op-interface-decls"],
-            "include/mlir/IR/" + name + ".cpp.inc": ["-gen-op-interface-defs"],
-            "include/mlir/IR/" + name + "AttrInterface.h.inc": ["-gen-attr-interface-decls"],
-            "include/mlir/IR/" + name + "AttrInterface.cpp.inc": ["-gen-attr-interface-defs"],
-        },
-        tblgen = ":mlir-tblgen",
-        td_file = "include/mlir/IR/" + name + ".td",
-        deps = [":OpBaseTdFiles"],
-    )
-    for name in [
-        "RegionKindInterface",
-        "SymbolInterfaces",
-    ]
-]
+gentbl_cc_library(
+    name = "RegionKindInterfaceIncGen",
+    tbl_outs = {
+        "include/mlir/IR/RegionKindInterface.h.inc": ["-gen-op-interface-decls"],
+        "include/mlir/IR/RegionKindInterface.cpp.inc": ["-gen-op-interface-defs"],
+        "include/mlir/IR/RegionKindInterfaceAttrInterface.h.inc": ["-gen-attr-interface-decls"],
+        "include/mlir/IR/RegionKindInterfaceAttrInterface.cpp.inc": ["-gen-attr-interface-defs"],
+    },
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/IR/RegionKindInterface.td",
+    deps = [":OpBaseTdFiles"],
+)
+
+gentbl_cc_library(
+    name = "SymbolInterfacesIncGen",
+    tbl_outs = {
+        "include/mlir/IR/SymbolInterfaces.h.inc": ["-gen-op-interface-decls"],
+        "include/mlir/IR/SymbolInterfaces.cpp.inc": ["-gen-op-interface-defs"],
+        "include/mlir/IR/SymbolInterfacesAttrInterface.h.inc": ["-gen-attr-interface-decls"],
+        "include/mlir/IR/SymbolInterfacesAttrInterface.cpp.inc": ["-gen-attr-interface-defs"],
+        "include/mlir/IR/SymbolInterfacesTypeInterface.h.inc": ["-gen-type-interface-decls"],
+        "include/mlir/IR/SymbolInterfacesTypeInterface.cpp.inc": ["-gen-type-interface-defs"],
+    },
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/IR/SymbolInterfaces.td",
+    deps = [":OpBaseTdFiles"],
+)
 
 gentbl_cc_library(
     name = "OpAsmInterfaceIncGen",


### PR DESCRIPTION
This change adds SymbolUserTypeInterface, analogous to SymbolUserAttrInterface, and extends SymbolTable verification to check participating types.

Verification visits the types owned by an operation, (operand/result types, block argument types, attribute-contained types, nested type parameters) and checks each distinct type at most once, interrupting on the first failure. Deduplication spans the whole symbol-table walk, so a type used by multiple operations is checked only once.

Attribute (SymbolUserAttrInterface) verification also gets deduped the same way.

Assisted-by: Codex (OpenAI)
Assisted-by: Claude (Anthropic)