### PR TITLE
[SLP] Unify IR flag and metadata propagation in vectorizeTree

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -22634,6 +22634,67 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
       });
     return IsSigned;
   };
+  auto PropagateIRFlags = [&](Value *V, unsigned Opcode = 0,
+                              ArrayRef<Value *> VL = {}) -> Value * {
+    ArrayRef<Value *> Scalars = VL.empty() ? E->Scalars : VL;
+    SmallSetVector<Value *, 4> UniqueInsts;
+    for (Value *Scalar : Scalars) {
+      auto *I = dyn_cast<Instruction>(Scalar);
+      if (!I)
+        continue;
+      if (E->hasCopyableElements() && E->isCopyableElement(I))
+        continue;
+      UniqueInsts.insert(I);
+    }
+    if (!Opcode)
+      Opcode = E->getOpcode();
+    propagateIRFlags(V, UniqueInsts.getArrayRef(), nullptr, It == MinBWs.end());
+    auto *I = dyn_cast<Instruction>(V);
+    if (!I)
+      return V;
+    I = ::propagateMetadata(I, UniqueInsts.getArrayRef());
+    // For copyable elements the lane is synthesized using a binop identity
+    // value, so the operand at that lane is the copyable scalar's value.
+    // fast-math flags that turn defined NaN/Inf inputs into poison (nnan,
+    // ninf) are only justified if every copyable scalar at the synthesized
+    // lane is itself provably non-NaN/non-Inf - either an FPMathOperator
+    // with the matching flag set, or a constant FP that is not NaN/Inf.
+    if (E->hasCopyableElements() && isa<FPMathOperator>(I)) {
+      bool AllNoNaNs = true;
+      bool AllNoInfs = true;
+      for (Value *Scalar : Scalars) {
+        if (!E->isCopyableElement(Scalar))
+          continue;
+        if (auto *FPMO = dyn_cast<FPMathOperator>(Scalar)) {
+          AllNoNaNs &= FPMO->hasNoNaNs();
+          AllNoInfs &= FPMO->hasNoInfs();
+          continue;
+        }
+        if (auto *CFP = dyn_cast<ConstantFP>(Scalar)) {
+          AllNoNaNs &= !CFP->isNaN();
+          AllNoInfs &= !CFP->isInfinity();
+          continue;
+        }
+        AllNoNaNs = false;
+        AllNoInfs = false;
+        break;
+      }
+      if (!AllNoNaNs)
+        I->setHasNoNaNs(false);
+      if (!AllNoInfs)
+        I->setHasNoInfs(false);
+    }
+    // Drop nuw flags for abs(sub(commutative), true).
+    if (!MinBWs.contains(E) && Opcode == Instruction::Sub &&
+        (E->hasCopyableElements() || any_of(Scalars, [](Value *Scalar) {
+           auto *SI = dyn_cast<Instruction>(Scalar);
+           return !SI || isCommutative(SI);
+         })))
+      I->setHasNoUnsignedWrap(/*b=*/false);
+    if (auto *ICmp = dyn_cast<ICmpInst>(I); ICmp && It == MinBWs.end())
+      ICmp->setSameSign(/*B=*/false);
+    return I;
+  };
   switch (ShuffleOrOp) {
     case Instruction::PHI: {
       assert((E->ReorderIndices.empty() || !E->ReuseShuffleIndices.empty() ||
@@ -22713,7 +22774,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
       Builder.SetInsertPoint(LI);
       Value *Ptr = LI->getPointerOperand();
       LoadInst *V = Builder.CreateAlignedLoad(VecTy, Ptr, LI->getAlign());
-      Value *NewV = ::propagateMetadata(V, E->Scalars);
+      Value *NewV = PropagateIRFlags(V);
       NewV = FinalShuffle(NewV, E);
       E->VectorizedValue = NewV;
       return NewV;
@@ -22985,9 +23046,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
 
       CmpInst::Predicate P0 = cast<CmpInst>(VL0)->getPredicate();
       Value *V = Builder.CreateCmp(P0, L, R);
-      propagateIRFlags(V, E->Scalars, VL0);
-      if (auto *ICmp = dyn_cast<ICmpInst>(V); ICmp && It == MinBWs.end())
-        ICmp->setSameSign(/*B=*/false);
+      V = PropagateIRFlags(V);
       // Do not cast for cmps.
       VecTy = cast<FixedVectorType>(V->getType());
       V = FinalShuffle(V, E);
@@ -23045,9 +23104,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
 
       Value *V = Builder.CreateUnOp(
           static_cast<Instruction::UnaryOps>(E->getOpcode()), Op);
-      propagateIRFlags(V, E->Scalars, VL0);
-      if (auto *I = dyn_cast<Instruction>(V))
-        V = ::propagateMetadata(I, E->Scalars);
+      V = PropagateIRFlags(V);
 
       V = FinalShuffle(V, E);
 
@@ -23126,18 +23183,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
       Value *V = Builder.CreateBinOp(
           static_cast<Instruction::BinaryOps>(E->getOpcode()), LHS,
           RHS);
-      propagateIRFlags(V, E->Scalars, nullptr, It == MinBWs.end());
-      if (auto *I = dyn_cast<Instruction>(V)) {
-        V = ::propagateMetadata(I, E->Scalars);
-        // Drop nuw flags for abs(sub(commutative), true).
-        if (!MinBWs.contains(E) && ShuffleOrOp == Instruction::Sub &&
-            any_of(E->Scalars, [E](Value *V) {
-              return isa<PoisonValue>(V) ||
-                     (E->hasCopyableElements() && E->isCopyableElement(V)) ||
-                     isCommutative(cast<Instruction>(V));
-            }))
-          I->setHasNoUnsignedWrap(/*b=*/false);
-      }
+      V = PropagateIRFlags(V);
 
       V = FinalShuffle(V, E);
 
@@ -23178,7 +23224,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
         } else {
           NewLI = Builder.CreateAlignedLoad(LoadVecTy, PO, CommonAlignment);
         }
-        NewLI = ::propagateMetadata(NewLI, E->Scalars);
+        NewLI = cast<Instruction>(PropagateIRFlags(NewLI));
         // TODO: include this cost into CommonCost.
         if (auto *VecTy = dyn_cast<FixedVectorType>(LI->getType())) {
           assert(SLPReVec && "FixedVectorType is not expected.");
@@ -23253,7 +23299,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
       }
       Value *V = E->State == TreeEntry::CompressVectorize
                      ? NewLI
-                     : ::propagateMetadata(NewLI, E->Scalars);
+                     : PropagateIRFlags(NewLI);
 
       if (StridedLoadTy != VecTy)
         V = Builder.CreateBitOrPointerCast(V, VecTy);
@@ -23309,7 +23355,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
         ST = Inst;
       }
 
-      Value *V = ::propagateMetadata(ST, E->Scalars);
+      Value *V = PropagateIRFlags(ST);
 
       E->VectorizedValue = V;
       ++NumVectorInstructions;
@@ -23334,7 +23380,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
           if (isa<GetElementPtrInst>(V))
             GEPs.push_back(V);
         }
-        V = ::propagateMetadata(I, GEPs);
+        V = PropagateIRFlags(I);
       }
 
       V = FinalShuffle(V, E);
@@ -23412,7 +23458,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
       CI->getOperandBundlesAsDefs(OpBundles);
       Value *V = Builder.CreateCall(CF, OpVecs, OpBundles);
 
