### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Check arguments of CXXConstructExpr

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -159,10 +159,15 @@ bool isSmartPtrClass(const std::string &Name) {
          Name == "ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr";
 }
 
+std::string getConstructorName(const clang::FunctionDecl *F) {
+  if (auto *Ctor = dyn_cast_or_null<CXXConstructorDecl>(F))
+    return safeGetName(Ctor->getParent());
+  return safeGetName(F);
+}
+
 bool isCtorOfRefCounted(const clang::FunctionDecl *F) {
   assert(F);
-  const std::string &FunctionName = safeGetName(F);
-
+  auto FunctionName = getConstructorName(F);
   return isRefType(FunctionName) || FunctionName == "adoptRef" ||
          FunctionName == "UniqueRef" || FunctionName == "makeUniqueRef" ||
          FunctionName == "makeUniqueRefWithoutFastMallocCheck"
@@ -175,16 +180,16 @@ bool isCtorOfRefCounted(const clang::FunctionDecl *F) {
 
 bool isCtorOfCheckedPtr(const clang::FunctionDecl *F) {
   assert(F);
-  return isCheckedPtr(safeGetName(F));
+  return isCheckedPtr(getConstructorName(F));
 }
 
 bool isCtorOfRetainPtrOrOSPtr(const clang::FunctionDecl *F) {
-  const std::string &FunctionName = safeGetName(F);
-  return FunctionName == "RetainPtr" || FunctionName == "adoptNS" ||
+  auto FunctionName = getConstructorName(F);
+  return isRetainPtrOrOSPtr(FunctionName) || FunctionName == "adoptNS" ||
          FunctionName == "adoptNSNullable" || FunctionName == "adoptCF" ||
          FunctionName == "adoptCFNullable" || FunctionName == "retainPtr" ||
-         FunctionName == "RetainPtrArc" || FunctionName == "adoptNSArc" ||
-         FunctionName == "adoptOSObject" || FunctionName == "adoptOSObjectArc";
+         FunctionName == "adoptNSArc" || FunctionName == "adoptOSObject" ||
+         FunctionName == "adoptOSObjectArc";
 }
 
 bool isCtorOfSafePtr(const clang::FunctionDecl *F) {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -85,6 +85,11 @@ public:
         return true;
       }
 
+      bool VisitCXXConstructExpr(CXXConstructExpr *CE) override {
+        Checker->visitConstructExpr(CE, DeclWithIssue);
+        return true;
+      }
+
       bool VisitTypedefDecl(TypedefDecl *TD) override {
         if (Checker->RTC)
           Checker->RTC->visitTypedef(TD);
@@ -103,11 +108,10 @@ public:
     visitor.TraverseDecl(const_cast<TranslationUnitDecl *>(TUD));
   }
 
-  void visitCallExpr(const CallExpr *CE, const Decl *D) const {
-    if (shouldSkipCall(CE))
-      return;
-
-    if (auto *F = CE->getDirectCallee()) {
+  template <typename CallOrConstrcut>
+  void visitCallOrConstructExpr(const CallOrConstrcut *CE,
+                                const FunctionDecl *F, const Decl *D) const {
+    if (F) {
       // Skip the first argument for overloaded member operators (e. g. lambda
       // or std::function call operator).
       unsigned ArgIdx =
@@ -127,7 +131,17 @@ public:
         auto *Arg = CE->getArg(ArgIdx);
         checkArg(Arg, Arg->getType(), nullptr, D);
       }
-    } else if (auto *Decl = CE->getCalleeDecl()) {
+    }
+  }
+
+  void visitCallExpr(const CallExpr *CE, const Decl *D) const {
+    auto *Callee = CE->getDirectCallee();
+    if (shouldSkipCall(CE, Callee))
+      return;
+
+    if (Callee)
+      visitCallOrConstructExpr(CE, Callee, D);
+    else if (auto *Decl = CE->getCalleeDecl()) {
       if (auto *FnType = Decl->getFunctionType()) {
         if (auto *ProtoType = dyn_cast<FunctionProtoType>(FnType)) {
           if (auto *MemberCallExpr = dyn_cast<CXXMemberCallExpr>(CE))
@@ -144,6 +158,14 @@ public:
         }
       }
     }
+  }
+
+  void visitConstructExpr(const CXXConstructExpr *CE, const Decl *D) const {
+    auto *Constructor = CE->getConstructor();
+    if (shouldSkipCall(CE, Constructor))
+      return;
+    if (Constructor)
+      visitCallOrConstructExpr(CE, Constructor, D);
   }
 
   void visitObjCMessageExpr(const ObjCMessageExpr *E, const Decl *D) const {
@@ -245,9 +267,9 @@ public:
         });
   }
 
-  bool shouldSkipCall(const CallExpr *CE) const {
-    const auto *Callee = CE->getDirectCallee();
-
+  template <typename CallOrConstruct>
+  bool shouldSkipCall(const CallOrConstruct *CE,
+                      const FunctionDecl *Callee) const {
     if (BR->getSourceManager().isInSystemHeader(CE->getExprLoc()))
       return true;
 

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -444,6 +444,30 @@ namespace call_with_explicit_temporary_obj {
 }
 
 namespace call_with_explicit_construct {
+  class Obj {
+  public:
+    Obj(RefCountable* obj = provide(), RefCountable* otherObj = nullptr) {
+      // expected-warning@-1{{Call argument for parameter 'obj' is uncounted and unsafe}}
+      consume_refcntbl(obj);
+      if (otherObj)
+        otherObj->method();
+    }
+    Obj(RefCountable& obj) {
+      obj.method();
+    }
+  };
+
+  void foo(RefCountable* arg) {
+    Obj obj1;
+    Obj obj2(provide());
+    // expected-warning@-1{{Call argument for parameter 'obj' is uncounted and unsafe}}
+    Obj obj3(*provide());
+    // expected-warning@-1{{Call argument for parameter 'obj' is uncounted and unsafe}}
+    Obj obj4(Ref<RefCountable> { *provide() }.get());
+    Obj obj5(arg);
+    Obj obj6(arg, provide());
+    // expected-warning@-1{{Call argument for parameter 'otherObj' is uncounted and unsafe}}
+  }
 }
 
 namespace call_with_adopt_ref {
@@ -479,5 +503,4 @@ namespace call_with_weak_ptr {
     weakPtr->method();
     // expected-warning@-1{{Call argument for 'this' parameter is uncounted and unsafe}}
   }
-
 }

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -372,7 +372,7 @@ private:
   template <typename U> friend class CanMakeWeakPtr;
   template <typename U> friend class WeakPtr;
 
-  WeakPtrImpl& createWeakPtrImpl() {
+  WeakPtrImpl& [[clang::annotate_type("webkit.nodelete")]] createWeakPtrImpl() {
     if (!impl)
       impl = WeakPtrImpl::create(static_cast<T&>(*this));
     return *impl;

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -482,9 +482,18 @@ public:
   int nonTrivial14() { int r = 0xff; r |= otherFunction(); return r; }
   void nonTrivial15() { ++complex; }
   void nonTrivial16() { complex++; }
-  ComplexNumber nonTrivial17() { return complex << 2; }
-  ComplexNumber nonTrivial18() { return +complex; }
-  ComplexNumber* nonTrivial19() { return new ComplexNumber(complex); }
+  ComplexNumber nonTrivial17() {
+    return complex << 2;
+    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  }
+  ComplexNumber nonTrivial18() {
+    return +complex;
+    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  }
+  ComplexNumber* nonTrivial19() {
+    return new ComplexNumber(complex);
+    // expected-warning@-1{{Call argument is uncounted and unsafe}}
+  }
   unsigned nonTrivial20() { return ObjectWithMutatingDestructor { 7 }.value(); }
   unsigned nonTrivial21() { return Number("123").value(); }
   unsigned nonTrivial22() { return ComplexNumber(123, "456").real().value(); }


### PR DESCRIPTION
Check arguments of CXXConstructExpr like CallExpr.

This PR fixes a subtle bug in isCtorOfRetainPtrOrOSPtr that it was missing a check for OSObjectPtr,
and it was getting an empty string for the name when getting called on a CXXConstructorDecl
as well as similar bugs in isCtorOf* functions.