### PR TITLE
[CUF] Fix `do concurrent` PFT navigation in `cuf.kernel` lowering

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -4058,8 +4058,9 @@ private:
 
     if (crtEval->lowerAsStructured()) {
       crtEval = &crtEval->getFirstNestedEvaluation();
-      for (int64_t i = 1; i < nestedLoops; i++)
-        crtEval = &*std::next(crtEval->getNestedEvaluations().begin());
+      if (!outerDoConstruct->IsDoConcurrent())
+        for (int64_t i = 1; i < nestedLoops; i++)
+          crtEval = &*std::next(crtEval->getNestedEvaluations().begin());
     }
 
     // Generate loop body

--- a/flang/test/Lower/CUDA/cuda-doconc.cuf
+++ b/flang/test/Lower/CUDA/cuda-doconc.cuf
@@ -69,3 +69,30 @@ end
 ! CHECK: fir.store %[[CONV]] to %[[IV]]#0 : !fir.ref<i32>
 ! CHECK: %[[LOADED:.*]] = fir.load %[[IV]]#0 : !fir.ref<i32>
 ! CHECK: fir.convert %[[LOADED]] : (i32) -> f32
+
+! Test that do concurrent with multiple index variables and an explicit loop
+! count (do(2)) generates correct IR.  Previously the PFT navigation loop
+! assumed nested regular do-loops and asserted when it encountered the flat
+! do concurrent structure.
+subroutine doconc_do2
+  integer :: i, j, k, n
+  real, managed :: a(4, 2)
+  k = 2
+  n = 4
+  !$cuf kernel do(2) <<<k, n>>>
+  do concurrent(i=1:k, j=1:n)
+    a(j,i) = 1.0
+  end do
+end
+
+! CHECK-LABEL: func.func @_QPdoconc_do2()
+! j is allocated before i in the alloca block (loop control order).
+! CHECK: %[[JMEM:.*]] = fir.alloca i32 {bindc_name = "j"}
+! CHECK: %[[IMEM:.*]] = fir.alloca i32 {bindc_name = "i"}
+! CHECK: %[[IDECL:.*]]:2 = hlfir.declare %[[IMEM]] {uniq_name = "_QFdoconc_do2Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: %[[JDECL:.*]]:2 = hlfir.declare %[[JMEM]] {uniq_name = "_QFdoconc_do2Ej"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK: cuf.kernel{{.*}} (%[[ARG0:[^ ]*]] : index, %[[ARG1:[^ ]*]] : index) =
+! CHECK: %[[CONVI:.*]] = fir.convert %[[ARG0]] : (index) -> i32
+! CHECK: fir.store %[[CONVI]] to %[[IDECL]]#0 : !fir.ref<i32>
+! CHECK: %[[CONVJ:.*]] = fir.convert %[[ARG1]] : (index) -> i32
+! CHECK: fir.store %[[CONVJ]] to %[[JDECL]]#0 : !fir.ref<i32>


### PR DESCRIPTION
When lowering a cuf kernel directive with an explicit loop depth (e.g. `do(2)`), the code navigated `nestedLoops-1` levels deeper in the PFT expecting nested regular do-loops. For a `do concurrent` construct with multiple index variables (e.g. `do concurrent(i=1:k,j=1:n)`), the PFT represents the entire construct as a single node, so the extra navigation stepped off into a plain statement with no nested evaluations and triggered an assertion in `getNestedEvaluations()`.

Fix by skipping the depth navigation loop for `do concurrent`, which is always a single flat PFT construct regardless of how many index variables it declares.

PR stack:
- https://github.com/llvm/llvm-project/pull/198584 
- https://github.com/llvm/llvm-project/pull/198585 ◀️