### PR TITLE
[alpha.webkit.UncheckedCallArgsChecker] EnsureFunctionAnalysis allows unsafe code

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -403,15 +403,18 @@ public:
   }
 };
 
-bool EnsureFunctionAnalysis::isACallToEnsureFn(const clang::Expr *E) const {
+bool EnsureFunctionAnalysis::isACallToEnsureFn(
+    const clang::Expr *E, const class TrivialFunctionAnalysis &TFA) const {
   auto *MCE = dyn_cast<CXXMemberCallExpr>(E);
   if (!MCE)
     return false;
-  auto *Callee = MCE->getDirectCallee();
+  auto *Callee = MCE->getMethodDecl();
   if (!Callee)
     return false;
   auto *Body = Callee->getBody();
-  if (!Body || Callee->isVirtualAsWritten())
+  if (!Body || Callee->isVirtual())
+    return false;
+  if (!TFA.isTrivial(Body))
     return false;
   auto [CacheIt, IsNew] = Cache.insert(std::make_pair(Callee, false));
   if (IsNew)

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.h
@@ -88,7 +88,8 @@ class EnsureFunctionAnalysis {
   mutable CacheTy Cache{};
 
 public:
-  bool isACallToEnsureFn(const Expr *E) const;
+  bool isACallToEnsureFn(const Expr *E,
+                         const class TrivialFunctionAnalysis &) const;
 };
 
 /// \returns name of AST node or empty string.

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -259,7 +259,7 @@ public:
             return true;
           if (isASafeCallArg(ArgOrigin))
             return true;
-          if (EFA.isACallToEnsureFn(ArgOrigin))
+          if (EFA.isACallToEnsureFn(ArgOrigin, TFA))
             return true;
           if (isSafeExpr(ArgOrigin))
             return true;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -166,6 +166,7 @@ bool isGuardedScopeEmbeddedInGuardianScope(const VarDecl *Guarded,
 class RawPtrRefLocalVarsChecker
     : public Checker<check::ASTDecl<TranslationUnitDecl>> {
   BugType Bug;
+  TrivialFunctionAnalysis TFA;
   EnsureFunctionAnalysis EFA;
 
 protected:
@@ -194,10 +195,10 @@ public:
       const RawPtrRefLocalVarsChecker *Checker;
       Decl *DeclWithIssue{nullptr};
 
-      TrivialFunctionAnalysis TFA;
+      const TrivialFunctionAnalysis &TFA;
 
       explicit LocalVisitor(const RawPtrRefLocalVarsChecker *Checker)
-          : Checker(Checker) {
+          : Checker(Checker), TFA(Checker->TFA) {
         assert(Checker);
         ShouldVisitTemplateInstantiations = true;
         ShouldVisitImplicitCode = false;
@@ -314,7 +315,7 @@ public:
                 if (isConstOwnerPtrMemberExpr(InitArgOrigin))
                   return true;
 
-                if (EFA.isACallToEnsureFn(InitArgOrigin))
+                if (EFA.isACallToEnsureFn(InitArgOrigin, TFA))
                   return true;
 
                 if (isSafeExpr(InitArgOrigin))

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked-const-member.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked-const-member.cpp
@@ -66,7 +66,7 @@ public:
   CheckedObj* ensureObj5() {
     if (!m_obj5)
       const_cast<std::unique_ptr<CheckedObj>&>(m_obj5) = new CheckedObj;
-    if (m_obj5->next())
+    if (m_obj5->trivial())
       return nullptr;
     return m_obj5.get();
   }
@@ -74,18 +74,41 @@ public:
   CheckedObj* ensureObj6() {
     if (!m_obj6)
       const_cast<std::unique_ptr<CheckedObj>&>(m_obj6) = new CheckedObj;
-    if (m_obj6->next())
+    if (m_obj6->trivial())
       return (CheckedObj *)0;
     return m_obj6.get();
   }
 
+  virtual CheckedObj* ensureObj7() {
+    if (!m_obj7)
+      const_cast<std::unique_ptr<CheckedObj>&>(m_obj7) = new CheckedObj;
+    return m_obj7.get();
+  }
+
+  CheckedObj* ensureObj8() {
+    if (!m_obj8)
+      const_cast<std::unique_ptr<CheckedObj>&>(m_obj8) = new CheckedObj;
+    if (auto* next = m_obj8->next())
+      return next;
+    return m_obj8.get();
+  }
+
+  CheckedObj* ensureObj9() {
+    someFunction();
+    return nullptr;
+  }
+
 private:
+  void someFunction();
+
   const std::unique_ptr<CheckedObj> m_obj1;
   std::unique_ptr<CheckedObj> m_obj2;
   const std::unique_ptr<CheckedObj> m_obj3;
   const std::unique_ptr<CheckedObj> m_obj4;
   const std::unique_ptr<CheckedObj> m_obj5;
   const std::unique_ptr<CheckedObj> m_obj6;
+  const std::unique_ptr<CheckedObj> m_obj7;
+  const std::unique_ptr<CheckedObj> m_obj8;
 };
 
 void Foo::bar() {
@@ -97,6 +120,25 @@ void Foo::bar() {
   // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
   ensureObj5()->method();
   ensureObj6()->method();
+  ensureObj7()->method();
+  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  ensureObj8()->method();
+  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  ensureObj9()->method();
+  // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
 }
+
+class Bar : public Foo {
+
+  CheckedObj* ensureObj7() override {
+    return nullptr;
+  }
+
+  void caller() {
+    ensureObj7()->method();
+    // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
+  }
+
+};
 
 } // namespace call_args_const_unique_ptr


### PR DESCRIPTION
Recall that "ensure" function in WebKit is a pattern for lazy initialization. "ensure" functions returns a member variable's value if the object had been initialized before, and otherwise creates the relevant object and returns it.

EnsureFunctionAnalysis has two bugs which allow unsafe code:
 * It allows a virtual "ensure" function that doesn't use literal "virtual keyword".
 * It allows non-trivial code to appear within an "ensure" function.

This PR addresses both of these bugs by replacing isVirtual with isVirtualAsWritten and checking the "ensure" function body's trivial-ness with TrivialFunctionAnalysis.