### PR TITLE
[offload][LIT] Remove XFAIL: intelgpu from 5 virtual function tests

### DIFF
--- a/offload/test/api/omp_indirect_call.c
+++ b/offload/test/api/omp_indirect_call.c
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compile-run-and-check-generic
-// XFAIL: intelgpu
 
 #include <assert.h>
 #include <stdio.h>

--- a/offload/test/api/omp_virtual_func.cpp
+++ b/offload/test/api/omp_virtual_func.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func_multiple_inheritance_01.cpp
+++ b/offload/test/api/omp_virtual_func_multiple_inheritance_01.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func_multiple_inheritance_02.cpp
+++ b/offload/test/api/omp_virtual_func_multiple_inheritance_02.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>

--- a/offload/test/api/omp_virtual_func_reference.cpp
+++ b/offload/test/api/omp_virtual_func_reference.cpp
@@ -1,5 +1,4 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
-// XFAIL: intelgpu
 // REQUIRES: gpu
 
 #include <assert.h>


### PR DESCRIPTION
Passing on the buildbot now, probably [this](https://github.com/llvm/llvm-project/pull/197556) change fixed them.