### PR TITLE
[lldb] Document lldb-mcp helper for MCP clients

### DIFF
--- a/lldb/docs/use/mcp.md
+++ b/lldb/docs/use/mcp.md
@@ -34,29 +34,26 @@ respectively.
 
 MCP uses standard input/output (stdio) for communication between client and
 server. The exact configuration depends on the client, but most applications
-allow you to specify an MCP server as a binary and arguments. This means that
-you need to use something like `netcat` to connect to LLDB's MCP server and
-forward communication over stdio over the network connection.
+allow you to specify an MCP server as a binary and arguments. LLDB ships with
+`lldb-mcp`, a small helper that bridges stdio to LLDB's MCP server socket.
 
 ```
 ┌──────────┐               ┌──────────┐               ┌──────────┐
 │          │               │          │               │          │
-│   LLDB   ├─────socket────┤  netcat  ├─────stdio─────┤MCP Client│
+│   LLDB   ├─────socket────┤ lldb-mcp ├─────stdio─────┤MCP Client│
 │          │               │          │               │          │
 └──────────┘               └──────────┘               └──────────┘
 ```
 
+`lldb-mcp` automatically discovers a running LLDB MCP server, so there is no
+need to specify a port. If no server is running, it will launch `lldb` in the
+background and connect to it. The `lldb` binary located next to `lldb-mcp` is
+used by default; set the `LLDB_EXE_PATH` environment variable to override this.
+
 Configuration example for [Claude Code](https://modelcontextprotocol.io/quickstart/user):
 
-```json
-{
-  "mcpServers": {
-    "tool": {
-      "command": "/usr/bin/nc",
-      "args": ["localhost", "59999"]
-    }
-  }
-}
+```
+claude mcp add --transport stdio -- lldb-mcp /path/to/lldb-mcp
 ```
 
 Configuration example (`mcp.json`) for [Visual Studio Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers):
@@ -66,8 +63,7 @@ Configuration example (`mcp.json`) for [Visual Studio Code](https://code.visuals
   "servers": {
     "lldb": {
       "type": "stdio",
-      "command": "/usr/bin/nc",
-      "args": ["localhost", "59999"]
+      "command": "/path/to/lldb-mcp"
     }
   }
 }


### PR DESCRIPTION
Replace the netcat-based MCP client setup with lldb-mcp, the helper binary that bridges stdio to LLDB's MCP server socket. lldb-mcp auto-discovers a running server and will launch lldb itself when none is running, so clients no longer need to hard-code a port or manage the server lifecycle.