### PR TITLE
[AArch64][GlobalISel] Add BF16 fabs and fneg

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -67,6 +67,7 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
 
   const LLT bf16 = LLT::bfloat16();
   const LLT v4bf16 = LLT::fixed_vector(4, bf16);
+  const LLT v8bf16 = LLT::fixed_vector(8, bf16);
 
   const LLT f16 = LLT::float16();
   const LLT v4f16 = LLT::fixed_vector(4, f16);
@@ -465,14 +466,14 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
 
   getActionDefinitionsBuilder({G_FABS, G_FNEG})
       .legalFor({f32, f64, v2f32, v4f32, v2f64})
-      .legalFor(HasFP16, {f16, v4f16, v8f16})
+      .legalFor(HasFP16, {f16, bf16, v4f16, v4bf16, v8f16, v8bf16})
       .scalarizeIf(scalarOrEltWiderThan(0, 64), 0)
       .lowerIf(scalarOrEltWiderThan(0, 64))
       .clampNumElements(0, v4s16, v8s16)
       .clampNumElements(0, v2s32, v4s32)
       .clampNumElements(0, v2s64, v2s64)
       .moreElementsToNextPow2(0)
-      .lowerFor({f16, v4f16, v8f16});
+      .lowerFor({f16, bf16, v4f16, v4bf16, v8f16, v8bf16});
 
   getActionDefinitionsBuilder(G_FREM)
       .libcallFor({f32, f64, f128})

--- a/llvm/test/CodeGen/AArch64/bf16-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-instructions.ll
@@ -33,8 +33,6 @@
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log10
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log2
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fabs
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fneg
 ;
 ; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_frem
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i32
@@ -65,8 +63,6 @@
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log10
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log2
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fabs
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fneg
 
 define bfloat @test_fadd(bfloat %a, bfloat %b) #0 {
 ; CHECK-CVT-SD-LABEL: test_fadd:
@@ -2614,14 +2610,41 @@ define bfloat @test_fabs(bfloat %a) #0 {
 }
 
 define bfloat @test_fneg(bfloat %a) #0 {
-; CHECK-LABEL: test_fneg:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    // kill: def $h0 killed $h0 def $s0
-; CHECK-NEXT:    fmov w8, s0
-; CHECK-NEXT:    eor w8, w8, #0x8000
-; CHECK-NEXT:    fmov s0, w8
-; CHECK-NEXT:    // kill: def $h0 killed $h0 killed $s0
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fneg:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-CVT-SD-NEXT:    fmov w8, s0
+; CHECK-CVT-SD-NEXT:    eor w8, w8, #0x8000
+; CHECK-CVT-SD-NEXT:    fmov s0, w8
+; CHECK-CVT-SD-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fneg:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-BF16-SD-NEXT:    fmov w8, s0
+; CHECK-BF16-SD-NEXT:    eor w8, w8, #0x8000
+; CHECK-BF16-SD-NEXT:    fmov s0, w8
+; CHECK-BF16-SD-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fneg:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-CVT-GI-NEXT:    fmov w8, s0
+; CHECK-CVT-GI-NEXT:    eor w8, w8, #0xffff8000
+; CHECK-CVT-GI-NEXT:    fmov s0, w8
+; CHECK-CVT-GI-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fneg:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-BF16-GI-NEXT:    fmov w8, s0
+; CHECK-BF16-GI-NEXT:    eor w8, w8, #0xffff8000
+; CHECK-BF16-GI-NEXT:    fmov s0, w8
+; CHECK-BF16-GI-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-BF16-GI-NEXT:    ret
   %r = fneg bfloat %a
   ret bfloat %r
 }

