### PR TITLE
[CI] Successful build and no tests running is now a notification

### DIFF
--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -212,7 +212,11 @@ def generate_report(
             report.extend(
                 [
                     ":white_check_mark: The build succeeded and no tests ran. "
-                    "This is expected in some build configurations."
+                    "This is not expected and likely means something was "
+                    "configured incorrectly. If you suspect an infrastructure "
+                    "issue, please open an issue at "
+                    "https://github.com/llvm/llvm-project/issues and attach the"
+                    "infrastructure label."
                 ]
             )
         else:

--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -215,7 +215,7 @@ def generate_report(
                     "This is not expected and likely means something was "
                     "configured incorrectly. If you suspect an infrastructure "
                     "issue, please open an issue at "
-                    "https://github.com/llvm/llvm-project/issues and attach the"
+                    "https://github.com/llvm/llvm-project/issues and attach the "
                     "infrastructure label."
                 ]
             )

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -196,7 +196,7 @@ class TestReports(unittest.TestCase):
                     """\
                     # Foo
 
-                    :white_check_mark: The build succeeded and no tests ran. This is not expected and likely means something was configured incorrectly. If you suspect an infrastructure issue, please open an issue at https://github.com/llvm/llvm-project/issues and attach theinfrastructure label."""
+                    :white_check_mark: The build succeeded and no tests ran. This is not expected and likely means something was configured incorrectly. If you suspect an infrastructure issue, please open an issue at https://github.com/llvm/llvm-project/issues and attach the infrastructure label."""
                 ),
                 True,
             ),

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -194,9 +194,9 @@ class TestReports(unittest.TestCase):
             (
                 dedent(
                     """\
-                # Foo
+                    # Foo
 
-                :white_check_mark: The build succeeded and no tests ran. This is expected in some build configurations."""
+                    :white_check_mark: The build succeeded and no tests ran. This is not expected and likely means something was configured incorrectly. If you suspect an infrastructure issue, please open an issue at https://github.com/llvm/llvm-project/issues and attach theinfrastructure label."""
                 ),
                 True,
             ),


### PR DESCRIPTION
check-libc now uses llvm-lit to run tests instead of running the unittests directly through ninja. This means there should not be any cases in tree where the build could succeed but we do not pick up any tests as running. Still pass the build in this case because if everything passes with exit code 0 it is wrong not to, but make a note to the user that this is unexpected.