### PR TITLE
[dsymutil] Add missing --linker {classic,parallel} in tests

### DIFF
--- a/llvm/test/tools/dsymutil/AArch64/debug-names-accel-table-types.ll
+++ b/llvm/test/tools/dsymutil/AArch64/debug-names-accel-table-types.ll
@@ -1,5 +1,6 @@
 ; RUN: %llc_dwarf -debugger-tune=lldb -accel-tables=Dwarf -filetype=obj -o %t < %s
 ; RUN: dsymutil %t -o %t.dSYM
+; RUN: dsymutil --linker parallel %t -o %t.parallel.dSYM
 ; RUN: llvm-dwarfdump %t | FileCheck %s
 ; RUN: llvm-dwarfdump -debug-names %t | FileCheck --check-prefix=SAME-NAME %s
 ; RUN: llvm-dwarfdump -debug-names %t | FileCheck --check-prefix=DIFFERENT-NAME %s

--- a/llvm/test/tools/dsymutil/AArch64/inlined-low_pc.c
+++ b/llvm/test/tools/dsymutil/AArch64/inlined-low_pc.c
@@ -3,7 +3,7 @@
 static int foo(int i) { return 42 + i; }
 int bar(int a) { return foo(a); }
 
-// RUN: dsymutil -f -y %p/dummy-debug-map-arm64.map -oso-prepend-path %p/../Inputs/inlined-low_pc -o - | llvm-dwarfdump - | FileCheck %s
+// RUN: dsymutil --linker classic -f -y %p/dummy-debug-map-arm64.map -oso-prepend-path %p/../Inputs/inlined-low_pc -o - | llvm-dwarfdump - | FileCheck %s
 
 // RUN: dsymutil --linker parallel -f -y %p/dummy-debug-map-arm64.map \
 // RUN: -oso-prepend-path %p/../Inputs/inlined-low_pc -o - | \

--- a/llvm/test/tools/dsymutil/ARM/scattered.c
+++ b/llvm/test/tools/dsymutil/ARM/scattered.c
@@ -1,4 +1,4 @@
-RUN: dsymutil -y %p/dummy-debug-map.map -oso-prepend-path \
+RUN: dsymutil --linker classic -y %p/dummy-debug-map.map -oso-prepend-path \
 RUN:  %p/../Inputs/scattered-reloc/ -f -o - | \
 RUN:  llvm-dwarfdump -debug-info - | FileCheck %s
 

--- a/llvm/test/tools/dsymutil/ARM/thumb.c
+++ b/llvm/test/tools/dsymutil/ARM/thumb.c
@@ -1,5 +1,5 @@
-// RUN: dsymutil -f -oso-prepend-path=%p/.. %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
-// RUN: dsymutil -arch armv7m -f -oso-prepend-path=%p/.. %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/.. %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
+// RUN: dsymutil --linker classic -arch armv7m -f -oso-prepend-path=%p/.. %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s
 
 // RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/.. \
 // RUN:  %p/../Inputs/thumb.armv7m -o - | llvm-dwarfdump - | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/dead-stripped.cpp
+++ b/llvm/test/tools/dsymutil/X86/dead-stripped.cpp
@@ -1,4 +1,4 @@
-// RUN: dsymutil -f -y %p/dummy-debug-map.map -oso-prepend-path %p/../Inputs/dead-stripped -o - | llvm-dwarfdump - --debug-info | FileCheck %s --implicit-check-not "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}"
+// RUN: dsymutil --linker classic -f -y %p/dummy-debug-map.map -oso-prepend-path %p/../Inputs/dead-stripped -o - | llvm-dwarfdump - --debug-info | FileCheck %s --implicit-check-not "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}"
 
 // The test was compiled with:
 // clang++ -O2 -g -c dead-strip.cpp -o 1.o

--- a/llvm/test/tools/dsymutil/X86/empty_range.s
+++ b/llvm/test/tools/dsymutil/X86/empty_range.s
@@ -4,7 +4,7 @@
 # Compile with:
 #        llvm-mc -triple x86_64-apple-darwin -filetype=obj -o 1.o empty_range.o
 
-# RUN: dsymutil -f -y %p/dummy-debug-map.map -oso-prepend-path %p/../Inputs/empty_range -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+# RUN: dsymutil --linker classic -f -y %p/dummy-debug-map.map -oso-prepend-path %p/../Inputs/empty_range -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
         .section	__TEXT,__text,regular,pure_instructions
 	.macosx_version_min 10, 11

--- a/llvm/test/tools/dsymutil/X86/global_downgraded_to_static.c
+++ b/llvm/test/tools/dsymutil/X86/global_downgraded_to_static.c
@@ -1,5 +1,5 @@
 // REQUIRES: system-darwin
-// RUN: dsymutil -oso-prepend-path %p/.. -dump-debug-map \
+// RUN: dsymutil --linker classic -oso-prepend-path %p/.. -dump-debug-map \
 // RUN: %p/../Inputs/global_downgraded_to_static.x86_64 2>&1 | FileCheck %s
 //
 // RUN: dsymutil --linker parallel -oso-prepend-path %p/.. -dump-debug-map \

