### PR TITLE
[IR] Explicitly note C standard library UB

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -14027,8 +14027,8 @@ Example:
 llvm treats calls to some functions with names and arguments that match
 the standard C99 library as being the C99 library functions, and may
 perform optimizations or generate code for them under that assumption.
-This is something we'd like to change in the future to provide better
-support for freestanding environments and non-C-based languages.
+This implies that undefined behavior in C standard library functions recognized
+by LLVM is also undefined behavior at the IR level.
 
 .. _i_va_arg:
 


### PR DESCRIPTION
This language is to my understanding a bit outdated (if we're in a freestanding environment, we should be handling things fine to my knowledge, or at least I'm not aware of any outstanding issues reported by people compiling for freestanding environments/different languages which are somewhat prominent at this point). The language here dates back to
68f971b1d67d51272f5c141fc9e4740e27e279f4 with some minor modifications in 722212d1a0672ae18a23db58c4cfb7e38073abfa. Explicitly note the UB aspect as this came up recently when working on llubi in #190147 and I do not think hurts to explicitly note.