### PR TITLE
[llvm-dwp] Fix incorrect ELF OS/ABI in DWP output

### DIFF
--- a/llvm/include/llvm/Object/ELFObjectFile.h
+++ b/llvm/include/llvm/Object/ELFObjectFile.h
@@ -110,6 +110,8 @@ public:
 
   virtual uint8_t getEIdentABIVersion() const = 0;
 
+  virtual uint8_t getEIdentOSABI() const = 0;
+
   std::vector<ELFPltEntry> getPltEntries(const MCSubtargetInfo &STI) const;
 
   /// Returns a vector containing a symbol version for each dynamic symbol.
@@ -269,6 +271,7 @@ template <class ELFT> class ELFObjectFile : public ELFObjectFileBase {
   uint16_t getEMachine() const override;
   uint16_t getEType() const override;
   uint8_t getEIdentABIVersion() const override;
+  uint8_t getEIdentOSABI() const override;
   uint64_t getSymbolSize(DataRefImpl Sym) const override;
 
 public:
@@ -688,6 +691,10 @@ template <class ELFT> uint16_t ELFObjectFile<ELFT>::getEType() const {
 
 template <class ELFT> uint8_t ELFObjectFile<ELFT>::getEIdentABIVersion() const {
   return EF.getHeader().e_ident[ELF::EI_ABIVERSION];
+}
+
+template <class ELFT> uint8_t ELFObjectFile<ELFT>::getEIdentOSABI() const {
+  return EF.getHeader().e_ident[ELF::EI_OSABI];
 }
 
 template <class ELFT>

--- a/llvm/lib/DWP/DWP.cpp
+++ b/llvm/lib/DWP/DWP.cpp
@@ -757,7 +757,7 @@ Error write(DWPWriter &Out, ArrayRef<std::string> Inputs,
     if (!MachineSet) {
       if (auto *ELFObj = dyn_cast<ELFObjectFileBase>(&Obj)) {
         Out.setMachine(ELFObj->getEMachine());
-        Out.setOSABI(ELFObj->getOS());
+        Out.setOSABI(ELFObj->getEIdentOSABI());
       } else if (Obj.isWasm()) {
         Out.setIsWASM(true);
       }

--- a/llvm/test/tools/llvm-dwp/X86/osabi.test
+++ b/llvm/test/tools/llvm-dwp/X86/osabi.test
@@ -1,0 +1,25 @@
+# Verify llvm-dwp preserves the ELF OS/ABI from input .dwo files.
+
+# RUN: yaml2obj %s -o %t.dwo
+# RUN: llvm-dwp %t.dwo -o %t.dwp
+# RUN: llvm-readobj --file-headers %t.dwp | FileCheck %s
+
+# CHECK: OS/ABI: GNU/Linux (0x3)
+
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_X86_64
+  OSABI:   ELFOSABI_GNU
+Sections:
+  - Name:    .debug_info.dwo
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_EXCLUDE ]
+    Content: '110000000500050800000000887766554433221101'
+  - Name:    .debug_abbrev.dwo
+    Type:    SHT_PROGBITS
+    Flags:   [ SHF_EXCLUDE ]
+    Content: '011100000000'
+...


### PR DESCRIPTION
I received a report internally that https://github.com/llvm/llvm-project/pull/192112 caused issues with lldb.
LLDB has not able to load the dwp files because of the OS mismatch between the binary and dwp file.

Investigating, it turns out that the refactor caused DWPWriter to call `ELFObjectFileBase::getOS()` which sets the output OS/ABI, but getOS() returns `Triple::OSType`, not the raw `e_ident[EI_OSABI]` byte. These enums have different numbering :( oops.

This caused certain tools that validate OS/ABI consistency between a binary and its DWP to reject the debug info.
Fix by adding getEIdentOSABI() to ELFObjectFileBase (parallel to getEIdentABIVersion()) and using it instead of getOS().

Assisted-by: Claude