### PR TITLE
[Clang] Disallow `break`/`continue` in loop conditions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -40,6 +40,37 @@ Potentially Breaking Changes
 C/C++ Language Potentially Breaking Changes
 -------------------------------------------
 
+- Clang now makes it ill-formed to try to ``break`` out of or ``continue`` a loop inside its own condition,
+  increment, or init-statement in all C and C++ language modes. This means that code such as
+
+  .. code-block:: c++
+
+    while (({ break; })) {}
+
+  is now ill-formed. An outer loop can still be broken out of or continued so long as the inner loop is
+  in the body of the outer loop:
+
+  .. code-block:: c++
+
+    // Ok, this breaks out of the 'for' loop.
+    for (;;) {
+      while (({ break; true; })) {}
+    }
+
+    // Error: can't break out of the 'for' loop from within its increment.
+    for (;;({ while (({ break; true; })) {} })) {}
+
+  This also resolves a divergence from GCC: in a construct such as
+
+  .. code-block:: c++
+
+    for (;;) {
+      while (({ break; true; })) {}
+    }
+
+  Clang would previously ``break`` out of the ``while`` loop, whereas GCC (since version 9) would
+  ``break`` out of the ``for`` loop here.
+
 C++ Specific Potentially Breaking Changes
 -----------------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -57,7 +57,7 @@ C/C++ Language Potentially Breaking Changes
       while (({ break; true; })) {}
     }
 
-    // Error: can't break out of the 'for' loop from within its increment.
+    // Error: can't break out of the 'for' loop from within its own increment.
     for (;;({ while (({ break; true; })) {} })) {}
 
   This also resolves a divergence from GCC: in a construct such as
@@ -69,7 +69,7 @@ C/C++ Language Potentially Breaking Changes
     }
 
   Clang would previously ``break`` out of the ``while`` loop, whereas GCC (since version 9) would
-  ``break`` out of the ``for`` loop here.
+  ``break`` out of the ``for`` loop here. Now, Clang and GCC both break out of the ``for`` loop.
 
 C++ Specific Potentially Breaking Changes
 -----------------------------------------

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6899,9 +6899,6 @@ def note_goto_ms_asm_label : Note<
 def warn_unused_label : Warning<"unused label %0">,
   InGroup<UnusedLabel>, DefaultIgnore;
 
-def err_continue_from_cond_var_init : Error<
-  "cannot jump from this continue statement to the loop increment; "
-  "jump bypasses initialization of loop condition variable">;
 def err_goto_into_protected_scope : Error<
   "cannot jump from this goto statement to its label">;
 def ext_goto_into_protected_scope : ExtWarn<
@@ -11191,9 +11188,6 @@ def err_break_continue_label_not_found : Error<
   "%select{loop or 'switch'|loop}0">;
 def err_continue_switch : Error<
   "label of 'continue' refers to a switch statement">;
-def warn_loop_ctrl_binds_to_inner : Warning<
-  "'%0' is bound to current loop, GCC binds it to the enclosing loop">,
-  InGroup<GccCompat>;
 def err_omp_bind_required_on_loop : Error<
   "expected 'bind' clause for 'loop' construct without an enclosing OpenMP "
   "construct">;
@@ -11201,9 +11195,6 @@ def err_omp_loop_reduction_clause : Error<
   "'reduction' clause not allowed with '#pragma omp loop bind(teams)'">;
 def err_omp_split_counts_not_one_omp_fill : Error<
   "exactly one 'omp_fill' must appear in the 'counts' clause">;
-def warn_break_binds_to_switch : Warning<
-  "'break' is bound to loop, GCC binds it to switch">,
-  InGroup<GccCompat>;
 def err_default_not_in_switch : Error<
   "'default' statement not in switch statement">;
 def err_case_not_in_switch : Error<"'case' statement not in switch statement">;

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -5035,16 +5035,12 @@ private:
   /// present will be parsed and stored here, and a null result will be
   /// returned.
   ///
-  /// \param EnterForConditionScope If true, enter a continue/break scope at the
-  /// appropriate moment for a 'for' loop.
-  ///
   /// \returns The parsed condition.
   Sema::ConditionResult ParseCXXCondition(StmtResult *InitStmt,
                                           SourceLocation Loc,
                                           Sema::ConditionKind CK,
                                           bool MissingOK,
-                                          ForRangeInfo *FRI = nullptr,
-                                          bool EnterForConditionScope = false);
+                                          ForRangeInfo *FRI = nullptr);
   DeclGroupPtrTy ParseAliasDeclarationInInitStatement(DeclaratorContext Context,
                                                       ParsedAttributes &Attrs);
 

--- a/clang/include/clang/Sema/Scope.h
+++ b/clang/include/clang/Sema/Scope.h
@@ -140,12 +140,8 @@ public:
     /// This is the scope of a C++ catch statement.
     CatchScope = 0x1000000,
 
-    /// This is the scope corresponding to a C++26 expansion statement.
-    ///
-    /// NOTE: While currently unused, this flag is reserved for the
-    /// implementation of expansion statements; do not remove it or
-    /// reuse it for anything else.
-    ExpansionStmtScope = 0x2000000,
+    /// This bit is currently unused.
+    Unused = 0x2000000,
 
     /// This is a scope of some OpenMP directive with
     /// order clause which specifies concurrent

--- a/clang/include/clang/Sema/Scope.h
+++ b/clang/include/clang/Sema/Scope.h
@@ -140,7 +140,7 @@ public:
     /// This is the scope of a C++ catch statement.
     CatchScope = 0x1000000,
 
-    /// This is the scope corresponding of a C++26 expansion statement.
+    /// This is the scope corresponding to a C++26 expansion statement.
     ///
     /// NOTE: While currently unused, this flag is reserved for the
     /// implementation of expansion statements; do not remove it or

--- a/clang/include/clang/Sema/Scope.h
+++ b/clang/include/clang/Sema/Scope.h
@@ -140,10 +140,12 @@ public:
     /// This is the scope of a C++ catch statement.
     CatchScope = 0x1000000,
 