-      propagateIRFlags(V, E->Scalars, VL0);
+      V = PropagateIRFlags(V);
       cast<CallInst>(V)->setCallingConv(CF->getCallingConv());
       V = FinalShuffle(V, E);
 
@@ -23436,9 +23482,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
         } else {
           V = Builder.CreateShuffleVector(Src, ThisMask);
         }
-        propagateIRFlags(V, E->Scalars, VL0);
-        if (auto *I = dyn_cast<Instruction>(V))
-          V = ::propagateMetadata(I, E->Scalars);
+        V = PropagateIRFlags(V);
         V = FinalShuffle(V, E);
       } else {
         assert(E->isAltShuffle() &&
@@ -23506,8 +23550,7 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
                 LHS = Builder.CreateIntCast(LHS, VecTy, It->second.first);
               assert(LHS->getType() == VecTy &&
                      "Expected same type as operand.");
-              if (auto *I = dyn_cast<Instruction>(LHS))
-                LHS = ::propagateMetadata(I, E->Scalars);
+              LHS = PropagateIRFlags(LHS);
               LHS = FinalShuffle(LHS, E);
               E->VectorizedValue = LHS;
               ++NumVectorInstructions;
@@ -23542,24 +23585,8 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
             },
             Mask, &OpScalars, &AltScalars);
 
-        propagateIRFlags(V0, OpScalars, E->getMainOp(), It == MinBWs.end());
-        propagateIRFlags(V1, AltScalars, E->getAltOp(), It == MinBWs.end());
-        auto DropNuwFlag = [&](Value *Vec, unsigned Opcode) {
-          // Drop nuw flags for abs(sub(commutative), true).
-          if (auto *I = dyn_cast<Instruction>(Vec);
-              I && Opcode == Instruction::Sub && !MinBWs.contains(E) &&
-              any_of(E->Scalars, [E](Value *V) {
-                if (isa<PoisonValue>(V))
-                  return false;
-                if (E->hasCopyableElements() && E->isCopyableElement(V))
-                  return false;
-                auto *IV = cast<Instruction>(V);
-                return IV->getOpcode() == Instruction::Sub && isCommutative(IV);
-              }))
-            I->setHasNoUnsignedWrap(/*b=*/false);
-        };
-        DropNuwFlag(V0, E->getOpcode());
-        DropNuwFlag(V1, E->getAltOpcode());
+        PropagateIRFlags(V0, E->getOpcode(), OpScalars);
+        PropagateIRFlags(V1, E->getAltOpcode(), AltScalars);
 
         if (auto *VecTy = dyn_cast<FixedVectorType>(ScalarTy)) {
           assert(SLPReVec && "FixedVectorType is not expected.");
@@ -23567,7 +23594,6 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
         }
         V = Builder.CreateShuffleVector(V0, V1, Mask);
         if (auto *I = dyn_cast<Instruction>(V)) {
-          V = ::propagateMetadata(I, E->Scalars);
           GatherShuffleExtractSeq.insert(I);
           CSEBlocks.insert(I->getParent());
         }

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-loads.ll
@@ -914,7 +914,7 @@ define void @rt_stride_mul_scev(ptr %pl, i64 %base_stride, ptr %ps) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = mul nsw <8 x i64> [[TMP2]], <i64 0, i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7>
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x ptr> poison, ptr [[PL]], i32 0
 ; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <8 x ptr> [[TMP4]], <8 x ptr> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr i8, <8 x ptr> [[TMP5]], <8 x i64> [[TMP3]]
+; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds i8, <8 x ptr> [[TMP5]], <8 x i64> [[TMP3]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call <8 x i8> @llvm.masked.gather.v8i8.v8p0(<8 x ptr> align 1 [[TMP6]], <8 x i1> splat (i1 true), <8 x i8> poison)
 ; CHECK-NEXT:    store <8 x i8> [[TMP7]], ptr [[GEP_S0]], align 1
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/buildvector-all-external-scalars.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/buildvector-all-external-scalars.ll
@@ -206,7 +206,7 @@ define void @test(ptr %__last.addr.011.i.i, ptr %call3) {
 ; CHECK-NEXT:    [[__LAST_ADDR_0_I_I_31:%.*]] = getelementptr inbounds i8, ptr [[INCDEC_PTR2_I_I_20]], i32 -4
 ; CHECK-NEXT:    [[TMP52:%.*]] = insertelement <2 x ptr> poison, ptr [[__LAST_ADDR_0_I_I_20]], i32 0
 ; CHECK-NEXT:    [[TMP53:%.*]] = insertelement <2 x ptr> [[TMP52]], ptr [[INCDEC_PTR2_I_I_20]], i32 1
-; CHECK-NEXT:    [[TMP92:%.*]] = getelementptr i8, <2 x ptr> [[TMP53]], <2 x i32> <i32 4, i32 -4>
+; CHECK-NEXT:    [[TMP92:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP53]], <2 x i32> <i32 4, i32 -4>
 ; CHECK-NEXT:    [[INCDEC_PTR2_I_I_31:%.*]] = getelementptr inbounds nuw i8, ptr [[__LAST_ADDR_0_I_I_20]], i32 4
 ; CHECK-NEXT:    [[CMP1_I_I_31:%.*]] = icmp ult ptr [[INCDEC_PTR2_I_I_31]], [[__LAST_ADDR_0_I_I_31]]
 ; CHECK-NEXT:    [[TMP76]] = shufflevector <2 x ptr> [[TMP92]], <2 x ptr> poison, <2 x i32> <i32 1, i32 0>
@@ -351,7 +351,7 @@ define void @test(ptr %__last.addr.011.i.i, ptr %call3) {
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_20:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_19]], i32 -4
 ; EXP-NEXT:    [[TMP47:%.*]] = insertelement <2 x ptr> poison, ptr [[INCDEC_PTR2_I_I_19]], i32 0
 ; EXP-NEXT:    [[TMP48:%.*]] = insertelement <2 x ptr> [[TMP47]], ptr [[__LAST_ADDR_0_I_I_19]], i32 1
-; EXP-NEXT:    [[TMP49:%.*]] = getelementptr i8, <2 x ptr> [[TMP48]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP49:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP48]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_20:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_19]], i32 4
 ; EXP-NEXT:    [[TMP50:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_20]], align 4
 ; EXP-NEXT:    [[TMP51:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_20]], align 4
@@ -359,89 +359,89 @@ define void @test(ptr %__last.addr.011.i.i, ptr %call3) {
 ; EXP-NEXT:    store float [[TMP50]], ptr [[__LAST_ADDR_0_I_I_20]], align 4
 ; EXP-NEXT:    [[TMP52:%.*]] = insertelement <2 x ptr> poison, ptr [[__LAST_ADDR_0_I_I_20]], i32 0
 ; EXP-NEXT:    [[TMP53:%.*]] = insertelement <2 x ptr> [[TMP52]], ptr [[INCDEC_PTR2_I_I_20]], i32 1
-; EXP-NEXT:    [[TMP54:%.*]] = getelementptr i8, <2 x ptr> [[TMP53]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP54:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP53]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_21:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_20]], i32 -4
-; EXP-NEXT:    [[TMP55:%.*]] = getelementptr i8, <2 x ptr> [[TMP49]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP55:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP49]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_21:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_20]], i32 4
 ; EXP-NEXT:    [[TMP56:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_21]], align 4
 ; EXP-NEXT:    [[TMP57:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_21]], align 4
 ; EXP-NEXT:    store float [[TMP57]], ptr [[INCDEC_PTR2_I_I_21]], align 4
 ; EXP-NEXT:    store float [[TMP56]], ptr [[__LAST_ADDR_0_I_I_21]], align 4
