### PR TITLE
[AMDGPU] Do not combine V_ASHRREV_I16* to make sdwa

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -399,6 +399,9 @@ MachineInstr *SDWASrcOperand::potentialToConvert(const SIInstrInfo *TII,
 }
 
 bool SDWASrcOperand::convertToSDWA(MachineInstr &MI, const SIInstrInfo *TII) {
+  assert((!Sext || !TII->getSubtarget().zeroesHigh16BitsOfDest(
+                       getParentInst()->getOpcode())) &&
+         "Cannot use sign-extension with instruction that zeroes high bits");
   switch (MI.getOpcode()) {
   case AMDGPU::V_CVT_F32_FP8_sdwa:
   case AMDGPU::V_CVT_F32_BF8_sdwa:

--- a/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
+++ b/llvm/lib/Target/AMDGPU/SIPeepholeSDWA.cpp
@@ -708,18 +708,16 @@ SIPeepholeSDWA::matchSDWAOperand(MachineInstr &MI) {
   }
 
   case AMDGPU::V_LSHRREV_B16_e32:
-  case AMDGPU::V_ASHRREV_I16_e32:
   case AMDGPU::V_LSHLREV_B16_e32:
   case AMDGPU::V_LSHRREV_B16_e64:
   case AMDGPU::V_LSHRREV_B16_opsel_e64:
-  case AMDGPU::V_ASHRREV_I16_e64:
   case AMDGPU::V_LSHLREV_B16_opsel_e64:
   case AMDGPU::V_LSHLREV_B16_e64: {
+    // V_ASHRREV_I16_e32 and V_ASHRREV_I16_e64 are
+    // not included here because they zero-fill the high 16-bits.
+
     // from: v_lshrrev_b16_e32 v1, 8, v0
     // to SDWA src:v0 src_sel:BYTE_1
-
-    // from: v_ashrrev_i16_e32 v1, 8, v0
-    // to SDWA src:v0 src_sel:BYTE_1 sext:1
 
     // from: v_lshlrev_b16_e32 v1, 8, v0
     // to SDWA dst:v1 dst_sel:BYTE_1 dst_unused:UNUSED_PAD
@@ -739,11 +737,8 @@ SIPeepholeSDWA::matchSDWAOperand(MachineInstr &MI) {
         Opcode == AMDGPU::V_LSHLREV_B16_opsel_e64 ||
         Opcode == AMDGPU::V_LSHLREV_B16_e64)
       return std::make_unique<SDWADstOperand>(Dst, Src1, BYTE_1, UNUSED_PAD);
-    return std::make_unique<SDWASrcOperand>(
-        Src1, Dst, BYTE_1, false, false,
-        Opcode != AMDGPU::V_LSHRREV_B16_e32 &&
-            Opcode != AMDGPU::V_LSHRREV_B16_opsel_e64 &&
-            Opcode != AMDGPU::V_LSHRREV_B16_e64);
+    return std::make_unique<SDWASrcOperand>(Src1, Dst, BYTE_1, false, false,
+                                            false);
     break;
   }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/saddsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/saddsat.ll
@@ -283,10 +283,11 @@ define i16 @v_saddsat_v2i8(i16 %lhs.arg, i16 %rhs.arg) {
 ; GFX8-NEXT:    v_max_i16_e32 v2, v4, v2
 ; GFX8-NEXT:    v_min_i16_e32 v1, v2, v1
 ; GFX8-NEXT:    v_add_u16_e32 v1, v3, v1
-; GFX8-NEXT:    v_mov_b32_e32 v2, 0xff
-; GFX8-NEXT:    v_and_b32_sdwa v0, sext(v0), v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v1), v2 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX8-NEXT:    v_ashrrev_i16_e32 v1, 8, v1
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX8-NEXT:    v_ashrrev_i16_e32 v0, 8, v0
+; GFX8-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
+; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_saddsat_v2i8:
@@ -561,50 +562,53 @@ define i32 @v_saddsat_v4i8(i32 %lhs.arg, i32 %rhs.arg) {
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 24, v0
 ; GFX8-NEXT:    v_lshlrev_b16_e32 v0, 8, v0
-; GFX8-NEXT:    v_min_i16_e32 v9, 0, v0
-; GFX8-NEXT:    v_lshrrev_b32_sdwa v2, v2, v1 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX8-NEXT:    v_lshrrev_b32_e32 v7, 24, v1
+; GFX8-NEXT:    v_min_i16_e32 v10, 0, v0
+; GFX8-NEXT:    v_lshrrev_b32_sdwa v6, v2, v1 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
+; GFX8-NEXT:    v_lshrrev_b32_e32 v8, 24, v1
 ; GFX8-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
-; GFX8-NEXT:    v_max_i16_e32 v8, 0, v0
-; GFX8-NEXT:    v_sub_u16_e32 v9, 0x8000, v9
-; GFX8-NEXT:    v_sub_u16_e32 v8, 0x7fff, v8
-; GFX8-NEXT:    v_max_i16_e32 v1, v9, v1
-; GFX8-NEXT:    v_min_i16_e32 v1, v1, v8
-; GFX8-NEXT:    v_min_i16_e32 v8, 0, v3
+; GFX8-NEXT:    v_max_i16_e32 v9, 0, v0
+; GFX8-NEXT:    v_sub_u16_e32 v10, 0x8000, v10
+; GFX8-NEXT:    v_sub_u16_e32 v9, 0x7fff, v9
+; GFX8-NEXT:    v_max_i16_e32 v1, v10, v1
+; GFX8-NEXT:    v_min_i16_e32 v1, v1, v9
+; GFX8-NEXT:    v_min_i16_e32 v9, 0, v3
 ; GFX8-NEXT:    v_add_u16_e32 v0, v0, v1
 ; GFX8-NEXT:    v_max_i16_e32 v1, 0, v3
-; GFX8-NEXT:    v_sub_u16_e32 v8, 0x8000, v8
+; GFX8-NEXT:    v_sub_u16_e32 v9, 0x8000, v9
 ; GFX8-NEXT:    v_sub_u16_e32 v1, 0x7fff, v1
-; GFX8-NEXT:    v_max_i16_e32 v2, v8, v2
-; GFX8-NEXT:    v_min_i16_e32 v1, v2, v1
-; GFX8-NEXT:    v_lshlrev_b16_e32 v2, 8, v4
+; GFX8-NEXT:    v_max_i16_e32 v6, v9, v6
+; GFX8-NEXT:    v_min_i16_e32 v1, v6, v1
 ; GFX8-NEXT:    v_add_u16_e32 v1, v3, v1
-; GFX8-NEXT:    v_lshlrev_b16_e32 v3, 8, v6
-; GFX8-NEXT:    v_min_i16_e32 v6, 0, v2
-; GFX8-NEXT:    v_max_i16_e32 v4, 0, v2
-; GFX8-NEXT:    v_sub_u16_e32 v6, 0x8000, v6
-; GFX8-NEXT:    v_sub_u16_e32 v4, 0x7fff, v4
-; GFX8-NEXT:    v_max_i16_e32 v3, v6, v3
-; GFX8-NEXT:    v_min_i16_e32 v3, v3, v4
-; GFX8-NEXT:    v_add_u16_e32 v2, v2, v3
-; GFX8-NEXT:    v_lshlrev_b16_e32 v3, 8, v5
-; GFX8-NEXT:    v_min_i16_e32 v6, 0, v3
+; GFX8-NEXT:    v_lshlrev_b16_e32 v3, 8, v4
 ; GFX8-NEXT:    v_lshlrev_b16_e32 v4, 8, v7
-; GFX8-NEXT:    v_max_i16_e32 v5, 0, v3
-; GFX8-NEXT:    v_sub_u16_e32 v6, 0x8000, v6
-; GFX8-NEXT:    v_sub_u16_e32 v5, 0x7fff, v5
-; GFX8-NEXT:    v_max_i16_e32 v4, v6, v4
-; GFX8-NEXT:    v_min_i16_e32 v4, v4, v5
+; GFX8-NEXT:    v_min_i16_e32 v7, 0, v3
+; GFX8-NEXT:    v_max_i16_e32 v6, 0, v3
+; GFX8-NEXT:    v_sub_u16_e32 v7, 0x8000, v7
+; GFX8-NEXT:    v_sub_u16_e32 v6, 0x7fff, v6
+; GFX8-NEXT:    v_max_i16_e32 v4, v7, v4
+; GFX8-NEXT:    v_min_i16_e32 v4, v4, v6
 ; GFX8-NEXT:    v_add_u16_e32 v3, v3, v4
-; GFX8-NEXT:    v_mov_b32_e32 v4, 0xff
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v1), v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_and_b32_sdwa v0, sext(v0), v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX8-NEXT:    v_lshlrev_b16_e32 v4, 8, v5
+; GFX8-NEXT:    v_min_i16_e32 v7, 0, v4
+; GFX8-NEXT:    v_lshlrev_b16_e32 v5, 8, v8
+; GFX8-NEXT:    v_max_i16_e32 v6, 0, v4
+; GFX8-NEXT:    v_sub_u16_e32 v7, 0x8000, v7
+; GFX8-NEXT:    v_ashrrev_i16_e32 v1, 8, v1
+; GFX8-NEXT:    v_sub_u16_e32 v6, 0x7fff, v6
+; GFX8-NEXT:    v_max_i16_e32 v5, v7, v5
+; GFX8-NEXT:    v_ashrrev_i16_e32 v0, 8, v0
+; GFX8-NEXT:    v_ashrrev_i16_e32 v3, 8, v3
+; GFX8-NEXT:    v_min_i16_e32 v5, v5, v6
+; GFX8-NEXT:    v_lshlrev_b32_sdwa v1, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GFX8-NEXT:    v_add_u16_e32 v4, v4, v5
+; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xff, v3
+; GFX8-NEXT:    v_ashrrev_i16_e32 v4, 8, v4
+; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v2), v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v3), v4 dst_sel:BYTE_3 dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xff, v4
+; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 24, v1
 ; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/ssubsat.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/ssubsat.ll
