### PR TITLE
[mlir][affine] Modernize AffineLoopNormalizePass constructor using inherited constructors (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Affine/Transforms/Passes.h
@@ -56,12 +56,6 @@ std::unique_ptr<OperationPass<func::FuncOp>> createAffineParallelizePass();
 /// Creates a pass that converts some memref operators to affine operators.
 std::unique_ptr<OperationPass<func::FuncOp>> createRaiseMemrefToAffine();
 
-/// Apply normalization transformations to affine loop-like ops. If
-/// `promoteSingleIter` is true, single iteration loops are promoted (i.e., the
-/// loop is replaced by its loop body).
-std::unique_ptr<OperationPass<func::FuncOp>>
-createAffineLoopNormalizePass(bool promoteSingleIter = false);
-
 /// Performs packing (or explicit copying) of accessed memref regions into
 /// buffers in the specified faster memory space through either pointwise copies
 /// or DMA operations.

--- a/mlir/include/mlir/Dialect/Affine/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Affine/Transforms/Passes.td
@@ -380,11 +380,10 @@ def AffineParallelize : Pass<"affine-parallelize", "func::FuncOp"> {
 }
 
 def AffineLoopNormalize : Pass<"affine-loop-normalize", "func::FuncOp"> {
-  let summary = "Apply normalization transformations to affine loop-like ops";
-  let constructor = "mlir::affine::createAffineLoopNormalizePass()";
+  let summary = "Apply normalization transformations to affine loop-like ops"; 
   let options = [
     Option<"promoteSingleIter", "promote-single-iter", "bool",
-           /*default=*/"true", "Promote single iteration loops">,
+           /*default=*/"false", "Promote single iteration loops">,
   ];
 }
 

--- a/mlir/lib/Dialect/Affine/Transforms/AffineLoopNormalize.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/AffineLoopNormalize.cpp
@@ -47,9 +47,3 @@ struct AffineLoopNormalizePass
 };
 
 } // namespace
-
-std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::affine::createAffineLoopNormalizePass(bool promoteSingleIter) {
-  AffineLoopNormalizeOptions options{promoteSingleIter};
-  return std::make_unique<AffineLoopNormalizePass>(options);
-}

--- a/mlir/lib/Dialect/Affine/Transforms/AffineLoopNormalize.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/AffineLoopNormalize.cpp
@@ -33,9 +33,8 @@ namespace {
 /// that are already in a normalized form.
 struct AffineLoopNormalizePass
     : public affine::impl::AffineLoopNormalizeBase<AffineLoopNormalizePass> {
-  explicit AffineLoopNormalizePass(bool promoteSingleIter) {
-    this->promoteSingleIter = promoteSingleIter;
-  }
+  using affine::impl::AffineLoopNormalizeBase<
+      AffineLoopNormalizePass>::AffineLoopNormalizeBase;
 
   void runOnOperation() override {
     getOperation().walk([&](Operation *op) {
@@ -51,5 +50,6 @@ struct AffineLoopNormalizePass
 
 std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::affine::createAffineLoopNormalizePass(bool promoteSingleIter) {
-  return std::make_unique<AffineLoopNormalizePass>(promoteSingleIter);
+  AffineLoopNormalizeOptions options{promoteSingleIter};
+  return std::make_unique<AffineLoopNormalizePass>(options);
 }


### PR DESCRIPTION
This PR removes the explicit constructor of AffineLoopNormalizePass and switches to inheriting the base class constructors to utilize promoteSingleIter.