### PR TITLE
[clang-cl] Add new option `/pathmap:<from>=<to>` to replace the path prefix <from> with <to>.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -362,6 +362,18 @@ New Compiler Flags
   be aligned to 4-byte alignment rather than fully unaligned or fully (8-byte)
   aligned.
 
+- New ``-cl`` option ``/pathmap:`` added to match MSVC. This option acts as a
+  clang's ``-ffile-prefix-map=value`` and has known differences in behaviour
+  with the CL's option that do not affect the functionality:
+  * nomalizes the macro prefix map pathes -- removes `./` and uses the target's 
+    platform-specific path separator character when exanding the preprocessor
+    macros -- ``-ffile-reproducible`` (but not the debug and coverage prefix maps).
+  * does not require ``/experimental:deterministic`` as by MSVC. It needed for
+    removing a hostname from a mangling hash gen, but clang-cl does not use a hostname 
+    when generates the hashes.
+  Known issues:
+  * does not remap the source file pathes within PCH/PCM files.
+
 Deprecated Compiler Flags
 -------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -364,15 +364,14 @@ New Compiler Flags
 
 - New ``-cl`` option ``/pathmap:`` added to match MSVC. This option acts as a
   clang's ``-ffile-prefix-map=value`` and has known differences in behaviour
-  with the CL's option that do not affect the functionality:
-  * nomalizes the macro prefix map pathes -- removes `./` and uses the target's 
-    platform-specific path separator character when exanding the preprocessor
-    macros -- ``-ffile-reproducible`` (but not the debug and coverage prefix maps).
-  * does not require ``/experimental:deterministic`` as by MSVC. It needed for
-    removing a hostname from a mangling hash gen, but clang-cl does not use a hostname 
-    when generates the hashes.
-  Known issues:
-  * does not remap the source file pathes within PCH/PCM files.
+  with the CL's option that do not affect the functionality: nomalizes the
+  macro prefix map pathes -- removes `./` and uses the target's platform-
+  specific path separator character when expanding the preprocessor macros -- 
+  ``-ffile-reproducible`` (but not the debug and coverage prefix maps);
+  does not require ``/experimental:deterministic`` as by MSVC. It needed for
+  removing a hostname from a mangling hash gen, but clang-cl does not use
+  a hostname when generates the hashes. Known issues -- does not remap the
+  source file pathes within PCH/PCM files.
 
 Deprecated Compiler Flags
 -------------------------

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9318,6 +9318,8 @@ def _SLASH_QIntel_jcc_erratum : CLFlag<"QIntel-jcc-erratum">,
   Alias<mbranches_within_32B_boundaries>;
 def _SLASH_arm64EC : CLFlag<"arm64EC">,
   HelpText<"Set build target to arm64ec">;
+def _SLASH_pathmap : CLCompileJoined<"pathmap:">,
+  Alias<ffile_prefix_map_EQ>;
 def : CLFlag<"Qgather-">, Alias<mno_gather>,
       HelpText<"Disable generation of gather instructions in auto-vectorization(x86 only)">;
 def : CLFlag<"Qscatter-">, Alias<mno_scatter>,

--- a/clang/test/CodeGenCXX/cl-pathmap.cpp
+++ b/clang/test/CodeGenCXX/cl-pathmap.cpp
@@ -1,5 +1,4 @@
-// RUN: %clang_cl /clang:-emit-llvm /pathmap:%p=x:/path-to/ /Fo:%t.bc /c %s
-// RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=CHECK-PREFIX-MAP 
+// RUN: %clang_cl /clang:-emit-llvm /pathmap:%p=x:/path-to/ -clang:-S -clang:-o- -- %s  2>&1 | FileCheck %s --check-prefix=CHECK-PREFIX-MAP 
 
 // CHECK-PREFIX-MAP: c"x:\\path-to\\cl-pathmap.cpp\00"
 

--- a/clang/test/CodeGenCXX/cl-pathmap.cpp
+++ b/clang/test/CodeGenCXX/cl-pathmap.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cl /clang:-emit-llvm /pathmap:%p=x:/path-to/ /Fo:%t.bc /c %s
+// RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=CHECK-PREFIX-MAP 
+
+// CHECK-PREFIX-MAP: c"x:\\path-to\\cl-pathmap.cpp\00"
+
+namespace std {
+class source_location {
+public:
+struct __impl {
+  const char *_M_file_name;
+  const char *_M_function_name;
+  unsigned _M_line;
+  unsigned _M_column;
+};
+};
+} // namespace std
+
+const std::source_location::__impl *__m_impl = static_cast<const std::source_location::__impl *>(__builtin_source_location());
+const char* file = __m_impl->_M_file_name;

--- a/clang/test/Driver/cl-pathmap.c
+++ b/clang/test/Driver/cl-pathmap.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cl -E -### /pathmap:%p=. %s 2>&1 | FileCheck %s --check-prefix CHECK-CC1-OPTS
+// CHECK-CC1-OPTS: -fdebug-prefix-map=
+// CHECK-CC1-OPTS: -fmacro-prefix-map=
+// CHECK-CC1-OPTS: -fcoverage-prefix-map=

--- a/clang/test/Preprocessor/cl-pathmap.c
+++ b/clang/test/Preprocessor/cl-pathmap.c
@@ -1,7 +1,6 @@
 // RUN: %clang_cl -E /pathmap:%p=x:/path-to/ %s | FileCheck %s --check-prefix CHECK-REPRODUCABLE
 // CHECK-REPRODUCABLE: filename: "x:\\path-to\\cl-pathmap.c"
 // CHECK-REPRODUCABLE-NOT: filename:
-// CHECK-REPRODUCABLE-NOT: filename: "x:/path-to/cl-pathmap.c"
 
 //NOTE: currently . and .\ just gets eliminated after mapping 
 // RUN: %clang_cl -E /pathmap:%p=. %s | FileCheck %s --check-prefix CHECK-SIMPLE

--- a/clang/test/Preprocessor/cl-pathmap.c
+++ b/clang/test/Preprocessor/cl-pathmap.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cl -E /pathmap:%p=x:/path-to/ %s | FileCheck %s --check-prefix CHECK-REPRODUCABLE
+// CHECK-REPRODUCABLE: filename: "x:\\path-to\\cl-pathmap.c"
+// CHECK-REPRODUCABLE-NOT: filename:
+// CHECK-REPRODUCABLE-NOT: filename: "x:/path-to/cl-pathmap.c"
+
+//NOTE: currently . and .\ just gets eliminated after mapping 
+// RUN: %clang_cl -E /pathmap:%p=. %s | FileCheck %s --check-prefix CHECK-SIMPLE
+// CHECK-SIMPLE: filename: "cl-pathmap.c"
+// CHECK-SIMPLE-NOT: filename:
+filename: __FILE__


### PR DESCRIPTION
This option matches MSVC options and does the path substitution for the file
references in the preprocessor macros, debug and coverage information.

This option acts as a clang's ``-ffile-prefix-map=value`` and with some known
differences in behaviour with original CL's option that do not affect 
the functionality:
 * nomalizes the macro prefix map pathes -- removes `./` and uses the target's 
   platform-specific path separator character when exanding the preprocessor
   macros -- ``-ffile-reproducible`` (but not the debug and coverage prefix maps).
 * does not require ``/experimental:deterministic`` as by MSVC. It needed for
   removing a hostname from a mangling hash gen, but clang-cl does not use a hostname 
   when generates the hashes.

Known issues:
  * does not remap the pathes within PCH/PCM files.