@@ -283,10 +283,11 @@ define i16 @v_ssubsat_v2i8(i16 %lhs.arg, i16 %rhs.arg) {
 ; GFX8-NEXT:    v_max_i16_e32 v1, v1, v2
 ; GFX8-NEXT:    v_min_i16_e32 v1, v1, v4
 ; GFX8-NEXT:    v_sub_u16_e32 v1, v3, v1
-; GFX8-NEXT:    v_mov_b32_e32 v2, 0xff
-; GFX8-NEXT:    v_and_b32_sdwa v0, sext(v0), v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v1), v2 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX8-NEXT:    v_ashrrev_i16_e32 v1, 8, v1
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xff, v1
+; GFX8-NEXT:    v_ashrrev_i16_e32 v0, 8, v0
+; GFX8-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
+; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX9-LABEL: v_ssubsat_v2i8:
@@ -561,50 +562,53 @@ define i32 @v_ssubsat_v4i8(i32 %lhs.arg, i32 %rhs.arg) {
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v4, 16, v0
 ; GFX8-NEXT:    v_lshrrev_b32_e32 v5, 24, v0
 ; GFX8-NEXT:    v_lshlrev_b16_e32 v0, 8, v0
-; GFX8-NEXT:    v_max_i16_e32 v8, -1, v0
-; GFX8-NEXT:    v_lshrrev_b32_sdwa v2, v2, v1 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
-; GFX8-NEXT:    v_lshrrev_b32_e32 v6, 16, v1
-; GFX8-NEXT:    v_lshrrev_b32_e32 v7, 24, v1
+; GFX8-NEXT:    v_max_i16_e32 v9, -1, v0
+; GFX8-NEXT:    v_lshrrev_b32_sdwa v6, v2, v1 dst_sel:BYTE_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:DWORD
+; GFX8-NEXT:    v_lshrrev_b32_e32 v7, 16, v1
+; GFX8-NEXT:    v_lshrrev_b32_e32 v8, 24, v1
 ; GFX8-NEXT:    v_lshlrev_b16_e32 v1, 8, v1
-; GFX8-NEXT:    v_add_u16_e32 v8, 0x8001, v8
-; GFX8-NEXT:    v_min_i16_e32 v9, -1, v0
-; GFX8-NEXT:    v_add_u16_e32 v9, 0x8000, v9
-; GFX8-NEXT:    v_max_i16_e32 v1, v8, v1
-; GFX8-NEXT:    v_min_i16_e32 v1, v1, v9
+; GFX8-NEXT:    v_add_u16_e32 v9, 0x8001, v9
+; GFX8-NEXT:    v_min_i16_e32 v10, -1, v0
+; GFX8-NEXT:    v_add_u16_e32 v10, 0x8000, v10
+; GFX8-NEXT:    v_max_i16_e32 v1, v9, v1
+; GFX8-NEXT:    v_min_i16_e32 v1, v1, v10
 ; GFX8-NEXT:    v_sub_u16_e32 v0, v0, v1
 ; GFX8-NEXT:    v_max_i16_e32 v1, -1, v3
 ; GFX8-NEXT:    v_add_u16_e32 v1, 0x8001, v1
-; GFX8-NEXT:    v_min_i16_e32 v8, -1, v3
-; GFX8-NEXT:    v_add_u16_e32 v8, 0x8000, v8
-; GFX8-NEXT:    v_max_i16_e32 v1, v1, v2
-; GFX8-NEXT:    v_lshlrev_b16_e32 v2, 8, v4
-; GFX8-NEXT:    v_min_i16_e32 v1, v1, v8
-; GFX8-NEXT:    v_max_i16_e32 v4, -1, v2
+; GFX8-NEXT:    v_min_i16_e32 v9, -1, v3
+; GFX8-NEXT:    v_add_u16_e32 v9, 0x8000, v9
+; GFX8-NEXT:    v_max_i16_e32 v1, v1, v6
+; GFX8-NEXT:    v_min_i16_e32 v1, v1, v9
 ; GFX8-NEXT:    v_sub_u16_e32 v1, v3, v1
-; GFX8-NEXT:    v_lshlrev_b16_e32 v3, 8, v6
-; GFX8-NEXT:    v_add_u16_e32 v4, 0x8001, v4
-; GFX8-NEXT:    v_min_i16_e32 v6, -1, v2
-; GFX8-NEXT:    v_add_u16_e32 v6, 0x8000, v6
-; GFX8-NEXT:    v_max_i16_e32 v3, v4, v3
-; GFX8-NEXT:    v_min_i16_e32 v3, v3, v6
-; GFX8-NEXT:    v_sub_u16_e32 v2, v2, v3
-; GFX8-NEXT:    v_lshlrev_b16_e32 v3, 8, v5
-; GFX8-NEXT:    v_max_i16_e32 v5, -1, v3
+; GFX8-NEXT:    v_lshlrev_b16_e32 v3, 8, v4
+; GFX8-NEXT:    v_max_i16_e32 v6, -1, v3
 ; GFX8-NEXT:    v_lshlrev_b16_e32 v4, 8, v7
-; GFX8-NEXT:    v_add_u16_e32 v5, 0x8001, v5
-; GFX8-NEXT:    v_min_i16_e32 v6, -1, v3
-; GFX8-NEXT:    v_add_u16_e32 v6, 0x8000, v6
-; GFX8-NEXT:    v_max_i16_e32 v4, v5, v4
-; GFX8-NEXT:    v_min_i16_e32 v4, v4, v6
+; GFX8-NEXT:    v_add_u16_e32 v6, 0x8001, v6
+; GFX8-NEXT:    v_min_i16_e32 v7, -1, v3
+; GFX8-NEXT:    v_add_u16_e32 v7, 0x8000, v7
+; GFX8-NEXT:    v_max_i16_e32 v4, v6, v4
+; GFX8-NEXT:    v_min_i16_e32 v4, v4, v7
 ; GFX8-NEXT:    v_sub_u16_e32 v3, v3, v4
-; GFX8-NEXT:    v_mov_b32_e32 v4, 0xff
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v1), v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_and_b32_sdwa v0, sext(v0), v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX8-NEXT:    v_lshlrev_b16_e32 v4, 8, v5
+; GFX8-NEXT:    v_max_i16_e32 v6, -1, v4
+; GFX8-NEXT:    v_lshlrev_b16_e32 v5, 8, v8
+; GFX8-NEXT:    v_add_u16_e32 v6, 0x8001, v6
+; GFX8-NEXT:    v_min_i16_e32 v7, -1, v4
+; GFX8-NEXT:    v_ashrrev_i16_e32 v1, 8, v1
+; GFX8-NEXT:    v_add_u16_e32 v7, 0x8000, v7
+; GFX8-NEXT:    v_max_i16_e32 v5, v6, v5
+; GFX8-NEXT:    v_ashrrev_i16_e32 v0, 8, v0
+; GFX8-NEXT:    v_ashrrev_i16_e32 v3, 8, v3
+; GFX8-NEXT:    v_min_i16_e32 v5, v5, v7
+; GFX8-NEXT:    v_lshlrev_b32_sdwa v1, v2, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:BYTE_0
+; GFX8-NEXT:    v_sub_u16_e32 v4, v4, v5
+; GFX8-NEXT:    v_or_b32_sdwa v0, v0, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:DWORD
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xff, v3
+; GFX8-NEXT:    v_ashrrev_i16_e32 v4, 8, v4
+; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
 ; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v2), v4 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
