### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Check every lambdas passed to makeVisitor

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -52,7 +52,8 @@ public:
       llvm::DenseSet<const ValueDecl *> ProtectedThisDecls;
       llvm::DenseSet<const CallExpr *> CallToIgnore;
       llvm::DenseSet<const CXXConstructExpr *> ConstructToIgnore;
-      llvm::DenseMap<const VarDecl *, const LambdaExpr *> LambdaOwnerMap;
+      llvm::DenseMap<const VarDecl *, SmallVector<const LambdaExpr *>>
+          LambdaOwnerMap;
 
       QualType ClsType;
 
@@ -121,21 +122,15 @@ public:
               auto *Arg = CE->getArg(0);
               if (auto *E = dyn_cast<MaterializeTemporaryExpr>(Arg))
                 Arg = E->getSubExpr();
-              if (auto *L = dyn_cast<LambdaExpr>(Arg)) {
-                LambdaOwnerMap.insert(std::make_pair(VD, L));
-                CallToIgnore.insert(CE);
-                LambdasToIgnore.insert(L);
-              }
+              if (auto *L = dyn_cast<LambdaExpr>(Arg))
+                addLambdaOwner(VD, CE, L);
             } else if (FnName == "makeVisitor") {
               for (unsigned ArgIndex = 0; ArgIndex < ArgCnt; ++ArgIndex) {
                 auto *Arg = CE->getArg(ArgIndex);
                 if (auto *E = dyn_cast<MaterializeTemporaryExpr>(Arg))
                   Arg = E->getSubExpr();
-                if (auto *L = dyn_cast<LambdaExpr>(Arg)) {
-                  LambdaOwnerMap.insert(std::make_pair(VD, L));
-                  CallToIgnore.insert(CE);
-                  LambdasToIgnore.insert(L);
-                }
+                if (auto *L = dyn_cast<LambdaExpr>(Arg))
+                  addLambdaOwner(VD, CE, L);
               }
             }
           }
@@ -148,16 +143,31 @@ public:
                 auto *Arg = CE->getArg(0);
                 if (auto *E = dyn_cast<MaterializeTemporaryExpr>(Arg))
                   Arg = E->getSubExpr();
-                if (auto *L = dyn_cast<LambdaExpr>(Arg)) {
-                  LambdaOwnerMap.insert(std::make_pair(VD, L));
-                  ConstructToIgnore.insert(CE);
-                  LambdasToIgnore.insert(L);
-                }
+                if (auto *L = dyn_cast<LambdaExpr>(Arg))
+                  addLambdaOwner(VD, CE, L);
               }
             }
           }
         }
         return true;
+      }
+
+      void addLambdaOwner(VarDecl *VD, CallExpr *CE, LambdaExpr *L) {
+        auto result = LambdaOwnerMap.insert(
+            std::make_pair(VD, SmallVector<const LambdaExpr *>{L}));
+        if (!result.second)
+          result.first->second.push_back(L);
+        CallToIgnore.insert(CE);
+        LambdasToIgnore.insert(L);
+      }
+
+      void addLambdaOwner(VarDecl *VD, CXXConstructExpr *CE, LambdaExpr *L) {
+        auto result = LambdaOwnerMap.insert(
+            std::make_pair(VD, SmallVector<const LambdaExpr *>{L}));
+        if (!result.second)
+          result.first->second.push_back(L);
+        ConstructToIgnore.insert(CE);
+        LambdasToIgnore.insert(L);
       }
 
       bool VisitDeclRefExpr(DeclRefExpr *DRE) override {
@@ -167,9 +177,10 @@ public:
         if (!VD)
           return true;
         if (auto It = LambdaOwnerMap.find(VD); It != LambdaOwnerMap.end()) {
-          auto *L = It->second;
-          Checker->visitLambdaExpr(L, shouldCheckThis() && !hasProtectedThis(L),
-                                   ClsType);
+          for (auto *L : It->second) {
+            Checker->visitLambdaExpr(
+                L, shouldCheckThis() && !hasProtectedThis(L), ClsType);
+          }
           return true;
         }
         auto *Init = VD->getInit();

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -670,6 +670,18 @@ void static_visitor(RefCountable* obj) {
   });
 }
 
+void make_visitor_with_multiple_lambdas(RefCountable* obj) {
+  auto* otherObj = make_obj();
+  auto visitor = WTF::makeVisitor([&] {
+    obj->method();
+    // expected-warning@-1{{Implicitly captured raw-pointer 'obj' to uncounted type is unsafe [webkit.UncountedLambdaCapturesChecker]}}
+  }, [&] {
+    otherObj->method();
+    // expected-warning@-1{{Implicitly captured raw-pointer 'otherObj' to uncounted type is unsafe [webkit.UncountedLambdaCapturesChecker]}}
+  });
+  bad_visit(visitor, obj);
+}
+
 void bad_use_visitor(RefCountable* obj) {
   auto visitor = WTF::makeVisitor([&] {
     obj->method();


### PR DESCRIPTION
This PR fixes the bug in UncountedLambdaCapturesChecker that we were failing to check variable captures of a non-first lambdas passed to WTF::makeVisitor. To support this, we store a SmallVector of LambdaExpr's instead of a single LambdaExpr in LambdaOwnerMap.