### PR TITLE
[lldb-dap] Add missing `arguments` field to LldbDapProcessEntry

### DIFF
--- a/lldb/tools/lldb-dap/extension/src/process-tree.ts
+++ b/lldb/tools/lldb-dap/extension/src/process-tree.ts
@@ -57,6 +57,7 @@ interface LldbDapProcessEntry {
   pid: number;
   name?: string;
   executable?: string;
+  arguments?: string;
   triple?: string;
   user?: number;
 }


### PR DESCRIPTION
The TypeScript interface was missing the optional `arguments` field that `parseListProcessesOutput` reads and `pick-process` displays, breaking the extension build.