-; GFX8-NEXT:    v_and_b32_sdwa v1, sext(v3), v4 dst_sel:BYTE_3 dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
+; GFX8-NEXT:    v_and_b32_e32 v1, 0xff, v4
+; GFX8-NEXT:    v_lshlrev_b32_e32 v1, 24, v1
 ; GFX8-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/ashr.v2i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/ashr.v2i16.ll
@@ -468,18 +468,19 @@ define amdgpu_kernel void @ashr_v_imm_v2i16(ptr addrspace(1) %out, ptr addrspace
 ; VI:       ; %bb.0:
 ; VI-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
 ; VI-NEXT:    v_lshlrev_b32_e32 v2, 2, v0
+; VI-NEXT:    v_mov_b32_e32 v4, 8
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v1, s3
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, s2, v2
 ; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; VI-NEXT:    flat_load_dword v3, v[0:1]
-; VI-NEXT:    v_add_u32_e32 v0, vcc, s0, v2
-; VI-NEXT:    v_mov_b32_e32 v2, 8
 ; VI-NEXT:    v_mov_b32_e32 v1, s1
+; VI-NEXT:    v_add_u32_e32 v0, vcc, s0, v2
 ; VI-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    v_ashrrev_i16_sdwa v2, v2, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_1
-; VI-NEXT:    v_or_b32_sdwa v2, sext(v3), v2 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
+; VI-NEXT:    v_ashrrev_i16_e32 v2, 8, v3
+; VI-NEXT:    v_ashrrev_i16_sdwa v3, v4, v3 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_1
+; VI-NEXT:    v_or_b32_e32 v2, v2, v3
 ; VI-NEXT:    flat_store_dword v[0:1], v2
 ; VI-NEXT:    s_endpgm
 ;
@@ -666,10 +667,12 @@ define amdgpu_kernel void @ashr_v_imm_v4i16(ptr addrspace(1) %out, ptr addrspace
 ; VI-NEXT:    v_add_u32_e32 v2, vcc, s0, v2
 ; VI-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; VI-NEXT:    s_waitcnt vmcnt(0)
-; VI-NEXT:    v_ashrrev_i16_sdwa v5, v4, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_1
-; VI-NEXT:    v_ashrrev_i16_sdwa v4, v4, v0 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_1
-; VI-NEXT:    v_or_b32_sdwa v1, sext(v1), v5 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
-; VI-NEXT:    v_or_b32_sdwa v0, sext(v0), v4 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_1 src1_sel:DWORD
+; VI-NEXT:    v_ashrrev_i16_e32 v5, 8, v1
+; VI-NEXT:    v_ashrrev_i16_sdwa v1, v4, v1 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_1
+; VI-NEXT:    v_ashrrev_i16_e32 v6, 8, v0
+; VI-NEXT:    v_ashrrev_i16_sdwa v0, v4, v0 dst_sel:WORD_1 dst_unused:UNUSED_PAD src0_sel:DWORD src1_sel:WORD_1
+; VI-NEXT:    v_or_b32_e32 v1, v5, v1
+; VI-NEXT:    v_or_b32_e32 v0, v6, v0
 ; VI-NEXT:    flat_store_dwordx2 v[2:3], v[0:1]
 ; VI-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/sdwa-peephole-instr.mir
+++ b/llvm/test/CodeGen/AMDGPU/sdwa-peephole-instr.mir
@@ -469,6 +469,7 @@ body:             |
 
 # GCN-LABEL: name: negative_v_ashrrev_i16
 # GCN-NOT: V_XOR_B32_sdwa
+# GCN: S_ENDPGM 0
 ---
 # Ensure that V_ASHRREV_I16_* 8, ... instructions are not combined into a sdwa instruction.
 # These instructions zero-fill the high 16-bits and thus do not produce a sign-extended

--- a/llvm/test/CodeGen/AMDGPU/sdwa-peephole-instr.mir
+++ b/llvm/test/CodeGen/AMDGPU/sdwa-peephole-instr.mir
@@ -467,4 +467,26 @@ body:             |
     %7:vgpr_32 = nnan nofpexcept V_ADD_F32_e32 %5, %6, implicit $mode, implicit $exec
     S_ENDPGM 0, implicit %7
 
+# GCN-LABEL: name: negative_v_ashrrev_i16
+# GCN-NOT: V_XOR_B32_sdwa
+---
+# Ensure that V_ASHRREV_I16_* 8, ... instructions are not combined into a sdwa instruction.
+# These instructions zero-fill the high 16-bits and thus do not produce a sign-extended
+# 8-bit value.
+
+name: negative_v_ashrrev_i16
+tracksRegLiveness: true
+
+body:             |
+  bb.0:
+    liveins: $vgpr0
+    liveins: $vgpr1
+
+    %0:vgpr_32 = COPY $vgpr0
+    %1:vgpr_32 = COPY $vgpr1
+    %2:vgpr_32 = V_ASHRREV_I16_e32 8, %0, implicit $exec
+    %3:vgpr_32 = V_XOR_B32_e32 %1, %2, implicit $exec
+    %4:vgpr_32 = V_ASHRREV_I16_e64 8, %0, implicit $exec
+    %5:vgpr_32 = V_XOR_B32_e32 %1, %4, implicit $exec
+    S_ENDPGM 0, implicit %3
 ...


### PR DESCRIPTION
Do not combine V_ASHRREV_I16* instructions to form sdwa instructions.  These instructions zero-fill the high 16-bits.