### PR TITLE
[clang-format] Fix unrecognized qualifiers breaking east-const

### DIFF
--- a/clang/lib/Format/QualifierAlignmentFixer.cpp
+++ b/clang/lib/Format/QualifierAlignmentFixer.cpp
@@ -169,6 +169,12 @@ static bool isQualifier(const FormatToken *const Tok) {
   case tok::kw_constexpr:
   case tok::kw_restrict:
   case tok::kw_friend:
+  case tok::kw__Nonnull:
+  case tok::kw__Nullable:
+  case tok::kw__Null_unspecified:
+  case tok::kw___ptr32:
+  case tok::kw___ptr64:
+  case tok::kw___funcref:
     return true;
   default:
     return false;

--- a/clang/unittests/Format/QualifierFixerTest.cpp
+++ b/clang/unittests/Format/QualifierFixerTest.cpp
@@ -1331,6 +1331,25 @@ TEST_F(QualifierFixerTest, WithCpp11Attribute) {
                "[[maybe_unused]] constexpr static int A", Style);
 }
 
+TEST_F(QualifierFixerTest, WithPointerQualifierKeywords) {
+  FormatStyle Style = getLLVMStyle();
+  Style.QualifierAlignment = FormatStyle::QAS_Custom;
+  Style.QualifierOrder = {"type", "const", "volatile"};
+
+  verifyFormat("T const *_Nullable const a;", Style);
+  verifyFormat("T const *_Nonnull const b;", Style);
+  verifyFormat("T const *_Null_unspecified const c;", Style);
+  verifyFormat("T const *__ptr32 const d;", Style);
+  verifyFormat("T const *__ptr64 const e;", Style);
+  verifyFormat("T const *__funcref const f;", Style);
+  verifyFormat("T const *_Nullable const a = x;", Style);
+
+  verifyFormat("T *_Nullable const a;", "T *const _Nullable a;", Style);
+  verifyFormat("T const *_Nullable const volatile g;", Style);
+  verifyFormat("T const *_Nullable const volatile g;",
+               "T const *_Nullable volatile const g;", Style);
+}
+
 TEST_F(QualifierFixerTest, WithQualifiedTypeName) {
   auto Style = getLLVMStyle();
   Style.QualifierAlignment = FormatStyle::QAS_Custom;


### PR DESCRIPTION
Long time reader, first time contributor. :3

I've been experimenting with `_Nullable` and `_Nonnull` qualifiers in my project for which the `.clang-format` configures:
```
QualifierAlignment: Custom
QualifierOrder: [type, const, volatile]
```

This results in the following form:
```cpp
T const* _Nullable const identifier =
```
Formatting as:
```cpp
T const* _Nullable identifier const =
```
Which naturally doesn't compile. This is semi-blocking my project, so I would like to contribute it reasonably quickly if possible. I'll try to respond to feedback promptly.

This is possible to fix in a targeted way within the format rule, but I believe the underlying issue is these qualifiers need to hold true under `isQualifier`. That seems to fix my issue and may fix others I haven't discovered. I've extended this to other qualifiers I know of, but not `__ptrauth` family which seems to have its own special handling.

Assisted-by: Cursor/Claude Opus