### PR TITLE
[AArch64] Use fp16 FNEG and FABS for bf16.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -5553,6 +5553,13 @@ def : Pat<(i64 (any_llrint f32:$Rn)),
 def : Pat<(i64 (any_llrint f64:$Rn)),
           (FCVTZSUXDr (FRINTXDr f64:$Rn))>;
 
+let Predicates = [HasFullFP16] in {
+  def : Pat<(bf16 (fabs (bf16 FPR16:$Rn))),
+            (bf16 (FABSHr (bf16 FPR16:$Rn)))>;
+  def : Pat<(bf16 (fneg (bf16 FPR16:$Rn))),
+            (bf16 (FNEGHr (bf16 FPR16:$Rn)))>;
+}
+
 //===----------------------------------------------------------------------===//
 // Floating point two operand instructions.
 //===----------------------------------------------------------------------===//
@@ -5980,6 +5987,17 @@ def : InstAlias<"mvn{ $Vd.8b, $Vn.8b|.8b $Vd, $Vn}",
                 (NOTv8i8 V64:$Vd, V64:$Vn)>;
 def : InstAlias<"mvn{ $Vd.16b, $Vn.16b|.16b $Vd, $Vn}",
                 (NOTv16i8 V128:$Vd, V128:$Vn)>;
+}
+
+let Predicates = [HasFullFP16] in {
+  def : Pat<(v4bf16 (fabs (v4bf16 V64:$Rn))),
+            (v4bf16 (FABSv4f16 (v4bf16 V64:$Rn)))>;
+  def : Pat<(v8bf16 (fabs (v8bf16 V128:$Rn))),
+            (v8bf16 (FABSv8f16 (v8bf16 V128:$Rn)))>;
+  def : Pat<(v4bf16 (fneg (v4bf16 V64:$Rn))),
+            (v4bf16 (FNEGv4f16 (v4bf16 V64:$Rn)))>;
+  def : Pat<(v8bf16 (fneg (v8bf16 V128:$Rn))),
+            (v8bf16 (FNEGv8f16 (v8bf16 V128:$Rn)))>;
 }
 
 def : Pat<(vnot (v4i16 V64:$Rn)),  (NOTv8i8  V64:$Rn)>;

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -6818,20 +6818,52 @@ define <8 x bfloat> @test_fma(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c)
 }
 
 define <8 x bfloat> @test_fabs(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fabs:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NEXT:    ret
+; CHECK-CVT-LABEL: test_fabs:
+; CHECK-CVT:       // %bb.0:
+; CHECK-CVT-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-CVT-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fabs:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fabs:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    fabs v0.8h, v0.8h
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fabs:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-BF16-GI-NEXT:    ret
   %r = call <8 x bfloat> @llvm.fabs.v8bf16(<8 x bfloat> %a)
   ret <8 x bfloat> %r
 }
 
 define <8 x bfloat> @test_fneg(<8 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fneg:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.8h, #128, lsl #8
-; CHECK-NEXT:    eor v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    ret
+; CHECK-CVT-LABEL: test_fneg:
+; CHECK-CVT:       // %bb.0:
+; CHECK-CVT-NEXT:    movi v1.8h, #128, lsl #8
+; CHECK-CVT-NEXT:    eor v0.16b, v0.16b, v1.16b
+; CHECK-CVT-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fneg:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    movi v1.8h, #128, lsl #8
+; CHECK-BF16-SD-NEXT:    eor v0.16b, v0.16b, v1.16b
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-BF16SVE-SD-LABEL: test_fneg:
+; CHECK-BF16SVE-SD:       // %bb.0:
+; CHECK-BF16SVE-SD-NEXT:    fneg v0.8h, v0.8h
+; CHECK-BF16SVE-SD-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fneg:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    movi v1.8h, #128, lsl #8
+; CHECK-BF16-GI-NEXT:    eor v0.16b, v0.16b, v1.16b
+; CHECK-BF16-GI-NEXT:    ret
   %r = fneg <8 x bfloat> %a
   ret <8 x bfloat> %r
 }

