### PR TITLE
[lldb-dap] Fall back to name when arguments are missing

### DIFF
--- a/lldb/tools/lldb-dap/extension/src/process-tree.ts
+++ b/lldb/tools/lldb-dap/extension/src/process-tree.ts
@@ -106,7 +106,7 @@ export function parseListProcessesOutput(stdout: string): Process[] {
     return {
       id: entry.pid,
       command: entry.executable ?? entry.name ?? "",
-      arguments: entry.arguments ?? "",
+      arguments: entry.arguments ?? entry.name ?? "",
     };
   });
 }


### PR DESCRIPTION
When `lldb-dap --list-processes` omits the `arguments` field for a process, fall back to `name` (matching the `command` field's fallback) instead of an empty string. This keeps the process picker from showing blank entries for processes whose full command line is unavailable.