### PR TITLE
[clang][SYCL] Enable possibility for device-only calling convention

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5885,12 +5885,28 @@ bool Sema::CheckCallingConvAttr(const ParsedAttr &Attrs, CallingConv &CC,
     if (A == TargetInfo::CCCR_OK && CheckDevice && DeviceTI)
       A = DeviceTI->checkCallingConvention(CC);
   } else if (LangOpts.SYCLIsDevice) {
-    // In SYCL we may meet unsupported calling conventions in host code,
-    // especially inside of included headers. Now we don't know if they will be
-    // emitted, so we just defer any diagnostics. Check for the host triple if
-    // we have one, since everything is still emitted for the host.
-    if (Aux)
+    // During device compilation, calling conventions that are valid for the
+    // host, for the device, and for both the host and the device may be
+    // encountered. Diagnostics are desired for cases where the calling
+    // convention is not supported by either the host or the device. If Aux is
+    // null (which should rarely be the case), it isn't possible to check
+    // whether the calling convention is supported by the host, so just assume
+    // that it is. If the calling convention is supported for the device, there
+    // is no need to check the host; the device target gets priority since this
+    // check is only performed during device compilation.
+    A = TI.checkCallingConvention(CC);
+    if (Aux && A == TargetInfo::CCCR_Warning) {
+      // If the calling convention would provoke a warning for the device, check
+      // the host and preserve the warning only if the calling convention would
+      // provoke an error for the host. Otherwise, assume this calling
+      // convention is only used for host only functions.
       A = Aux->checkCallingConvention(CC);
+      if (A == TargetInfo::CCCR_Error)
+        A = TargetInfo::CCCR_Warning;
+    } else if (Aux && A == TargetInfo::CCCR_Error) {
+      // Assume this calling convention is only used for host only functions.
+      A = Aux->checkCallingConvention(CC);
+    }
   } else {
     A = TI.checkCallingConvention(CC);
   }

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -1,25 +1,33 @@
 // RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple spirv64 -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
-// RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple spirv64 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -isystem %S/Inputs/ -fsycl-is-device -triple spirv64 -fsyntax-only -verify=expected,no-aux %s
 
 // Check that there is no error/warning emitted for cdecl functions compiled for
 // SYCL device. Make sure variadic calls from within device code are diagnosed.
 
+// no-aux-warning@+2 {{'__cdecl' calling convention is not supported for this target}}
+// no-aux-error@+1 {{variadic function cannot use spir_function calling convention}}
 __inline __cdecl int printf(char const* const _Format, ...) { return 0; }
 
 // FIXME: that should be diagnosed.
 [[clang::sycl_external]] int foo(int, ...) { return 0; }
 
+// no-aux-warning@+1 {{'__cdecl' calling convention is not supported for this target}}
 __inline __cdecl int moo() { return 0; }
 
 void bar() {
   printf("hello\n");
 }
 
+// Check some weird calling convention that is not supported even by x86_64 aux.
+// no-aux-warning@+1 {{'__swiftasynccall__' calling convention is not supported for this target}}
+void __attribute__((__swiftasynccall__)) g(void) {}
+
 template<typename KN, typename...Args>
 void sycl_kernel_launch(Args ...args) {}
 
 template<typename KN, typename K>
 [[clang::sycl_kernel_entry_point(KN)]]
+// no-aux-warning@+1 {{'__cdecl' calling convention is not supported for this target}}
 __cdecl void sycl_entry_point(K k) {
   k(); // expected-note {{called by}}
 }


### PR DESCRIPTION
After 94ca49099ef77751a33e4babe41b2ae03ff228e1 DPC++ downstream experienced failures. This happened because it has a calling convention attribute that applies calling convention valid only for device targets which given SYCL model is quite unusual and was not expected by 94ca49099ef77751a33e4babe41b2ae03ff228e1 . Even though there is no device-only calling conventions, we should not prevent a possibility for it. So this patch preserves the semantics of the device over those of the host while also preserving device side diagnostics if they are less severe than the host.