### PR TITLE
[JumpThreading] Add phi translation legality check in `duplicateCondBranchOnPHIIntoPred`

### DIFF
--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -549,6 +549,30 @@ static Constant *getKnownConstant(Value *Val, ConstantPreference Preference) {
   return dyn_cast<ConstantInt>(Val);
 }
 
+/// Return true if phi-translating PN's incoming value from PredBB is safe.
+/// Translation is unsafe when the incoming value is not loop invariant,
+/// i.e., when its defining block is in a cycle.
+/// TODO: A more precise check would determine whether the incoming value is
+/// loop invariant specifically with respect to PredBB.
+static bool canPhiTranslate(PHINode *PN, BasicBlock *PredBB) {
+  Value *InVal = PN->getIncomingValueForBlock(PredBB);
+
+  // Non-instructions (constants, arguments) are always loop invariant.
+  auto *Inst = dyn_cast<Instruction>(InVal);
+  if (!Inst)
+    return true;
+
+  BasicBlock *DefBB = Inst->getParent();
+  // Instructions in the entry block cannot be part of a loop.
+  if (DefBB->isEntryBlock())
+    return true;
+  // InVal is loop invariant if its defining block is not in a cycle.
+  // Avoid the DomTree, which may have pending lazy updates at this point.
+  SmallVector<BasicBlock *> Succs(successors(DefBB));
+  return !isPotentiallyReachableFromMany(Succs, DefBB, /*ExclusionSet=*/nullptr,
+                                         /*DT=*/nullptr, /*LI=*/nullptr);
+}
+
 /// computeValueKnownInPredecessors - Given a basic block BB and a value V, see
 /// if we can infer that the value is a known ConstantInt/BlockAddress or undef
 /// in any of our predecessors.  If so, return the known list of value and pred
@@ -2646,6 +2670,13 @@ bool JumpThreadingPass::duplicateCondBranchOnPHIIntoPred(
                       << "' - Cost is too high: " << DuplicationCost << "\n");
     return false;
   }
+
+  // Bail out before any CFG modification if phi translation is illegal for any
+  // predecessor.
+  for (BasicBlock *Pred : PredBBs)
+    for (PHINode &PN : BB->phis())
+      if (!canPhiTranslate(&PN, Pred))
+        return false;
 
   // And finally, do it!  Start by factoring the predecessors if needed.
   std::vector<DominatorTree::UpdateType> Updates;

--- a/llvm/test/Transforms/JumpThreading/phi-copy-to-pred.ll
+++ b/llvm/test/Transforms/JumpThreading/phi-copy-to-pred.ll
@@ -72,8 +72,8 @@ EXIT2:
 define i32 @PR197725() {
 ; CHECK-LABEL: @PR197725(
 ; CHECK-NEXT:  exit:
-; CHECK-NEXT:    [[NOT:%.*]] = xor i32 0, 1
-; CHECK-NEXT:    ret i32 0
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 1, 1
+; CHECK-NEXT:    ret i32 1
 ;
 entry:
   br i1 false, label %loop2, label %loop1

--- a/llvm/test/Transforms/JumpThreading/phi-copy-to-pred.ll
+++ b/llvm/test/Transforms/JumpThreading/phi-copy-to-pred.ll
@@ -67,3 +67,28 @@ EXIT1:
 EXIT2:
   ret i32 1
 }
+
+
+define i32 @PR197725() {
+; CHECK-LABEL: @PR197725(
+; CHECK-NEXT:  exit:
+; CHECK-NEXT:    [[NOT:%.*]] = xor i32 0, 1
+; CHECK-NEXT:    ret i32 0
+;
+entry:
+  br i1 false, label %loop2, label %loop1
+
+loop1:                                         ; preds = %loop2, %entry
+  %cond = phi i1 [ %tobool, %loop2 ], [ false, %entry ]
+  %val = phi i32 [ %not_phi, %loop2 ], [ 0, %entry ]
+  %not = xor i32 %val, 1
+  br i1 %cond, label %exit, label %loop2
+
+exit:                                         ; preds = %loop2
+  ret i32 %val
+
+loop2:                                         ; preds = %loop1, %entry
+  %not_phi = phi i32 [ %not, %loop1 ], [ 0, %entry ]
+  %tobool = icmp ne i8 1, 0
+  br label %loop1
+}


### PR DESCRIPTION
Fixes #197725.
The following patch will release the need for `LoopHeaders` in https://github.com/llvm/llvm-project/issues/70651.