### PR TITLE
[Driver][MSVC] Use LLD if DWARF is requested

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -279,12 +279,26 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     AddRunTimeLibs(TC, TC.getDriver(), CmdArgs, Args);
   }
 
-  StringRef Linker = Args.getLastArgValue(options::OPT_fuse_ld_EQ,
-                                          TC.getDriver().getPreferredLinker());
+  StringRef PreferredLinker = TC.getDriver().getPreferredLinker();
+  if (PreferredLinker.empty()) {
+    // If DWARF is requested, use LLD, because MSVC's link.exe will silently
+    // truncate the .debug_* sections to eight characters. PE/COFF doesn't allow
+    // section names longer than eight bytes in executables - LLD uses the same
+    // name length extension as in object files (where long names are allowed).
+    if (Args.hasArg(options::OPT_gdwarf, options::OPT_gdwarf_2,
+                    options::OPT_gdwarf_3, options::OPT_gdwarf_4,
+                    options::OPT_gdwarf_5, options::OPT_gdwarf_6))
+      PreferredLinker = "lld-link";
+    else
+      PreferredLinker = "link";
+  }
+
+  StringRef Linker =
+      Args.getLastArgValue(options::OPT_fuse_ld_EQ, PreferredLinker);
   if (Linker.empty())
-    Linker = "link";
+    Linker = PreferredLinker;
   // We need to translate 'lld' into 'lld-link'.
-  else if (Linker.equals_insensitive("lld"))
+  if (Linker.equals_insensitive("lld"))
     Linker = "lld-link";
 
   if (Linker == "lld-link") {

--- a/clang/test/Driver/msvc-link.c
+++ b/clang/test/Driver/msvc-link.c
@@ -51,3 +51,21 @@
 // RUN: %clang -c -marm64x  --target=arm64ec-pc-windows-msvc -fuse-ld=link -### %s 2>&1 | \
 // RUN:        FileCheck --check-prefix=HYBRID-WARN %s
 // HYBRID-WARN: warning: argument unused during compilation: '-marm64x' [-Wunused-command-line-argument]
+
+// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
+// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
+// DEBUG-LINK: link.exe"
+// DEBUG-LINK-SAME: "-debug"
+// DEBUG-LINK-NOT: lld
+
+// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld-link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -gdwarf -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-2 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-3 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-4 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-5 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-6 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
+// DEBUG-LLD: lld-link"
+// DEBUG-LLD-SAME: "-debug"
+// DEBUG-LLD-NOT: link.exe


### PR DESCRIPTION
Clang can emit DWARF on Windows if requested with `-gdwarf` (or `-gdwarf-N`). The generated object files will then have the `.debug_*` sections. These section names are all larger than eight bytes. This creates an issue in the final executable. PE/COFF executables don't allow section names longer than eight characters. From the [docs](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers):

> **Name**: An 8-byte, null-padded UTF-8 encoded string. If the string is  exactly 8 characters long, there is no terminating null. For longer names, this field contains a slash (/) that is followed by an ASCII representation of a decimal number that is an offset into the string  table. Executable images do not use a string table and do not support section names longer than 8 characters.

MSVC's linker follows this and will truncate section names in executables. So a `.debug_info` would become `.debug_i`. LLD on the other hand does allow these long section names (with a warning). This makes DWARF work on MinGW.

The MSVC toolchain will use the MSVC linker by default (unless `CLANG_DEFAULT_LINKER` specifies a different one). This will truncate the section names. So if one would want to use DWARF, they'd also need to link with LLD.

This PR changes the default linker to LLD if DWARF is requested. Otherwise, the old default will be used.