### PR TITLE
[AMDGPU] Enable support for Wave64 on gfx13

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -870,7 +870,7 @@ public:
 
   bool supportsWave32() const { return getGeneration() >= GFX10; }
 
-  bool supportsWave64() const { return !hasGFX1250Insts(); }
+  bool supportsWave64() const { return !hasGFX1250Insts() || HasGFX13Insts; }
 
   bool isWave32() const { return getWavefrontSize() == 32; }
 


### PR DESCRIPTION
This is a temporary workaround needed to unblock ongoing GFX13-related changes. This will be removed by https://github.com/llvm/llvm-project/pull/197991