-; EXP-NEXT:    [[TMP58:%.*]] = getelementptr i8, <2 x ptr> [[TMP54]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP58:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP54]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_22:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_21]], i32 -4
-; EXP-NEXT:    [[TMP59:%.*]] = getelementptr i8, <2 x ptr> [[TMP55]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP59:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP55]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_22:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_21]], i32 4
 ; EXP-NEXT:    [[TMP60:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_22]], align 4
 ; EXP-NEXT:    [[TMP61:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_22]], align 4
 ; EXP-NEXT:    store float [[TMP61]], ptr [[INCDEC_PTR2_I_I_22]], align 4
 ; EXP-NEXT:    store float [[TMP60]], ptr [[__LAST_ADDR_0_I_I_22]], align 4
-; EXP-NEXT:    [[TMP62:%.*]] = getelementptr i8, <2 x ptr> [[TMP58]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP62:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP58]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_23:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_22]], i32 -4
-; EXP-NEXT:    [[TMP63:%.*]] = getelementptr i8, <2 x ptr> [[TMP59]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP63:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP59]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_23:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_22]], i32 4
 ; EXP-NEXT:    [[TMP64:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_23]], align 4
 ; EXP-NEXT:    [[TMP65:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_23]], align 4
 ; EXP-NEXT:    store float [[TMP65]], ptr [[INCDEC_PTR2_I_I_23]], align 4
 ; EXP-NEXT:    store float [[TMP64]], ptr [[__LAST_ADDR_0_I_I_23]], align 4
-; EXP-NEXT:    [[TMP66:%.*]] = getelementptr i8, <2 x ptr> [[TMP62]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP66:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP62]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_24:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_23]], i32 -4
-; EXP-NEXT:    [[TMP67:%.*]] = getelementptr i8, <2 x ptr> [[TMP63]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP67:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP63]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_24:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_23]], i32 4
 ; EXP-NEXT:    [[TMP68:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_24]], align 4
 ; EXP-NEXT:    [[TMP69:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_24]], align 4
 ; EXP-NEXT:    store float [[TMP69]], ptr [[INCDEC_PTR2_I_I_24]], align 4
 ; EXP-NEXT:    store float [[TMP68]], ptr [[__LAST_ADDR_0_I_I_24]], align 4
-; EXP-NEXT:    [[TMP70:%.*]] = getelementptr i8, <2 x ptr> [[TMP66]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP70:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP66]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_25:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_24]], i32 -4
-; EXP-NEXT:    [[TMP71:%.*]] = getelementptr i8, <2 x ptr> [[TMP67]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP71:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP67]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_25:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_24]], i32 4
 ; EXP-NEXT:    [[TMP72:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_25]], align 4
 ; EXP-NEXT:    [[TMP73:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_25]], align 4
 ; EXP-NEXT:    store float [[TMP73]], ptr [[INCDEC_PTR2_I_I_25]], align 4
 ; EXP-NEXT:    store float [[TMP72]], ptr [[__LAST_ADDR_0_I_I_25]], align 4
-; EXP-NEXT:    [[TMP74:%.*]] = getelementptr i8, <2 x ptr> [[TMP70]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP74:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP70]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_26:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_25]], i32 -4
-; EXP-NEXT:    [[TMP75:%.*]] = getelementptr i8, <2 x ptr> [[TMP71]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP75:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP71]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_26:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_25]], i32 4
 ; EXP-NEXT:    [[TMP76:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_26]], align 4
 ; EXP-NEXT:    [[TMP77:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_26]], align 4
 ; EXP-NEXT:    store float [[TMP77]], ptr [[INCDEC_PTR2_I_I_26]], align 4
 ; EXP-NEXT:    store float [[TMP76]], ptr [[__LAST_ADDR_0_I_I_26]], align 4
-; EXP-NEXT:    [[TMP78:%.*]] = getelementptr i8, <2 x ptr> [[TMP74]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP78:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP74]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_27:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_26]], i32 -4
-; EXP-NEXT:    [[TMP79:%.*]] = getelementptr i8, <2 x ptr> [[TMP75]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP79:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP75]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_27:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_26]], i32 4
 ; EXP-NEXT:    [[TMP80:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_27]], align 4
 ; EXP-NEXT:    [[TMP81:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_27]], align 4
 ; EXP-NEXT:    store float [[TMP81]], ptr [[INCDEC_PTR2_I_I_27]], align 4
 ; EXP-NEXT:    store float [[TMP80]], ptr [[__LAST_ADDR_0_I_I_27]], align 4
-; EXP-NEXT:    [[TMP82:%.*]] = getelementptr i8, <2 x ptr> [[TMP78]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP82:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP78]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_28:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_27]], i32 -4
-; EXP-NEXT:    [[TMP83:%.*]] = getelementptr i8, <2 x ptr> [[TMP79]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP83:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP79]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_28:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_27]], i32 4
 ; EXP-NEXT:    [[TMP84:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_28]], align 4
 ; EXP-NEXT:    [[TMP85:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_28]], align 4
 ; EXP-NEXT:    store float [[TMP85]], ptr [[INCDEC_PTR2_I_I_28]], align 4
 ; EXP-NEXT:    store float [[TMP84]], ptr [[__LAST_ADDR_0_I_I_28]], align 4
-; EXP-NEXT:    [[TMP86:%.*]] = getelementptr i8, <2 x ptr> [[TMP82]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP86:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP82]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_29:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_28]], i32 -4
-; EXP-NEXT:    [[TMP87:%.*]] = getelementptr i8, <2 x ptr> [[TMP83]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP87:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP83]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_29:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_28]], i32 4
 ; EXP-NEXT:    [[TMP88:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_29]], align 4
 ; EXP-NEXT:    [[TMP89:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_29]], align 4
 ; EXP-NEXT:    store float [[TMP89]], ptr [[INCDEC_PTR2_I_I_29]], align 4
 ; EXP-NEXT:    store float [[TMP88]], ptr [[__LAST_ADDR_0_I_I_29]], align 4
-; EXP-NEXT:    [[TMP90:%.*]] = getelementptr i8, <2 x ptr> [[TMP86]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP90:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP86]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_30:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_29]], i32 -4
-; EXP-NEXT:    [[TMP91:%.*]] = getelementptr i8, <2 x ptr> [[TMP87]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP91:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP87]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_30:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_29]], i32 4
 ; EXP-NEXT:    [[TMP92:%.*]] = load float, ptr [[INCDEC_PTR2_I_I_30]], align 4
 ; EXP-NEXT:    [[TMP93:%.*]] = load float, ptr [[__LAST_ADDR_0_I_I_30]], align 4
 ; EXP-NEXT:    store float [[TMP93]], ptr [[INCDEC_PTR2_I_I_30]], align 4
 ; EXP-NEXT:    store float [[TMP92]], ptr [[__LAST_ADDR_0_I_I_30]], align 4
-; EXP-NEXT:    [[TMP94]] = getelementptr i8, <2 x ptr> [[TMP90]], <2 x i32> <i32 -4, i32 4>
+; EXP-NEXT:    [[TMP94]] = getelementptr inbounds i8, <2 x ptr> [[TMP90]], <2 x i32> <i32 -4, i32 4>
 ; EXP-NEXT:    [[__LAST_ADDR_0_I_I_31:%.*]] = getelementptr inbounds i8, ptr [[__LAST_ADDR_0_I_I_30]], i32 -4
