### PR TITLE
[RISCV][NFC] Merge two `isLegalElementTypeForRVV`s into RISCVSubtarget

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVCallLowering.cpp
@@ -264,27 +264,6 @@ struct RISCVCallReturnHandler : public RISCVIncomingValueHandler {
 RISCVCallLowering::RISCVCallLowering(const RISCVTargetLowering &TLI)
     : CallLowering(&TLI) {}
 
-/// Return true if scalable vector with ScalarTy is legal for lowering.
-static bool isLegalElementTypeForRVV(Type *EltTy,
-                                     const RISCVSubtarget &Subtarget) {
-  if (EltTy->isPointerTy())
-    return Subtarget.is64Bit() ? Subtarget.hasVInstructionsI64() : true;
-  if (EltTy->isIntegerTy(1) || EltTy->isIntegerTy(8) ||
-      EltTy->isIntegerTy(16) || EltTy->isIntegerTy(32))
-    return true;
-  if (EltTy->isIntegerTy(64))
-    return Subtarget.hasVInstructionsI64();
-  if (EltTy->isHalfTy())
-    return Subtarget.hasVInstructionsF16Minimal();
-  if (EltTy->isBFloatTy())
-    return Subtarget.hasVInstructionsBF16Minimal();
-  if (EltTy->isFloatTy())
-    return Subtarget.hasVInstructionsF32();
-  if (EltTy->isDoubleTy())
-    return Subtarget.hasVInstructionsF64();
-  return false;
-}
-
 // TODO: Support all argument types.
 // TODO: Remove IsLowerArgs argument by adding support for vectors in lowerCall.
 static bool isSupportedArgumentType(Type *T, const RISCVSubtarget &Subtarget,
@@ -301,7 +280,7 @@ static bool isSupportedArgumentType(Type *T, const RISCVSubtarget &Subtarget,
   // TODO: Support fixed vector types.
   if (IsLowerArgs && T->isVectorTy() && Subtarget.hasVInstructions() &&
       T->isScalableTy() &&
-      isLegalElementTypeForRVV(T->getScalarType(), Subtarget))
+      Subtarget.isLegalElementTypeForRVV(T->getScalarType()))
     return true;
   return false;
 }
@@ -327,7 +306,7 @@ static bool isSupportedReturnType(Type *T, const RISCVSubtarget &Subtarget,
 
   if (IsLowerRetVal && T->isVectorTy() && Subtarget.hasVInstructions() &&
       T->isScalableTy() &&
-      isLegalElementTypeForRVV(T->getScalarType(), Subtarget))
+      Subtarget.isLegalElementTypeForRVV(T->getScalarType()))
     return true;
 
   return false;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -3105,32 +3105,6 @@ bool RISCVTargetLowering::mergeStoresAfterLegalization(EVT VT) const {
          (VT.isFixedLengthVector() && VT.getVectorElementType() == MVT::i1);
 }
 
-bool RISCVTargetLowering::isLegalElementTypeForRVV(EVT ScalarTy) const {
-  if (!ScalarTy.isSimple())
-    return false;
-  switch (ScalarTy.getSimpleVT().SimpleTy) {
-  case MVT::iPTR:
-    return Subtarget.is64Bit() ? Subtarget.hasVInstructionsI64() : true;
-  case MVT::i8:
-  case MVT::i16:
-  case MVT::i32:
-    return Subtarget.hasVInstructions();
-  case MVT::i64:
-    return Subtarget.hasVInstructionsI64();
-  case MVT::f16:
-    return Subtarget.hasVInstructionsF16Minimal();
-  case MVT::bf16:
-    return Subtarget.hasVInstructionsBF16Minimal();
-  case MVT::f32:
-    return Subtarget.hasVInstructionsF32();
-  case MVT::f64:
-    return Subtarget.hasVInstructionsF64();
-  default:
-    return false;
-  }
-}
-
-
 unsigned RISCVTargetLowering::combineRepeatedFPDivisors() const {
   return NumRepeatedDivisors;
 }
@@ -26209,7 +26183,7 @@ bool RISCVTargetLowering::isLegalStridedLoadStore(EVT DataType,
     return false;
 
   EVT ScalarType = DataType.getScalarType();
-  if (!isLegalElementTypeForRVV(ScalarType))
+  if (!Subtarget.isLegalElementTypeForRVV(ScalarType))
     return false;
 
   if (!Subtarget.enableUnalignedVectorMem() &&
@@ -26225,7 +26199,7 @@ bool RISCVTargetLowering::isLegalFirstFaultLoad(EVT DataType,
     return false;
 
   EVT ScalarType = DataType.getScalarType();
-  if (!isLegalElementTypeForRVV(ScalarType))
+  if (!Subtarget.isLegalElementTypeForRVV(ScalarType))
     return false;
 
   if (!Subtarget.enableUnalignedVectorMem() &&
@@ -26326,7 +26300,7 @@ bool RISCVTargetLowering::isCtpopFast(EVT VT) const {
   if (VT.isVector()) {
     EVT SVT = VT.getVectorElementType();
     // If the element type is legal we can use cpop.v if it is enabled.
-    if (isLegalElementTypeForRVV(SVT))
+    if (Subtarget.isLegalElementTypeForRVV(SVT))
       return Subtarget.hasStdExtZvbb();
     // Don't consider it fast if the type needs to be legalized or scalarized.
     return false;

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -379,8 +379,6 @@ public:
 
   bool shouldRemoveExtendFromGSIndex(SDValue Extend, EVT DataVT) const override;
 
-  bool isLegalElementTypeForRVV(EVT ScalarTy) const;
-
   bool shouldConvertFpToSat(unsigned Op, EVT FPVT, EVT VT) const override;
 
   unsigned getJumpTableEncoding() const override;

--- a/llvm/lib/Target/RISCV/RISCVInterleavedAccess.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInterleavedAccess.cpp
@@ -32,7 +32,7 @@ bool RISCVTargetLowering::isLegalInterleavedAccessType(
   if (!isTypeLegal(VT))
     return false;
 
-  if (!isLegalElementTypeForRVV(VT.getScalarType()) ||
+  if (!Subtarget.isLegalElementTypeForRVV(VT.getScalarType()) ||
       !allowsMemoryAccessForAlignment(VTy->getContext(), DL, VT, AddrSpace,
                                       Alignment))
     return false;

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -252,7 +252,6 @@ bool RISCVSubtarget::isLegalElementTypeForRVV(EVT ScalarTy) const {
   switch (ScalarTy.getSimpleVT().SimpleTy) {
   case MVT::iPTR:
     return is64Bit() ? hasVInstructionsI64() : true;
-  case MVT::i1:
   case MVT::i8:
   case MVT::i16:
   case MVT::i32:

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -240,6 +240,36 @@ bool RISCVSubtarget::useRVVForFixedLengthVectors() const {
          getMinRVVVectorSizeInBits() >= RISCV::RVVBitsPerBlock;
 }
 
+bool RISCVSubtarget::isLegalElementTypeForRVV(Type *EltTy) const {
+  return isLegalElementTypeForRVV(EVT::getEVT(EltTy));
+}
+
+bool RISCVSubtarget::isLegalElementTypeForRVV(EVT ScalarTy) const {
+  if (!ScalarTy.isSimple())
+    return false;
+
+  switch (ScalarTy.getSimpleVT().SimpleTy) {
+  case MVT::iPTR:
+    return is64Bit() ? hasVInstructionsI64() : true;
+  case MVT::i8:
+  case MVT::i16:
+  case MVT::i32:
+    return hasVInstructions();
+  case MVT::i64:
+    return hasVInstructionsI64();
+  case MVT::f16:
+    return hasVInstructionsF16Minimal();
+  case MVT::bf16:
+    return hasVInstructionsBF16Minimal();
+  case MVT::f32:
+    return hasVInstructionsF32();
+  case MVT::f64:
+    return hasVInstructionsF64();
+  default:
+    return false;
+  }
+}
+
 bool RISCVSubtarget::enableSubRegLiveness() const { return true; }
 
 bool RISCVSubtarget::enableMachinePipeliner() const {

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -241,8 +241,22 @@ bool RISCVSubtarget::useRVVForFixedLengthVectors() const {
 }
 
 bool RISCVSubtarget::isLegalElementTypeForRVV(Type *EltTy) const {
-  return isLegalElementTypeForRVV(
-      TLInfo.getValueType(TLInfo.getTargetMachine().createDataLayout(), EltTy));
+  if (EltTy->isPointerTy())
+    return is64Bit() ? hasVInstructionsI64() : true;
+  if (EltTy->isIntegerTy(1) || EltTy->isIntegerTy(8) ||
+      EltTy->isIntegerTy(16) || EltTy->isIntegerTy(32))
+    return true;
+  if (EltTy->isIntegerTy(64))
+    return hasVInstructionsI64();
+  if (EltTy->isHalfTy())
+    return hasVInstructionsF16Minimal();
+  if (EltTy->isBFloatTy())
+    return hasVInstructionsBF16Minimal();
+  if (EltTy->isFloatTy())
+    return hasVInstructionsF32();
+  if (EltTy->isDoubleTy())
+    return hasVInstructionsF64();
+  return false;
 }
 
 bool RISCVSubtarget::isLegalElementTypeForRVV(EVT ScalarTy) const {

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -251,6 +251,7 @@ bool RISCVSubtarget::isLegalElementTypeForRVV(EVT ScalarTy) const {
   switch (ScalarTy.getSimpleVT().SimpleTy) {
   case MVT::iPTR:
     return is64Bit() ? hasVInstructionsI64() : true;
+  case MVT::i1:
   case MVT::i8:
   case MVT::i16:
   case MVT::i32:

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.cpp
@@ -241,7 +241,8 @@ bool RISCVSubtarget::useRVVForFixedLengthVectors() const {
 }
 
 bool RISCVSubtarget::isLegalElementTypeForRVV(Type *EltTy) const {
-  return isLegalElementTypeForRVV(EVT::getEVT(EltTy));
+  return isLegalElementTypeForRVV(
+      TLInfo.getValueType(TLInfo.getTargetMachine().createDataLayout(), EltTy));
 }
 
 bool RISCVSubtarget::isLegalElementTypeForRVV(EVT ScalarTy) const {

--- a/llvm/lib/Target/RISCV/RISCVSubtarget.h
+++ b/llvm/lib/Target/RISCV/RISCVSubtarget.h
@@ -384,6 +384,8 @@ public:
 
   unsigned getMaxLMULForFixedLengthVectors() const;
   bool useRVVForFixedLengthVectors() const;
+  bool isLegalElementTypeForRVV(Type *EltTy) const;
+  bool isLegalElementTypeForRVV(EVT ScalarTy) const;
 
   bool enableSubRegLiveness() const override;
 

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -3717,7 +3717,7 @@ RISCVTTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
       !DL.fitsInLegalInteger(NewEltBW))
     return {};
   auto *NewEltTy = IntegerType::get(II.getContext(), NewEltBW);
-  if (!TLI->isLegalElementTypeForRVV(TLI->getValueType(DL, NewEltTy)))
+  if (!ST->isLegalElementTypeForRVV(TLI->getValueType(DL, NewEltTy)))
     return {};
   ElementCount NewEC = SourceEC.divideCoefficientBy(TargetScale);
   Type *RetTy = VectorType::get(NewEltTy, NewEC);

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -275,7 +275,7 @@ public:
       const Instruction *CxtI = nullptr) const override;
 
   bool isElementTypeLegalForScalableVector(Type *Ty) const override {
-    return TLI->isLegalElementTypeForRVV(TLI->getValueType(DL, Ty));
+    return ST->isLegalElementTypeForRVV(TLI->getValueType(DL, Ty));
   }
 
   bool isLegalMaskedLoadStore(Type *DataType, Align Alignment) const {
@@ -292,7 +292,7 @@ public:
     if (!ST->enableUnalignedVectorMem() && Alignment < ElemType.getStoreSize())
       return false;
 
-    return TLI->isLegalElementTypeForRVV(ElemType);
+    return ST->isLegalElementTypeForRVV(ElemType);
   }
 
   bool isLegalMaskedLoad(Type *DataType, Align Alignment,
@@ -319,14 +319,14 @@ public:
     // We also need to check if the vector of address is valid.
     EVT PointerTypeVT = EVT(TLI->getPointerTy(DL));
     if (DataTypeVT.isScalableVector() &&
-        !TLI->isLegalElementTypeForRVV(PointerTypeVT))
+        !ST->isLegalElementTypeForRVV(PointerTypeVT))
       return false;
 
     EVT ElemType = DataTypeVT.getScalarType();
     if (!ST->enableUnalignedVectorMem() && Alignment < ElemType.getStoreSize())
       return false;
 
-    return TLI->isLegalElementTypeForRVV(ElemType);
+    return ST->isLegalElementTypeForRVV(ElemType);
   }
 
   bool isLegalMaskedGather(Type *DataType, Align Alignment) const override {
@@ -416,7 +416,7 @@ public:
       return true;
 
     Type *Ty = RdxDesc.getRecurrenceType();
-    if (!TLI->isLegalElementTypeForRVV(TLI->getValueType(DL, Ty)))
+    if (!ST->isLegalElementTypeForRVV(TLI->getValueType(DL, Ty)))
       return false;
 
     switch (RdxDesc.getRecurrenceKind()) {


### PR DESCRIPTION
We have two similar implementations in `RISCVTargetLowering.cpp`
and `RISCVCallLowering.cpp`.

We move them to `RISCVSubtarget` and merge the implementations to
remove the duplication.
