### PR TITLE
[flang-rt] Silence -Wfenv-access in the runtime fenv wrappers (part 1)

### DIFF
--- a/flang-rt/lib/runtime/exceptions.cpp
+++ b/flang-rt/lib/runtime/exceptions.cpp
@@ -96,8 +96,8 @@ void RTNAME(feclearexcept)(uint32_t excepts) {
 #endif
 }
 void RTDEF(feraiseexcept)(uint32_t excepts) {
-  FLANG_FP_TRAP_ON
 #if !defined(RT_DEVICE_COMPILATION)
+  FLANG_FP_TRAP_ON
   feraiseexcept(excepts);
 #if defined(_MM_EXCEPT_DENORM)
   _mm_setcsr(_mm_getcsr() | (excepts & _MM_EXCEPT_MASK));

--- a/flang-rt/lib/runtime/exceptions.cpp
+++ b/flang-rt/lib/runtime/exceptions.cpp
@@ -10,6 +10,7 @@
 
 #include "flang/Runtime/exceptions.h"
 #include "flang-rt/runtime/terminator.h"
+#include "flang/Common/fp-control.h"
 #include <cfenv>
 #if defined(__aarch64__) && defined(__GLIBC__)
 #include <fpu_control.h>
@@ -88,12 +89,14 @@ uint32_t RTDEF(MapException)(uint32_t excepts) {
 // component; both are needed.
 
 void RTNAME(feclearexcept)(uint32_t excepts) {
+  FLANG_FP_TRAP_ON
   feclearexcept(excepts);
 #if defined(_MM_EXCEPT_DENORM)
   _mm_setcsr(_mm_getcsr() & ~(excepts & _MM_EXCEPT_MASK));
 #endif
 }
 void RTDEF(feraiseexcept)(uint32_t excepts) {
+  FLANG_FP_TRAP_ON
 #if !defined(RT_DEVICE_COMPILATION)
   feraiseexcept(excepts);
 #if defined(_MM_EXCEPT_DENORM)
@@ -102,6 +105,7 @@ void RTDEF(feraiseexcept)(uint32_t excepts) {
 #endif
 }
 uint32_t RTNAME(fetestexcept)(uint32_t excepts) {
+  FLANG_FP_TRAP_ON
 #if defined(_MM_EXCEPT_DENORM)
   return (_mm_getcsr() & _MM_EXCEPT_MASK & excepts) | fetestexcept(excepts);
 #else

--- a/flang-rt/unittests/Runtime/CMakeLists.txt
+++ b/flang-rt/unittests/Runtime/CMakeLists.txt
@@ -18,6 +18,7 @@ add_flangrt_unittest(RuntimeTests
   CrashHandlerFixture.cpp
   Derived.cpp
   Descriptor.cpp
+  Exceptions.cpp
   ExternalIOTest.cpp
   Format.cpp
   InputExtensions.cpp

--- a/flang-rt/unittests/Runtime/Exceptions.cpp
+++ b/flang-rt/unittests/Runtime/Exceptions.cpp
@@ -1,0 +1,132 @@
+//===-- unittests/Runtime/Exceptions.cpp ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// Tests for the Fortran runtime fenv-wrapping entry points
+/// (feclearexcept / feraiseexcept / fetestexcept).
+///
+/// These checks also guard against an optimizer eliding the wrapped libm
+/// calls: under Clang's default `-ffp-exception-behavior=ignore`, the
+/// compiler is free to drop calls to fenv functions, which would silently
+/// break ieee_arithmetic flag handling.  exceptions.cpp uses
+/// `FLANG_FP_TRAP_ON` to disable that optimization; if it were ever removed
+/// or weakened, the round-trip assertions below would fail.
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Runtime/exceptions.h"
+#include "flang/Common/fp-control.h"
+#include <cfenv>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+using namespace Fortran::runtime;
+
+namespace {
+
+// Saves and restores the host floating-point environment so tests do not
+// leak exception flags into each other or into the rest of the suite.
+class FenvScope {
+public:
+  FenvScope() {
+    FLANG_FP_TRAP_ON
+    std::fegetenv(&saved_);
+  }
+  ~FenvScope() {
+    FLANG_FP_TRAP_ON
+    std::fesetenv(&saved_);
+  }
+
+private:
+  std::fenv_t saved_;
+};
+
+// Bitmask of every standard exception this platform defines.  C99 lets
+// some be absent (e.g. on musl/emscripten); the runtime itself guards
+// each one, so the tests mirror that.
+constexpr std::uint32_t kAllSupported = 0u
+#ifdef FE_INVALID
+    | FE_INVALID
+#endif
+#ifdef FE_DIVBYZERO
+    | FE_DIVBYZERO
+#endif
+#ifdef FE_OVERFLOW
+    | FE_OVERFLOW
+#endif
+#ifdef FE_UNDERFLOW
+    | FE_UNDERFLOW
+#endif
+#ifdef FE_INEXACT
+    | FE_INEXACT
+#endif
+    ;
+
+} // namespace
+
+TEST(Exceptions, ClearLeavesAllUnset) {
+  FenvScope guard;
+  if (kAllSupported == 0u) {
+    GTEST_SKIP() << "no FE_* exceptions defined on this platform";
+  }
+  RTNAME(feraiseexcept)(kAllSupported);
+  RTNAME(feclearexcept)(kAllSupported);
+  EXPECT_EQ(RTNAME(fetestexcept)(kAllSupported), 0u);
+}
+
+TEST(Exceptions, RaiseSetsExactlyRequestedFlag) {
+  FenvScope guard;
+  RTNAME(feclearexcept)(kAllSupported);
+
+  // Walk every supported exception bit individually.  After raising one,
+  // fetestexcept(that bit) must report it set; fetestexcept(other bits)
+  // must not spuriously light up.
+  const std::uint32_t bits[] = {
+#ifdef FE_INVALID
+      static_cast<std::uint32_t>(FE_INVALID),
+#endif
+#ifdef FE_DIVBYZERO
+      static_cast<std::uint32_t>(FE_DIVBYZERO),
+#endif
+#ifdef FE_OVERFLOW
+      static_cast<std::uint32_t>(FE_OVERFLOW),
+#endif
+#ifdef FE_UNDERFLOW
+      static_cast<std::uint32_t>(FE_UNDERFLOW),
+#endif
+#ifdef FE_INEXACT
+      static_cast<std::uint32_t>(FE_INEXACT),
+#endif
+  };
+  if (sizeof(bits) == 0) {
+    GTEST_SKIP() << "no FE_* exceptions defined on this platform";
+  }
+
+  for (std::uint32_t bit : bits) {
+    RTNAME(feclearexcept)(kAllSupported);
+    RTNAME(feraiseexcept)(bit);
+    EXPECT_NE(RTNAME(fetestexcept)(bit), 0u) << "bit 0x" << std::hex << bit;
+    EXPECT_EQ(RTNAME(fetestexcept)(kAllSupported & ~bit), 0u)
+        << "spurious flag set when raising 0x" << std::hex << bit;
+  }
+}
+
+TEST(Exceptions, ClearOneLeavesOthersAlone) {
+  FenvScope guard;
+#if defined(FE_OVERFLOW) && defined(FE_INVALID)
+  RTNAME(feclearexcept)(kAllSupported);
+  RTNAME(feraiseexcept)(FE_OVERFLOW | FE_INVALID);
+  ASSERT_NE(RTNAME(fetestexcept)(FE_OVERFLOW), 0u);
+  ASSERT_NE(RTNAME(fetestexcept)(FE_INVALID), 0u);
+
+  RTNAME(feclearexcept)(FE_OVERFLOW);
+  EXPECT_EQ(RTNAME(fetestexcept)(FE_OVERFLOW), 0u);
+  EXPECT_NE(RTNAME(fetestexcept)(FE_INVALID), 0u);
+#else
+  GTEST_SKIP() << "FE_OVERFLOW and FE_INVALID required for this test";
+#endif
+}

--- a/flang-rt/unittests/Runtime/Exceptions.cpp
+++ b/flang-rt/unittests/Runtime/Exceptions.cpp
@@ -106,11 +106,23 @@ TEST(Exceptions, RaiseSetsExactlyRequestedFlag) {
     GTEST_SKIP() << "no FE_* exceptions defined on this platform";
   }
 
+  // C99 7.6.2.3 p2 leaves it implementation-defined whether feraiseexcept
+  // additionally raises FE_INEXACT when raising FE_OVERFLOW or FE_UNDERFLOW.
+  // AArch64 glibc does, so exclude FE_INEXACT from the "no spurious flag"
+  // mask to keep the test portable.
+  constexpr std::uint32_t kInexactTolerated =
+#ifdef FE_INEXACT
+      static_cast<std::uint32_t>(FE_INEXACT);
+#else
+      0u;
+#endif
+
   for (std::uint32_t bit : bits) {
     RTNAME(feclearexcept)(kAllSupported);
     RTNAME(feraiseexcept)(bit);
     EXPECT_NE(RTNAME(fetestexcept)(bit), 0u) << "bit 0x" << std::hex << bit;
-    EXPECT_EQ(RTNAME(fetestexcept)(kAllSupported & ~bit), 0u)
+    const std::uint32_t forbidden = kAllSupported & ~bit & ~kInexactTolerated;
+    EXPECT_EQ(RTNAME(fetestexcept)(forbidden), 0u)
         << "spurious flag set when raising 0x" << std::hex << bit;
   }
 }

--- a/flang-rt/unittests/Runtime/Exceptions.cpp
+++ b/flang-rt/unittests/Runtime/Exceptions.cpp
@@ -10,7 +10,7 @@
 /// (feclearexcept / feraiseexcept / fetestexcept).
 ///
 /// These checks also guard against an optimizer eliding the wrapped libm
-/// calls: under Clang's default `-ffp-exception-behavior=ignore`, the
+/// calls: under clang's default `-ffp-exception-behavior=ignore`, the
 /// compiler is free to drop calls to fenv functions, which would silently
 /// break ieee_arithmetic flag handling.  exceptions.cpp uses
 /// `FLANG_FP_TRAP_ON` to disable that optimization; if it were ever removed

--- a/flang/include/flang/Common/fp-control.h
+++ b/flang/include/flang/Common/fp-control.h
@@ -1,0 +1,36 @@
+//===-- include/flang/Common/fp-control.h -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// FLANG_FP_TRAP_ON enables floating-point exception access in the
+// enclosing scope.  It silences Clang's -Wfenv-access on calls to fenv.h
+// primitives (feraiseexcept, fesetround, fetestexcept, ...).
+//
+// Use as a statement at the top of a function body:
+//
+//   void f() {
+//     FLANG_FP_TRAP_ON
+//     feraiseexcept(FE_INVALID);
+//   }
+//
+// File-scope use is also valid C/C++ but triggers a Clang codegen assertion
+// in template-heavy translation units, so prefer function scope.
+
+#ifndef FORTRAN_COMMON_FP_CONTROL_H_
+#define FORTRAN_COMMON_FP_CONTROL_H_
+
+#if defined(__clang__) && (__clang_major__ >= 10)
+// Clang >= 10 supports `#pragma clang fp exceptions(maytrap)`, which is the
+// local-scope equivalent of `-ffp-exception-behavior=maytrap` and is what the
+// -Wfenv-access diagnostic recommends.
+#define FLANG_FP_TRAP_ON _Pragma("clang fp exceptions(maytrap)")
+#else
+// Portable fallback for GCC, MSVC, or older Clang.
+#define FLANG_FP_TRAP_ON _Pragma("STDC FENV_ACCESS ON")
+#endif
+
+#endif // FORTRAN_COMMON_FP_CONTROL_H_

--- a/flang/include/flang/Common/fp-control.h
+++ b/flang/include/flang/Common/fp-control.h
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // FLANG_FP_TRAP_ON enables floating-point exception access in the
-// enclosing scope.  It silences Clang's -Wfenv-access on calls to fenv.h
-// primitives (feraiseexcept, fesetround, fetestexcept, ...).
+// enclosing scope.  It silences clang's -Wfenv-access warning on calls to
+// fenv.h primitives (feraiseexcept, fesetround, fetestexcept, ...).
 //
 // Use as a statement at the top of a function body:
 //
@@ -17,8 +17,6 @@
 //     feraiseexcept(FE_INVALID);
 //   }
 //
-// File-scope use is also valid C/C++ but triggers a Clang codegen assertion
-// in template-heavy translation units, so prefer function scope.
 
 #ifndef FORTRAN_COMMON_FP_CONTROL_H_
 #define FORTRAN_COMMON_FP_CONTROL_H_
@@ -29,7 +27,7 @@
 // -Wfenv-access diagnostic recommends.
 #define FLANG_FP_TRAP_ON _Pragma("clang fp exceptions(maytrap)")
 #else
-// Portable fallback for GCC, MSVC, or older Clang.
+// Portable fallback for GCC, MSVC, or older clang.
 #define FLANG_FP_TRAP_ON _Pragma("STDC FENV_ACCESS ON")
 #endif
 


### PR DESCRIPTION
Upstream clang's commit 5f2bedca, PR #187860, enabled a warning that fires whenever code calls a `<fenv.h>` / `<cfenv>` primitive without enabling proper FP exception behavior. This caused warnings in compiling flang-rt, which in turn caused certain buildsbots to fail with `-Werror`.

This change enables FP trap behavior for parts of flang-rt that are known to require it. The other parts will be addressed by a future change.

Assisted-by: AI