### PR TITLE
[Coroutines] Expand materialization tests (NFC)

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-materialize.ll
+++ b/llvm/test/Transforms/Coroutines/coro-materialize.ll
@@ -8,14 +8,62 @@ target datalayout = "e-m:e-p:64:64-i64:64-f80:128-n8:16:32:64-S128"
 
 ; CHECK-LABEL: @f(
 ; CHECK: malloc(i32 24)
+; CHECK: store i32 %n
+; CHECK-NOT: store i32 %inc
+
 ; CHECK-LABEL: @f_optnone
 ; CHECK: malloc(i32 32)
+; CHECK: store i32 %inc1
+
 ; CHECK-LABEL: @f_multiple_remat(
 ; CHECK: malloc(i32 24)
+; CHECK: store i32 %n
+; CHECK-NOT: store i32 %inc
+
 ; CHECK-LABEL: @f_common_def(
 ; CHECK: malloc(i32 24)
+; CHECK: store i32 %n
+; CHECK-NOT: store i32 %inc
+
 ; CHECK-LABEL: @f_common_def_multi_result(
 ; CHECK: malloc(i32 24)
+; CHECK: store i32 %n
+; CHECK-NOT: store i32 %inc
+
+; CHECK-LABEL: @f.resume(
+; CHECK: %n.reload{{.*}} = load i32
+; CHECK: add i32 %n.reload{{.*}}, 1
+; CHECK: add i32 %{{.*}}, 1
+
+; CHECK-LABEL: @f_optnone.resume(
+; CHECK: %inc1.reload{{.*}} = load i32, ptr
+; CHECK: add i32 %inc1.reload{{.*}}, 1
+
+; CHECK-LABEL: @f_multiple_remat.resume(
+; CHECK: %n.reload{{.*}} = load i32
+; CHECK: add i32 %n.reload{{.*}}, 1
+; CHECK: add i32 %{{.*}}, 2
+; CHECK: add i32 %{{.*}}, 3
+; CHECK: add i32 %{{.*}}, 4
+; CHECK: add i32 %{{.*}}, 5
+; CHECK: add i32 %{{.*}}, 5
+
+; CHECK-LABEL: @f_common_def.resume(
+; CHECK: %n.reload{{.*}} = load i32
+; CHECK: add i32 %n.reload{{.*}}, 3
+; CHECK: add i32 %n.reload{{.*}}, 1
+; CHECK: add i32 %{{.*}}, %{{.*}}
+; CHECK: add i32 %{{.*}}, %{{.*}}
+; CHECK: add i32 %{{.*}}, 5
+
+; CHECK-LABEL: @f_common_def_multi_result.resume(
+; CHECK: %n.reload{{.*}} = load i32
+; CHECK: add i32 %n.reload{{.*}}, 3
+; CHECK: add i32 %n.reload{{.*}}, 1
+; CHECK: add i32 %{{.*}}, %{{.*}}
+; CHECK: add i32 %{{.*}}, %{{.*}}
+; CHECK: add i32 %{{.*}}, 4
+; CHECK: add i32 %{{.*}}, 5
 
 define ptr @f(i32 %n) presplitcoroutine {
 entry:


### PR DESCRIPTION
Expand checks so they check that the operation has been rematerialized, and computed values are not being stored.

Assisted-by: Claude Code