### PR TITLE
[clang] associate newline and function decl. trailing Doxygen comments

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -246,17 +246,12 @@ RawComment *ASTContext::getRawCommentForDeclNoCacheImpl(
          isa<ObjCMethodDecl>(D) || isa<ObjCPropertyDecl>(D) ||
          isa<FunctionDecl>(D))) {
 
-      const auto DeclLineNumber =
-          SourceMgr.getLineNumber(DeclLocDecomp.first, DeclLocDecomp.second);
-
-      const auto DeclOfCommentLine =
+      // Check that Doxygen trailing comment comes after the declaration and in
+      // the same file as the declaration.
+      if (SourceMgr.getLineNumber(DeclLocDecomp.first, DeclLocDecomp.second) <=
           Comments.getCommentBeginLine(CommentBehindDecl, DeclLocDecomp.first,
-                                       OffsetCommentBehindDecl->first);
+                                       OffsetCommentBehindDecl->first)) {
 
-      // Check that Doxygen trailing comment comes after the declaration, starts
-      // on the same or next line and in the same file as the declaration.
-      if (DeclLineNumber == std::clamp(DeclLineNumber, DeclOfCommentLine,
-                                       DeclOfCommentLine + 1)) {
         return CommentBehindDecl;
       }
     }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -243,13 +243,20 @@ RawComment *ASTContext::getRawCommentForDeclNoCacheImpl(
          LangOpts.CommentOpts.ParseAllComments) &&
         CommentBehindDecl->isTrailingComment() &&
         (isa<FieldDecl>(D) || isa<EnumConstantDecl>(D) || isa<VarDecl>(D) ||
-         isa<ObjCMethodDecl>(D) || isa<ObjCPropertyDecl>(D))) {
+         isa<ObjCMethodDecl>(D) || isa<ObjCPropertyDecl>(D) ||
+         isa<FunctionDecl>(D))) {
+
+      const auto DeclLineNumber =
+          SourceMgr.getLineNumber(DeclLocDecomp.first, DeclLocDecomp.second);
+
+      const auto DeclOfCommentLine =
+          Comments.getCommentBeginLine(CommentBehindDecl, DeclLocDecomp.first,
+                                       OffsetCommentBehindDecl->first);
 
       // Check that Doxygen trailing comment comes after the declaration, starts
-      // on the same line and in the same file as the declaration.
-      if (SourceMgr.getLineNumber(DeclLocDecomp.first, DeclLocDecomp.second) ==
-          Comments.getCommentBeginLine(CommentBehindDecl, DeclLocDecomp.first,
-                                       OffsetCommentBehindDecl->first)) {
+      // on the same or next line and in the same file as the declaration.
+      if (DeclLineNumber == std::clamp(DeclLineNumber, DeclOfCommentLine,
+                                       DeclOfCommentLine + 1)) {
         return CommentBehindDecl;
       }
     }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -272,15 +272,20 @@ RawComment *ASTContext::getRawCommentNoCacheImpl(
     if ((CommentBehindDecl->isDocumentation() ||
          LangOpts.CommentOpts.ParseAllComments) &&
         CommentBehindDecl->isTrailingComment() &&
-        (IsMacro || (D && (isa<FieldDecl>(D) || isa<EnumConstantDecl>(D) ||
-                           isa<VarDecl>(D) || isa<ObjCMethodDecl>(D) ||
-                           isa<ObjCPropertyDecl>(D))))) {
+        (IsMacro ||
+         (D && (isa<FieldDecl>(D) || isa<EnumConstantDecl>(D) ||
+                isa<VarDecl>(D) || isa<ObjCMethodDecl>(D) ||
+                isa<ObjCPropertyDecl>(D) || isa<FunctionDecl>(D))))) {
 
       // Check that Doxygen trailing comment comes after the declaration, starts
-      // on the same line and in the same file as the declaration.
-      if (SourceMgr.getLineNumber(LocDecomp.first, LocDecomp.second) ==
-          Comments.getCommentBeginLine(CommentBehindDecl, LocDecomp.first,
-                                       OffsetCommentBehindDecl->first)) {
+      // on the same or the next line, and in the same file as the declaration.
+      auto LocLineNumber =
+          SourceMgr.getLineNumber(LocDecomp.first, LocDecomp.second);
+      auto CommentBeginLine = Comments.getCommentBeginLine(
+          CommentBehindDecl, LocDecomp.first, OffsetCommentBehindDecl->first);
+      if (LocLineNumber == CommentBeginLine ||
+          (LocLineNumber + 1 == CommentBeginLine &&
+           CommentBehindDecl->isDocumentation())) {
         return CommentBehindDecl;
       }
     }


### PR DESCRIPTION
The clang AST now correctly matches trailing Doxygen comments for function declarations and also comments that come after the declaration with the same `<` trailing directive.