-; EXP-NEXT:    [[TMP95:%.*]] = getelementptr i8, <2 x ptr> [[TMP91]], <2 x i32> <i32 4, i32 -4>
+; EXP-NEXT:    [[TMP95:%.*]] = getelementptr inbounds i8, <2 x ptr> [[TMP91]], <2 x i32> <i32 4, i32 -4>
 ; EXP-NEXT:    [[INCDEC_PTR2_I_I_31:%.*]] = getelementptr inbounds nuw i8, ptr [[INCDEC_PTR2_I_I_30]], i32 4
 ; EXP-NEXT:    [[CMP1_I_I_31:%.*]] = icmp ult ptr [[INCDEC_PTR2_I_I_31]], [[__LAST_ADDR_0_I_I_31]]
 ; EXP-NEXT:    br i1 [[CMP1_I_I_31]], label %[[WHILE_BODY_I_I]], label %[[INVOKE_CONT21_EXITSTUB:.*]]

--- a/llvm/test/Transforms/SLPVectorizer/X86/bad-reduction.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/bad-reduction.ll
@@ -117,7 +117,7 @@ define i64 @load64le(ptr %arg) {
 ; CHECK-LABEL: @load64le(
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i8>, ptr [[ARG:%.*]], align 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = zext <8 x i8> [[TMP1]] to <8 x i64>
-; CHECK-NEXT:    [[TMP3:%.*]] = shl <8 x i64> [[TMP2]], <i64 0, i64 8, i64 16, i64 24, i64 32, i64 40, i64 48, i64 56>
+; CHECK-NEXT:    [[TMP3:%.*]] = shl nuw <8 x i64> [[TMP2]], <i64 0, i64 8, i64 16, i64 24, i64 32, i64 40, i64 48, i64 56>
 ; CHECK-NEXT:    [[O7:%.*]] = call i64 @llvm.vector.reduce.or.v8i64(<8 x i64> [[TMP3]])
 ; CHECK-NEXT:    ret i64 [[O7]]
 ;

--- a/llvm/test/Transforms/SLPVectorizer/X86/copyable_reorder.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/copyable_reorder.ll
@@ -97,7 +97,7 @@ define void @test_add_udiv(ptr %arr1, ptr %arr2, i32 %a0, i32 %a1, i32 %a2, i32 
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i32>, ptr [[ARR1:%.*]], align 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x i32> <i32 0, i32 0, i32 poison, i32 0>, i32 [[A2:%.*]], i32 2
-; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i32> [[TMP1]], <i32 1, i32 1, i32 42, i32 1>
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw <4 x i32> [[TMP1]], <i32 1, i32 1, i32 42, i32 1>
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i32> <i32 poison, i32 poison, i32 0, i32 poison>, i32 [[A0:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <4 x i32> [[TMP3]], i32 [[A1:%.*]], i32 1
 ; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <4 x i32> [[TMP4]], i32 [[A3:%.*]], i32 3
@@ -138,7 +138,7 @@ define void @test_add_udiv_reorder_add(ptr %arr1, ptr %arr2, i32 %a0, i32 %a1, i
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i32>, ptr [[ARR1:%.*]], align 4
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x i32> <i32 0, i32 0, i32 poison, i32 0>, i32 [[A2:%.*]], i32 2
-; CHECK-NEXT:    [[TMP2:%.*]] = add <4 x i32> [[TMP1]], <i32 1, i32 1, i32 42, i32 1>
+; CHECK-NEXT:    [[TMP2:%.*]] = add nsw <4 x i32> [[TMP1]], <i32 1, i32 1, i32 42, i32 1>
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i32> <i32 poison, i32 poison, i32 0, i32 poison>, i32 [[A0:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <4 x i32> [[TMP3]], i32 [[A1:%.*]], i32 1
 ; CHECK-NEXT:    [[TMP6:%.*]] = insertelement <4 x i32> [[TMP5]], i32 [[V3:%.*]], i32 3
@@ -179,7 +179,7 @@ define void @test_add_udiv_commuted(ptr %arr1, ptr %arr2, i32 %a0, i32 %a1, i32 
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i32>, ptr [[ARR1:%.*]], align 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <4 x i32> <i32 0, i32 0, i32 poison, i32 0>, i32 [[A2:%.*]], i32 2
-; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i32> [[TMP4]], <i32 1, i32 1, i32 42, i32 1>
+; CHECK-NEXT:    [[TMP6:%.*]] = add nsw <4 x i32> [[TMP4]], <i32 1, i32 1, i32 42, i32 1>
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x i32> <i32 poison, i32 poison, i32 0, i32 poison>, i32 [[A0:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i32> [[TMP1]], i32 [[A1:%.*]], i32 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i32> [[TMP2]], i32 [[A3:%.*]], i32 3

--- a/llvm/test/Transforms/SLPVectorizer/X86/extract_in_tree_user.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/extract_in_tree_user.ll
@@ -12,7 +12,7 @@ define void @fn1() {
 ; CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr @a, align 8
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x ptr> poison, ptr [[TMP0]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <2 x ptr> [[TMP1]], <2 x ptr> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i64, <2 x ptr> [[TMP2]], <2 x i64> <i64 11, i64 56>
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds i64, <2 x ptr> [[TMP2]], <2 x i64> <i64 11, i64 56>
 ; CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i64, ptr [[TMP0]], i64 11
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint <2 x ptr> [[TMP3]] to <2 x i64>
 ; CHECK-NEXT:    store <2 x i64> [[TMP4]], ptr [[ADD_PTR]], align 8
@@ -118,7 +118,7 @@ define void @externally_used_ptrs() {
 ; CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i64, ptr [[TMP0]], i64 11
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x ptr> poison, ptr [[TMP0]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <2 x ptr> [[TMP1]], <2 x ptr> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i64, <2 x ptr> [[TMP2]], <2 x i64> <i64 56, i64 11>
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds i64, <2 x ptr> [[TMP2]], <2 x i64> <i64 56, i64 11>
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint <2 x ptr> [[TMP3]] to <2 x i64>
 ; CHECK-NEXT:    [[TMP5:%.*]] = load <2 x i64>, ptr [[ADD_PTR]], align 8
 ; CHECK-NEXT:    [[TMP6:%.*]] = add <2 x i64> [[TMP4]], [[TMP5]]

--- a/llvm/test/Transforms/SLPVectorizer/X86/gep.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/gep.ll
@@ -14,7 +14,7 @@ define void @foo1 (ptr noalias %x, ptr noalias %y) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds { ptr, ptr }, ptr [[Y:%.*]], i64 0, i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = getelementptr inbounds { ptr, ptr }, ptr [[X:%.*]], i64 0, i32 0
 ; CHECK-NEXT:    [[TMP4:%.*]] = load <2 x ptr>, ptr [[TMP1]], align 8
-; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i32, <2 x ptr> [[TMP4]], <2 x i64> splat (i64 16)
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds i32, <2 x ptr> [[TMP4]], <2 x i64> splat (i64 16)
 ; CHECK-NEXT:    store <2 x ptr> [[TMP5]], ptr [[TMP2]], align 8
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/SLPVectorizer/X86/load-merge-inseltpoison.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/load-merge-inseltpoison.ll
@@ -12,7 +12,7 @@ define i32 @_Z9load_le32Ph(ptr nocapture readonly %data) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i8>, ptr [[DATA:%.*]], align 1
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext <4 x i8> [[TMP0]] to <4 x i32>
-; CHECK-NEXT:    [[TMP2:%.*]] = shl <4 x i32> [[TMP1]], <i32 0, i32 8, i32 16, i32 24>
+; CHECK-NEXT:    [[TMP2:%.*]] = shl nuw <4 x i32> [[TMP1]], <i32 0, i32 8, i32 16, i32 24>
 ; CHECK-NEXT:    [[OR11:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP2]])
 ; CHECK-NEXT:    ret i32 [[OR11]]
 ;

--- a/llvm/test/Transforms/SLPVectorizer/X86/load-merge.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/load-merge.ll
@@ -12,7 +12,7 @@ define i32 @_Z9load_le32Ph(ptr nocapture readonly %data) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i8>, ptr [[DATA:%.*]], align 1
 ; CHECK-NEXT:    [[TMP1:%.*]] = zext <4 x i8> [[TMP0]] to <4 x i32>
-; CHECK-NEXT:    [[TMP2:%.*]] = shl <4 x i32> [[TMP1]], <i32 0, i32 8, i32 16, i32 24>
+; CHECK-NEXT:    [[TMP2:%.*]] = shl nuw <4 x i32> [[TMP1]], <i32 0, i32 8, i32 16, i32 24>
 ; CHECK-NEXT:    [[OR11:%.*]] = call i32 @llvm.vector.reduce.or.v4i32(<4 x i32> [[TMP2]])
 ; CHECK-NEXT:    ret i32 [[OR11]]
 ;

--- a/llvm/test/Transforms/SLPVectorizer/X86/no_alternate_divrem.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/no_alternate_divrem.ll
@@ -6,7 +6,7 @@ define void @test_add_sdiv(ptr %arr1, ptr %arr2, i32 %a0, i32 %a1, i32 %a2, i32 
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i32>, ptr [[ARR1:%.*]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <4 x i32> <i32 0, i32 0, i32 poison, i32 0>, i32 [[A2:%.*]], i32 2
-; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i32> [[TMP5]], <i32 1, i32 1, i32 42, i32 1>
+; CHECK-NEXT:    [[TMP6:%.*]] = add nsw <4 x i32> [[TMP5]], <i32 1, i32 1, i32 42, i32 1>
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x i32> <i32 poison, i32 poison, i32 0, i32 poison>, i32 [[A0:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i32> [[TMP1]], i32 [[A1:%.*]], i32 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i32> [[TMP2]], i32 [[A3:%.*]], i32 3
@@ -53,7 +53,7 @@ define void @test_add_udiv(ptr %arr1, ptr %arr2, i32 %a0, i32 %a1, i32 %a2, i32 
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i32>, ptr [[ARR1:%.*]], align 4
 ; CHECK-NEXT:    [[TMP5:%.*]] = insertelement <4 x i32> <i32 0, i32 0, i32 poison, i32 0>, i32 [[A2:%.*]], i32 2
-; CHECK-NEXT:    [[TMP6:%.*]] = add <4 x i32> [[TMP5]], <i32 1, i32 1, i32 42, i32 1>
+; CHECK-NEXT:    [[TMP6:%.*]] = add nsw <4 x i32> [[TMP5]], <i32 1, i32 1, i32 42, i32 1>
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <4 x i32> <i32 poison, i32 poison, i32 0, i32 poison>, i32 [[A0:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <4 x i32> [[TMP1]], i32 [[A1:%.*]], i32 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = insertelement <4 x i32> [[TMP2]], i32 [[A3:%.*]], i32 3

--- a/llvm/test/Transforms/SLPVectorizer/X86/non-power-of-2-bswap.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/non-power-of-2-bswap.ll
@@ -8,7 +8,7 @@ define i32 @test(i8 %0) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <3 x i8> [[TMP2]], <3 x i8> poison, <3 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP4:%.*]] = and <3 x i8> [[TMP3]], splat (i8 1)
 ; CHECK-NEXT:    [[TMP5:%.*]] = zext <3 x i8> [[TMP4]] to <3 x i32>
-; CHECK-NEXT:    [[TMP6:%.*]] = shl <3 x i32> [[TMP5]], <i32 0, i32 8, i32 16>
+; CHECK-NEXT:    [[TMP6:%.*]] = shl nuw nsw <3 x i32> [[TMP5]], <i32 0, i32 8, i32 16>
 ; CHECK-NEXT:    [[TMP7:%.*]] = call i32 @llvm.vector.reduce.or.v3i32(<3 x i32> [[TMP6]])
 ; CHECK-NEXT:    ret i32 [[TMP7]]
 ;

--- a/llvm/test/Transforms/SLPVectorizer/X86/opaque-ptr.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/opaque-ptr.ll
@@ -54,7 +54,7 @@ define void @test2(ptr %a, ptr %b) {
 ; CHECK-LABEL: @test2(
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x ptr> poison, ptr [[A:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = insertelement <2 x ptr> [[TMP1]], ptr [[B:%.*]], i32 1
-; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr i64, <2 x ptr> [[TMP2]], <2 x i64> <i64 1, i64 3>
+; CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds i64, <2 x ptr> [[TMP2]], <2 x i64> <i64 1, i64 3>
 ; CHECK-NEXT:    [[A1:%.*]] = getelementptr inbounds i64, ptr [[A]], i64 1
 ; CHECK-NEXT:    [[TMP4:%.*]] = ptrtoint <2 x ptr> [[TMP3]] to <2 x i64>
 ; CHECK-NEXT:    [[TMP5:%.*]] = load <2 x i64>, ptr [[A1]], align 8

--- a/llvm/test/Transforms/SLPVectorizer/X86/pr47642.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/pr47642.ll
@@ -8,7 +8,7 @@ define <4 x i32> @foo(<4 x i32> %x, i32 %f) {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:    [[VECINIT:%.*]] = insertelement <4 x i32> poison, i32 [[F:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <4 x i32> [[VECINIT]], <4 x i32> poison, <4 x i32> zeroinitializer
-; CHECK-NEXT:    [[VECINIT51:%.*]] = add <4 x i32> [[TMP2]], <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[VECINIT51:%.*]] = add nsw <4 x i32> [[TMP2]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:    ret <4 x i32> [[VECINIT51]]
 ;
   %vecinit = insertelement <4 x i32> undef, i32 %f, i32 0

--- a/llvm/test/Transforms/SLPVectorizer/X86/pr48879-sroa.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/pr48879-sroa.ll
@@ -13,14 +13,14 @@ define { i64, i64 } @compute_min(ptr nocapture noundef nonnull readonly align 2 
 ; SSE-NEXT:    [[TMP1:%.*]] = load <4 x i16>, ptr [[X]], align 2
 ; SSE-NEXT:    [[TMP2:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[TMP0]], <4 x i16> [[TMP1]])
 ; SSE-NEXT:    [[TMP3:%.*]] = zext <4 x i16> [[TMP2]] to <4 x i64>
-; SSE-NEXT:    [[TMP4:%.*]] = shl <4 x i64> [[TMP3]], <i64 0, i64 16, i64 32, i64 48>
+; SSE-NEXT:    [[TMP4:%.*]] = shl nuw <4 x i64> [[TMP3]], <i64 0, i64 16, i64 32, i64 48>
 ; SSE-NEXT:    [[RETVAL_SROA_0_0_INSERT_INSERT:%.*]] = call i64 @llvm.vector.reduce.or.v4i64(<4 x i64> [[TMP4]])
 ; SSE-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue { i64, i64 } poison, i64 [[RETVAL_SROA_0_0_INSERT_INSERT]], 0
 ; SSE-NEXT:    [[TMP6:%.*]] = load <4 x i16>, ptr [[ARRAYIDX_I_I10_4]], align 2
 ; SSE-NEXT:    [[TMP7:%.*]] = load <4 x i16>, ptr [[ARRAYIDX_I_I_4]], align 2
 ; SSE-NEXT:    [[TMP8:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[TMP6]], <4 x i16> [[TMP7]])
 ; SSE-NEXT:    [[TMP9:%.*]] = zext <4 x i16> [[TMP8]] to <4 x i64>
-; SSE-NEXT:    [[TMP10:%.*]] = shl <4 x i64> [[TMP9]], <i64 0, i64 16, i64 32, i64 48>
+; SSE-NEXT:    [[TMP10:%.*]] = shl nuw <4 x i64> [[TMP9]], <i64 0, i64 16, i64 32, i64 48>
 ; SSE-NEXT:    [[RETVAL_SROA_5_8_INSERT_INSERT:%.*]] = call i64 @llvm.vector.reduce.or.v4i64(<4 x i64> [[TMP10]])
 ; SSE-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue { i64, i64 } [[DOTFCA_0_INSERT]], i64 [[RETVAL_SROA_5_8_INSERT_INSERT]], 1
 ; SSE-NEXT:    ret { i64, i64 } [[DOTFCA_1_INSERT]]
@@ -33,14 +33,14 @@ define { i64, i64 } @compute_min(ptr nocapture noundef nonnull readonly align 2 
 ; AVX-NEXT:    [[TMP1:%.*]] = load <4 x i16>, ptr [[X]], align 2
 ; AVX-NEXT:    [[TMP2:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[TMP0]], <4 x i16> [[TMP1]])
 ; AVX-NEXT:    [[TMP3:%.*]] = zext <4 x i16> [[TMP2]] to <4 x i64>
-; AVX-NEXT:    [[TMP4:%.*]] = shl <4 x i64> [[TMP3]], <i64 0, i64 16, i64 32, i64 48>
+; AVX-NEXT:    [[TMP4:%.*]] = shl nuw <4 x i64> [[TMP3]], <i64 0, i64 16, i64 32, i64 48>
 ; AVX-NEXT:    [[TMP24:%.*]] = call i64 @llvm.vector.reduce.or.v4i64(<4 x i64> [[TMP4]])
 ; AVX-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue { i64, i64 } poison, i64 [[TMP24]], 0
 ; AVX-NEXT:    [[TMP6:%.*]] = load <4 x i16>, ptr [[ARRAYIDX_I_I10_4]], align 2
 ; AVX-NEXT:    [[TMP7:%.*]] = load <4 x i16>, ptr [[ARRAYIDX_I_I_4]], align 2
 ; AVX-NEXT:    [[TMP8:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[TMP6]], <4 x i16> [[TMP7]])
 ; AVX-NEXT:    [[TMP9:%.*]] = zext <4 x i16> [[TMP8]] to <4 x i64>
-; AVX-NEXT:    [[TMP10:%.*]] = shl <4 x i64> [[TMP9]], <i64 0, i64 16, i64 32, i64 48>
+; AVX-NEXT:    [[TMP10:%.*]] = shl nuw <4 x i64> [[TMP9]], <i64 0, i64 16, i64 32, i64 48>
 ; AVX-NEXT:    [[TMP25:%.*]] = call i64 @llvm.vector.reduce.or.v4i64(<4 x i64> [[TMP10]])
 ; AVX-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue { i64, i64 } [[DOTFCA_0_INSERT]], i64 [[TMP25]], 1
 ; AVX-NEXT:    ret { i64, i64 } [[DOTFCA_1_INSERT]]
@@ -53,14 +53,14 @@ define { i64, i64 } @compute_min(ptr nocapture noundef nonnull readonly align 2 
 ; AVX2-NEXT:    [[TMP1:%.*]] = load <4 x i16>, ptr [[X]], align 2
 ; AVX2-NEXT:    [[TMP2:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[TMP0]], <4 x i16> [[TMP1]])
 ; AVX2-NEXT:    [[TMP3:%.*]] = zext <4 x i16> [[TMP2]] to <4 x i64>
-; AVX2-NEXT:    [[TMP4:%.*]] = shl <4 x i64> [[TMP3]], <i64 0, i64 16, i64 32, i64 48>
+; AVX2-NEXT:    [[TMP4:%.*]] = shl nuw <4 x i64> [[TMP3]], <i64 0, i64 16, i64 32, i64 48>
 ; AVX2-NEXT:    [[TMP24:%.*]] = call i64 @llvm.vector.reduce.or.v4i64(<4 x i64> [[TMP4]])
 ; AVX2-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue { i64, i64 } poison, i64 [[TMP24]], 0
 ; AVX2-NEXT:    [[TMP6:%.*]] = load <4 x i16>, ptr [[ARRAYIDX_I_I10_4]], align 2
 ; AVX2-NEXT:    [[TMP7:%.*]] = load <4 x i16>, ptr [[ARRAYIDX_I_I_4]], align 2
 ; AVX2-NEXT:    [[TMP8:%.*]] = call <4 x i16> @llvm.smin.v4i16(<4 x i16> [[TMP6]], <4 x i16> [[TMP7]])
 ; AVX2-NEXT:    [[TMP9:%.*]] = zext <4 x i16> [[TMP8]] to <4 x i64>
-; AVX2-NEXT:    [[TMP10:%.*]] = shl <4 x i64> [[TMP9]], <i64 0, i64 16, i64 32, i64 48>
+; AVX2-NEXT:    [[TMP10:%.*]] = shl nuw <4 x i64> [[TMP9]], <i64 0, i64 16, i64 32, i64 48>
 ; AVX2-NEXT:    [[TMP25:%.*]] = call i64 @llvm.vector.reduce.or.v4i64(<4 x i64> [[TMP10]])
 ; AVX2-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue { i64, i64 } [[DOTFCA_0_INSERT]], i64 [[TMP25]], 1
 ; AVX2-NEXT:    ret { i64, i64 } [[DOTFCA_1_INSERT]]

--- a/llvm/test/Transforms/SLPVectorizer/X86/remark_gather-load-redux-cost.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/remark_gather-load-redux-cost.ll
@@ -10,7 +10,7 @@ define i32 @test(ptr noalias %p, ptr noalias %addr) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <15 x i32> [[TMP0]], <15 x i32> poison, <8 x i32> <i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12, i32 14>
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x ptr> poison, ptr [[P:%.*]], i32 0
 ; CHECK-NEXT:    [[TMP5:%.*]] = shufflevector <8 x ptr> [[TMP4]], <8 x ptr> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr i32, <8 x ptr> [[TMP5]], <8 x i32> [[TMP3]]
+; CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds i32, <8 x ptr> [[TMP5]], <8 x i32> [[TMP3]]
 ; CHECK-NEXT:    [[TMP7:%.*]] = call <8 x i32> @llvm.masked.gather.v8i32.v8p0(<8 x ptr> align 4 [[TMP6]], <8 x i1> splat (i1 true), <8 x i32> poison)
 ; CHECK-NEXT:    [[TMP8:%.*]] = call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> [[TMP7]])
 ; CHECK-NEXT:    ret i32 [[TMP8]]

--- a/llvm/test/Transforms/SLPVectorizer/X86/split-load8_2_unord_geps.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/split-load8_2_unord_geps.ll
@@ -9,11 +9,11 @@ define void @test(ptr noalias %p, ptr noalias %addr, ptr noalias %s) {
 ; CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <15 x i32> [[TMP0]], <15 x i32> poison, <8 x i32> <i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12, i32 14>
 ; CHECK-NEXT:    [[TMP4:%.*]] = insertelement <8 x ptr> poison, ptr [[P:%.*]], i32 0
 ; CHECK-NEXT:    [[SHUFFLE2:%.*]] = shufflevector <8 x ptr> [[TMP4]], <8 x ptr> poison, <8 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr i32, <8 x ptr> [[SHUFFLE2]], <8 x i32> [[TMP3]]
+; CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds i32, <8 x ptr> [[SHUFFLE2]], <8 x i32> [[TMP3]]
 ; CHECK-NEXT:    [[TMP6:%.*]] = call <8 x i32> @llvm.masked.gather.v8i32.v8p0(<8 x ptr> align 4 [[TMP5]], <8 x i1> splat (i1 true), <8 x i32> poison)
 ; CHECK-NEXT:    [[TMP11:%.*]] = call <15 x i32> @llvm.masked.load.v15i32.p0(ptr align 8 [[GEP2]], <15 x i1> <i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true, i1 false, i1 true>, <15 x i32> poison)
 ; CHECK-NEXT:    [[TMP7:%.*]] = shufflevector <15 x i32> [[TMP11]], <15 x i32> poison, <8 x i32> <i32 0, i32 2, i32 4, i32 6, i32 8, i32 10, i32 12, i32 14>
-; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr i32, <8 x ptr> [[SHUFFLE2]], <8 x i32> [[TMP7]]
+; CHECK-NEXT:    [[TMP8:%.*]] = getelementptr inbounds i32, <8 x ptr> [[SHUFFLE2]], <8 x i32> [[TMP7]]
 ; CHECK-NEXT:    [[TMP9:%.*]] = call <8 x i32> @llvm.masked.gather.v8i32.v8p0(<8 x ptr> align 4 [[TMP8]], <8 x i1> splat (i1 true), <8 x i32> poison)
 ; CHECK-NEXT:    [[TMP10:%.*]] = add nsw <8 x i32> [[TMP9]], [[TMP6]]
 ; CHECK-NEXT:    store <8 x i32> [[TMP10]], ptr [[S:%.*]], align 4

--- a/llvm/test/Transforms/SLPVectorizer/X86/vect_copyable_in_binops.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/vect_copyable_in_binops.ll
@@ -36,7 +36,7 @@ define void @add1(ptr noalias %dst, ptr noalias %src) {
 ; CHECK-LABEL: @add1(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x i32>, ptr [[SRC:%.*]], align 4
-; CHECK-NEXT:    [[TMP1:%.*]] = add <4 x i32> [[TMP0]], <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[TMP1:%.*]] = add nsw <4 x i32> [[TMP0]], <i32 0, i32 1, i32 2, i32 3>
 ; CHECK-NEXT:    store <4 x i32> [[TMP1]], ptr [[DST:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
@@ -339,7 +339,7 @@ define void @add1f(ptr noalias %dst, ptr noalias %src) {
 ; CHECK-LABEL: @add1f(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr [[SRC:%.*]], align 4
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd <4 x float> [[TMP0]], <float -0.000000e+00, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>
+; CHECK-NEXT:    [[TMP1:%.*]] = fadd reassoc nsz arcp contract afn <4 x float> [[TMP0]], <float -0.000000e+00, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>
 ; CHECK-NEXT:    store <4 x float> [[TMP1]], ptr [[DST:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
@@ -368,7 +368,7 @@ define void @sub0f(ptr noalias %dst, ptr noalias %src) {
 ; CHECK-LABEL: @sub0f(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr [[SRC:%.*]], align 4
-; CHECK-NEXT:    [[TMP1:%.*]] = fadd fast <4 x float> [[TMP0]], <float -1.000000e+00, float -0.000000e+00, float -2.000000e+00, float -3.000000e+00>
+; CHECK-NEXT:    [[TMP1:%.*]] = fadd reassoc nsz arcp contract afn <4 x float> [[TMP0]], <float -1.000000e+00, float -0.000000e+00, float -2.000000e+00, float -3.000000e+00>
 ; CHECK-NEXT:    store <4 x float> [[TMP1]], ptr [[DST:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
@@ -537,7 +537,7 @@ define void @mulf(ptr noalias %dst, ptr noalias %src) {
 ; CHECK-LABEL: @mulf(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[TMP0:%.*]] = load <4 x float>, ptr [[SRC:%.*]], align 4
-; CHECK-NEXT:    [[TMP1:%.*]] = fmul fast <4 x float> [[TMP0]], <float 2.570000e+02, float -3.000000e+00, float 1.000000e+00, float -9.000000e+00>
+; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc nsz arcp contract afn <4 x float> [[TMP0]], <float 2.570000e+02, float -3.000000e+00, float 1.000000e+00, float -9.000000e+00>
 ; CHECK-NEXT:    store <4 x float> [[TMP1]], ptr [[DST:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;

--- a/llvm/test/Transforms/SLPVectorizer/X86/vectorize-pair-path.ll
+++ b/llvm/test/Transforms/SLPVectorizer/X86/vectorize-pair-path.ll
@@ -26,9 +26,9 @@ define double @root_selection(double %a, double %b, double %c, double %d) local_
 ; CHECK-NEXT:    [[TMP9:%.*]] = insertelement <4 x double> [[TMP8]], double [[D:%.*]], i32 1
 ; CHECK-NEXT:    [[TMP10:%.*]] = shufflevector <2 x double> [[TMP7]], <2 x double> poison, <4 x i32> <i32 0, i32 1, i32 poison, i32 poison>
 ; CHECK-NEXT:    [[TMP11:%.*]] = shufflevector <4 x double> [[TMP9]], <4 x double> [[TMP10]], <4 x i32> <i32 0, i32 1, i32 4, i32 5>
-; CHECK-NEXT:    [[TMP12:%.*]] = fsub <4 x double> [[TMP11]], <double 0.000000e+00, double 0.000000e+00, double undef, double 1.100000e+01>
-; CHECK-NEXT:    [[TMP13:%.*]] = fmul <4 x double> [[TMP12]], <double 1.000000e+00, double 1.000000e+00, double 4.000000e+00, double 1.200000e+01>
-; CHECK-NEXT:    [[TMP14:%.*]] = fdiv <4 x double> [[TMP13]], <double 1.000000e+00, double 1.000000e+00, double 1.400000e+00, double 1.400000e+00>
+; CHECK-NEXT:    [[TMP12:%.*]] = fsub reassoc nsz arcp contract afn <4 x double> [[TMP11]], <double 0.000000e+00, double 0.000000e+00, double undef, double 1.100000e+01>
+; CHECK-NEXT:    [[TMP13:%.*]] = fmul reassoc nsz arcp contract afn <4 x double> [[TMP12]], <double 1.000000e+00, double 1.000000e+00, double 4.000000e+00, double 1.200000e+01>
+; CHECK-NEXT:    [[TMP14:%.*]] = fdiv reassoc nsz arcp contract afn <4 x double> [[TMP13]], <double 1.000000e+00, double 1.000000e+00, double 1.400000e+00, double 1.400000e+00>
 ; CHECK-NEXT:    [[TMP15:%.*]] = call fast double @llvm.vector.reduce.fadd.v4f64(double 0.000000e+00, <4 x double> [[TMP14]])
 ; CHECK-NEXT:    [[I18:%.*]] = fadd fast double [[TMP15]], undef
 ; CHECK-NEXT:    ret double [[I18]]

--- a/llvm/test/Transforms/SLPVectorizer/alternate-non-profitable.ll
+++ b/llvm/test/Transforms/SLPVectorizer/alternate-non-profitable.ll
@@ -34,7 +34,7 @@ define <2 x float> @replace_through_casts(i16 %inp) {
 ; CHECK-SAME: i16 [[INP:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i16> poison, i16 [[INP]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <2 x i16> [[TMP1]], <2 x i16> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP3:%.*]] = add <2 x i16> [[TMP2]], <i16 0, i16 -10>
+; CHECK-NEXT:    [[TMP3:%.*]] = add nsw <2 x i16> [[TMP2]], <i16 0, i16 -10>
 ; CHECK-NEXT:    [[TMP4:%.*]] = uitofp <2 x i16> [[TMP3]] to <2 x float>
 ; CHECK-NEXT:    [[TMP5:%.*]] = sitofp <2 x i16> [[TMP3]] to <2 x float>
 ; CHECK-NEXT:    [[R:%.*]] = shufflevector <2 x float> [[TMP4]], <2 x float> [[TMP5]], <2 x i32> <i32 0, i32 3>
@@ -121,7 +121,7 @@ define <2 x i32> @replace_through_int_casts(i16 %inp, <2 x i16> %dead) {
 ; CHECK-SAME: i16 [[INP:%.*]], <2 x i16> [[DEAD:%.*]]) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i16> poison, i16 [[INP]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <2 x i16> [[TMP1]], <2 x i16> poison, <2 x i32> zeroinitializer
-; CHECK-NEXT:    [[TMP3:%.*]] = add <2 x i16> [[TMP2]], <i16 0, i16 -10>
+; CHECK-NEXT:    [[TMP3:%.*]] = add nsw <2 x i16> [[TMP2]], <i16 0, i16 -10>
 ; CHECK-NEXT:    [[TMP4:%.*]] = zext <2 x i16> [[TMP3]] to <2 x i32>
 ; CHECK-NEXT:    [[TMP5:%.*]] = sext <2 x i16> [[TMP3]] to <2 x i32>
 ; CHECK-NEXT:    [[R:%.*]] = shufflevector <2 x i32> [[TMP4]], <2 x i32> [[TMP5]], <2 x i32> <i32 0, i32 3>
@@ -178,7 +178,7 @@ define <2 x i8> @replace_through_binop_preserve_flags(i8 %inp, <2 x i8> %d, <2 x
 ; CHECK-NEXT:    [[TMP1:%.*]] = insertelement <2 x i8> poison, i8 [[INP]], i32 0
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <2 x i8> [[TMP1]], <2 x i8> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:    [[TMP3:%.*]] = xor <2 x i8> [[TMP2]], <i8 123, i8 5>
-; CHECK-NEXT:    [[R:%.*]] = add <2 x i8> [[TMP3]], <i8 0, i8 1>
+; CHECK-NEXT:    [[R:%.*]] = add nsw <2 x i8> [[TMP3]], <i8 0, i8 1>
 ; CHECK-NEXT:    ret <2 x i8> [[R]]
 ;
   %add = xor i8 %inp, 5

--- a/llvm/test/Transforms/SLPVectorizer/crash_exceed_scheduling.ll
+++ b/llvm/test/Transforms/SLPVectorizer/crash_exceed_scheduling.ll
@@ -75,7 +75,7 @@ define void @exceed(double %0, double %1) {
 ; AARCH64-NEXT:    [[TMP8:%.*]] = fadd fast <2 x double> [[TMP3]], [[TMP5]]
 ; AARCH64-NEXT:    [[TMP9:%.*]] = shufflevector <2 x double> [[TMP3]], <2 x double> [[TMP5]], <2 x i32> <i32 0, i32 2>
 ; AARCH64-NEXT:    [[TMP10:%.*]] = shufflevector <2 x double> [[TMP5]], <2 x double> <double poison, double 1.000000e+00>, <2 x i32> <i32 0, i32 3>
-; AARCH64-NEXT:    [[TMP11:%.*]] = fdiv fast <2 x double> [[TMP9]], [[TMP10]]
+; AARCH64-NEXT:    [[TMP11:%.*]] = fdiv reassoc nsz arcp contract afn <2 x double> [[TMP9]], [[TMP10]]
 ; AARCH64-NEXT:    [[TMP12:%.*]] = extractelement <2 x double> [[TMP6]], i32 1
 ; AARCH64-NEXT:    [[IX:%.*]] = fmul double [[TMP12]], undef
 ; AARCH64-NEXT:    [[IX1:%.*]] = fmul double [[TMP12]], undef

--- a/llvm/test/Transforms/SLPVectorizer/insertelement-postpone.ll
+++ b/llvm/test/Transforms/SLPVectorizer/insertelement-postpone.ll
@@ -16,7 +16,7 @@ define <4 x double> @test(ptr %p2, double %i1754, double %i1781, double %i1778) 
 ; X86-NEXT:    [[TMP11:%.*]] = shufflevector <2 x double> [[TMP3]], <2 x double> poison, <4 x i32> <i32 poison, i32 poison, i32 poison, i32 1>
 ; X86-NEXT:    [[TMP8:%.*]] = shufflevector <4 x double> [[TMP4]], <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double poison>, <4 x i32> <i32 4, i32 5, i32 6, i32 1>
 ; X86-NEXT:    [[TMP9:%.*]] = shufflevector <4 x double> [[TMP2]], <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double poison>, <4 x i32> <i32 4, i32 5, i32 6, i32 2>
-; X86-NEXT:    [[TMP6:%.*]] = fmul <4 x double> [[TMP8]], [[TMP9]]
+; X86-NEXT:    [[TMP6:%.*]] = fmul fast <4 x double> [[TMP8]], [[TMP9]]
 ; X86-NEXT:    [[TMP7:%.*]] = fadd fast <4 x double> [[TMP5]], [[TMP6]]
 ; X86-NEXT:    ret <4 x double> [[TMP7]]
 ;
@@ -33,7 +33,7 @@ define <4 x double> @test(ptr %p2, double %i1754, double %i1781, double %i1778) 
 ; AARCH86-NEXT:    [[TMP7:%.*]] = shufflevector <2 x double> [[TMP3]], <2 x double> poison, <4 x i32> <i32 poison, i32 poison, i32 poison, i32 1>
 ; AARCH86-NEXT:    [[TMP8:%.*]] = shufflevector <4 x double> [[TMP4]], <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double poison>, <4 x i32> <i32 4, i32 5, i32 6, i32 1>
 ; AARCH86-NEXT:    [[TMP9:%.*]] = shufflevector <4 x double> [[TMP2]], <4 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00, double poison>, <4 x i32> <i32 4, i32 5, i32 6, i32 2>
-; AARCH86-NEXT:    [[TMP6:%.*]] = fmul <4 x double> [[TMP8]], [[TMP9]]
+; AARCH86-NEXT:    [[TMP6:%.*]] = fmul fast <4 x double> [[TMP8]], [[TMP9]]
 ; AARCH86-NEXT:    [[I1994:%.*]] = fadd fast <4 x double> [[TMP5]], [[TMP6]]
 ; AARCH86-NEXT:    ret <4 x double> [[I1994]]
 ;


### PR DESCRIPTION
Replace scattered propagateIRFlags/propagateMetadata calls with a single
PropagateIRFlags lambda. Excludes copyable scalars from the flag
intersection set and drops nnan/ninf when a copyable lane cannot prove
its operand is non-NaN/non-Inf.
