### PR TITLE
[AArch64] Fix fmaxv/fminv/fmaxnmv/fminnmv/lasta/lastb sched info in A64FX

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedA64FX.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedA64FX.td
@@ -2290,7 +2290,7 @@ def A64FXWrite_FMAXVD : SchedWriteRes<[A64FXGI03]> {
   let NumMicroOps = 7;
   let ReleaseAtCycles = [7];
 }
-def : InstRW<[A64FXWrite_FMAXVH], (instregex "^F(MAX|MIN)(NM)?V_VPZ_D")>;
+def : InstRW<[A64FXWrite_FMAXVD], (instregex "^F(MAX|MIN)(NM)?V_VPZ_D")>;
 
 def A64FXWrite_INDEX_RI_BH : SchedWriteRes<[A64FXGI0, A64FXGI2]> {
   let Latency = 17;
@@ -2334,7 +2334,7 @@ def : InstRW<[A64FXWrite_INSR_ZR], (instregex "^INSR_ZR")>;
 def A64FXWrite_LAST_R : SchedWriteRes<[A64FXGI0, A64FXGI56]> {
   let Latency = 25;
 }
-def : InstRW<[A64FXWrite_CLAST_R], (instregex "^LAST[AB]_R")>;
+def : InstRW<[A64FXWrite_LAST_R], (instregex "^LAST[AB]_R")>;
 
 def A64FXWrite_GLD_S_ZI : SchedWriteRes<[A64FXGI0, A64FXGI5, A64FXGI6]> {
   let Latency = 19;

--- a/llvm/test/tools/llvm-mca/AArch64/A64FX/A64FX-sve-instructions.s
+++ b/llvm/test/tools/llvm-mca/AArch64/A64FX/A64FX-sve-instructions.s
@@ -3092,10 +3092,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      4     1.00                        fmaxnm	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  1      4     1.00                        fmaxnm	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  1      4     1.00                        fmaxnm	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  11     54    5.50                        fmaxnmv	d0, p7, z31.d
+# CHECK-NEXT:  7      34    3.50                        fmaxnmv	d0, p7, z31.d
 # CHECK-NEXT:  11     54    5.50                        fmaxnmv	h0, p7, z31.h
 # CHECK-NEXT:  9      44    4.50                        fmaxnmv	s0, p7, z31.s
-# CHECK-NEXT:  11     54    5.50                        fmaxv	d0, p7, z31.d
+# CHECK-NEXT:  7      34    3.50                        fmaxv	d0, p7, z31.d
 # CHECK-NEXT:  11     54    5.50                        fmaxv	h0, p7, z31.h
 # CHECK-NEXT:  9      44    4.50                        fmaxv	s0, p7, z31.s
 # CHECK-NEXT:  1      4     1.00                        fmin	z0.d, p0/m, z0.d, #0.0
@@ -3116,10 +3116,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      4     1.00                        fminnm	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  1      4     1.00                        fminnm	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  1      4     1.00                        fminnm	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  11     54    5.50                        fminnmv	d0, p7, z31.d
+# CHECK-NEXT:  7      34    3.50                        fminnmv	d0, p7, z31.d
 # CHECK-NEXT:  11     54    5.50                        fminnmv	h0, p7, z31.h
 # CHECK-NEXT:  9      44    4.50                        fminnmv	s0, p7, z31.s
-# CHECK-NEXT:  11     54    5.50                        fminv	d0, p7, z31.d
+# CHECK-NEXT:  7      34    3.50                        fminv	d0, p7, z31.d
 # CHECK-NEXT:  11     54    5.50                        fminv	h0, p7, z31.h
 # CHECK-NEXT:  9      44    4.50                        fminv	s0, p7, z31.s
 # CHECK-NEXT:  1      9     0.50                        fmla	z0.d, p7/m, z1.d, z31.d
@@ -3338,18 +3338,18 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  1      6     1.00                        lasta	d0, p7, z31.d
 # CHECK-NEXT:  1      6     1.00                        lasta	h0, p7, z31.h
 # CHECK-NEXT:  1      6     1.00                        lasta	s0, p7, z31.s
-# CHECK-NEXT:  1      29    1.00                        lasta	w0, p7, z31.b
-# CHECK-NEXT:  1      29    1.00                        lasta	w0, p7, z31.h
-# CHECK-NEXT:  1      29    1.00                        lasta	w0, p7, z31.s
-# CHECK-NEXT:  1      29    1.00                        lasta	x0, p7, z31.d
+# CHECK-NEXT:  1      25    1.00                        lasta	w0, p7, z31.b
+# CHECK-NEXT:  1      25    1.00                        lasta	w0, p7, z31.h
+# CHECK-NEXT:  1      25    1.00                        lasta	w0, p7, z31.s
+# CHECK-NEXT:  1      25    1.00                        lasta	x0, p7, z31.d
 # CHECK-NEXT:  1      6     1.00                        lastb	b0, p7, z31.b
 # CHECK-NEXT:  1      6     1.00                        lastb	d0, p7, z31.d
 # CHECK-NEXT:  1      6     1.00                        lastb	h0, p7, z31.h
 # CHECK-NEXT:  1      6     1.00                        lastb	s0, p7, z31.s
-# CHECK-NEXT:  1      29    1.00                        lastb	w0, p7, z31.b
-# CHECK-NEXT:  1      29    1.00                        lastb	w0, p7, z31.h
-# CHECK-NEXT:  1      29    1.00                        lastb	w0, p7, z31.s
-# CHECK-NEXT:  1      29    1.00                        lastb	x0, p7, z31.d
+# CHECK-NEXT:  1      25    1.00                        lastb	w0, p7, z31.b
+# CHECK-NEXT:  1      25    1.00                        lastb	w0, p7, z31.h
+# CHECK-NEXT:  1      25    1.00                        lastb	w0, p7, z31.s
+# CHECK-NEXT:  1      25    1.00                        lastb	x0, p7, z31.d
 # CHECK-NEXT:  1      11    0.50    *                   ld1b	{ z0.b }, p0/z, [sp, x0]
 # CHECK-NEXT:  1      11    0.50    *                   ld1b	{ z0.b }, p0/z, [x0, x0]
 # CHECK-NEXT:  1      11    0.50    *                   ld1b	{ z0.b }, p0/z, [x0]
@@ -5014,7 +5014,7 @@ zip2	z31.s, z31.s, z31.s
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -     1390.00 1376.00 599.00 256.00 4631.00 681.00 340.00
+# CHECK-NEXT:  -     1390.00 1376.00 599.00 256.00 4623.00 673.00 340.00
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
@@ -5604,10 +5604,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fmaxnm	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fmaxnm	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fmaxnm	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fmaxnmv	d0, p7, z31.d
+# CHECK-NEXT:  -      -      -      -      -     3.50   3.50    -     fmaxnmv	d0, p7, z31.d
 # CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fmaxnmv	h0, p7, z31.h
 # CHECK-NEXT:  -      -      -      -      -     4.50   4.50    -     fmaxnmv	s0, p7, z31.s
-# CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fmaxv	d0, p7, z31.d
+# CHECK-NEXT:  -      -      -      -      -     3.50   3.50    -     fmaxv	d0, p7, z31.d
 # CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fmaxv	h0, p7, z31.h
 # CHECK-NEXT:  -      -      -      -      -     4.50   4.50    -     fmaxv	s0, p7, z31.s
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fmin	z0.d, p0/m, z0.d, #0.0
@@ -5628,10 +5628,10 @@ zip2	z31.s, z31.s, z31.s
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fminnm	z31.d, p7/m, z31.d, #1.0
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fminnm	z31.h, p7/m, z31.h, #1.0
 # CHECK-NEXT:  -      -      -      -      -     1.00    -      -     fminnm	z31.s, p7/m, z31.s, #1.0
-# CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fminnmv	d0, p7, z31.d
+# CHECK-NEXT:  -      -      -      -      -     3.50   3.50    -     fminnmv	d0, p7, z31.d
 # CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fminnmv	h0, p7, z31.h
 # CHECK-NEXT:  -      -      -      -      -     4.50   4.50    -     fminnmv	s0, p7, z31.s
-# CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fminv	d0, p7, z31.d
+# CHECK-NEXT:  -      -      -      -      -     3.50   3.50    -     fminv	d0, p7, z31.d
 # CHECK-NEXT:  -      -      -      -      -     5.50   5.50    -     fminv	h0, p7, z31.h
 # CHECK-NEXT:  -      -      -      -      -     4.50   4.50    -     fminv	s0, p7, z31.s
 # CHECK-NEXT:  -      -      -      -      -     0.50   0.50    -     fmla	z0.d, p7/m, z1.d, z31.d


### PR DESCRIPTION
I've been experimenting with a new TableGen warning on unused defs and it found a couple bugs in the A64FX scheduling model [1]:

    llvm/lib/Target/AArch64/AArch64SchedA64FX.td:2288:5: warning: def 'A64FXWrite_FMAXVD' appears to be unused
    llvm/lib/Target/AArch64/AArch64SchedA64FX.td:2334:5: warning: def 'A64FXWrite_LAST_R' appears to be unused

It looks like similarly named defs were used where they should have been and the microarchitecture manual [2] seems to confirm it.

[1] https://raw.githubusercontent.com/c-rhodes/llvm-project/860eb23fae9bd40b36bcc56534f3d43b36522173/tblgen-unused-defs-warnings.unique.txt
[2] https://github.com/fujitsu/A64FX/blob/master/doc/A64FX_Microarchitecture_Manual_en_1.8.pdf