### PR TITLE
[mlir/memref] handle rank-0 contiguous check

### DIFF
--- a/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
+++ b/mlir/lib/Dialect/MemRef/Utils/MemRefUtils.cpp
@@ -24,6 +24,10 @@ bool isStaticShapeAndContiguousRowMajor(MemRefType type) {
   if (!type.hasStaticShape())
     return false;
 
+  int64_t rank = type.getRank();
+  if (rank == 0)
+    return true;
+
   SmallVector<int64_t> strides;
   int64_t offset;
   if (failed(type.getStridesAndOffset(strides, offset)))
@@ -32,7 +36,7 @@ bool isStaticShapeAndContiguousRowMajor(MemRefType type) {
   // MemRef is contiguous if outer dimensions are size-1 and inner
   // dimensions have unit strides.
   int64_t runningStride = 1;
-  int64_t curDim = strides.size() - 1;
+  int64_t curDim = rank - 1;
   // Finds all inner dimensions with unit strides.
   while (curDim >= 0 && strides[curDim] == runningStride) {
     runningStride *= type.getDimSize(curDim);
@@ -123,7 +127,8 @@ getLinearizedMemRefOffsetAndSize(OpBuilder &builder, Location loc, int srcBits,
     strides.back() = builder.getIndexAttr(1);
     AffineExpr s0, s1;
     bindSymbols(builder.getContext(), s0, s1);
-    for (int index = sizes.size() - 1; index > 0; --index) {
+    for (int64_t index = static_cast<int64_t>(sizes.size()) - 1; index > 0;
+         --index) {
       strides[index - 1] = affine::makeComposedFoldedAffineApply(
           builder, loc, s0 * s1,
           ArrayRef<OpFoldResult>{strides[index], sizes[index]});
@@ -185,7 +190,7 @@ computeSuffixProductIRBlockImpl(Location loc, OpBuilder &builder,
   AffineExpr s0, s1;
   bindSymbols(builder.getContext(), s0, s1);
 
-  for (int64_t r = strides.size() - 1; r > 0; --r) {
+  for (int64_t r = static_cast<int64_t>(strides.size()) - 1; r > 0; --r) {
     strides[r - 1] = affine::makeComposedFoldedAffineApply(
         builder, loc, s0 * s1, {strides[r], sizes[r]});
   }

--- a/mlir/unittests/Dialect/MemRef/CMakeLists.txt
+++ b/mlir/unittests/Dialect/MemRef/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_mlir_unittest(MLIRMemRefTests
   InferShapeTest.cpp
+  MemRefUtilsTest.cpp
 )
 mlir_target_link_libraries(MLIRMemRefTests
   PRIVATE
   MLIRMemRefDialect
+  MLIRMemRefUtils
   )

--- a/mlir/unittests/Dialect/MemRef/MemRefUtilsTest.cpp
+++ b/mlir/unittests/Dialect/MemRef/MemRefUtilsTest.cpp
@@ -1,0 +1,33 @@
+//===- MemRefUtilsTest.cpp - MemRef utils unit tests ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+
+TEST(MemRefUtilsTest, IsStaticShapeAndContiguousRowMajor) {
+  MLIRContext ctx;
+  OpBuilder builder(&ctx);
+
+  // Rank-0 memrefs are scalar values and should return before stride analysis.
+  EXPECT_TRUE(memref::isStaticShapeAndContiguousRowMajor(
+      MemRefType::get({}, builder.getI32Type())));
+}
+
+TEST(MemRefUtilsTest, ComputeSuffixProductIRBlockEmptySizes) {
+  MLIRContext ctx;
+  OpBuilder builder(&ctx);
+
+  // Empty size lists should not underflow the reverse loop's initial index.
+  EXPECT_TRUE(
+      memref::computeSuffixProductIRBlock(builder.getUnknownLoc(), builder, {})
+          .empty());
+}


### PR DESCRIPTION
The old loop initialized its signed cursor with `strides.size() - 1`. For rank-0 memrefs, this
underflowed as `size_t` before the cast. On 32-bit hosts, the value became a large positive index and crashed in SmallVector during narrow-type emulation. 


Change to do early return for rank-0 memref and add coverage tests.


This addresses the issue exposed in tests checked in in https://github.com/llvm/llvm-project/pull/196945,
specifically on x86 32bit system reported in : https://github.com/llvm/llvm-project/pull/196945#issuecomment-4428581243 