### PR TITLE
[AMDGPU] Coverity fixes - check ret val and init class members

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
@@ -286,9 +286,10 @@ simplifyAMDGCNImageIntrinsic(const GCNSubtarget *ST,
         // Obtain the original image sample intrinsic's signature
         // and replace its return type with the half-vector for D16 folding
         SmallVector<Type *, 8> OverloadTys;
-        Intrinsic::isSignatureValid(II.getCalledFunction(), OverloadTys);
-        OverloadTys[0] = HalfVecTy;
+        if (!Intrinsic::isSignatureValid(II.getCalledFunction(), OverloadTys))
+          return std::nullopt;
 
+        OverloadTys[0] = HalfVecTy;
         Module *M = II.getModule();
         Function *HalfDecl = Intrinsic::getOrInsertDeclaration(
             M, ImageDimIntr->Intr, OverloadTys);

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -303,12 +303,12 @@ private:
   GCNRegPressure RP;
 
   /// Target number of SGPRs.
-  unsigned MaxSGPRs;
+  unsigned MaxSGPRs = 0;
   /// Target number of ArchVGPRs and AGPRs.
-  unsigned MaxVGPRs;
+  unsigned MaxVGPRs = 0;
   /// Target number of overall VGPRs for subtargets with unified RFs. Always 0
   /// for subtargets with non-unified RFs.
-  unsigned MaxUnifiedVGPRs;
+  unsigned MaxUnifiedVGPRs = 0;
 
   GCNRPTarget(const GCNRegPressure &RP, const MachineFunction &MF)
       : MF(MF), UnifiedRF(MF.getSubtarget<GCNSubtarget>().hasGFX90AInsts()),


### PR DESCRIPTION
Coverity fixes:
* calling getIntrinsicSignature without checking return value (as is done elsewhere 4 out of 5 times) in llvm/lib/Target/AMDGPU/AMDGPUInstCombineIntrinsic.cpp
* non-static class member MaxSGPRs, MaxVGPRs and MaxUnifiedVGPRs is not initialized in this constructor nor in any functions that it calls in llvm/lib/Target/AMDGPU/GCNRegPressure.h
