### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Check lambdas in constructors and destructors

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -63,6 +63,18 @@ public:
         ShouldVisitImplicitCode = false;
       }
 
+      bool TraverseCXXConstructorDecl(CXXConstructorDecl *Ctor) override {
+        llvm::SaveAndRestore SavedDecl(ClsType);
+        ClsType = Ctor->getThisType();
+        return DynamicRecursiveASTVisitor::TraverseCXXConstructorDecl(Ctor);
+      }
+
+      bool TraverseCXXDestructorDecl(CXXDestructorDecl *Dtor) override {
+        llvm::SaveAndRestore SavedDecl(ClsType);
+        ClsType = Dtor->getThisType();
+        return DynamicRecursiveASTVisitor::TraverseCXXDestructorDecl(Dtor);
+      }
+
       bool TraverseCXXMethodDecl(CXXMethodDecl *CXXMD) override {
         llvm::SaveAndRestore SavedDecl(ClsType);
         if (CXXMD->isInstance())

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -677,3 +677,25 @@ void bad_use_visitor(RefCountable* obj) {
   });
   bad_visit(visitor, obj);
 }
+
+class LambdaInConstructorDestructor {
+public:
+  LambdaInConstructorDestructor() {
+    call([this]() {
+      // expected-warning@-1{{Captured raw-pointer 'this' to uncounted type is unsafe [webkit.UncountedLambdaCapturesChecker]}}
+      doWork();
+    });
+  }
+
+  ~LambdaInConstructorDestructor() {
+    call([this]() {
+      // expected-warning@-1{{Captured raw-pointer 'this' to uncounted type is unsafe [webkit.UncountedLambdaCapturesChecker]}}
+      doWork();
+    });
+  }
+
+  void ref() const;
+  void deref() const;
+
+  void doWork();
+};


### PR DESCRIPTION
This PR fixes the bug that lambda captures checkers don't check for "this" pointer captured in a lambda inside C++ constructors and destructors.