### PR TITLE
[llvm-profgen] Fix assertion condition for the top-level probes address range checks

### DIFF
--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1243,10 +1243,11 @@ void ProfiledBinary::loadSymbolsFromPseudoProbe() {
               InlineTreeNode->Parent);
 
         auto TopLevelProbes = InlineTreeNode->getProbes();
-        assert(find_if(TopLevelProbes,
-                       [Start = StartAddr, End = EndAddr](const auto &P) {
-                         return P.getAddress() >= Start && P.getAddress() < End;
-                       }) != TopLevelProbes.end() &&
+        assert(llvm::any_of(TopLevelProbes,
+                            [Start = StartAddr, End = EndAddr](const auto &P) {
+                              return P.getAddress() >= Start &&
+                                     P.getAddress() < End;
+                            }) &&
                "Top level pseudo probe does not match function range");
 
         const auto *ProbeDesc = getFuncDescForGUID(InlineTreeNode->Guid);

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1243,13 +1243,11 @@ void ProfiledBinary::loadSymbolsFromPseudoProbe() {
               InlineTreeNode->Parent);
 
         auto TopLevelProbes = InlineTreeNode->getProbes();
-        assert(TopLevelProbes.end() !=
-                   find_if(TopLevelProbes,
-                           [StartAddr, EndAddr](const auto &P) {
-                             return P.getAddress() >= StartAddr &&
-                                    P.getAddress() < EndAddr;
-                           }) &&
-               "Top level pseudo probe does not match function range");
+        assert(find_if(TopLevelProbes,
+                       [Start = StartAddr, End = EndAddr](const auto &P) {
+                         return P.getAddress() >= Start && P.getAddress() < End;
+                       }) != TopLevelProbes.end() &&
+               "Top level pseudo probe does not match funAddrction range");
 
         const auto *ProbeDesc = getFuncDescForGUID(InlineTreeNode->Guid);
         auto Ret = PseudoProbeNames.emplace(Func, ProbeDesc->FuncName);

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1247,7 +1247,7 @@ void ProfiledBinary::loadSymbolsFromPseudoProbe() {
                        [Start = StartAddr, End = EndAddr](const auto &P) {
                          return P.getAddress() >= Start && P.getAddress() < End;
                        }) != TopLevelProbes.end() &&
-               "Top level pseudo probe does not match funAddrction range");
+               "Top level pseudo probe does not match function range");
 
         const auto *ProbeDesc = getFuncDescForGUID(InlineTreeNode->Guid);
         auto Ret = PseudoProbeNames.emplace(Func, ProbeDesc->FuncName);

--- a/llvm/tools/llvm-profgen/ProfiledBinary.cpp
+++ b/llvm/tools/llvm-profgen/ProfiledBinary.cpp
@@ -1243,10 +1243,12 @@ void ProfiledBinary::loadSymbolsFromPseudoProbe() {
               InlineTreeNode->Parent);
 
         auto TopLevelProbes = InlineTreeNode->getProbes();
-        [[maybe_unused]] auto TopProbe = TopLevelProbes.begin();
-        assert(TopProbe != TopLevelProbes.end() &&
-               TopProbe->getAddress() >= StartAddr &&
-               TopProbe->getAddress() < EndAddr &&
+        assert(TopLevelProbes.end() !=
+                   find_if(TopLevelProbes,
+                           [StartAddr, EndAddr](const auto &P) {
+                             return P.getAddress() >= StartAddr &&
+                                    P.getAddress() < EndAddr;
+                           }) &&
                "Top level pseudo probe does not match function range");
 
         const auto *ProbeDesc = getFuncDescForGUID(InlineTreeNode->Guid);


### PR DESCRIPTION
Top-level functions may contains multiple disjoint address ranges, and the pseudo probes may not be stored as sorted. The original assertion check is problematic because the first pseudo probe may not necessarily falls into the current function range even though they are both part of the same function.

Update the assertion condition so that we won't hit the assertion failure as long as there one pseudo probe falls in the checked function range.