### PR TITLE
[libc] move mblen to stdlib

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1349,6 +1349,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.stdlib.setenv
     libc.src.stdlib.mbstowcs
     libc.src.stdlib.mbtowc
+    libc.src.stdlib.mblen
     libc.src.stdlib.quick_exit
     libc.src.stdlib.wcstombs
     libc.src.stdlib.wctomb
@@ -1462,7 +1463,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sys.select.select
 
     # wchar.h entrypoints
-    libc.src.wchar.mblen
     libc.src.wchar.mbrlen
     libc.src.wchar.mbsinit
     libc.src.wchar.mbrtowc

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -158,6 +158,13 @@ functions:
       - type: wchar_t *__restrict
       - type: const char *__restrict
       - type: size_t
+  - name: mblen
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: const char *
+      - type: size_t
   - name: memalignment
     standards:
       - stdc

--- a/libc/include/wchar.yaml
+++ b/libc/include/wchar.yaml
@@ -79,13 +79,6 @@ functions:
     return_type: int
     arguments:
       - type: mbstate_t *
-  - name: mblen
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: const char *
-      - type: size_t
   - name: mbrlen
     standards:
       - stdc

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -416,6 +416,21 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  mblen
+  SRCS
+    mblen.cpp
+  HDRS
+    mblen.h
+  DEPENDS
+    libc.hdr.types.size_t
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.libc_errno
+    libc.src.__support.wchar.mbrtowc
+    libc.src.__support.wchar.mbstate
+)
+
+add_entrypoint_object(
   mbstowcs
   SRCS
     mbstowcs.cpp

--- a/libc/src/stdlib/mblen.cpp
+++ b/libc/src/stdlib/mblen.cpp
@@ -1,12 +1,17 @@
-//===-- Implementation of mblen -------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of mblen.
+///
+//===----------------------------------------------------------------------===//
 
-#include "src/wchar/mblen.h"
+#include "src/stdlib/mblen.h"
 
 #include "hdr/types/size_t.h"
 #include "src/__support/common.h"

--- a/libc/src/stdlib/mblen.h
+++ b/libc/src/stdlib/mblen.h
@@ -1,13 +1,18 @@
-//===-- Implementation header for mblen -----------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation header for mblen.
+///
+//===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_WCHAR_MBLEN_H
-#define LLVM_LIBC_SRC_WCHAR_MBLEN_H
+#ifndef LLVM_LIBC_SRC_STDLIB_MBLEN_H
+#define LLVM_LIBC_SRC_STDLIB_MBLEN_H
 
 #include "hdr/types/size_t.h"
 #include "src/__support/macros/config.h"
@@ -18,4 +23,4 @@ int mblen(const char *s, size_t n);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_MBLEN_H
+#endif // LLVM_LIBC_SRC_STDLIB_MBLEN_H

--- a/libc/src/wchar/CMakeLists.txt
+++ b/libc/src/wchar/CMakeLists.txt
@@ -246,20 +246,6 @@ add_entrypoint_object(
     libc.src.__support.libc_errno
 )
 
-add_entrypoint_object(
-  mblen
-  SRCS
-    mblen.cpp
-  HDRS
-    mblen.h
-  DEPENDS
-    libc.hdr.types.size_t
-    libc.src.__support.common
-    libc.src.__support.macros.config
-    libc.src.__support.libc_errno
-    libc.src.__support.wchar.mbrtowc
-    libc.src.__support.wchar.mbstate
-)
 
 add_entrypoint_object(
   mbrlen

--- a/libc/test/src/stdlib/CMakeLists.txt
+++ b/libc/test/src/stdlib/CMakeLists.txt
@@ -402,6 +402,18 @@ add_libc_test(
 )
 
 add_libc_test(
+  mblen_test
+  SUITE
+    libc-stdlib-tests
+  SRCS
+    mblen_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.stdlib.mblen
+    libc.test.UnitTest.ErrnoCheckingTest
+)
+
+add_libc_test(
   mbstowcs_test
   SUITE
     libc-stdlib-tests

--- a/libc/test/src/stdlib/mblen_test.cpp
+++ b/libc/test/src/stdlib/mblen_test.cpp
@@ -1,13 +1,18 @@
-//===-- Unittests for mblen -----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unittests for mblen.
+///
+//===----------------------------------------------------------------------===//
 
 #include "hdr/errno_macros.h"
-#include "src/wchar/mblen.h"
+#include "src/stdlib/mblen.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 

--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -62,17 +62,6 @@ add_libc_test(
     libc.test.UnitTest.ErrnoCheckingTest
 )
 
-add_libc_test(
-  mblen_test
-  SUITE
-    libc_wchar_unittests
-  SRCS
-    mblen_test.cpp
-  DEPENDS
-    libc.hdr.errno_macros
-    libc.src.wchar.mblen
-    libc.test.UnitTest.ErrnoCheckingTest
-)
 
 add_libc_test(
   mbsrtowcs_test


### PR DESCRIPTION
Move mblen from wchar to stdlib to conform with C standard. Also update
headers to match new style.

Assisted-by: Automated tooling, human reviewed.
