### PR TITLE
[cmake][runtimes] Pass variable type for passthrough CMake options

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -107,6 +107,14 @@ macro(append_passthrough_options out type names)
             list(APPEND ${out} -C ${cache})
           endforeach()
         else()
+          # Type is important for cache variables.
+          # For example PATH variables will be made relative to CMAKE_BINARY_DIR
+          # at the point of set(CACHE) if the type isn't passed along.
+          get_property(type CACHE ${variable_name} PROPERTY TYPE)
+          if(NOT type STREQUAL "UNINITIALIZED")
+            string(APPEND new_name ":${type}")
+          endif()
+
           string(REPLACE ";" "|" new_value "${${variable_name}}")
           list(APPEND ${out} "-D${new_name}=${new_value}")
         endif()


### PR DESCRIPTION
Depends on #198505 and #198506.

---
Passing the types affects the handling of `PATH` cache variables.
The motivating case is setting `COMPILER_RT_INSTALL_LIBRARY_DIR` without `CMAKE_BINARY_DIR` getting prepended to it.