### PR TITLE
[Flang][test] Require x86 target for test

### DIFF
--- a/flang/test/Driver/intrinsic-module-path_per_target.f90
+++ b/flang/test/Driver/intrinsic-module-path_per_target.f90
@@ -1,4 +1,5 @@
 ! Ensure argument -fintrinsic-modules-path works as expected.
+! REQUIRES: x86-registered-target
 
 !-----------------------------------------
 ! FLANG DRIVER


### PR DESCRIPTION
#196558 uses x86_64-unknown-linux-gnu in a target and needs LLVM_TARGETS_TO_BUILD=X86, even though it uses -fsyntax-only to not generate code.

Reported by https://github.com/llvm/llvm-project/pull/196558#issuecomment-4487790588