### PR TITLE
[Flang][bbc] Add support for -fintrinsic-module-path

### DIFF
--- a/flang/test/Driver/Inputs/ieee_arithmetic.mod
+++ b/flang/test/Driver/Inputs/ieee_arithmetic.mod
@@ -1,8 +1,0 @@
-! DUMMY module
-! Added for testing purposes. The contents of this file are currently not relevant.
-! Using this file will cause an error because of missing checksum
-module ieee_arithmetic
-type::ieee_round_type
-integer(1),private::mode=0_1
-end type
-end

--- a/flang/test/Driver/Inputs/iso_fortran_env.mod
+++ b/flang/test/Driver/Inputs/iso_fortran_env.mod
@@ -1,8 +1,0 @@
-! DUMMY module
-! Added for testing purposes. The contents of this file are currently not relevant.
-! Using this file will cause an error because of missing checksum
-module iso_fortran_env
-use __fortran_builtins,only:event_type=>__builtin_event_type
-use __fortran_builtins,only:lock_type=>__builtin_lock_type
-use __fortran_builtins,only:team_type=>__builtin_team_type
-end

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -1,6 +1,6 @@
 ! Ensure argument -fintrinsic-modules-path works as expected.
 ! WITHOUT the option, the default location for the module is checked and no error generated.
-! With the option WRONG and GIVEN, find the module in the first first
+! With the option WRONG and GIVEN, find the module in the first
 ! -fintrinsic-modules-path that contains a matching file.
 
 !-----------------------------------------

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -14,7 +14,7 @@
 ! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir-one -fintrinsic-modules-path %S/Inputs/module-dir     %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
 
 !-----------------------------------------
-! BURNSIDE BRIDGE_COMPILER (bbc)
+! BURNSIDE BRIDGE COMPILER (bbc)
 !-----------------------------------------
 ! RUN: not bbc                                                                                                     %s 2>&1 | FileCheck %s --check-prefix=WITHOUT
 ! RUN: not bbc -fintrinsic-modules-path %S/Inputs/module-dir                                                       %s 2>&1 | FileCheck %s --check-prefix=WRONG

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -6,22 +6,58 @@
 !-----------------------------------------
 ! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
-! RUN: not %flang_fc1 -fsyntax-only                                                                                                     %s 2>&1 | FileCheck %s --check-prefix=WITHOUT
-! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir                                                       %s 2>&1 | FileCheck %s --check-prefix=WRONG
-! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir     -fintrinsic-modules-path %S/Inputs/module-dir-one %s 2>&1 | FileCheck %s --check-prefix=WRONG
-! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path=%S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
-! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
-! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir-one -fintrinsic-modules-path %S/Inputs/module-dir     %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+! RUN: not %flang_fc1 %s -fsyntax-only \
+! RUN:     %s 2>&1 | FileCheck %s --check-prefix=WITHOUT
+!
+! RUN: not %flang_fc1 %s -fsyntax-only \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir \
+! RUN:     2>&1 | FileCheck %s --check-prefix=WRONG
+!
+! RUN: not %flang_fc1 %s -fsyntax-only \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir-one \
+! RUN:     2>&1 | FileCheck %s --check-prefix=WRONG
+!
+! RUN:     %flang_fc1 %s -fsyntax-only \
+! RUN:     -fintrinsic-modules-path=%S/Inputs/module-dir-one \
+! RUN:     2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+!
+! RUN:     %flang_fc1 %s -fsyntax-only \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir-one \
+! RUN:     2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+!
+! RUN:     %flang_fc1 %s -fsyntax-only \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir-one \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir \
+! RUN:     2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
 
 !-----------------------------------------
 ! BURNSIDE BRIDGE COMPILER (bbc)
 !-----------------------------------------
-! RUN: not bbc                                                                                                     %s 2>&1 | FileCheck %s --check-prefix=WITHOUT
-! RUN: not bbc -fintrinsic-modules-path %S/Inputs/module-dir                                                       %s 2>&1 | FileCheck %s --check-prefix=WRONG
-! RUN: not bbc -fintrinsic-modules-path %S/Inputs/module-dir     -fintrinsic-modules-path %S/Inputs/module-dir-one %s 2>&1 | FileCheck %s --check-prefix=WRONG
-! RUN:     bbc -fintrinsic-modules-path=%S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
-! RUN:     bbc -fintrinsic-modules-path %S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
-! RUN:     bbc -fintrinsic-modules-path %S/Inputs/module-dir-one -fintrinsic-modules-path %S/Inputs/module-dir     %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+! RUN: not bbc %s \
+! RUN:     2>&1 | FileCheck %s --check-prefix=WITHOUT
+!
+! RUN: not bbc %s \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir \
+! RUN:     2>&1 | FileCheck %s --check-prefix=WRONG
+!
+! RUN: not bbc %s \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir-one \
+! RUN:     2>&1 | FileCheck %s --check-prefix=WRONG
+!
+! RUN:     bbc %s \
+! RUN:     -fintrinsic-modules-path=%S/Inputs/module-dir-one \
+! RUN:     2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+!
+! RUN:     bbc %s \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir-one \
+! RUN:     2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+!
+! RUN:     bbc %s \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir-one \
+! RUN:     -fintrinsic-modules-path %S/Inputs/module-dir \
+! RUN:     2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
 
 
 ! WITHOUT: error: Cannot parse module file for module 'basictestmoduleone': Source file 'basictestmoduleone.mod' was not found

