### PR TITLE
[AllocToken] Propagate !alloc_token through inlined allocation wrappers

### DIFF
--- a/clang/docs/AllocToken.rst
+++ b/clang/docs/AllocToken.rst
@@ -174,6 +174,15 @@ For example:
     ptr1 = __alloc_token_custom_malloc(size, token_id);
     ptr2 = __alloc_token_my_malloc(size, token_id);
 
+Note: Even in the default mode (without ``-fsanitize-alloc-token-extended``),
+an *inline* allocation wrapper marked with the `malloc
+<https://clang.llvm.org/docs/AttributeReference.html#malloc>`_ or `alloc_size
+<https://clang.llvm.org/docs/AttributeReference.html#alloc-size>`_ attribute is
+supported if it is inlined into its caller: the inferred token is propagated to
+the allocation call the wrapper returns, which is then instrumented normally.
+Wrappers that are not inlined still require
+``-fsanitize-alloc-token-extended``.
+
 Disabling Instrumentation
 -------------------------
 

--- a/clang/test/CodeGen/alloc-token-inline.c
+++ b/clang/test/CodeGen/alloc-token-inline.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -O -fsanitize=alloc-token -fsanitize-alloc-token-extended -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -O -fsanitize=alloc-token -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s
+
+typedef __typeof(sizeof(int)) size_t;
+
+void *sink;
+
+void *malloc(size_t size);
+void *external_ptr_helper(void);
+void external_void_helper(void);
+
+__attribute__((malloc, always_inline)) inline void *wrapper(size_t size) {
+  sink = external_ptr_helper();
+  external_void_helper();
+  return malloc(size);
+}
+
+// CHECK-LABEL: @test_inlined_wrapper(
+// CHECK: call ptr @external_ptr_helper()
+// CHECK-NOT: __alloc_token_external_ptr_helper
+// CHECK: call void @external_void_helper()
+// CHECK-NOT: __alloc_token_external_void_helper
+// CHECK: call{{.*}} @__alloc_token_malloc(i64 noundef 4, i64 2689373973731826898){{.*}} !alloc_token [[META_INT:![0-9]+]]
+void test_inlined_wrapper(void) {
+  sink = wrapper(sizeof(int));
+}
+
+// CHECK: [[META_INT]] = !{!"int", i1 false}

--- a/clang/test/CodeGen/alloc-token-inline.c
+++ b/clang/test/CodeGen/alloc-token-inline.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -O -fsanitize=alloc-token -fsanitize-alloc-token-extended -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s
-// RUN: %clang_cc1 -O -fsanitize=alloc-token -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -O -fsanitize=alloc-token -fsanitize-alloc-token-extended -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s --implicit-check-not=__alloc_token
+// RUN: %clang_cc1 -O -fsanitize=alloc-token -triple x86_64-linux-gnu -emit-llvm %s -o - | FileCheck %s --implicit-check-not=__alloc_token
 
 typedef __typeof(sizeof(int)) size_t;
 
@@ -17,12 +17,11 @@ __attribute__((malloc, always_inline)) inline void *wrapper(size_t size) {
 
 // CHECK-LABEL: @test_inlined_wrapper(
 // CHECK: call ptr @external_ptr_helper()
-// CHECK-NOT: __alloc_token_external_ptr_helper
 // CHECK: call void @external_void_helper()
-// CHECK-NOT: __alloc_token_external_void_helper
 // CHECK: call{{.*}} @__alloc_token_malloc(i64 noundef 4, i64 2689373973731826898){{.*}} !alloc_token [[META_INT:![0-9]+]]
 void test_inlined_wrapper(void) {
   sink = wrapper(sizeof(int));
 }
 
+// CHECK: declare{{.*}} @__alloc_token_malloc(
 // CHECK: [[META_INT]] = !{!"int", i1 false}

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -937,6 +937,62 @@ propagateMemProfMetadata(Function *Callee, CallBase &CB,
   }
 }
 
