### PR TITLE
[lldb] Recheck connection state in webinspector-wasm EnsureConnected

### DIFF
--- a/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.cpp
+++ b/lldb/source/Plugins/Platform/WebAssembly/PlatformWebInspectorWasm.cpp
@@ -133,7 +133,7 @@ llvm::Error PlatformWebInspectorWasm::LaunchPlatformServer() {
 }
 
 llvm::Error PlatformWebInspectorWasm::EnsureConnected() {
-  if (m_remote_platform_sp)
+  if (m_remote_platform_sp && m_remote_platform_sp->IsConnected())
     return llvm::Error::success();
   return LaunchPlatformServer();
 }


### PR DESCRIPTION
m_remote_platform_sp can be non-null while the remote is disconnected (PlatformWasm::ConnectRemote installs the pointer before the connect call). Also check IsConnected() so a prior failed connect doesn't make EnsureConnected falsely report success.