### PR TITLE
[CIR] Handle co_return exits in cleanup scope flattening

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -476,7 +476,11 @@ static void emitCleanup(CIRGenFunction &cgf, cir::CleanupScopeOp cleanupScope,
 static bool bodyHasBranchThroughExits(mlir::Region &bodyRegion) {
   return bodyRegion
       .walk([&](mlir::Operation *op) {
-        if (isa<cir::ReturnOp, cir::GotoOp>(op))
+        // A cir.co_return inside cir.coro.body exits that coroutine body, not
+        // the cleanup scope currently being analyzed.
+        if (isa<cir::CoroBodyOp>(op))
+          return mlir::WalkResult::skip();
+        if (isa<cir::ReturnOp, cir::CoReturnOp, cir::GotoOp>(op))
           return mlir::WalkResult::interrupt();
         return mlir::WalkResult::advance();
       })

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -793,7 +793,11 @@ public:
     // because break and continue never branch out of the loop.
     auto collectExitsInLoop = [&](mlir::Operation *loopOp) {
       loopOp->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *nestedOp) {
-        if (isa<cir::ReturnOp>(nestedOp)) {
+        // A cir.co_return inside cir.coro.body exits that coroutine body, not
+        // the cleanup scope currently being analyzed.
+        if (isa<cir::CoroBodyOp>(nestedOp))
+          return mlir::WalkResult::skip();
+        if (isa<cir::ReturnOp, cir::CoReturnOp>(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
         } else if (isGotoThatExitsCleanup(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
@@ -820,7 +824,10 @@ public:
         } else if (isa<cir::LoopOpInterface>(nestedOp)) {
           collectExitsInLoop(nestedOp);
           return mlir::WalkResult::skip();
-        } else if (isa<cir::ReturnOp, cir::ContinueOp>(nestedOp)) {
+        } else if (isa<cir::CoroBodyOp>(nestedOp)) {
+          return mlir::WalkResult::skip();
+        } else if (isa<cir::ReturnOp, cir::CoReturnOp, cir::ContinueOp>(
+                       nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
         } else if (isGotoThatExitsCleanup(nestedOp)) {
           exits.emplace_back(nestedOp, nextId++);
@@ -842,7 +849,7 @@ public:
         // the nested cleanup.
         if (!ignoreBreak && isa<cir::BreakOp>(op)) {
           exits.emplace_back(op, nextId++);
-        } else if (isa<cir::ContinueOp, cir::ReturnOp>(op)) {
+        } else if (isa<cir::ContinueOp, cir::ReturnOp, cir::CoReturnOp>(op)) {
           exits.emplace_back(op, nextId++);
         } else if (isGotoThatExitsCleanup(op)) {
           exits.emplace_back(op, nextId++);
@@ -850,6 +857,8 @@ public:
           // Recurse into nested cleanup's body region.
           collectExitsInCleanup(cast<cir::CleanupScopeOp>(op).getBodyRegion(),
                                 /*ignoreBreak=*/ignoreBreak);
+          return mlir::WalkResult::skip();
+        } else if (isa<cir::CoroBodyOp>(op)) {
           return mlir::WalkResult::skip();
         } else if (isa<cir::LoopOpInterface>(op)) {
           // This kicks off a separate walk rather than continuing to dig deeper
@@ -1008,6 +1017,12 @@ public:
           }
           return mlir::success();
         })
+        .Case<cir::CoReturnOp>([&](auto) {
+          // A cir.co_return exits the cleanup scope and resumes at the
+          // coroutine's final suspend point after cleanup has run.
+          cir::CoReturnOp::create(rewriter, loc);
+          return mlir::success();
+        })
         .Case<cir::GotoOp>([&](auto gotoOp) {
           // Gotos that target a label within the cleanup body region are
           // filtered out by collectExits and never reach this code, so any
@@ -1037,9 +1052,9 @@ public:
               // assume that it doesn't happen simplifies the implementation.
               // If we ever need to handle this case, the code will need to
               // be updated to handle it.
-              .Case<cir::YieldOp, cir::ReturnOp, cir::ResumeFlatOp,
-                    cir::ContinueOp, cir::BreakOp, cir::GotoOp>(
-                  [](auto) { return false; })
+              .Case<cir::YieldOp, cir::ReturnOp, cir::CoReturnOp,
+                    cir::ResumeFlatOp, cir::ContinueOp, cir::BreakOp,
+                    cir::GotoOp>([](auto) { return false; })
               // We expect that call operations have not yet been rewritten
               // as try_call operations. A call can unwind out of the cleanup
               // scope, but we will be handling that during flattening. The

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-coro-return.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-coro-return.cir
@@ -1,0 +1,39 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+cir.func coroutine @co_return_from_cleanup() {
+  %true = cir.const #cir.bool<true> : !cir.bool
+  cir.coro.body {
+    cir.await(user, ready : {
+      cir.condition(%true)
+    }, suspend : {
+      cir.yield
+    }, resume : {
+      cir.yield
+    },)
+    cir.cleanup.scope {
+      cir.co_return
+    } cleanup normal {
+      cir.call @cleanup() : () -> ()
+      cir.yield
+    }
+    cir.yield
+  }
+  cir.return
+}
+
+// CHECK-LABEL: cir.func coroutine @co_return_from_cleanup()
+// CHECK-NOT:     cir.cleanup.scope
+// CHECK:         cir.coro.body
+// CHECK:           cir.br ^[[BODY:bb[0-9]+]]
+// CHECK:         ^[[BODY]]:
+// CHECK:           cir.br ^[[CLEANUP:bb[0-9]+]]
+// CHECK:         ^[[CLEANUP]]:
+// CHECK:           cir.call @cleanup()
+// CHECK:           cir.br ^[[EXIT:bb[0-9]+]]
+// CHECK:         ^[[EXIT]]:
+// CHECK:           cir.co_return
+// CHECK-NOT:     cir.cleanup.scope
+// CHECK:       cir.func private @cleanup()
+
+cir.func private @cleanup()


### PR DESCRIPTION
Handle the FlattenCFG follow-up from #189281 by treating cir.co_return as a cleanup-scope exit and preserving it after cleanup code runs.