--- a/llvm/test/CodeGen/AArch64/fabs.ll
+++ b/llvm/test/CodeGen/AArch64/fabs.ll
@@ -44,14 +44,19 @@ entry:
 }
 
 define bfloat @fabs_bf16(bfloat %a) {
-; CHECK-LABEL: fabs_bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    // kill: def $h0 killed $h0 def $s0
-; CHECK-NEXT:    fmov w8, s0
-; CHECK-NEXT:    and w8, w8, #0x7fff
-; CHECK-NEXT:    fmov s0, w8
-; CHECK-NEXT:    // kill: def $h0 killed $h0 killed $s0
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fabs_bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-NOFP16-NEXT:    fmov w8, s0
+; CHECK-NOFP16-NEXT:    and w8, w8, #0x7fff
+; CHECK-NOFP16-NEXT:    fmov s0, w8
+; CHECK-NOFP16-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fabs_bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fabs h0, h0
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = call bfloat @llvm.fabs.f16(bfloat %a)
   ret bfloat %c
@@ -260,41 +265,62 @@ entry:
 }
 
 define <7 x bfloat> @fabs_v7bf16(<7 x bfloat> %a) {
-; CHECK-LABEL: fabs_v7bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fabs_v7bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fabs_v7bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fabs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = call <7 x bfloat> @llvm.fabs.v7bf16(<7 x bfloat> %a)
   ret <7 x bfloat> %c
 }
 
 define <4 x bfloat> @fabs_v4bf16(<4 x bfloat> %a) {
-; CHECK-LABEL: fabs_v4bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    bic v0.4h, #128, lsl #8
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fabs_v4bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    bic v0.4h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fabs_v4bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fabs v0.4h, v0.4h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %a)
   ret <4 x bfloat> %c
 }
 
 define <8 x bfloat> @fabs_v8bf16(<8 x bfloat> %a) {
-; CHECK-LABEL: fabs_v8bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fabs_v8bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fabs_v8bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fabs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = call <8 x bfloat> @llvm.fabs.v8bf16(<8 x bfloat> %a)
   ret <8 x bfloat> %c
 }
 
 define <16 x bfloat> @fabs_v16bf16(<16 x bfloat> %a) {
-; CHECK-LABEL: fabs_v16bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NEXT:    bic v1.8h, #128, lsl #8
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fabs_v16bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    bic v1.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fabs_v16bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fabs v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fabs v1.8h, v1.8h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = call <16 x bfloat> @llvm.fabs.v16bf16(<16 x bfloat> %a)
   ret <16 x bfloat> %c

--- a/llvm/test/CodeGen/AArch64/fixed-length-bf16-arith.ll
+++ b/llvm/test/CodeGen/AArch64/fixed-length-bf16-arith.ll
@@ -11,7 +11,7 @@ target triple = "aarch64-unknown-linux-gnu"
 define <4 x bfloat> @fabs_v4bf16(<4 x bfloat> %a) {
 ; CHECK-LABEL: fabs_v4bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    bic v0.4h, #128, lsl #8
+; CHECK-NEXT:    fabs v0.4h, v0.4h
 ; CHECK-NEXT:    ret
   %res = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %a)
   ret <4 x bfloat> %res
@@ -20,7 +20,7 @@ define <4 x bfloat> @fabs_v4bf16(<4 x bfloat> %a) {
 define <8 x bfloat> @fabs_v8bf16(<8 x bfloat> %a) {
 ; CHECK-LABEL: fabs_v8bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NEXT:    fabs v0.8h, v0.8h
 ; CHECK-NEXT:    ret
   %res = call <8 x bfloat> @llvm.fabs.v8bf16(<8 x bfloat> %a)
   ret <8 x bfloat> %res
@@ -795,8 +795,7 @@ define <8 x bfloat> @abs_fmul_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; NOB16B16-NEXT:    bfmlalt v3.4s, v0.8h, v1.8h
 ; NOB16B16-NEXT:    bfcvt z2.h, p0/m, z2.s
 ; NOB16B16-NEXT:    bfcvtnt z2.h, p0/m, z3.s
-; NOB16B16-NEXT:    bic v2.8h, #128, lsl #8
-; NOB16B16-NEXT:    mov v0.16b, v2.16b
+; NOB16B16-NEXT:    fabs v0.8h, v2.8h
 ; NOB16B16-NEXT:    ret
 ;
 ; B16B16-LABEL: abs_fmul_v8bf16:
@@ -805,8 +804,7 @@ define <8 x bfloat> @abs_fmul_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 ; B16B16-NEXT:    // kill: def $q0 killed $q0 def $z0
 ; B16B16-NEXT:    // kill: def $q1 killed $q1 def $z1
 ; B16B16-NEXT:    bfmul z0.h, p0/m, z0.h, z1.h
-; B16B16-NEXT:    bic v0.8h, #128, lsl #8
-; B16B16-NEXT:    // kill: def $q0 killed $q0 killed $z0
+; B16B16-NEXT:    fabs v0.8h, v0.8h
 ; B16B16-NEXT:    ret
   %mul = fmul <8 x bfloat> %a, %b
   %res = call <8 x bfloat> @llvm.fabs.v8f16(<8 x bfloat> %mul)
@@ -820,8 +818,7 @@ define <8 x bfloat> @abs_fmul_v8bf16(<8 x bfloat> %a, <8 x bfloat> %b) {
 define <4 x bfloat> @fneg_v4bf16(<4 x bfloat> %a) {
 ; CHECK-LABEL: fneg_v4bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.4h, #128, lsl #8
-; CHECK-NEXT:    eor v0.8b, v0.8b, v1.8b
+; CHECK-NEXT:    fneg v0.4h, v0.4h
 ; CHECK-NEXT:    ret
   %res = fneg <4 x bfloat> %a
   ret <4 x bfloat> %res
@@ -830,8 +827,7 @@ define <4 x bfloat> @fneg_v4bf16(<4 x bfloat> %a) {
 define <8 x bfloat> @fneg_v8bf16(<8 x bfloat> %a) {
 ; CHECK-LABEL: fneg_v8bf16:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.8h, #128, lsl #8
-; CHECK-NEXT:    eor v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    fneg v0.8h, v0.8h
 ; CHECK-NEXT:    ret
   %res = fneg <8 x bfloat> %a
   ret <8 x bfloat> %res

--- a/llvm/test/CodeGen/AArch64/fneg.ll
+++ b/llvm/test/CodeGen/AArch64/fneg.ll
@@ -53,14 +53,19 @@ entry:
 }
 
 define bfloat @fneg_bf16(bfloat %a) {
-; CHECK-LABEL: fneg_bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    // kill: def $h0 killed $h0 def $s0
-; CHECK-NEXT:    fmov w8, s0
-; CHECK-NEXT:    eor w8, w8, #0x8000
-; CHECK-NEXT:    fmov s0, w8
-; CHECK-NEXT:    // kill: def $h0 killed $h0 killed $s0
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fneg_bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-NOFP16-NEXT:    fmov w8, s0
+; CHECK-NOFP16-NEXT:    eor w8, w8, #0x8000
+; CHECK-NOFP16-NEXT:    fmov s0, w8
+; CHECK-NOFP16-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fneg_bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fneg h0, h0
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = fneg bfloat %a
   ret bfloat %c
@@ -248,45 +253,66 @@ entry:
 }
 
 define <7 x bfloat> @fneg_v7bf16(<7 x bfloat> %a) {
-; CHECK-LABEL: fneg_v7bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    movi v1.8h, #128, lsl #8
-; CHECK-NEXT:    eor v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fneg_v7bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    movi v1.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    eor v0.16b, v0.16b, v1.16b
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fneg_v7bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fneg v0.8h, v0.8h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = fneg <7 x bfloat> %a
   ret <7 x bfloat> %c
 }
 
 define <4 x bfloat> @fneg_v4bf16(<4 x bfloat> %a) {
-; CHECK-LABEL: fneg_v4bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    movi v1.4h, #128, lsl #8
-; CHECK-NEXT:    eor v0.8b, v0.8b, v1.8b
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fneg_v4bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    movi v1.4h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    eor v0.8b, v0.8b, v1.8b
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fneg_v4bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fneg v0.4h, v0.4h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = fneg <4 x bfloat> %a
   ret <4 x bfloat> %c
 }
 
 define <8 x bfloat> @fneg_v8bf16(<8 x bfloat> %a) {
-; CHECK-LABEL: fneg_v8bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    movi v1.8h, #128, lsl #8
-; CHECK-NEXT:    eor v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fneg_v8bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    movi v1.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    eor v0.16b, v0.16b, v1.16b
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fneg_v8bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fneg v0.8h, v0.8h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = fneg <8 x bfloat> %a
   ret <8 x bfloat> %c
 }
 
 define <16 x bfloat> @fneg_v16bf16(<16 x bfloat> %a) {
-; CHECK-LABEL: fneg_v16bf16:
-; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    movi v2.8h, #128, lsl #8
-; CHECK-NEXT:    eor v0.16b, v0.16b, v2.16b
-; CHECK-NEXT:    eor v1.16b, v1.16b, v2.16b
-; CHECK-NEXT:    ret
+; CHECK-NOFP16-LABEL: fneg_v16bf16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    movi v2.8h, #128, lsl #8
+; CHECK-NOFP16-NEXT:    eor v0.16b, v0.16b, v2.16b
+; CHECK-NOFP16-NEXT:    eor v1.16b, v1.16b, v2.16b
+; CHECK-NOFP16-NEXT:    ret
+;
+; CHECK-FP16-LABEL: fneg_v16bf16:
+; CHECK-FP16:       // %bb.0: // %entry
+; CHECK-FP16-NEXT:    fneg v0.8h, v0.8h
+; CHECK-FP16-NEXT:    fneg v1.8h, v1.8h
+; CHECK-FP16-NEXT:    ret
 entry:
   %c = fneg <16 x bfloat> %a
   ret <16 x bfloat> %c

--- a/llvm/test/CodeGen/AArch64/partial-reduction-sub-fp.ll
+++ b/llvm/test/CodeGen/AArch64/partial-reduction-sub-fp.ll
@@ -52,8 +52,7 @@ define <vscale x 4 x float> @fmlslbt_f16_f32_extended_fadd(<vscale x 4 x float> 
 define <4 x float> @fixed_fmlslbt_bf16_f32(<4 x float> %acc, <8 x bfloat> %a, <8 x bfloat> %b) "target-features"="+sve2p1,+bf16" {
 ; CHECK-LABEL: fixed_fmlslbt_bf16_f32:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v3.8h, #128, lsl #8
-; CHECK-NEXT:    eor v2.16b, v2.16b, v3.16b
+; CHECK-NEXT:    fneg v2.8h, v2.8h
 ; CHECK-NEXT:    bfmlalb v0.4s, v1.8h, v2.8h
 ; CHECK-NEXT:    bfmlalt v0.4s, v1.8h, v2.8h
 ; CHECK-NEXT:    ret


### PR DESCRIPTION
These operations are bitwise and can be used for bf16 fneg and fabs as equally as they can be used for fp16.