### PR TITLE
[lldb] Fix possible invalidated iterator.

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -978,10 +978,10 @@ void Target::DescribeBreakpointOverrides(Stream &stream,
     return;
   }
 
-  const bool empty = idxs.empty();
+  bool empty = idxs.empty();
   bool print_first = true;
-  for (const auto &[id, resolver] : m_breakpoint_overrides) {
-    auto idx_pos = llvm::find(idxs, id);
+  for (auto const &elem : m_breakpoint_overrides) {
+    auto idx_pos = llvm::find(idxs, elem.first);
     if (empty || idx_pos != idxs.end()) {
       if (print_first) {
         // FIXME: Is there some good way to flow the description?
@@ -989,7 +989,7 @@ void Target::DescribeBreakpointOverrides(Stream &stream,
         stream << "----  -----------\n";
         print_first = false;
       }
-      stream.Format("{0,4}  {1}\n", id, resolver->GetDescription());
+      stream.Format("{0,4}  {1}\n", elem.first, elem.second->GetDescription());
       if (!empty)
         idxs.erase(idx_pos);
     }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -72,6 +72,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/ErrorExtras.h"
@@ -977,20 +978,18 @@ void Target::DescribeBreakpointOverrides(Stream &stream,
     return;
   }
 
-  auto begin = idxs.begin();
-  auto end = idxs.end();
-  bool empty = idxs.empty();
+  const bool empty = idxs.empty();
   bool print_first = true;
-  for (auto const &elem : m_breakpoint_overrides) {
-    auto idx_pos = empty ? end : std::find(begin, end, elem.first);
-    if (empty || idx_pos != end) {
+  for (const auto &[id, resolver] : m_breakpoint_overrides) {
+    auto idx_pos = llvm::find(idxs, id);
+    if (empty || idx_pos != idxs.end()) {
       if (print_first) {
         // FIXME: Is there some good way to flow the description?
         stream << "ID    Description\n";
         stream << "----  -----------\n";
         print_first = false;
       }
-      stream.Format("{0,4}  {1}\n", elem.first, elem.second->GetDescription());
+      stream.Format("{0,4}  {1}\n", id, resolver->GetDescription());
       if (!empty)
         idxs.erase(idx_pos);
     }


### PR DESCRIPTION
The begin or end interator may be invalidated when a idx_pos in erased from the vector. 

Unblocks sanitised CI. 