### PR TITLE
[Clang] Emit prefix map normalization before generating hashes for the unique linkage names.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -320,6 +320,11 @@ Modified Compiler Flags
 - The `-mno-outline` flag will now add the `nooutline` IR attribute, so that
   `-mno-outline` and `-moutline` objects can be mixed correctly during LTO.
 
+- Slightly changed hash id generation to get the unique linkage symbols names 
+  by ``-unique-internal-linkage-names`` option. Now it uses a path that
+  normalized in favor of the target system (same as the preprocessor does
+  for the file macros) and allows the reproducable IDs on any build system.
+
 Removed Compiler Flags
 ----------------------
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -48,6 +48,7 @@
 #include "clang/Basic/Version.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
+#include "clang/Lex/Preprocessor.h"
 #include "llvm/ABI/IRTypeMapper.h"
 #include "llvm/ABI/TargetInfo.h"
 #include "llvm/ADT/STLExtras.h"
@@ -548,13 +549,10 @@ CodeGenModule::CodeGenModule(ASTContext &C,
   // Generate the module name hash here if needed.
   if (CodeGenOpts.UniqueInternalLinkageNames &&
       !getModule().getSourceFileName().empty()) {
-    std::string Path = getModule().getSourceFileName();
+    SmallString<256> Path(getModule().getSourceFileName());
     // Check if a path substitution is needed from the MacroPrefixMap.
-    for (const auto &Entry : LangOpts.MacroPrefixMap)
-      if (Path.rfind(Entry.first, 0) != std::string::npos) {
-        Path = Entry.second + Path.substr(Entry.first.size());
-        break;
-      }
+    clang::Preprocessor::processPathForFileMacro(Path, LangOpts,
+                                                 Context.getTargetInfo());
     ModuleNameHash = llvm::getUniqueInternalLinkagePostfix(Path);
   }
 

--- a/clang/test/CodeGen/unique-internal-linkage-names.cpp
+++ b/clang/test/CodeGen/unique-internal-linkage-names.cpp
@@ -1,7 +1,12 @@
 // This test checks if internal linkage symbols get unique names with
 // -funique-internal-linkage-names option.
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -x c++ -emit-llvm -o - < %s | FileCheck %s --check-prefix=PLAIN
+// Note: gets a module path as '-' instead of a full path to the source test file that allows using the same module path for any build environment. 
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -x c++  -emit-llvm -funique-internal-linkage-names -o - < %s | FileCheck %s --check-prefix=UNIQUE
+// Check with path mapping. The unique id must be reproducable for the specified target on any build system.
+// Note: we expect path normalization for the specified prefix map in favor of the target system accordingly.
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -x c++  -emit-llvm -funique-internal-linkage-names -fmacro-prefix-map=%S/=/repro/./src/path/ %s -o - | FileCheck %s --check-prefix=UNIQUE-PATH-MAP-LINUX
+// RUN: %clang_cc1 -triple x86_64-pc-windows-msvc -x c++  -emit-llvm -funique-internal-linkage-names -fmacro-prefix-map=%S/=/repro/src/./path/ %s -o - | FileCheck %s --check-prefix=UNIQUE-PATH-MAP-WINDOWS
 
 static int glob;
 static int foo() {
@@ -76,3 +81,31 @@ void test() {
 // UNIQUE: define internal noundef i32 @_ZL4mverv.[[MODHASH]]()
 // UNIQUE: define internal noundef i32 @_ZL4mverv.[[MODHASH]].sse4.2
 // UNIQUE: attributes #[[#ATTR]] = { {{.*}}"sample-profile-suffix-elision-policy"{{.*}} }
+
+// Expected module path and unique ID
+// /repro/src/path/unique-internal-linkage-names.cpp => __uniq.5283619504002921413211664429594652319
+
+// UNIQUE-PATH-MAP-LINUX: @_ZL4glob = internal global
+// UNIQUE-PATH-MAP-LINUX: @_ZZ8retAnonMvE5fGlob = internal global
+// UNIQUE-PATH-MAP-LINUX: @_ZN12_GLOBAL__N_16anon_mE = internal global
+// UNIQUE-PATH-MAP-LINUX: define internal noundef i32 @_ZL3foov.__uniq.5283619504002921413211664429594652319() #[[#ATTR:]] {
+// UNIQUE-PATH-MAP-LINUX: define internal noundef i32 @_ZN12_GLOBAL__N_14getMEv.__uniq.5283619504002921413211664429594652319
+// UNIQUE-PATH-MAP-LINUX: define internal ptr @_ZL4mverv.__uniq.5283619504002921413211664429594652319.resolver()
+// UNIQUE-PATH-MAP-LINUX: define internal void @_ZN12_GLOBAL__N_11AC1Ev.__uniq.5283619504002921413211664429594652319
+// UNIQUE-PATH-MAP-LINUX: define internal void @_ZN12_GLOBAL__N_11AD1Ev.__uniq.5283619504002921413211664429594652319
+// UNIQUE-PATH-MAP-LINUX: define internal noundef i32 @_ZL4mverv.__uniq.5283619504002921413211664429594652319()
+// UNIQUE-PATH-MAP-LINUX: define internal noundef i32 @_ZL4mverv.__uniq.5283619504002921413211664429594652319.sse4.2
+// UNIQUE-PATH-MAP-LINUX: attributes #[[#ATTR]] = { {{.*}}"sample-profile-suffix-elision-policy"{{.*}} }
+
+// Expected module path and unique ID
+// \repro\src\path\unique-internal-linkage-names.cpp => __uniq.68451533753012730514350177221027644473
+
+// UNIQUE-PATH-MAP-WINDOWS: @glob = internal global
+// UNIQUE-PATH-MAP-WINDOWS: @"?fGlob@?1??retAnonM@@YAHXZ@4HA" = internal global
+// UNIQUE-PATH-MAP-WINDOWS: @"?anon_m@?{{.*}}@@3HA" = internal global
+// UNIQUE-PATH-MAP-WINDOWS: ret ptr @"?foo@@YAHXZ.__uniq.68451533753012730514350177221027644473"
+// UNIQUE-PATH-MAP-WINDOWS: define internal noundef i32 @"?foo@@YAHXZ.__uniq.68451533753012730514350177221027644473"
+// UNIQUE-PATH-MAP-WINDOWS: define internal i32 @"?mver@@YAHXZ.__uniq.68451533753012730514350177221027644473.resolver"()
+// UNIQUE-PATH-MAP-WINDOWS: define internal noundef ptr @"??0A@?{{.*}}@XZ.__uniq.68451533753012730514350177221027644473"
+// UNIQUE-PATH-MAP-WINDOWS: define internal noundef i32 @"?mver@@YAHXZ.__uniq.68451533753012730514350177221027644473"()
+// UNIQUE-PATH-MAP-WINDOWS: define internal noundef i32 @"?mver@@YAHXZ.__uniq.68451533753012730514350177221027644473.sse4.2"()


### PR DESCRIPTION
Use normalized path from the macro prefix map to generate the unique ids for the internal linkage names. That allows a reproducible hash on any build system. Regularly the macro prefix map gets normalized in favor of the target system before the path substitution.