### PR TITLE
[Flang] Reject keyword arguments in statement function calls

### DIFF
--- a/flang/lib/Evaluate/characteristics.cpp
+++ b/flang/lib/Evaluate/characteristics.cpp
@@ -642,6 +642,10 @@ static std::optional<Procedure> CharacterizeProcedure(
           [&](const semantics::SubprogramDetails &subp)
               -> std::optional<Procedure> {
             Procedure result;
+            if (subp.stmtFunction()) {
+              // Statement functions have implicit interfaces (F'2018 15.5.1)
+              result.attrs.set(Procedure::Attr::ImplicitInterface);
+            }
             if (subp.isFunction()) {
               if (auto fr{CharacterizeFunctionResult(
                       subp.result(), context, seenProcs, emitError)}) {

--- a/flang/lib/Evaluate/characteristics.cpp
+++ b/flang/lib/Evaluate/characteristics.cpp
@@ -642,10 +642,6 @@ static std::optional<Procedure> CharacterizeProcedure(
           [&](const semantics::SubprogramDetails &subp)
               -> std::optional<Procedure> {
             Procedure result;
-            if (subp.stmtFunction()) {
-              // Statement functions have implicit interfaces (F'2018 15.5.1)
-              result.attrs.set(Procedure::Attr::ImplicitInterface);
-            }
             if (subp.isFunction()) {
               if (auto fr{CharacterizeFunctionResult(
                       subp.result(), context, seenProcs, emitError)}) {

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -27,7 +27,7 @@ namespace characteristics = Fortran::evaluate::characteristics;
 
 namespace Fortran::semantics {
 
-static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
+void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
     parser::ContextualMessages &messages, SemanticsContext &context) {
   auto restorer{
       messages.SetLocation(arg.sourceLocation().value_or(messages.at()))};

--- a/flang/lib/Semantics/check-call.h
+++ b/flang/lib/Semantics/check-call.h
@@ -25,6 +25,11 @@ namespace Fortran::semantics {
 class Scope;
 class SemanticsContext;
 
+// Check constraints on actual arguments for procedures with implicit
+// interfaces. Used for statement function calls and external procedures.
+void CheckImplicitInterfaceArg(evaluate::ActualArgument &,
+    parser::ContextualMessages &, SemanticsContext &);
+
 // Argument treatingExternalAsImplicit should be true when the called procedure
 // does not actually have an explicit interface at the call site, but
 // its characteristics are known because it is a subroutine or function

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3770,9 +3770,8 @@ std::optional<characteristics::Procedure> ExpressionAnalyzer::CheckCall(
       IsExternalCalledImplicitly(callSite, proc.GetSymbol())};
   const Symbol *procSymbol{proc.GetSymbol()};
   // Statement functions have implicit interfaces and require the same checks
-  bool isStatementFunction{procSymbol &&
-      procSymbol->has<semantics::SubprogramDetails>() &&
-      procSymbol->get<semantics::SubprogramDetails>().stmtFunction()};
+  bool isStatementFunction{
+      procSymbol && procSymbol->flags().test(Symbol::Flag::StmtFunction)};
   std::optional<characteristics::Procedure> chars;
   if (procSymbol && procSymbol->has<semantics::ProcEntityDetails>() &&
       procSymbol->owner().IsGlobal()) {

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -3769,6 +3769,10 @@ std::optional<characteristics::Procedure> ExpressionAnalyzer::CheckCall(
   bool treatExternalAsImplicit{
       IsExternalCalledImplicitly(callSite, proc.GetSymbol())};
   const Symbol *procSymbol{proc.GetSymbol()};
+  // Statement functions have implicit interfaces and require the same checks
+  bool isStatementFunction{procSymbol &&
+      procSymbol->has<semantics::SubprogramDetails>() &&
+      procSymbol->get<semantics::SubprogramDetails>().stmtFunction()};
   std::optional<characteristics::Procedure> chars;
   if (procSymbol && procSymbol->has<semantics::ProcEntityDetails>() &&
       procSymbol->owner().IsGlobal()) {
@@ -3836,6 +3840,17 @@ std::optional<characteristics::Procedure> ExpressionAnalyzer::CheckCall(
         Say(callSite,
             "Procedure %s referenced in pure subprogram '%s' must be pure too"_err_en_US,
             name, DEREF(pure->symbol()).name());
+      }
+    }
+    if (isStatementFunction) {
+      // Statement functions have implicit interfaces; check for
+      // keyword arguments and other implicit interface constraints
+      parser::ContextualMessages &messages{
+          context_.foldingContext().messages()};
+      for (auto &arg : arguments) {
+        if (arg) {
+          semantics::CheckImplicitInterfaceArg(*arg, messages, context_);
+        }
       }
     }
     ok &= semantics::CheckArguments(*chars, arguments, context_,

--- a/flang/test/Semantics/call47.f90
+++ b/flang/test/Semantics/call47.f90
@@ -1,15 +1,26 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
-! Test F'2018 15.5.1 C1535 - keyword arguments are not allowed when the
+! Test F2018 15.5.1 C1535 - keyword arguments are not allowed when the
 ! interface is implicit. Statement functions have implicit interfaces.
 
 program test_stmt_func_keyword
-  integer :: f1, x, c
+  integer :: f1, f2, x, y, c
 
-  ! Statement function definition
+  ! Statement function definitions
   f1(x) = x / 2
+  f2(x, y) = x + y
 
   ! Calling a statement function with a keyword argument is not allowed
   ! because statement functions have implicit interfaces.
   !ERROR: Keyword 'x=' may not appear in a reference to a procedure with an implicit interface
   c = f1(x=10)
+
+  ! Wrong keyword name - gets both implicit interface error and unrecognized keyword error
+  !ERROR: Keyword 'y=' may not appear in a reference to a procedure with an implicit interface
+  !ERROR: Argument keyword 'y=' is not recognized for this procedure reference
+  c = f1(y=10)
+
+  ! Two keyword arguments - each gets its own diagnostic
+  !ERROR: Keyword 'x=' may not appear in a reference to a procedure with an implicit interface
+  !ERROR: Keyword 'y=' may not appear in a reference to a procedure with an implicit interface
+  c = f2(x=10, y=20)
 end program

--- a/flang/test/Semantics/call47.f90
+++ b/flang/test/Semantics/call47.f90
@@ -1,0 +1,15 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! Test F'2018 15.5.1 C1535 - keyword arguments are not allowed when the
+! interface is implicit. Statement functions have implicit interfaces.
+
+program test_stmt_func_keyword
+  integer :: f1, x, c
+
+  ! Statement function definition
+  f1(x) = x / 2
+
+  ! Calling a statement function with a keyword argument is not allowed
+  ! because statement functions have implicit interfaces.
+  !ERROR: Keyword 'x=' may not appear in a reference to a procedure with an implicit interface
+  c = f1(x=10)
+end program


### PR DESCRIPTION
**Problem**
Flang silently accepted keyword arguments in calls to statement functions, violating F2018 C1535.


**Standard: F2018 §15.5.1 C1535**: In a reference to a procedure whose interface is implicit at the point of the reference, the actual argument shall not be a keyword argument.

Flang silently compiles the following code without giving error` Keyword argument 'x' at (1) is invalid in a statement function
`
```
program test
  integer :: f1, x, c
  f1(x) = x / 2
  c = f1(x=10)  ! Should be an error
end program

```

**Summary**
Fixed an issue where statement functions were incorrectly treated as having an explicit interface, causing argument checks to be skipped. Now, statement functions are marked correctly so existing checks run and proper errors are shown

**Fixes** : [198523](https://github.com/llvm/llvm-project/issues/198523)
