### PR TITLE
[llvm][DebugInfo] Require non-null debug metadata fields when writing bitcode

### DIFF
--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -2227,7 +2227,11 @@ void ModuleBitcodeWriter::writeDISubprogram(const DISubprogram *N,
   Record.push_back(VE.getMetadataOrNullID(N->getRawLinkageName()));
   Record.push_back(VE.getMetadataOrNullID(N->getFile()));
   Record.push_back(N->getLine());
-  Record.push_back(VE.getMetadataOrNullID(N->getType()));
+  // This field uses the metadata-or-null encoding in bitcode: 0 means null,
+  // otherwise the stored value is the metadata ID plus 1. Use getMetadataID()
+  // to assert that DISubprogram::type is present, then translate back to the
+  // existing encoding.
+  Record.push_back(VE.getMetadataID(N->getType()) + 1);
   Record.push_back(N->getScopeLine());
   Record.push_back(VE.getMetadataOrNullID(N->getContainingType()));
   Record.push_back(N->getSPFlags());


### PR DESCRIPTION
  Follow-up to #196299.

  This updates BitcodeWriter to use `getMetadataID()` for debug metadata fields
  that LLParser parses as required non-null `MDField` operands.

  These bitcode record fields still use the existing metadata-or-null encoding,
  so the writer preserves the on-disk encoding by writing the metadata ID plus
  one. This makes the writer assert the in-memory invariant without changing
  MetadataLoader's compatibility behavior for older bitcode.

  MetadataLoader is intentionally left permissive in this patch because older
  bitcode can still contain null operands for these fields.
