### PR TITLE
[CIR] Lower calling through a variable

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2360,8 +2360,8 @@ CIRGenCallee CIRGenFunction::emitCallee(const clang::Expr *e) {
            "unexpected implicit cast on function pointers");
   } else if (const auto *declRef = dyn_cast<DeclRefExpr>(e)) {
     // Resolve direct calls.
-    const auto *funcDecl = cast<FunctionDecl>(declRef->getDecl());
-    return emitDirectCallee(funcDecl);
+    if (const auto *funcDecl = dyn_cast<FunctionDecl>(declRef->getDecl()))
+      return emitDirectCallee(funcDecl);
   } else if (auto me = dyn_cast<MemberExpr>(e)) {
     if (const auto *fd = dyn_cast<FunctionDecl>(me->getMemberDecl())) {
       emitIgnoredExpr(me->getBase());

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -143,12 +143,12 @@ void use_TakesFunc() {
 
 // CIR-LABEL: _Z9TakesFuncIFivEEDcRKT_
 // CIR-NEXT: %[[FUNC_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.func<() -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, ["f", init, const]
-// CIR-NEXT: %[[FUNC_LOAD:.*]] = cir.load %[[FUNC_ALLOCA]] : !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, !cir.ptr<!cir.func<() -> !s32i>>
+// CIR: %[[FUNC_LOAD:.*]] = cir.load %[[FUNC_ALLOCA]] : !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, !cir.ptr<!cir.func<() -> !s32i>>
 // CIR-NEXT: %[[CALL:.*]] = cir.call %[[FUNC_LOAD]]() : (!cir.ptr<!cir.func<() -> !s32i>>) -> (!s32i {llvm.noundef})
 
 // LLVM-LABEL: _Z9TakesFuncIFivEEDcRKT_
 // LLVM-NEXT: %[[FUNC_ALLOCA:.*]] = alloca ptr
-// LLVM-NEXT: %[[FUNC_LOAD:.*]] = load ptr, ptr %[[FUNC_ALLOCA]]
+// LLVM: %[[FUNC_LOAD:.*]] = load ptr, ptr %[[FUNC_ALLOCA]]
 // LLVM-NEXT: %[[CALL:.*]] = call noundef i32 %[[FUNC_LOAD]]()
 
 // LLVM: attributes #[[LLVM_ATTR_0]] = { nounwind }

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -143,20 +143,12 @@ void use_TakesFunc() {
 
 // CIR-LABEL: _Z9TakesFuncIFivEEDcRKT_
 // CIR-NEXT: %[[FUNC_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.func<() -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, ["f", init, const]
-// CIR-NEXT: %[[RET_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
-// CIR-NEXT: cir.store %{{.*}}, %[[FUNC_ALLOCA]] : !cir.ptr<!cir.func<() -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>
 // CIR-NEXT: %[[FUNC_LOAD:.*]] = cir.load %[[FUNC_ALLOCA]] : !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, !cir.ptr<!cir.func<() -> !s32i>>
 // CIR-NEXT: %[[CALL:.*]] = cir.call %[[FUNC_LOAD]]() : (!cir.ptr<!cir.func<() -> !s32i>>) -> (!s32i {llvm.noundef})
-// CIR-NEXT: cir.store %[[CALL]], %[[RET_ALLOCA]] : !s32i, !cir.ptr<!s32i>
 
 // LLVM-LABEL: _Z9TakesFuncIFivEEDcRKT_
 // LLVM-NEXT: %[[FUNC_ALLOCA:.*]] = alloca ptr
-// LLVM-NEXT: %[[RET_ALLOCA:.*]] = alloca i32
-// LLVM-NEXT: store ptr %{{.*}}, ptr %[[FUNC_ALLOCA]]
 // LLVM-NEXT: %[[FUNC_LOAD:.*]] = load ptr, ptr %[[FUNC_ALLOCA]]
 // LLVM-NEXT: %[[CALL:.*]] = call noundef i32 %[[FUNC_LOAD]]()
-// LLVM-NEXT: store i32 %[[CALL]], ptr %[[RET_ALLOCA]]
-
-
 
 // LLVM: attributes #[[LLVM_ATTR_0]] = { nounwind }

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -130,4 +130,33 @@ void f16() {
 // LLVM-NEXT:    %{{.+}} = call{{.*}} i32 @_Z3f15v()
 // LLVM:       }
 
+template<typename Func>
+inline decltype(auto) TakesFunc(const Func &f) {
+  return f();
+}
+
+int Passed();
+
+void use_TakesFunc() {
+  TakesFunc(Passed);
+}
+
+// CIR-LABEL: _Z9TakesFuncIFivEEDcRKT_
+// CIR-NEXT: %[[FUNC_ALLOCA:.*]] = cir.alloca !cir.ptr<!cir.func<() -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, ["f", init, const]
+// CIR-NEXT: %[[RET_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
+// CIR-NEXT: cir.store %{{.*}}, %[[FUNC_ALLOCA]] : !cir.ptr<!cir.func<() -> !s32i>>, !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>
+// CIR-NEXT: %[[FUNC_LOAD:.*]] = cir.load %[[FUNC_ALLOCA]] : !cir.ptr<!cir.ptr<!cir.func<() -> !s32i>>>, !cir.ptr<!cir.func<() -> !s32i>>
+// CIR-NEXT: %[[CALL:.*]] = cir.call %[[FUNC_LOAD]]() : (!cir.ptr<!cir.func<() -> !s32i>>) -> (!s32i {llvm.noundef})
+// CIR-NEXT: cir.store %[[CALL]], %[[RET_ALLOCA]] : !s32i, !cir.ptr<!s32i>
+
+// LLVM-LABEL: _Z9TakesFuncIFivEEDcRKT_
+// LLVM-NEXT: %[[FUNC_ALLOCA:.*]] = alloca ptr
+// LLVM-NEXT: %[[RET_ALLOCA:.*]] = alloca i32
+// LLVM-NEXT: store ptr %{{.*}}, ptr %[[FUNC_ALLOCA]]
+// LLVM-NEXT: %[[FUNC_LOAD:.*]] = load ptr, ptr %[[FUNC_ALLOCA]]
+// LLVM-NEXT: %[[CALL:.*]] = call noundef i32 %[[FUNC_LOAD]]()
+// LLVM-NEXT: store i32 %[[CALL]], ptr %[[RET_ALLOCA]]
+
+
+
 // LLVM: attributes #[[LLVM_ATTR_0]] = { nounwind }


### PR DESCRIPTION
We managed to miss a condition when lowering emitCallee, where a DeclRefExpr referenced a function object.  This patch adds that condition, which will result in these being lowered properly as an indirect call.