### PR TITLE
[flang] Improved FIR AA for acc.compute_region.

### DIFF
--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -1413,7 +1413,7 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
     if (accSourceReturn)
       return *accSourceReturn;
 
-    if (!breakFromLoop) {
+    if (!breakFromLoop && v) {
       // If we have reached a BlockArgument, try to pass through it
       // for some OpenACC operations.
       if (mlir::Value accOperand = mlir::acc::getACCOperandForBlockArg(v)) {

--- a/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
+++ b/flang/lib/Optimizer/Analysis/AliasAnalysis.cpp
@@ -1412,6 +1412,15 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
       return *regionBranchReturn;
     if (accSourceReturn)
       return *accSourceReturn;
+
+    if (!breakFromLoop) {
+      // If we have reached a BlockArgument, try to pass through it
+      // for some OpenACC operations.
+      if (mlir::Value accOperand = mlir::acc::getACCOperandForBlockArg(v)) {
+        v = accOperand;
+        defOp = v.getDefiningOp();
+      }
+    }
   }
   if (!defOp && type == SourceKind::Unknown) {
     // Check if the memory source is coming through a dummy argument.
@@ -1427,14 +1436,6 @@ AliasAnalysis::Source AliasAnalysis::getSource(mlir::Value v,
       // hlfir.eval_in_mem block operands is allocated by the operation.
       type = SourceKind::Allocate;
       ty = v.getType();
-    } else if (mlir::Operation *accOp =
-                   mlir::acc::getACCDataClauseOpForBlockArg(v)) {
-      return getSourceForACCMappedValue(
-          v, accOp,
-          [&](mlir::Value x) {
-            return getSource(x, getLastInstantiationPoint);
-          },
-          followingData, attributes);
     }
   }
 

--- a/flang/lib/Optimizer/Dialect/FIROps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIROps.cpp
@@ -190,9 +190,8 @@ bool fir::mayBeAbsentBox(mlir::Value val) {
       // arguments to the operands (though, the meaning
       // of operands/block-arguments of acc.compute_region
       // is tricky).
-      if (mlir::Operation *accOp =
-              mlir::acc::getACCDataClauseOpForBlockArg(val)) {
-        val = mlir::acc::getVar(accOp);
+      if (mlir::Value accOperand = mlir::acc::getACCOperandForBlockArg(val)) {
+        val = accOperand;
         continue;
       }
 
@@ -215,6 +214,11 @@ bool fir::mayBeAbsentBox(mlir::Value val) {
       return reboxAROp.getOptional();
     if (mlir::isa<fir::LoadOp>(defOp))
       return false;
+
+    if (mlir::isa<ACC_DATA_ENTRY_AND_INIT_OPS>(defOp)) {
+      val = mlir::acc::getVar(defOp);
+      continue;
+    }
 
     if (auto viewIface =
             mlir::dyn_cast<fir::FortranObjectViewOpInterface>(defOp)) {

--- a/flang/test/Analysis/AliasAnalysis/alias-analysis-acc.mlir
+++ b/flang/test/Analysis/AliasAnalysis/alias-analysis-acc.mlir
@@ -544,3 +544,22 @@ func.func @testBothInsideKernels() {
   }
   return
 }
+
+// -----
+
+// Test passing through acc.compute_region boundary inside acc routine.
+// The two dummy arguments cannot alias:
+// CHECK-LABEL: Testing : "test_acc_routine__0"
+// CHECK-DAG: arg_a#0 <-> arg_b#0: NoAlias
+func.func @test_acc_routine__0(%arg0: !fir.ref<f32> {fir.bindc_name = "a"}, %arg1: !fir.ref<f32> {fir.bindc_name = "b"}) attributes {acc.specialized_routine = #acc.specialized_routine<@acc_routine_0, <vector>, "test_acc_routine_">, fir.internal_name = "_QPtest_acc_routine"} {
+  %0 = acc.par_width {par_dim = #acc.par_dim<thread_x>}
+  acc.compute_region launch(%arg2 = %0) ins(%arg3 = %arg0, %arg4 = %arg1) : (!fir.ref<f32>, !fir.ref<f32>) {
+    %1 = fir.dummy_scope : !fir.dscope
+    %2 = fir.declare %arg3 dummy_scope %1 arg 1 {uniq_name = "_QFtest_acc_routineEa", test.ptr = "arg_a"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
+    %3 = fir.declare %arg4 dummy_scope %1 arg 2 {uniq_name = "_QFtest_acc_routineEb", test.ptr = "arg_b"} : (!fir.ref<f32>, !fir.dscope) -> !fir.ref<f32>
+    %4 = fir.load %3 : !fir.ref<f32>
+    fir.store %4 to %2 : !fir.ref<f32>
+    acc.yield
+  } {origin = "acc.routine"}
+  return
+}

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCUtils.h
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCUtils.h
@@ -30,6 +30,10 @@ namespace acc {
 mlir::Operation *getEnclosingComputeOp(mlir::Region &region);
 
 /// If `v` is not a block argument of an `acc.compute_region` body, returns
+/// nullptr. Otherwise maps the block argument to its operand and returns it.
+mlir::Value getACCOperandForBlockArg(mlir::Value v);
+
+/// If `v` is not a block argument of an `acc.compute_region` body, returns
 /// nullptr. Otherwise maps the block argument to its operand and returns the
 /// defining operation if it is one of `ACC_DATA_ENTRY_OPS`.
 mlir::Operation *getACCDataClauseOpForBlockArg(mlir::Value v);

--- a/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
+++ b/mlir/lib/Dialect/OpenACC/Utils/OpenACCUtils.cpp
@@ -25,7 +25,7 @@ mlir::Operation *mlir::acc::getEnclosingComputeOp(mlir::Region &region) {
       .getParentOfType<ACC_COMPUTE_CONSTRUCT_OPS, mlir::acc::ComputeRegionOp>();
 }
 
-mlir::Operation *mlir::acc::getACCDataClauseOpForBlockArg(mlir::Value v) {
+mlir::Value mlir::acc::getACCOperandForBlockArg(mlir::Value v) {
   auto barg = mlir::dyn_cast<mlir::BlockArgument>(v);
   if (!barg)
     return nullptr;
@@ -33,10 +33,15 @@ mlir::Operation *mlir::acc::getACCDataClauseOpForBlockArg(mlir::Value v) {
   mlir::Block *block = barg.getOwner();
   auto computeReg =
       mlir::dyn_cast<mlir::acc::ComputeRegionOp>(block->getParentOp());
-  if (!computeReg || block != computeReg.getBody())
+  if (!computeReg)
     return nullptr;
+  assert(block == computeReg.getBody() &&
+         "block must be the body of acc.compute_region");
+  return computeReg.getOperand(barg);
+}
 
-  mlir::Value orig = computeReg.getOperand(barg);
+mlir::Operation *mlir::acc::getACCDataClauseOpForBlockArg(mlir::Value v) {
+  mlir::Value orig = getACCOperandForBlockArg(v);
   if (!orig)
     return nullptr;
   mlir::Operation *def = orig.getDefiningOp();


### PR DESCRIPTION
We should actually treat the operand<->block-arg association
in `acc.compute_region` as a pass-through link, so that we can
accumulate the whole chain of addressing inside the compute region.
This is especially important for acc routines, where all `[hl]fir.declare`
operations are located inside `acc.compute_region`. The input operand,
in this case, is not a result of ACC entry/init operation.

The change in `FIROps.cpp` should be NFC, currently. I made it
just to align the pass-through handling with the AA change.
Even though I effectively replaced `ACC_DATA_ENTRY_OPS` with
`ACC_DATA_ENTRY_AND_INIT_OPS`, this change is not testable, because
boxed reductions are currently unsupported.
