### PR TITLE
[AggressiveInstCombine] Recognizing tail truncation in the popcount pattern

### DIFF
--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -487,12 +487,17 @@ static bool foldAnyOrAllBitsSet(Instruction &I) {
 }
 
 /// Helper function to replace an instruction with a popcount intrinsic.
-/// This creates the ctpop intrinsic and replaces all uses of the instruction.
-static void replaceWithPopCount(Instruction &I, Value *Root) {
+/// This creates the ctpop intrinsic with an optional truncation appended at the
+/// end, and replaces all uses of the instruction.
+static void replaceWithPopCount(Instruction &I, Value *Root,
+                                Value *Trunc = nullptr) {
   LLVM_DEBUG(dbgs() << "Recognized popcount intrinsic\n");
   IRBuilder<> Builder(&I);
-  I.replaceAllUsesWith(
-      Builder.CreateIntrinsic(Intrinsic::ctpop, I.getType(), {Root}));
+  Value *NewVal =
+      Builder.CreateIntrinsic(Intrinsic::ctpop, Root->getType(), {Root});
+  if (Trunc)
+    NewVal = Builder.CreateTrunc(NewVal, Trunc->getType());
+  I.replaceAllUsesWith(NewVal);
   ++NumPopCountRecognized;
 }
 
@@ -728,6 +733,21 @@ static bool tryToRecognizePopCount2n3(Instruction &I) {
     return false;
 
   unsigned Len = Ty->getScalarSizeInBits();
+  Value *Add1;
+  const APInt *MaskRes;
+  if (!match(&I, m_And(m_Value(Add1), m_APInt(MaskRes))))
+    return false;
+
+  // Since `(trunc (and x, C))` might be canonicalized into `(and (trunc x), C)`
+  // we might loose the opportunity to recognize `(trunc (popcount y))`. The
+  // following block tries to capture such truncation, update `Len`, and append
+  // the truncation at the end of the emitting popcount, if there is any.
+  Value *TruncSrc, *TailTrunc = nullptr;
+  if (match(Add1, m_OneUse(m_Trunc(m_Value(TruncSrc))))) {
+    TailTrunc = Add1;
+    Add1 = TruncSrc;
+    Len = Add1->getType()->getScalarSizeInBits();
+  }
 
   if (Len > 64 || Len <= 8 || Len % 8 != 0)
     return false;
@@ -740,10 +760,6 @@ static bool tryToRecognizePopCount2n3(Instruction &I) {
   APInt Mask33 = APInt::getSplat(Len, APInt(8, 0x33));
   APInt Mask0F = APInt::getSplat(Len, APInt(8, 0x0F));
 
-  Value *Add1;
-  const APInt *MaskRes;
-  if (!match(&I, m_And(m_Value(Add1), m_APInt(MaskRes))))
-    return false;
   // Number of bits needed to represent Len.
   unsigned NumLenBits = Log2_32(Len) + 1;
   // The "mask" here really only needs to fulfill two conditions:
@@ -792,7 +808,7 @@ static bool tryToRecognizePopCount2n3(Instruction &I) {
                                m_SpecificInt(Mask55)))))
     return false;
 
-  replaceWithPopCount(I, Root);
+  replaceWithPopCount(I, Root, TailTrunc);
   return true;
 }
 

