### PR TITLE
[lldb][windows] add bin to PATH in API tests

### DIFF
--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -12,9 +12,6 @@ class TestSBCommandReturnObject(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfNoSBHeaders
-    @expectedFailureAll(
-        oslist=["windows"], archs=["i[3-6]86", "x86_64"], bugnumber="llvm.org/pr43570"
-    )
     @skipIfHostIncompatibleWithTarget
     def test_sb_command_return_object(self):
         self.driver_exe = self.getBuildArtifact("command-return-object")

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -15,9 +15,6 @@ class TestMultipleTargets(TestBase):
 
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])
     @skipIfNoSBHeaders
-    @expectedFailureAll(
-        oslist=["windows"], archs=["i[3-6]86", "x86_64"], bugnumber="llvm.org/pr20282"
-    )
     @expectedFlakeyNetBSD
     @skipIfHostIncompatibleWithTarget
     def test_multiple_targets(self):

--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -170,6 +170,13 @@ if is_configured("shared_libs"):
             "unable to inject shared library path on '{}'".format(platform.system())
         )
 
+# Windows has no rpath: drivers built by API tests link against
+# liblldb.dll and need its directory on PATH at launch.
+if platform.system() == "Windows":
+    config.environment["PATH"] = os.path.pathsep.join(
+        (config.llvm_shlib_dir, config.environment.get("PATH", ""))
+    )
+
 lldb_use_simulator = lit_config.params.get("lldb-run-with-simulator", None)
 if lldb_use_simulator:
     if lldb_use_simulator == "ios":


### PR DESCRIPTION
API tests that build drivers which link against `liblldb.dll` fail on Windows because `liblldb.dll` is not in the PATH. This does not happen on macOS and Linux because they use rpaths, which do not exist on Windows.

This is a reland of https://github.com/llvm/llvm-project/pull/197251 with the `bin` build directory added to the PATH env variable in the API tests.

We could look into enabling the following tests as well, however they do not run because they use POSIX APIs that do not exist on Windows:
- `lldb-api :: api/multiple-debuggers/TestMultipleDebuggers.py`
- `lldb-api :: api/multithreaded/TestMultithreaded.py`

rdar://177435313