### PR TITLE
[CUF] Fix `do concurrent` IV type in `cuf.kernel` lowering

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -3974,7 +3974,7 @@ private:
           mlir::OpBuilder::InsertPoint insPt = builder->saveInsertionPoint();
           builder->setInsertionPointToStart(builder->getAllocaBlock());
           ivValue = builder->createTemporaryAlloc(
-              loc, idxTy, toStringRef(name.symbol->name()));
+              loc, genType(*name.symbol), toStringRef(name.symbol->name()));
           builder->restoreInsertionPoint(insPt);
         }
 

--- a/flang/test/Lower/CUDA/cuda-doconc.cuf
+++ b/flang/test/Lower/CUDA/cuda-doconc.cuf
@@ -14,11 +14,13 @@ subroutine doconc1
   end do
 end
 
-! CHECK: func.func @_QPdoconc1() {
-! CHECK: %[[DECL:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFdoconc1Ei"} : (!fir.ref<index>) -> (!fir.ref<index>, !fir.ref<index>)
-! CHECK: cuf.kernel<<<*, *>>> (%arg0 : index)
-! CHECK: fir.store %arg0 to %[[DECL]]#0 : !fir.ref<index>
-! CHECK: %{{.*}} = fir.load %[[DECL]]#0 : !fir.ref<index>
+! CHECK-LABEL: func.func @_QPdoconc1()
+! CHECK: %[[IMEM:.*]] = fir.alloca i32 {bindc_name = "i"}
+! CHECK: %[[IV:.*]]:2 = hlfir.declare %[[IMEM]] {uniq_name = "_QFdoconc1Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: cuf.kernel<<<*, *>>> (%[[ARG0:[^ ]*]] : index) =
+! CHECK: %[[CONV:.*]] = fir.convert %[[ARG0]] : (index) -> i32
+! CHECK: fir.store %[[CONV]] to %[[IV]]#0 : !fir.ref<i32>
+! CHECK: fir.load %[[IV]]#0 : !fir.ref<i32>
 
 subroutine doconc2
   integer :: i, j, m, n
@@ -32,11 +34,38 @@ subroutine doconc2
   end do
 end
 
-! CHECK: func.func @_QPdoconc2() {
-! CHECK: %[[DECLI:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFdoconc2Ei"} : (!fir.ref<index>) -> (!fir.ref<index>, !fir.ref<index>)
-! CHECK: %[[DECLJ:.*]]:2 = hlfir.declare %{{.*}} {uniq_name = "_QFdoconc2Ej"} : (!fir.ref<index>) -> (!fir.ref<index>, !fir.ref<index>)
-! CHECK: cuf.kernel<<<*, *>>> (%arg0 : index, %arg1 : index) = (%{{.*}}, %{{.*}} : index, index) to (%{{.*}}, %{{.*}} : index, index)  step (%{{.*}}, %{{.*}} : index, index) {
-! CHECK: fir.store %arg0 to %[[DECLI]]#0 : !fir.ref<index>
-! CHECK: fir.store %arg1 to %[[DECLJ]]#0 : !fir.ref<index>
-! CHECK: %{{.*}} = fir.load %[[DECLI]]#0 : !fir.ref<index>
-! CHECK: %{{.*}} = fir.load %[[DECLJ]]#0 : !fir.ref<index>
+! CHECK-LABEL: func.func @_QPdoconc2()
+! CHECK: %[[JMEM:.*]] = fir.alloca i32 {bindc_name = "j"}
+! CHECK: %[[IMEM:.*]] = fir.alloca i32 {bindc_name = "i"}
+! CHECK: %[[IDECL:.*]]:2 = hlfir.declare %[[IMEM]] {uniq_name = "_QFdoconc2Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[JDECL:.*]]:2 = hlfir.declare %[[JMEM]] {uniq_name = "_QFdoconc2Ej"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: cuf.kernel<<<*, *>>> (%[[ARG0:[^ ]*]] : index, %[[ARG1:[^ ]*]] : index) =
+! CHECK: %[[CONVI:.*]] = fir.convert %[[ARG0]] : (index) -> i32
+! CHECK: fir.store %[[CONVI]] to %[[IDECL]]#0 : !fir.ref<i32>
+! CHECK: %[[CONVJ:.*]] = fir.convert %[[ARG1]] : (index) -> i32
+! CHECK: fir.store %[[CONVJ]] to %[[JDECL]]#0 : !fir.ref<i32>
+! CHECK: fir.load %[[IDECL]]#0 : !fir.ref<i32>
+! CHECK: fir.load %[[JDECL]]#0 : !fir.ref<i32>
+
+! Test that do concurrent index variables in a cuf.kernel are allocated with
+! their declared Fortran integer type (i32), not the loop index type (index).
+! Previously the allocation used index, which prevented type conversions such
+! as real(i) from compiling correctly.
+subroutine doconc_real
+  integer :: i, n
+  real, managed :: a(4)
+  n = 4
+  !$cuf kernel do
+  do concurrent(i=1:n)
+    a(i) = real(i)
+  end do
+end
+
+! CHECK-LABEL: func.func @_QPdoconc_real()
+! CHECK: %[[IMEM:.*]] = fir.alloca i32 {bindc_name = "i"}
+! CHECK: %[[IV:.*]]:2 = hlfir.declare %[[IMEM]] {uniq_name = "_QFdoconc_realEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: cuf.kernel<<<*, *>>> (%[[ARG0:[^ ]*]] : index) =
+! CHECK: %[[CONV:.*]] = fir.convert %[[ARG0]] : (index) -> i32
+! CHECK: fir.store %[[CONV]] to %[[IV]]#0 : !fir.ref<i32>
+! CHECK: %[[LOADED:.*]] = fir.load %[[IV]]#0 : !fir.ref<i32>
+! CHECK: fir.convert %[[LOADED]] : (i32) -> f32


### PR DESCRIPTION
Induction variables in a `do concurrent` construct inside a cuf kernel directive were allocated with the `index` type instead of the Fortran-declared `integer` type. This caused a type conversion failure when the index variable was used in a context requiring a different integer or real type (e.g. `real(i)`).

Fix by using `genType(*name.symbol)` to derive the allocation type from the symbol's Fortran declaration.

PR stack:
- https://github.com/llvm/llvm-project/pull/198584 ◀️ 
- https://github.com/llvm/llvm-project/pull/198585