### PR TITLE
[Support] Add single byte fast path to LEB decoding (NFC)

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -15,6 +15,7 @@ add_benchmark(MustacheBench Mustache.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(SpecialCaseListBM SpecialCaseListBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(DWARFVerifierBM DWARFVerifierBM.cpp PARTIAL_SOURCES_INTENDED)
 add_benchmark(PointerUnionBM PointerUnionBM.cpp PARTIAL_SOURCES_INTENDED)
+add_benchmark(LEB128BM LEB128BM.cpp PARTIAL_SOURCES_INTENDED)
 
 add_benchmark(RuntimeLibcallsBench RuntimeLibcalls.cpp PARTIAL_SOURCES_INTENDED)
 

--- a/llvm/benchmarks/LEB128BM.cpp
+++ b/llvm/benchmarks/LEB128BM.cpp
@@ -1,12 +1,13 @@
-#include "llvm/Support/LEB128.h"
 #include "benchmark/benchmark.h"
+#include "llvm/Support/LEB128.h"
 
 #include <cstdint>
 #include <vector>
 
 using namespace llvm;
 
-static std::vector<uint8_t> encodeManyULEB128(const std::vector<uint64_t> &Vals) {
+static std::vector<uint8_t>
+encodeManyULEB128(const std::vector<uint64_t> &Vals) {
   std::vector<uint8_t> Buf;
   Buf.resize(Vals.size() * 10);
   uint8_t *P = Buf.data();
@@ -16,7 +17,8 @@ static std::vector<uint8_t> encodeManyULEB128(const std::vector<uint64_t> &Vals)
   return Buf;
 }
 
-static std::vector<uint8_t> encodeManySLEB128(const std::vector<int64_t> &Vals) {
+static std::vector<uint8_t>
+encodeManySLEB128(const std::vector<int64_t> &Vals) {
   std::vector<uint8_t> Buf;
   Buf.resize(Vals.size() * 10);
   uint8_t *P = Buf.data();
@@ -140,7 +142,8 @@ static void BM_DecodeSLEB128_2Byte(benchmark::State &State) {
   State.SetBytesProcessed(State.iterations() * Encoded.size());
 }
 
-// Mixed: 70% 1-byte, 20% 2-byte, 10% 5-byte (realistic DWARF-like distribution).
+// Mixed: 70% 1-byte, 20% 2-byte, 10% 5-byte (realistic DWARF-like
+// distribution).
 static void BM_DecodeULEB128_Mixed(benchmark::State &State) {
   std::vector<uint64_t> Vals(4096);
   for (size_t I = 0; I < Vals.size(); ++I) {

--- a/llvm/benchmarks/LEB128BM.cpp
+++ b/llvm/benchmarks/LEB128BM.cpp
@@ -1,0 +1,177 @@
+#include "llvm/Support/LEB128.h"
+#include "benchmark/benchmark.h"
+
+#include <cstdint>
+#include <vector>
+
+using namespace llvm;
+
+static std::vector<uint8_t> encodeManyULEB128(const std::vector<uint64_t> &Vals) {
+  std::vector<uint8_t> Buf;
+  Buf.resize(Vals.size() * 10);
+  uint8_t *P = Buf.data();
+  for (uint64_t V : Vals)
+    P += encodeULEB128(V, P);
+  Buf.resize(P - Buf.data());
+  return Buf;
+}
+
+static std::vector<uint8_t> encodeManySLEB128(const std::vector<int64_t> &Vals) {
+  std::vector<uint8_t> Buf;
+  Buf.resize(Vals.size() * 10);
+  uint8_t *P = Buf.data();
+  for (int64_t V : Vals)
+    P += encodeSLEB128(V, P);
+  Buf.resize(P - Buf.data());
+  return Buf;
+}
+
+// Decode a stream of ULEB128 values where all values fit in one byte (0-127).
+static void BM_DecodeULEB128_1Byte(benchmark::State &State) {
+  std::vector<uint64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I)
+    Vals[I] = I & 0x7f;
+  auto Encoded = encodeManyULEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeULEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+// Decode a stream of ULEB128 values needing 2 bytes (128-16383).
+static void BM_DecodeULEB128_2Byte(benchmark::State &State) {
+  std::vector<uint64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I)
+    Vals[I] = 128 + (I & 0x3fff);
+  auto Encoded = encodeManyULEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeULEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+// Decode a stream of ULEB128 values needing 5 bytes.
+static void BM_DecodeULEB128_5Byte(benchmark::State &State) {
+  std::vector<uint64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I)
+    Vals[I] = (1ULL << 28) + I;
+  auto Encoded = encodeManyULEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeULEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+// Decode a stream of ULEB128 values needing 10 bytes (max for uint64_t).
+static void BM_DecodeULEB128_10Byte(benchmark::State &State) {
+  std::vector<uint64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I)
+    Vals[I] = UINT64_MAX - I;
+  auto Encoded = encodeManyULEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeULEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+// Decode a stream of SLEB128 values where all values fit in one byte (-64..63).
+static void BM_DecodeSLEB128_1Byte(benchmark::State &State) {
+  std::vector<int64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I)
+    Vals[I] = (int64_t)(I & 0x7f) - 64;
+  auto Encoded = encodeManySLEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeSLEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+// Decode a stream of SLEB128 values needing 2 bytes.
+static void BM_DecodeSLEB128_2Byte(benchmark::State &State) {
+  std::vector<int64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I)
+    Vals[I] = (int64_t)(I & 0x1fff) - 4096;
+  auto Encoded = encodeManySLEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeSLEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+// Mixed: 70% 1-byte, 20% 2-byte, 10% 5-byte (realistic DWARF-like distribution).
+static void BM_DecodeULEB128_Mixed(benchmark::State &State) {
+  std::vector<uint64_t> Vals(4096);
+  for (size_t I = 0; I < Vals.size(); ++I) {
+    unsigned Bucket = I % 10;
+    if (Bucket < 7)
+      Vals[I] = I & 0x7f;
+    else if (Bucket < 9)
+      Vals[I] = 128 + (I & 0x3fff);
+    else
+      Vals[I] = (1ULL << 28) + I;
+  }
+  auto Encoded = encodeManyULEB128(Vals);
+
+  for (auto _ : State) {
+    const uint8_t *P = Encoded.data();
+    const uint8_t *End = P + Encoded.size();
+    while (P < End) {
+      unsigned N;
+      benchmark::DoNotOptimize(decodeULEB128(P, &N, End));
+      P += N;
+    }
+  }
+  State.SetBytesProcessed(State.iterations() * Encoded.size());
+}
+
+BENCHMARK(BM_DecodeULEB128_1Byte);
+BENCHMARK(BM_DecodeULEB128_2Byte);
+BENCHMARK(BM_DecodeULEB128_5Byte);
+BENCHMARK(BM_DecodeULEB128_10Byte);
+BENCHMARK(BM_DecodeSLEB128_1Byte);
+BENCHMARK(BM_DecodeSLEB128_2Byte);
+BENCHMARK(BM_DecodeULEB128_Mixed);
+
+BENCHMARK_MAIN();

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -130,6 +130,12 @@ inline unsigned encodeULEB128(uint64_t Value, uint8_t *p,
 inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
                               const uint8_t *end = nullptr,
                               const char **error = nullptr) {
+  if (LLVM_LIKELY(p != end && (*p < 128))) {
+    if (n)
+      *n = 1;
+    return *p;
+  }
+
   const uint8_t *orig_p = p;
   uint64_t Value = 0;
   unsigned Shift = 0;
@@ -164,6 +170,14 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
 inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
                              const uint8_t *end = nullptr,
                              const char **error = nullptr) {
+  if (LLVM_LIKELY(p != end && (*p < 128))) {
+    if (n)
+      *n = 1;
+    // Handle negatives. Shift the value to move the sign bit from position 6
+    // (SLEB) to 7 (int8_t), then unshift while propagating the sign bit.
+    return static_cast<int8_t>(*p << 1) >> 1;
+  }
+
   const uint8_t *orig_p = p;
   int64_t Value = 0;
   unsigned Shift = 0;

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -130,7 +130,7 @@ inline unsigned encodeULEB128(uint64_t Value, uint8_t *p,
 inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
                               const uint8_t *end = nullptr,
                               const char **error = nullptr) {
-  if (p != end && (*p < 128)) {
+  if (p != end && *p < 128) {
     if (n)
       *n = 1;
     return *p;
@@ -170,7 +170,7 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
 inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
                              const uint8_t *end = nullptr,
                              const char **error = nullptr) {
-  if (p != end && (*p < 128)) {
+  if (p != end && *p < 128) {
     if (n)
       *n = 1;
     // Handle negatives. Shift the value to move the sign bit from position 6

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -130,7 +130,7 @@ inline unsigned encodeULEB128(uint64_t Value, uint8_t *p,
 inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
                               const uint8_t *end = nullptr,
                               const char **error = nullptr) {
-  if (LLVM_LIKELY(p != end && (*p < 128))) {
+  if (p != end && (*p < 128)) {
     if (n)
       *n = 1;
     return *p;
@@ -170,7 +170,7 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
 inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
                              const uint8_t *end = nullptr,
                              const char **error = nullptr) {
-  if (LLVM_LIKELY(p != end && (*p < 128))) {
+  if (p != end && (*p < 128)) {
     if (n)
       *n = 1;
     // Handle negatives. Shift the value to move the sign bit from position 6


### PR DESCRIPTION
For single-byte values (0–127 for ULEB128, −64 to 63 for SLEB128), the fast path returns quickly using a small number of instructions.

Single-byte values are a common case in DWARF, which uses LEB128 extensively (ex abbreviation codes, attribute forms, etc). This change avoids the overhead of looping, and the internal overflow checks.

Assisted-by: claude