--- a/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v4-instructions.ll
@@ -38,8 +38,6 @@
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log10
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log2
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fabs
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fneg
 ;
 ; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_frem
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i8
@@ -75,8 +73,6 @@
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log10
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log2
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fabs
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fneg
 
 define <4 x bfloat> @test_build(<4 x bfloat> %a) {
 ; CHECK-CVT-SD-LABEL: test_build:
@@ -3659,10 +3655,27 @@ define <4 x bfloat> @test_fma(<4 x bfloat> %a, <4 x bfloat> %b, <4 x bfloat> %c)
 }
 
 define <4 x bfloat> @test_fabs(<4 x bfloat> %a) #0 {
-; CHECK-LABEL: test_fabs:
-; CHECK:       // %bb.0:
-; CHECK-NEXT:    bic v0.4h, #128, lsl #8
-; CHECK-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fabs:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    bic v0.4h, #128, lsl #8
+; CHECK-CVT-SD-NEXT:    ret
+;
+; CHECK-BF16-SD-LABEL: test_fabs:
+; CHECK-BF16-SD:       // %bb.0:
+; CHECK-BF16-SD-NEXT:    bic v0.4h, #128, lsl #8
+; CHECK-BF16-SD-NEXT:    ret
+;
+; CHECK-CVT-GI-LABEL: test_fabs:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    mvni v1.4h, #128, lsl #8
+; CHECK-CVT-GI-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-CVT-GI-NEXT:    ret
+;
+; CHECK-BF16-GI-LABEL: test_fabs:
+; CHECK-BF16-GI:       // %bb.0:
+; CHECK-BF16-GI-NEXT:    mvni v1.4h, #128, lsl #8
+; CHECK-BF16-GI-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-BF16-GI-NEXT:    ret
   %r = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %a)
   ret <4 x bfloat> %r
 }

--- a/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
+++ b/llvm/test/CodeGen/AArch64/bf16-v8-instructions.ll
@@ -43,8 +43,6 @@
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log10
 ; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_log2
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fabs
-; CHECK-CVT-GI-NEXT:  warning: Instruction selection used fallback path for test_fneg
 ;
 ; CHECK-BF16-GI:       warning: Instruction selection used fallback path for test_frem
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fptosi_i8
@@ -84,8 +82,6 @@
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log10
 ; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_log2
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fabs
-; CHECK-BF16-GI-NEXT:  warning: Instruction selection used fallback path for test_fneg
 
 define <8 x bfloat> @test_build(<8 x bfloat> %a) {
 ; CHECK-CVT-SD-LABEL: test_build:
@@ -6818,10 +6814,10 @@ define <8 x bfloat> @test_fma(<8 x bfloat> %a, <8 x bfloat> %b, <8 x bfloat> %c)
 }
 
 define <8 x bfloat> @test_fabs(<8 x bfloat> %a) #0 {
-; CHECK-CVT-LABEL: test_fabs:
-; CHECK-CVT:       // %bb.0:
-; CHECK-CVT-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-CVT-NEXT:    ret
+; CHECK-CVT-SD-LABEL: test_fabs:
+; CHECK-CVT-SD:       // %bb.0:
+; CHECK-CVT-SD-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-CVT-SD-NEXT:    ret
 ;
 ; CHECK-BF16-SD-LABEL: test_fabs:
 ; CHECK-BF16-SD:       // %bb.0:
@@ -6833,9 +6829,16 @@ define <8 x bfloat> @test_fabs(<8 x bfloat> %a) #0 {
 ; CHECK-BF16SVE-SD-NEXT:    fabs v0.8h, v0.8h
 ; CHECK-BF16SVE-SD-NEXT:    ret
 ;
+; CHECK-CVT-GI-LABEL: test_fabs:
+; CHECK-CVT-GI:       // %bb.0:
+; CHECK-CVT-GI-NEXT:    mvni v1.8h, #128, lsl #8
+; CHECK-CVT-GI-NEXT:    and v0.16b, v0.16b, v1.16b
+; CHECK-CVT-GI-NEXT:    ret
+;
 ; CHECK-BF16-GI-LABEL: test_fabs:
 ; CHECK-BF16-GI:       // %bb.0:
