### PR TITLE
[lldb][windows] remove path separator replacement from TestGDBRemoteClient.py

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemoteClient.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBRemoteClient.py
@@ -256,8 +256,7 @@ class TestGDBRemoteClient(GDBRemoteTestBase):
         self.server.responder = MyResponder()
 
         target = self.createTarget("a.yaml")
-        # NB: apparently GDB packets are using "/" on Windows too
-        exe_path = self.getBuildArtifact("a").replace(os.path.sep, "/")
+        exe_path = self.getBuildArtifact("a")
         exe_hex = binascii.b2a_hex(exe_path.encode()).decode()
         process = self.connect(target)
         lldbutil.expect_state_changes(
@@ -317,8 +316,7 @@ class TestGDBRemoteClient(GDBRemoteTestBase):
         self.server.responder = MyResponder()
 
         target = self.createTarget("a.yaml")
-        # NB: apparently GDB packets are using "/" on Windows too
-        exe_path = self.getBuildArtifact("a").replace(os.path.sep, "/")
+        exe_path = self.getBuildArtifact("a")
         exe_hex = binascii.b2a_hex(exe_path.encode()).decode()
         process = self.connect(target)
         lldbutil.expect_state_changes(
@@ -389,8 +387,7 @@ class TestGDBRemoteClient(GDBRemoteTestBase):
         self.server.responder = MyResponder()
 
         target = self.createTarget("a.yaml")
-        # NB: apparently GDB packets are using "/" on Windows too
-        exe_path = self.getBuildArtifact("a").replace(os.path.sep, "/")
+        exe_path = self.getBuildArtifact("a")
         exe_hex = binascii.b2a_hex(exe_path.encode()).decode()
         process = self.connect(target)
         lldbutil.expect_state_changes(


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/197942, vRun packets use the native path separators. TestGDBRemoteClient.py now fails on Windows because it converts the path to POSIX style paths, which is a workaround for what https://github.com/llvm/llvm-project/pull/197942 fixed.

rdar://177342572
