### PR TITLE
[clang][Sema] Make passing a non-POD type to `va_arg` an error, not a warning

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -653,6 +653,7 @@ Miscellaneous Clang Crashes Fixed
 - Fixed an assertion failure when parsing an invalid out-of-line enum definition with template parameters. (#GH187909)
 - Fixed an assertion failure on invalid template template parameter during typo correction. (#GH183983)
 - Fixed an assertion failure in ``isAtEndOfMacroExpansion`` on macro expansions crossing the boundary of two fileIDs. (#GH115007), (#GH21755)
+- Fixed an assertion failure when passing a non-POD type as the second argument to ``va_arg``. (#GH107836)
 
 OpenACC Specific Changes
 ------------------------

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11327,9 +11327,8 @@ def err_second_parameter_to_va_arg_incomplete: Error<
   "second argument to 'va_arg' is of incomplete type %0">;
 def err_second_parameter_to_va_arg_abstract: Error<
   "second argument to 'va_arg' is of abstract type %0">;
-def warn_second_parameter_to_va_arg_not_pod : Warning<
-  "second argument to 'va_arg' is of non-POD type %0">,
-  InGroup<NonPODVarargs>, DefaultError;
+def err_second_parameter_to_va_arg_not_pod : Error<
+  "second argument to 'va_arg' is of non-POD type %0">;
 def warn_second_parameter_to_va_arg_ownership_qualified : Warning<
   "second argument to 'va_arg' is of ARC ownership-qualified type %0">,
   InGroup<NonPODVarargs>, DefaultError;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -17279,10 +17279,9 @@ ExprResult Sema::BuildVAArgExpr(SourceLocation BuiltinLoc,
     if (!TInfo->getType().isPODType(Context)) {
       Diag(TInfo->getTypeLoc().getBeginLoc(),
            TInfo->getType()->isObjCLifetimeType()
-             ? diag::warn_second_parameter_to_va_arg_ownership_qualified
-             : diag::warn_second_parameter_to_va_arg_not_pod)
-        << TInfo->getType()
-        << TInfo->getTypeLoc().getSourceRange();
+               ? diag::warn_second_parameter_to_va_arg_ownership_qualified
+               : diag::err_second_parameter_to_va_arg_not_pod)
+          << TInfo->getType() << TInfo->getTypeLoc().getSourceRange();
     }
 
     if (TInfo->getType()->isArrayType()) {

--- a/clang/test/SemaCXX/va_arg-non-pod-crash.cpp
+++ b/clang/test/SemaCXX/va_arg-non-pod-crash.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -emit-llvm-only -verify -Wno-everything %s
+
+struct NonPODType {
+  NonPODType(const NonPODType&);
+  NonPODType& operator=(const NonPODType&);
+  NonPODType(NonPODType&&);
+  NonPODType& operator=(NonPODType&&);
+};
+
+void f(int first_arg, ...) {
+  __builtin_va_list args;
+  __builtin_va_start(args, first_arg);
+  NonPODType s = __builtin_va_arg(args, NonPODType); // expected-error {{second argument to 'va_arg' is of non-POD type 'NonPODType'}}
+  __builtin_va_end(args);
+}

--- a/clang/test/SemaCXX/vararg-non-pod.cpp
+++ b/clang/test/SemaCXX/vararg-non-pod.cpp
@@ -173,7 +173,7 @@ void t6b(Foo somearg, ... ) {
 void t7(int n, ...) {
   __builtin_va_list list;
   __builtin_va_start(list, n);
-  (void)__builtin_va_arg(list, C); // expected-warning{{second argument to 'va_arg' is of non-POD type 'C'}}
+  (void)__builtin_va_arg(list, C); // expected-error {{second argument to 'va_arg' is of non-POD type 'C'}}
   __builtin_va_end(list);
 }
 


### PR DESCRIPTION
Fixes #107836.

For code like `auto s = va_arg(foo, std::string)`, clang currently emits an error-by-default warning (`-Wnon-pod-varargs`), but if this code gets to the IR generation phase, it trips this assertion:
https://github.com/llvm/llvm-project/blob/d63ca96ec35e963e651d1b8765283117ca83e1f9/clang/lib/CodeGen/CGExprAgg.cpp#L2264-L2270
Make it an unconditional error so that it never gets that far.
