### PR TITLE
[NFC] Remove fractional part of Estimated cost per lane in memory-interleave.ll

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/WebAssembly/memory-interleave.ll
+++ b/llvm/test/Transforms/LoopVectorize/WebAssembly/memory-interleave.ll
@@ -26,14 +26,14 @@ target triple = "wasm32-unknown-wasi"
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 2: 27 (Estimated cost per lane: 13.5)
+; CHECK: Cost for VF 2: 27 (Estimated cost per lane: 13.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 4: 24 (Estimated cost per lane: 6.0)
+; CHECK: Cost for VF 4: 24 (Estimated cost per lane: 6.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_ints_same_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -71,14 +71,14 @@ define hidden void @two_ints_same_op(ptr noalias nocapture noundef writeonly %0,
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 2: 27 (Estimated cost per lane: 13.5)
+; CHECK: Cost for VF 2: 27 (Estimated cost per lane: 13.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 4: 24 (Estimated cost per lane: 6.0)
+; CHECK: Cost for VF 4: 24 (Estimated cost per lane: 6.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_ints_vary_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -113,11 +113,11 @@ define hidden void @two_ints_vary_op(ptr noalias nocapture noundef writeonly %0,
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.5)
+; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 12 for VF 4: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.8)
+; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @three_ints(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -159,15 +159,15 @@ define hidden void @three_ints(ptr noalias nocapture noundef writeonly %0, ptr n
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.5)
+; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 12 for VF 4: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.8)
+; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.
 ; CHECK: Cost of 24 for VF 8: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 24 for VF 8: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 24 for VF 8: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 8: 223 (Estimated cost per lane: 27.9)
+; CHECK: Cost for VF 8: 223 (Estimated cost per lane: 27.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @three_shorts(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -216,7 +216,7 @@ define hidden void @three_shorts(ptr noalias nocapture noundef writeonly %0, ptr
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 2: 62 (Estimated cost per lane: 31.0)
+; CHECK: Cost for VF 2: 62 (Estimated cost per lane: 31.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -227,7 +227,7 @@ define hidden void @three_shorts(ptr noalias nocapture noundef writeonly %0, ptr
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.5)
+; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.
 ; CHECK: Cost of 68 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -238,7 +238,7 @@ define hidden void @three_shorts(ptr noalias nocapture noundef writeonly %0, ptr
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 8: 212 (Estimated cost per lane: 26.5)
+; CHECK: Cost for VF 8: 212 (Estimated cost per lane: 26.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_shorts_same_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -294,7 +294,7 @@ define hidden void @four_shorts_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 2: 62 (Estimated cost per lane: 31.0)
+; CHECK: Cost for VF 2: 62 (Estimated cost per lane: 31.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -305,7 +305,7 @@ define hidden void @four_shorts_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.5)
+; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.
 ; CHECK: Cost of 68 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -316,7 +316,7 @@ define hidden void @four_shorts_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 8: 212 (Estimated cost per lane: 26.5)
+; CHECK: Cost for VF 8: 212 (Estimated cost per lane: 26.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_shorts_split_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -372,7 +372,7 @@ define hidden void @four_shorts_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 2: 62 (Estimated cost per lane: 31.0)
+; CHECK: Cost for VF 2: 62 (Estimated cost per lane: 31.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -383,7 +383,7 @@ define hidden void @four_shorts_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.5)
+; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.
 ; CHECK: Cost of 68 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -394,7 +394,7 @@ define hidden void @four_shorts_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 8: 212 (Estimated cost per lane: 26.5)
+; CHECK: Cost for VF 8: 212 (Estimated cost per lane: 26.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_shorts_interleave_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -443,7 +443,7 @@ define hidden void @four_shorts_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 99 (Estimated cost per lane: 49.5)
+; CHECK: Cost for VF 2: 99 (Estimated cost per lane: 49.
 ; CHECK: Cost of 42 for VF 4: INTERLEAVE-GROUP with factor 5 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -456,7 +456,7 @@ define hidden void @four_shorts_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
 ; CHECK-NEXT:   store ir<%37> to index 4
-; CHECK: Cost for VF 4: 135 (Estimated cost per lane: 33.8)
+; CHECK: Cost for VF 4: 135 (Estimated cost per lane: 33.
 ; CHECK: Cost of 84 for VF 8: INTERLEAVE-GROUP with factor 5 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -469,7 +469,7 @@ define hidden void @four_shorts_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
 ; CHECK-NEXT:   store ir<%37> to index 4
-; CHECK: Cost for VF 8: 261 (Estimated cost per lane: 32.6)
+; CHECK: Cost for VF 8: 261 (Estimated cost per lane: 32.
 ; CHECK: Cost of 168 for VF 16: INTERLEAVE-GROUP with factor 5 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -482,7 +482,7 @@ define hidden void @four_shorts_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
 ; CHECK-NEXT:   store ir<%37> to index 4
-; CHECK: Cost for VF 16: 513 (Estimated cost per lane: 32.1)
+; CHECK: Cost for VF 16: 513 (Estimated cost per lane: 32.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @five_shorts(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -538,28 +538,28 @@ define hidden void @five_shorts(ptr noalias nocapture noundef writeonly %0, ptr 
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 52 (Estimated cost per lane: 26.0)
+; CHECK: Cost for VF 2: 52 (Estimated cost per lane: 26.
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 4: 61 (Estimated cost per lane: 15.2)
+; CHECK: Cost for VF 4: 61 (Estimated cost per lane: 15.
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 8: 33 (Estimated cost per lane: 4.1)
+; CHECK: Cost for VF 8: 33 (Estimated cost per lane: 4.
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 16: 30 (Estimated cost per lane: 1.9)
+; CHECK: Cost for VF 16: 30 (Estimated cost per lane: 1.
 ; CHECK: LV: Selecting VF: 16.
 define hidden void @two_bytes_same_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -594,28 +594,28 @@ define hidden void @two_bytes_same_op(ptr noalias nocapture noundef writeonly %0
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 47 (Estimated cost per lane: 23.5)
+; CHECK: Cost for VF 2: 47 (Estimated cost per lane: 23.
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 4: 50 (Estimated cost per lane: 12.5)
+; CHECK: Cost for VF 4: 50 (Estimated cost per lane: 12.
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 8: 30 (Estimated cost per lane: 3.8)
+; CHECK: Cost for VF 8: 30 (Estimated cost per lane: 3.
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at <badref>, ir<%14>
 ; CHECK-NEXT:   store ir<%13> to index 0
 ; CHECK-NEXT:   store ir<%19> to index 1
-; CHECK: Cost for VF 16: 27 (Estimated cost per lane: 1.7)
+; CHECK: Cost for VF 16: 27 (Estimated cost per lane: 1.
 ; CHECK: LV: Selecting VF: 16.
 define hidden void @two_bytes_vary_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -650,19 +650,19 @@ define hidden void @two_bytes_vary_op(ptr noalias nocapture noundef writeonly %0
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.5)
+; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 12 for VF 4: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.8)
+; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.
 ; CHECK: Cost of 24 for VF 8: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 24 for VF 8: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 24 for VF 8: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 8: 223 (Estimated cost per lane: 27.9)
+; CHECK: Cost for VF 8: 223 (Estimated cost per lane: 27.
 ; CHECK: Cost of 48 for VF 16: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 48 for VF 16: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 48 for VF 16: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 16: 439 (Estimated cost per lane: 27.4)
+; CHECK: Cost for VF 16: 439 (Estimated cost per lane: 27.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @three_bytes_same_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -704,19 +704,19 @@ define hidden void @three_bytes_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.5)
+; CHECK: Cost for VF 2: 61 (Estimated cost per lane: 30.
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 12 for VF 4: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 12 for VF 4: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.8)
+; CHECK: Cost for VF 4: 115 (Estimated cost per lane: 28.
 ; CHECK: Cost of 24 for VF 8: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 24 for VF 8: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 24 for VF 8: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 8: 223 (Estimated cost per lane: 27.9)
+; CHECK: Cost for VF 8: 223 (Estimated cost per lane: 27.
 ; CHECK: Cost of 48 for VF 16: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 48 for VF 16: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 48 for VF 16: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 16: 439 (Estimated cost per lane: 27.4)
+; CHECK: Cost for VF 16: 439 (Estimated cost per lane: 27.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @three_bytes_interleave_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -758,7 +758,7 @@ define hidden void @three_bytes_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 80 (Estimated cost per lane: 40.0)
+; CHECK: Cost for VF 2: 80 (Estimated cost per lane: 40.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -769,7 +769,7 @@ define hidden void @three_bytes_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.5)
+; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.
 ; CHECK: Cost of 26 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -780,7 +780,7 @@ define hidden void @three_bytes_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 8: 86 (Estimated cost per lane: 10.8)
+; CHECK: Cost for VF 8: 86 (Estimated cost per lane: 10.
 ; CHECK: Cost of 132 for VF 16: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -791,7 +791,7 @@ define hidden void @three_bytes_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 16: 404 (Estimated cost per lane: 25.2)
+; CHECK: Cost for VF 16: 404 (Estimated cost per lane: 25.
 ; CHECK: LV: Selecting VF: 8.
 define hidden void @four_bytes_same_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -840,7 +840,7 @@ define hidden void @four_bytes_same_op(ptr noalias nocapture noundef writeonly %
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 90 (Estimated cost per lane: 45.0)
+; CHECK: Cost for VF 2: 90 (Estimated cost per lane: 45.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -851,7 +851,7 @@ define hidden void @four_bytes_same_op(ptr noalias nocapture noundef writeonly %
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 4: 84 (Estimated cost per lane: 21.0)
+; CHECK: Cost for VF 4: 84 (Estimated cost per lane: 21.
 ; CHECK: Cost of 26 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -862,7 +862,7 @@ define hidden void @four_bytes_same_op(ptr noalias nocapture noundef writeonly %
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 8: 92 (Estimated cost per lane: 11.5)
+; CHECK: Cost for VF 8: 92 (Estimated cost per lane: 11.
 ; CHECK: Cost of 132 for VF 16: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -873,7 +873,7 @@ define hidden void @four_bytes_same_op(ptr noalias nocapture noundef writeonly %
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 16: 410 (Estimated cost per lane: 25.6)
+; CHECK: Cost for VF 16: 410 (Estimated cost per lane: 25.
 ; CHECK: LV: Selecting VF: 8.
 define hidden void @four_bytes_split_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -923,7 +923,7 @@ define hidden void @four_bytes_split_op(ptr noalias nocapture noundef writeonly 
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%10> = load ir<%9>
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%12> = load ir<%11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%13>, ir<%14>
-; CHECK: Cost for VF 2: 80 (Estimated cost per lane: 40.0)
+; CHECK: Cost for VF 2: 80 (Estimated cost per lane: 40.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -934,7 +934,7 @@ define hidden void @four_bytes_split_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.5)
+; CHECK: Cost for VF 4: 62 (Estimated cost per lane: 15.
 ; CHECK: Cost of 26 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -945,7 +945,7 @@ define hidden void @four_bytes_split_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 8: 86 (Estimated cost per lane: 10.8)
+; CHECK: Cost for VF 8: 86 (Estimated cost per lane: 10.
 ; CHECK: Cost of 132 for VF 16: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -956,7 +956,7 @@ define hidden void @four_bytes_split_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%19> to index 1
 ; CHECK-NEXT:   store ir<%25> to index 2
 ; CHECK-NEXT:   store ir<%31> to index 3
-; CHECK: Cost for VF 16: 404 (Estimated cost per lane: 25.2)
+; CHECK: Cost for VF 16: 404 (Estimated cost per lane: 25.
 ; CHECK: LV: Selecting VF: 8.
 define hidden void @four_bytes_interleave_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -1021,7 +1021,7 @@ define hidden void @four_bytes_interleave_op(ptr noalias nocapture noundef write
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 2: 154 (Estimated cost per lane: 77.0)
+; CHECK: Cost for VF 2: 154 (Estimated cost per lane: 77.
 ; CHECK: Cost of 66 for VF 4: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1040,7 +1040,7 @@ define hidden void @four_bytes_interleave_op(ptr noalias nocapture noundef write
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 4: 298 (Estimated cost per lane: 74.5)
+; CHECK: Cost for VF 4: 298 (Estimated cost per lane: 74.
 ; CHECK: Cost of 132 for VF 8: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1059,7 +1059,7 @@ define hidden void @four_bytes_interleave_op(ptr noalias nocapture noundef write
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 8: 432 (Estimated cost per lane: 54.0)
+; CHECK: Cost for VF 8: 432 (Estimated cost per lane: 54.
 ; CHECK: Cost of 264 for VF 16: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1078,7 +1078,7 @@ define hidden void @four_bytes_interleave_op(ptr noalias nocapture noundef write
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 16: 828 (Estimated cost per lane: 51.8)
+; CHECK: Cost for VF 16: 828 (Estimated cost per lane: 51.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @eight_bytes_same_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -1170,7 +1170,7 @@ define hidden void @eight_bytes_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 2: 114 (Estimated cost per lane: 57.0)
+; CHECK: Cost for VF 2: 114 (Estimated cost per lane: 57.
 ; CHECK: Cost of 66 for VF 4: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1189,7 +1189,7 @@ define hidden void @eight_bytes_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 4: 210 (Estimated cost per lane: 52.5)
+; CHECK: Cost for VF 4: 210 (Estimated cost per lane: 52.
 ; CHECK: Cost of 132 for VF 8: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1208,7 +1208,7 @@ define hidden void @eight_bytes_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 8: 408 (Estimated cost per lane: 51.0)
+; CHECK: Cost for VF 8: 408 (Estimated cost per lane: 51.
 ; CHECK: Cost of 264 for VF 16: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1227,7 +1227,7 @@ define hidden void @eight_bytes_same_op(ptr noalias nocapture noundef writeonly 
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 16: 804 (Estimated cost per lane: 50.2)
+; CHECK: Cost for VF 16: 804 (Estimated cost per lane: 50.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @eight_bytes_split_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -1319,7 +1319,7 @@ define hidden void @eight_bytes_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 2: 114 (Estimated cost per lane: 57.0)
+; CHECK: Cost for VF 2: 114 (Estimated cost per lane: 57.
 ; CHECK: Cost of 66 for VF 4: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1338,7 +1338,7 @@ define hidden void @eight_bytes_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 4: 210 (Estimated cost per lane: 52.5)
+; CHECK: Cost for VF 4: 210 (Estimated cost per lane: 52.
 ; CHECK: Cost of 132 for VF 8: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1357,7 +1357,7 @@ define hidden void @eight_bytes_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 8: 408 (Estimated cost per lane: 51.0)
+; CHECK: Cost for VF 8: 408 (Estimated cost per lane: 51.
 ; CHECK: Cost of 264 for VF 16: INTERLEAVE-GROUP with factor 8 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%16> = load from index 1
@@ -1376,7 +1376,7 @@ define hidden void @eight_bytes_split_op(ptr noalias nocapture noundef writeonly
 ; CHECK-NEXT:   store ir<%43> to index 5
 ; CHECK-NEXT:   store ir<%49> to index 6
 ; CHECK-NEXT:   store ir<%55> to index 7
-; CHECK: Cost for VF 16: 804 (Estimated cost per lane: 50.2)
+; CHECK: Cost for VF 16: 804 (Estimated cost per lane: 50.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @eight_bytes_interleave_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -1463,7 +1463,7 @@ define hidden void @eight_bytes_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%28> to index 1
 ; CHECK-NEXT:   store ir<%38> to index 2
 ; CHECK-NEXT:   store ir<%48> to index 3
-; CHECK: Cost for VF 2: 88 (Estimated cost per lane: 44.0)
+; CHECK: Cost for VF 2: 88 (Estimated cost per lane: 44.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%20> = load from index 1
@@ -1475,7 +1475,7 @@ define hidden void @eight_bytes_interleave_op(ptr noalias nocapture noundef writ
 ; CHECK-NEXT:   store ir<%28> to index 1
 ; CHECK-NEXT:   store ir<%38> to index 2
 ; CHECK-NEXT:   store ir<%48> to index 3
-; CHECK: Cost for VF 4: 104 (Estimated cost per lane: 26.0)
+; CHECK: Cost for VF 4: 104 (Estimated cost per lane: 26.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_bytes_into_four_ints_same_op(ptr noalias nocapture noundef %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -1545,7 +1545,7 @@ define hidden void @four_bytes_into_four_ints_same_op(ptr noalias nocapture noun
 ; CHECK-NEXT:   store ir<%23> to index 1
 ; CHECK-NEXT:   store ir<%31> to index 2
 ; CHECK-NEXT:   store ir<%38> to index 3
-; CHECK: Cost for VF 2: 71 (Estimated cost per lane: 35.5)
+; CHECK: Cost for VF 2: 71 (Estimated cost per lane: 35.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, ir<%9>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%18> = load from index 1
@@ -1557,7 +1557,7 @@ define hidden void @four_bytes_into_four_ints_same_op(ptr noalias nocapture noun
 ; CHECK-NEXT:   store ir<%23> to index 1
 ; CHECK-NEXT:   store ir<%31> to index 2
 ; CHECK-NEXT:   store ir<%38> to index 3
-; CHECK: Cost for VF 4: 80 (Estimated cost per lane: 20.0)
+; CHECK: Cost for VF 4: 80 (Estimated cost per lane: 20.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_bytes_into_four_ints_vary_op(ptr noalias nocapture noundef writeonly %0, ptr nocapture noundef readonly %1, ptr nocapture noundef readonly %2, i32 noundef %3) {
   %5 = icmp eq i32 %3, 0
@@ -1616,21 +1616,21 @@ define hidden void @four_bytes_into_four_ints_vary_op(ptr noalias nocapture noun
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%11> to index 0
 ; CHECK-NEXT:   store ir<%13> to index 1
-; CHECK: Cost for VF 4: 35 (Estimated cost per lane: 8.8)
+; CHECK: Cost for VF 4: 35 (Estimated cost per lane: 8.
 ; CHECK: Cost of 26 for VF 8: INTERLEAVE-GROUP with factor 4 at %11, ir<%10>
 ; CHECK-NEXT:   ir<%11> = load from index 0
 ; CHECK-NEXT:   ir<%13> = load from index 1
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%11> to index 0
 ; CHECK-NEXT:   store ir<%13> to index 1
-; CHECK: Cost for VF 8: 39 (Estimated cost per lane: 4.9)
+; CHECK: Cost for VF 8: 39 (Estimated cost per lane: 4.
 ; CHECK: Cost of 68 for VF 16: INTERLEAVE-GROUP with factor 4 at %11, ir<%10>
 ; CHECK-NEXT:   ir<%11> = load from index 0
 ; CHECK-NEXT:   ir<%13> = load from index 1
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%11> to index 0
 ; CHECK-NEXT:   store ir<%13> to index 1
-; CHECK: Cost for VF 16: 80 (Estimated cost per lane: 5.0)
+; CHECK: Cost for VF 16: 80 (Estimated cost per lane: 5.
 ; CHECK: LV: Selecting VF: 8.
 define hidden void @scale_uv_row_down2(ptr nocapture noundef readonly %0, i32 noundef %1, ptr nocapture noundef writeonly %2, i32 noundef %3) {
   %5 = icmp sgt i32 %3, 0
@@ -1663,7 +1663,7 @@ define hidden void @scale_uv_row_down2(ptr nocapture noundef readonly %0, i32 no
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%17> = load ir<%16> (!alias.scope {{.*}})
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%20> = load ir<%19> (!alias.scope {{.*}})
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%48>, ir<%49>
-; CHECK: Cost for VF 2: 78 (Estimated cost per lane: 39.0)
+; CHECK: Cost for VF 2: 78 (Estimated cost per lane: 39.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %14, vp<%next.gep>
 ; CHECK-NEXT:   ir<%14> = load from index 0
 ; CHECK-NEXT:   ir<%32> = load from index 1
@@ -1673,7 +1673,7 @@ define hidden void @scale_uv_row_down2(ptr nocapture noundef readonly %0, i32 no
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%30> to index 0
 ; CHECK-NEXT:   store ir<%48> to index 1
-; CHECK: Cost for VF 4: 73 (Estimated cost per lane: 18.2)
+; CHECK: Cost for VF 4: 73 (Estimated cost per lane: 18.
 ; CHECK: Cost of 26 for VF 8: INTERLEAVE-GROUP with factor 4 at %14, vp<%next.gep>
 ; CHECK-NEXT:   ir<%14> = load from index 0
 ; CHECK-NEXT:   ir<%32> = load from index 1
@@ -1683,7 +1683,7 @@ define hidden void @scale_uv_row_down2(ptr nocapture noundef readonly %0, i32 no
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%30> to index 0
 ; CHECK-NEXT:   store ir<%48> to index 1
-; CHECK: Cost for VF 8: 89 (Estimated cost per lane: 11.1)
+; CHECK: Cost for VF 8: 89 (Estimated cost per lane: 11.
 ; CHECK: Cost of 132 for VF 16: INTERLEAVE-GROUP with factor 4 at %14, vp<%next.gep>
 ; CHECK-NEXT:   ir<%14> = load from index 0
 ; CHECK-NEXT:   ir<%32> = load from index 1
@@ -1693,7 +1693,7 @@ define hidden void @scale_uv_row_down2(ptr nocapture noundef readonly %0, i32 no
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%30> to index 0
 ; CHECK-NEXT:   store ir<%48> to index 1
-; CHECK: Cost for VF 16: 322 (Estimated cost per lane: 20.1)
+; CHECK: Cost for VF 16: 322 (Estimated cost per lane: 20.
 ; CHECK: LV: Selecting VF: 8.
 define hidden void @scale_uv_row_down2_box(ptr nocapture noundef readonly %0, i32 noundef %1, ptr nocapture noundef writeonly %2, i32 noundef %3) {
   %5 = icmp sgt i32 %3, 0
@@ -1763,7 +1763,7 @@ define hidden void @scale_uv_row_down2_box(ptr nocapture noundef readonly %0, i3
 ; CHECK: Cost of 6 for VF 2: REPLICATE ir<%13> = load ir<%12> (!alias.scope {{.*}})
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%18>, vp<%next.gep>.1 (!alias.scope {{.*}}, !noalias {{.*}})
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%28>, ir<%29>
-; CHECK: Cost for VF 2: 50 (Estimated cost per lane: 25.0)
+; CHECK: Cost for VF 2: 50 (Estimated cost per lane: 25.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %10, vp<%next.gep>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%20> = load from index 1
@@ -1772,7 +1772,7 @@ define hidden void @scale_uv_row_down2_box(ptr nocapture noundef readonly %0, i3
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%18> to index 0
 ; CHECK-NEXT:   store ir<%28> to index 1
-; CHECK: Cost for VF 4: 47 (Estimated cost per lane: 11.8)
+; CHECK: Cost for VF 4: 47 (Estimated cost per lane: 11.
 ; CHECK: Cost of 26 for VF 8: INTERLEAVE-GROUP with factor 4 at %10, vp<%next.gep>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%20> = load from index 1
@@ -1781,7 +1781,7 @@ define hidden void @scale_uv_row_down2_box(ptr nocapture noundef readonly %0, i3
 ; CHECK: Cost of 7 for VF 8: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%18> to index 0
 ; CHECK-NEXT:   store ir<%28> to index 1
-; CHECK: Cost for VF 8: 55 (Estimated cost per lane: 6.9)
+; CHECK: Cost for VF 8: 55 (Estimated cost per lane: 6.
 ; CHECK: Cost of 132 for VF 16: INTERLEAVE-GROUP with factor 4 at %10, vp<%next.gep>
 ; CHECK-NEXT:   ir<%10> = load from index 0
 ; CHECK-NEXT:   ir<%20> = load from index 1
@@ -1790,7 +1790,7 @@ define hidden void @scale_uv_row_down2_box(ptr nocapture noundef readonly %0, i3
 ; CHECK: Cost of 6 for VF 16: INTERLEAVE-GROUP with factor 2 at <badref>, vp<%next.gep>.1
 ; CHECK-NEXT:   store ir<%18> to index 0
 ; CHECK-NEXT:   store ir<%28> to index 1
-; CHECK: Cost for VF 16: 174 (Estimated cost per lane: 10.9)
+; CHECK: Cost for VF 16: 174 (Estimated cost per lane: 10.
 ; CHECK: LV: Selecting VF: 8.
 define hidden void @scale_uv_row_down2_linear(ptr nocapture noundef readonly %0, i32 noundef %1, ptr nocapture noundef writeonly %2, i32 noundef %3) {
   %5 = icmp sgt i32 %3, 0
@@ -1843,7 +1843,7 @@ define hidden void @scale_uv_row_down2_linear(ptr nocapture noundef readonly %0,
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%mul> to index 0
 ; CHECK-NEXT:   store ir<%mul8> to index 1
-; CHECK: Cost for VF 2: 29 (Estimated cost per lane: 14.5)
+; CHECK: Cost for VF 2: 29 (Estimated cost per lane: 14.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -1853,7 +1853,7 @@ define hidden void @scale_uv_row_down2_linear(ptr nocapture noundef readonly %0,
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%mul> to index 0
 ; CHECK-NEXT:   store ir<%mul8> to index 1
-; CHECK: Cost for VF 4: 26 (Estimated cost per lane: 6.5)
+; CHECK: Cost for VF 4: 26 (Estimated cost per lane: 6.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_floats_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -1895,7 +1895,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%add> to index 0
 ; CHECK-NEXT:   store ir<%sub> to index 1
-; CHECK: Cost for VF 2: 29 (Estimated cost per lane: 14.5)
+; CHECK: Cost for VF 2: 29 (Estimated cost per lane: 14.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -1905,7 +1905,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%add> to index 0
 ; CHECK-NEXT:   store ir<%sub> to index 1
-; CHECK: Cost for VF 4: 26 (Estimated cost per lane: 6.5)
+; CHECK: Cost for VF 4: 26 (Estimated cost per lane: 6.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_floats_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -1944,7 +1944,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%mul> to index 0
 ; CHECK-NEXT:   store ir<%mul11> to index 1
-; CHECK: Cost for VF 2: 51 (Estimated cost per lane: 25.5)
+; CHECK: Cost for VF 2: 51 (Estimated cost per lane: 25.
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -1954,7 +1954,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%mul> to index 0
 ; CHECK-NEXT:   store ir<%mul11> to index 1
-; CHECK: Cost for VF 4: 48 (Estimated cost per lane: 12.0)
+; CHECK: Cost for VF 4: 48 (Estimated cost per lane: 12.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_bytes_two_floats_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -1997,7 +1997,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%add> to index 0
 ; CHECK-NEXT:   store ir<%sub> to index 1
-; CHECK: Cost for VF 2: 51 (Estimated cost per lane: 25.5)
+; CHECK: Cost for VF 2: 51 (Estimated cost per lane: 25.
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2007,7 +2007,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%add> to index 0
 ; CHECK-NEXT:   store ir<%sub> to index 1
-; CHECK: Cost for VF 4: 48 (Estimated cost per lane: 12.0)
+; CHECK: Cost for VF 4: 48 (Estimated cost per lane: 12.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_bytes_two_floats_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2052,7 +2052,7 @@ for.body:
 ; CHECK-NEXT:   ir<%3> = load from index 1
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv>, ir<%arrayidx3>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv9>, ir<%y11>
-; CHECK: Cost for VF 2: 46 (Estimated cost per lane: 23.0)
+; CHECK: Cost for VF 2: 46 (Estimated cost per lane: 23.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2062,7 +2062,7 @@ for.body:
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%conv> to index 0
 ; CHECK-NEXT:   store ir<%conv9> to index 1
-; CHECK: Cost for VF 4: 43 (Estimated cost per lane: 10.8)
+; CHECK: Cost for VF 4: 43 (Estimated cost per lane: 10.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_floats_two_bytes_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2105,7 +2105,7 @@ for.body:
 ; CHECK-NEXT:   ir<%3> = load from index 1
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv8>
-; CHECK: Cost for VF 2: 46 (Estimated cost per lane: 23.0)
+; CHECK: Cost for VF 2: 46 (Estimated cost per lane: 23.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2115,7 +2115,7 @@ for.body:
 ; CHECK: Cost of 11 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%conv> to index 0
 ; CHECK-NEXT:   store ir<%conv8> to index 1
-; CHECK: Cost for VF 4: 43 (Estimated cost per lane: 10.8)
+; CHECK: Cost for VF 4: 43 (Estimated cost per lane: 10.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_floats_two_bytes_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2159,7 +2159,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%mul> to index 0
 ; CHECK-NEXT:   store ir<%mul11> to index 1
-; CHECK: Cost for VF 2: 45 (Estimated cost per lane: 22.5)
+; CHECK: Cost for VF 2: 45 (Estimated cost per lane: 22.
 ; CHECK: Cost of 7 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2169,7 +2169,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%mul> to index 0
 ; CHECK-NEXT:   store ir<%mul11> to index 1
-; CHECK: Cost for VF 4: 36 (Estimated cost per lane: 9.0)
+; CHECK: Cost for VF 4: 36 (Estimated cost per lane: 9.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_shorts_two_floats_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2215,7 +2215,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%add> to index 0
 ; CHECK-NEXT:   store ir<%sub> to index 1
-; CHECK: Cost for VF 2: 45 (Estimated cost per lane: 22.5)
+; CHECK: Cost for VF 2: 45 (Estimated cost per lane: 22.
 ; CHECK: Cost of 7 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2225,7 +2225,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%add> to index 0
 ; CHECK-NEXT:   store ir<%sub> to index 1
-; CHECK: Cost for VF 4: 36 (Estimated cost per lane: 9.0)
+; CHECK: Cost for VF 4: 36 (Estimated cost per lane: 9.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_shorts_two_floats_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2271,7 +2271,7 @@ for.body:
 ; CHECK: Cost of 11 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%conv> to index 0
 ; CHECK-NEXT:   store ir<%conv9> to index 1
-; CHECK: Cost for VF 2: 41 (Estimated cost per lane: 20.5)
+; CHECK: Cost for VF 2: 41 (Estimated cost per lane: 20.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2281,7 +2281,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%conv> to index 0
 ; CHECK-NEXT:   store ir<%conv9> to index 1
-; CHECK: Cost for VF 4: 35 (Estimated cost per lane: 8.8)
+; CHECK: Cost for VF 4: 35 (Estimated cost per lane: 8.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_floats_two_shorts_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2325,7 +2325,7 @@ for.body:
 ; CHECK: Cost of 11 for VF 2: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%conv> to index 0
 ; CHECK-NEXT:   store ir<%conv8> to index 1
-; CHECK: Cost for VF 2: 41 (Estimated cost per lane: 20.5)
+; CHECK: Cost for VF 2: 41 (Estimated cost per lane: 20.
 ; CHECK: Cost of 6 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2335,7 +2335,7 @@ for.body:
 ; CHECK: Cost of 7 for VF 4: INTERLEAVE-GROUP with factor 2
 ; CHECK-NEXT:   store ir<%conv> to index 0
 ; CHECK-NEXT:   store ir<%conv8> to index 1
-; CHECK: Cost for VF 4: 35 (Estimated cost per lane: 8.8)
+; CHECK: Cost for VF 4: 35 (Estimated cost per lane: 8.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @two_floats_two_shorts_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2385,8 +2385,8 @@ for.body:
 ; CHECK-NEXT:   store ir<%mul8> to index 1
 ; CHECK-NEXT:   store ir<%mul14> to index 2
 ; CHECK-NEXT:   store ir<%mul20> to index 3
-; CHECK: Cost for VF 2: 54 (Estimated cost per lane: 27.0)
-; CHECK: Cost for VF 4: 12 (Estimated cost per lane: 3.0)
+; CHECK: Cost for VF 2: 54 (Estimated cost per lane: 27.
+; CHECK: Cost for VF 4: 12 (Estimated cost per lane: 3.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_floats_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2448,7 +2448,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%sub> to index 1
 ; CHECK-NEXT:   store ir<%mul> to index 2
 ; CHECK-NEXT:   store ir<%div> to index 3
-; CHECK: Cost for VF 2: 54 (Estimated cost per lane: 27.0)
+; CHECK: Cost for VF 2: 54 (Estimated cost per lane: 27.
 ; CHECK: Cost of 36 for VF 4: INTERLEAVE-GROUP with factor 4
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2464,7 +2464,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%sub> to index 1
 ; CHECK-NEXT:   store ir<%mul> to index 2
 ; CHECK-NEXT:   store ir<%div> to index 3
-; CHECK: Cost for VF 4: 120 (Estimated cost per lane: 30.0)
+; CHECK: Cost for VF 4: 120 (Estimated cost per lane: 30.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @four_floats_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2519,7 +2519,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%mul11> to index 1
 ; CHECK-NEXT:   store ir<%mul19> to index 2
 ; CHECK-NEXT:   store ir<%mul27> to index 3
-; CHECK: Cost for VF 2: 98 (Estimated cost per lane: 49.0)
+; CHECK: Cost for VF 2: 98 (Estimated cost per lane: 49.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2535,7 +2535,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%mul11> to index 1
 ; CHECK-NEXT:   store ir<%mul19> to index 2
 ; CHECK-NEXT:   store ir<%mul27> to index 3
-; CHECK: Cost for VF 4: 108 (Estimated cost per lane: 27.0)
+; CHECK: Cost for VF 4: 108 (Estimated cost per lane: 27.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_bytes_four_floats_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2598,7 +2598,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%add> to index 1
 ; CHECK-NEXT:   store ir<%div> to index 2
 ; CHECK-NEXT:   store ir<%sub> to index 3
-; CHECK: Cost for VF 2: 98 (Estimated cost per lane: 49.0)
+; CHECK: Cost for VF 2: 98 (Estimated cost per lane: 49.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2614,7 +2614,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%add> to index 1
 ; CHECK-NEXT:   store ir<%div> to index 2
 ; CHECK-NEXT:   store ir<%sub> to index 3
-; CHECK: Cost for VF 4: 108 (Estimated cost per lane: 27.0)
+; CHECK: Cost for VF 4: 108 (Estimated cost per lane: 27.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_bytes_four_floats_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2682,7 +2682,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv>, ir<%arrayidx3>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv9>, ir<%y11>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv16>, ir<%z18>
-; CHECK: Cost for VF 2: 88 (Estimated cost per lane: 44.0)
+; CHECK: Cost for VF 2: 88 (Estimated cost per lane: 44.
 ; CHECK: Cost of 36 for VF 4: INTERLEAVE-GROUP with factor 4 at %0, ir<%arrayidx>
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2694,7 +2694,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%conv9> to index 1
 ; CHECK-NEXT:   store ir<%conv16> to index 2
 ; CHECK-NEXT:   store ir<%conv23> to index 3
-; CHECK: Cost for VF 4: 126 (Estimated cost per lane: 31.5)
+; CHECK: Cost for VF 4: 126 (Estimated cost per lane: 31.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @four_floats_four_bytes_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2758,7 +2758,7 @@ for.body:
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv>, ir<%arrayidx3>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv8>, ir<%y10>
 ; CHECK: Cost of 6 for VF 2: REPLICATE store ir<%conv14>, ir<%z16>
-; CHECK: Cost for VF 2: 88 (Estimated cost per lane: 44.0)
+; CHECK: Cost for VF 2: 88 (Estimated cost per lane: 44.
 ; CHECK: Cost of 36 for VF 4: INTERLEAVE-GROUP with factor 4 at %0, ir<%arrayidx>
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2770,7 +2770,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%conv8> to index 1
 ; CHECK-NEXT:   store ir<%conv14> to index 2
 ; CHECK-NEXT:   store ir<%conv20> to index 3
-; CHECK: Cost for VF 4: 126 (Estimated cost per lane: 31.5)
+; CHECK: Cost for VF 4: 126 (Estimated cost per lane: 31.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @four_floats_four_bytes_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2832,7 +2832,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%mul11> to index 1
 ; CHECK-NEXT:   store ir<%mul19> to index 2
 ; CHECK-NEXT:   store ir<%mul27> to index 3
-; CHECK: Cost for VF 2: 78 (Estimated cost per lane: 39.0)
+; CHECK: Cost for VF 2: 78 (Estimated cost per lane: 39.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %0, ir<%arrayidx>
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2844,7 +2844,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%mul11> to index 1
 ; CHECK-NEXT:   store ir<%mul19> to index 2
 ; CHECK-NEXT:   store ir<%mul27> to index 3
-; CHECK: Cost for VF 4: 100 (Estimated cost per lane: 25.0)
+; CHECK: Cost for VF 4: 100 (Estimated cost per lane: 25.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_shorts_four_floats_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2910,7 +2910,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%add> to index 1
 ; CHECK-NEXT:   store ir<%div> to index 2
 ; CHECK-NEXT:   store ir<%sub> to index 3
-; CHECK: Cost for VF 2: 78 (Estimated cost per lane: 39.0)
+; CHECK: Cost for VF 2: 78 (Estimated cost per lane: 39.
 ; CHECK: Cost of 18 for VF 4: INTERLEAVE-GROUP with factor 4 at %0, ir<%arrayidx>
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -2922,7 +2922,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%add> to index 1
 ; CHECK-NEXT:   store ir<%div> to index 2
 ; CHECK-NEXT:   store ir<%sub> to index 3
-; CHECK: Cost for VF 4: 100 (Estimated cost per lane: 25.0)
+; CHECK: Cost for VF 4: 100 (Estimated cost per lane: 25.
 ; CHECK: LV: Selecting VF: 4.
 define hidden void @four_shorts_four_floats_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -2992,7 +2992,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%conv9> to index 1
 ; CHECK-NEXT:   store ir<%conv16> to index 2
 ; CHECK-NEXT:   store ir<%conv23> to index 3
-; CHECK: Cost for VF 2: 74 (Estimated cost per lane: 37.0)
+; CHECK: Cost for VF 2: 74 (Estimated cost per lane: 37.
 ; CHECK: Cost of 36 for VF 4: INTERLEAVE-GROUP with factor 4 at %0, ir<%arrayidx>
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -3004,7 +3004,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%conv9> to index 1
 ; CHECK-NEXT:   store ir<%conv16> to index 2
 ; CHECK-NEXT:   store ir<%conv23> to index 3
-; CHECK: Cost for VF 4: 118 (Estimated cost per lane: 29.5)
+; CHECK: Cost for VF 4: 118 (Estimated cost per lane: 29.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @four_floats_four_shorts_same_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:
@@ -3070,7 +3070,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%conv8> to index 1
 ; CHECK-NEXT:   store ir<%conv14> to index 2
 ; CHECK-NEXT:   store ir<%conv20> to index 3
-; CHECK: Cost for VF 2: 74 (Estimated cost per lane: 37.0)
+; CHECK: Cost for VF 2: 74 (Estimated cost per lane: 37.
 ; CHECK: Cost of 36 for VF 4: INTERLEAVE-GROUP with factor 4 at %0, ir<%arrayidx>
 ; CHECK-NEXT:   ir<%0> = load from index 0
 ; CHECK-NEXT:   ir<%2> = load from index 1
@@ -3082,7 +3082,7 @@ for.body:
 ; CHECK-NEXT:   store ir<%conv8> to index 1
 ; CHECK-NEXT:   store ir<%conv14> to index 2
 ; CHECK-NEXT:   store ir<%conv20> to index 3
-; CHECK: Cost for VF 4: 118 (Estimated cost per lane: 29.5)
+; CHECK: Cost for VF 4: 118 (Estimated cost per lane: 29.
 ; CHECK: LV: Selecting VF: 1.
 define hidden void @four_floats_four_shorts_vary_op(ptr noundef readonly captures(none) %a, ptr noundef readonly captures(none) %b, ptr noundef writeonly captures(none) %res, i32 noundef %N) {
 entry:


### PR DESCRIPTION
On the memory-interleave.ll test, some of the CHECK lines are failing on z/OS, due to difference in rounding behaviour when printing the Estimated cost per lane. Resolve this by removing the fractional part, similar to what done in the past with https://github.com/llvm/llvm-project/commit/e8556ff6b664df6e595f8aed175eff3a27a4a020 and https://github.com/llvm/llvm-project/commit/aeb88f6778756ea889918308241a2b34bd7f64e2 .