### PR TITLE
[Offload] Fix build install directory and remove 'add_llvm_library'

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -90,18 +90,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED NO)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 # Set the path of all resulting libraries to a unified location so that it can
-# be used for testing.
-# TODO: Use common runtimes infrastructure for output and install paths
-set(LIBOMPTARGET_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+# be used for testing and found in the build tree.
+if(LLVM_LIBRARY_OUTPUT_INTDIR)
+  if(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR AND NOT APPLE)
+    set(LIBOMPTARGET_LIBRARY_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR}/${OFFLOAD_TARGET_SUBDIR})
+  else()
+    set(LIBOMPTARGET_LIBRARY_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR})
+  endif()
+else()
+  set(LIBOMPTARGET_LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+endif()
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIBOMPTARGET_LIBRARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBOMPTARGET_LIBRARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${LIBOMPTARGET_LIBRARY_DIR})
-
-if(NOT LLVM_LIBRARY_OUTPUT_INTDIR)
-  set(LIBOMPTARGET_INTDIR ${LIBOMPTARGET_LIBRARY_DIR})
-else()
-  set(LIBOMPTARGET_INTDIR ${LLVM_LIBRARY_OUTPUT_INTDIR})
-endif()
 
 # Get dependencies for the different components of the project.
 include(LibomptargetGetDependencies)
@@ -286,7 +287,7 @@ endif()
 # TODO: Use RUNTIMES_OUTPUT_RESOURCE_LIB_DIR instead
 set(LIBOMPTARGET_LLVM_LIBRARY_DIR "${LLVM_LIBRARY_DIR}" CACHE STRING
   "Path to folder containing llvm library libomptarget.so")
-set(LIBOMPTARGET_LLVM_LIBRARY_INTDIR "${LIBOMPTARGET_INTDIR}" CACHE STRING
+set(LIBOMPTARGET_LLVM_LIBRARY_INTDIR "${LIBOMPTARGET_LIBRARY_DIR}" CACHE STRING
   "Path to folder where intermediate libraries will be output")
 
 add_subdirectory(tools/offload-tblgen)

--- a/offload/liboffload/CMakeLists.txt
+++ b/offload/liboffload/CMakeLists.txt
@@ -1,18 +1,13 @@
 add_subdirectory(API)
 
-add_llvm_library(
-  LLVMOffload SHARED
+add_library(LLVMOffload SHARED
   src/OffloadLib.cpp
   src/OffloadImpl.cpp
+)
+add_dependencies(LLVMOffload OffloadAPI PluginErrcodes)
 
-  LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-
-  DEPENDS
-  OffloadAPI
-  PluginErrcodes
-  )
+llvm_map_components_to_libnames(llvm_libs FrontendOpenMP Support)
+target_link_libraries(LLVMOffload PRIVATE ${llvm_libs})
 
 foreach(plugin IN LISTS LIBOMPTARGET_PLUGINS_TO_BUILD)
     target_link_libraries(LLVMOffload PRIVATE omptarget.rtl.${plugin})

--- a/offload/libomptarget/CMakeLists.txt
+++ b/offload/libomptarget/CMakeLists.txt
@@ -4,9 +4,7 @@ if(NOT TARGET "omp")
   message(FATAL_ERROR "Error: omp target dependency of libomptarget not found. Please ensure 'openmp' is on LLVM_ENABLE_RUNTIMES list.")
 endif()
 
-add_llvm_library(omptarget
-  SHARED
-
+add_library(omptarget SHARED
   device.cpp
   interface.cpp
   omptarget.cpp
@@ -21,23 +19,10 @@ add_llvm_library(omptarget
   OpenMP/OMPT/Callback.cpp
 
   KernelLanguage/API.cpp
-
-  ADDITIONAL_HEADER_DIRS
-  ${LIBOMPTARGET_INCLUDE_DIR}
-  ${LIBOMPTARGET_BINARY_INCLUDE_DIR}
-
-  LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  Object
-
-  LINK_LIBS
-  PUBLIC
-  omp
-
-  NO_INSTALL_RPATH
-  BUILDTREE_ONLY
 )
+
+llvm_map_components_to_libnames(llvm_libs FrontendOpenMP Support Object)
+target_link_libraries(omptarget PRIVATE omp ${llvm_libs})
 target_include_directories(omptarget PRIVATE
   ${LIBOMPTARGET_INCLUDE_DIR} ${LIBOMPTARGET_BINARY_INCLUDE_DIR}
 )

--- a/offload/plugins-nextgen/CMakeLists.txt
+++ b/offload/plugins-nextgen/CMakeLists.txt
@@ -3,43 +3,18 @@ set(common_dir ${CMAKE_CURRENT_SOURCE_DIR}/common)
 set(common_bin_dir ${CMAKE_CURRENT_BINARY_DIR}/common)
 add_subdirectory(common)
 function(add_target_library target_name lib_name)
-  add_llvm_library(${target_name} STATIC
-    LINK_COMPONENTS
-      AggressiveInstCombine
-      Analysis
-      BinaryFormat
-      BitReader
-      BitWriter
-      CodeGen
-      Core
-      Extensions
-      FrontendOffloading
-      InstCombine
-      Instrumentation
-      IPO
-      IRReader
-      Linker
-      MC
-      Object
-      Passes
-      ProfileData
-      Remarks
-      ScalarOpts
-      Support
-      Target
-      TargetParser
-      TransformUtils
-      Vectorize
+  add_library(${target_name} STATIC)
 
-    NO_INSTALL_RPATH
-    BUILDTREE_ONLY
-  )
-
+  llvm_map_components_to_libnames(llvm_libs
+    AggressiveInstCombine Analysis BinaryFormat BitReader BitWriter CodeGen
+    Core Extensions FrontendOffloading InstCombine Instrumentation IPO IRReader
+    Linker MC Object Passes ProfileData Remarks ScalarOpts Support Target
+    TargetParser TransformUtils Vectorize)
   llvm_update_compile_flags(${target_name})
   target_include_directories(${target_name} PUBLIC ${common_dir}/include
                              ${common_bin_dir}/include)
   target_link_libraries(${target_name} PRIVATE
-                        PluginCommon ${OFFLOAD_PTHREAD_LIB})
+                        PluginCommon ${OFFLOAD_PTHREAD_LIB} ${llvm_libs})
 
   target_compile_definitions(${target_name} PRIVATE TARGET_NAME=${lib_name})
   target_compile_definitions(${target_name} PRIVATE


### PR DESCRIPTION
Summary:
The problem is that we do not correctly set the build directory output
for offload/. Normally, it's supposed to mirror the install pattern.
This is because we both have variants and so people can use the compiler
from the build directory.

Currently, if you build more than one variant of the offload/ library
they will clobber each-other in `<build>/lib/`, so no cross compiling
allowed. Additionally, these will not be usable in the build directory
because the compiler will think that they are in the triple directory
when they are not.

Relatively simple fix, just copy-paste the pattern every other runtime
uses and then remove the implicit handling we get from
`add_llvm_libraries`. The only this it did for us was automatically map
component names to the libraries, which is easy enough to do.