+/// Collect all calls that produce RetVal, following only pointer-preserving
+/// instructions (cast, phi, select).
+static void collectPointerReturningCalls(Value *RetVal,
+                                         SmallVectorImpl<CallBase *> &Out) {
+  SmallVector<Value *, 8> Worklist{RetVal};
+  SmallPtrSet<Value *, 8> Visited;
+  while (!Worklist.empty()) {
+    Value *V = Worklist.pop_back_val();
+    if (!V->getType()->isPointerTy() || !Visited.insert(V).second)
+      continue;
+    if (auto *CB = dyn_cast<CallBase>(V))
+      Out.push_back(CB);
+    else if (isa<BitCastInst, AddrSpaceCastInst>(V))
+      Worklist.push_back(cast<CastInst>(V)->getOperand(0));
+    else if (auto *PN = dyn_cast<PHINode>(V))
+      append_range(Worklist, PN->incoming_values());
+    else if (auto *SI = dyn_cast<SelectInst>(V)) {
+      Worklist.push_back(SI->getTrueValue());
+      Worklist.push_back(SI->getFalseValue());
+    }
+  }
+}
+
+/// When inlining a call that carries !alloc_token metadata, propagate that
+/// metadata onto calls exposed by inlining the wrapper body.  Propagation is
+/// restricted to return-value producing calls, which avoids instrumenting
+/// unrelated calls in the wrapper body.
+static void
+propagateAllocTokenMetadata(Function *CalledFunc, CallBase &CB,
+                            const ValueMap<const Value *, WeakTrackingVH> &VMap,
+                            ClonedCodeInfo &InlinedFunctionInfo) {
+  MDNode *AllocTokenMD = CB.getMetadata(LLVMContext::MD_alloc_token);
+  if (!AllocTokenMD)
+    return;
+
+  SmallVector<CallBase *, 2> AllocCalls;
+  for (BasicBlock &BB : *CalledFunc)
+    if (auto *RI = dyn_cast<ReturnInst>(BB.getTerminator()))
+      if (Value *RV = RI->getReturnValue())
+        collectPointerReturningCalls(RV, AllocCalls);
+
+  for (CallBase *OrigCall : AllocCalls) {
+    auto *ClonedCall = dyn_cast_or_null<CallBase>(VMap.lookup(OrigCall));
+    if (!ClonedCall)
+      continue;
+    // Skip calls simplified during inlining; propagation may be incorrect.
+    if (InlinedFunctionInfo.isSimplified(OrigCall, ClonedCall))
+      continue;
+    // Fill missing only: never overwrite a more specific token the wrapper
+    // already set on an internal allocation.
+    if (ClonedCall->getMetadata(LLVMContext::MD_alloc_token))
+      continue;
+    ClonedCall->setMetadata(LLVMContext::MD_alloc_token, AllocTokenMD);
+  }
+}
+
 /// When inlining a call site that has !llvm.mem.parallel_loop_access,
 /// !llvm.access.group, !alias.scope or !noalias metadata, that metadata should
 /// be propagated to all memory-accessing cloned instructions.
@@ -2902,6 +2958,9 @@ void llvm::InlineFunctionImpl(CallBase &CB, InlineFunctionInfo &IFI,
 
     // Propagate metadata on the callsite if necessary.
     PropagateCallSiteMetadata(CB, FirstNewBlock, Caller->end());
+
+    // Propagate an allocation wrapper's !alloc_token if necessary.
+    propagateAllocTokenMetadata(CalledFunc, CB, VMap, InlinedFunctionInfo);
 
     // Propagate implicit ref metadata.
     if (CalledFunc->hasMetadata(LLVMContext::MD_implicit_ref)) {

--- a/llvm/test/Transforms/Inline/alloc-token.ll
+++ b/llvm/test/Transforms/Inline/alloc-token.ll
@@ -1,0 +1,37 @@
+; RUN: opt < %s -passes='cgscc(inline)' -S | FileCheck %s
+
+declare ptr @malloc(i64)
+declare ptr @helper()
+
+define internal ptr @wrapper(i64 %size) alwaysinline {
+  ; Not returned: must not inherit the token.
+  %h = call ptr @helper()
+  %p = call ptr @malloc(i64 %size)
+  ret ptr %p
+}
+
+; CHECK-LABEL: define ptr @inherits(
+; CHECK: call ptr @helper(){{$}}
+; CHECK: call ptr @malloc(i64 4){{.*}}, !alloc_token [[MD:![0-9]+]]
+define ptr @inherits() {
+  %c = call ptr @wrapper(i64 4), !alloc_token !0
+  ret ptr %c
+}
+
+define internal ptr @wrapper_own(i64 %size) alwaysinline {
+  %p = call ptr @malloc(i64 %size), !alloc_token !1
+  ret ptr %p
+}
+
+; Metadata the wrapper set itself is never overwritten.
+; CHECK-LABEL: define ptr @no_overwrite(
+; CHECK: call ptr @malloc(i64 4){{.*}}, !alloc_token [[OWN:![0-9]+]]
+define ptr @no_overwrite() {
+  %c = call ptr @wrapper_own(i64 4), !alloc_token !0
+  ret ptr %c
+}
+
+; CHECK-DAG: [[MD]] = !{!"Outer", i1 true}
+; CHECK-DAG: [[OWN]] = !{!"Inner", i1 false}
+!0 = !{!"Outer", i1 true}
+!1 = !{!"Inner", i1 false}


### PR DESCRIPTION
Simple inline allocation wrappers have been preventing AllocToken coverage for such callsites. Instead of converting such inline wrappers to macros, we can support covering standard allocation calls in inline allocation wrappers when inlined.

When an allocation wrapper with malloc/alloc_size attributes is inlined, propagate its call-site !alloc_token onto return-value producing calls exposed by inlining, so the late AllocToken pass assigns the correct type-derived token even in default (non-extended) mode.

Propagation is restricted to calls producing the return-value(s) that the wrapper actually returns. This keeps unrelated calls in the wrapper body unchanged, which matters under -fsanitize-alloc-token-extended, where any !alloc_token-carrying call is instrumented.