### PR TITLE
[CIR][X86][NFC] Add _mm_alignr_epi8 edge immediate tests

### DIFF
--- a/clang/test/CIR/CodeGenBuiltins/X86/ssse3-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/ssse3-builtins.c
@@ -8,26 +8,50 @@
 
 #include <immintrin.h>
 
-__m128i test0_mm_alignr_epi8(__m128i a, __m128i b) {
-  // CIR-LABEL: _mm_alignr_epi8
+__m128i mm_alignr_epi8_imm2(__m128i a, __m128i b) {
+  // CIR-LABEL: mm_alignr_epi8_imm2
   // CIR: %{{.*}} = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<16 x !s8i>) [#cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i, #cir.int<7> : !s32i, #cir.int<8> : !s32i, #cir.int<9> : !s32i, #cir.int<10> : !s32i, #cir.int<11> : !s32i, #cir.int<12> : !s32i, #cir.int<13> : !s32i, #cir.int<14> : !s32i, #cir.int<15> : !s32i, #cir.int<16> : !s32i, #cir.int<17> : !s32i] : !cir.vector<16 x !s8i>
 
-  // LLVM-LABEL: test0_mm_alignr_epi8
+  // LLVM-LABEL: mm_alignr_epi8_imm2
   // LLVM: shufflevector <16 x i8> %{{.*}}, <16 x i8> %{{.*}}, <16 x i32> <i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17>
 
-  // OGCG-LABEL: test0_mm_alignr_epi8
+  // OGCG-LABEL: mm_alignr_epi8_imm2
   // OGCG: shufflevector <16 x i8> %{{.*}}, <16 x i8> %{{.*}}, <16 x i32> <i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17>
   return _mm_alignr_epi8(a, b, 2);
 }
 
-__m128i test1_mm_alignr_epi8(__m128i a, __m128i b) {
-  // CIR-LABEL: test1_mm_alignr_epi8
+__m128i mm_alignr_epi8_imm16(__m128i a, __m128i b) {
+  // CIR-LABEL: mm_alignr_epi8_imm16
+  // CIR: %{{.*}} = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<16 x !s8i>) [#cir.int<16> : !s32i, #cir.int<17> : !s32i, #cir.int<18> : !s32i, #cir.int<19> : !s32i, #cir.int<20> : !s32i, #cir.int<21> : !s32i, #cir.int<22> : !s32i, #cir.int<23> : !s32i, #cir.int<24> : !s32i, #cir.int<25> : !s32i, #cir.int<26> : !s32i, #cir.int<27> : !s32i, #cir.int<28> : !s32i, #cir.int<29> : !s32i, #cir.int<30> : !s32i, #cir.int<31> : !s32i] : !cir.vector<16 x !s8i>
+
+  // LLVM-LABEL: mm_alignr_epi8_imm16
+  // LLVM: shufflevector <16 x i8> %{{.*}}, <16 x i8> %{{.*}}, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+
+  // OGCG-LABEL: mm_alignr_epi8_imm16
+  // OGCG: shufflevector <16 x i8> %{{.*}}, <16 x i8> %{{.*}}, <16 x i32> <i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+  return _mm_alignr_epi8(a, b, 16);
+}
+
+__m128i mm_alignr_epi8_imm17(__m128i a, __m128i b) {
+  // CIR-LABEL: mm_alignr_epi8_imm17
   // CIR: %{{.*}} = cir.vec.shuffle(%{{.*}}, %{{.*}} : !cir.vector<16 x !s8i>) [#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i, #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i, #cir.int<7> : !s32i, #cir.int<8> : !s32i, #cir.int<9> : !s32i, #cir.int<10> : !s32i, #cir.int<11> : !s32i, #cir.int<12> : !s32i, #cir.int<13> : !s32i, #cir.int<14> : !s32i, #cir.int<15> : !s32i, #cir.int<16> : !s32i] : !cir.vector<16 x !s8i>
 
-  // LLVM-LABEL: test1_mm_alignr_epi8
+  // LLVM-LABEL: mm_alignr_epi8_imm17
   // LLVM: shufflevector <16 x i8> %{{.*}}, <16 x i8> zeroinitializer, <16 x i32> <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16>
 
-  // OGCG-LABEL: test1_mm_alignr_epi8
+  // OGCG-LABEL: mm_alignr_epi8_imm17
   // OGCG: shufflevector <16 x i8> %{{.*}}, <16 x i8> zeroinitializer, <16 x i32> <i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16>
   return _mm_alignr_epi8(a, b, 17);
+}
+
+__m128i mm_alignr_epi8_imm32(__m128i a, __m128i b) {
+  // CIR-LABEL: mm_alignr_epi8_imm32
+  // CIR: cir.const #cir.zero : !cir.vector<16 x !s8i>
+
+  // LLVM-LABEL: mm_alignr_epi8_imm32
+  // LLVM: store <2 x i64> zeroinitializer
+
+  // OGCG-LABEL: mm_alignr_epi8_imm32
+  // OGCG: ret <2 x i64> zeroinitializer
+  return _mm_alignr_epi8(a, b, 32);
 }


### PR DESCRIPTION
Cover the 16-byte boundary and all-zero result cases in `ssse3-builtins.c`. These cases mirror the coverage in `clang/test/CodeGen/palignr.c`.

Rename the existing `_mm_alignr_epi8` cases consistently with the new tests.

Partially addresses https://github.com/llvm/llvm-project/issues/156747.