### PR TITLE
[IR] Add fast-math support to {u,s}itofp

### DIFF
--- a/clang/test/CodeGenCUDA/amdgpu-atomic-ops.cu
+++ b/clang/test/CodeGenCUDA/amdgpu-atomic-ops.cu
@@ -164,7 +164,7 @@ __device__ double ffp4(double *p, float f) {
 
 __device__ double ffp5(double *p, int i) {
   // FUN-LABEL: @_Z4ffp5Pdi
-  // CHECK: sitofp i32 {{.*}} to double
+  // CHECK: sitofp contract i32 {{.*}} to double
   // SAFEIR: atomicrmw fsub ptr {{.*}} monotonic, align 8, [[DEFMD]]
   // UNSAFEIR: atomicrmw fsub ptr {{.*}} monotonic, align 8, [[DEFMD]]
   __atomic_fetch_sub(p, i, memory_order_relaxed);

--- a/clang/test/CodeGenCUDA/managed-var.cu
+++ b/clang/test/CodeGenCUDA/managed-var.cu
@@ -143,7 +143,7 @@ float load3() {
 // HOST:  %3 = ptrtoint ptr %2 to i64
 // HOST:  %4 = sub i64 %3, %1
 // HOST:  %sub.ptr.div = sdiv exact i64 %4, 4
-// HOST:  %conv = sitofp i64 %sub.ptr.div to float
+// HOST:  %conv = sitofp contract i64 %sub.ptr.div to float
 // HOST:  ret float %conv
 float addr_taken2() {
   return (float)reinterpret_cast<long>(&(v2[1].y)-&(v[1].x));

--- a/clang/test/CodeGenHIP/builtins-amdgcn-vi-f16.hip
+++ b/clang/test/CodeGenHIP/builtins-amdgcn-vi-f16.hip
@@ -225,7 +225,7 @@ __device__ void test_fract_f16(_Float16 *out, _Float16 a) {
 // CHECK-NEXT:    [[TMP0:%.*]] = load half, ptr [[A_ADDR_ASCAST]], align 2
 // CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[B_ADDR_ASCAST]], align 4
 // CHECK-NEXT:    [[TMP2:%.*]] = call i1 @llvm.amdgcn.class.f16(half [[TMP0]], i32 [[TMP1]])
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp i1 [[TMP2]] to half
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp contract i1 [[TMP2]] to half
 // CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[OUT_ADDR_ASCAST]], align 8
 // CHECK-NEXT:    store half [[CONV]], ptr [[TMP3]], align 2
 // CHECK-NEXT:    ret void

--- a/clang/test/CodeGenHLSL/BasicFeatures/AggregateSplatCast.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/AggregateSplatCast.hlsl
@@ -61,7 +61,7 @@ struct S {
 // CHECK-NEXT: [[G1:%.*]] = getelementptr inbounds %struct.S, ptr [[s]], i32 0, i32 0
 // CHECK-NEXT: [[G2:%.*]] = getelementptr inbounds %struct.S, ptr [[s]], i32 0, i32 1
 // CHECK-NEXT: store i32 [[L]], ptr [[G1]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[L]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[L]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call3(int A) {
   S s = (S)A;
@@ -77,7 +77,7 @@ export void call3(int A) {
 // CHECK-NEXT: [[G1:%.*]] = getelementptr inbounds %struct.S, ptr [[s]], i32 0, i32 0
 // CHECK-NEXT: [[G2:%.*]] = getelementptr inbounds %struct.S, ptr [[s]], i32 0, i32 1
 // CHECK-NEXT: store i32 [[VL]], ptr [[G1]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[VL]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[VL]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call5() {
   int1 A = {1};
@@ -110,7 +110,7 @@ export void call9() {
 // CHECK-NEXT: [[G1:%.*]] = getelementptr inbounds %struct.S, ptr [[s]], i32 0, i32 0
 // CHECK-NEXT: [[G2:%.*]] = getelementptr inbounds %struct.S, ptr [[s]], i32 0, i32 1
 // CHECK-NEXT: store i32 [[ML]], ptr [[G1]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[ML]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[ML]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call10() {
   int1x1 M = {1};
@@ -139,7 +139,7 @@ struct Derived : BFields {
 // CHECK-NEXT: [[Gep1:%.*]] = getelementptr inbounds %struct.Derived, ptr [[D]], i32 0, i32 0, i32 0
 // CHECK-NEXT: [[Gep2:%.*]] = getelementptr inbounds %struct.Derived, ptr [[D]], i32 0, i32 0, i32 2
 // CHECK-NEXT: [[Gep3:%.*]] = getelementptr inbounds %struct.Derived, ptr [[D]], i32 0, i32 1
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[B]] to double
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[B]] to double
 // CHECK-NEXT: store double [[C]], ptr [[Gep1]], align 8
 // CHECK-NEXT: [[H:%.*]] = trunc i32 [[B]] to i24
 // CHECK-NEXT: [[BFL:%.*]] = load i24, ptr [[E]], align 1
@@ -147,7 +147,7 @@ struct Derived : BFields {
 // CHECK-NEXT: [[BFC:%.*]] = and i24 [[BFL]], -32768
 // CHECK-NEXT: [[BFS:%.*]] = or i24 [[BFC]], [[BFV]]
 // CHECK-NEXT: store i24 [[BFS]], ptr [[E]], align 1
-// CHECK-NEXT: [[C4:%.*]] = sitofp i32 [[B]] to float
+// CHECK-NEXT: [[C4:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[B]] to float
 // CHECK-NEXT: store float [[C4]], ptr [[Gep2]], align 4
 // CHECK-NEXT: store i32 [[B]], ptr [[Gep3]], align 4
 // CHECK-NEXT: ret void

--- a/clang/test/CodeGenHLSL/BasicFeatures/ArrayElementwiseCast.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/ArrayElementwiseCast.hlsl
@@ -10,7 +10,7 @@
 // CHECK-NEXT: [[G1:%.*]] = getelementptr inbounds [2 x i32], ptr [[Tmp]], i32 0, i32 0
 // CHECK-NEXT: [[G2:%.*]] = getelementptr inbounds [2 x i32], ptr [[Tmp]], i32 0, i32 1
 // CHECK-NEXT: [[L:%.*]] = load i32, ptr [[G1]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[L]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[L]] to float
 // CHECK-NEXT: store float [[C]], ptr [[B]], align 4
 export void call0() {
   int A[2] = {0,1};
@@ -47,7 +47,7 @@ export void call1() {
 // CHECK-NEXT: [[G1:%.*]] = getelementptr inbounds [1 x float], ptr [[B]], i32 0, i32 0
 // CHECK-NEXT: [[G2:%.*]] = getelementptr inbounds [1 x i32], ptr [[Tmp]], i32 0, i32 0
 // CHECK-NEXT: [[L:%.*]] = load i32, ptr [[G2]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[L]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[L]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G1]], align 4
 export void call2() {
   int A[1] = {0};

--- a/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/InitLists.hlsl
@@ -97,7 +97,7 @@ TwoFloats case2() {
 // CHECK-NEXT:    store i32 [[VAL]], ptr [[VAL_ADDR]], align 4
 // CHECK-NEXT:    [[X:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[AGG_RESULT]], i32 0, i32 0
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[VAL_ADDR]], align 4
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[TMP0]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[TMP0]] to float
 // CHECK-NEXT:    store float [[CONV]], ptr [[X]], align 1
 // CHECK-NEXT:    [[Y:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[AGG_RESULT]], i32 0, i32 1
 // CHECK-NEXT:    store float 2.000000e+00, ptr [[Y]], align 1
@@ -119,12 +119,12 @@ TwoFloats case3(int Val) {
 // CHECK-NEXT:    [[X:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[AGG_RESULT]], i32 0, i32 0
 // CHECK-NEXT:    [[TMP0:%.*]] = load <2 x i32>, ptr [[TWOVALS_ADDR]], align 4
 // CHECK-NEXT:    [[VECEXT:%.*]] = extractelement <2 x i32> [[TMP0]], i64 0
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[VECEXT]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[VECEXT]] to float
 // CHECK-NEXT:    store float [[CONV]], ptr [[X]], align 1
 // CHECK-NEXT:    [[Y:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[AGG_RESULT]], i32 0, i32 1
 // CHECK-NEXT:    [[TMP1:%.*]] = load <2 x i32>, ptr [[TWOVALS_ADDR]], align 4
 // CHECK-NEXT:    [[VECEXT1:%.*]] = extractelement <2 x i32> [[TMP1]], i64 1
-// CHECK-NEXT:    [[CONV2:%.*]] = sitofp i32 [[VECEXT1]] to float
+// CHECK-NEXT:    [[CONV2:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[VECEXT1]] to float
 // CHECK-NEXT:    store float [[CONV2]], ptr [[Y]], align 1
 // CHECK-NEXT:    ret void
 //
@@ -205,7 +205,7 @@ TwoInts case6(TwoFloats TF4) {
 // CHECK-NEXT:    store i32 [[TMP4]], ptr [[TAILSTATE]], align 1
 // CHECK-NEXT:    [[HAIRCOUNT:%.*]] = getelementptr inbounds nuw [[STRUCT_DOGGO]], ptr [[AGG_RESULT]], i32 0, i32 2
 // CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[VAL_ADDR]], align 4
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[TMP5]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[TMP5]] to float
 // CHECK-NEXT:    store float [[CONV]], ptr [[HAIRCOUNT]], align 1
 // CHECK-NEXT:    [[EARDIRECTION:%.*]] = getelementptr inbounds nuw [[STRUCT_DOGGO]], ptr [[AGG_RESULT]], i32 0, i32 3
 // CHECK-NEXT:    [[X:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[TF1]], i32 0, i32 0
@@ -433,7 +433,7 @@ AnimalBits case8(Doggo D1) {
 // CHECK-NEXT:    [[HAIRCOUNT58:%.*]] = getelementptr inbounds nuw [[STRUCT_DOGGO]], ptr [[ARRAYINIT_ELEMENT44]], i32 0, i32 2
 // CHECK-NEXT:    [[COUNTER:%.*]] = getelementptr inbounds nuw [[STRUCT_ANIMALBITS]], ptr [[A1]], i32 0, i32 2
 // CHECK-NEXT:    [[TMP19:%.*]] = load i64, ptr [[COUNTER]], align 1
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i64 [[TMP19]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i64 [[TMP19]] to float
 // CHECK-NEXT:    store float [[CONV]], ptr [[HAIRCOUNT58]], align 1
 // CHECK-NEXT:    [[EARDIRECTION59:%.*]] = getelementptr inbounds nuw [[STRUCT_DOGGO]], ptr [[ARRAYINIT_ELEMENT44]], i32 0, i32 3
 // CHECK-NEXT:    [[LEFTDIR:%.*]] = getelementptr inbounds nuw [[STRUCT_ANIMALBITS]], ptr [[A1]], i32 0, i32 3
@@ -568,7 +568,7 @@ AnimalBits case8(Doggo D1) {
 // CHECK-NEXT:    [[HAIRCOUNT149:%.*]] = getelementptr inbounds nuw [[STRUCT_KITTEH]], ptr [[ARRAYINIT_ELEMENT133]], i32 0, i32 2
 // CHECK-NEXT:    [[COUNTER150:%.*]] = getelementptr inbounds nuw [[STRUCT_ANIMALBITS]], ptr [[A1]], i32 0, i32 2
 // CHECK-NEXT:    [[TMP47:%.*]] = load i64, ptr [[COUNTER150]], align 1
-// CHECK-NEXT:    [[CONV151:%.*]] = sitofp i64 [[TMP47]] to float
+// CHECK-NEXT:    [[CONV151:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i64 [[TMP47]] to float
 // CHECK-NEXT:    store float [[CONV151]], ptr [[HAIRCOUNT149]], align 1
 // CHECK-NEXT:    [[CLAWS152:%.*]] = getelementptr inbounds nuw [[STRUCT_KITTEH]], ptr [[ARRAYINIT_ELEMENT133]], i32 0, i32 3
 // CHECK-NEXT:    [[LEFTDIR153:%.*]] = getelementptr inbounds nuw [[STRUCT_ANIMALBITS]], ptr [[A1]], i32 0, i32 3
@@ -703,7 +703,7 @@ AnimalBits case8(Doggo D1) {
 // CHECK-NEXT:    [[HAIRCOUNT246:%.*]] = getelementptr inbounds nuw [[STRUCT_KITTEH]], ptr [[ARRAYINIT_ELEMENT230]], i32 0, i32 2
 // CHECK-NEXT:    [[COUNTER247:%.*]] = getelementptr inbounds nuw [[STRUCT_ANIMALBITS]], ptr [[A1]], i32 0, i32 2
 // CHECK-NEXT:    [[TMP75:%.*]] = load i64, ptr [[COUNTER247]], align 1
-// CHECK-NEXT:    [[CONV248:%.*]] = sitofp i64 [[TMP75]] to float
+// CHECK-NEXT:    [[CONV248:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i64 [[TMP75]] to float
 // CHECK-NEXT:    store float [[CONV248]], ptr [[HAIRCOUNT246]], align 1
 // CHECK-NEXT:    [[CLAWS249:%.*]] = getelementptr inbounds nuw [[STRUCT_KITTEH]], ptr [[ARRAYINIT_ELEMENT230]], i32 0, i32 3
 // CHECK-NEXT:    [[LEFTDIR250:%.*]] = getelementptr inbounds nuw [[STRUCT_ANIMALBITS]], ptr [[A1]], i32 0, i32 3
@@ -899,13 +899,13 @@ TwoInts case14(SlicyBits SB) {
 // CHECK-NEXT:    [[X:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[AGG_RESULT]], i32 0, i32 0
 // CHECK-NEXT:    [[BF_LOAD:%.*]] = load i8, ptr [[SB]], align 1
 // CHECK-NEXT:    [[BF_CAST:%.*]] = sext i8 [[BF_LOAD]] to i32
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[BF_CAST]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[BF_CAST]] to float
 // CHECK-NEXT:    store float [[CONV]], ptr [[X]], align 1
 // CHECK-NEXT:    [[Y:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOFLOATS]], ptr [[AGG_RESULT]], i32 0, i32 1
 // CHECK-NEXT:    [[W:%.*]] = getelementptr inbounds nuw [[STRUCT_SLICYBITS]], ptr [[SB]], i32 0, i32 1
 // CHECK-NEXT:    [[BF_LOAD1:%.*]] = load i8, ptr [[W]], align 1
 // CHECK-NEXT:    [[BF_CAST2:%.*]] = sext i8 [[BF_LOAD1]] to i32
-// CHECK-NEXT:    [[CONV3:%.*]] = sitofp i32 [[BF_CAST2]] to float
+// CHECK-NEXT:    [[CONV3:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[BF_CAST2]] to float
 // CHECK-NEXT:    store float [[CONV3]], ptr [[Y]], align 1
 // CHECK-NEXT:    ret void
 //
@@ -1130,22 +1130,22 @@ void case25(EmptyDerived ED, UnnamedDerived UD) {
 // CHECK-NEXT:    [[F2:%.*]] = alloca <3 x float>, align 4
 // CHECK-NEXT:    [[Z:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOINTS]], ptr [[TI]], i32 0, i32 0
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[Z]], align 1
-// CHECK-NEXT:    [[CONV:%.*]] = sitofp i32 [[TMP0]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[TMP0]] to float
 // CHECK-NEXT:    [[VECINIT:%.*]] = insertelement <4 x float> poison, float [[CONV]], i32 0
 // CHECK-NEXT:    [[W:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOINTS]], ptr [[TI]], i32 0, i32 1
 // CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[W]], align 1
-// CHECK-NEXT:    [[CONV1:%.*]] = sitofp i32 [[TMP1]] to float
+// CHECK-NEXT:    [[CONV1:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[TMP1]] to float
 // CHECK-NEXT:    [[VECINIT2:%.*]] = insertelement <4 x float> [[VECINIT]], float [[CONV1]], i32 1
 // CHECK-NEXT:    [[VECINIT3:%.*]] = insertelement <4 x float> [[VECINIT2]], float 1.000000e+00, i32 2
 // CHECK-NEXT:    [[VECINIT4:%.*]] = insertelement <4 x float> [[VECINIT3]], float 2.000000e+00, i32 3
 // CHECK-NEXT:    store <4 x float> [[VECINIT4]], ptr [[F]], align 4
 // CHECK-NEXT:    [[Z5:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOINTS]], ptr [[TI]], i32 0, i32 0
 // CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[Z5]], align 1
-// CHECK-NEXT:    [[CONV6:%.*]] = sitofp i32 [[TMP2]] to float
+// CHECK-NEXT:    [[CONV6:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[TMP2]] to float
 // CHECK-NEXT:    [[VECINIT7:%.*]] = insertelement <3 x float> <float 3.000000e+00, float poison, float poison>, float [[CONV6]], i32 1
 // CHECK-NEXT:    [[W8:%.*]] = getelementptr inbounds nuw [[STRUCT_TWOINTS]], ptr [[TI]], i32 0, i32 1
 // CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[W8]], align 1
-// CHECK-NEXT:    [[CONV9:%.*]] = sitofp i32 [[TMP3]] to float
+// CHECK-NEXT:    [[CONV9:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[TMP3]] to float
 // CHECK-NEXT:    [[VECINIT10:%.*]] = insertelement <3 x float> [[VECINIT7]], float [[CONV9]], i32 2
 // CHECK-NEXT:    store <3 x float> [[VECINIT10]], ptr [[F2]], align 4
 // CHECK-NEXT:    ret void

--- a/clang/test/CodeGenHLSL/BasicFeatures/MatrixSplat.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/MatrixSplat.hlsl
@@ -154,7 +154,7 @@ void ExplicitFloatToBoolCastThenSplat(float2 Value) {
 // CHECK-NEXT:    store i32 [[STOREDV]], ptr [[VALUE_ADDR]], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[VALUE_ADDR]], align 4
 // CHECK-NEXT:    [[LOADEDV:%.*]] = icmp ne i32 [[TMP0]], 0
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp i1 [[LOADEDV]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp reassoc nnan ninf nsz arcp afn i1 [[LOADEDV]] to float
 // CHECK-NEXT:    [[SPLAT_SPLATINSERT:%.*]] = insertelement <6 x float> poison, float [[CONV]], i64 0
 // CHECK-NEXT:    [[SPLAT_SPLAT:%.*]] = shufflevector <6 x float> [[SPLAT_SPLATINSERT]], <6 x float> poison, <6 x i32> zeroinitializer
 // CHECK-NEXT:    store <6 x float> [[SPLAT_SPLAT]], ptr [[M]], align 4
@@ -193,7 +193,7 @@ void ImplicitFloatToBoolCastThenSplat(float Value) {
 // CHECK-NEXT:    store i32 [[STOREDV]], ptr [[VALUE_ADDR]], align 4
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[VALUE_ADDR]], align 4
 // CHECK-NEXT:    [[LOADEDV:%.*]] = icmp ne i32 [[TMP0]], 0
-// CHECK-NEXT:    [[CONV:%.*]] = uitofp i1 [[LOADEDV]] to float
+// CHECK-NEXT:    [[CONV:%.*]] = uitofp reassoc nnan ninf nsz arcp afn i1 [[LOADEDV]] to float
 // CHECK-NEXT:    [[SPLAT_SPLATINSERT:%.*]] = insertelement <6 x float> poison, float [[CONV]], i64 0
 // CHECK-NEXT:    [[SPLAT_SPLAT:%.*]] = shufflevector <6 x float> [[SPLAT_SPLATINSERT]], <6 x float> poison, <6 x i32> zeroinitializer
 // CHECK-NEXT:    store <6 x float> [[SPLAT_SPLAT]], ptr [[M]], align 4

--- a/clang/test/CodeGenHLSL/BasicFeatures/OutputArguments.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/OutputArguments.hlsl
@@ -17,10 +17,10 @@ void trunc_Param(inout int X) {}
 // CHECK: store i32 [[IVal]], ptr [[ArgTmp]]
 // CHECK: call void {{.*}}trunc_Param{{.*}}(ptr noalias noundef nonnull align 4 dereferenceable(4) [[ArgTmp]])
 // CHECK: [[IRet:%.*]] = load i32, ptr [[ArgTmp]]
-// CHECK: [[FRet:%.*]] = sitofp i32 [[IRet]] to float
+// CHECK: [[FRet:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[IRet]] to float
 // CHECK: store float [[FRet]], ptr [[F]]
 // OPT: [[IVal:%.*]] = fptosi float {{.*}} to i32
-// OPT: [[FVal:%.*]] = sitofp i32 [[IVal]] to float
+// OPT: [[FVal:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[IVal]] to float
 // OPT: ret float [[FVal]]
 export float case1(float F) {
   trunc_Param(F);
@@ -212,11 +212,11 @@ void trunc_vec(inout int3 V) {}
 // CHECK: store <3 x i32> [[IVal]], ptr [[Tmp]]
 // CHECK: call void {{.*}}trunc_vec{{.*}}(ptr noalias noundef nonnull align 4 dereferenceable(12) [[Tmp]])
 // CHECK: [[IRet:%.*]] = load <3 x i32>, ptr [[Tmp]]
-// CHECK: [[FRet:%.*]] = sitofp <3 x i32> [[IRet]] to <3 x float>
+// CHECK: [[FRet:%.*]] = sitofp reassoc nnan ninf nsz arcp afn <3 x i32> [[IRet]] to <3 x float>
 // CHECK: store <3 x float> [[FRet]], ptr [[V]]
 
 // OPT: [[IVal:%.*]] = fptosi <3 x float> {{.*}} to <3 x i32>
-// OPT: [[FVal:%.*]] = sitofp <3 x i32> [[IVal]] to <3 x float>
+// OPT: [[FVal:%.*]] = sitofp reassoc nnan ninf nsz arcp afn <3 x i32> [[IVal]] to <3 x float>
 // OPT: ret <3 x float> [[FVal]]
 
 export float3 case8(float3 V) {

--- a/clang/test/CodeGenHLSL/BasicFeatures/StructElementwiseCast.hlsl
+++ b/clang/test/CodeGenHLSL/BasicFeatures/StructElementwiseCast.hlsl
@@ -32,7 +32,7 @@ export void call0() {
 // CHECK-NEXT: [[VL:%.*]] = extractelement <2 x i32> [[L]], i64 0
 // CHECK-NEXT: store i32 [[VL]], ptr [[G1]], align 4
 // CHECK-NEXT: [[VL2:%.*]] = extractelement <2 x i32> [[L]], i64 1
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[VL2]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[VL2]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call1() {
   int2 A = {1,2};
@@ -54,7 +54,7 @@ export void call1() {
 // CHECK-NEXT: [[L:%.*]] = load i32, ptr [[G3]], align 4
 // CHECK-NEXT: store i32 [[L]], ptr [[G1]], align 4
 // CHECK-NEXT: [[L4:%.*]] = load i32, ptr [[G4]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[L4]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[L4]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call2() {
   int A[2] = {1,2};
@@ -104,7 +104,7 @@ export void call6() {
 // CHECK-NEXT: [[L:%.*]] = load i32, ptr [[G3]], align 4
 // CHECK-NEXT: store i32 [[L]], ptr [[G1]], align 4
 // CHECK-NEXT: [[L4:%.*]] = load i32, ptr [[G4]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[L4]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[L4]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call7() {
   int A[2] = {1,2};
@@ -132,7 +132,7 @@ struct T {
 // CHECK-NEXT: [[L1:%.*]] = load i32, ptr [[G3]], align 4
 // CHECK-NEXT: store i32 [[L1]], ptr [[G1]], align 4
 // CHECK-NEXT: [[L2:%.*]] = load i32, ptr [[G4]], align 4
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[L2]] to float
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[L2]] to float
 // CHECK-NEXT: store float [[C]], ptr [[G2]], align 4
 export void call8() {
   T t = {1,2,3};
@@ -179,7 +179,7 @@ export void call9(Derived D) {
 // CHECK-NEXT: [[Gep2:%.*]] = getelementptr inbounds %struct.Derived, ptr [[D]], i32 0, i32 0, i32 2
 // CHECK-NEXT: [[Gep3:%.*]] = getelementptr inbounds %struct.Derived, ptr [[D]], i32 0, i32 1
 // CHECK-NEXT: [[VL:%.*]] = extractelement <4 x i32> [[A]], i64 0
-// CHECK-NEXT: [[C:%.*]] = sitofp i32 [[VL]] to double
+// CHECK-NEXT: [[C:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[VL]] to double
 // CHECK-NEXT: store double [[C]], ptr [[Gep1]], align 8
 // CHECK-NEXT: [[VL4:%.*]] = extractelement <4 x i32> [[A]], i64 1
 // CHECK-NEXT: [[B:%.*]] = trunc i32 [[VL4]] to i24
@@ -189,7 +189,7 @@ export void call9(Derived D) {
 // CHECK-NEXT: [[BFSet:%.*]] = or i24 [[BFC]], [[BFV]]
 // CHECK-NEXT: store i24 [[BFSet]], ptr [[E]], align 1
 // CHECK-NEXT: [[VL5:%.*]] = extractelement <4 x i32> [[A]], i64 2
-// CHECK-NEXT: [[C6:%.*]] = sitofp i32 [[VL5]] to float
+// CHECK-NEXT: [[C6:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[VL5]] to float
 // CHECK-NEXT: store float [[C6]], ptr [[Gep2]], align 4
 // CHECK-NEXT: [[VL7:%.*]] = extractelement <4 x i32> [[A]], i64 3
 // CHECK-NEXT: store i32 [[VL7]], ptr [[Gep3]], align 4
@@ -284,7 +284,7 @@ struct MoreBFields {
 // CHECK-NEXT: [[BFS:%.*]] = or i64 [[BFC]], [[BFV]]
 // CHECK-NEXT: store i64 [[BFS]], ptr [[FieldB]], align 1
 // store int A into field C
-// CHECK-NEXT: [[Conv5:%.*]] = sitofp i32 [[Z]] to float
+// CHECK-NEXT: [[Conv5:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[Z]] to float
 // CHECK-NEXT: store float [[Conv5]], ptr [[FieldC]], align 4
 // store int A into bitfield D
 // CHECK-NEXT: [[Conv6:%.*]] = trunc i32 [[Z]] to i16
@@ -302,7 +302,7 @@ struct MoreBFields {
 // CHECK-NEXT: [[FES:%.*]] = or i16 [[FEC]], [[FESHL]]
 // CHECK-NEXT: store i16 [[FES]], ptr [[FieldE]], align 1
 // store int A into field F
-// CHECK-NEXT: [[Conv16:%.*]] = sitofp i32 [[Z]] to double
+// CHECK-NEXT: [[Conv16:%.*]] = sitofp reassoc nnan ninf nsz arcp afn i32 [[Z]] to double
 // CHECK-NEXT: store double [[Conv16]], ptr [[FieldF]], align 8
 // store int A into field G
 // CHECK-NEXT: store i32 [[Z]], ptr [[FieldG]], align 4

--- a/clang/test/CodeGenHLSL/Operators/logical-not.hlsl
+++ b/clang/test/CodeGenHLSL/Operators/logical-not.hlsl
@@ -19,7 +19,7 @@ export int32_t3 case2(int32_t3 b) {
 // CHECK-LABEL: case3
 // CHECK: [[ToBool:%.*]] = fcmp reassoc nnan ninf nsz arcp afn une half {{.*}}, 0.000000e+00
 // CHECK-NEXT: [[BoolCmp:%.*]] = xor i1 [[ToBool]], true
-// CHECK-NEXT: {{.*}} = uitofp i1 [[BoolCmp]] to half
+// CHECK-NEXT: {{.*}} = uitofp reassoc nnan ninf nsz arcp afn i1 [[BoolCmp]] to half
 export float16_t case3(float16_t b) {
     return !b;
 }
@@ -27,7 +27,7 @@ export float16_t case3(float16_t b) {
 // CHECK-LABEL: case4
 // CHECK: [[ToBool:%.*]] = fcmp reassoc nnan ninf nsz arcp afn une <4 x float> {{.*}}, zeroinitializer
 // CHECK-NEXT: [[BoolCmp:%.*]] = icmp eq <4 x i1> [[ToBool]], zeroinitializer
-// CHECK-NEXT: {{.*}} = uitofp <4 x i1> [[BoolCmp]] to <4 x float>
+// CHECK-NEXT: {{.*}} = uitofp reassoc nnan ninf nsz arcp afn <4 x i1> [[BoolCmp]] to <4 x float>
 export float4 case4(float4 b) {
     return !b;
 }

--- a/clang/test/CodeGenHLSL/builtins/acos-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/acos-overloads.hlsl
@@ -47,7 +47,7 @@ float4 test_acos_double4 ( double4 p0 ) {
 
 // CHECK: define [[FNATTRS]] float @_Z13test_acos_inti(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_int ( int p0 ) {
@@ -57,7 +57,7 @@ float test_acos_int ( int p0 ) {
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_acos_int2Dv2_i(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_int2 ( int2 p0 ) {
@@ -67,7 +67,7 @@ float2 test_acos_int2 ( int2 p0 ) {
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_acos_int3Dv3_i(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_int3 ( int3 p0 ) {
@@ -77,7 +77,7 @@ float3 test_acos_int3 ( int3 p0 ) {
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_acos_int4Dv4_i(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_int4 ( int4 p0 ) {
@@ -87,7 +87,7 @@ float4 test_acos_int4 ( int4 p0 ) {
 
 // CHECK: define [[FNATTRS]] float @_Z14test_acos_uintj(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_uint ( uint p0 ) {
@@ -97,7 +97,7 @@ float test_acos_uint ( uint p0 ) {
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_acos_uint2Dv2_j(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_uint2 ( uint2 p0 ) {
@@ -107,7 +107,7 @@ float2 test_acos_uint2 ( uint2 p0 ) {
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_acos_uint3Dv3_j(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_uint3 ( uint3 p0 ) {
@@ -117,7 +117,7 @@ float3 test_acos_uint3 ( uint3 p0 ) {
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_acos_uint4Dv4_j(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_uint4 ( uint4 p0 ) {
@@ -127,7 +127,7 @@ float4 test_acos_uint4 ( uint4 p0 ) {
 
 // CHECK: define [[FNATTRS]] float @_Z17test_acos_int64_tl(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_int64_t ( int64_t p0 ) {
@@ -137,7 +137,7 @@ float test_acos_int64_t ( int64_t p0 ) {
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_acos_int64_t2Dv2_l(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_int64_t2 ( int64_t2 p0 ) {
@@ -147,7 +147,7 @@ float2 test_acos_int64_t2 ( int64_t2 p0 ) {
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_acos_int64_t3Dv3_l(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_int64_t3 ( int64_t3 p0 ) {
@@ -157,7 +157,7 @@ float3 test_acos_int64_t3 ( int64_t3 p0 ) {
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_acos_int64_t4Dv4_l(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_int64_t4 ( int64_t4 p0 ) {
@@ -167,7 +167,7 @@ float4 test_acos_int64_t4 ( int64_t4 p0 ) {
 
 // CHECK: define [[FNATTRS]] float @_Z18test_acos_uint64_tm(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.acos.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_acos_uint64_t ( uint64_t p0 ) {
@@ -177,7 +177,7 @@ float test_acos_uint64_t ( uint64_t p0 ) {
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_acos_uint64_t2Dv2_m(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.acos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_acos_uint64_t2 ( uint64_t2 p0 ) {
@@ -187,7 +187,7 @@ float2 test_acos_uint64_t2 ( uint64_t2 p0 ) {
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_acos_uint64_t3Dv3_m(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.acos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_acos_uint64_t3 ( uint64_t3 p0 ) {
@@ -197,7 +197,7 @@ float3 test_acos_uint64_t3 ( uint64_t3 p0 ) {
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_acos_uint64_t4Dv4_m(
 // CHECK:    [[V0:%.*]] = call token @llvm.experimental.convergence.entry()
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.acos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_acos_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/asin-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/asin-overloads.hlsl
@@ -42,7 +42,7 @@ float4 test_asin_double4 ( double4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_asin_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_int ( int p0 ) {
@@ -51,7 +51,7 @@ float test_asin_int ( int p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_asin_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_int2 ( int2 p0 ) {
@@ -60,7 +60,7 @@ float2 test_asin_int2 ( int2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_asin_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_int3 ( int3 p0 ) {
@@ -69,7 +69,7 @@ float3 test_asin_int3 ( int3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_asin_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_int4 ( int4 p0 ) {
@@ -78,7 +78,7 @@ float4 test_asin_int4 ( int4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_asin_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_uint ( uint p0 ) {
@@ -87,7 +87,7 @@ float test_asin_uint ( uint p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_asin_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_uint2 ( uint2 p0 ) {
@@ -96,7 +96,7 @@ float2 test_asin_uint2 ( uint2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_asin_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_uint3 ( uint3 p0 ) {
@@ -105,7 +105,7 @@ float3 test_asin_uint3 ( uint3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_asin_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_uint4 ( uint4 p0 ) {
@@ -114,7 +114,7 @@ float4 test_asin_uint4 ( uint4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_asin_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_int64_t ( int64_t p0 ) {
@@ -123,7 +123,7 @@ float test_asin_int64_t ( int64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_asin_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_int64_t2 ( int64_t2 p0 ) {
@@ -132,7 +132,7 @@ float2 test_asin_int64_t2 ( int64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_asin_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_int64_t3 ( int64_t3 p0 ) {
@@ -141,7 +141,7 @@ float3 test_asin_int64_t3 ( int64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_asin_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_int64_t4 ( int64_t4 p0 ) {
@@ -150,7 +150,7 @@ float4 test_asin_int64_t4 ( int64_t4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_asin_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.asin.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_asin_uint64_t ( uint64_t p0 ) {
@@ -159,7 +159,7 @@ float test_asin_uint64_t ( uint64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_asin_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.asin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_asin_uint64_t2 ( uint64_t2 p0 ) {
@@ -168,7 +168,7 @@ float2 test_asin_uint64_t2 ( uint64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_asin_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.asin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_asin_uint64_t3 ( uint64_t3 p0 ) {
@@ -177,7 +177,7 @@ float3 test_asin_uint64_t3 ( uint64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_asin_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.asin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_asin_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/atan-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan-overloads.hlsl
@@ -42,7 +42,7 @@ float4 test_atan_double4 ( double4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_atan_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_int ( int p0 ) {
@@ -51,7 +51,7 @@ float test_atan_int ( int p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_atan_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_int2 ( int2 p0 ) {
@@ -60,7 +60,7 @@ float2 test_atan_int2 ( int2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_atan_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_int3 ( int3 p0 ) {
@@ -69,7 +69,7 @@ float3 test_atan_int3 ( int3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_atan_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_int4 ( int4 p0 ) {
@@ -78,7 +78,7 @@ float4 test_atan_int4 ( int4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_atan_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_uint ( uint p0 ) {
@@ -87,7 +87,7 @@ float test_atan_uint ( uint p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_atan_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_uint2 ( uint2 p0 ) {
@@ -96,7 +96,7 @@ float2 test_atan_uint2 ( uint2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_atan_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_uint3 ( uint3 p0 ) {
@@ -105,7 +105,7 @@ float3 test_atan_uint3 ( uint3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_atan_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_uint4 ( uint4 p0 ) {
@@ -114,7 +114,7 @@ float4 test_atan_uint4 ( uint4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_atan_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_int64_t ( int64_t p0 ) {
@@ -123,7 +123,7 @@ float test_atan_int64_t ( int64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_atan_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_int64_t2 ( int64_t2 p0 ) {
@@ -132,7 +132,7 @@ float2 test_atan_int64_t2 ( int64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_atan_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_int64_t3 ( int64_t3 p0 ) {
@@ -141,7 +141,7 @@ float3 test_atan_int64_t3 ( int64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_atan_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_int64_t4 ( int64_t4 p0 ) {
@@ -150,7 +150,7 @@ float4 test_atan_int64_t4 ( int64_t4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_atan_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.atan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_atan_uint64_t ( uint64_t p0 ) {
@@ -159,7 +159,7 @@ float test_atan_uint64_t ( uint64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_atan_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.atan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_atan_uint64_t2 ( uint64_t2 p0 ) {
@@ -168,7 +168,7 @@ float2 test_atan_uint64_t2 ( uint64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_atan_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.atan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_atan_uint64_t3 ( uint64_t3 p0 ) {
@@ -177,7 +177,7 @@ float3 test_atan_uint64_t3 ( uint64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_atan_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.atan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_atan_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/atan2-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan2-overloads.hlsl
@@ -39,8 +39,8 @@ float4 test_atan2_double4 (double4 p0, double4 p1) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_atan2_intii(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V5:%.*]] = call {{.*}} float @llvm.atan2.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[V5]]
 float test_atan2_int (int p0, int p1) {
@@ -48,8 +48,8 @@ float test_atan2_int (int p0, int p1) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_atan2_int2Dv2_iS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <2 x float> @llvm.atan2.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[V5]]
 float2 test_atan2_int2 (int2 p0, int2 p1) {
@@ -57,8 +57,8 @@ float2 test_atan2_int2 (int2 p0, int2 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_atan2_int3Dv3_iS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <3 x float> @llvm.atan2.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[V5]]
 float3 test_atan2_int3 (int3 p0, int3 p1) {
@@ -66,8 +66,8 @@ float3 test_atan2_int3 (int3 p0, int3 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_atan2_int4Dv4_iS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <4 x float> @llvm.atan2.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[V5]]
 float4 test_atan2_int4 (int4 p0, int4 p1) {
@@ -75,8 +75,8 @@ float4 test_atan2_int4 (int4 p0, int4 p1) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_atan2_uintjj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V5:%.*]] = call {{.*}} float @llvm.atan2.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[V5]]
 float test_atan2_uint (uint p0, uint p1) {
@@ -84,8 +84,8 @@ float test_atan2_uint (uint p0, uint p1) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_atan2_uint2Dv2_jS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <2 x float> @llvm.atan2.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[V5]]
 float2 test_atan2_uint2 (uint2 p0, uint2 p1) {
@@ -93,8 +93,8 @@ float2 test_atan2_uint2 (uint2 p0, uint2 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_atan2_uint3Dv3_jS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <3 x float> @llvm.atan2.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[V5]]
 float3 test_atan2_uint3 (uint3 p0, uint3 p1) {
@@ -102,8 +102,8 @@ float3 test_atan2_uint3 (uint3 p0, uint3 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_atan2_uint4Dv4_jS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <4 x float> @llvm.atan2.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[V5]]
 float4 test_atan2_uint4 (uint4 p0, uint4 p1) {
@@ -111,8 +111,8 @@ float4 test_atan2_uint4 (uint4 p0, uint4 p1) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_atan2_int64_tll(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V5:%.*]] = call {{.*}} float @llvm.atan2.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[V5]]
 float test_atan2_int64_t (int64_t p0, int64_t p1) {
@@ -120,8 +120,8 @@ float test_atan2_int64_t (int64_t p0, int64_t p1) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_atan2_int64_t2Dv2_lS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <2 x float> @llvm.atan2.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[V5]]
 float2 test_atan2_int64_t2 (int64_t2 p0, int64_t2 p1) {
@@ -129,8 +129,8 @@ float2 test_atan2_int64_t2 (int64_t2 p0, int64_t2 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_atan2_int64_t3Dv3_lS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <3 x float> @llvm.atan2.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[V5]]
 float3 test_atan2_int64_t3 (int64_t3 p0, int64_t3 p1) {
@@ -138,8 +138,8 @@ float3 test_atan2_int64_t3 (int64_t3 p0, int64_t3 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_atan2_int64_t4Dv4_lS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <4 x float> @llvm.atan2.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[V5]]
 float4 test_atan2_int64_t4 (int64_t4 p0, int64_t4 p1) {
@@ -147,8 +147,8 @@ float4 test_atan2_int64_t4 (int64_t4 p0, int64_t4 p1) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_atan2_uint64_tmm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V5:%.*]] = call {{.*}} float @llvm.atan2.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[V5]]
 float test_atan2_uint64_t (uint64_t p0, uint64_t p1) {
@@ -156,8 +156,8 @@ float test_atan2_uint64_t (uint64_t p0, uint64_t p1) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_atan2_uint64_t2Dv2_mS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <2 x float> @llvm.atan2.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[V5]]
 float2 test_atan2_uint64_t2 (uint64_t2 p0, uint64_t2 p1) {
@@ -165,8 +165,8 @@ float2 test_atan2_uint64_t2 (uint64_t2 p0, uint64_t2 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_atan2_uint64_t3Dv3_mS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <3 x float> @llvm.atan2.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[V5]]
 float3 test_atan2_uint64_t3 (uint64_t3 p0, uint64_t3 p1) {
@@ -174,8 +174,8 @@ float3 test_atan2_uint64_t3 (uint64_t3 p0, uint64_t3 p1) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_atan2_uint64_t4Dv4_mS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <4 x float> @llvm.atan2.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[V5]]
 float4 test_atan2_uint64_t4 (uint64_t4 p0, uint64_t4 p1) {

--- a/clang/test/CodeGenHLSL/builtins/atan2-overloads_mat.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan2-overloads_mat.hlsl
@@ -16,8 +16,8 @@ float3x4 test_atan2_double3x4 (double3x4 p0, double3x4 p1) {
 }
 
 // CHECK: define hidden [[SPIR_FUNC]]noundef nofpclass(nan inf) <12 x float> @_{{.*}}test_atan2_uint3x4{{.*}}(
-// CHECK:    [[CONVI:%.*]] = uitofp <12 x i32> %{{.*}} to <12 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <12 x i32> %{{.*}} to <12 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <12 x i32> %{{.*}} to <12 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <12 x i32> %{{.*}} to <12 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <12 x float> @llvm.atan2.v12f32(<12 x float> [[CONVI]], <12 x float> [[CONV1I]])
 // CHECK:    ret <12 x float> [[V5]]
 float3x4 test_atan2_uint3x4 (uint3x4 p0, uint3x4 p1) {
@@ -25,8 +25,8 @@ float3x4 test_atan2_uint3x4 (uint3x4 p0, uint3x4 p1) {
 }
 
 // CHECK: define hidden [[SPIR_FUNC]]noundef nofpclass(nan inf) <12 x float> @_{{.*}}test_atan2_int3x4{{.*}}(
-// CHECK:    [[CONVI:%.*]] = sitofp <12 x i32> %{{.*}} to <12 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <12 x i32> %{{.*}} to <12 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <12 x i32> %{{.*}} to <12 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <12 x i32> %{{.*}} to <12 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <12 x float> @llvm.atan2.v12f32(<12 x float> [[CONVI]], <12 x float> [[CONV1I]])
 // CHECK:    ret <12 x float> [[V5]]
 float3x4 test_atan2_int3x4 (int3x4 p0, int3x4 p1) {
@@ -34,8 +34,8 @@ float3x4 test_atan2_int3x4 (int3x4 p0, int3x4 p1) {
 }
 
 // CHECK: define hidden [[SPIR_FUNC]]noundef nofpclass(nan inf) <12 x float> @_{{.*}}test_atan2_int64_t3x4{{.*}}(
-// CHECK:    [[CONVI:%.*]] = sitofp <12 x i64> %{{.*}} to <12 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <12 x i64> %{{.*}} to <12 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <12 x i64> %{{.*}} to <12 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <12 x i64> %{{.*}} to <12 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <12 x float> @llvm.atan2.v12f32(<12 x float> [[CONVI]], <12 x float> [[CONV1I]])
 // CHECK:    ret <12 x float> [[V5]]
 float3x4 test_atan2_int64_t3x4 (int64_t3x4 p0, int64_t3x4 p1) {
@@ -43,8 +43,8 @@ float3x4 test_atan2_int64_t3x4 (int64_t3x4 p0, int64_t3x4 p1) {
 }
 
 // CHECK: define hidden [[SPIR_FUNC]]noundef nofpclass(nan inf) <12 x float> @_{{.*}}test_atan2_uint64_t3x4{{.*}}(
-// CHECK:    [[CONVI:%.*]] = uitofp <12 x i64> %{{.*}} to <12 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <12 x i64> %{{.*}} to <12 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <12 x i64> %{{.*}} to <12 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <12 x i64> %{{.*}} to <12 x float>
 // CHECK:    [[V5:%.*]] = call {{.*}} <12 x float> @llvm.atan2.v12f32(<12 x float> [[CONVI]], <12 x float> [[CONV1I]])
 // CHECK:    ret <12 x float> [[V5]]
 float3x4 test_atan2_uint64_t3x4 (uint64_t3x4 p0, uint64_t3x4 p1) {

--- a/clang/test/CodeGenHLSL/builtins/ceil-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ceil-overloads.hlsl
@@ -26,69 +26,69 @@ float3 test_ceil_double3(double3 p0) { return ceil(p0); }
 float4 test_ceil_double4(double4 p0) { return ceil(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_ceil_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 float test_ceil_int(int p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_ceil_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 float2 test_ceil_int2(int2 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_ceil_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 float3 test_ceil_int3(int3 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_ceil_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 float4 test_ceil_int4(int4 p0) { return ceil(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_ceil_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 float test_ceil_uint(uint p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_ceil_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 float2 test_ceil_uint2(uint2 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_ceil_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 float3 test_ceil_uint3(uint3 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_ceil_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 float4 test_ceil_uint4(uint4 p0) { return ceil(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_ceil_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 float test_ceil_int64_t(int64_t p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_ceil_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 float2 test_ceil_int64_t2(int64_t2 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_ceil_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 float3 test_ceil_int64_t3(int64_t3 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_ceil_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 float4 test_ceil_int64_t4(int64_t4 p0) { return ceil(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_ceil_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 float test_ceil_uint64_t(uint64_t p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_ceil_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 float2 test_ceil_uint64_t2(uint64_t2 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_ceil_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 float3 test_ceil_uint64_t3(uint64_t3 p0) { return ceil(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_ceil_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 float4 test_ceil_uint64_t4(uint64_t4 p0) { return ceil(p0); }

--- a/clang/test/CodeGenHLSL/builtins/cos-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cos-overloads.hlsl
@@ -24,85 +24,85 @@ float3 test_cos_double3(double3 p0) { return cos(p0); }
 float4 test_cos_double4(double4 p0) { return cos(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_cos_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.cos.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_cos_int(int p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_cos_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.cos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_cos_int2(int2 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_cos_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.cos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_cos_int3(int3 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_cos_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.cos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_cos_int4(int4 p0) { return cos(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_cos_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.cos.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_cos_uint(uint p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_cos_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.cos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_cos_uint2(uint2 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_cos_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.cos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_cos_uint3(uint3 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_cos_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.cos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_cos_uint4(uint4 p0) { return cos(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_cos_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.cos.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_cos_int64_t(int64_t p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_cos_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.cos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_cos_int64_t2(int64_t2 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_cos_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.cos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_cos_int64_t3(int64_t3 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_cos_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.cos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_cos_int64_t4(int64_t4 p0) { return cos(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_cos_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.cos.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_cos_uint64_t(uint64_t p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_cos_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.cos.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_cos_uint64_t2(uint64_t2 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_cos_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.cos.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_cos_uint64_t3(uint64_t3 p0) { return cos(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_cos_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.cos.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_cos_uint64_t4(uint64_t4 p0) { return cos(p0); }

--- a/clang/test/CodeGenHLSL/builtins/cosh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cosh-overloads.hlsl
@@ -42,7 +42,7 @@ float4 test_cosh_double4 ( double4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_cosh_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_int ( int p0 ) {
@@ -51,7 +51,7 @@ float test_cosh_int ( int p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_cosh_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_int2 ( int2 p0 ) {
@@ -60,7 +60,7 @@ float2 test_cosh_int2 ( int2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_cosh_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_int3 ( int3 p0 ) {
@@ -69,7 +69,7 @@ float3 test_cosh_int3 ( int3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_cosh_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_int4 ( int4 p0 ) {
@@ -78,7 +78,7 @@ float4 test_cosh_int4 ( int4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_cosh_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_uint ( uint p0 ) {
@@ -87,7 +87,7 @@ float test_cosh_uint ( uint p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_cosh_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_uint2 ( uint2 p0 ) {
@@ -96,7 +96,7 @@ float2 test_cosh_uint2 ( uint2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_cosh_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_uint3 ( uint3 p0 ) {
@@ -105,7 +105,7 @@ float3 test_cosh_uint3 ( uint3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_cosh_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_uint4 ( uint4 p0 ) {
@@ -114,7 +114,7 @@ float4 test_cosh_uint4 ( uint4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_cosh_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_int64_t ( int64_t p0 ) {
@@ -123,7 +123,7 @@ float test_cosh_int64_t ( int64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_cosh_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_int64_t2 ( int64_t2 p0 ) {
@@ -132,7 +132,7 @@ float2 test_cosh_int64_t2 ( int64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_cosh_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_int64_t3 ( int64_t3 p0 ) {
@@ -141,7 +141,7 @@ float3 test_cosh_int64_t3 ( int64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_cosh_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_int64_t4 ( int64_t4 p0 ) {
@@ -150,7 +150,7 @@ float4 test_cosh_int64_t4 ( int64_t4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_cosh_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.cosh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_cosh_uint64_t ( uint64_t p0 ) {
@@ -159,7 +159,7 @@ float test_cosh_uint64_t ( uint64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_cosh_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.cosh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_cosh_uint64_t2 ( uint64_t2 p0 ) {
@@ -168,7 +168,7 @@ float2 test_cosh_uint64_t2 ( uint64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_cosh_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.cosh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_cosh_uint64_t3 ( uint64_t3 p0 ) {
@@ -177,7 +177,7 @@ float3 test_cosh_uint64_t3 ( uint64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_cosh_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.cosh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_cosh_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/degrees-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/degrees-overloads.hlsl
@@ -37,100 +37,100 @@ float3 test_degrees_double3(double3 p0) { return degrees(p0); }
 float4 test_degrees_double4(double4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_degrees_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_int(int p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_degrees_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_int2(int2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_degrees_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_int3(int3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_degrees_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_int4(int4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_degrees_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_uint(uint p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_degrees_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_uint2(uint2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_degrees_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_uint3(uint3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_degrees_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_uint4(uint4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z20test_degrees_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_int64_t(int64_t p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z21test_degrees_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_int64_t2(int64_t2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z21test_degrees_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_int64_t3(int64_t3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z21test_degrees_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float4 test_degrees_int64_t4(int64_t4 p0) { return degrees(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z21test_degrees_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} float @llvm.[[TARGET]].degrees.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float test_degrees_uint64_t(uint64_t p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z22test_degrees_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].degrees.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float2 test_degrees_uint64_t2(uint64_t2 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z22test_degrees_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].degrees.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}
 float3 test_degrees_uint64_t3(uint64_t3 p0) { return degrees(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z22test_degrees_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLDEGREESI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].degrees.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLDEGREESI]]
 // expected-warning@+1 {{'degrees' is deprecated: In 202x int lowering for degrees is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/dot2add.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/dot2add.hlsl
@@ -106,8 +106,8 @@ float test_double_arg1_arg2_type(double2 p1, double2 p2, float p3) {
 
 // CHECK-LABEL: define {{.*}}test_int16_arg1_arg2_type
 float test_int16_arg1_arg2_type(int16_t2 p1, int16_t2 p2, float p3) {
-  // CHECK:  %conv = sitofp <2 x i16> %{{.*}} to <2 x half>
-  // CHECK:  %conv1 = sitofp <2 x i16> %{{.*}} to <2 x half>
+  // CHECK:  %conv = sitofp reassoc nnan ninf nsz arcp afn <2 x i16> %{{.*}} to <2 x half>
+  // CHECK:  %conv1 = sitofp reassoc nnan ninf nsz arcp afn <2 x i16> %{{.*}} to <2 x half>
   // CHECK-SPIRV:  %[[MUL:.*]] = call reassoc nnan ninf nsz arcp afn half @llvm.spv.fdot.v2f16(<2 x half> %{{.*}}, <2 x half> %{{.*}})
   // CHECK-SPIRV:  %[[CONV:.*]] = fpext reassoc nnan ninf nsz arcp afn half %[[MUL]] to float
   // CHECK-SPIRV:  %[[C:.*]] = load float, ptr %c.addr.i, align 4
@@ -123,8 +123,8 @@ float test_int16_arg1_arg2_type(int16_t2 p1, int16_t2 p2, float p3) {
 
 // CHECK-LABEL: define {{.*}}test_int32_arg1_arg2_type
 float test_int32_arg1_arg2_type(int32_t2 p1, int32_t2 p2, float p3) {
-  // CHECK:  %conv = sitofp <2 x i32> %{{.*}} to <2 x half>
-  // CHECK:  %conv1 = sitofp <2 x i32> %{{.*}} to <2 x half>
+  // CHECK:  %conv = sitofp reassoc nnan ninf nsz arcp afn <2 x i32> %{{.*}} to <2 x half>
+  // CHECK:  %conv1 = sitofp reassoc nnan ninf nsz arcp afn <2 x i32> %{{.*}} to <2 x half>
   // CHECK-SPIRV:  %[[MUL:.*]] = call reassoc nnan ninf nsz arcp afn half @llvm.spv.fdot.v2f16(<2 x half> %{{.*}}, <2 x half> %{{.*}})
   // CHECK-SPIRV:  %[[CONV:.*]] = fpext reassoc nnan ninf nsz arcp afn half %[[MUL]] to float
   // CHECK-SPIRV:  %[[C:.*]] = load float, ptr %c.addr.i, align 4
@@ -140,8 +140,8 @@ float test_int32_arg1_arg2_type(int32_t2 p1, int32_t2 p2, float p3) {
 
 // CHECK-LABEL: define {{.*}}test_int64_arg1_arg2_type
 float test_int64_arg1_arg2_type(int64_t2 p1, int64_t2 p2, float p3) {
-  // CHECK:  %conv = sitofp <2 x i64> %{{.*}} to <2 x half>
-  // CHECK:  %conv1 = sitofp <2 x i64> %{{.*}} to <2 x half>
+  // CHECK:  %conv = sitofp reassoc nnan ninf nsz arcp afn <2 x i64> %{{.*}} to <2 x half>
+  // CHECK:  %conv1 = sitofp reassoc nnan ninf nsz arcp afn <2 x i64> %{{.*}} to <2 x half>
   // CHECK-SPIRV:  %[[MUL:.*]] = call reassoc nnan ninf nsz arcp afn half @llvm.spv.fdot.v2f16(<2 x half> %{{.*}}, <2 x half> %{{.*}})
   // CHECK-SPIRV:  %[[CONV:.*]] = fpext reassoc nnan ninf nsz arcp afn half %[[MUL]] to float
   // CHECK-SPIRV:  %[[C:.*]] = load float, ptr %c.addr.i, align 4
@@ -158,9 +158,9 @@ float test_int64_arg1_arg2_type(int64_t2 p1, int64_t2 p2, float p3) {
 // CHECK-LABEL: define {{.*}}test_bool_arg1_arg2_type
 float test_bool_arg1_arg2_type(bool2 p1, bool2 p2, float p3) {
   // CHECK:  %loadedv = icmp ne <2 x i32> %{{.*}}, zeroinitializer
-  // CHECK:  %conv = uitofp <2 x i1> %loadedv to <2 x half>
+  // CHECK:  %conv = uitofp {{.*}} <2 x i1> %loadedv to <2 x half>
   // CHECK:  %loadedv1 = icmp ne <2 x i32> %{{.*}}, zeroinitializer
-  // CHECK:  %conv2 = uitofp <2 x i1> %loadedv1 to <2 x half>
+  // CHECK:  %conv2 = uitofp {{.*}} <2 x i1> %loadedv1 to <2 x half>
   // CHECK-SPIRV:  %[[MUL:.*]] = call reassoc nnan ninf nsz arcp afn half @llvm.spv.fdot.v2f16(<2 x half> %{{.*}}, <2 x half> %{{.*}})
   // CHECK-SPIRV:  %[[CONV:.*]] = fpext reassoc nnan ninf nsz arcp afn half %[[MUL]] to float
   // CHECK-SPIRV:  %[[C:.*]] = load float, ptr %c.addr.i, align 4

--- a/clang/test/CodeGenHLSL/builtins/exp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp-overloads.hlsl
@@ -30,100 +30,100 @@ float3 test_exp_double3(double3 p0) { return exp(p0); }
 float4 test_exp_double4(double4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_exp_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_int(int p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_exp_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_int2(int2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_exp_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_int3(int3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_exp_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_int4(int4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_exp_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_uint(uint p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_exp_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_uint2(uint2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_exp_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_uint3(uint3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_exp_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_uint4(uint4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_exp_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_int64_t(int64_t p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_exp_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_int64_t2(int64_t2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_exp_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_int64_t3(int64_t3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_exp_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp_int64_t4(int64_t4 p0) { return exp(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_exp_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float test_exp_uint64_t(uint64_t p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_exp_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp_uint64_t2(uint64_t2 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_exp_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp_uint64_t3(uint64_t3 p0) { return exp(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_exp_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp' is deprecated: In 202x int lowering for exp is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/exp2-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp2-overloads.hlsl
@@ -30,100 +30,100 @@ float3 test_exp2_double3(double3 p0) { return exp2(p0); }
 float4 test_exp2_double4(double4 p0) { return exp2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_exp2_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float test_exp2_int(int p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_exp2_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp2_int2(int2 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_exp2_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp2_int3(int3 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_exp2_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp2_int4(int4 p0) { return exp2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_exp2_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float test_exp2_uint(uint p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_exp2_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp2_uint2(uint2 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_exp2_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp2_uint3(uint3 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_exp2_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp2_uint4(uint4 p0) { return exp2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_exp2_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float test_exp2_int64_t(int64_t p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_exp2_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp2_int64_t2(int64_t2 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_exp2_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp2_int64_t3(int64_t3 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_exp2_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_exp2_int64_t4(int64_t4 p0) { return exp2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_exp2_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.exp2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float test_exp2_uint64_t(uint64_t p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_exp2_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.exp2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_exp2_uint64_t2(uint64_t2 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_exp2_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.exp2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_exp2_uint64_t3(uint64_t3 p0) { return exp2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_exp2_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.exp2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'exp2' is deprecated: In 202x int lowering for exp2 is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/floor-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/floor-overloads.hlsl
@@ -34,85 +34,85 @@ float3 test_floor_double3(double3 p0) { return floor(p0); }
 float4 test_floor_double4(double4 p0) { return floor(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_floor_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_int(int p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_floor_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_int2(int2 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_floor_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_int3(int3 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_floor_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_int4(int4 p0) { return floor(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_floor_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_uint(uint p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_floor_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_uint2(uint2 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_floor_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_uint3(uint3 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_floor_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_uint4(uint4 p0) { return floor(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_floor_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_int64_t(int64_t p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_floor_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_int64_t2(int64_t2 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_floor_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_int64_t3(int64_t3 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_floor_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_int64_t4(int64_t4 p0) { return floor(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_floor_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float test_floor_uint64_t(uint64_t p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_floor_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float2 test_floor_uint64_t2(uint64_t2 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_floor_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float3 test_floor_uint64_t3(uint64_t3 p0) { return floor(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_floor_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'floor' is deprecated: In 202x int lowering for floor is deprecated. Explicitly cast parameters to float types.}}
 float4 test_floor_uint64_t4(uint64_t4 p0) { return floor(p0); }

--- a/clang/test/CodeGenHLSL/builtins/frac-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/frac-overloads.hlsl
@@ -37,100 +37,100 @@ float3 test_frac_double3(double3 p0) { return frac(p0); }
 float4 test_frac_double4(double4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_frac_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_int(int p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_frac_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_int2(int2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_frac_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_int3(int3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_frac_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_int4(int4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_frac_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_uint(uint p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_frac_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_uint2(uint2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_frac_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_uint3(uint3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_frac_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_uint4(uint4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_frac_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_int64_t(int64_t p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_frac_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_int64_t2(int64_t2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_frac_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_int64_t3(int64_t3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_frac_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float4 test_frac_int64_t4(int64_t4 p0) { return frac(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_frac_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} float @llvm.[[TARGET]].frac.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float test_frac_uint64_t(uint64_t p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_frac_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].frac.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float2 test_frac_uint64_t2(uint64_t2 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_frac_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].frac.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}
 float3 test_frac_uint64_t3(uint64_t3 p0) { return frac(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_frac_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLFRACI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].frac.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLFRACI]]
 // expected-warning@+1 {{'frac' is deprecated: In 202x int lowering for frac is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/lerp-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/lerp-overloads.hlsl
@@ -36,129 +36,129 @@ float3 test_lerp_double3(double3 p0) { return lerp(p0, p0, p0); }
 float4 test_lerp_double4(double4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_lerp_inti(
-// CHECK:    [[CONV0:%.*]] = sitofp i32 %{{.*}} to float
-// CHECK:    [[CONV1:%.*]] = sitofp i32 %{{.*}} to float
-// CHECK:    [[CONV2:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
 // CHECK:    ret float [[LERP]]
 float test_lerp_int(int p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_lerp_int2Dv2_i(
-// CHECK:    [[CONV0:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV2:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
 // CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_int2(int2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_lerp_int3Dv3_i(
-// CHECK:    [[CONV0:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV2:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
 // CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_int3(int3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_lerp_int4Dv4_i(
-// CHECK:    [[CONV0:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV2:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
 // CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_int4(int4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_lerp_uintj(
-// CHECK:    [[CONV0:%.*]] = uitofp i32 %{{.*}} to float
-// CHECK:    [[CONV1:%.*]] = uitofp i32 %{{.*}} to float
-// CHECK:    [[CONV2:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
 // CHECK:    ret float [[LERP]]
 float test_lerp_uint(uint p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_lerp_uint2Dv2_j(
-// CHECK:    [[CONV0:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV2:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
 // CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_uint2(uint2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_lerp_uint3Dv3_j(
-// CHECK:    [[CONV0:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV2:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
 // CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_uint3(uint3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_lerp_uint4Dv4_j(
-// CHECK:    [[CONV0:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV2:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
 // CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_uint4(uint4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_lerp_int64_tl(
-// CHECK:    [[CONV0:%.*]] = sitofp i64 %{{.*}} to float
-// CHECK:    [[CONV1:%.*]] = sitofp i64 %{{.*}} to float
-// CHECK:    [[CONV2:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
 // CHECK:    ret float [[LERP]]
 float test_lerp_int64_t(int64_t p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_lerp_int64_t2Dv2_l(
-// CHECK:    [[CONV0:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV2:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
 // CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_int64_t2(int64_t2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_lerp_int64_t3Dv3_l(
-// CHECK:    [[CONV0:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV2:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
 // CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_int64_t3(int64_t3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_lerp_int64_t4Dv4_l(
-// CHECK:    [[CONV0:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV2:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV0:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
 // CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_int64_t4(int64_t4 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_lerp_uint64_tm(
-// CHECK:    [[CONV0:%.*]] = uitofp i64 %{{.*}} to float
-// CHECK:    [[CONV1:%.*]] = uitofp i64 %{{.*}} to float
-// CHECK:    [[CONV2:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[LERP:%.*]] = call {{.*}} float @llvm.[[TARGET]].lerp.f32(float [[CONV0]], float [[CONV1]], float [[CONV2]])
 // CHECK:    ret float [[LERP]]
 float test_lerp_uint64_t(uint64_t p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_lerp_uint64_t2Dv2_m(
-// CHECK:    [[CONV0:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV2:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]], <2 x float> [[CONV2]])
 // CHECK:    ret <2 x float> [[LERP]]
 float2 test_lerp_uint64_t2(uint64_t2 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_lerp_uint64_t3Dv3_m(
-// CHECK:    [[CONV0:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV2:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]], <3 x float> [[CONV2]])
 // CHECK:    ret <3 x float> [[LERP]]
 float3 test_lerp_uint64_t3(uint64_t3 p0) { return lerp(p0, p0, p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_lerp_uint64_t4Dv4_m(
-// CHECK:    [[CONV0:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV2:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV0:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV2:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[LERP:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]], <4 x float> [[CONV2]])
 // CHECK:    ret <4 x float> [[LERP]]
 float4 test_lerp_uint64_t4(uint64_t4 p0) { return lerp(p0, p0, p0); }

--- a/clang/test/CodeGenHLSL/builtins/log-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log-overloads.hlsl
@@ -31,100 +31,100 @@ float3 test_log_double3(double3 p0) { return log(p0); }
 float4 test_log_double4(double4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_log_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_int(int p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_log_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_int2(int2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_log_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_int3(int3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_log_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_int4(int4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_log_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_uint(uint p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_log_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_uint2(uint2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_log_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_uint3(uint3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_log_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_uint4(uint4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_log_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_int64_t(int64_t p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_log_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_int64_t2(int64_t2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_log_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_int64_t3(int64_t3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_log_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log_int64_t4(int64_t4 p0) { return log(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_log_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float test_log_uint64_t(uint64_t p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_log_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log_uint64_t2(uint64_t2 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_log_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log_uint64_t3(uint64_t3 p0) { return log(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_log_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log' is deprecated: In 202x int lowering for log is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/log10-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log10-overloads.hlsl
@@ -30,100 +30,100 @@ float3 test_log10_double3(double3 p0) { return log10(p0); }
 float4 test_log10_double4(double4 p0) { return log10(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_log10_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log10.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float test_log10_int(int p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_log10_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log10.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log10_int2(int2 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_log10_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log10.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log10_int3(int3 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_log10_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log10.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log10_int4(int4 p0) { return log10(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_log10_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log10.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float test_log10_uint(uint p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_log10_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log10.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log10_uint2(uint2 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_log10_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log10.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log10_uint3(uint3 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_log10_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log10.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log10_uint4(uint4 p0) { return log10(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_log10_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log10.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float test_log10_int64_t(int64_t p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_log10_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log10.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log10_int64_t2(int64_t2 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_log10_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log10.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log10_int64_t3(int64_t3 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_log10_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log10.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log10_int64_t4(int64_t4 p0) { return log10(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_log10_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log10.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float test_log10_uint64_t(uint64_t p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_log10_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log10.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log10_uint64_t2(uint64_t2 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_log10_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log10.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log10_uint64_t3(uint64_t3 p0) { return log10(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_log10_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log10.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log10' is deprecated: In 202x int lowering for log10 is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/log2-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log2-overloads.hlsl
@@ -31,100 +31,100 @@ float3 test_log2_double3(double3 p0) { return log2(p0); }
 float4 test_log2_double4(double4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_log2_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_int(int p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_log2_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_int2(int2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_log2_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_int3(int3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_log2_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_int4(int4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_log2_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_uint(uint p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_log2_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_uint2(uint2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_log2_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_uint3(uint3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_log2_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_uint4(uint4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_log2_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_int64_t(int64_t p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_log2_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_int64_t2(int64_t2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_log2_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_int64_t3(int64_t3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_log2_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float4 test_log2_int64_t4(int64_t4 p0) { return log2(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_log2_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.log2.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float test_log2_uint64_t(uint64_t p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_log2_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.log2.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float2 test_log2_uint64_t2(uint64_t2 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_log2_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.log2.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}
 float3 test_log2_uint64_t3(uint64_t3 p0) { return log2(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_log2_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.log2.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'log2' is deprecated: In 202x int lowering for log2 is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/normalize-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/normalize-overloads.hlsl
@@ -49,7 +49,7 @@ float4 test_length_double4(double4 p0)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_normalize_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_int(int p0)
@@ -58,7 +58,7 @@ float test_normalize_int(int p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_normalize_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_int2(int2 p0)
@@ -67,7 +67,7 @@ float2 test_normalize_int2(int2 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_normalize_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_int3(int3 p0)
@@ -76,7 +76,7 @@ float3 test_normalize_int3(int3 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_length_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_int4(int4 p0)
@@ -86,7 +86,7 @@ float4 test_length_int4(int4 p0)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_normalize_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_uint(uint p0)
@@ -96,7 +96,7 @@ float test_normalize_uint(uint p0)
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_normalize_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_uint2(uint2 p0)
@@ -105,7 +105,7 @@ float2 test_normalize_uint2(uint2 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_normalize_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_uint3(uint3 p0)
@@ -114,7 +114,7 @@ float3 test_normalize_uint3(uint3 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_length_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_uint4(uint4 p0)
@@ -124,7 +124,7 @@ float4 test_length_uint4(uint4 p0)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z22test_normalize_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_int64_t(int64_t p0)
@@ -134,7 +134,7 @@ float test_normalize_int64_t(int64_t p0)
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z23test_normalize_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_int64_t2(int64_t2 p0)
@@ -143,7 +143,7 @@ float2 test_normalize_int64_t2(int64_t2 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z23test_normalize_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_int64_t3(int64_t3 p0)
@@ -152,7 +152,7 @@ float3 test_normalize_int64_t3(int64_t3 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_length_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_int64_t4(int64_t4 p0)
@@ -162,7 +162,7 @@ float4 test_length_int64_t4(int64_t4 p0)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z23test_normalize_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} float @llvm.[[TARGET]].normalize.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLNORMALIZEI]]
 float test_normalize_uint64_t(uint64_t p0)
@@ -172,7 +172,7 @@ float test_normalize_uint64_t(uint64_t p0)
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z24test_normalize_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLNORMALIZEI]]
 float2 test_normalize_uint64_t2(uint64_t2 p0)
@@ -181,7 +181,7 @@ float2 test_normalize_uint64_t2(uint64_t2 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z24test_normalize_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].normalize.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLNORMALIZEI]]
 float3 test_normalize_uint64_t3(uint64_t3 p0)
@@ -190,7 +190,7 @@ float3 test_normalize_uint64_t3(uint64_t3 p0)
     return normalize(p0);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z21test_length_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLNORMALIZEI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].normalize.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLNORMALIZEI]]
 float4 test_length_uint64_t4(uint64_t4 p0)

--- a/clang/test/CodeGenHLSL/builtins/pow-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/pow-overloads.hlsl
@@ -28,101 +28,101 @@ float3 test_pow_double3(double3 p0, double3 p1) { return pow(p0, p1); }
 float4 test_pow_double4(double4 p0, double4 p1) { return pow(p0, p1); }
 
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_pow_int
-// CHECK: [[CONV0:%.*]] = sitofp i32 %{{.*}} to float
-// CHECK: [[CONV1:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) float @llvm.pow.f32(float [[CONV0]], float [[CONV1]])
 // CHECK: ret float [[POW]]
 float test_pow_int(int p0, int p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_pow_int2
-// CHECK: [[CONV0:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK: [[CONV1:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <2 x float> @llvm.pow.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]])
 // CHECK: ret <2 x float> [[POW]]
 float2 test_pow_int2(int2 p0, int2 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_pow_int3
-// CHECK: [[CONV0:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK: [[CONV1:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <3 x float> @llvm.pow.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]])
 // CHECK: ret <3 x float> [[POW]]
 float3 test_pow_int3(int3 p0, int3 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_pow_int4
-// CHECK: [[CONV0:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK: [[CONV1:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <4 x float> @llvm.pow.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]])
 // CHECK: ret <4 x float> [[POW]]
 float4 test_pow_int4(int4 p0, int4 p1) { return pow(p0, p1); }
 
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_pow_uint
-// CHECK: [[CONV0:%.*]] = uitofp i32 %{{.*}} to float
-// CHECK: [[CONV1:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) float @llvm.pow.f32(float [[CONV0]], float [[CONV1]])
 // CHECK: ret float [[POW]]
 float test_pow_uint(uint p0, uint p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_pow_uint2
-// CHECK: [[CONV0:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK: [[CONV1:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <2 x float> @llvm.pow.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]])
 // CHECK: ret <2 x float> [[POW]]
 float2 test_pow_uint2(uint2 p0, uint2 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_pow_uint3
-// CHECK: [[CONV0:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK: [[CONV1:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <3 x float> @llvm.pow.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]])
 // CHECK: ret <3 x float> [[POW]]
 float3 test_pow_uint3(uint3 p0, uint3 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_pow_uint4
-// CHECK: [[CONV0:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK: [[CONV1:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <4 x float> @llvm.pow.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]])
 // CHECK: ret <4 x float> [[POW]]
 float4 test_pow_uint4(uint4 p0, uint4 p1) { return pow(p0, p1); }
 
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_pow_int64_t
-// CHECK: [[CONV0:%.*]] = sitofp i64 %{{.*}} to float
-// CHECK: [[CONV1:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) float @llvm.pow.f32(float [[CONV0]], float [[CONV1]])
 // CHECK: ret float [[POW]]
 float test_pow_int64_t(int64_t p0, int64_t p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_pow_int64_t2
-// CHECK: [[CONV0:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK: [[CONV1:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <2 x float> @llvm.pow.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]])
 // CHECK: ret <2 x float> [[POW]]
 float2 test_pow_int64_t2(int64_t2 p0, int64_t2 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_pow_int64_t3
-// CHECK: [[CONV0:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK: [[CONV1:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <3 x float> @llvm.pow.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]])
 // CHECK: ret <3 x float> [[POW]]
 float3 test_pow_int64_t3(int64_t3 p0, int64_t3 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_pow_int64_t4
-// CHECK: [[CONV0:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK: [[CONV1:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK: [[CONV0:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK: [[CONV1:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <4 x float> @llvm.pow.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]])
 // CHECK: ret <4 x float> [[POW]]
 float4 test_pow_int64_t4(int64_t4 p0, int64_t4 p1) { return pow(p0, p1); }
 
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) float {{.*}}test_pow_uint64_t
-// CHECK: [[CONV0:%.*]] = uitofp i64 %{{.*}} to float
-// CHECK: [[CONV1:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) float @llvm.pow.f32(float [[CONV0]], float [[CONV1]])
 // CHECK: ret float [[POW]]
 float test_pow_uint64_t(uint64_t p0, uint64_t p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <2 x float> {{.*}}test_pow_uint64_t2
-// CHECK: [[CONV0:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK: [[CONV1:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <2 x float> @llvm.pow.v2f32(<2 x float> [[CONV0]], <2 x float> [[CONV1]])
 // CHECK: ret <2 x float> [[POW]]
 float2 test_pow_uint64_t2(uint64_t2 p0, uint64_t2 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <3 x float> {{.*}}test_pow_uint64_t3
-// CHECK: [[CONV0:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK: [[CONV1:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <3 x float> @llvm.pow.v3f32(<3 x float> [[CONV0]], <3 x float> [[CONV1]])
 // CHECK: ret <3 x float> [[POW]]
 float3 test_pow_uint64_t3(uint64_t3 p0, uint64_t3 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define hidden noundef nofpclass(nan inf) <4 x float> {{.*}}test_pow_uint64_t4
-// CHECK: [[CONV0:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK: [[CONV1:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK: [[CONV0:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK: [[CONV1:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK: [[POW:%.*]] = call [[FLOATATTRS]] noundef nofpclass(nan inf) <4 x float> @llvm.pow.v4f32(<4 x float> [[CONV0]], <4 x float> [[CONV1]])
 // CHECK: ret <4 x float> [[POW]]
 float4 test_pow_uint64_t4(uint64_t4 p0, uint64_t4 p1) { return pow(p0, p1); }

--- a/clang/test/CodeGenHLSL/builtins/radians-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/radians-overloads.hlsl
@@ -29,85 +29,85 @@ float3 test_radians_double3(double3 p0) { return radians(p0); }
 float4 test_radians_double4(double4 p0) { return radians(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_radians_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} float @llvm.[[TARGET]].radians.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRADIANSI]]
 float test_radians_int(int p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_radians_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].radians.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRADIANSI]]
 float2 test_radians_int2(int2 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_radians_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].radians.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRADIANSI]]
 float3 test_radians_int3(int3 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_radians_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].radians.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRADIANSI]]
 float4 test_radians_int4(int4 p0) { return radians(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_radians_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} float @llvm.[[TARGET]].radians.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRADIANSI]]
 float test_radians_uint(uint p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_radians_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].radians.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRADIANSI]]
 float2 test_radians_uint2(uint2 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_radians_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].radians.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRADIANSI]]
 float3 test_radians_uint3(uint3 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_radians_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].radians.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRADIANSI]]
 float4 test_radians_uint4(uint4 p0) { return radians(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z20test_radians_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} float @llvm.[[TARGET]].radians.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRADIANSI]]
 float test_radians_int64_t(int64_t p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z21test_radians_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].radians.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRADIANSI]]
 float2 test_radians_int64_t2(int64_t2 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z21test_radians_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].radians.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRADIANSI]]
 float3 test_radians_int64_t3(int64_t3 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z21test_radians_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].radians.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRADIANSI]]
 float4 test_radians_int64_t4(int64_t4 p0) { return radians(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z21test_radians_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} float @llvm.[[TARGET]].radians.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRADIANSI]]
 float test_radians_uint64_t(uint64_t p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z22test_radians_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].radians.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRADIANSI]]
 float2 test_radians_uint64_t2(uint64_t2 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z22test_radians_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].radians.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRADIANSI]]
 float3 test_radians_uint64_t3(uint64_t3 p0) { return radians(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z22test_radians_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRADIANSI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].radians.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRADIANSI]]
 float4 test_radians_uint64_t4(uint64_t4 p0) { return radians(p0); }

--- a/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/round-overloads.hlsl
@@ -31,85 +31,85 @@ float3 test_round_double3(double3 p0) { return round(p0); }
 float4 test_round_double4(double4 p0) { return round(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_round_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_int(int p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_round_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_int2(int2 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_round_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_int3(int3 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_round_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_int4(int4 p0) { return round(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_round_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_uint(uint p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_round_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_uint2(uint2 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_round_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_uint3(uint3 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_round_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_uint4(uint4 p0) { return round(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_round_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_int64_t(int64_t p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_round_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_int64_t2(int64_t2 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_round_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_int64_t3(int64_t3 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_round_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_int64_t4(int64_t4 p0) { return round(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_round_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float test_round_uint64_t(uint64_t p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_round_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float2 test_round_uint64_t2(uint64_t2 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_round_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float3 test_round_uint64_t3(uint64_t3 p0) { return round(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_round_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'round' is deprecated: In 202x int lowering for round is deprecated. Explicitly cast parameters to float types.}}
 float4 test_round_uint64_t4(uint64_t4 p0) { return round(p0); }

--- a/clang/test/CodeGenHLSL/builtins/rsqrt-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rsqrt-overloads.hlsl
@@ -37,100 +37,100 @@ float3 test_rsqrt_double3(double3 p0) { return rsqrt(p0); }
 float4 test_rsqrt_double4(double4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_rsqrt_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_int(int p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_rsqrt_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_int2(int2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_rsqrt_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_int3(int3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_rsqrt_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_int4(int4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_rsqrt_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_uint(uint p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_rsqrt_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_uint2(uint2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_rsqrt_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_uint3(uint3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_rsqrt_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_uint4(uint4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_rsqrt_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_int64_t(int64_t p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_rsqrt_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_int64_t2(int64_t2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_rsqrt_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_int64_t3(int64_t3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_rsqrt_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_rsqrt_int64_t4(int64_t4 p0) { return rsqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_rsqrt_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} float @llvm.[[TARGET]].rsqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_rsqrt_uint64_t(uint64_t p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_rsqrt_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].rsqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_rsqrt_uint64_t2(uint64_t2 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_rsqrt_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].rsqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_rsqrt_uint64_t3(uint64_t3 p0) { return rsqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_rsqrt_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLRSQRTI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].rsqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[HLSLRSQRTI]]
 // expected-warning@+1 {{'rsqrt' is deprecated: In 202x int lowering for rsqrt is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/sin-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sin-overloads.hlsl
@@ -31,100 +31,100 @@ float3 test_sin_double3(double3 p0) { return sin(p0); }
 float4 test_sin_double4(double4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_sin_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_int(int p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_sin_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_int2(int2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_sin_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_int3(int3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_sin_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_int4(int4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_sin_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_uint(uint p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sin_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_uint2(uint2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sin_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_uint3(uint3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sin_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_uint4(uint4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_sin_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_int64_t(int64_t p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_sin_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_int64_t2(int64_t2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_sin_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_int64_t3(int64_t3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_sin_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sin_int64_t4(int64_t4 p0) { return sin(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_sin_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sin.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float test_sin_uint64_t(uint64_t p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sin_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sin.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sin_uint64_t2(uint64_t2 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sin_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sin.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sin_uint64_t3(uint64_t3 p0) { return sin(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sin_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sin.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sin' is deprecated: In 202x int lowering for sin is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/sinh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sinh-overloads.hlsl
@@ -41,7 +41,7 @@ float4 test_sinh_double4 ( double4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_sinh_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sinh.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_sinh_int ( int p0 ) {
@@ -50,7 +50,7 @@ float test_sinh_int ( int p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sinh_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sinh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_sinh_int2 ( int2 p0 ) {
@@ -59,7 +59,7 @@ float2 test_sinh_int2 ( int2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sinh_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sinh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_sinh_int3 ( int3 p0 ) {
@@ -68,7 +68,7 @@ float3 test_sinh_int3 ( int3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sinh_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sinh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_sinh_int4 ( int4 p0 ) {
@@ -77,7 +77,7 @@ float4 test_sinh_int4 ( int4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_sinh_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sinh.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_sinh_uint ( uint p0 ) {
@@ -86,7 +86,7 @@ float test_sinh_uint ( uint p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_sinh_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sinh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_sinh_uint2 ( uint2 p0 ) {
@@ -95,7 +95,7 @@ float2 test_sinh_uint2 ( uint2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_sinh_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sinh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_sinh_uint3 ( uint3 p0 ) {
@@ -104,7 +104,7 @@ float3 test_sinh_uint3 ( uint3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_sinh_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sinh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_sinh_uint4 ( uint4 p0 ) {
@@ -113,7 +113,7 @@ float4 test_sinh_uint4 ( uint4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_sinh_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sinh.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_sinh_int64_t ( int64_t p0 ) {
@@ -122,7 +122,7 @@ float test_sinh_int64_t ( int64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sinh_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sinh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_sinh_int64_t2 ( int64_t2 p0 ) {
@@ -131,7 +131,7 @@ float2 test_sinh_int64_t2 ( int64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sinh_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sinh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_sinh_int64_t3 ( int64_t3 p0 ) {
@@ -140,7 +140,7 @@ float3 test_sinh_int64_t3 ( int64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sinh_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sinh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_sinh_int64_t4 ( int64_t4 p0 ) {
@@ -149,7 +149,7 @@ float4 test_sinh_int64_t4 ( int64_t4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_sinh_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sinh.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 float test_sinh_uint64_t ( uint64_t p0 ) {
@@ -158,7 +158,7 @@ float test_sinh_uint64_t ( uint64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_sinh_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sinh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 float2 test_sinh_uint64_t2 ( uint64_t2 p0 ) {
@@ -167,7 +167,7 @@ float2 test_sinh_uint64_t2 ( uint64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_sinh_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sinh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 float3 test_sinh_uint64_t3 ( uint64_t3 p0 ) {
@@ -176,7 +176,7 @@ float3 test_sinh_uint64_t3 ( uint64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_sinh_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sinh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 float4 test_sinh_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/sqrt-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sqrt-overloads.hlsl
@@ -31,100 +31,100 @@ float3 test_sqrt_double3(double3 p0) { return sqrt(p0); }
 float4 test_sqrt_double4(double4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_sqrt_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_int(int p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_sqrt_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_int2(int2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_sqrt_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_int3(int3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_sqrt_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_int4(int4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_sqrt_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_uint(uint p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_sqrt_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_uint2(uint2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_sqrt_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_uint3(uint3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_sqrt_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_uint4(uint4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_sqrt_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_int64_t(int64_t p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_sqrt_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_int64_t2(int64_t2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_sqrt_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_int64_t3(int64_t3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_sqrt_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float4 test_sqrt_int64_t4(int64_t4 p0) { return sqrt(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_sqrt_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V2:%.*]] = call {{.*}} float @llvm.sqrt.f32(float [[CONVI]])
 // CHECK:    ret float [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float test_sqrt_uint64_t(uint64_t p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_sqrt_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <2 x float> @llvm.sqrt.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float2 test_sqrt_uint64_t2(uint64_t2 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_sqrt_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <3 x float> @llvm.sqrt.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}
 float3 test_sqrt_uint64_t3(uint64_t3 p0) { return sqrt(p0); }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_sqrt_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V2:%.*]] = call {{.*}} <4 x float> @llvm.sqrt.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V2]]
 // expected-warning@+1 {{'sqrt' is deprecated: In 202x int lowering for sqrt is deprecated. Explicitly cast parameters to float types.}}

--- a/clang/test/CodeGenHLSL/builtins/step-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/step-overloads.hlsl
@@ -53,8 +53,8 @@ float4 test_step_double4(double4 p0, double4 p1)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_step_intii(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_int(int p0, int p1)
@@ -63,8 +63,8 @@ float test_step_int(int p0, int p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_step_int2Dv2_iS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_int2(int2 p0, int2 p1)
@@ -73,8 +73,8 @@ float2 test_step_int2(int2 p0, int2 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_step_int3Dv3_iS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_int3(int3 p0, int3 p1)
@@ -83,8 +83,8 @@ float3 test_step_int3(int3 p0, int3 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_step_int4Dv4_iS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_int4(int4 p0, int4 p1)
@@ -94,8 +94,8 @@ float4 test_step_int4(int4 p0, int4 p1)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_step_uintjj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_uint(uint p0, uint p1)
@@ -104,8 +104,8 @@ float test_step_uint(uint p0, uint p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_step_uint2Dv2_jS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_uint2(uint2 p0, uint2 p1)
@@ -114,8 +114,8 @@ float2 test_step_uint2(uint2 p0, uint2 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_step_uint3Dv3_jS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_uint3(uint3 p0, uint3 p1)
@@ -124,8 +124,8 @@ float3 test_step_uint3(uint3 p0, uint3 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_step_uint4Dv4_jS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_uint4(uint4 p0, uint4 p1)
@@ -135,8 +135,8 @@ float4 test_step_uint4(uint4 p0, uint4 p1)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_step_int64_tll(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_int64_t(int64_t p0, int64_t p1)
@@ -145,8 +145,8 @@ float test_step_int64_t(int64_t p0, int64_t p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_step_int64_t2Dv2_lS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_int64_t2(int64_t2 p0, int64_t2 p1)
@@ -155,8 +155,8 @@ float2 test_step_int64_t2(int64_t2 p0, int64_t2 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_step_int64_t3Dv3_lS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_int64_t3(int64_t3 p0, int64_t3 p1)
@@ -165,8 +165,8 @@ float3 test_step_int64_t3(int64_t3 p0, int64_t3 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_step_int64_t4Dv4_lS_(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_int64_t4(int64_t4 p0, int64_t4 p1)
@@ -176,8 +176,8 @@ float4 test_step_int64_t4(int64_t4 p0, int64_t4 p1)
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_step_uint64_tmm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
-// CHECK:    [[CONV1I:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} float @llvm.[[TARGET]].step.f32(float [[CONVI]], float [[CONV1I]])
 // CHECK:    ret float [[HLSLSTEPI]]
 float test_step_uint64_t(uint64_t p0, uint64_t p1)
@@ -186,8 +186,8 @@ float test_step_uint64_t(uint64_t p0, uint64_t p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_step_uint64_t2Dv2_mS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <2 x float> @llvm.[[TARGET]].step.v2f32(<2 x float> [[CONVI]], <2 x float> [[CONV1I]])
 // CHECK:    ret <2 x float> [[HLSLSTEPI]]
 float2 test_step_uint64_t2(uint64_t2 p0, uint64_t2 p1)
@@ -196,8 +196,8 @@ float2 test_step_uint64_t2(uint64_t2 p0, uint64_t2 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_step_uint64_t3Dv3_mS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <3 x float> @llvm.[[TARGET]].step.v3f32(<3 x float> [[CONVI]], <3 x float> [[CONV1I]])
 // CHECK:    ret <3 x float> [[HLSLSTEPI]]
 float3 test_step_uint64_t3(uint64_t3 p0, uint64_t3 p1)
@@ -206,8 +206,8 @@ float3 test_step_uint64_t3(uint64_t3 p0, uint64_t3 p1)
     return step(p0, p1);
 }
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_step_uint64_t4Dv4_mS_(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
-// CHECK:    [[CONV1I:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONV1I:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[HLSLSTEPI:%.*]] = call {{.*}} <4 x float> @llvm.[[TARGET]].step.v4f32(<4 x float> [[CONVI]], <4 x float> [[CONV1I]])
 // CHECK:    ret <4 x float> [[HLSLSTEPI]]
 float4 test_step_uint64_t4(uint64_t4 p0, uint64_t4 p1)

--- a/clang/test/CodeGenHLSL/builtins/tan-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tan-overloads.hlsl
@@ -42,7 +42,7 @@ float4 test_tan_double4 ( double4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z12test_tan_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_int ( int p0 ) {
@@ -51,7 +51,7 @@ float test_tan_int ( int p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z13test_tan_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_int2 ( int2 p0 ) {
@@ -60,7 +60,7 @@ float2 test_tan_int2 ( int2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z13test_tan_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_int3 ( int3 p0 ) {
@@ -69,7 +69,7 @@ float3 test_tan_int3 ( int3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z13test_tan_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_int4 ( int4 p0 ) {
@@ -78,7 +78,7 @@ float4 test_tan_int4 ( int4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_tan_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_uint ( uint p0 ) {
@@ -87,7 +87,7 @@ float test_tan_uint ( uint p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_tan_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_uint2 ( uint2 p0 ) {
@@ -96,7 +96,7 @@ float2 test_tan_uint2 ( uint2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_tan_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_uint3 ( uint3 p0 ) {
@@ -105,7 +105,7 @@ float3 test_tan_uint3 ( uint3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_tan_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_uint4 ( uint4 p0 ) {
@@ -114,7 +114,7 @@ float4 test_tan_uint4 ( uint4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z16test_tan_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_int64_t ( int64_t p0 ) {
@@ -123,7 +123,7 @@ float test_tan_int64_t ( int64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z17test_tan_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_int64_t2 ( int64_t2 p0 ) {
@@ -132,7 +132,7 @@ float2 test_tan_int64_t2 ( int64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z17test_tan_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_int64_t3 ( int64_t3 p0 ) {
@@ -141,7 +141,7 @@ float3 test_tan_int64_t3 ( int64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z17test_tan_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_int64_t4 ( int64_t4 p0 ) {
@@ -150,7 +150,7 @@ float4 test_tan_int64_t4 ( int64_t4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_tan_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tan.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tan_uint64_t ( uint64_t p0 ) {
@@ -159,7 +159,7 @@ float test_tan_uint64_t ( uint64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_tan_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tan.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tan_uint64_t2 ( uint64_t2 p0 ) {
@@ -168,7 +168,7 @@ float2 test_tan_uint64_t2 ( uint64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_tan_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tan.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tan_uint64_t3 ( uint64_t3 p0 ) {
@@ -177,7 +177,7 @@ float3 test_tan_uint64_t3 ( uint64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_tan_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tan.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tan_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/tanh-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tanh-overloads.hlsl
@@ -42,7 +42,7 @@ float4 test_tanh_double4 ( double4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z13test_tanh_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_int ( int p0 ) {
@@ -51,7 +51,7 @@ float test_tanh_int ( int p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z14test_tanh_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_int2 ( int2 p0 ) {
@@ -60,7 +60,7 @@ float2 test_tanh_int2 ( int2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z14test_tanh_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_int3 ( int3 p0 ) {
@@ -69,7 +69,7 @@ float3 test_tanh_int3 ( int3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z14test_tanh_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_int4 ( int4 p0 ) {
@@ -78,7 +78,7 @@ float4 test_tanh_int4 ( int4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_tanh_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_uint ( uint p0 ) {
@@ -87,7 +87,7 @@ float test_tanh_uint ( uint p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_tanh_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_uint2 ( uint2 p0 ) {
@@ -96,7 +96,7 @@ float2 test_tanh_uint2 ( uint2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_tanh_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_uint3 ( uint3 p0 ) {
@@ -105,7 +105,7 @@ float3 test_tanh_uint3 ( uint3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_tanh_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_uint4 ( uint4 p0 ) {
@@ -114,7 +114,7 @@ float4 test_tanh_uint4 ( uint4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z17test_tanh_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_int64_t ( int64_t p0 ) {
@@ -123,7 +123,7 @@ float test_tanh_int64_t ( int64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z18test_tanh_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_int64_t2 ( int64_t2 p0 ) {
@@ -132,7 +132,7 @@ float2 test_tanh_int64_t2 ( int64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z18test_tanh_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_int64_t3 ( int64_t3 p0 ) {
@@ -141,7 +141,7 @@ float3 test_tanh_int64_t3 ( int64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z18test_tanh_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_int64_t4 ( int64_t4 p0 ) {
@@ -150,7 +150,7 @@ float4 test_tanh_int64_t4 ( int64_t4 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_tanh_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    [[V3:%.*]] = call {{.*}} float @llvm.tanh.f32(float [[CONVI]])
 // CHECK:    ret float [[V3]]
 float test_tanh_uint64_t ( uint64_t p0 ) {
@@ -159,7 +159,7 @@ float test_tanh_uint64_t ( uint64_t p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_tanh_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <2 x float> @llvm.tanh.v2f32(<2 x float> [[CONVI]])
 // CHECK:    ret <2 x float> [[V3]]
 float2 test_tanh_uint64_t2 ( uint64_t2 p0 ) {
@@ -168,7 +168,7 @@ float2 test_tanh_uint64_t2 ( uint64_t2 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_tanh_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <3 x float> @llvm.tanh.v3f32(<3 x float> [[CONVI]])
 // CHECK:    ret <3 x float> [[V3]]
 float3 test_tanh_uint64_t3 ( uint64_t3 p0 ) {
@@ -177,7 +177,7 @@ float3 test_tanh_uint64_t3 ( uint64_t3 p0 ) {
 }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_tanh_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    [[V3:%.*]] = call {{.*}} <4 x float> @llvm.tanh.v4f32(<4 x float> [[CONVI]])
 // CHECK:    ret <4 x float> [[V3]]
 float4 test_tanh_uint64_t4 ( uint64_t4 p0 ) {

--- a/clang/test/CodeGenHLSL/builtins/trunc-overloads.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/trunc-overloads.hlsl
@@ -34,97 +34,97 @@ float3 test_trunc_double3(double3 p0) { return trunc(p0); }
 float4 test_trunc_double4(double4 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z14test_trunc_inti(
-// CHECK:    [[CONVI:%.*]] = sitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_int(int p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z15test_trunc_int2Dv2_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_int2(int2 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z15test_trunc_int3Dv3_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_int3(int3 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z15test_trunc_int4Dv4_i(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_int4(int4 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z15test_trunc_uintj(
-// CHECK:    [[CONVI:%.*]] = uitofp i32 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i32 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_uint(uint p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z16test_trunc_uint2Dv2_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i32> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i32> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_uint2(uint2 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z16test_trunc_uint3Dv3_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i32> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i32> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_uint3(uint3 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z16test_trunc_uint4Dv4_j(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i32> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i32> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_uint4(uint4 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z18test_trunc_int64_tl(
-// CHECK:    [[CONVI:%.*]] = sitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_int64_t(int64_t p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z19test_trunc_int64_t2Dv2_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_int64_t2(int64_t2 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z19test_trunc_int64_t3Dv3_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_int64_t3(int64_t3 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z19test_trunc_int64_t4Dv4_l(
-// CHECK:    [[CONVI:%.*]] = sitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = sitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_int64_t4(int64_t4 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] float @_Z19test_trunc_uint64_tm(
-// CHECK:    [[CONVI:%.*]] = uitofp i64 %{{.*}} to float
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} i64 %{{.*}} to float
 // CHECK:    ret float [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float test_trunc_uint64_t(uint64_t p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <2 x float> @_Z20test_trunc_uint64_t2Dv2_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <2 x i64> %{{.*}} to <2 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <2 x i64> %{{.*}} to <2 x float>
 // CHECK:    ret <2 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float2 test_trunc_uint64_t2(uint64_t2 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <3 x float> @_Z20test_trunc_uint64_t3Dv3_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <3 x i64> %{{.*}} to <3 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <3 x i64> %{{.*}} to <3 x float>
 // CHECK:    ret <3 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float3 test_trunc_uint64_t3(uint64_t3 p0) { return trunc(p0); }
 
 // CHECK: define [[FNATTRS]] <4 x float> @_Z20test_trunc_uint64_t4Dv4_m(
-// CHECK:    [[CONVI:%.*]] = uitofp <4 x i64> %{{.*}} to <4 x float>
+// CHECK:    [[CONVI:%.*]] = uitofp {{.*}} <4 x i64> %{{.*}} to <4 x float>
 // CHECK:    ret <4 x float> [[CONVI]]
 // expected-warning@+1 {{'trunc' is deprecated: In 202x int lowering for trunc is deprecated. Explicitly cast parameters to float types.}}
 float4 test_trunc_uint64_t4(uint64_t4 p0) { return trunc(p0); }

--- a/clang/test/CodeGenHLSL/resources/Texture2D-GetDimensions.hlsl
+++ b/clang/test/CodeGenHLSL/resources/Texture2D-GetDimensions.hlsl
@@ -67,11 +67,11 @@ void test_float_dims() {
 // SPIRV: %[[RES:.*]] = call <2 x i32> @llvm.spv.resource.getdimensions.xy.tspirv.Image_f32_1_2_0_0_1_0t(target("spirv.Image", float, 1, 2, 0, 0, 1, 0) %[[HANDLE]])
 // CHECK: %[[W_PTR:.*]] = load ptr, ptr %[[WIDTH]]
 // CHECK: %[[W_VAL:.*]] = extractelement <2 x i32> %[[RES]], i64 0
-// CHECK: %[[W_F:.*]] = uitofp i32 %[[W_VAL]] to float
+// CHECK: %[[W_F:.*]] = uitofp reassoc nnan ninf nsz arcp afn i32 %[[W_VAL]] to float
 // CHECK: store float %[[W_F]], ptr %[[W_PTR]]
 // CHECK: %[[H_PTR:.*]] = load ptr, ptr %[[HEIGHT]]
 // CHECK: %[[H_VAL:.*]] = extractelement <2 x i32> %[[RES]], i64 1
-// CHECK: %[[H_F:.*]] = uitofp i32 %[[H_VAL]] to float
+// CHECK: %[[H_F:.*]] = uitofp reassoc nnan ninf nsz arcp afn i32 %[[H_VAL]] to float
 // CHECK: store float %[[H_F]], ptr %[[H_PTR]]
 
 // CHECK: define {{.*}} void @test_float_levels_dims{{.*}}(i32 noundef %[[MIP_LEVEL:.*]])
@@ -91,13 +91,13 @@ void test_float_levels_dims(uint mipLevel) {
 // SPIRV: %[[RES:.*]] = call <3 x i32> @llvm.spv.resource.getdimensions.levels.xy.tspirv.Image_f32_1_2_0_0_1_0t(target("spirv.Image", float, 1, 2, 0, 0, 1, 0) %[[HANDLE]], i32 %[[MIP_VAL]])
 // CHECK: %[[W_PTR:.*]] = load ptr, ptr %[[WIDTH]]
 // CHECK: %[[W_VAL:.*]] = extractelement <3 x i32> %[[RES]], i64 0
-// CHECK: %[[W_F:.*]] = uitofp i32 %[[W_VAL]] to float
+// CHECK: %[[W_F:.*]] = uitofp reassoc nnan ninf nsz arcp afn i32 %[[W_VAL]] to float
 // CHECK: store float %[[W_F]], ptr %[[W_PTR]]
 // CHECK: %[[H_PTR:.*]] = load ptr, ptr %[[HEIGHT]]
 // CHECK: %[[H_VAL:.*]] = extractelement <3 x i32> %[[RES]], i64 1
-// CHECK: %[[H_F:.*]] = uitofp i32 %[[H_VAL]] to float
+// CHECK: %[[H_F:.*]] = uitofp reassoc nnan ninf nsz arcp afn i32 %[[H_VAL]] to float
 // CHECK: store float %[[H_F]], ptr %[[H_PTR]]
 // CHECK: %[[L_PTR:.*]] = load ptr, ptr %[[LEVELS]]
 // CHECK: %[[L_VAL:.*]] = extractelement <3 x i32> %[[RES]], i64 2
-// CHECK: %[[L_F:.*]] = uitofp i32 %[[L_VAL]] to float
+// CHECK: %[[L_F:.*]] = uitofp reassoc nnan ninf nsz arcp afn i32 %[[L_VAL]] to float
 // CHECK: store float %[[L_F]], ptr %[[L_PTR]]

--- a/clang/test/Headers/__clang_hip_math.hip
+++ b/clang/test/Headers/__clang_hip_math.hip
@@ -3878,7 +3878,7 @@ extern "C" __device__ double test_log2(double x) {
 // DEFAULT-NEXT:    [[TMP0:%.*]] = tail call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 // DEFAULT-NEXT:    [[TMP1:%.*]] = extractvalue { float, i32 } [[TMP0]], 1
 // DEFAULT-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// DEFAULT-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to float
+// DEFAULT-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to float
 // DEFAULT-NEXT:    [[TMP4:%.*]] = tail call contract float @llvm.fabs.f32(float [[X]])
 // DEFAULT-NEXT:    [[TMP5:%.*]] = fcmp contract one float [[TMP4]], +inf
 // DEFAULT-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], float [[TMP3]], float [[TMP4]]
@@ -3892,7 +3892,7 @@ extern "C" __device__ double test_log2(double x) {
 // FINITEONLY-NEXT:    [[TMP0:%.*]] = tail call { float, i32 } @llvm.frexp.f32.i32(float nofpclass(nan inf) [[X]])
 // FINITEONLY-NEXT:    [[TMP1:%.*]] = extractvalue { float, i32 } [[TMP0]], 1
 // FINITEONLY-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// FINITEONLY-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to float
+// FINITEONLY-NEXT:    [[TMP3:%.*]] = sitofp nnan ninf contract i32 [[TMP2]] to float
 // FINITEONLY-NEXT:    ret float [[TMP3]]
 //
 // APPROX-LABEL: define dso_local float @test_logbf(
@@ -3901,7 +3901,7 @@ extern "C" __device__ double test_log2(double x) {
 // APPROX-NEXT:    [[TMP0:%.*]] = tail call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 // APPROX-NEXT:    [[TMP1:%.*]] = extractvalue { float, i32 } [[TMP0]], 1
 // APPROX-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// APPROX-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to float
+// APPROX-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to float
 // APPROX-NEXT:    [[TMP4:%.*]] = tail call contract float @llvm.fabs.f32(float [[X]])
 // APPROX-NEXT:    [[TMP5:%.*]] = fcmp contract one float [[TMP4]], +inf
 // APPROX-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], float [[TMP3]], float [[TMP4]]
@@ -3915,7 +3915,7 @@ extern "C" __device__ double test_log2(double x) {
 // NCRDIV-NEXT:    [[TMP0:%.*]] = tail call { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 // NCRDIV-NEXT:    [[TMP1:%.*]] = extractvalue { float, i32 } [[TMP0]], 1
 // NCRDIV-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// NCRDIV-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to float
+// NCRDIV-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to float
 // NCRDIV-NEXT:    [[TMP4:%.*]] = tail call contract float @llvm.fabs.f32(float [[X]])
 // NCRDIV-NEXT:    [[TMP5:%.*]] = fcmp contract one float [[TMP4]], +inf
 // NCRDIV-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], float [[TMP3]], float [[TMP4]]
@@ -3929,7 +3929,7 @@ extern "C" __device__ double test_log2(double x) {
 // AMDGCNSPIRV-NEXT:    [[TMP0:%.*]] = tail call addrspace(4) { float, i32 } @llvm.frexp.f32.i32(float [[X]])
 // AMDGCNSPIRV-NEXT:    [[TMP1:%.*]] = extractvalue { float, i32 } [[TMP0]], 1
 // AMDGCNSPIRV-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// AMDGCNSPIRV-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to float
+// AMDGCNSPIRV-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to float
 // AMDGCNSPIRV-NEXT:    [[TMP4:%.*]] = tail call contract addrspace(4) float @llvm.fabs.f32(float [[X]])
 // AMDGCNSPIRV-NEXT:    [[TMP5:%.*]] = fcmp contract one float [[TMP4]], +inf
 // AMDGCNSPIRV-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], float [[TMP3]], float [[TMP4]]
@@ -3947,7 +3947,7 @@ extern "C" __device__ float test_logbf(float x) {
 // DEFAULT-NEXT:    [[TMP0:%.*]] = tail call { double, i32 } @llvm.frexp.f64.i32(double [[X]])
 // DEFAULT-NEXT:    [[TMP1:%.*]] = extractvalue { double, i32 } [[TMP0]], 1
 // DEFAULT-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// DEFAULT-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to double
+// DEFAULT-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to double
 // DEFAULT-NEXT:    [[TMP4:%.*]] = tail call contract double @llvm.fabs.f64(double [[X]])
 // DEFAULT-NEXT:    [[TMP5:%.*]] = fcmp contract one double [[TMP4]], +inf
 // DEFAULT-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], double [[TMP3]], double [[TMP4]]
@@ -3961,7 +3961,7 @@ extern "C" __device__ float test_logbf(float x) {
 // FINITEONLY-NEXT:    [[TMP0:%.*]] = tail call { double, i32 } @llvm.frexp.f64.i32(double nofpclass(nan inf) [[X]])
 // FINITEONLY-NEXT:    [[TMP1:%.*]] = extractvalue { double, i32 } [[TMP0]], 1
 // FINITEONLY-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// FINITEONLY-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to double
+// FINITEONLY-NEXT:    [[TMP3:%.*]] = sitofp nnan ninf contract i32 [[TMP2]] to double
 // FINITEONLY-NEXT:    ret double [[TMP3]]
 //
 // APPROX-LABEL: define dso_local double @test_logb(
@@ -3970,7 +3970,7 @@ extern "C" __device__ float test_logbf(float x) {
 // APPROX-NEXT:    [[TMP0:%.*]] = tail call { double, i32 } @llvm.frexp.f64.i32(double [[X]])
 // APPROX-NEXT:    [[TMP1:%.*]] = extractvalue { double, i32 } [[TMP0]], 1
 // APPROX-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// APPROX-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to double
+// APPROX-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to double
 // APPROX-NEXT:    [[TMP4:%.*]] = tail call contract double @llvm.fabs.f64(double [[X]])
 // APPROX-NEXT:    [[TMP5:%.*]] = fcmp contract one double [[TMP4]], +inf
 // APPROX-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], double [[TMP3]], double [[TMP4]]
@@ -3984,7 +3984,7 @@ extern "C" __device__ float test_logbf(float x) {
 // NCRDIV-NEXT:    [[TMP0:%.*]] = tail call { double, i32 } @llvm.frexp.f64.i32(double [[X]])
 // NCRDIV-NEXT:    [[TMP1:%.*]] = extractvalue { double, i32 } [[TMP0]], 1
 // NCRDIV-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// NCRDIV-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to double
+// NCRDIV-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to double
 // NCRDIV-NEXT:    [[TMP4:%.*]] = tail call contract double @llvm.fabs.f64(double [[X]])
 // NCRDIV-NEXT:    [[TMP5:%.*]] = fcmp contract one double [[TMP4]], +inf
 // NCRDIV-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], double [[TMP3]], double [[TMP4]]
@@ -3998,7 +3998,7 @@ extern "C" __device__ float test_logbf(float x) {
 // AMDGCNSPIRV-NEXT:    [[TMP0:%.*]] = tail call addrspace(4) { double, i32 } @llvm.frexp.f64.i32(double [[X]])
 // AMDGCNSPIRV-NEXT:    [[TMP1:%.*]] = extractvalue { double, i32 } [[TMP0]], 1
 // AMDGCNSPIRV-NEXT:    [[TMP2:%.*]] = add nsw i32 [[TMP1]], -1
-// AMDGCNSPIRV-NEXT:    [[TMP3:%.*]] = sitofp i32 [[TMP2]] to double
+// AMDGCNSPIRV-NEXT:    [[TMP3:%.*]] = sitofp contract i32 [[TMP2]] to double
 // AMDGCNSPIRV-NEXT:    [[TMP4:%.*]] = tail call contract addrspace(4) double @llvm.fabs.f64(double [[X]])
 // AMDGCNSPIRV-NEXT:    [[TMP5:%.*]] = fcmp contract one double [[TMP4]], +inf
 // AMDGCNSPIRV-NEXT:    [[TMP6:%.*]] = select contract i1 [[TMP5]], double [[TMP3]], double [[TMP4]]

--- a/clang/test/Headers/openmp_device_math_isnan.cpp
+++ b/clang/test/Headers/openmp_device_math_isnan.cpp
@@ -29,7 +29,7 @@ double math(float f, double d) {
   double r = 0;
   // INT_RETURN: call noundef i32 @__nv_isnanf(float
   // AMD_INT_RETURN_SAFE: call i1 @llvm.is.fpclass.f32(float{{.*}}, i32 3)
-  // AMD_INT_RETURN_FAST: sitofp i32 {{.*}} to double
+  // AMD_INT_RETURN_FAST: sitofp fast i32 {{.*}} to double
   // SPIRV_INT_RETURN: call spir_func noundef i32 @_Z5isnanf(float
   // BOOL_RETURN: call noundef i32 @__nv_isnanf(float
   // SPIRV_BOOL_RETURN: call spir_func noundef zeroext i1 @_Z5isnanf(float 
@@ -39,7 +39,7 @@ double math(float f, double d) {
   // INT_RETURN: call noundef i32 @__nv_isnand(double
   // SPIRV_INT_RETURN: call spir_func noundef i32 @_Z5isnand(double
   // AMD_INT_RETURN_SAFE: call i1 @llvm.is.fpclass.f64(double{{.*}}, i32 3)
-  // AMD_INT_RETURN_FAST: sitofp i32 {{.*}} to double
+  // AMD_INT_RETURN_FAST: sitofp fast i32 {{.*}} to double
   // BOOL_RETURN: call noundef i32 @__nv_isnand(double
   // SPIRV_BOOL_RETURN: call spir_func noundef zeroext i1 @_Z5isnand(double
   // AMD_BOOL_RETURN_SAFE: call i1 @llvm.is.fpclass.f64(double{{.*}}, i32 3)

--- a/clang/test/SemaHLSL/VectorOverloadResolution.hlsl
+++ b/clang/test/SemaHLSL/VectorOverloadResolution.hlsl
@@ -68,7 +68,7 @@ void Fn4( float2 p0);
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'int64_t2':'vector<int64_t, 2>' <LValueToRValue>
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int64_t2':'vector<int64_t, 2>' lvalue ParmVar {{.*}} 'p0' 'int64_t2':'vector<int64_t, 2>'
 // CHECKIR-LABEL: Call5
-// CHECKIR: {{.*}} = sitofp <2 x i64> {{.*}} to <2 x float>
+// CHECKIR: {{.*}} = sitofp reassoc nnan ninf nsz arcp afn <2 x i64> {{.*}} to <2 x float>
 void Call5(int64_t2 p0) {
   Fn4(p0);
 }

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4214,9 +4214,10 @@ Fast-Math Flags
 LLVM IR floating-point operations (:ref:`fneg <i_fneg>`, :ref:`fadd <i_fadd>`,
 :ref:`fsub <i_fsub>`, :ref:`fmul <i_fmul>`, :ref:`fdiv <i_fdiv>`,
 :ref:`frem <i_frem>`, :ref:`fcmp <i_fcmp>`, :ref:`fptrunc <i_fptrunc>`,
-:ref:`fpext <i_fpext>`), and :ref:`phi <i_phi>`, :ref:`select <i_select>`, or
-:ref:`call <i_call>` instructions that return floating-point types may use the
-following flags to enable otherwise unsafe floating-point transformations.
+:ref:`fpext <i_fpext>`), :ref::`uitofp <i_uitofp>`, :ref::`sitofp <i_sitofp>`,
+and :ref:`phi <i_phi>`, :ref:`select <i_select>`, or :ref:`call <i_call>`
+instructions that return floating-point types may use the following flags to
+enable otherwise unsafe floating-point transformations.
 
 ``fast``
    This flag is a shorthand for specifying all fast-math flags at once, and
@@ -13108,6 +13109,8 @@ Example:
       %Y = fptosi float 1.0E-247 to i1      ; yields undefined:1
       %Z = fptosi float 1.04E+17 to i8      ; yields undefined:1
 
+.. _i_uitofp:
+
 '``uitofp .. to``' Instruction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -13116,7 +13119,7 @@ Syntax:
 
 ::
 
-      <result> = uitofp <ty> <value> to <ty2>             ; yields ty2
+      <result> = uitofp [fast-math flags]* [nneg] <ty> <value> to <ty2> ; yields ty2
 
 Overview:
 """""""""
@@ -13160,6 +13163,8 @@ Example:
       %a = uitofp nneg i32 256 to float    ; yields float:256.0
       %b = uitofp nneg i32 -256 to float   ; yields float poison
 
+.. _i_sitofp:
+
 '``sitofp .. to``' Instruction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -13168,7 +13173,7 @@ Syntax:
 
 ::
 
-      <result> = sitofp <ty> <value> to <ty2>             ; yields ty2
+      <result> = sitofp [fast-math flags]* <ty> <value> to <ty2> ; yields ty2
 
 Overview:
 """""""""

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -87,6 +87,8 @@ Makes programs 10x faster by doing Special New Thing.
   and `ccc` agree for `void(ptr)` (x86_64, AArch64, RISC-V, ...) but is an ABI
   break on i686, MIPS O32, PowerPC64 ELFv1, and Lanai.
 
+* Fast math flags are now permitted on `uitofp` and `sitofp`.
+
 ### Changes to LLVM infrastructure
 
 * Removed ``Constant::isZeroValue``. It was functionally identical to

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -2178,23 +2178,23 @@ public:
   }
 
   Value *CreateUIToFP(Value *V, Type *DestTy, const Twine &Name = "",
-                      bool IsNonNeg = false) {
+                      bool IsNonNeg = false, MDNode *FPMathTag = nullptr) {
     if (IsFPConstrained)
       return CreateConstrainedFPCast(Intrinsic::experimental_constrained_uitofp,
                                      V, DestTy, nullptr, Name);
-    if (Value *Folded = Folder.FoldCast(Instruction::UIToFP, V, DestTy))
-      return Folded;
-    Instruction *I = Insert(new UIToFPInst(V, DestTy), Name);
-    if (IsNonNeg)
-      I->setNonNeg();
-    return I;
+    Value *Val = CreateCast(Instruction::UIToFP, V, DestTy, Name, FPMathTag);
+    if (auto *I = dyn_cast<Instruction>(Val))
+      if (IsNonNeg)
+        I->setNonNeg();
+    return Val;
   }
 
-  Value *CreateSIToFP(Value *V, Type *DestTy, const Twine &Name = ""){
+  Value *CreateSIToFP(Value *V, Type *DestTy, const Twine &Name = "",
+                      MDNode *FPMathTag = nullptr) {
     if (IsFPConstrained)
       return CreateConstrainedFPCast(Intrinsic::experimental_constrained_sitofp,
                                      V, DestTy, nullptr, Name);
-    return CreateCast(Instruction::SIToFP, V, DestTy, Name);
+    return CreateCast(Instruction::SIToFP, V, DestTy, Name, FPMathTag);
   }
 
   Value *CreateFPTrunc(Value *V, Type *DestTy, const Twine &Name = "",

--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -4951,7 +4951,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 /// This class represents a cast unsigned integer to floating point.
-class UIToFPInst : public CastInst {
+class UIToFPInst : public CastInst, public FastMathFlagsStorage {
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
   friend class Instruction;
@@ -4983,7 +4983,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 /// This class represents a cast from signed integer to floating point.
-class SIToFPInst : public CastInst {
+class SIToFPInst : public CastInst, public FastMathFlagsStorage {
 protected:
   // Note: Instruction needs to be a friend here to call cloneImpl.
   friend class Instruction;

--- a/llvm/include/llvm/IR/Operator.h
+++ b/llvm/include/llvm/IR/Operator.h
@@ -320,6 +320,8 @@ public:
     case Instruction::FRem:
     case Instruction::FPTrunc:
     case Instruction::FPExt:
+    case Instruction::UIToFP:
+    case Instruction::SIToFP:
     // FIXME: To clean up and correct the semantics of fast-math-flags, FCmp
     //        should not be treated as a math op, but the other opcodes should.
     //        This would make things consistent with Select/PHI (FP value type

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -7680,7 +7680,17 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
   }
 
   // Casts.
-  case lltok::kw_uitofp:
+  case lltok::kw_uitofp: {
+    FastMathFlags FMF = EatFastMathFlagsIfPresent();
+    bool NonNeg = EatIfPresent(lltok::kw_nneg);
+    bool Res = parseCast(Inst, PFS, KeywordVal);
+    if (Res != 0)
+      return Res;
+    if (NonNeg)
+      Inst->setNonNeg();
+    Inst->setFastMathFlags(FMF);
+    return 0;
+  }
   case lltok::kw_zext: {
     bool NonNeg = EatIfPresent(lltok::kw_nneg);
     bool Res = parseCast(Inst, PFS, KeywordVal);
@@ -7706,7 +7716,6 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
   case lltok::kw_sext:
   case lltok::kw_bitcast:
   case lltok::kw_addrspacecast:
-  case lltok::kw_sitofp:
   case lltok::kw_fptoui:
   case lltok::kw_fptosi:
   case lltok::kw_inttoptr:
@@ -7714,7 +7723,8 @@ int LLParser::parseInstruction(Instruction *&Inst, BasicBlock *BB,
   case lltok::kw_ptrtoint:
     return parseCast(Inst, PFS, KeywordVal);
   case lltok::kw_fptrunc:
-  case lltok::kw_fpext: {
+  case lltok::kw_fpext:
+  case lltok::kw_sitofp: {
     FastMathFlags FMF = EatFastMathFlagsIfPresent();
     if (parseCast(Inst, PFS, KeywordVal))
       return true;

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -5308,7 +5308,10 @@ Error BitcodeReader::parseFunctionBody(Function *F) {
             cast<TruncInst>(I)->setHasNoSignedWrap(true);
         }
         if (isa<FPMathOperator>(I)) {
-          FastMathFlags FMF = getDecodedFastMathFlags(Record[OpNum]);
+          uint64_t Flags = Record[OpNum];
+          if (isa<UIToFPInst>(I))
+            Flags >>= 1;
+          FastMathFlags FMF = getDecodedFastMathFlags(Flags);
           if (FMF.any())
             I->setFastMathFlags(FMF);
         }

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1815,6 +1815,13 @@ static uint64_t getOptimizationFlags(const Value *V) {
       Flags |= bitc::AllowContract;
     if (FPMO->hasApproxFunc())
       Flags |= bitc::ApproxFunc;
+
+    // Handle uitofp.
+    if (const auto *NNI = dyn_cast<PossiblyNonNegInst>(V)) {
+      Flags <<= 1;
+      if (NNI->hasNonNeg())
+        Flags |= 1 << bitc::PNNI_NON_NEG;
+    }
   } else if (const auto *NNI = dyn_cast<PossiblyNonNegInst>(V)) {
     if (NNI->hasNonNeg())
       Flags |= 1 << bitc::PNNI_NON_NEG;
@@ -4152,7 +4159,7 @@ void ModuleBitcodeWriter::writeBlockInfo() {
     Abbv->Add(ValAbbrevOp); // OpVal
     Abbv->Add(TypeAbbrevOp); // dest ty
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
-    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 8)); // flags
+    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 9)); // flags
     if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
         FUNCTION_INST_CAST_FLAGS_ABBREV)
       llvm_unreachable("Unexpected abbrev ordering!");

--- a/llvm/lib/IR/Instructions.cpp
+++ b/llvm/lib/IR/Instructions.cpp
@@ -4485,11 +4485,15 @@ FPExtInst *FPExtInst::cloneImpl() const {
 }
 
 UIToFPInst *UIToFPInst::cloneImpl() const {
-  return new UIToFPInst(getOperand(0), getType());
+  auto *Result = new UIToFPInst(getOperand(0), getType());
+  Result->FMF = FMF;
+  return Result;
 }
 
 SIToFPInst *SIToFPInst::cloneImpl() const {
-  return new SIToFPInst(getOperand(0), getType());
+  auto *Result = new SIToFPInst(getOperand(0), getType());
+  Result->FMF = FMF;
+  return Result;
 }
 
 FPToUIInst *FPToUIInst::cloneImpl() const {

--- a/llvm/lib/IR/Operator.cpp
+++ b/llvm/lib/IR/Operator.cpp
@@ -320,6 +320,10 @@ FastMathFlags &FPMathOperator::getFastMathFlagsImpl() {
     return Op->FMF;
   if (FastMathFlagsStorage *Op = dyn_cast<CallInst>(I))
     return Op->FMF;
+  if (FastMathFlagsStorage *Op = dyn_cast<UIToFPInst>(I))
+    return Op->FMF;
+  if (FastMathFlagsStorage *Op = dyn_cast<SIToFPInst>(I))
+    return Op->FMF;
 
   llvm_unreachable("Unknown FPMathOperator!");
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2385,7 +2385,8 @@ bool VPIRFlags::flagsValidForOpcode(unsigned Opcode) const {
            Opcode == Instruction::FNeg || Opcode == Instruction::FDiv ||
            Opcode == Instruction::FRem || Opcode == Instruction::FPExt ||
            Opcode == Instruction::FPTrunc || Opcode == Instruction::PHI ||
-           Opcode == Instruction::Select ||
+           Opcode == Instruction::Select || Opcode == Instruction::SIToFP ||
+           Opcode == Instruction::UIToFP ||
            Opcode == VPInstruction::WideIVStep ||
            Opcode == VPInstruction::ReductionStartVector;
   case OperationType::FCmp:

--- a/llvm/test/Assembler/fast-math-flags.ll
+++ b/llvm/test/Assembler/fast-math-flags.ll
@@ -1,11 +1,13 @@
 ; RUN: llvm-as < %s | llvm-dis | FileCheck -strict-whitespace %s
-; RUN: opt -S < %s | FileCheck -strict-whitespace %s
+; XUN: opt -S < %s | FileCheck -strict-whitespace %s
 ; RUN: verify-uselistorder %s
 
 @addr   = external global i64
 @select = external global i1
 @vec    = external global <3 x float>
 @arr    = external global [3 x float]
+@int    = external global i32
+@ivec   = external global <3 x i32>
 
 declare float @foo(float)
 
@@ -19,6 +21,10 @@ entry:
   %arr    = load [3 x float], ptr @arr
 ; CHECK:  %scalable = load <vscale x 3 x float>, ptr @vec
   %scalable = load <vscale x 3 x float>, ptr @vec
+; CHECK: %int = load i32, ptr @int
+  %int = load i32, ptr @int
+; CHECK: %ivec = load <3 x i32>, ptr @ivec
+  %ivec = load <3 x i32>, ptr @ivec
 
 ; CHECK:  %a = fadd float %x, %y
   %a = fadd float %x, %y
@@ -56,6 +62,14 @@ entry:
   %h_vec = fptrunc <3 x float> %vec to <3 x half>
 ; CHECK: %h_scalable = fptrunc <vscale x 3 x float> %scalable to <vscale x 3 x half>
   %h_scalable = fptrunc <vscale x 3 x float> %scalable to <vscale x 3 x half>
+; CHECK: %i = uitofp i32 %int to float
+  %i = uitofp i32 %int to float
+; CHECK: %i_vec = uitofp <3 x i32> %ivec to <3 x float>
+  %i_vec = uitofp <3 x i32> %ivec to <3 x float>
+; CHECK: %j = sitofp i32 %int to float
+  %j = sitofp i32 %int to float
+; CHECK: %j_vec = sitofp <3 x i32> %ivec to <3 x float>
+  %j_vec = sitofp <3 x i32> %ivec to <3 x float>
 ; CHECK:  ret float %f
   ret  float %f
 }
@@ -211,6 +225,10 @@ entry:
   %select = load i1, ptr @select
 ; CHECK:  %arr = load [3 x float], ptr @arr
   %arr    = load [3 x float], ptr @arr
+; CHECK:  %int = load i32, ptr @int
+  %int    = load i32, ptr @int
+; CHECK: %ivec = load <3 x i32>, ptr @ivec
+  %ivec   = load <3 x i32>, ptr @ivec
 
 ; CHECK:  %a = fadd nnan ninf afn float %x, %y
   %a = fadd ninf nnan afn float %x, %y
@@ -236,6 +254,14 @@ entry:
   %f = fneg nnan nsz float %x
 ; CHECK:  %f_vec = fneg fast <3 x float> %vec
   %f_vec = fneg fast <3 x float> %vec
+; CHECK: %g = uitofp nsz nneg i32 %int to float
+  %g = uitofp nsz nneg i32 %int to float
+; CHECK: %g_vec = uitofp nsz nneg <3 x i32> %ivec to <3 x float>
+  %g_vec = uitofp nsz nneg <3 x i32> %ivec to <3 x float>
+; CHECK: %h = sitofp nnan nsz i32 %int to float
+  %h = sitofp nnan nsz i32 %int to float
+; CHECK: %h_vec = sitofp nnan nsz <3 x i32> %ivec to <3 x float>
+  %h_vec = sitofp nnan nsz <3 x i32> %ivec to <3 x float>
 ; CHECK:  ret float %f
   ret float %f
 }

--- a/llvm/test/Assembler/fast-math-flags.ll
+++ b/llvm/test/Assembler/fast-math-flags.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as < %s | llvm-dis | FileCheck -strict-whitespace %s
-; XUN: opt -S < %s | FileCheck -strict-whitespace %s
+; RUN: opt -S < %s | FileCheck -strict-whitespace %s
 ; RUN: verify-uselistorder %s
 
 @addr   = external global i64

--- a/llvm/test/Bitcode/compatibility.ll
+++ b/llvm/test/Bitcode/compatibility.ll
@@ -1280,6 +1280,48 @@ define void @fastmathflags_fptrunc(float %op1) {
   ret void
 }
 
+; CHECK-LABEL: fastmathflags_uitofp(
+define void @fastmathflags_uitofp(i32 %op1) {
+  %f.nnan = uitofp nnan i32 %op1 to float
+  ; CHECK: %f.nnan = uitofp nnan i32 %op1 to float
+  %f.ninf = uitofp nnan i32 %op1 to float
+  ; CHECK: %f.ninf = uitofp nnan i32 %op1 to float
+  %f.nsz = uitofp nnan i32 %op1 to float
+  ; CHECK: %f.nsz = uitofp nnan i32 %op1 to float
+  %f.arcp = uitofp nnan i32 %op1 to float
+  ; CHECK: %f.arcp = uitofp nnan i32 %op1 to float
+  %f.contract = uitofp contract i32 %op1 to float
+  ; CHECK: %f.contract = uitofp contract i32 %op1 to float
+  %f.afn = uitofp afn i32 %op1 to float
+  ; CHECK: %f.afn = uitofp afn i32 %op1 to float
+  %f.reassoc = uitofp reassoc i32 %op1 to float
+  ; CHECK: %f.reassoc = uitofp reassoc i32 %op1 to float
+  %f.fast = uitofp fast i32 %op1 to float
+  ; CHECK: %f.fast = uitofp fast i32 %op1 to float
+  ret void
+}
+
+; CHECK-LABEL: fastmathflags_sitofp(
+define void @fastmathflags_sitofp(i32 %op1) {
+  %f.nnan = sitofp nnan i32 %op1 to float
+  ; CHECK: %f.nnan = sitofp nnan i32 %op1 to float
+  %f.ninf = sitofp nnan i32 %op1 to float
+  ; CHECK: %f.ninf = sitofp nnan i32 %op1 to float
+  %f.nsz = sitofp nnan i32 %op1 to float
+  ; CHECK: %f.nsz = sitofp nnan i32 %op1 to float
+  %f.arcp = sitofp nnan i32 %op1 to float
+  ; CHECK: %f.arcp = sitofp nnan i32 %op1 to float
+  %f.contract = sitofp contract i32 %op1 to float
+  ; CHECK: %f.contract = sitofp contract i32 %op1 to float
+  %f.afn = sitofp afn i32 %op1 to float
+  ; CHECK: %f.afn = sitofp afn i32 %op1 to float
+  %f.reassoc = sitofp reassoc i32 %op1 to float
+  ; CHECK: %f.reassoc = sitofp reassoc i32 %op1 to float
+  %f.fast = sitofp fast i32 %op1 to float
+  ; CHECK: %f.fast = sitofp fast i32 %op1 to float
+  ret void
+}
+
 ;; Type System
 %opaquety = type opaque
 define void @typesystem() {

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-fold-binop-select.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-fold-binop-select.ll
@@ -91,7 +91,7 @@ define i32 @select_sdiv_lhs_opaque_const0_i32(i1 %cond) {
 ; IR-NEXT:    [[TMP2:%.*]] = xor i32 0, [[TMP1]]
 ; IR-NEXT:    [[TMP3:%.*]] = add i32 [[SELECT]], [[TMP1]]
 ; IR-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], [[TMP1]]
-; IR-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP4]] to float
+; IR-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; IR-NEXT:    [[TMP6:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP5]])
 ; IR-NEXT:    [[TMP7:%.*]] = fmul fast float [[TMP6]], f0x4F7FFFFE
 ; IR-NEXT:    [[TMP8:%.*]] = fptoui float [[TMP7]] to i32
@@ -173,7 +173,7 @@ define i32 @select_sdiv_lhs_opaque_const1_i32(i1 %cond) {
 ; IR-NEXT:    [[TMP2:%.*]] = xor i32 0, [[TMP1]]
 ; IR-NEXT:    [[TMP3:%.*]] = add i32 [[SELECT]], [[TMP1]]
 ; IR-NEXT:    [[TMP4:%.*]] = xor i32 [[TMP3]], [[TMP1]]
-; IR-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP4]] to float
+; IR-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; IR-NEXT:    [[TMP6:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP5]])
 ; IR-NEXT:    [[TMP7:%.*]] = fmul fast float [[TMP6]], f0x4F7FFFFE
 ; IR-NEXT:    [[TMP8:%.*]] = fptoui float [[TMP7]] to i32

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-idiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-idiv.ll
@@ -5,7 +5,7 @@
 
 define amdgpu_kernel void @udiv_i32(ptr addrspace(1) %out, i32 %x, i32 %y) {
 ; CHECK-LABEL: @udiv_i32(
-; CHECK-NEXT:    [[TMP1:%.*]] = uitofp i32 [[Y:%.*]] to float
+; CHECK-NEXT:    [[TMP1:%.*]] = uitofp fast i32 [[Y:%.*]] to float
 ; CHECK-NEXT:    [[TMP2:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = fmul fast float [[TMP2]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP4:%.*]] = fptoui float [[TMP3]] to i32
@@ -104,7 +104,7 @@ define amdgpu_kernel void @udiv_i32(ptr addrspace(1) %out, i32 %x, i32 %y) {
 
 define amdgpu_kernel void @urem_i32(ptr addrspace(1) %out, i32 %x, i32 %y) {
 ; CHECK-LABEL: @urem_i32(
-; CHECK-NEXT:    [[TMP1:%.*]] = uitofp i32 [[Y:%.*]] to float
+; CHECK-NEXT:    [[TMP1:%.*]] = uitofp fast i32 [[Y:%.*]] to float
 ; CHECK-NEXT:    [[TMP2:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = fmul fast float [[TMP2]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP4:%.*]] = fptoui float [[TMP3]] to i32
@@ -203,7 +203,7 @@ define amdgpu_kernel void @sdiv_i32(ptr addrspace(1) %out, i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[TMP5:%.*]] = add i32 [[Y]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = xor i32 [[TMP4]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = xor i32 [[TMP5]], [[TMP2]]
-; CHECK-NEXT:    [[TMP8:%.*]] = uitofp i32 [[TMP7]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = uitofp fast i32 [[TMP7]] to float
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP8]])
 ; CHECK-NEXT:    [[TMP10:%.*]] = fmul fast float [[TMP9]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP11:%.*]] = fptoui float [[TMP10]] to i32
@@ -322,7 +322,7 @@ define amdgpu_kernel void @srem_i32(ptr addrspace(1) %out, i32 %x, i32 %y) {
 ; CHECK-NEXT:    [[TMP4:%.*]] = add i32 [[Y]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = xor i32 [[TMP4]], [[TMP2]]
-; CHECK-NEXT:    [[TMP7:%.*]] = uitofp i32 [[TMP6]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = uitofp fast i32 [[TMP6]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP8]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP10:%.*]] = fptoui float [[TMP9]] to i32
@@ -428,8 +428,8 @@ define amdgpu_kernel void @udiv_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-LABEL: @udiv_i16(
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i16 [[X:%.*]] to i32
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i16 [[Y:%.*]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP4:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP5:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP4]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = fmul fast float [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.trunc.f32(float [[TMP6]])
@@ -497,8 +497,8 @@ define amdgpu_kernel void @urem_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-LABEL: @urem_i16(
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i16 [[X:%.*]] to i32
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i16 [[Y:%.*]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP4:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP5:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP4]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = fmul fast float [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.trunc.f32(float [[TMP6]])
@@ -575,8 +575,8 @@ define amdgpu_kernel void @sdiv_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP3]], 30
 ; CHECK-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP6:%.*]] = sitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP7:%.*]] = sitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = sitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = sitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP6]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.trunc.f32(float [[TMP9]])
@@ -656,8 +656,8 @@ define amdgpu_kernel void @srem_i16(ptr addrspace(1) %out, i16 %x, i16 %y) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP3]], 30
 ; CHECK-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP6:%.*]] = sitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP7:%.*]] = sitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = sitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = sitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP6]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.trunc.f32(float [[TMP9]])
@@ -740,8 +740,8 @@ define amdgpu_kernel void @udiv_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-LABEL: @udiv_i8(
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i8 [[X:%.*]] to i32
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i8 [[Y:%.*]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP4:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP5:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP4]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = fmul fast float [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.trunc.f32(float [[TMP6]])
@@ -803,8 +803,8 @@ define amdgpu_kernel void @urem_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-LABEL: @urem_i8(
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i8 [[X:%.*]] to i32
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i8 [[Y:%.*]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP4:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP5:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP4]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = fmul fast float [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.trunc.f32(float [[TMP6]])
@@ -877,8 +877,8 @@ define amdgpu_kernel void @sdiv_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP3]], 30
 ; CHECK-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP6:%.*]] = sitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP7:%.*]] = sitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = sitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = sitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP6]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.trunc.f32(float [[TMP9]])
@@ -958,8 +958,8 @@ define amdgpu_kernel void @srem_i8(ptr addrspace(1) %out, i8 %x, i8 %y) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP3]], 30
 ; CHECK-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP6:%.*]] = sitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP7:%.*]] = sitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = sitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = sitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP6]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.trunc.f32(float [[TMP9]])
@@ -1044,7 +1044,7 @@ define amdgpu_kernel void @udiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-LABEL: @udiv_v4i32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[X:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <4 x i32> [[Y:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP4:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP3]])
 ; CHECK-NEXT:    [[TMP5:%.*]] = fmul fast float [[TMP4]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP6:%.*]] = fptoui float [[TMP5]] to i32
@@ -1076,7 +1076,7 @@ define amdgpu_kernel void @udiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <4 x i32> poison, i32 [[TMP31]], i64 0
 ; CHECK-NEXT:    [[TMP33:%.*]] = extractelement <4 x i32> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP34:%.*]] = extractelement <4 x i32> [[Y]], i64 1
-; CHECK-NEXT:    [[TMP35:%.*]] = uitofp i32 [[TMP34]] to float
+; CHECK-NEXT:    [[TMP35:%.*]] = uitofp fast i32 [[TMP34]] to float
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP35]])
 ; CHECK-NEXT:    [[TMP37:%.*]] = fmul fast float [[TMP36]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP38:%.*]] = fptoui float [[TMP37]] to i32
@@ -1108,7 +1108,7 @@ define amdgpu_kernel void @udiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP64:%.*]] = insertelement <4 x i32> [[TMP32]], i32 [[TMP63]], i64 1
 ; CHECK-NEXT:    [[TMP65:%.*]] = extractelement <4 x i32> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP66:%.*]] = extractelement <4 x i32> [[Y]], i64 2
-; CHECK-NEXT:    [[TMP67:%.*]] = uitofp i32 [[TMP66]] to float
+; CHECK-NEXT:    [[TMP67:%.*]] = uitofp fast i32 [[TMP66]] to float
 ; CHECK-NEXT:    [[TMP68:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP67]])
 ; CHECK-NEXT:    [[TMP69:%.*]] = fmul fast float [[TMP68]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP70:%.*]] = fptoui float [[TMP69]] to i32
@@ -1140,7 +1140,7 @@ define amdgpu_kernel void @udiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP96:%.*]] = insertelement <4 x i32> [[TMP64]], i32 [[TMP95]], i64 2
 ; CHECK-NEXT:    [[TMP97:%.*]] = extractelement <4 x i32> [[X]], i64 3
 ; CHECK-NEXT:    [[TMP98:%.*]] = extractelement <4 x i32> [[Y]], i64 3
-; CHECK-NEXT:    [[TMP99:%.*]] = uitofp i32 [[TMP98]] to float
+; CHECK-NEXT:    [[TMP99:%.*]] = uitofp fast i32 [[TMP98]] to float
 ; CHECK-NEXT:    [[TMP100:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP99]])
 ; CHECK-NEXT:    [[TMP101:%.*]] = fmul fast float [[TMP100]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP102:%.*]] = fptoui float [[TMP101]] to i32
@@ -1372,7 +1372,7 @@ define amdgpu_kernel void @urem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-LABEL: @urem_v4i32(
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <4 x i32> [[X:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <4 x i32> [[Y:%.*]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP4:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP3]])
 ; CHECK-NEXT:    [[TMP5:%.*]] = fmul fast float [[TMP4]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP6:%.*]] = fptoui float [[TMP5]] to i32
@@ -1402,7 +1402,7 @@ define amdgpu_kernel void @urem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <4 x i32> poison, i32 [[TMP29]], i64 0
 ; CHECK-NEXT:    [[TMP31:%.*]] = extractelement <4 x i32> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP32:%.*]] = extractelement <4 x i32> [[Y]], i64 1
-; CHECK-NEXT:    [[TMP33:%.*]] = uitofp i32 [[TMP32]] to float
+; CHECK-NEXT:    [[TMP33:%.*]] = uitofp fast i32 [[TMP32]] to float
 ; CHECK-NEXT:    [[TMP34:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP33]])
 ; CHECK-NEXT:    [[TMP35:%.*]] = fmul fast float [[TMP34]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP36:%.*]] = fptoui float [[TMP35]] to i32
@@ -1432,7 +1432,7 @@ define amdgpu_kernel void @urem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP60:%.*]] = insertelement <4 x i32> [[TMP30]], i32 [[TMP59]], i64 1
 ; CHECK-NEXT:    [[TMP61:%.*]] = extractelement <4 x i32> [[X]], i64 2
 ; CHECK-NEXT:    [[TMP62:%.*]] = extractelement <4 x i32> [[Y]], i64 2
-; CHECK-NEXT:    [[TMP63:%.*]] = uitofp i32 [[TMP62]] to float
+; CHECK-NEXT:    [[TMP63:%.*]] = uitofp fast i32 [[TMP62]] to float
 ; CHECK-NEXT:    [[TMP64:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP63]])
 ; CHECK-NEXT:    [[TMP65:%.*]] = fmul fast float [[TMP64]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP66:%.*]] = fptoui float [[TMP65]] to i32
@@ -1462,7 +1462,7 @@ define amdgpu_kernel void @urem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP90:%.*]] = insertelement <4 x i32> [[TMP60]], i32 [[TMP89]], i64 2
 ; CHECK-NEXT:    [[TMP91:%.*]] = extractelement <4 x i32> [[X]], i64 3
 ; CHECK-NEXT:    [[TMP92:%.*]] = extractelement <4 x i32> [[Y]], i64 3
-; CHECK-NEXT:    [[TMP93:%.*]] = uitofp i32 [[TMP92]] to float
+; CHECK-NEXT:    [[TMP93:%.*]] = uitofp fast i32 [[TMP92]] to float
 ; CHECK-NEXT:    [[TMP94:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP93]])
 ; CHECK-NEXT:    [[TMP95:%.*]] = fmul fast float [[TMP94]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP96:%.*]] = fptoui float [[TMP95]] to i32
@@ -1680,7 +1680,7 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP7:%.*]] = add i32 [[TMP2]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = xor i32 [[TMP6]], [[TMP3]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = xor i32 [[TMP7]], [[TMP4]]
-; CHECK-NEXT:    [[TMP10:%.*]] = uitofp i32 [[TMP9]] to float
+; CHECK-NEXT:    [[TMP10:%.*]] = uitofp fast i32 [[TMP9]] to float
 ; CHECK-NEXT:    [[TMP11:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP10]])
 ; CHECK-NEXT:    [[TMP12:%.*]] = fmul fast float [[TMP11]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP13:%.*]] = fptoui float [[TMP12]] to i32
@@ -1721,7 +1721,7 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP48:%.*]] = add i32 [[TMP43]], [[TMP45]]
 ; CHECK-NEXT:    [[TMP49:%.*]] = xor i32 [[TMP47]], [[TMP44]]
 ; CHECK-NEXT:    [[TMP50:%.*]] = xor i32 [[TMP48]], [[TMP45]]
-; CHECK-NEXT:    [[TMP51:%.*]] = uitofp i32 [[TMP50]] to float
+; CHECK-NEXT:    [[TMP51:%.*]] = uitofp fast i32 [[TMP50]] to float
 ; CHECK-NEXT:    [[TMP52:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP51]])
 ; CHECK-NEXT:    [[TMP53:%.*]] = fmul fast float [[TMP52]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP54:%.*]] = fptoui float [[TMP53]] to i32
@@ -1762,7 +1762,7 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP89:%.*]] = add i32 [[TMP84]], [[TMP86]]
 ; CHECK-NEXT:    [[TMP90:%.*]] = xor i32 [[TMP88]], [[TMP85]]
 ; CHECK-NEXT:    [[TMP91:%.*]] = xor i32 [[TMP89]], [[TMP86]]
-; CHECK-NEXT:    [[TMP92:%.*]] = uitofp i32 [[TMP91]] to float
+; CHECK-NEXT:    [[TMP92:%.*]] = uitofp fast i32 [[TMP91]] to float
 ; CHECK-NEXT:    [[TMP93:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP92]])
 ; CHECK-NEXT:    [[TMP94:%.*]] = fmul fast float [[TMP93]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP95:%.*]] = fptoui float [[TMP94]] to i32
@@ -1803,7 +1803,7 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP130:%.*]] = add i32 [[TMP125]], [[TMP127]]
 ; CHECK-NEXT:    [[TMP131:%.*]] = xor i32 [[TMP129]], [[TMP126]]
 ; CHECK-NEXT:    [[TMP132:%.*]] = xor i32 [[TMP130]], [[TMP127]]
-; CHECK-NEXT:    [[TMP133:%.*]] = uitofp i32 [[TMP132]] to float
+; CHECK-NEXT:    [[TMP133:%.*]] = uitofp fast i32 [[TMP132]] to float
 ; CHECK-NEXT:    [[TMP134:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP133]])
 ; CHECK-NEXT:    [[TMP135:%.*]] = fmul fast float [[TMP134]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP136:%.*]] = fptoui float [[TMP135]] to i32
@@ -2092,7 +2092,7 @@ define amdgpu_kernel void @srem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP2]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = xor i32 [[TMP5]], [[TMP3]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = xor i32 [[TMP6]], [[TMP4]]
-; CHECK-NEXT:    [[TMP9:%.*]] = uitofp i32 [[TMP8]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = uitofp fast i32 [[TMP8]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP10]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP12:%.*]] = fptoui float [[TMP11]] to i32
@@ -2130,7 +2130,7 @@ define amdgpu_kernel void @srem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP44:%.*]] = add i32 [[TMP40]], [[TMP42]]
 ; CHECK-NEXT:    [[TMP45:%.*]] = xor i32 [[TMP43]], [[TMP41]]
 ; CHECK-NEXT:    [[TMP46:%.*]] = xor i32 [[TMP44]], [[TMP42]]
-; CHECK-NEXT:    [[TMP47:%.*]] = uitofp i32 [[TMP46]] to float
+; CHECK-NEXT:    [[TMP47:%.*]] = uitofp fast i32 [[TMP46]] to float
 ; CHECK-NEXT:    [[TMP48:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP47]])
 ; CHECK-NEXT:    [[TMP49:%.*]] = fmul fast float [[TMP48]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP50:%.*]] = fptoui float [[TMP49]] to i32
@@ -2168,7 +2168,7 @@ define amdgpu_kernel void @srem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP82:%.*]] = add i32 [[TMP78]], [[TMP80]]
 ; CHECK-NEXT:    [[TMP83:%.*]] = xor i32 [[TMP81]], [[TMP79]]
 ; CHECK-NEXT:    [[TMP84:%.*]] = xor i32 [[TMP82]], [[TMP80]]
-; CHECK-NEXT:    [[TMP85:%.*]] = uitofp i32 [[TMP84]] to float
+; CHECK-NEXT:    [[TMP85:%.*]] = uitofp fast i32 [[TMP84]] to float
 ; CHECK-NEXT:    [[TMP86:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP85]])
 ; CHECK-NEXT:    [[TMP87:%.*]] = fmul fast float [[TMP86]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP88:%.*]] = fptoui float [[TMP87]] to i32
@@ -2206,7 +2206,7 @@ define amdgpu_kernel void @srem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; CHECK-NEXT:    [[TMP120:%.*]] = add i32 [[TMP116]], [[TMP118]]
 ; CHECK-NEXT:    [[TMP121:%.*]] = xor i32 [[TMP119]], [[TMP117]]
 ; CHECK-NEXT:    [[TMP122:%.*]] = xor i32 [[TMP120]], [[TMP118]]
-; CHECK-NEXT:    [[TMP123:%.*]] = uitofp i32 [[TMP122]] to float
+; CHECK-NEXT:    [[TMP123:%.*]] = uitofp fast i32 [[TMP122]] to float
 ; CHECK-NEXT:    [[TMP124:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP123]])
 ; CHECK-NEXT:    [[TMP125:%.*]] = fmul fast float [[TMP124]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP126:%.*]] = fptoui float [[TMP125]] to i32
@@ -2462,8 +2462,8 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <4 x i16> [[Y:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = zext i16 [[TMP1]] to i32
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i16 [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP6:%.*]] = uitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP6]])
 ; CHECK-NEXT:    [[TMP8:%.*]] = fmul fast float [[TMP5]], [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.trunc.f32(float [[TMP8]])
@@ -2482,8 +2482,8 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <4 x i16> [[Y]], i64 1
 ; CHECK-NEXT:    [[TMP23:%.*]] = zext i16 [[TMP21]] to i32
 ; CHECK-NEXT:    [[TMP24:%.*]] = zext i16 [[TMP22]] to i32
-; CHECK-NEXT:    [[TMP25:%.*]] = uitofp i32 [[TMP23]] to float
-; CHECK-NEXT:    [[TMP26:%.*]] = uitofp i32 [[TMP24]] to float
+; CHECK-NEXT:    [[TMP25:%.*]] = uitofp fast i32 [[TMP23]] to float
+; CHECK-NEXT:    [[TMP26:%.*]] = uitofp fast i32 [[TMP24]] to float
 ; CHECK-NEXT:    [[TMP27:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP26]])
 ; CHECK-NEXT:    [[TMP28:%.*]] = fmul fast float [[TMP25]], [[TMP27]]
 ; CHECK-NEXT:    [[TMP29:%.*]] = call fast float @llvm.trunc.f32(float [[TMP28]])
@@ -2502,8 +2502,8 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <4 x i16> [[Y]], i64 2
 ; CHECK-NEXT:    [[TMP43:%.*]] = zext i16 [[TMP41]] to i32
 ; CHECK-NEXT:    [[TMP44:%.*]] = zext i16 [[TMP42]] to i32
-; CHECK-NEXT:    [[TMP45:%.*]] = uitofp i32 [[TMP43]] to float
-; CHECK-NEXT:    [[TMP46:%.*]] = uitofp i32 [[TMP44]] to float
+; CHECK-NEXT:    [[TMP45:%.*]] = uitofp fast i32 [[TMP43]] to float
+; CHECK-NEXT:    [[TMP46:%.*]] = uitofp fast i32 [[TMP44]] to float
 ; CHECK-NEXT:    [[TMP47:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP46]])
 ; CHECK-NEXT:    [[TMP48:%.*]] = fmul fast float [[TMP45]], [[TMP47]]
 ; CHECK-NEXT:    [[TMP49:%.*]] = call fast float @llvm.trunc.f32(float [[TMP48]])
@@ -2522,8 +2522,8 @@ define amdgpu_kernel void @udiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP62:%.*]] = extractelement <4 x i16> [[Y]], i64 3
 ; CHECK-NEXT:    [[TMP63:%.*]] = zext i16 [[TMP61]] to i32
 ; CHECK-NEXT:    [[TMP64:%.*]] = zext i16 [[TMP62]] to i32
-; CHECK-NEXT:    [[TMP65:%.*]] = uitofp i32 [[TMP63]] to float
-; CHECK-NEXT:    [[TMP66:%.*]] = uitofp i32 [[TMP64]] to float
+; CHECK-NEXT:    [[TMP65:%.*]] = uitofp fast i32 [[TMP63]] to float
+; CHECK-NEXT:    [[TMP66:%.*]] = uitofp fast i32 [[TMP64]] to float
 ; CHECK-NEXT:    [[TMP67:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP66]])
 ; CHECK-NEXT:    [[TMP68:%.*]] = fmul fast float [[TMP65]], [[TMP67]]
 ; CHECK-NEXT:    [[TMP69:%.*]] = call fast float @llvm.trunc.f32(float [[TMP68]])
@@ -2669,8 +2669,8 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <4 x i16> [[Y:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = zext i16 [[TMP1]] to i32
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i16 [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP6:%.*]] = uitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP6]])
 ; CHECK-NEXT:    [[TMP8:%.*]] = fmul fast float [[TMP5]], [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.trunc.f32(float [[TMP8]])
@@ -2691,8 +2691,8 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <4 x i16> [[Y]], i64 1
 ; CHECK-NEXT:    [[TMP25:%.*]] = zext i16 [[TMP23]] to i32
 ; CHECK-NEXT:    [[TMP26:%.*]] = zext i16 [[TMP24]] to i32
-; CHECK-NEXT:    [[TMP27:%.*]] = uitofp i32 [[TMP25]] to float
-; CHECK-NEXT:    [[TMP28:%.*]] = uitofp i32 [[TMP26]] to float
+; CHECK-NEXT:    [[TMP27:%.*]] = uitofp fast i32 [[TMP25]] to float
+; CHECK-NEXT:    [[TMP28:%.*]] = uitofp fast i32 [[TMP26]] to float
 ; CHECK-NEXT:    [[TMP29:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP28]])
 ; CHECK-NEXT:    [[TMP30:%.*]] = fmul fast float [[TMP27]], [[TMP29]]
 ; CHECK-NEXT:    [[TMP31:%.*]] = call fast float @llvm.trunc.f32(float [[TMP30]])
@@ -2713,8 +2713,8 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <4 x i16> [[Y]], i64 2
 ; CHECK-NEXT:    [[TMP47:%.*]] = zext i16 [[TMP45]] to i32
 ; CHECK-NEXT:    [[TMP48:%.*]] = zext i16 [[TMP46]] to i32
-; CHECK-NEXT:    [[TMP49:%.*]] = uitofp i32 [[TMP47]] to float
-; CHECK-NEXT:    [[TMP50:%.*]] = uitofp i32 [[TMP48]] to float
+; CHECK-NEXT:    [[TMP49:%.*]] = uitofp fast i32 [[TMP47]] to float
+; CHECK-NEXT:    [[TMP50:%.*]] = uitofp fast i32 [[TMP48]] to float
 ; CHECK-NEXT:    [[TMP51:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP50]])
 ; CHECK-NEXT:    [[TMP52:%.*]] = fmul fast float [[TMP49]], [[TMP51]]
 ; CHECK-NEXT:    [[TMP53:%.*]] = call fast float @llvm.trunc.f32(float [[TMP52]])
@@ -2735,8 +2735,8 @@ define amdgpu_kernel void @urem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP68:%.*]] = extractelement <4 x i16> [[Y]], i64 3
 ; CHECK-NEXT:    [[TMP69:%.*]] = zext i16 [[TMP67]] to i32
 ; CHECK-NEXT:    [[TMP70:%.*]] = zext i16 [[TMP68]] to i32
-; CHECK-NEXT:    [[TMP71:%.*]] = uitofp i32 [[TMP69]] to float
-; CHECK-NEXT:    [[TMP72:%.*]] = uitofp i32 [[TMP70]] to float
+; CHECK-NEXT:    [[TMP71:%.*]] = uitofp fast i32 [[TMP69]] to float
+; CHECK-NEXT:    [[TMP72:%.*]] = uitofp fast i32 [[TMP70]] to float
 ; CHECK-NEXT:    [[TMP73:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP72]])
 ; CHECK-NEXT:    [[TMP74:%.*]] = fmul fast float [[TMP71]], [[TMP73]]
 ; CHECK-NEXT:    [[TMP75:%.*]] = call fast float @llvm.trunc.f32(float [[TMP74]])
@@ -2902,8 +2902,8 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = ashr i32 [[TMP5]], 30
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i32 [[TMP6]], 1
-; CHECK-NEXT:    [[TMP8:%.*]] = sitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP9:%.*]] = sitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = sitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = sitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP8]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call fast float @llvm.trunc.f32(float [[TMP11]])
@@ -2926,8 +2926,8 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP29:%.*]] = xor i32 [[TMP27]], [[TMP28]]
 ; CHECK-NEXT:    [[TMP30:%.*]] = ashr i32 [[TMP29]], 30
 ; CHECK-NEXT:    [[TMP31:%.*]] = or i32 [[TMP30]], 1
-; CHECK-NEXT:    [[TMP32:%.*]] = sitofp i32 [[TMP27]] to float
-; CHECK-NEXT:    [[TMP33:%.*]] = sitofp i32 [[TMP28]] to float
+; CHECK-NEXT:    [[TMP32:%.*]] = sitofp fast i32 [[TMP27]] to float
+; CHECK-NEXT:    [[TMP33:%.*]] = sitofp fast i32 [[TMP28]] to float
 ; CHECK-NEXT:    [[TMP34:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP33]])
 ; CHECK-NEXT:    [[TMP35:%.*]] = fmul fast float [[TMP32]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.trunc.f32(float [[TMP35]])
@@ -2950,8 +2950,8 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP53:%.*]] = xor i32 [[TMP51]], [[TMP52]]
 ; CHECK-NEXT:    [[TMP54:%.*]] = ashr i32 [[TMP53]], 30
 ; CHECK-NEXT:    [[TMP55:%.*]] = or i32 [[TMP54]], 1
-; CHECK-NEXT:    [[TMP56:%.*]] = sitofp i32 [[TMP51]] to float
-; CHECK-NEXT:    [[TMP57:%.*]] = sitofp i32 [[TMP52]] to float
+; CHECK-NEXT:    [[TMP56:%.*]] = sitofp fast i32 [[TMP51]] to float
+; CHECK-NEXT:    [[TMP57:%.*]] = sitofp fast i32 [[TMP52]] to float
 ; CHECK-NEXT:    [[TMP58:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP57]])
 ; CHECK-NEXT:    [[TMP59:%.*]] = fmul fast float [[TMP56]], [[TMP58]]
 ; CHECK-NEXT:    [[TMP60:%.*]] = call fast float @llvm.trunc.f32(float [[TMP59]])
@@ -2974,8 +2974,8 @@ define amdgpu_kernel void @sdiv_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP77:%.*]] = xor i32 [[TMP75]], [[TMP76]]
 ; CHECK-NEXT:    [[TMP78:%.*]] = ashr i32 [[TMP77]], 30
 ; CHECK-NEXT:    [[TMP79:%.*]] = or i32 [[TMP78]], 1
-; CHECK-NEXT:    [[TMP80:%.*]] = sitofp i32 [[TMP75]] to float
-; CHECK-NEXT:    [[TMP81:%.*]] = sitofp i32 [[TMP76]] to float
+; CHECK-NEXT:    [[TMP80:%.*]] = sitofp fast i32 [[TMP75]] to float
+; CHECK-NEXT:    [[TMP81:%.*]] = sitofp fast i32 [[TMP76]] to float
 ; CHECK-NEXT:    [[TMP82:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP81]])
 ; CHECK-NEXT:    [[TMP83:%.*]] = fmul fast float [[TMP80]], [[TMP82]]
 ; CHECK-NEXT:    [[TMP84:%.*]] = call fast float @llvm.trunc.f32(float [[TMP83]])
@@ -3164,8 +3164,8 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = ashr i32 [[TMP5]], 30
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i32 [[TMP6]], 1
-; CHECK-NEXT:    [[TMP8:%.*]] = sitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP9:%.*]] = sitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = sitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = sitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP8]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call fast float @llvm.trunc.f32(float [[TMP11]])
@@ -3190,8 +3190,8 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP31:%.*]] = xor i32 [[TMP29]], [[TMP30]]
 ; CHECK-NEXT:    [[TMP32:%.*]] = ashr i32 [[TMP31]], 30
 ; CHECK-NEXT:    [[TMP33:%.*]] = or i32 [[TMP32]], 1
-; CHECK-NEXT:    [[TMP34:%.*]] = sitofp i32 [[TMP29]] to float
-; CHECK-NEXT:    [[TMP35:%.*]] = sitofp i32 [[TMP30]] to float
+; CHECK-NEXT:    [[TMP34:%.*]] = sitofp fast i32 [[TMP29]] to float
+; CHECK-NEXT:    [[TMP35:%.*]] = sitofp fast i32 [[TMP30]] to float
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP35]])
 ; CHECK-NEXT:    [[TMP37:%.*]] = fmul fast float [[TMP34]], [[TMP36]]
 ; CHECK-NEXT:    [[TMP38:%.*]] = call fast float @llvm.trunc.f32(float [[TMP37]])
@@ -3216,8 +3216,8 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP57:%.*]] = xor i32 [[TMP55]], [[TMP56]]
 ; CHECK-NEXT:    [[TMP58:%.*]] = ashr i32 [[TMP57]], 30
 ; CHECK-NEXT:    [[TMP59:%.*]] = or i32 [[TMP58]], 1
-; CHECK-NEXT:    [[TMP60:%.*]] = sitofp i32 [[TMP55]] to float
-; CHECK-NEXT:    [[TMP61:%.*]] = sitofp i32 [[TMP56]] to float
+; CHECK-NEXT:    [[TMP60:%.*]] = sitofp fast i32 [[TMP55]] to float
+; CHECK-NEXT:    [[TMP61:%.*]] = sitofp fast i32 [[TMP56]] to float
 ; CHECK-NEXT:    [[TMP62:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP61]])
 ; CHECK-NEXT:    [[TMP63:%.*]] = fmul fast float [[TMP60]], [[TMP62]]
 ; CHECK-NEXT:    [[TMP64:%.*]] = call fast float @llvm.trunc.f32(float [[TMP63]])
@@ -3242,8 +3242,8 @@ define amdgpu_kernel void @srem_v4i16(ptr addrspace(1) %out, <4 x i16> %x, <4 x 
 ; CHECK-NEXT:    [[TMP83:%.*]] = xor i32 [[TMP81]], [[TMP82]]
 ; CHECK-NEXT:    [[TMP84:%.*]] = ashr i32 [[TMP83]], 30
 ; CHECK-NEXT:    [[TMP85:%.*]] = or i32 [[TMP84]], 1
-; CHECK-NEXT:    [[TMP86:%.*]] = sitofp i32 [[TMP81]] to float
-; CHECK-NEXT:    [[TMP87:%.*]] = sitofp i32 [[TMP82]] to float
+; CHECK-NEXT:    [[TMP86:%.*]] = sitofp fast i32 [[TMP81]] to float
+; CHECK-NEXT:    [[TMP87:%.*]] = sitofp fast i32 [[TMP82]] to float
 ; CHECK-NEXT:    [[TMP88:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP87]])
 ; CHECK-NEXT:    [[TMP89:%.*]] = fmul fast float [[TMP86]], [[TMP88]]
 ; CHECK-NEXT:    [[TMP90:%.*]] = call fast float @llvm.trunc.f32(float [[TMP89]])
@@ -3449,8 +3449,8 @@ define amdgpu_kernel void @udiv_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-LABEL: @udiv_i3(
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i3 [[X:%.*]] to i32
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i3 [[Y:%.*]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP4:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP5:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP4]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = fmul fast float [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.trunc.f32(float [[TMP6]])
@@ -3518,8 +3518,8 @@ define amdgpu_kernel void @urem_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-LABEL: @urem_i3(
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext i3 [[X:%.*]] to i32
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext i3 [[Y:%.*]] to i32
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP4:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP5:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP4]])
 ; CHECK-NEXT:    [[TMP6:%.*]] = fmul fast float [[TMP3]], [[TMP5]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.trunc.f32(float [[TMP6]])
@@ -3599,8 +3599,8 @@ define amdgpu_kernel void @sdiv_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP3]], 30
 ; CHECK-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP6:%.*]] = sitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP7:%.*]] = sitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = sitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = sitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP6]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.trunc.f32(float [[TMP9]])
@@ -3682,8 +3682,8 @@ define amdgpu_kernel void @srem_i3(ptr addrspace(1) %out, i3 %x, i3 %y) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = ashr i32 [[TMP3]], 30
 ; CHECK-NEXT:    [[TMP5:%.*]] = or i32 [[TMP4]], 1
-; CHECK-NEXT:    [[TMP6:%.*]] = sitofp i32 [[TMP1]] to float
-; CHECK-NEXT:    [[TMP7:%.*]] = sitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = sitofp fast i32 [[TMP1]] to float
+; CHECK-NEXT:    [[TMP7:%.*]] = sitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP8:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP7]])
 ; CHECK-NEXT:    [[TMP9:%.*]] = fmul fast float [[TMP6]], [[TMP8]]
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.trunc.f32(float [[TMP9]])
@@ -3773,8 +3773,8 @@ define amdgpu_kernel void @udiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <3 x i16> [[Y:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = zext i16 [[TMP1]] to i32
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i16 [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP6:%.*]] = uitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP6]])
 ; CHECK-NEXT:    [[TMP8:%.*]] = fmul fast float [[TMP5]], [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.trunc.f32(float [[TMP8]])
@@ -3793,8 +3793,8 @@ define amdgpu_kernel void @udiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <3 x i16> [[Y]], i64 1
 ; CHECK-NEXT:    [[TMP23:%.*]] = zext i16 [[TMP21]] to i32
 ; CHECK-NEXT:    [[TMP24:%.*]] = zext i16 [[TMP22]] to i32
-; CHECK-NEXT:    [[TMP25:%.*]] = uitofp i32 [[TMP23]] to float
-; CHECK-NEXT:    [[TMP26:%.*]] = uitofp i32 [[TMP24]] to float
+; CHECK-NEXT:    [[TMP25:%.*]] = uitofp fast i32 [[TMP23]] to float
+; CHECK-NEXT:    [[TMP26:%.*]] = uitofp fast i32 [[TMP24]] to float
 ; CHECK-NEXT:    [[TMP27:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP26]])
 ; CHECK-NEXT:    [[TMP28:%.*]] = fmul fast float [[TMP25]], [[TMP27]]
 ; CHECK-NEXT:    [[TMP29:%.*]] = call fast float @llvm.trunc.f32(float [[TMP28]])
@@ -3813,8 +3813,8 @@ define amdgpu_kernel void @udiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <3 x i16> [[Y]], i64 2
 ; CHECK-NEXT:    [[TMP43:%.*]] = zext i16 [[TMP41]] to i32
 ; CHECK-NEXT:    [[TMP44:%.*]] = zext i16 [[TMP42]] to i32
-; CHECK-NEXT:    [[TMP45:%.*]] = uitofp i32 [[TMP43]] to float
-; CHECK-NEXT:    [[TMP46:%.*]] = uitofp i32 [[TMP44]] to float
+; CHECK-NEXT:    [[TMP45:%.*]] = uitofp fast i32 [[TMP43]] to float
+; CHECK-NEXT:    [[TMP46:%.*]] = uitofp fast i32 [[TMP44]] to float
 ; CHECK-NEXT:    [[TMP47:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP46]])
 ; CHECK-NEXT:    [[TMP48:%.*]] = fmul fast float [[TMP45]], [[TMP47]]
 ; CHECK-NEXT:    [[TMP49:%.*]] = call fast float @llvm.trunc.f32(float [[TMP48]])
@@ -3935,8 +3935,8 @@ define amdgpu_kernel void @urem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <3 x i16> [[Y:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = zext i16 [[TMP1]] to i32
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i16 [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP6:%.*]] = uitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP6]])
 ; CHECK-NEXT:    [[TMP8:%.*]] = fmul fast float [[TMP5]], [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.trunc.f32(float [[TMP8]])
@@ -3957,8 +3957,8 @@ define amdgpu_kernel void @urem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <3 x i16> [[Y]], i64 1
 ; CHECK-NEXT:    [[TMP25:%.*]] = zext i16 [[TMP23]] to i32
 ; CHECK-NEXT:    [[TMP26:%.*]] = zext i16 [[TMP24]] to i32
-; CHECK-NEXT:    [[TMP27:%.*]] = uitofp i32 [[TMP25]] to float
-; CHECK-NEXT:    [[TMP28:%.*]] = uitofp i32 [[TMP26]] to float
+; CHECK-NEXT:    [[TMP27:%.*]] = uitofp fast i32 [[TMP25]] to float
+; CHECK-NEXT:    [[TMP28:%.*]] = uitofp fast i32 [[TMP26]] to float
 ; CHECK-NEXT:    [[TMP29:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP28]])
 ; CHECK-NEXT:    [[TMP30:%.*]] = fmul fast float [[TMP27]], [[TMP29]]
 ; CHECK-NEXT:    [[TMP31:%.*]] = call fast float @llvm.trunc.f32(float [[TMP30]])
@@ -3979,8 +3979,8 @@ define amdgpu_kernel void @urem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <3 x i16> [[Y]], i64 2
 ; CHECK-NEXT:    [[TMP47:%.*]] = zext i16 [[TMP45]] to i32
 ; CHECK-NEXT:    [[TMP48:%.*]] = zext i16 [[TMP46]] to i32
-; CHECK-NEXT:    [[TMP49:%.*]] = uitofp i32 [[TMP47]] to float
-; CHECK-NEXT:    [[TMP50:%.*]] = uitofp i32 [[TMP48]] to float
+; CHECK-NEXT:    [[TMP49:%.*]] = uitofp fast i32 [[TMP47]] to float
+; CHECK-NEXT:    [[TMP50:%.*]] = uitofp fast i32 [[TMP48]] to float
 ; CHECK-NEXT:    [[TMP51:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP50]])
 ; CHECK-NEXT:    [[TMP52:%.*]] = fmul fast float [[TMP49]], [[TMP51]]
 ; CHECK-NEXT:    [[TMP53:%.*]] = call fast float @llvm.trunc.f32(float [[TMP52]])
@@ -4117,8 +4117,8 @@ define amdgpu_kernel void @sdiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = ashr i32 [[TMP5]], 30
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i32 [[TMP6]], 1
-; CHECK-NEXT:    [[TMP8:%.*]] = sitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP9:%.*]] = sitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = sitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = sitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP8]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call fast float @llvm.trunc.f32(float [[TMP11]])
@@ -4141,8 +4141,8 @@ define amdgpu_kernel void @sdiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP29:%.*]] = xor i32 [[TMP27]], [[TMP28]]
 ; CHECK-NEXT:    [[TMP30:%.*]] = ashr i32 [[TMP29]], 30
 ; CHECK-NEXT:    [[TMP31:%.*]] = or i32 [[TMP30]], 1
-; CHECK-NEXT:    [[TMP32:%.*]] = sitofp i32 [[TMP27]] to float
-; CHECK-NEXT:    [[TMP33:%.*]] = sitofp i32 [[TMP28]] to float
+; CHECK-NEXT:    [[TMP32:%.*]] = sitofp fast i32 [[TMP27]] to float
+; CHECK-NEXT:    [[TMP33:%.*]] = sitofp fast i32 [[TMP28]] to float
 ; CHECK-NEXT:    [[TMP34:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP33]])
 ; CHECK-NEXT:    [[TMP35:%.*]] = fmul fast float [[TMP32]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.trunc.f32(float [[TMP35]])
@@ -4165,8 +4165,8 @@ define amdgpu_kernel void @sdiv_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP53:%.*]] = xor i32 [[TMP51]], [[TMP52]]
 ; CHECK-NEXT:    [[TMP54:%.*]] = ashr i32 [[TMP53]], 30
 ; CHECK-NEXT:    [[TMP55:%.*]] = or i32 [[TMP54]], 1
-; CHECK-NEXT:    [[TMP56:%.*]] = sitofp i32 [[TMP51]] to float
-; CHECK-NEXT:    [[TMP57:%.*]] = sitofp i32 [[TMP52]] to float
+; CHECK-NEXT:    [[TMP56:%.*]] = sitofp fast i32 [[TMP51]] to float
+; CHECK-NEXT:    [[TMP57:%.*]] = sitofp fast i32 [[TMP52]] to float
 ; CHECK-NEXT:    [[TMP58:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP57]])
 ; CHECK-NEXT:    [[TMP59:%.*]] = fmul fast float [[TMP56]], [[TMP58]]
 ; CHECK-NEXT:    [[TMP60:%.*]] = call fast float @llvm.trunc.f32(float [[TMP59]])
@@ -4320,8 +4320,8 @@ define amdgpu_kernel void @srem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = ashr i32 [[TMP5]], 30
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i32 [[TMP6]], 1
-; CHECK-NEXT:    [[TMP8:%.*]] = sitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP9:%.*]] = sitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = sitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = sitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP8]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call fast float @llvm.trunc.f32(float [[TMP11]])
@@ -4346,8 +4346,8 @@ define amdgpu_kernel void @srem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP31:%.*]] = xor i32 [[TMP29]], [[TMP30]]
 ; CHECK-NEXT:    [[TMP32:%.*]] = ashr i32 [[TMP31]], 30
 ; CHECK-NEXT:    [[TMP33:%.*]] = or i32 [[TMP32]], 1
-; CHECK-NEXT:    [[TMP34:%.*]] = sitofp i32 [[TMP29]] to float
-; CHECK-NEXT:    [[TMP35:%.*]] = sitofp i32 [[TMP30]] to float
+; CHECK-NEXT:    [[TMP34:%.*]] = sitofp fast i32 [[TMP29]] to float
+; CHECK-NEXT:    [[TMP35:%.*]] = sitofp fast i32 [[TMP30]] to float
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP35]])
 ; CHECK-NEXT:    [[TMP37:%.*]] = fmul fast float [[TMP34]], [[TMP36]]
 ; CHECK-NEXT:    [[TMP38:%.*]] = call fast float @llvm.trunc.f32(float [[TMP37]])
@@ -4372,8 +4372,8 @@ define amdgpu_kernel void @srem_v3i16(ptr addrspace(1) %out, <3 x i16> %x, <3 x 
 ; CHECK-NEXT:    [[TMP57:%.*]] = xor i32 [[TMP55]], [[TMP56]]
 ; CHECK-NEXT:    [[TMP58:%.*]] = ashr i32 [[TMP57]], 30
 ; CHECK-NEXT:    [[TMP59:%.*]] = or i32 [[TMP58]], 1
-; CHECK-NEXT:    [[TMP60:%.*]] = sitofp i32 [[TMP55]] to float
-; CHECK-NEXT:    [[TMP61:%.*]] = sitofp i32 [[TMP56]] to float
+; CHECK-NEXT:    [[TMP60:%.*]] = sitofp fast i32 [[TMP55]] to float
+; CHECK-NEXT:    [[TMP61:%.*]] = sitofp fast i32 [[TMP56]] to float
 ; CHECK-NEXT:    [[TMP62:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP61]])
 ; CHECK-NEXT:    [[TMP63:%.*]] = fmul fast float [[TMP60]], [[TMP62]]
 ; CHECK-NEXT:    [[TMP64:%.*]] = call fast float @llvm.trunc.f32(float [[TMP63]])
@@ -4540,8 +4540,8 @@ define amdgpu_kernel void @udiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <3 x i15> [[Y:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = zext i15 [[TMP1]] to i32
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i15 [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP6:%.*]] = uitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP6]])
 ; CHECK-NEXT:    [[TMP8:%.*]] = fmul fast float [[TMP5]], [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.trunc.f32(float [[TMP8]])
@@ -4560,8 +4560,8 @@ define amdgpu_kernel void @udiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP22:%.*]] = extractelement <3 x i15> [[Y]], i64 1
 ; CHECK-NEXT:    [[TMP23:%.*]] = zext i15 [[TMP21]] to i32
 ; CHECK-NEXT:    [[TMP24:%.*]] = zext i15 [[TMP22]] to i32
-; CHECK-NEXT:    [[TMP25:%.*]] = uitofp i32 [[TMP23]] to float
-; CHECK-NEXT:    [[TMP26:%.*]] = uitofp i32 [[TMP24]] to float
+; CHECK-NEXT:    [[TMP25:%.*]] = uitofp fast i32 [[TMP23]] to float
+; CHECK-NEXT:    [[TMP26:%.*]] = uitofp fast i32 [[TMP24]] to float
 ; CHECK-NEXT:    [[TMP27:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP26]])
 ; CHECK-NEXT:    [[TMP28:%.*]] = fmul fast float [[TMP25]], [[TMP27]]
 ; CHECK-NEXT:    [[TMP29:%.*]] = call fast float @llvm.trunc.f32(float [[TMP28]])
@@ -4580,8 +4580,8 @@ define amdgpu_kernel void @udiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP42:%.*]] = extractelement <3 x i15> [[Y]], i64 2
 ; CHECK-NEXT:    [[TMP43:%.*]] = zext i15 [[TMP41]] to i32
 ; CHECK-NEXT:    [[TMP44:%.*]] = zext i15 [[TMP42]] to i32
-; CHECK-NEXT:    [[TMP45:%.*]] = uitofp i32 [[TMP43]] to float
-; CHECK-NEXT:    [[TMP46:%.*]] = uitofp i32 [[TMP44]] to float
+; CHECK-NEXT:    [[TMP45:%.*]] = uitofp fast i32 [[TMP43]] to float
+; CHECK-NEXT:    [[TMP46:%.*]] = uitofp fast i32 [[TMP44]] to float
 ; CHECK-NEXT:    [[TMP47:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP46]])
 ; CHECK-NEXT:    [[TMP48:%.*]] = fmul fast float [[TMP45]], [[TMP47]]
 ; CHECK-NEXT:    [[TMP49:%.*]] = call fast float @llvm.trunc.f32(float [[TMP48]])
@@ -4717,8 +4717,8 @@ define amdgpu_kernel void @urem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <3 x i15> [[Y:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP3:%.*]] = zext i15 [[TMP1]] to i32
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext i15 [[TMP2]] to i32
-; CHECK-NEXT:    [[TMP5:%.*]] = uitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP6:%.*]] = uitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP5:%.*]] = uitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP6:%.*]] = uitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP7:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP6]])
 ; CHECK-NEXT:    [[TMP8:%.*]] = fmul fast float [[TMP5]], [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call fast float @llvm.trunc.f32(float [[TMP8]])
@@ -4739,8 +4739,8 @@ define amdgpu_kernel void @urem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP24:%.*]] = extractelement <3 x i15> [[Y]], i64 1
 ; CHECK-NEXT:    [[TMP25:%.*]] = zext i15 [[TMP23]] to i32
 ; CHECK-NEXT:    [[TMP26:%.*]] = zext i15 [[TMP24]] to i32
-; CHECK-NEXT:    [[TMP27:%.*]] = uitofp i32 [[TMP25]] to float
-; CHECK-NEXT:    [[TMP28:%.*]] = uitofp i32 [[TMP26]] to float
+; CHECK-NEXT:    [[TMP27:%.*]] = uitofp fast i32 [[TMP25]] to float
+; CHECK-NEXT:    [[TMP28:%.*]] = uitofp fast i32 [[TMP26]] to float
 ; CHECK-NEXT:    [[TMP29:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP28]])
 ; CHECK-NEXT:    [[TMP30:%.*]] = fmul fast float [[TMP27]], [[TMP29]]
 ; CHECK-NEXT:    [[TMP31:%.*]] = call fast float @llvm.trunc.f32(float [[TMP30]])
@@ -4761,8 +4761,8 @@ define amdgpu_kernel void @urem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP46:%.*]] = extractelement <3 x i15> [[Y]], i64 2
 ; CHECK-NEXT:    [[TMP47:%.*]] = zext i15 [[TMP45]] to i32
 ; CHECK-NEXT:    [[TMP48:%.*]] = zext i15 [[TMP46]] to i32
-; CHECK-NEXT:    [[TMP49:%.*]] = uitofp i32 [[TMP47]] to float
-; CHECK-NEXT:    [[TMP50:%.*]] = uitofp i32 [[TMP48]] to float
+; CHECK-NEXT:    [[TMP49:%.*]] = uitofp fast i32 [[TMP47]] to float
+; CHECK-NEXT:    [[TMP50:%.*]] = uitofp fast i32 [[TMP48]] to float
 ; CHECK-NEXT:    [[TMP51:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP50]])
 ; CHECK-NEXT:    [[TMP52:%.*]] = fmul fast float [[TMP49]], [[TMP51]]
 ; CHECK-NEXT:    [[TMP53:%.*]] = call fast float @llvm.trunc.f32(float [[TMP52]])
@@ -4919,8 +4919,8 @@ define amdgpu_kernel void @sdiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = ashr i32 [[TMP5]], 30
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i32 [[TMP6]], 1
-; CHECK-NEXT:    [[TMP8:%.*]] = sitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP9:%.*]] = sitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = sitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = sitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP8]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call fast float @llvm.trunc.f32(float [[TMP11]])
@@ -4943,8 +4943,8 @@ define amdgpu_kernel void @sdiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP29:%.*]] = xor i32 [[TMP27]], [[TMP28]]
 ; CHECK-NEXT:    [[TMP30:%.*]] = ashr i32 [[TMP29]], 30
 ; CHECK-NEXT:    [[TMP31:%.*]] = or i32 [[TMP30]], 1
-; CHECK-NEXT:    [[TMP32:%.*]] = sitofp i32 [[TMP27]] to float
-; CHECK-NEXT:    [[TMP33:%.*]] = sitofp i32 [[TMP28]] to float
+; CHECK-NEXT:    [[TMP32:%.*]] = sitofp fast i32 [[TMP27]] to float
+; CHECK-NEXT:    [[TMP33:%.*]] = sitofp fast i32 [[TMP28]] to float
 ; CHECK-NEXT:    [[TMP34:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP33]])
 ; CHECK-NEXT:    [[TMP35:%.*]] = fmul fast float [[TMP32]], [[TMP34]]
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.trunc.f32(float [[TMP35]])
@@ -4967,8 +4967,8 @@ define amdgpu_kernel void @sdiv_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP53:%.*]] = xor i32 [[TMP51]], [[TMP52]]
 ; CHECK-NEXT:    [[TMP54:%.*]] = ashr i32 [[TMP53]], 30
 ; CHECK-NEXT:    [[TMP55:%.*]] = or i32 [[TMP54]], 1
-; CHECK-NEXT:    [[TMP56:%.*]] = sitofp i32 [[TMP51]] to float
-; CHECK-NEXT:    [[TMP57:%.*]] = sitofp i32 [[TMP52]] to float
+; CHECK-NEXT:    [[TMP56:%.*]] = sitofp fast i32 [[TMP51]] to float
+; CHECK-NEXT:    [[TMP57:%.*]] = sitofp fast i32 [[TMP52]] to float
 ; CHECK-NEXT:    [[TMP58:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP57]])
 ; CHECK-NEXT:    [[TMP59:%.*]] = fmul fast float [[TMP56]], [[TMP58]]
 ; CHECK-NEXT:    [[TMP60:%.*]] = call fast float @llvm.trunc.f32(float [[TMP59]])
@@ -5138,8 +5138,8 @@ define amdgpu_kernel void @srem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP5:%.*]] = xor i32 [[TMP3]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = ashr i32 [[TMP5]], 30
 ; CHECK-NEXT:    [[TMP7:%.*]] = or i32 [[TMP6]], 1
-; CHECK-NEXT:    [[TMP8:%.*]] = sitofp i32 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP9:%.*]] = sitofp i32 [[TMP4]] to float
+; CHECK-NEXT:    [[TMP8:%.*]] = sitofp fast i32 [[TMP3]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = sitofp fast i32 [[TMP4]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP8]], [[TMP10]]
 ; CHECK-NEXT:    [[TMP12:%.*]] = call fast float @llvm.trunc.f32(float [[TMP11]])
@@ -5164,8 +5164,8 @@ define amdgpu_kernel void @srem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP31:%.*]] = xor i32 [[TMP29]], [[TMP30]]
 ; CHECK-NEXT:    [[TMP32:%.*]] = ashr i32 [[TMP31]], 30
 ; CHECK-NEXT:    [[TMP33:%.*]] = or i32 [[TMP32]], 1
-; CHECK-NEXT:    [[TMP34:%.*]] = sitofp i32 [[TMP29]] to float
-; CHECK-NEXT:    [[TMP35:%.*]] = sitofp i32 [[TMP30]] to float
+; CHECK-NEXT:    [[TMP34:%.*]] = sitofp fast i32 [[TMP29]] to float
+; CHECK-NEXT:    [[TMP35:%.*]] = sitofp fast i32 [[TMP30]] to float
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP35]])
 ; CHECK-NEXT:    [[TMP37:%.*]] = fmul fast float [[TMP34]], [[TMP36]]
 ; CHECK-NEXT:    [[TMP38:%.*]] = call fast float @llvm.trunc.f32(float [[TMP37]])
@@ -5190,8 +5190,8 @@ define amdgpu_kernel void @srem_v3i15(ptr addrspace(1) %out, <3 x i15> %x, <3 x 
 ; CHECK-NEXT:    [[TMP57:%.*]] = xor i32 [[TMP55]], [[TMP56]]
 ; CHECK-NEXT:    [[TMP58:%.*]] = ashr i32 [[TMP57]], 30
 ; CHECK-NEXT:    [[TMP59:%.*]] = or i32 [[TMP58]], 1
-; CHECK-NEXT:    [[TMP60:%.*]] = sitofp i32 [[TMP55]] to float
-; CHECK-NEXT:    [[TMP61:%.*]] = sitofp i32 [[TMP56]] to float
+; CHECK-NEXT:    [[TMP60:%.*]] = sitofp fast i32 [[TMP55]] to float
+; CHECK-NEXT:    [[TMP61:%.*]] = sitofp fast i32 [[TMP56]] to float
 ; CHECK-NEXT:    [[TMP62:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP61]])
 ; CHECK-NEXT:    [[TMP63:%.*]] = fmul fast float [[TMP60]], [[TMP62]]
 ; CHECK-NEXT:    [[TMP64:%.*]] = call fast float @llvm.trunc.f32(float [[TMP63]])
@@ -5579,7 +5579,7 @@ define amdgpu_kernel void @udiv_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[SHL_Y:%.*]] = shl <2 x i32> splat (i32 4096), [[Y:%.*]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x i32> [[X:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <2 x i32> [[SHL_Y]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP4:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP3]])
 ; CHECK-NEXT:    [[TMP5:%.*]] = fmul fast float [[TMP4]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP6:%.*]] = fptoui float [[TMP5]] to i32
@@ -5611,7 +5611,7 @@ define amdgpu_kernel void @udiv_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[TMP32:%.*]] = insertelement <2 x i32> poison, i32 [[TMP31]], i64 0
 ; CHECK-NEXT:    [[TMP33:%.*]] = extractelement <2 x i32> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP34:%.*]] = extractelement <2 x i32> [[SHL_Y]], i64 1
-; CHECK-NEXT:    [[TMP35:%.*]] = uitofp i32 [[TMP34]] to float
+; CHECK-NEXT:    [[TMP35:%.*]] = uitofp fast i32 [[TMP34]] to float
 ; CHECK-NEXT:    [[TMP36:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP35]])
 ; CHECK-NEXT:    [[TMP37:%.*]] = fmul fast float [[TMP36]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP38:%.*]] = fptoui float [[TMP37]] to i32
@@ -5922,7 +5922,7 @@ define amdgpu_kernel void @urem_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[SHL_Y:%.*]] = shl <2 x i32> splat (i32 4096), [[Y:%.*]]
 ; CHECK-NEXT:    [[TMP1:%.*]] = extractelement <2 x i32> [[X:%.*]], i64 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = extractelement <2 x i32> [[SHL_Y]], i64 0
-; CHECK-NEXT:    [[TMP3:%.*]] = uitofp i32 [[TMP2]] to float
+; CHECK-NEXT:    [[TMP3:%.*]] = uitofp fast i32 [[TMP2]] to float
 ; CHECK-NEXT:    [[TMP4:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP3]])
 ; CHECK-NEXT:    [[TMP5:%.*]] = fmul fast float [[TMP4]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP6:%.*]] = fptoui float [[TMP5]] to i32
@@ -5952,7 +5952,7 @@ define amdgpu_kernel void @urem_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[TMP30:%.*]] = insertelement <2 x i32> poison, i32 [[TMP29]], i64 0
 ; CHECK-NEXT:    [[TMP31:%.*]] = extractelement <2 x i32> [[X]], i64 1
 ; CHECK-NEXT:    [[TMP32:%.*]] = extractelement <2 x i32> [[SHL_Y]], i64 1
-; CHECK-NEXT:    [[TMP33:%.*]] = uitofp i32 [[TMP32]] to float
+; CHECK-NEXT:    [[TMP33:%.*]] = uitofp fast i32 [[TMP32]] to float
 ; CHECK-NEXT:    [[TMP34:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP33]])
 ; CHECK-NEXT:    [[TMP35:%.*]] = fmul fast float [[TMP34]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP36:%.*]] = fptoui float [[TMP35]] to i32
@@ -6375,7 +6375,7 @@ define amdgpu_kernel void @sdiv_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[TMP7:%.*]] = add i32 [[TMP2]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = xor i32 [[TMP6]], [[TMP3]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = xor i32 [[TMP7]], [[TMP4]]
-; CHECK-NEXT:    [[TMP10:%.*]] = uitofp i32 [[TMP9]] to float
+; CHECK-NEXT:    [[TMP10:%.*]] = uitofp fast i32 [[TMP9]] to float
 ; CHECK-NEXT:    [[TMP11:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP10]])
 ; CHECK-NEXT:    [[TMP12:%.*]] = fmul fast float [[TMP11]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP13:%.*]] = fptoui float [[TMP12]] to i32
@@ -6416,7 +6416,7 @@ define amdgpu_kernel void @sdiv_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[TMP48:%.*]] = add i32 [[TMP43]], [[TMP45]]
 ; CHECK-NEXT:    [[TMP49:%.*]] = xor i32 [[TMP47]], [[TMP44]]
 ; CHECK-NEXT:    [[TMP50:%.*]] = xor i32 [[TMP48]], [[TMP45]]
-; CHECK-NEXT:    [[TMP51:%.*]] = uitofp i32 [[TMP50]] to float
+; CHECK-NEXT:    [[TMP51:%.*]] = uitofp fast i32 [[TMP50]] to float
 ; CHECK-NEXT:    [[TMP52:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP51]])
 ; CHECK-NEXT:    [[TMP53:%.*]] = fmul fast float [[TMP52]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP54:%.*]] = fptoui float [[TMP53]] to i32
@@ -6826,7 +6826,7 @@ define amdgpu_kernel void @srem_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[TMP6:%.*]] = add i32 [[TMP2]], [[TMP4]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = xor i32 [[TMP5]], [[TMP3]]
 ; CHECK-NEXT:    [[TMP8:%.*]] = xor i32 [[TMP6]], [[TMP4]]
-; CHECK-NEXT:    [[TMP9:%.*]] = uitofp i32 [[TMP8]] to float
+; CHECK-NEXT:    [[TMP9:%.*]] = uitofp fast i32 [[TMP8]] to float
 ; CHECK-NEXT:    [[TMP10:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP9]])
 ; CHECK-NEXT:    [[TMP11:%.*]] = fmul fast float [[TMP10]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP12:%.*]] = fptoui float [[TMP11]] to i32
@@ -6864,7 +6864,7 @@ define amdgpu_kernel void @srem_v2i32_pow2_shl_denom(ptr addrspace(1) %out, <2 x
 ; CHECK-NEXT:    [[TMP44:%.*]] = add i32 [[TMP40]], [[TMP42]]
 ; CHECK-NEXT:    [[TMP45:%.*]] = xor i32 [[TMP43]], [[TMP41]]
 ; CHECK-NEXT:    [[TMP46:%.*]] = xor i32 [[TMP44]], [[TMP42]]
-; CHECK-NEXT:    [[TMP47:%.*]] = uitofp i32 [[TMP46]] to float
+; CHECK-NEXT:    [[TMP47:%.*]] = uitofp fast i32 [[TMP46]] to float
 ; CHECK-NEXT:    [[TMP48:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP47]])
 ; CHECK-NEXT:    [[TMP49:%.*]] = fmul fast float [[TMP48]], f0x4F7FFFFE
 ; CHECK-NEXT:    [[TMP50:%.*]] = fptoui float [[TMP49]] to i32

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pow.ll
@@ -5079,7 +5079,7 @@ define float @test_pow_afn_nnan_ninf_f32_known_integral_sitofp(float %x, i32 %y)
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi float [[Y_CAST]] to i32
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[TMP1]] to float
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[TMP1]] to float
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[TMP1]], 31
@@ -5300,7 +5300,7 @@ define float @test_pow_afn_nnan_ninf_f32_known_integral_uitofp(float %x, i32 %y)
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi float [[Y_CAST]] to i32
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[TMP1]] to float
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[TMP1]] to float
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[TMP1]], 31
@@ -5451,7 +5451,7 @@ define float @test_pow_afn_nnan_ninf_f32_known_integral_uitofp_i256(float %x, i2
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi float [[Y_CAST]] to i32
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[TMP1]] to float
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[TMP1]] to float
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[TMP1]], 31
@@ -5488,7 +5488,7 @@ define float @test_pow_afn_nnan_ninf_f32_known_integral_sitofp_i256(float %x, i2
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi float [[Y_CAST]] to i32
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[TMP1]] to float
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[TMP1]] to float
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[TMP1]], 31
@@ -5525,7 +5525,7 @@ define <2 x float> @test_pow_afn_nnan_ninf_v2f32_known_integral_sitofp(<2 x floa
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi <2 x float> [[Y_CAST]] to <2 x i32>
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn <2 x float> @llvm.log2.v2f32(<2 x float> [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp <2 x i32> [[TMP1]] to <2 x float>
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn <2 x i32> [[TMP1]] to <2 x float>
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn <2 x float> [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) <2 x float> @llvm.exp2.v2f32(<2 x float> [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl <2 x i32> [[TMP1]], splat (i32 31)
@@ -5630,7 +5630,7 @@ define <2 x float> @test_pow_afn_nnan_ninf_v2f32_known_integral_uitofp(<2 x floa
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi <2 x float> [[Y_CAST]] to <2 x i32>
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn <2 x float> @llvm.log2.v2f32(<2 x float> [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp <2 x i32> [[TMP1]] to <2 x float>
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn <2 x i32> [[TMP1]] to <2 x float>
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn <2 x float> [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) <2 x float> @llvm.exp2.v2f32(<2 x float> [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl <2 x i32> [[TMP1]], splat (i32 31)
@@ -5830,7 +5830,7 @@ define float @test_pow_afn_f32_nnan_ninf__y_known_integral_trunc(float %x, float
 ; PRELINK-NEXT:    [[TMP1:%.*]] = fptosi float [[Y]] to i32
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[TMP1]] to float
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[TMP1]] to float
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[TMP1]], 31

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pown.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pown.ll
@@ -606,7 +606,7 @@ define float @test_pown_afn_f32(float %x, i32 %y) {
 ; NOPRELINK-NEXT:  entry:
 ; NOPRELINK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[Y]], 0
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = select afn i1 [[TMP0]], float 1.000000e+00, float [[X]]
-; NOPRELINK-NEXT:    [[TMP2:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP2:%.*]] = sitofp afn i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call afn float @llvm.fabs.f32(float [[TMP1]])
 ; NOPRELINK-NEXT:    [[TMP4:%.*]] = call afn float @llvm.log2.f32(float [[TMP3]])
 ; NOPRELINK-NEXT:    [[TMP5:%.*]] = fmul afn float [[TMP4]], [[TMP2]]
@@ -644,7 +644,7 @@ define <2 x float> @test_pown_afn_v2f32(<2 x float> %x, <2 x i32> %y) {
 ; NOPRELINK-NEXT:  entry:
 ; NOPRELINK-NEXT:    [[TMP0:%.*]] = icmp eq <2 x i32> [[Y]], zeroinitializer
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = select afn <2 x i1> [[TMP0]], <2 x float> splat (float 1.000000e+00), <2 x float> [[X]]
-; NOPRELINK-NEXT:    [[TMP2:%.*]] = sitofp <2 x i32> [[Y]] to <2 x float>
+; NOPRELINK-NEXT:    [[TMP2:%.*]] = sitofp afn <2 x i32> [[Y]] to <2 x float>
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[TMP1]])
 ; NOPRELINK-NEXT:    [[TMP4:%.*]] = call afn <2 x float> @llvm.log2.v2f32(<2 x float> [[TMP3]])
 ; NOPRELINK-NEXT:    [[TMP5:%.*]] = fmul afn <2 x float> [[TMP4]], [[TMP2]]
@@ -724,7 +724,7 @@ define float @test_pown_afn_nnan_ninf_f32(float %x, i32 %y) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to float
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[Y]] to float
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; CHECK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[Y]], 31
@@ -745,7 +745,7 @@ define <2 x float> @test_pown_afn_nnan_ninf_v2f32(<2 x float> %x, <2 x i32> %y) 
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[X]])
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn <2 x float> @llvm.log2.v2f32(<2 x float> [[__FABS]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp <2 x i32> [[Y]] to <2 x float>
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn <2 x i32> [[Y]] to <2 x float>
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn <2 x float> [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) <2 x float> @llvm.exp2.v2f32(<2 x float> [[__YLOGX]])
 ; CHECK-NEXT:    [[__YEVEN:%.*]] = shl <2 x i32> [[Y]], splat (i32 31)
@@ -766,7 +766,7 @@ define double @test_pown_afn_nnan_ninf_f64(double %x, i32 %y) {
 ; PRELINK-NEXT:  entry:
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn double @llvm.fabs.f64(double [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn double @_Z4log2d(double [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to double
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[Y]] to double
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn double [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) double @_Z4exp2d(double [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YTOU:%.*]] = zext i32 [[Y]] to i64
@@ -794,7 +794,7 @@ define <2 x double> @test_pown_afn_nnan_ninf_v2f64(<2 x double> %x, <2 x i32> %y
 ; PRELINK-NEXT:  entry:
 ; PRELINK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn <2 x double> @llvm.fabs.v2f64(<2 x double> [[X]])
 ; PRELINK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn <2 x double> @_Z4log2Dv2_d(<2 x double> [[__FABS]])
-; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp <2 x i32> [[Y]] to <2 x double>
+; PRELINK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn <2 x i32> [[Y]] to <2 x double>
 ; PRELINK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn <2 x double> [[__LOG2]], [[POWNI2F]]
 ; PRELINK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) <2 x double> @_Z4exp2Dv2_d(<2 x double> [[__YLOGX]])
 ; PRELINK-NEXT:    [[__YTOU:%.*]] = zext <2 x i32> [[Y]] to <2 x i64>
@@ -822,7 +822,7 @@ define half @test_pown_afn_nnan_ninf_f16(half %x, i32 %y) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn half @llvm.fabs.f16(half [[X]])
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn half @llvm.log2.f16(half [[__FABS]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to half
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[Y]] to half
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn half [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) half @llvm.exp2.f16(half [[__YLOGX]])
 ; CHECK-NEXT:    [[__YTOU:%.*]] = trunc i32 [[Y]] to i16
@@ -844,7 +844,7 @@ define <2 x half> @test_pown_afn_nnan_ninf_v2f16(<2 x half> %x, <2 x i32> %y) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn <2 x half> @llvm.fabs.v2f16(<2 x half> [[X]])
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn <2 x half> @llvm.log2.v2f16(<2 x half> [[__FABS]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp <2 x i32> [[Y]] to <2 x half>
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn <2 x i32> [[Y]] to <2 x half>
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn <2 x half> [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) <2 x half> @llvm.exp2.v2f16(<2 x half> [[__YLOGX]])
 ; CHECK-NEXT:    [[__YTOU:%.*]] = trunc <2 x i32> [[Y]] to <2 x i16>
@@ -1123,7 +1123,7 @@ define float @test_pown_afn_f32__x_known_positive(float nofpclass(ninf nsub nnor
 ; NOPRELINK-NEXT:  entry:
 ; NOPRELINK-NEXT:    [[TMP0:%.*]] = icmp eq i32 [[Y]], 0
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = select afn i1 [[TMP0]], float 1.000000e+00, float [[X]]
-; NOPRELINK-NEXT:    [[TMP2:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP2:%.*]] = sitofp afn i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call afn float @llvm.fabs.f32(float [[TMP1]])
 ; NOPRELINK-NEXT:    [[TMP4:%.*]] = call afn float @llvm.log2.f32(float [[TMP3]])
 ; NOPRELINK-NEXT:    [[TMP5:%.*]] = fmul afn float [[TMP4]], [[TMP2]]
@@ -1154,7 +1154,7 @@ define float @test_pown_afn_ninf_nnan_f32__x_known_positive(float nofpclass(ninf
 ; CHECK-SAME: (float nofpclass(ninf nsub nnorm) [[X:%.*]], i32 [[Y:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[X]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to float
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp nnan ninf afn i32 [[Y]] to float
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; CHECK-NEXT:    [[__YEVEN:%.*]] = shl i32 [[Y]], 31
@@ -1229,7 +1229,7 @@ define float @test_fast_pown_f32_y_known_even(float %x, i32 %y.arg) {
 ; CHECK-NEXT:    [[Y:%.*]] = shl i32 [[Y_ARG]], 1
 ; CHECK-NEXT:    [[__FABS:%.*]] = call fast float @llvm.fabs.f32(float [[X]])
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call fast float @llvm.log2.f32(float [[__FABS]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to float
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp fast i32 [[Y]] to float
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul fast float [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call fast nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; CHECK-NEXT:    ret float [[__EXP2]]
@@ -1246,7 +1246,7 @@ define float @test_fast_pown_f32_known_positive_y_known_even(float nofpclass(nin
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[Y:%.*]] = shl i32 [[Y_ARG]], 1
 ; CHECK-NEXT:    [[__LOG2:%.*]] = call fast float @llvm.log2.f32(float [[X]])
-; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to float
+; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp fast i32 [[Y]] to float
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul fast float [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call fast nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float [[__YLOGX]])
 ; CHECK-NEXT:    ret float [[__EXP2]]

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-rootn.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-rootn.ll
@@ -1009,7 +1009,7 @@ define float @test_rootn_afn_f32(float %x, i32 %y) {
 ; NOPRELINK-LABEL: define float @test_rootn_afn_f32(
 ; NOPRELINK-SAME: float [[X:%.*]], i32 [[Y:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp afn i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = fdiv nnan afn float 1.000000e+00, [[TMP0]]
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call afn float @llvm.fabs.f32(float [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call afn float @llvm.log2.f32(float [[TMP2]])
@@ -1051,7 +1051,7 @@ define <2 x float> @test_rootn_afn_v2f32(<2 x float> %x, <2 x i32> %y) {
 ; NOPRELINK-LABEL: define <2 x float> @test_rootn_afn_v2f32(
 ; NOPRELINK-SAME: <2 x float> [[X:%.*]], <2 x i32> [[Y:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp <2 x i32> [[Y]] to <2 x float>
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp afn <2 x i32> [[Y]] to <2 x float>
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = fdiv nnan afn <2 x float> splat (float 1.000000e+00), [[TMP0]]
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call afn <2 x float> @llvm.log2.v2f32(<2 x float> [[TMP2]])
@@ -1141,7 +1141,7 @@ define float @test_rootn_afn_nnan_ninf_f32(float %x, i32 %y) {
 ; NOPRELINK-LABEL: define float @test_rootn_afn_nnan_ninf_f32(
 ; NOPRELINK-SAME: float [[X:%.*]], i32 [[Y:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp nnan ninf afn i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = fdiv nnan ninf afn float 1.000000e+00, [[TMP0]]
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[TMP2]])
@@ -1180,7 +1180,7 @@ define <2 x float> @test_rootn_afn_nnan_ninf_v2f32(<2 x float> %x, <2 x i32> %y)
 ; NOPRELINK-LABEL: define <2 x float> @test_rootn_afn_nnan_ninf_v2f32(
 ; NOPRELINK-SAME: <2 x float> [[X:%.*]], <2 x i32> [[Y:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp <2 x i32> [[Y]] to <2 x float>
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp nnan ninf afn <2 x i32> [[Y]] to <2 x float>
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = fdiv nnan ninf afn <2 x float> splat (float 1.000000e+00), [[TMP0]]
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call nnan ninf afn <2 x float> @llvm.fabs.v2f32(<2 x float> [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call nnan ninf afn <2 x float> @llvm.log2.v2f32(<2 x float> [[TMP2]])
@@ -1701,7 +1701,7 @@ define float @test_rootn_afn_f32__x_known_positive(float nofpclass(ninf nsub nno
 ; NOPRELINK-LABEL: define float @test_rootn_afn_f32__x_known_positive(
 ; NOPRELINK-SAME: float nofpclass(ninf nsub nnorm) [[X:%.*]], i32 [[Y:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp afn i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = fdiv nnan afn float 1.000000e+00, [[TMP0]]
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call afn float @llvm.fabs.f32(float [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call afn float @llvm.log2.f32(float [[TMP2]])
@@ -1740,7 +1740,7 @@ define float @test_rootn_afn_ninf_nnan_f32__x_known_positive(float nofpclass(nin
 ; NOPRELINK-LABEL: define float @test_rootn_afn_ninf_nnan_f32__x_known_positive(
 ; NOPRELINK-SAME: float nofpclass(ninf nsub nnorm) [[X:%.*]], i32 [[Y:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp nnan ninf afn i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = fdiv nnan ninf afn float 1.000000e+00, [[TMP0]]
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = fmul nnan ninf afn float [[TMP1]], [[TMP2]]
@@ -1830,7 +1830,7 @@ define float @test_fast_rootn_f32_y_known_even(float %x, i32 %y.arg) {
 ; NOPRELINK-SAME: float [[X:%.*]], i32 [[Y_ARG:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
 ; NOPRELINK-NEXT:    [[Y:%.*]] = shl i32 [[Y_ARG]], 1
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp fast i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call fast float @llvm.fabs.f32(float [[X]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = call fast float @llvm.log2.f32(float [[TMP2]])
 ; NOPRELINK-NEXT:    [[TMP4:%.*]] = fdiv fast float [[TMP3]], [[TMP0]]
@@ -1864,7 +1864,7 @@ define float @test_fast_rootn_f32_known_positive_y_known_even(float nofpclass(ni
 ; NOPRELINK-SAME: float nofpclass(ninf nsub nnorm) [[X:%.*]], i32 [[Y_ARG:%.*]]) {
 ; NOPRELINK-NEXT:  entry:
 ; NOPRELINK-NEXT:    [[Y:%.*]] = shl i32 [[Y_ARG]], 1
-; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp i32 [[Y]] to float
+; NOPRELINK-NEXT:    [[TMP0:%.*]] = sitofp fast i32 [[Y]] to float
 ; NOPRELINK-NEXT:    [[TMP1:%.*]] = call fast float @llvm.fabs.f32(float [[X]])
 ; NOPRELINK-NEXT:    [[TMP2:%.*]] = call fast float @llvm.log2.f32(float [[TMP1]])
 ; NOPRELINK-NEXT:    [[TMP3:%.*]] = fdiv fast float [[TMP2]], [[TMP0]]

--- a/llvm/test/CodeGen/AMDGPU/divrem24-assume.ll
+++ b/llvm/test/CodeGen/AMDGPU/divrem24-assume.ll
@@ -4,11 +4,11 @@
 define amdgpu_kernel void @divrem24_assume(ptr addrspace(1) %arg, i32 %arg1) {
 ; CHECK-LABEL: @divrem24_assume(
 ; CHECK-NEXT:  bb:
-; CHECK-NEXT:    [[TMP:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x(), !range !0
+; CHECK-NEXT:    [[TMP:%.*]] = tail call i32 @llvm.amdgcn.workitem.id.x(), !range [[RNG0:![0-9]+]]
 ; CHECK-NEXT:    [[TMP2:%.*]] = icmp ult i32 [[ARG1:%.*]], 42
 ; CHECK-NEXT:    tail call void @llvm.assume(i1 [[TMP2]])
-; CHECK-NEXT:    [[TMP0:%.*]] = uitofp i32 [[TMP]] to float
-; CHECK-NEXT:    [[TMP1:%.*]] = uitofp i32 [[ARG1]] to float
+; CHECK-NEXT:    [[TMP0:%.*]] = uitofp fast i32 [[TMP]] to float
+; CHECK-NEXT:    [[TMP1:%.*]] = uitofp fast i32 [[ARG1]] to float
 ; CHECK-NEXT:    [[TMP2:%.*]] = call fast float @llvm.amdgcn.rcp.f32(float [[TMP1]])
 ; CHECK-NEXT:    [[TMP3:%.*]] = fmul fast float [[TMP0]], [[TMP2]]
 ; CHECK-NEXT:    [[TMP4:%.*]] = call fast float @llvm.trunc.f32(float [[TMP3]])

--- a/llvm/test/CodeGen/AMDGPU/simplify-libcalls.ll
+++ b/llvm/test/CodeGen/AMDGPU/simplify-libcalls.ll
@@ -359,7 +359,7 @@ declare half @_Z4pownDhi(half, i32)
 ; GCN-LABEL: {{^}}define half @test_pown_f16(
 ; GCN-NATIVE: %__fabs = tail call fast half @llvm.fabs.f16(half %x)
 ; GCN-NATIVE: %__log2 = tail call fast half @llvm.log2.f16(half %__fabs)
-; GCN-NATIVE: %pownI2F = sitofp i32 %y to half
+; GCN-NATIVE: %pownI2F = sitofp fast i32 %y to half
 ; GCN-NATIVE: %__ylogx = fmul fast half %__log2, %pownI2F
 ; GCN-NATIVE: %__exp2 = tail call fast nofpclass(nan ninf nzero nsub nnorm) half @llvm.exp2.f16(half %__ylogx)
 ; GCN-NATIVE: %__ytou = trunc i32 %y to i16
@@ -410,7 +410,7 @@ entry:
 ; GCN: %conv = fptosi float %tmp1 to i32
 ; GCN: %__fabs = tail call fast float @llvm.fabs.f32(float %tmp)
 ; GCN: %__log2 = tail call fast float @llvm.log2.f32(float %__fabs)
-; GCN: %pownI2F = sitofp i32 %conv to float
+; GCN: %pownI2F = sitofp fast i32 %conv to float
 ; GCN: %__ylogx = fmul fast float %__log2, %pownI2F
 ; GCN: %__exp2 = tail call fast nofpclass(nan ninf nzero nsub nnorm) float @llvm.exp2.f32(float %__ylogx)
 ; GCN: %__yeven = shl i32 %conv, 31

--- a/llvm/test/Transforms/InstCombine/log-pow.ll
+++ b/llvm/test/Transforms/InstCombine/log-pow.ll
@@ -26,7 +26,7 @@ define double @log_powi_const(double %x) {
 define double @log_powi_nonconst(double %x, i32 %y) {
 ; CHECK-LABEL: @log_powi_nonconst(
 ; CHECK-NEXT:    [[LOG1:%.*]] = call fast double @llvm.log.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[CAST:%.*]] = sitofp i32 [[Y:%.*]] to double
+; CHECK-NEXT:    [[CAST:%.*]] = sitofp fast i32 [[Y:%.*]] to double
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast double [[LOG1]], [[CAST]]
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
@@ -38,7 +38,7 @@ define double @log_powi_nonconst(double %x, i32 %y) {
 define double @logf64_powi_nonconst(double %x, i32 %y) {
 ; CHECK-LABEL: @logf64_powi_nonconst(
 ; CHECK-NEXT:    [[LOG1:%.*]] = call fast double @llvm.log.f64(double [[X:%.*]])
-; CHECK-NEXT:    [[CAST:%.*]] = sitofp i32 [[Y:%.*]] to double
+; CHECK-NEXT:    [[CAST:%.*]] = sitofp fast i32 [[Y:%.*]] to double
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast double [[LOG1]], [[CAST]]
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
@@ -61,7 +61,7 @@ define float @logf_powfi_const(float %x) {
 define float @logf_powfi_nonconst(float %x, i32 %y) {
 ; CHECK-LABEL: @logf_powfi_nonconst(
 ; CHECK-NEXT:    [[LOG1:%.*]] = call fast float @llvm.log.f32(float [[X:%.*]])
-; CHECK-NEXT:    [[CAST:%.*]] = sitofp i32 [[Y:%.*]] to float
+; CHECK-NEXT:    [[CAST:%.*]] = sitofp fast i32 [[Y:%.*]] to float
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast float [[LOG1]], [[CAST]]
 ; CHECK-NEXT:    ret float [[MUL]]
 ;


### PR DESCRIPTION
- `{u,s}itofp` are floating point typed values.
- CodeGen part (foldFPToIntToFP in DAGCombiner) needs `nsz` to fold pattern (uitofp (fptoui x)) -> (trunc x).
- LLVM has intrinsic variants of `{u,s}itofp`, which already support fast-math flags.

Now optimization flags require 9 bits in bitcode, fast-math flags of `uitofp` are stored in high 8 bits.
VPlan part may need some extra work, it assumes optimization flags from different categories are disjoint.