--- a/llvm/test/tools/dsymutil/X86/inlined-static-variable.cpp
+++ b/llvm/test/tools/dsymutil/X86/inlined-static-variable.cpp
@@ -1,4 +1,4 @@
-// RUN: dsymutil -f -y %p/dummy-debug-map.map -oso-prepend-path \
+// RUN: dsymutil --linker classic -f -y %p/dummy-debug-map.map -oso-prepend-path \
 // RUN:   %p/../Inputs/inlined-static-variable -o - -keep-function-for-static \
 // RUN:   | llvm-dwarfdump - | FileCheck %s --implicit-check-not \
 // RUN:   "{{DW_AT_low_pc|DW_AT_high_pc|DW_AT_location|DW_TAG|NULL}}" \

--- a/llvm/test/tools/dsymutil/X86/mismatch.m
+++ b/llvm/test/tools/dsymutil/X86/mismatch.m
@@ -17,7 +17,7 @@
 // RUN: rm -rf %t.dir && mkdir %t.dir
 // RUN: cp %p/../Inputs/mismatch/1.o %p/../Inputs/mismatch/mismatch.pcm %t.dir
 // RUN: cp %p/../Inputs/mismatch/1.o %t.dir/2.o
-// RUN: dsymutil --verbose -f -oso-prepend-path=%t.dir \
+// RUN: dsymutil --linker classic --verbose -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o %t.bin 2>&1 | FileCheck %s
 // RUN: dsymutil --linker parallel --verbose -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o %t.bin 2>&1 | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/modules-dwarf-version.m
+++ b/llvm/test/tools/dsymutil/X86/modules-dwarf-version.m
@@ -8,7 +8,7 @@
 // RUN: mkdir %t.dir
 // RUN: cp %p/../Inputs/modules/Bar.pcm %t.dir
 // RUN: cp %p/../Inputs/modules-dwarf-version/1.o %t.dir
-// RUN: dsymutil -verify -f -oso-prepend-path=%t.dir \
+// RUN: dsymutil --linker classic -verify -f -oso-prepend-path=%t.dir \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s
 // RUN: dsymutil --linker parallel -verify -f -oso-prepend-path=%t.dir \

--- a/llvm/test/tools/dsymutil/X86/modules-empty.m
+++ b/llvm/test/tools/dsymutil/X86/modules-empty.m
@@ -14,7 +14,7 @@ EOF
 // RUN: mkdir %t.dir
 // RUN: cp %p/../Inputs/modules-empty/1.o %p/../Inputs/modules-empty/Empty.pcm \
 // RUN: %t.dir
-// RUN: dsymutil -f -oso-prepend-path=%t.dir \
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%t.dir \
 // RUN:   -verify \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --debug-info - | FileCheck %s

--- a/llvm/test/tools/dsymutil/X86/modules-pruning.cpp
+++ b/llvm/test/tools/dsymutil/X86/modules-pruning.cpp
@@ -3,6 +3,11 @@
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump --name isRef -p - | FileCheck %s
 
+// RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/modules-pruning \
+// RUN:   -verify \
+// RUN:   -y %p/dummy-debug-map.map -o - \
+// RUN:     | llvm-dwarfdump --name isRef -p - | FileCheck %s
+
 /* Compile with:
    cat >modules.modulemap <<EOF
    module Outer {

--- a/llvm/test/tools/dsymutil/X86/modules.m
+++ b/llvm/test/tools/dsymutil/X86/modules.m
@@ -18,11 +18,11 @@ EOF
    clang -c -g odr_violation.c -o 2.o
 */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/modules \
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/modules \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump -v --debug-info - | FileCheck %s
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/modules -y \
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/modules -y \
 // RUN:   %p/dummy-debug-map.map -o %t 2>&1 | FileCheck --check-prefix=WARN %s
 
 // Verify both linkers emit a valid .debug_names section for input with

--- a/llvm/test/tools/dsymutil/X86/odr-anon-namespace.cpp
+++ b/llvm/test/tools/dsymutil/X86/odr-anon-namespace.cpp
@@ -4,7 +4,7 @@
    done
  */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-anon-namespace -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-anon-namespace -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 #ifdef FILE1
 // Currently dsymutil will unique the contents of anonymous

--- a/llvm/test/tools/dsymutil/X86/odr-fwd-declaration.cpp
+++ b/llvm/test/tools/dsymutil/X86/odr-fwd-declaration.cpp
@@ -4,7 +4,7 @@
    done
  */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-fwd-declaration -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-fwd-declaration -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 #ifdef FILE1
 # 1 "Header.h" 1

--- a/llvm/test/tools/dsymutil/X86/odr-fwd-declaration2.cpp
+++ b/llvm/test/tools/dsymutil/X86/odr-fwd-declaration2.cpp
@@ -4,7 +4,7 @@
    done
  */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-fwd-declaration2 -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-fwd-declaration2 -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 #ifdef FILE1
 # 1 "Header.h" 1

