### PR TITLE
[SLP] Properly select base pointer for reordered strided loads

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -23280,7 +23280,9 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
       } else {
         assert(E->State == TreeEntry::StridedVectorize &&
                "Expected either strided or consecutive stores.");
-        if (!E->ReorderIndices.empty()) {
+        bool IsReverseOrder =
+            !E->ReorderIndices.empty() && isReverseOrder(E->ReorderIndices);
+        if (IsReverseOrder) {
           SI = cast<StoreInst>(E->Scalars[E->ReorderIndices.front()]);
           Ptr = SI->getPointerOperand();
         }

--- a/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-stores.ll
+++ b/llvm/test/Transforms/SLPVectorizer/RISCV/basic-strided-stores.ll
@@ -784,7 +784,7 @@ define void @reversed_addr_data_reorder(ptr %pl, ptr %ps) {
 ; CHECK-LABEL: define void @reversed_addr_data_reorder(
 ; CHECK-SAME: ptr [[PL:%.*]], ptr [[PS:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:    [[L0:%.*]] = getelementptr i8, ptr [[PL]], i64 0
-; CHECK-NEXT:    [[S3:%.*]] = getelementptr i8, ptr [[PS]], i64 8
+; CHECK-NEXT:    [[S3:%.*]] = getelementptr i8, ptr [[PS]], i64 0
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <8 x i8>, ptr [[L0]], align 1
 ; CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <8 x i8> [[TMP1]], <8 x i8> poison, <8 x i32> <i32 4, i32 5, i32 7, i32 2, i32 6, i32 1, i32 3, i32 0>
 ; CHECK-NEXT:    call void @llvm.experimental.vp.strided.store.v8i8.p0.i64(<8 x i8> [[TMP2]], ptr align 1 [[S3]], i64 2, <8 x i1> splat (i1 true), i32 8)


### PR DESCRIPTION
Prior to supporting strided stores, strided stores were used as an optimization for reversed stores. This logic was left over from that, updated so that the pointer is only adjusted in the case of reversed stores.