### PR TITLE
[VPlan] Add branch-on-cond false original unconditional latch (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -6638,15 +6638,15 @@ void LoopVectorizationPlanner::buildVPlans(ElementCount MinVF,
 
   // Create recipes for header phis. For outer loops, reductions, recurrences
   // and in-loop reductions are empty since legality doesn't detect them.
-  if (!RUN_VPLAN_PASS_NO_VERIFY(
-          VPlanTransforms::createHeaderPhiRecipes, *VPlan0, PSE, *OrigLoop,
-          Legal->getInductionVars(), Legal->getReductionVars(),
-          Legal->getFixedOrderRecurrences(), Config.getInLoopReductions(),
-          Hints.allowReordering()))
+  if (!RUN_VPLAN_PASS(VPlanTransforms::createHeaderPhiRecipes, *VPlan0, PSE,
+                      *OrigLoop, Legal->getInductionVars(),
+                      Legal->getReductionVars(),
+                      Legal->getFixedOrderRecurrences(),
+                      Config.getInLoopReductions(), Hints.allowReordering()))
     return;
 
-  RUN_VPLAN_PASS_NO_VERIFY(VPlanTransforms::simplifyRecipes, *VPlan0);
-  RUN_VPLAN_PASS_NO_VERIFY(VPlanTransforms::removeDeadRecipes, *VPlan0);
+  RUN_VPLAN_PASS(VPlanTransforms::simplifyRecipes, *VPlan0);
+  RUN_VPLAN_PASS(VPlanTransforms::removeDeadRecipes, *VPlan0);
   RUN_VPLAN_PASS(VPlanTransforms::addCanonicalIVRecipes, *VPlan0,
                  getDebugLocFromInstOrOperands(Legal->getPrimaryInduction()));
   // If we're vectorizing a loop with an uncountable exit, make sure that the

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -543,7 +543,9 @@ static void addInitialSkeleton(VPlan &Plan, Type *InductionTy,
   // The canonical LatchVPBB has the header block as last successor. If it has
   // another successor, this successor is an exit block - insert middle block on
   // its edge. Otherwise, add middle block as another successor retaining header
-  // as last. In the latter case, the latch has no conditional terminator yet, so insert a placeholder BranchOnCond that always continues to the header. addCanonicalIVRecipes will replace it with the BranchOnCount.
+  // as last. In the latter case, the latch has no conditional terminator yet,
+  // so insert a placeholder BranchOnCond that always continues to the header.
+  // It will be canonicalized to a BranchOnCount later
   if (LatchVPBB->getNumSuccessors() == 2) {
     VPBlockBase *LatchExitVPB = LatchVPBB->getSuccessors()[0];
     VPBlockUtils::insertOnEdge(LatchVPBB, LatchExitVPB, MiddleVPBB);

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -543,13 +543,15 @@ static void addInitialSkeleton(VPlan &Plan, Type *InductionTy,
   // The canonical LatchVPBB has the header block as last successor. If it has
   // another successor, this successor is an exit block - insert middle block on
   // its edge. Otherwise, add middle block as another successor retaining header
-  // as last.
+  // as last. In the latter case, the latch has no conditional terminator yet, so insert a placeholder BranchOnCond that always continues to the header. addCanonicalIVRecipes will replace it with the BranchOnCount.
   if (LatchVPBB->getNumSuccessors() == 2) {
     VPBlockBase *LatchExitVPB = LatchVPBB->getSuccessors()[0];
     VPBlockUtils::insertOnEdge(LatchVPBB, LatchExitVPB, MiddleVPBB);
   } else {
     VPBlockUtils::connectBlocks(LatchVPBB, MiddleVPBB);
     LatchVPBB->swapSuccessors();
+    VPBuilder(LatchVPBB).createNaryOp(VPInstruction::BranchOnCond,
+                                      {Plan.getFalse()});
   }
 
   // Create SCEV and VPValue for the trip count.


### PR DESCRIPTION
For loops where the latch does not exit, addInitialSkeleton adds the middle block as additional successor, as early canonicalization.

But then we end up with a block without terminator and multiple successors. Fix this by adding a branch-on-cond false as terminator. This preserves the original behavior (backegdge always taken) and resolves the verifier issue.