### PR TITLE
[CodeGen] Always print 64 bit hash value in MachineBlockHashInfoPrinterPass

### DIFF
--- a/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
+++ b/llvm/lib/CodeGen/MachineBlockHashInfo.cpp
@@ -163,7 +163,7 @@ MachineBlockHashInfoPrinterPass::run(MachineFunction &MF,
   OS << "Machine Block Hash Info for function: " << MF.getName() << "\n";
   for (const auto &MBB : MF) {
     OS << "  BB#" << MBB.getNumber() << ": "
-       << format_hex(MBHI.getMBBHash(MBB), 16) << "\n";
+       << format_hex(MBHI.getMBBHash(MBB), 18) << "\n";
   }
   return PreservedAnalyses::all();
 }

--- a/llvm/test/CodeGen/X86/machine-block-hash.mir
+++ b/llvm/test/CodeGen/X86/machine-block-hash.mir
@@ -50,3 +50,10 @@ constants:
     value:           'float 1.000000e+00'
     alignment:       4
 ...
+---
+name:            func_empty
+body:             |
+  ; HASH-LABEL: Machine Block Hash Info for function: func_empty
+  ; HASH-NEXT:  BB#0: 0x0000000000000000
+  bb.0:
+...


### PR DESCRIPTION
Hash must be fixed-size. 0x prefix is counted against the width in format_hex. Increasing from 16 to 18.