-    /// This is a scope in which a condition variable is currently being
-    /// parsed. If such a scope is a ContinueScope, it's invalid to jump to the
-    /// continue block from here.
-    ConditionVarScope = 0x2000000,
+    /// This is the scope corresponding of a C++26 expansion statement.
+    ///
+    /// NOTE: While currently unused, this flag is reserved for the
+    /// implementation of expansion statements; do not remove it or
+    /// reuse it for anything else.
+    ExpansionStmtScope = 0x2000000,
 
     /// This is a scope of some OpenMP directive with
     /// order clause which specifies concurrent
@@ -274,11 +276,6 @@ public:
 
   /// Get the label that precedes this scope.
   LabelDecl *getPrecedingLabel() const { return PrecedingLabel; }
-  void setPrecedingLabel(LabelDecl *LD) {
-    assert((Flags & BreakScope || Flags & ContinueScope) &&
-           "not a loop or switch");
-    PrecedingLabel = LD;
-  }
 
   /// isBlockScope - Return true if this scope correspond to a closure.
   bool isBlockScope() const { return Flags & BlockScope; }
@@ -304,17 +301,6 @@ public:
 
   const Scope *getContinueParent() const {
     return const_cast<Scope*>(this)->getContinueParent();
-  }
-
-  // Set whether we're in the scope of a condition variable, where 'continue'
-  // is disallowed despite being a continue scope.
-  void setIsConditionVarScope(bool InConditionVarScope) {
-    Flags = (Flags & ~ConditionVarScope) |
-            (InConditionVarScope ? ConditionVarScope : NoScope);
-  }
-
-  bool isConditionVarScope() const {
-    return Flags & ConditionVarScope;
   }
 
   /// getBreakParent - Return the closest scope that a break statement
@@ -636,6 +622,16 @@ public:
   /// is an ancestor of the other.
   bool Contains(const Scope& rhs) const { return Depth < rhs.Depth; }
 
+  /// Mark that we're entering the body of a loop (for, while, do).
+  void EnterLoopBody(LabelDecl *PrecedingLabel);
+
+  /// Mark that we're entering the body of a switch statement.
+  void EnterSwitchBody(LabelDecl *PrecedingLabel);
+
+  /// Mark that we're leaving the body of a loop; this is only needed for do
+  /// loops where the condition follows the loop body.
+  void LeaveLoopBody();
+
   /// containedInPrototypeScope - Return true if this or a parent scope
   /// is a FunctionPrototypeScope.
   bool containedInPrototypeScope() const;
@@ -658,10 +654,6 @@ public:
 
   /// Init - This is used by the parser to implement scope caching.
   void Init(Scope *parent, unsigned flags);
-
-  /// Sets up the specified scope flags and adjusts the scope state
-  /// variables accordingly.
-  void AddFlags(unsigned Flags);
 
   void dumpImpl(raw_ostream &OS) const;
   void dump() const;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11338,10 +11338,6 @@ private:
   /// issuing a diagnostic and returning false if not.
   bool checkMustTailAttr(const Stmt *St, const Attr &MTA);
 
