### PR TITLE
[VPlan] Sink VPRecipeValue dtors.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -149,7 +149,6 @@ Type *VPIRValue::getType() const { return getUnderlyingValue()->getType(); }
 VPRecipeValue::~VPRecipeValue() {
   assert(Users.empty() &&
          "trying to delete a VPRecipeValue with remaining users");
-  getDefiningRecipe()->removeDefinedValue(this);
 }
 
 VPSingleDefValue::VPSingleDefValue(VPSingleDefRecipe *Def, Value *UV)
@@ -158,10 +157,18 @@ VPSingleDefValue::VPSingleDefValue(VPSingleDefRecipe *Def, Value *UV)
   Def->addDefinedValue(this);
 }
 
+VPSingleDefValue::~VPSingleDefValue() {
+  getDefiningRecipe()->removeDefinedValue(this);
+}
+
 VPMultiDefValue::VPMultiDefValue(VPRecipeBase *Def, Value *UV)
     : VPRecipeValue(VPVMultiDefValueSC, UV), Def(Def) {
   assert(Def && "VPMultiDefValue requires a defining recipe");
   Def->addDefinedValue(this);
+}
+
+VPMultiDefValue::~VPMultiDefValue() {
+  getDefiningRecipe()->removeDefinedValue(this);
 }
 
 // Get the top-most entry block of \p Start. This is the entry block of the

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -342,7 +342,7 @@ protected:
                                      Value *UV = nullptr);
 
 public:
-  ~VPSingleDefValue() override = default;
+  ~VPSingleDefValue() override;
 
   static bool classof(const VPValue *V) {
     return V->getVPValueID() == VPVSingleDefValueSC;
@@ -359,7 +359,7 @@ class VPMultiDefValue : public VPRecipeValue {
 public:
   LLVM_ABI_FOR_TEST VPMultiDefValue(VPRecipeBase *Def, Value *UV = nullptr);
 
-  ~VPMultiDefValue() override = default;
+  ~VPMultiDefValue() override;
 
   VPRecipeBase *getDef() const { return Def; }
 


### PR DESCRIPTION
Currently (after https://github.com/llvm/llvm-project/pull/195483) the VPRecipeValue accesses the defining value and removes it. This can cause uninitialized memory reads, because the Def pointer held by the VPMultiDefValue is destroyed before the super class destructor runs.