--- a/llvm/test/tools/dsymutil/X86/odr-member-functions.cpp
+++ b/llvm/test/tools/dsymutil/X86/odr-member-functions.cpp
@@ -4,7 +4,7 @@
    done
  */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-member-functions -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-member-functions -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -debug-info - | FileCheck %s
 
 struct S {
   __attribute__((always_inline)) void foo() { bar(); }

--- a/llvm/test/tools/dsymutil/X86/odr-uniquing.cpp
+++ b/llvm/test/tools/dsymutil/X86/odr-uniquing.cpp
@@ -11,8 +11,8 @@
     - without ODR uniquing: all types are re-emited in the second CU
  */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=ODR,CHECK %s
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=NOODR,CHECK %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=ODR,CHECK %s
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=NOODR,CHECK %s
 
 // RUN: dsymutil --linker parallel -f -oso-prepend-path=%p/../Inputs/odr-uniquing -y %p/dummy-debug-map.map -no-odr -o - | llvm-dwarfdump -v -debug-info - | FileCheck -check-prefixes=NOODR,CHECK %s
 

--- a/llvm/test/tools/dsymutil/X86/remarks-linking-archive.text
+++ b/llvm/test/tools/dsymutil/X86/remarks-linking-archive.text
@@ -2,7 +2,7 @@ RUN: rm -rf %t
 RUN: mkdir -p %t
 RUN: cat %p/../Inputs/remarks/basic.macho.remarks.archive.x86_64 > %t/basic.macho.remarks.archive.x86_64
 
-RUN: dsymutil -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64
+RUN: dsymutil --linker classic -oso-prepend-path=%p/../Inputs -remarks-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64
 
 Check that the remark file in the bundle exists and is sane:
 RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.archive.x86_64.dSYM/Contents/Resources/Remarks/basic.macho.remarks.archive.x86_64 | FileCheck %s
@@ -14,7 +14,7 @@ RUN: llvm-bcanalyzer -dump %t/basic.macho.remarks.archive.x86_64.dSYM/Contents/R
 
 Check that we don't error if we're missing remark files from an archive, but we warn instead.
 Instead of creating a new binary, just remove the remarks prepend path.
-RUN: dsymutil -oso-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=CHECK-MISSING
+RUN: dsymutil --linker classic -oso-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=CHECK-MISSING
 
 RUN: dsymutil --linker parallel -oso-prepend-path=%p/../Inputs %t/basic.macho.remarks.archive.x86_64 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=CHECK-MISSING
 

--- a/llvm/test/tools/dsymutil/X86/reproducer.test
+++ b/llvm/test/tools/dsymutil/X86/reproducer.test
@@ -14,19 +14,19 @@ RUN: cp %p/../Inputs/basic3.macho.x86_64.o %t/Inputs
 RUN: dsymutil --linker classic -f -o - -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 | llvm-dwarfdump -a - | FileCheck %s
 
 # Make sure we don't crash with an empty TMPDIR.
-RUN: env TMPDIR="" dsymutil -o -f -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1
+RUN: env TMPDIR="" dsymutil --linker classic -o -f -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1
 
 # Make sure we don't leave around a temporary directory.
-RUN: env TMPDIR="%t/tempdir" dsymutil -o - -f %t/Inputs/basic.macho.x86_64
+RUN: env TMPDIR="%t/tempdir" dsymutil --linker classic -o - -f %t/Inputs/basic.macho.x86_64
 RUN: not ls %t/tempdir/dsymutil-*
 
 # Create a reproducer.
 RUN: rm -rf %t.repro
-RUN: env DSYMUTIL_REPRODUCER_PATH=%t.repro dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
+RUN: env DSYMUTIL_REPRODUCER_PATH=%t.repro dsymutil --linker classic -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
 RUN: llvm-dwarfdump -a %t.generate | FileCheck %s
 
 RUN: rm -rf %t.diags
-RUN: env LLVM_DIAGNOSTIC_DIR=%t.diags dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
+RUN: env LLVM_DIAGNOSTIC_DIR=%t.diags dsymutil --linker classic -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
 RUN: ls %t.diags | grep 'dsymutil-' | count 1
 
 # Remove the input files and verify that was successful.

--- a/llvm/test/tools/dsymutil/X86/submodules.m
+++ b/llvm/test/tools/dsymutil/X86/submodules.m
@@ -16,7 +16,7 @@ EOF
      -fdisable-module-hash submodules.m -o 1.o
 */
 
-// RUN: dsymutil -f -oso-prepend-path=%p/../Inputs/submodules \
+// RUN: dsymutil --linker classic -f -oso-prepend-path=%p/../Inputs/submodules \
 // RUN:   -y %p/dummy-debug-map.map -o - \
 // RUN:     | llvm-dwarfdump -v --debug-info - | FileCheck %s
 


### PR DESCRIPTION
As I'm preparing to toggle the default, I found another set of tests that don't explicitly pass the linker to dsymutil.