-  /// Check if the given expression contains 'break' or 'continue'
-  /// statement that produces control flow different from GCC.
-  void CheckBreakContinueBinding(Expr *E);
-
   ///@}
 
   //

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1868,22 +1868,7 @@ Parser::ParseAliasDeclarationInInitStatement(DeclaratorContext Context,
 Sema::ConditionResult
 Parser::ParseCXXCondition(StmtResult *InitStmt, SourceLocation Loc,
                           Sema::ConditionKind CK, bool MissingOK,
-                          ForRangeInfo *FRI, bool EnterForConditionScope) {
-  // Helper to ensure we always enter a continue/break scope if requested.
-  struct ForConditionScopeRAII {
-    Scope *S;
-    void enter(bool IsConditionVariable) {
-      if (S) {
-        S->AddFlags(Scope::BreakScope | Scope::ContinueScope);
-        S->setIsConditionVarScope(IsConditionVariable);
-      }
-    }
-    ~ForConditionScopeRAII() {
-      if (S)
-        S->setIsConditionVarScope(false);
-    }
-  } ForConditionScope{EnterForConditionScope ? getCurScope() : nullptr};
-
+                          ForRangeInfo *FRI) {
   ParenBraceBracketBalancer BalancerRAIIObj(*this);
   PreferredType.enterCondition(Actions, Tok.getLocation());
 
@@ -1907,9 +1892,6 @@ Parser::ParseCXXCondition(StmtResult *InitStmt, SourceLocation Loc,
   // Determine what kind of thing we have.
   switch (isCXXConditionDeclarationOrInitStatement(InitStmt, FRI)) {
   case ConditionOrInitStatement::Expression: {
-    // If this is a for loop, we're entering its condition.
-    ForConditionScope.enter(/*IsConditionVariable=*/false);
-
     ProhibitAttributes(attrs);
 
     // We can have an empty expression here.
@@ -1982,9 +1964,6 @@ Parser::ParseCXXCondition(StmtResult *InitStmt, SourceLocation Loc,
   case ConditionOrInitStatement::Error:
     break;
   }
-
-  // If this is a for loop, we're entering its condition.
-  ForConditionScope.enter(/*IsConditionVariable=*/true);
 
   // type-specifier-seq
   DeclSpec DS(AttrFactory);

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -1865,10 +1865,11 @@ Parser::ParseAliasDeclarationInInitStatement(DeclaratorContext Context,
   return DG;
 }
 
-Sema::ConditionResult
-Parser::ParseCXXCondition(StmtResult *InitStmt, SourceLocation Loc,
-                          Sema::ConditionKind CK, bool MissingOK,
-                          ForRangeInfo *FRI) {
+Sema::ConditionResult Parser::ParseCXXCondition(StmtResult *InitStmt,
+                                                SourceLocation Loc,
+                                                Sema::ConditionKind CK,
+                                                bool MissingOK,
+                                                ForRangeInfo *FRI) {
   ParenBraceBracketBalancer BalancerRAIIObj(*this);
   PreferredType.enterCondition(Actions, Tok.getLocation());
 

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1697,8 +1697,7 @@ StmtResult Parser::ParseSwitchStatement(SourceLocation *TrailingElseLoc,
   // See comments in ParseIfStatement for why we create a scope for the
   // condition and a new scope for substatement in C++.
   //
-  getCurScope()->AddFlags(Scope::BreakScope);
-  getCurScope()->setPrecedingLabel(PrecedingLabel);
+  getCurScope()->EnterSwitchBody(PrecedingLabel);
   ParseScope InnerScope(this, Scope::DeclScope, C99orCXX, Tok.is(tok::l_brace));
 
   // We have incremented the mangling number for the SwitchScope and the
@@ -1742,12 +1741,7 @@ StmtResult Parser::ParseWhileStatement(SourceLocation *TrailingElseLoc,
   // while, for, and switch statements are local to the if, while, for, or
   // switch statement (including the controlled statement).
   //
-  unsigned ScopeFlags;
-  if (C99orCXX)
-    ScopeFlags = Scope::BreakScope | Scope::ContinueScope |
-                 Scope::DeclScope  | Scope::ControlScope;
-  else
-    ScopeFlags = Scope::BreakScope | Scope::ContinueScope;
+  unsigned ScopeFlags = Scope::ControlScope | (C99orCXX ? Scope::DeclScope : 0);
   ParseScope WhileScope(this, ScopeFlags);
 
   // Parse the condition.
@@ -1762,7 +1756,7 @@ StmtResult Parser::ParseWhileStatement(SourceLocation *TrailingElseLoc,
   // combinations, so diagnose that here in OpenACC mode.
   SemaOpenACC::LoopInConstructRAII LCR{getActions().OpenACC()};
   getActions().OpenACC().ActOnWhileStmt(WhileLoc);
-  getCurScope()->setPrecedingLabel(PrecedingLabel);
+  getCurScope()->EnterLoopBody(PrecedingLabel);
 
   // C99 6.8.5p5 - In C99, the body of the while statement is a scope, even if
   // there is no compound stmt.  C90 does not have this clause.  We only do this
@@ -1800,19 +1794,14 @@ StmtResult Parser::ParseDoStatement(LabelDecl *PrecedingLabel) {
 
   // C99 6.8.5p5 - In C99, the do statement is a block.  This is not
   // the case for C90.  Start the loop scope.
-  unsigned ScopeFlags;
-  if (getLangOpts().C99)
-    ScopeFlags = Scope::BreakScope | Scope::ContinueScope | Scope::DeclScope;
-  else
-    ScopeFlags = Scope::BreakScope | Scope::ContinueScope;
-
+  unsigned ScopeFlags = getLangOpts().C99 ? Scope::DeclScope : 0;
   ParseScope DoScope(this, ScopeFlags);
 
   // OpenACC Restricts a do-while-loop inside of certain construct/clause
   // combinations, so diagnose that here in OpenACC mode.
   SemaOpenACC::LoopInConstructRAII LCR{getActions().OpenACC()};
   getActions().OpenACC().ActOnDoStmt(DoLoc);
-  getCurScope()->setPrecedingLabel(PrecedingLabel);
+  getCurScope()->EnterLoopBody(PrecedingLabel);
 
   // C99 6.8.5p5 - In C99, the body of the do statement is a scope, even if
   // there is no compound stmt.  C90 does not have this clause. We only do this
@@ -1832,7 +1821,7 @@ StmtResult Parser::ParseDoStatement(LabelDecl *PrecedingLabel) {
   InnerScope.Exit();
 
   // Reset this to disallow break/continue out of the condition.
-  getCurScope()->setPrecedingLabel(nullptr);
+  getCurScope()->LeaveLoopBody();
 
   if (Tok.isNot(tok::kw_while)) {
     if (!Body.isInvalid()) {
@@ -1928,10 +1917,12 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
   // Names declared in the for-init-statement are in the same declarative-region
   // as those declared in the condition.
   //
-  unsigned ScopeFlags = 0;
-  if (C99orCXXorObjC)
-    ScopeFlags = Scope::DeclScope | Scope::ControlScope;
-
+  // Always enter a ControlScope, even in C90 mode; this is harmless as it
+  // doesn't cause declarations to bind to this scope. We use this to avoid
+  // diagnosing a comma operator in e.g. the third part of a for loop when
+  // '-Wcomma' is enabled.
+  unsigned ScopeFlags =
+      Scope::ControlScope | (C99orCXXorObjC ? Scope::DeclScope : 0);
   ParseScope ForScope(this, ScopeFlags);
 
   BalancedDelimiterTracker T(*this, tok::l_paren);
@@ -2112,8 +2103,7 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
         SecondPart = ParseCXXCondition(
             /*InitStmt=*/nullptr, ForLoc, CK,
             // FIXME: recovery if we don't see another semi!
-            /*MissingOK=*/true, MightBeForRangeStmt ? &ForRangeInfo : nullptr,
-            /*EnterForConditionScope=*/true);
+            /*MissingOK=*/true, MightBeForRangeStmt ? &ForRangeInfo : nullptr);
 
         if (ForRangeInfo.ParsedForRangeDecl()) {
           Diag(FirstPart.get() ? FirstPart.get()->getBeginLoc()
@@ -2143,9 +2133,6 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
         }
 
       } else {
-        // We permit 'continue' and 'break' in the condition of a for loop.
-        getCurScope()->AddFlags(Scope::BreakScope | Scope::ContinueScope);
-
         ExprResult SecondExpr = ParseExpression();
         if (SecondExpr.isInvalid())
           SecondPart = Sema::ConditionError();
@@ -2156,11 +2143,6 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
       }
     }
   }
-
-  // Enter a break / continue scope, if we didn't already enter one while
-  // parsing the second part.
-  if (!getCurScope()->isContinueScope())
-    getCurScope()->AddFlags(Scope::BreakScope | Scope::ContinueScope);
 
   // Parse the third part of the for statement.
   if (!ForEach && !ForRangeInfo.ParsedForRangeDecl()) {
@@ -2230,7 +2212,7 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc,
 
   // Set this only right before parsing the body to disallow break/continue in
   // the other parts.
-  getCurScope()->setPrecedingLabel(PrecedingLabel);
+  getCurScope()->EnterLoopBody(PrecedingLabel);
 
   // C99 6.8.5p5 - In C99, the body of the for statement is a scope, even if
   // there is no compound stmt.  C90 does not have this clause.  We only do this

--- a/clang/lib/Sema/Scope.cpp
+++ b/clang/lib/Sema/Scope.cpp
@@ -113,18 +113,23 @@ bool Scope::containedInPrototypeScope() const {
   return false;
 }
 
-void Scope::AddFlags(unsigned FlagsToSet) {
-  assert((FlagsToSet & ~(BreakScope | ContinueScope)) == 0 &&
-         "Unsupported scope flags");
-  if (FlagsToSet & BreakScope) {
-    assert((Flags & BreakScope) == 0 && "Already set");
-    BreakParent = this;
-  }
-  if (FlagsToSet & ContinueScope) {
-    assert((Flags & ContinueScope) == 0 && "Already set");
-    ContinueParent = this;
-  }
-  Flags |= FlagsToSet;
+void Scope::EnterLoopBody(LabelDecl *LD) {
+  Flags |= BreakScope | ContinueScope;
+  BreakParent = ContinueParent = this;
+  PrecedingLabel = LD;
+}
+
+void Scope::EnterSwitchBody(LabelDecl *LD) {
+  Flags |= BreakScope;
+  BreakParent = this;
+  PrecedingLabel = LD;
+}
+
+void Scope::LeaveLoopBody() {
+  Flags &= ~(BreakScope | ContinueScope);
+  BreakParent = getParent()->BreakParent;
+  ContinueParent = getParent()->ContinueParent;
+  PrecedingLabel = nullptr;
 }
 
 // The algorithm for updating NRVO candidate is as follows:
@@ -229,7 +234,7 @@ void Scope::dumpImpl(raw_ostream &OS) const {
       {CompoundStmtScope, "CompoundStmtScope"},
       {ClassInheritanceScope, "ClassInheritanceScope"},
       {CatchScope, "CatchScope"},
-      {ConditionVarScope, "ConditionVarScope"},
+      {ExpansionStmtScope, "ExpansionStmtScope"},
       {OpenMPOrderClauseScope, "OpenMPOrderClauseScope"},
       {LambdaScope, "LambdaScope"},
       {OpenACCComputeConstructScope, "OpenACCComputeConstructScope"},

--- a/clang/lib/Sema/Scope.cpp
+++ b/clang/lib/Sema/Scope.cpp
@@ -234,7 +234,7 @@ void Scope::dumpImpl(raw_ostream &OS) const {
       {CompoundStmtScope, "CompoundStmtScope"},
       {ClassInheritanceScope, "ClassInheritanceScope"},
       {CatchScope, "CatchScope"},
-      {ExpansionStmtScope, "ExpansionStmtScope"},
+      {Unused, "Unused"},
       {OpenMPOrderClauseScope, "OpenMPOrderClauseScope"},
       {LambdaScope, "LambdaScope"},
       {OpenACCComputeConstructScope, "OpenACCComputeConstructScope"},

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -14636,15 +14636,7 @@ void Sema::DiagnoseCommaOperator(const Expr *LHS, SourceLocation Loc) {
   // The listed locations are the initialization and increment portions
   // of a for loop.  The additional checks are on the condition of
   // if statements, do/while loops, and for loops.
-  // Differences in scope flags for C89 mode requires the extra logic.
-  const unsigned ForIncrementFlags =
-      getLangOpts().C99 || getLangOpts().CPlusPlus
-          ? Scope::ControlScope | Scope::ContinueScope | Scope::BreakScope
-          : Scope::ContinueScope | Scope::BreakScope;
-  const unsigned ForInitFlags = Scope::ControlScope | Scope::DeclScope;
-  const unsigned ScopeFlags = getCurScope()->getFlags();
-  if ((ScopeFlags & ForIncrementFlags) == ForIncrementFlags ||
-      (ScopeFlags & ForInitFlags) == ForInitFlags)
+  if (getCurScope()->isControlScope())
     return;
 
   // If there are multiple comma operators used together, get the RHS of the

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -1794,7 +1794,6 @@ StmtResult Sema::ActOnWhileStmt(SourceLocation WhileLoc,
     return StmtError();
 
   auto CondVal = Cond.get();
-  CheckBreakContinueBinding(CondVal.second);
 
   if (CondVal.second &&
       !Diags.isIgnored(diag::warn_comma_operator, CondVal.second->getExprLoc()))
@@ -1822,7 +1821,6 @@ Sema::ActOnDoStmt(SourceLocation DoLoc, Stmt *Body,
                   Expr *Cond, SourceLocation CondRParen) {
   assert(Cond && "ActOnDoStmt(): missing expression");
 
-  CheckBreakContinueBinding(Cond);
   ExprResult CondResult = CheckBooleanCondition(DoLoc, Cond);
   if (CondResult.isInvalid())
     return StmtError();
@@ -1832,11 +1830,6 @@ Sema::ActOnDoStmt(SourceLocation DoLoc, Stmt *Body,
   if (CondResult.isInvalid())
     return StmtError();
   Cond = CondResult.get();
-
-  // Only call the CommaVisitor for C89 due to differences in scope flags.
-  if (Cond && !getLangOpts().C99 && !getLangOpts().CPlusPlus &&
-      !Diags.isIgnored(diag::warn_comma_operator, Cond->getExprLoc()))
-    CommaVisitor(*this).Visit(Cond);
 
   // OpenACC3.3 2.14.4:
   // The update directive is executable.  It must not appear in place of the
@@ -2255,25 +2248,6 @@ namespace {
 
 } // end namespace
 
-
-void Sema::CheckBreakContinueBinding(Expr *E) {
-  if (!E || getLangOpts().CPlusPlus)
-    return;
-  BreakContinueFinder BCFinder(*this, E);
-  Scope *BreakParent = CurScope->getBreakParent();
-  if (BCFinder.BreakFound() && BreakParent) {
-    if (BreakParent->getFlags() & Scope::SwitchScope) {
-      Diag(BCFinder.GetBreakLoc(), diag::warn_break_binds_to_switch);
-    } else {
-      Diag(BCFinder.GetBreakLoc(), diag::warn_loop_ctrl_binds_to_inner)
-          << "break";
-    }
-  } else if (BCFinder.ContinueFound() && CurScope->getContinueParent()) {
-    Diag(BCFinder.GetContinueLoc(), diag::warn_loop_ctrl_binds_to_inner)
-        << "continue";
-  }
-}
-
 StmtResult Sema::ActOnForStmt(SourceLocation ForLoc, SourceLocation LParenLoc,
                               Stmt *First, ConditionResult Second,
                               FullExprArg third, SourceLocation RParenLoc,
@@ -2316,9 +2290,6 @@ StmtResult Sema::ActOnForStmt(SourceLocation ForLoc, SourceLocation LParenLoc,
                                : diag::ext_c23_non_variable_decl_in_for);
     }
   }
-
-  CheckBreakContinueBinding(Second.get().second);
-  CheckBreakContinueBinding(third.get());
 
   if (!Second.get().first)
     CheckForLoopConditionalStatement(*this, Second.get().second, third.get(),
@@ -3364,12 +3335,6 @@ StmtResult Sema::ActOnContinueStmt(SourceLocation ContinueLoc, Scope *CurScope,
   if (!S) {
     // C99 6.8.6.2p1: A break shall appear only in or as a loop body.
     return StmtError(Diag(ContinueLoc, diag::err_continue_not_in_loop));
-  }
-  if (S->isConditionVarScope()) {
-    // We cannot 'continue;' from within a statement expression in the
-    // initializer of a condition variable because we would jump past the
-    // initialization of that variable.
-    return StmtError(Diag(ContinueLoc, diag::err_continue_from_cond_var_init));
   }
 
   // A 'continue' that would normally have execution continue on a block outside

--- a/clang/test/Analysis/dead-stores.c
+++ b/clang/test/Analysis/dead-stores.c
@@ -504,20 +504,6 @@ int f26_nestedblocks(void) {
   return y;
 }
 
-// The FOREACH macro in QT uses 'break' statements within statement expressions
-// placed within the increment code of for loops.
-void rdar8014335(void) {
-  for (int i = 0 ; i != 10 ; ({ break; })) {
-    for (;; ({ ++i; break; }))
-      ;
-    // non-nested-warning@-2 {{'break' is bound to current loop, GCC binds it to the enclosing loop}}
-    // Note that the next value stored to 'i' is never executed
-    // because the next statement to be executed is the 'break'
-    // in the increment code of the first loop.
-    i = i * 3; // non-nested-warning {{Value stored to 'i' is never read}}
-  }
-}
-
 // NullStmts followed by do...while() can lead to disconnected CFG
 //
 // This previously caused bogus dead-stores warnings because the body of the first do...while was

--- a/clang/test/CoverageMapping/break.c
+++ b/clang/test/CoverageMapping/break.c
@@ -31,14 +31,3 @@ int main(void) {     // CHECK: File 0, [[@LINE]]:16 -> {{[0-9]+}}:2 = #0
     ++cnt;
   }
 }
-
-// CHECK-LABEL: break_continue_in_increment:
-// CHECK:  [[@LINE+6]]:11 -> [[@LINE+6]]:45 = #1
-// CHECK:  [[@LINE+5]]:18 -> [[@LINE+5]]:19 = #1
-// CHECK:  [[@LINE+4]]:21 -> [[@LINE+4]]:26 = #2
-// CHECK:  [[@LINE+3]]:33 -> [[@LINE+3]]:41 = (#1 - #2)
-// CHECK:  [[@LINE+3]]:5 -> [[@LINE+3]]:6 = #1
-void break_continue_in_increment(int x) {
-  for (;; ({ if (x) break; else continue; }))
-    ;
-}

--- a/clang/test/Sema/break-continue-cond.c
+++ b/clang/test/Sema/break-continue-cond.c
@@ -1,0 +1,88 @@
+// RUN: %clang_cc1 -verify -fsyntax-only -std=c90 -DPRE_C99 %s
+// RUN: %clang_cc1 -verify -fsyntax-only -std=c99 %s
+// RUN: %clang_cc1 -verify -fsyntax-only -std=c2y %s
+// RUN: %clang_cc1 -verify -fsyntax-only -x c++ %s
+
+void err(int q) {
+  while (({ continue; 1; })) {} // expected-error {{'continue' statement not in loop statement}}
+  while (({ break; 1; })) {} // expected-error {{'break' statement not in loop or switch statement}}
+
+  do {} while (({ continue; 1; })); // expected-error {{'continue' statement not in loop statement}}
+  do {} while (({ break; 1; })); // expected-error {{'break' statement not in loop or switch statement}}
+
+  for (({continue;});;) {} // expected-error {{'continue' statement not in loop statement}}
+  for (({break;});;) {} // expected-error {{'break' statement not in loop or switch statement}}
+#ifndef PRE_C99
+  for (int x = ({continue; 1;});;) {} // expected-error {{'continue' statement not in loop statement}}
+  for (int x = ({break; 1;});;) {} // expected-error {{'break' statement not in loop or switch statement}}
+#endif
+  for (; ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
+  for (; ({break; 1;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+#if __cplusplus
+  for (; int x = ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
+  for (; int x = ({break; 1;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+#endif
+  for (;;({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
+  for (;;({break;})) {} // expected-error {{'break' statement not in loop or switch statement}}
+
+  switch (({continue; q;})) {} // expected-error {{'continue' statement not in loop statement}}
+  switch (({break; q;})) {} // expected-error {{'break' statement not in loop or switch statement}}
+}
+
+void in_outer_loop(int q) {
+  for (;;) {
+    while (({ continue; 1; })) {}
+    while (({ break; 1; })) {}
+
+    do {} while (({ continue; 1; }));
+    do {} while (({ break; 1; }));
+
+    for (({continue;});;) {}
+    for (({break;});;) {}
+#ifndef PRE_C99
+    for (int x = ({continue; 1;});;) {}
+    for (int x = ({break; 1;});;) {}
+#endif
+    for (; ({continue; 1;});) {}
+    for (; ({break; 1;});) {}
+  #if __cplusplus
+    for (; int x = ({continue; 1;});) {}
+    for (; int x = ({break; 1;});) {}
+  #endif
+    for (;;({continue;})) {}
+    for (;;({break;})) {}
+
+    switch (({continue; q;})) {}
+    switch (({break; q;})) {}
+  }
+}
+
+void in_outer_switch(int y) {
+  switch (y) {
+    default: {
+      while (({ continue; 1; })) {} // expected-error {{'continue' statement not in loop statement}}
+      while (({ break; 1; })) {}
+
+      do {} while (({ continue; 1; })); // expected-error {{'continue' statement not in loop statement}}
+      do {} while (({ break; 1; }));
+
+      for (({continue;});;) {} // expected-error {{'continue' statement not in loop statement}}
+      for (({break;});;) {}
+#ifndef PRE_C99
+      for (int x = ({continue; 1;});;) {} // expected-error {{'continue' statement not in loop statement}}
+      for (int x = ({break; 1;});;) {}
+#endif
+      for (; ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
+      for (; ({break; 1;});) {}
+#if __cplusplus
+      for (; int x = ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
+      for (; int x = ({break; 1;});) {}
+#endif
+      for (;;({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
+      for (;;({break;})) {}
+
+      switch (({continue; y;})) {} // expected-error {{'continue' statement not in loop statement}}
+      switch (({break; y;})) {}
+    }
+  }
+}

--- a/clang/test/Sema/break-continue-cond.c
+++ b/clang/test/Sema/break-continue-cond.c
@@ -1,7 +1,9 @@
 // RUN: %clang_cc1 -verify -fsyntax-only -std=c90 -DPRE_C99 %s
 // RUN: %clang_cc1 -verify -fsyntax-only -std=c99 %s
 // RUN: %clang_cc1 -verify -fsyntax-only -std=c2y %s
-// RUN: %clang_cc1 -verify -fsyntax-only -x c++ %s
+// RUN: %clang_cc1 -verify -fsyntax-only -x c++ -std=c++20 %s
+
+int arr[5];
 
 void err(int q) {
   while (({ continue; 1; })) {} // expected-error {{'continue' statement not in loop statement}}
@@ -12,18 +14,26 @@ void err(int q) {
 
   for (({continue;});;) {} // expected-error {{'continue' statement not in loop statement}}
   for (({break;});;) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (; ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
+  for (; ({break; 1;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (;;({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
+  for (;;({break;})) {} // expected-error {{'break' statement not in loop or switch statement}}
+
 #ifndef PRE_C99
   for (int x = ({continue; 1;});;) {} // expected-error {{'continue' statement not in loop statement}}
   for (int x = ({break; 1;});;) {} // expected-error {{'break' statement not in loop or switch statement}}
 #endif
-  for (; ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
-  for (; ({break; 1;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+
 #if __cplusplus
   for (; int x = ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
   for (; int x = ({break; 1;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (({continue;}); int x : arr) {} // expected-error {{'continue' statement not in loop statement}}
+  for (({break;}); int x : arr) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (int y = ({continue; 5;}); int x : arr) {} // expected-error {{'continue' statement not in loop statement}}
+  for (int y = ({break; 5;}); int x : arr) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (int x : *({ continue; &arr; })) {} // expected-error {{'continue' statement not in loop statement}}
+  for (int x : *({ break; &arr; })) {} // expected-error {{'break' statement not in loop or switch statement}}
 #endif
-  for (;;({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
-  for (;;({break;})) {} // expected-error {{'break' statement not in loop or switch statement}}
 
   switch (({continue; q;})) {} // expected-error {{'continue' statement not in loop statement}}
   switch (({break; q;})) {} // expected-error {{'break' statement not in loop or switch statement}}
@@ -39,18 +49,26 @@ void in_outer_loop(int q) {
 
     for (({continue;});;) {}
     for (({break;});;) {}
+    for (; ({continue; 1;});) {}
+    for (; ({break; 1;});) {}
+    for (;;({continue;})) {}
+    for (;;({break;})) {}
+
 #ifndef PRE_C99
     for (int x = ({continue; 1;});;) {}
     for (int x = ({break; 1;});;) {}
 #endif
-    for (; ({continue; 1;});) {}
-    for (; ({break; 1;});) {}
-  #if __cplusplus
+
+#if __cplusplus
     for (; int x = ({continue; 1;});) {}
     for (; int x = ({break; 1;});) {}
-  #endif
-    for (;;({continue;})) {}
-    for (;;({break;})) {}
+    for (({continue;}); int x : arr) {}
+    for (({break;}); int x : arr) {}
+    for (int y = ({continue; 5;}); int x : arr) {}
+    for (int y = ({break; 5;}); int x : arr) {}
+    for (int x : *({ continue; &arr; })) {}
+    for (int x : *({ break; &arr; })) {}
+#endif
 
     switch (({continue; q;})) {}
     switch (({break; q;})) {}
@@ -68,18 +86,26 @@ void in_outer_switch(int y) {
 
       for (({continue;});;) {} // expected-error {{'continue' statement not in loop statement}}
       for (({break;});;) {}
+      for (; ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
+      for (; ({break; 1;});) {}
+      for (;;({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
+      for (;;({break;})) {}
+
 #ifndef PRE_C99
       for (int x = ({continue; 1;});;) {} // expected-error {{'continue' statement not in loop statement}}
       for (int x = ({break; 1;});;) {}
 #endif
-      for (; ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
-      for (; ({break; 1;});) {}
+
 #if __cplusplus
       for (; int x = ({continue; 1;});) {} // expected-error {{'continue' statement not in loop statement}}
       for (; int x = ({break; 1;});) {}
+      for (({continue;}); int x : arr) {} // expected-error {{'continue' statement not in loop statement}}
+      for (({break;}); int x : arr) {}
+      for (int y = ({continue; 5;}); int x : arr) {} // expected-error {{'continue' statement not in loop statement}}
+      for (int y = ({break; 5;}); int x : arr) {}
+      for (int x : *({ continue; &arr; })) {} // expected-error {{'continue' statement not in loop statement}}
+      for (int x : *({ break; &arr; })) {}
 #endif
-      for (;;({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
-      for (;;({break;})) {}
 
       switch (({continue; y;})) {} // expected-error {{'continue' statement not in loop statement}}
       switch (({break; y;})) {}

--- a/clang/test/Sema/loop-control.c
+++ b/clang/test/Sema/loop-control.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify -x c++ %s
 
 int pr8880_1(void) {
   int first = 1;

--- a/clang/test/Sema/loop-control.c
+++ b/clang/test/Sema/loop-control.c
@@ -1,79 +1,78 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
-// RUN: %clang_cc1 -fsyntax-only -x c++ -Werror %s
 
 int pr8880_1(void) {
   int first = 1;
-  for ( ; ({ if (first) { first = 0; continue; } 0; }); )
+  for ( ; ({ if (first) { first = 0; continue; } 0; }); ) // expected-error {{'continue' statement not in loop statement}}
     return 0;
   return 1;
 }
 
 void pr8880_2(int first) {
-  for ( ; ({ if (first) { first = 0; break; } 0; }); ) {}
+  for ( ; ({ if (first) { first = 0; break; } 0; }); ) {} // expected-error {{'break' statement not in loop or switch statement}}
 }
 
 void pr8880_3(int first) {
-  for ( ; ; (void)({ if (first) { first = 0; continue; } 0; })) {}
+  for ( ; ; (void)({ if (first) { first = 0; continue; } 0; })) {} // expected-error {{'continue' statement not in loop statement}}
 }
 
 void pr8880_4(int first) {
-  for ( ; ; (void)({ if (first) { first = 0; break; } 0; })) {}
+  for ( ; ; (void)({ if (first) { first = 0; break; } 0; })) {} // expected-error {{'break' statement not in loop or switch statement}}
 }
 
 void pr8880_5 (int first) {
-  while(({ if (first) { first = 0; continue; } 0; })) {}
+  while(({ if (first) { first = 0; continue; } 0; })) {} // expected-error {{'continue' statement not in loop statement}}
 }
 
 void pr8880_6 (int first) {
-  while(({ if (first) { first = 0; break; } 0; })) {}
+  while(({ if (first) { first = 0; break; } 0; })) {} // expected-error {{'break' statement not in loop or switch statement}}
 }
 
 void pr8880_7 (int first) {
-  do {} while(({ if (first) { first = 0; continue; } 0; }));
+  do {} while(({ if (first) { first = 0; continue; } 0; })); // expected-error {{'continue' statement not in loop statement}}
 }
 
 void pr8880_8 (int first) {
-  do {} while(({ if (first) { first = 0; break; } 0; }));
+  do {} while(({ if (first) { first = 0; break; } 0; })); // expected-error {{'break' statement not in loop or switch statement}}
 }
 
 void pr8880_10(int i) {
   for ( ; i != 10 ; i++ )
-    for ( ; ; (void)({ ++i; continue; i;})) {} // expected-warning{{'continue' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ; (void)({ ++i; continue; i;})) {}
 }
 
 void pr8880_11(int i) {
   for ( ; i != 10 ; i++ )
-    for ( ; ; (void)({ ++i; break; i;})) {} // expected-warning{{'break' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ; (void)({ ++i; break; i;})) {}
 }
 
 void pr8880_12(int i, int j) {
   for ( ; i != 10 ; i++ )
-    for ( ; ({if (i) continue; i;}); j++) {} // expected-warning {{'continue' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ({if (i) continue; i;}); j++) {}
 }
 
 void pr8880_13(int i, int j) {
   for ( ; i != 10 ; i++ )
-    for ( ; ({if (i) break; i;}); j++) {} // expected-warning{{'break' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ({if (i) break; i;}); j++) {}
 }
 
 void pr8880_14(int i) {
   for ( ; i != 10 ; i++ )
-    while(({if (i) break; i;})) {} // expected-warning {{'break' is bound to current loop, GCC binds it to the enclosing loop}}
+    while(({if (i) break; i;})) {}
 }
 
 void pr8880_15(int i) {
   while (--i)
-    while(({if (i) continue; i;})) {} // expected-warning {{'continue' is bound to current loop, GCC binds it to the enclosing loop}}
+    while(({if (i) continue; i;})) {}
 }
 
 void pr8880_16(int i) {
   for ( ; i != 10 ; i++ )
-    do {} while(({if (i) break; i;})); // expected-warning {{'break' is bound to current loop, GCC binds it to the enclosing loop}}
+    do {} while(({if (i) break; i;}));
 }
 
 void pr8880_17(int i) {
   for ( ; i != 10 ; i++ )
-    do {} while(({if (i) continue; i;})); // expected-warning {{'continue' is bound to current loop, GCC binds it to the enclosing loop}}
+    do {} while(({if (i) continue; i;}));
 }
 
 void pr8880_18(int x, int y) {
@@ -95,28 +94,28 @@ void pr8880_19(int x, int y) {
 void pr8880_20(int x, int y) {
   switch(x) {
   case 1:
-    while(({if (y) break; y;})) {} //expected-warning {{'break' is bound to loop, GCC binds it to switch}}
+    while(({if (y) break; y;})) {}
   }
 }
 
 void pr8880_21(int x, int y) {
   switch(x) {
   case 1:
-    do {} while(({if (y) break; y;})); //expected-warning {{'break' is bound to loop, GCC binds it to switch}}
+    do {} while(({if (y) break; y;}));
   }
 }
 
 void pr8880_22(int x, int y) {
   switch(x) {
   case 1:
-    for ( ; ; (void)({ ++y; break; y;})) {} // expected-warning{{'break' is bound to loop, GCC binds it to switc}}
+    for ( ; ; (void)({ ++y; break; y;})) {}
   }
 }
 
 void pr8880_23(int x, int y) {
   switch(x) {
   case 1:
-    for ( ; ({ ++y; break; y;}); ++y) {} // expected-warning{{'break' is bound to loop, GCC binds it to switch}}
+    for ( ; ({ ++y; break; y;}); ++y) {}
   }
 }
 
@@ -129,7 +128,7 @@ void pr32648_1(int x, int y) {
 
 void pr32648_2(int x, int y) {
   while(x) {
-    for ( ; ({ ++y; switch (y) { case 0: continue; } y;}); ++y) {}  // expected-warning {{'continue' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ({ ++y; switch (y) { case 0: continue; } y;}); ++y) {}
   }
 }
 
@@ -143,21 +142,21 @@ void pr32648_3(int x, int y) {
 void pr32648_4(int x, int y) {
   switch(x) {
   case 1:
-    for ( ; ({ ++y; for (({ break; }); y; y++) { } y;}); ++y) {} // expected-warning{{'break' is bound to loop, GCC binds it to switch}}
+    for ( ; ({ ++y; for (({ break; }); y; y++) { } y;}); ++y) {}
   }
 }
 
 void pr32648_5(int x, int y) {
   switch(x) {
   case 1:
-    for ( ; ({ ++y; while (({ break; y; })) {} y;}); ++y) {} // expected-warning{{'break' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ({ ++y; while (({ break; y; })) {} y;}); ++y) {}
   }
 }
 
 void pr32648_6(int x, int y) {
   switch(x) {
   case 1:
-    for ( ; ({ ++y; do {} while (({ break; y; })); y;}); ++y) {} // expected-warning{{'break' is bound to current loop, GCC binds it to the enclosing loop}}
+    for ( ; ({ ++y; do {} while (({ break; y; })); y;}); ++y) {}
   }
 }
 

--- a/clang/test/Sema/statements.c
+++ b/clang/test/Sema/statements.c
@@ -100,7 +100,7 @@ void foo(enum x X) {
 
 int test_pr8880(void) {
   int first = 1;
-  for ( ; ({ if (first) { first = 0; continue; } 0; }); )
+  for ( ; ({ if (first) { first = 0; continue; } 0; }); ) // expected-error {{'continue' statement not in loop statement}}
     return 0;
   return 1;
 }

--- a/clang/test/SemaCXX/scope-check.cpp
+++ b/clang/test/SemaCXX/scope-check.cpp
@@ -631,16 +631,12 @@ l: // expected-note 4 {{possible target of indirect goto statement}}
 } // namespace seh
 
 void continue_scope_check() {
-  // These are OK.
-  for (; ({break; true;});) {}
-  for (; ({continue; true;});) {}
-  for (; int n = ({break; 0;});) {}
-  for (; int n = 0; ({break;})) {}
-  for (; int n = 0; ({continue;})) {}
-
-  // This would jump past the initialization of 'n' to the increment (where 'n'
-  // is in scope).
-  for (; int n = ({continue; 0;});) {} // expected-error {{cannot jump from this continue statement to the loop increment; jump bypasses initialization of loop condition variable}}
+  for (; ({break; true;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (; ({continue; true;});) {} // expected-error {{'continue' statement not in loop statement}}
+  for (; int n = ({break; 0;});) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (; int n = 0; ({break;})) {} // expected-error {{'break' statement not in loop or switch statement}}
+  for (; int n = 0; ({continue;})) {} // expected-error {{'continue' statement not in loop statement}}
+  for (; int n = ({continue; 0;});) {} // expected-error {{'continue' statement not in loop statement}}
 
   // An intervening loop makes it OK again.
   for (; int n = ({while (true) continue; 0;});) {}


### PR DESCRIPTION
tl;dr: This makes e.g. `while (({ break; 1; })) {}` ill-formed.

GCC used to allow this a long time ago (< GCC 9 I believe), but eventually removed support for it; we originally allowed this both for GCC compatibility and because there was actual code in the wild using it (see Richard’s comment here for more background: https://github.com/llvm/llvm-project/pull/152606#issuecomment-3166130973).

Note that this _is_ still allowed inside another loop, e.g. this
```c++
for (;;) {
    while (({ break; true; })) {}
}
```
is well-formed; the `break` here will break out of the `for` loop.

Removing support for this gets rid of quite a bit of code and has a few more benefits:

1. Currently, GCC and Clang _disagree_ on the meaning of this construct in nested loops: in the code snippet above, Clang breaks out of the `while` loop, whereas GCC breaks out of the `for` loop; this patch changes Clang to align with GCC here. As a result, we can also remove code that emits a warning for such cases.

2. It frees up a bit in `ScopeFlags::Flags`, which is a good thing because I need one for expansion statements, and we’re out of bits. This is because we currently use a bit as a hack to disallow `continue` inside the declaration of the condition variable (because we’d `continue` to the condition before initialising the variable); this bit becomes obsolete with this patch because `continue` is now disallowed entirely within the condition (if there is no outer loop).

    Without this change, I’d have to refactor `Flags` to be a 64-bit integer, which would also entail updating every place where we use an `unsigned` to store scope flags.

There is another change that I needed to make here: we currently suppress `-Wcomma` (which warns about comma operators, because in most contexts, you probably didn’t mean to use one) in some places, including the third part of a C-style `for` loop. This is implemented by checking if we’re in a `BreakScope | ContinueScope`, but those scope flags are now only set when parsing the loop body. Instead, we now check for `ControlScope`. This requires us to also set that flag in C90 mode, but that seems to be harmless as the only use of `ControlScope` I was able to find is in C++ code paths, where that bit was already set anyway.

When we introduced named loops for C2y, we purposefully didn’t support labeled break/continue in the condition, so there’s nothing to be done there (we already have tests for this too).
