### PR TITLE
[Analysis][NFC] Reduce memory usage of CodeMetrics

### DIFF
--- a/llvm/include/llvm/Analysis/CodeMetrics.h
+++ b/llvm/include/llvm/Analysis/CodeMetrics.h
@@ -14,7 +14,7 @@
 #ifndef LLVM_ANALYSIS_CODEMETRICS_H
 #define LLVM_ANALYSIS_CODEMETRICS_H
 
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/InstructionCost.h"
 
@@ -45,23 +45,20 @@ struct CodeMetrics {
   /// one or more 'noduplicate' instructions.
   bool notDuplicatable = false;
 
-  /// The kind of convergence specified in this function.
-  ConvergenceKind Convergence = ConvergenceKind::None;
-
   /// True if this function calls alloca (in the C sense).
   bool usesDynamicAlloca = false;
+
+  /// The kind of convergence specified in this function.
+  ConvergenceKind Convergence = ConvergenceKind::None;
 
   /// Code size cost of the analyzed blocks.
   InstructionCost NumInsts = 0;
 
-  /// Number of analyzed blocks.
-  unsigned NumBlocks = false;
-
-  /// Keeps track of basic block code size estimates.
-  DenseMap<const BasicBlock *, InstructionCost> NumBBInsts;
+  /// Keeps track of basic block code size estimates. Indexed by block number.
+  SmallVector<InstructionCost, 0> NumBBInsts;
 
   /// Keep track of the number of calls to 'big' functions.
-  unsigned NumCalls = false;
+  unsigned NumCalls = 0;
 
   /// The number of calls to internal functions with a single caller.
   ///

--- a/llvm/lib/Analysis/CodeMetrics.cpp
+++ b/llvm/lib/Analysis/CodeMetrics.cpp
@@ -130,7 +130,6 @@ void CodeMetrics::analyzeBasicBlock(
     const BasicBlock *BB, const TargetTransformInfo &TTI,
     const SmallPtrSetImpl<const Value *> &EphValues, bool PrepareForLTO,
     const Loop *L) {
-  ++NumBlocks;
   InstructionCost NumInstsBeforeThisBB = NumInsts;
   for (const Instruction &I : *BB) {
     // Skip ephemeral values.
@@ -231,5 +230,7 @@ void CodeMetrics::analyzeBasicBlock(
 
   // Remember NumInsts for this BB.
   InstructionCost NumInstsThisBB = NumInsts - NumInstsBeforeThisBB;
-  NumBBInsts[BB] = NumInstsThisBB;
+  if (NumBBInsts.size() <= BB->getNumber())
+    NumBBInsts.resize(BB->getParent()->getMaxBlockNumber());
+  NumBBInsts[BB->getNumber()] = NumInstsThisBB;
 }


### PR DESCRIPTION
FunctionSpecializer will keep the CodeMetrics of many functions at the
same time, causing the hash table in CodeMetrics to substantially
contribute to overall memory usage. Therefore, replace the DenseMap with
a vector indexed by block number.

On ArrayFunctionsRegistration.bc, this reduces the memory usage at the
time IPSCCP runs from 655.0MiB to 577.5MiB (measured with massif).