--- a/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
+++ b/llvm/lib/Transforms/AggressiveInstCombine/AggressiveInstCombine.cpp
@@ -489,14 +489,18 @@ static bool foldAnyOrAllBitsSet(Instruction &I) {
 /// Helper function to replace an instruction with a popcount intrinsic.
 /// This creates the ctpop intrinsic with an optional truncation appended at the
 /// end, and replaces all uses of the instruction.
-static void replaceWithPopCount(Instruction &I, Value *Root,
-                                Value *Trunc = nullptr) {
+static void replaceWithPopCount(Instruction &I, Value *Root) {
   LLVM_DEBUG(dbgs() << "Recognized popcount intrinsic\n");
+  Type *RootTy = Root->getType();
+  Type *OrigTy = I.getType();
+
   IRBuilder<> Builder(&I);
-  Value *NewVal =
-      Builder.CreateIntrinsic(Intrinsic::ctpop, Root->getType(), {Root});
-  if (Trunc)
-    NewVal = Builder.CreateTrunc(NewVal, Trunc->getType());
+  Value *NewVal = Builder.CreateIntrinsic(Intrinsic::ctpop, RootTy, {Root});
+  if (OrigTy != RootTy) {
+    assert(RootTy->getScalarSizeInBits() > OrigTy->getScalarSizeInBits() &&
+           "Only truncation is supported for now");
+    NewVal = Builder.CreateTrunc(NewVal, OrigTy);
+  }
   I.replaceAllUsesWith(NewVal);
   ++NumPopCountRecognized;
 }
@@ -742,9 +746,8 @@ static bool tryToRecognizePopCount2n3(Instruction &I) {
   // we might loose the opportunity to recognize `(trunc (popcount y))`. The
   // following block tries to capture such truncation, update `Len`, and append
   // the truncation at the end of the emitting popcount, if there is any.
-  Value *TruncSrc, *TailTrunc = nullptr;
+  Value *TruncSrc;
   if (match(Add1, m_OneUse(m_Trunc(m_Value(TruncSrc))))) {
-    TailTrunc = Add1;
     Add1 = TruncSrc;
     Len = Add1->getType()->getScalarSizeInBits();
   }
@@ -808,7 +811,7 @@ static bool tryToRecognizePopCount2n3(Instruction &I) {
                                m_SpecificInt(Mask55)))))
     return false;
 
-  replaceWithPopCount(I, Root, TailTrunc);
+  replaceWithPopCount(I, Root);
   return true;
 }
 

--- a/llvm/test/Transforms/AggressiveInstCombine/popcount.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/popcount.ll
@@ -1520,6 +1520,89 @@ define i64 @popcnt2_64_large_mask(i64 noundef %0) {
   ret i64 %18
 }
 
