### PR TITLE
[OpenMP][OMPIRBuilder] Avoid querying SmallPtrSet during removal

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6560,38 +6560,41 @@ static void redirectAllPredecessorsTo(BasicBlock *OldTarget,
 /// Determine which blocks in \p BBs are reachable from outside and remove the
 /// ones that are not reachable from the function.
 static void removeUnusedBlocksFromParent(ArrayRef<BasicBlock *> BBs) {
-  SmallPtrSet<BasicBlock *, 6> BBsToErase(llvm::from_range, BBs);
-  auto HasRemainingUses = [&BBsToErase](BasicBlock *BB) {
-    for (Use &U : BB->uses()) {
-      auto *UseInst = dyn_cast<Instruction>(U.getUser());
-      if (!UseInst)
-        continue;
-      if (BBsToErase.count(UseInst->getParent()))
-        continue;
-      return true;
+  DenseMap<BasicBlock *, unsigned> BB2Index(BBs.size());
+  for (const auto [I, BB] : enumerate(BBs))
+    BB2Index.insert({BB, I});
+
+  // Optimistically assume all BBs are dead. We iteratively remove
+  // immediately-used blocks from this set until we reach a fixed point.
+  SmallBitVector BBsToErase(BBs.size(), true);
+  // Accumulates immediately-used blocks for one iteration.
+  SmallBitVector BBsToKeep(BBs.size());
+  do {
+    BBsToKeep.reset();
+    for (unsigned BBToEraseIndex : BBsToErase.set_bits()) {
+      for (Use &U : BBs[BBToEraseIndex]->uses()) {
+        auto *UseInst = dyn_cast<Instruction>(U.getUser());
+        if (!UseInst)
+          continue;
+        BasicBlock *UseBB = UseInst->getParent();
+        auto UseBBIndexI = BB2Index.find(UseBB);
+        // If this use is from an external block, or from a block in BBs we have
+        // already proved is transitively used by an external block, then this
+        // block is also used.
+        if (UseBBIndexI == BB2Index.end() ||
+            !BBsToErase.test(UseBBIndexI->second)) {
+          BBsToKeep.set(BBToEraseIndex);
+          break;
+        }
+      }
     }
-    return false;
-  };
+    BBsToErase &= ~BBsToKeep;
+  } while (BBsToKeep.any());
 
-  // HasRemainingUses queries BBsToErase, so it cannot be used as a predicate
-  // for SmallPtrSet::remove_if on the same set.
-  SmallVector<BasicBlock *> BBsToKeep;
-  while (true) {
-    bool Changed = false;
-    BBsToKeep.clear();
-
-    for (BasicBlock *BB : BBsToErase)
-      if (HasRemainingUses(BB))
-        BBsToKeep.push_back(BB);
-    for (BasicBlock *BB : BBsToKeep)
-      Changed |= BBsToErase.erase(BB);
-
-    if (!Changed)
-      break;
-  }
-
-  SmallVector<BasicBlock *, 7> BBVec(BBsToErase.begin(), BBsToErase.end());
-  DeleteDeadBlocks(BBVec);
+  SmallVector<BasicBlock *> FinalBBsToErase;
+  for (unsigned BBToEraseIndex : BBsToErase.set_bits())
+    FinalBBsToErase.push_back(BBs[BBToEraseIndex]);
+  DeleteDeadBlocks(FinalBBsToErase);
 }
 
 CanonicalLoopInfo *

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6573,17 +6573,21 @@ static void removeUnusedBlocksFromParent(ArrayRef<BasicBlock *> BBs) {
     return false;
   };
 
-  // Compute the keep set before mutating BBsToErase; otherwise the result can
-  // depend on SmallPtrSet iteration order.
-  bool Changed = true;
-  while (Changed) {
-    Changed = false;
-    SmallVector<BasicBlock *, 4> BBsToKeep;
+  // HasRemainingUses queries BBsToErase, so it cannot be used as a predicate
+  // for SmallPtrSet::remove_if on the same set.
+  SmallVector<BasicBlock *> BBsToKeep;
+  while (true) {
+    bool Changed = false;
+    BBsToKeep.clear();
+
     for (BasicBlock *BB : BBsToErase)
       if (HasRemainingUses(BB))
         BBsToKeep.push_back(BB);
     for (BasicBlock *BB : BBsToKeep)
       Changed |= BBsToErase.erase(BB);
+
+    if (!Changed)
+      break;
   }
 
   SmallVector<BasicBlock *, 7> BBVec(BBsToErase.begin(), BBsToErase.end());

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6573,8 +6573,17 @@ static void removeUnusedBlocksFromParent(ArrayRef<BasicBlock *> BBs) {
     return false;
   };
 
-  while (BBsToErase.remove_if(HasRemainingUses)) {
-    // Try again if anything was removed.
+  // Compute the keep set before mutating BBsToErase; otherwise the result can
+  // depend on SmallPtrSet iteration order.
+  bool Changed = true;
+  while (Changed) {
+    Changed = false;
+    SmallVector<BasicBlock *, 4> BBsToKeep;
+    for (BasicBlock *BB : BBsToErase)
+      if (HasRemainingUses(BB))
+        BBsToKeep.push_back(BB);
+    for (BasicBlock *BB : BBsToKeep)
+      Changed |= BBsToErase.erase(BB);
   }
 
   SmallVector<BasicBlock *, 7> BBVec(BBsToErase.begin(), BBsToErase.end());

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -8461,6 +8461,9 @@ TEST_F(OpenMPIRBuilderTest, ScopeDirectiveNowait) {
   }
 }
 
+// This test ensures loop fusion does not leave orphaned non-entry blocks.
+// It's a regression test for SmallPtrSet::remove_if behavior change from
+// #197637.
 TEST_F(OpenMPIRBuilderTest, FuseLoopRangeNoDeadBlocks) {
   using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
   OpenMPIRBuilder OMPBuilder(*M);

--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -8461,4 +8461,55 @@ TEST_F(OpenMPIRBuilderTest, ScopeDirectiveNowait) {
   }
 }
 
+TEST_F(OpenMPIRBuilderTest, FuseLoopRangeNoDeadBlocks) {
+  using InsertPointTy = OpenMPIRBuilder::InsertPointTy;
+  OpenMPIRBuilder OMPBuilder(*M);
+  OMPBuilder.initialize();
+  F->setName("func");
+
+  IRBuilder<> Builder(BB);
+  Type *LCTy = F->getArg(0)->getType();
+  Value *TripCount = F->getArg(0);
+
+  auto LoopBodyGenCB = [&](InsertPointTy CodeGenIP, Value *LC) {
+    Builder.restoreIP(CodeGenIP);
+    createPrintfCall(Builder, "%d\n", {LC});
+    return Error::success();
+  };
+
+  OpenMPIRBuilder::LocationDescription Loc1({Builder.saveIP(), DL});
+  ASSERT_EXPECTED_INIT(
+      CanonicalLoopInfo *, Loop1,
+      OMPBuilder.createCanonicalLoop(Loc1, LoopBodyGenCB, TripCount, "loop1"));
+  Builder.restoreIP(Loop1->getAfterIP());
+
+  Value *TripCount2 = Builder.CreateAdd(TripCount, ConstantInt::get(LCTy, 1));
+  OpenMPIRBuilder::LocationDescription Loc2({Builder.saveIP(), DL});
+  ASSERT_EXPECTED_INIT(
+      CanonicalLoopInfo *, Loop2,
+      OMPBuilder.createCanonicalLoop(Loc2, LoopBodyGenCB, TripCount2, "loop2"));
+  Builder.restoreIP(Loop2->getAfterIP());
+
+  Value *TripCount3 = Builder.CreateAdd(TripCount, ConstantInt::get(LCTy, 2));
+  OpenMPIRBuilder::LocationDescription Loc3({Builder.saveIP(), DL});
+  ASSERT_EXPECTED_INIT(
+      CanonicalLoopInfo *, Loop3,
+      OMPBuilder.createCanonicalLoop(Loc3, LoopBodyGenCB, TripCount3, "loop3"));
+  Builder.restoreIP(Loop3->getAfterIP());
+  Builder.CreateRetVoid();
+
+  CanonicalLoopInfo *Fused = OMPBuilder.fuseLoops(DL, {Loop1, Loop2});
+
+  OMPBuilder.finalize();
+  ASSERT_FALSE(verifyModule(*M, &errs()));
+
+  Fused->assertOK();
+  for (BasicBlock &Block : *F) {
+    if (&Block == &F->getEntryBlock())
+      continue;
+    EXPECT_TRUE(Block.hasNPredecessorsOrMore(1))
+        << "Dead block found: " << Block.getName().str();
+  }
+}
+
 } // namespace


### PR DESCRIPTION
openmp-cli-fuse02.mlir can intermittently leave behind a dead block after loop fusion, causing LLVM IR verification to fail. (https://github.com/llvm/llvm-project/pull/197637#issuecomment-4497502486)

This happened because `removeUnusedBlocksFromParent` queried `BBsToErase` while using `SmallPtrSet::remove_if` on the same set, which made the result depend on the set's internal mutation order during removal.

This patch tracks candidate blocks by index with `SmallBitVector` instead of mutating and querying the same `SmallPtrSet`. This also preserves the original `BBs` order when collecting the final dead blocks.

---

The original PR was created with assistance from Copilot. The later analysis and fix were revised based on reviewer feedback.

Co-authored-by: @slinder1 