### PR TITLE
[AMDGPU][test] Replace invalid intrinsic calls in two tests [NFC]

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
+++ b/llvm/test/CodeGen/AMDGPU/sched.barrier.inverted.mask.ll
@@ -10,7 +10,7 @@
 define amdgpu_kernel void @invert1() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 1) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -19,7 +19,7 @@ entry:
 define amdgpu_kernel void @invert2() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 2) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -28,7 +28,7 @@ entry:
 define amdgpu_kernel void @invert4() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 4) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -37,7 +37,7 @@ entry:
 define amdgpu_kernel void @invert8() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 8) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -46,7 +46,7 @@ entry:
 define amdgpu_kernel void @invert16() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 16) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -55,7 +55,7 @@ entry:
 define amdgpu_kernel void @invert32() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 32) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -64,7 +64,7 @@ entry:
 define amdgpu_kernel void @invert64() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 64) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -73,7 +73,7 @@ entry:
 define amdgpu_kernel void @invert128() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 128) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -82,7 +82,7 @@ entry:
 define amdgpu_kernel void @invert256() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 256) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -91,7 +91,7 @@ entry:
 define amdgpu_kernel void @invert512() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 512) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -100,7 +100,7 @@ entry:
 define amdgpu_kernel void @invert1024() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 1024) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
@@ -109,12 +109,12 @@ entry:
 define amdgpu_kernel void @invert2048() #0 {
 entry:
   call void @llvm.amdgcn.sched.barrier(i32 2048) #1
-  call void @llvm.amdcn.s.nop(i16 0) #1
+  call void @llvm.amdgcn.s.nop(i16 0) #1
   ret void
 }
 
 declare void @llvm.amdgcn.sched.barrier(i32) #1
-declare void @llvm.amdcn.s.nop(i16) #1
+declare void @llvm.amdgcn.s.nop(i16) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { convergent nounwind }

--- a/llvm/test/CodeGen/AMDGPU/si-split-load-store-alias-info.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-split-load-store-alias-info.ll
@@ -19,14 +19,13 @@ define amdgpu_kernel void @test(ptr addrspace(3) noalias %in, ptr addrspace(3) n
   %idx = call i32 @llvm.amdgcn.workitem.id.x()
   %in.addr = getelementptr <16 x float>, ptr addrspace(3) %in, i32 %idx
   %val.0 = load <16 x float>, ptr addrspace(3) %in.addr, align 32, !alias.scope !4, !noalias !5
-  %val.1 = call <16 x float> @llvm.amdgcn.wmma.f32.16x16x16.f32.v16f32.v16f32(<16 x float> %val.0, <16 x float> %val.0, <16 x float> %val.0, i1 false)
+  %val.1 = fadd <16 x float> %val.0, %val.0
   %out.addr = getelementptr <16 x float>, ptr addrspace(3) %out, i32 %idx
   store <16 x float> %val.1, ptr addrspace(3) %out.addr, align 32, !alias.scope !5, !noalias !4
   ret void
 }
 
 declare i32 @llvm.amdgcn.workitem.id.x()
-declare <16 x float> @llvm.amdgcn.wmma.f32.16x16x16.f32.v16f32.v16f32(<16 x float>, <16 x float>, <16 x float>, i1 immarg)
 
 !0 = !{!"inout.domain"}
 !1 = !{!"in.scope", !0}


### PR DESCRIPTION
These tests reference intrinsics that do not exist:

- sched.barrier.inverted.mask.ll calls @llvm.amdcn.s.nop, a typo of @llvm.amdgcn.s.nop that has been in the test since it was added in f1156fb622a7.
- si-split-load-store-alias-info.ll calls @llvm.amdgcn.wmma.f32.16x16x16.f32, which has never existed (only the .f16/.bf16/.fp8/.bf8 input variants are defined). The intrinsic was only used to keep the loaded value alive between the load and the store; an fadd serves the same purpose while exercising the same alias-info propagation path being tested.

The dyn_cast<IntrinsicInst> we rely on in passes such as ReplaceWithVeclib only checks the "llvm." prefix and does not validate the intrinsic name, so these calls have silently become IntrinsicInst with Intrinsic::not_intrinsic. Fix the tests so that strengthening the check does not turn into a spurious regression.

Assisted-by: Opus 4.7