--- a/flang/test/Driver/intrinsic-module-path.f90
+++ b/flang/test/Driver/intrinsic-module-path.f90
@@ -1,23 +1,37 @@
 ! Ensure argument -fintrinsic-modules-path works as expected.
 ! WITHOUT the option, the default location for the module is checked and no error generated.
-! With the option GIVEN, the module with the same name is PREPENDED, and considered over the
-! default one, causing an error.
+! With the option WRONG and GIVEN, find the module in the first first
+! -fintrinsic-modules-path that contains a matching file.
 
 !-----------------------------------------
 ! FRONTEND FLANG DRIVER (flang -fc1)
 !-----------------------------------------
-! RUN: %flang_fc1 -fsyntax-only %s  2>&1 | FileCheck %s --allow-empty --check-prefix=WITHOUT
-! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/ %s  2>&1 | FileCheck %s --check-prefix=GIVEN
-! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path=%S/Inputs/ %s  2>&1 | FileCheck %s --check-prefix=GIVEN
+! RUN: not %flang_fc1 -fsyntax-only                                                                                                     %s 2>&1 | FileCheck %s --check-prefix=WITHOUT
+! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir                                                       %s 2>&1 | FileCheck %s --check-prefix=WRONG
+! RUN: not %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir     -fintrinsic-modules-path %S/Inputs/module-dir-one %s 2>&1 | FileCheck %s --check-prefix=WRONG
+! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path=%S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+! RUN:     %flang_fc1 -fsyntax-only -fintrinsic-modules-path %S/Inputs/module-dir-one -fintrinsic-modules-path %S/Inputs/module-dir     %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
 
-! WITHOUT-NOT: 'ieee_arithmetic.mod' was not found
-! WITHOUT-NOT: 'iso_fortran_env.mod' was not found
+!-----------------------------------------
+! BURNSIDE BRIDGE_COMPILER (bbc)
+!-----------------------------------------
+! RUN: not bbc                                                                                                     %s 2>&1 | FileCheck %s --check-prefix=WITHOUT
+! RUN: not bbc -fintrinsic-modules-path %S/Inputs/module-dir                                                       %s 2>&1 | FileCheck %s --check-prefix=WRONG
+! RUN: not bbc -fintrinsic-modules-path %S/Inputs/module-dir     -fintrinsic-modules-path %S/Inputs/module-dir-one %s 2>&1 | FileCheck %s --check-prefix=WRONG
+! RUN:     bbc -fintrinsic-modules-path=%S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+! RUN:     bbc -fintrinsic-modules-path %S/Inputs/module-dir-one                                                   %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
+! RUN:     bbc -fintrinsic-modules-path %S/Inputs/module-dir-one -fintrinsic-modules-path %S/Inputs/module-dir     %s 2>&1 | FileCheck %s --allow-empty --check-prefix=GIVEN
 
-! GIVEN: error: Cannot read module file for module 'ieee_arithmetic': 'ieee_arithmetic.mod' is not a module file for this compiler
-! GIVEN: error: Cannot read module file for module 'iso_fortran_env': 'iso_fortran_env.mod' is not a module file for this compiler
+
+! WITHOUT: error: Cannot parse module file for module 'basictestmoduleone': Source file 'basictestmoduleone.mod' was not found
+
+! WRONG: error: 't1' not found in module 'basictestmoduleone'
+
+! Do not emit any message about the absence of basictestmoduleone
+! GIVEN-NOT: basictestmoduleone
 
 
-program test_intrinsic_module_path
-   use ieee_arithmetic, only: ieee_round_type
-   use iso_fortran_env, only: team_type, event_type, lock_type
+program test_intrinsic_modules_path
+   use basictestmoduleone, only: t1
 end program

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -100,6 +100,11 @@ static llvm::cl::alias
                           llvm::cl::desc("intrinsic module directory"),
                           llvm::cl::aliasopt(intrinsicIncludeDirs));
 
+static llvm::cl::alias
+    intrinsicModulePath("fintrinsic-modules-path",
+                        llvm::cl::desc("intrinsic module search paths"),
+                        llvm::cl::aliasopt(intrinsicIncludeDirs));
+
 static llvm::cl::opt<std::string>
     moduleDir("module", llvm::cl::desc("module output directory (default .)"),
               llvm::cl::init("."));


### PR DESCRIPTION
Add support for -fintrinsic-module-path to bbc. With #196558 the default search path in the resource directory is determined by the driver, not by the frontend (-fc1 and bbc). For tests of either frontend the tests will need to append the search path themselves. Adding support for `-fintrinsic-module-path` will allow using the same additional argument for flang_fc1 and bbc tests.

Also rewriting the awkward tests that expect standard modules to fail only because they do not contain a checksum. Maintaining this way of testing became burdonsome because there are multiple ways of how default modules are resolved. Fixing one breaks another.

Extracted out of #171515 to make that patch a bit smaller.