### PR TITLE
[flang][OpenMP] Remove ompFlagsRequireMark from symbol resolution

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -171,7 +171,6 @@ protected:
   Symbol *DeclareNewAccessEntity(const Symbol &, Symbol::Flag, Scope &);
   Symbol *DeclareAccessEntity(const parser::Name &, Symbol::Flag, Scope &);
   Symbol *DeclareAccessEntity(Symbol &, Symbol::Flag, Scope &);
-  Symbol *DeclareOrMarkOtherAccessEntity(const parser::Name &, Symbol::Flag);
 
   UnorderedSymbolSet dataSharingAttributeObjects_; // on one directive
   SemanticsContext &context_;
@@ -1024,11 +1023,6 @@ private:
       Symbol::Flag::OmpCopyIn, Symbol::Flag::OmpUseDevicePtr,
       Symbol::Flag::OmpUseDeviceAddr, Symbol::Flag::OmpIsDevicePtr,
       Symbol::Flag::OmpHasDeviceAddr, Symbol::Flag::OmpUniform};
-
-  Symbol::Flags ompFlagsRequireMark{Symbol::Flag::OmpThreadprivate,
-      Symbol::Flag::OmpDeclareTarget, Symbol::Flag::OmpExclusiveScan,
-      Symbol::Flag::OmpInclusiveScan, Symbol::Flag::OmpInScanReduction,
-      Symbol::Flag::OmpGroupPrivate};
 
   Symbol::Flags dataCopyingAttributeFlags{
       Symbol::Flag::OmpCopyIn, Symbol::Flag::OmpCopyPrivate};
@@ -2980,9 +2974,7 @@ void OmpAttributeVisitor::PropagateOmpFlagToEquivalenceSet(
       // Set the OpenMP flag on the equivalenced symbol
       if (Symbol * resolvedSymbol{ResolveOmp(eqSymbol, ompFlag, currScope())}) {
         // Also add to the context if needed
-        if (ompFlagsRequireMark.test(ompFlag)) {
-          AddToContextObjectWithExplicitDSA(*resolvedSymbol, ompFlag);
-        }
+        AddToContextObjectWithExplicitDSA(*resolvedSymbol, ompFlag);
       }
     }
   }
@@ -3073,9 +3065,7 @@ Symbol *OmpAttributeVisitor::DeclareOrMarkOtherAccessEntity(
 
 Symbol *OmpAttributeVisitor::DeclareOrMarkOtherAccessEntity(
     Symbol &object, Symbol::Flag ompFlag) {
-  if (ompFlagsRequireMark.test(ompFlag)) {
-    object.set(ompFlag);
-  }
+  object.set(ompFlag);
   return &object;
 }
 

--- a/flang/test/Semantics/OpenMP/declare-simd-uniform.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-uniform.f90
@@ -14,7 +14,7 @@ end
 
 ! CHECK-LABEL: Subprogram scope: add2 size=48 alignment=8 sourceRange=189 bytes
 ! CHECK-NEXT:    a (OmpUniform): ObjectEntity dummy type: REAL(8) shape: 1_8:*
-! CHECK-NEXT:    add2 (Function): HostAssoc
+! CHECK-NEXT:    add2 (Function, OmpDeclareSimd): HostAssoc
 ! CHECK-NEXT:    alc, POINTER size=24 offset=8: ObjectEntity dummy type: INTEGER(4)
 ! CHECK-NEXT:    b (OmpUniform): ObjectEntity dummy type: REAL(8) shape: 1_8:*
 ! CHECK-NEXT:    c size=8 offset=40: ObjectEntity funcResult type: REAL(8)


### PR DESCRIPTION
The `ompFlagsRequireMark` set was there to make sure that we put the flags from it on symbols even when no new symbols needed to be created.

Instead of doing that, we can just put the flag on the symbol every time. There is no harm in having these flags, it's just extra information.