+define i32 @popcnt2_64_tail_trunc(i64 noundef %0) {
+; CHECK-LABEL: @popcnt2_64_tail_trunc(
+; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.ctpop.i64(i64 [[TMP0:%.*]])
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc i64 [[TMP2]] to i32
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+  %2 = lshr i64 %0, 1
+  %3 = and i64 %2, 6148914691236517205
+  %4 = sub i64 %0, %3
+  %5 = and i64 %4, 3689348814741910323
+  %6 = lshr i64 %4, 2
+  %7 = and i64 %6, 3689348814741910323
+  %8 = add nuw nsw i64 %7, %5
+  %9 = lshr i64 %8, 4
+  %10 = add nuw nsw i64 %9, %8
+  %11 = and i64 %10, 1085102592571150095
+  %12 = lshr i64 %11, 8
+  %13 = add nuw nsw i64 %12, %11
+  %14 = lshr i64 %13, 16
+  %15 = add nuw nsw i64 %14, %13
+  %16 = lshr i64 %15, 32
+  %17 = add nuw nsw i64 %16, %15
+  %t = trunc i64 %17 to i32
+  %18 = and i32 %t, 127
+  ret i32 %18
+}
+
+define i32 @popcnt2_64_tail_trunc2(i64 noundef %0) {
+; CHECK-LABEL: @popcnt2_64_tail_trunc2(
+; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.ctpop.i64(i64 [[TMP0:%.*]])
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc i64 [[TMP2]] to i32
+; CHECK-NEXT:    ret i32 [[TMP3]]
+;
+  %2 = lshr i64 %0, 1
+  %3 = and i64 %2, 6148914691236517205
+  %4 = sub i64 %0, %3
+  %5 = and i64 %4, 3689348814741910323
+  %6 = lshr i64 %4, 2
+  %7 = and i64 %6, 3689348814741910323
+  %8 = add nuw nsw i64 %7, %5
+  %9 = lshr i64 %8, 4
+  %10 = add nuw nsw i64 %9, %8
+  %11 = and i64 %10, 1085102592571150095
+  %12 = lshr i64 %11, 8
+  %13 = add nuw nsw i64 %12, %11
+  %14 = lshr i64 %13, 16
+  %15 = add nuw nsw i64 %14, %13
+  %16 = lshr i64 %15, 32
+  %17 = add nuw nsw i64 %16, %15
+  %t = trunc i64 %17 to i32
+  %18 = and i32 %t, 255
+  ret i32 %18
+}
+
+; The power-of-two condition only applies on popcount, no the truncated
+; value's bit width.
+define i17 @popcnt2_64_tail_trunc_non_power_of_two(i64 noundef %0) {
+; CHECK-LABEL: @popcnt2_64_tail_trunc_non_power_of_two(
+; CHECK-NEXT:    [[TMP2:%.*]] = call i64 @llvm.ctpop.i64(i64 [[TMP0:%.*]])
+; CHECK-NEXT:    [[TMP3:%.*]] = trunc i64 [[TMP2]] to i17
+; CHECK-NEXT:    ret i17 [[TMP3]]
+;
+  %2 = lshr i64 %0, 1
+  %3 = and i64 %2, 6148914691236517205
+  %4 = sub i64 %0, %3
+  %5 = and i64 %4, 3689348814741910323
+  %6 = lshr i64 %4, 2
+  %7 = and i64 %6, 3689348814741910323
+  %8 = add nuw nsw i64 %7, %5
+  %9 = lshr i64 %8, 4
+  %10 = add nuw nsw i64 %9, %8
+  %11 = and i64 %10, 1085102592571150095
+  %12 = lshr i64 %11, 8
+  %13 = add nuw nsw i64 %12, %11
+  %14 = lshr i64 %13, 16
+  %15 = add nuw nsw i64 %14, %13
+  %16 = lshr i64 %15, 32
+  %17 = add nuw nsw i64 %16, %15
+  %t = trunc i64 %17 to i17
+  %18 = and i17 %t, 255
+  ret i17 %18
+}
+
 ; The last mask is not big enough
 define i64 @negative_popcnt2_64_large_mask(i64 noundef %0) {
 ; CHECK-LABEL: @negative_popcnt2_64_large_mask(
@@ -1560,6 +1643,50 @@ define i64 @negative_popcnt2_64_large_mask(i64 noundef %0) {
   %17 = add nuw nsw i64 %16, %15
   %18 = and i64 %17, 63
   ret i64 %18
+}
+
+; Since this is really a 64-bit popcount, the last AND mask is too small
+define i32 @negative_popcnt2_64_tail_trunc(i64 noundef %0) {
+; CHECK-LABEL: @negative_popcnt2_64_tail_trunc(
+; CHECK-NEXT:    [[TMP2:%.*]] = lshr i64 [[TMP0:%.*]], 1
+; CHECK-NEXT:    [[TMP3:%.*]] = and i64 [[TMP2]], 6148914691236517205
+; CHECK-NEXT:    [[TMP4:%.*]] = sub i64 [[TMP0]], [[TMP3]]
+; CHECK-NEXT:    [[TMP5:%.*]] = and i64 [[TMP4]], 3689348814741910323
+; CHECK-NEXT:    [[TMP6:%.*]] = lshr i64 [[TMP4]], 2
+; CHECK-NEXT:    [[TMP7:%.*]] = and i64 [[TMP6]], 3689348814741910323
+; CHECK-NEXT:    [[TMP8:%.*]] = add nuw nsw i64 [[TMP7]], [[TMP5]]
+; CHECK-NEXT:    [[TMP9:%.*]] = lshr i64 [[TMP8]], 4
+; CHECK-NEXT:    [[TMP10:%.*]] = add nuw nsw i64 [[TMP9]], [[TMP8]]
+; CHECK-NEXT:    [[TMP11:%.*]] = and i64 [[TMP10]], 1085102592571150095
+; CHECK-NEXT:    [[TMP12:%.*]] = lshr i64 [[TMP11]], 8
+; CHECK-NEXT:    [[TMP13:%.*]] = add nuw nsw i64 [[TMP12]], [[TMP11]]
+; CHECK-NEXT:    [[TMP14:%.*]] = lshr i64 [[TMP13]], 16
+; CHECK-NEXT:    [[TMP15:%.*]] = add nuw nsw i64 [[TMP14]], [[TMP13]]
+; CHECK-NEXT:    [[TMP16:%.*]] = lshr i64 [[TMP15]], 32
+; CHECK-NEXT:    [[TMP17:%.*]] = add nuw nsw i64 [[TMP16]], [[TMP15]]
+; CHECK-NEXT:    [[T:%.*]] = trunc i64 [[TMP17]] to i32
+; CHECK-NEXT:    [[TMP18:%.*]] = and i32 [[T]], 63
+; CHECK-NEXT:    ret i32 [[TMP18]]
+;
+  %2 = lshr i64 %0, 1
+  %3 = and i64 %2, 6148914691236517205
+  %4 = sub i64 %0, %3
+  %5 = and i64 %4, 3689348814741910323
+  %6 = lshr i64 %4, 2
+  %7 = and i64 %6, 3689348814741910323
+  %8 = add nuw nsw i64 %7, %5
+  %9 = lshr i64 %8, 4
+  %10 = add nuw nsw i64 %9, %8
+  %11 = and i64 %10, 1085102592571150095
+  %12 = lshr i64 %11, 8
+  %13 = add nuw nsw i64 %12, %11
+  %14 = lshr i64 %13, 16
+  %15 = add nuw nsw i64 %14, %13
+  %16 = lshr i64 %15, 32
+  %17 = add nuw nsw i64 %16, %15
+  %t = trunc i64 %17 to i32
+  %18 = and i32 %t, 63
+  ret i32 %18
 }
 
 ; 16-bit vector popcount

--- a/llvm/test/Transforms/AggressiveInstCombine/popcount.ll
+++ b/llvm/test/Transforms/AggressiveInstCombine/popcount.ll
@@ -1574,7 +1574,7 @@ define i32 @popcnt2_64_tail_trunc2(i64 noundef %0) {
   ret i32 %18
 }
 
-; The power-of-two condition only applies on popcount, no the truncated
+; The power-of-two condition only applies on popcount, not the truncated
 ; value's bit width.
 define i17 @popcnt2_64_tail_trunc_non_power_of_two(i64 noundef %0) {
 ; CHECK-LABEL: @popcnt2_64_tail_trunc_non_power_of_two(


### PR DESCRIPTION
We're currently able to recognize the following popcount pattern
```
int popcnt(unsigned x) {
 x = x - ((x >> 1) & 0x55555555);
 x = x - 3*((x >> 2) & 0x33333333);
 x = (x + (x >> 4)) & 0x0F0F0F0F;
 x = x + (x >> 8);
 x = x + (x >> 16);
 return x & 0x0000003F;
}
```
but if a truncation follows right after the last AND instruction:
```
int16_t popcnt(unsigned x) {
 x = x - ((x >> 1) & 0x55555555);
 x = x - 3*((x >> 2) & 0x33333333);
 x = (x + (x >> 4)) & 0x0F0F0F0F;
 x = x + (x >> 8);
 x = x + (x >> 16);
 return int16_t(x & 0x0000003F);
}
```
since InstCombine canonicalizes `(trunc (and y, C))` into `(and trunc(y), C')`, we might loose the opportunity to turn the above snippet into `(trunc (popcount x))` as there is a `trunc` interrupting the pattern matching.

This patch fixes this issue by considering this extra `trunc` during pattern matching, and appending it in the final popcount result, if there is any.