-; CHECK-BF16-GI-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-BF16-GI-NEXT:    mvni v1.8h, #128, lsl #8
+; CHECK-BF16-GI-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-BF16-GI-NEXT:    ret
   %r = call <8 x bfloat> @llvm.fabs.v8bf16(<8 x bfloat> %a)
   ret <8 x bfloat> %r

--- a/llvm/test/CodeGen/AArch64/fabs.ll
+++ b/llvm/test/CodeGen/AArch64/fabs.ll
@@ -265,62 +265,87 @@ entry:
 }
 
 define <7 x bfloat> @fabs_v7bf16(<7 x bfloat> %a) {
-; CHECK-NOFP16-LABEL: fabs_v7bf16:
-; CHECK-NOFP16:       // %bb.0: // %entry
-; CHECK-NOFP16-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NOFP16-NEXT:    ret
+; CHECK-NOFP16-SD-LABEL: fabs_v7bf16:
+; CHECK-NOFP16-SD:       // %bb.0: // %entry
+; CHECK-NOFP16-SD-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NOFP16-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: fabs_v7bf16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    fabs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
+;
+; CHECK-NOFP16-GI-LABEL: fabs_v7bf16:
+; CHECK-NOFP16-GI:       // %bb.0: // %entry
+; CHECK-NOFP16-GI-NEXT:    mvni v1.8h, #128, lsl #8
+; CHECK-NOFP16-GI-NEXT:    and v0.16b, v0.16b, v1.16b
+; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %c = call <7 x bfloat> @llvm.fabs.v7bf16(<7 x bfloat> %a)
   ret <7 x bfloat> %c
 }
 
 define <4 x bfloat> @fabs_v4bf16(<4 x bfloat> %a) {
-; CHECK-NOFP16-LABEL: fabs_v4bf16:
-; CHECK-NOFP16:       // %bb.0: // %entry
-; CHECK-NOFP16-NEXT:    bic v0.4h, #128, lsl #8
-; CHECK-NOFP16-NEXT:    ret
+; CHECK-NOFP16-SD-LABEL: fabs_v4bf16:
+; CHECK-NOFP16-SD:       // %bb.0: // %entry
+; CHECK-NOFP16-SD-NEXT:    bic v0.4h, #128, lsl #8
+; CHECK-NOFP16-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: fabs_v4bf16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    fabs v0.4h, v0.4h
 ; CHECK-FP16-NEXT:    ret
+;
+; CHECK-NOFP16-GI-LABEL: fabs_v4bf16:
+; CHECK-NOFP16-GI:       // %bb.0: // %entry
+; CHECK-NOFP16-GI-NEXT:    mvni v1.4h, #128, lsl #8
+; CHECK-NOFP16-GI-NEXT:    and v0.8b, v0.8b, v1.8b
+; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %c = call <4 x bfloat> @llvm.fabs.v4bf16(<4 x bfloat> %a)
   ret <4 x bfloat> %c
 }
 
 define <8 x bfloat> @fabs_v8bf16(<8 x bfloat> %a) {
-; CHECK-NOFP16-LABEL: fabs_v8bf16:
-; CHECK-NOFP16:       // %bb.0: // %entry
-; CHECK-NOFP16-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NOFP16-NEXT:    ret
+; CHECK-NOFP16-SD-LABEL: fabs_v8bf16:
+; CHECK-NOFP16-SD:       // %bb.0: // %entry
+; CHECK-NOFP16-SD-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NOFP16-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: fabs_v8bf16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    fabs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    ret
+;
+; CHECK-NOFP16-GI-LABEL: fabs_v8bf16:
+; CHECK-NOFP16-GI:       // %bb.0: // %entry
+; CHECK-NOFP16-GI-NEXT:    mvni v1.8h, #128, lsl #8
+; CHECK-NOFP16-GI-NEXT:    and v0.16b, v0.16b, v1.16b
+; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %c = call <8 x bfloat> @llvm.fabs.v8bf16(<8 x bfloat> %a)
   ret <8 x bfloat> %c
 }
 
 define <16 x bfloat> @fabs_v16bf16(<16 x bfloat> %a) {
-; CHECK-NOFP16-LABEL: fabs_v16bf16:
-; CHECK-NOFP16:       // %bb.0: // %entry
-; CHECK-NOFP16-NEXT:    bic v0.8h, #128, lsl #8
-; CHECK-NOFP16-NEXT:    bic v1.8h, #128, lsl #8
-; CHECK-NOFP16-NEXT:    ret
+; CHECK-NOFP16-SD-LABEL: fabs_v16bf16:
+; CHECK-NOFP16-SD:       // %bb.0: // %entry
+; CHECK-NOFP16-SD-NEXT:    bic v0.8h, #128, lsl #8
+; CHECK-NOFP16-SD-NEXT:    bic v1.8h, #128, lsl #8
+; CHECK-NOFP16-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: fabs_v16bf16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    fabs v0.8h, v0.8h
 ; CHECK-FP16-NEXT:    fabs v1.8h, v1.8h
 ; CHECK-FP16-NEXT:    ret
+;
+; CHECK-NOFP16-GI-LABEL: fabs_v16bf16:
+; CHECK-NOFP16-GI:       // %bb.0: // %entry
+; CHECK-NOFP16-GI-NEXT:    mvni v2.8h, #128, lsl #8
+; CHECK-NOFP16-GI-NEXT:    and v0.16b, v0.16b, v2.16b
+; CHECK-NOFP16-GI-NEXT:    and v1.16b, v1.16b, v2.16b
+; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %c = call <16 x bfloat> @llvm.fabs.v16bf16(<16 x bfloat> %a)
   ret <16 x bfloat> %c

--- a/llvm/test/CodeGen/AArch64/fneg.ll
+++ b/llvm/test/CodeGen/AArch64/fneg.ll
@@ -53,19 +53,28 @@ entry:
 }
 
 define bfloat @fneg_bf16(bfloat %a) {
-; CHECK-NOFP16-LABEL: fneg_bf16:
-; CHECK-NOFP16:       // %bb.0: // %entry
-; CHECK-NOFP16-NEXT:    // kill: def $h0 killed $h0 def $s0
-; CHECK-NOFP16-NEXT:    fmov w8, s0
-; CHECK-NOFP16-NEXT:    eor w8, w8, #0x8000
-; CHECK-NOFP16-NEXT:    fmov s0, w8
-; CHECK-NOFP16-NEXT:    // kill: def $h0 killed $h0 killed $s0
-; CHECK-NOFP16-NEXT:    ret
+; CHECK-NOFP16-SD-LABEL: fneg_bf16:
+; CHECK-NOFP16-SD:       // %bb.0: // %entry
+; CHECK-NOFP16-SD-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-NOFP16-SD-NEXT:    fmov w8, s0
+; CHECK-NOFP16-SD-NEXT:    eor w8, w8, #0x8000
+; CHECK-NOFP16-SD-NEXT:    fmov s0, w8
+; CHECK-NOFP16-SD-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-NOFP16-SD-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: fneg_bf16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    fneg h0, h0
 ; CHECK-FP16-NEXT:    ret
+;
+; CHECK-NOFP16-GI-LABEL: fneg_bf16:
+; CHECK-NOFP16-GI:       // %bb.0: // %entry
+; CHECK-NOFP16-GI-NEXT:    // kill: def $h0 killed $h0 def $s0
+; CHECK-NOFP16-GI-NEXT:    fmov w8, s0
+; CHECK-NOFP16-GI-NEXT:    eor w8, w8, #0xffff8000
+; CHECK-NOFP16-GI-NEXT:    fmov s0, w8
+; CHECK-NOFP16-GI-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %c = fneg bfloat %a
   ret bfloat %c


### PR DESCRIPTION
These should be very simple as they are just legal or expanded based on whether
fullfp16 is available, as the FP16 FNEG and FABS instructions can be used
equally for BF16.