### PR TITLE
[libc] Add regex_macros dependency to regex header

### DIFF
--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -317,6 +317,7 @@ add_header_macro(
   regex.h
   DEPENDS
     .llvm_libc_common_h
+    .llvm-libc-macros.regex_macros
     .llvm-libc-types.regex_t
     .llvm-libc-types.regmatch_t
     .llvm-libc-types.regoff_t


### PR DESCRIPTION
Added the regex_macros dependency to the regex header target. regex-macros.h was not being installed when regex entrypoints were enabled.

Assisted-by: Automated tooling, human reviewed.