### PR TITLE
[CMake] Create and link against object libraries for each component

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -682,6 +682,7 @@ function(llvm_add_library name)
           add_dependencies(${obj_name} ${link_lib})
         endif()
       endforeach()
+      target_link_libraries(${obj_name} ${ARG_LINK_LIBS})
     endif()
 
     if(ARG_DISABLE_LLVM_LINK_LLVM_DYLIB)
@@ -994,7 +995,7 @@ function(add_llvm_component_library name)
     "COMPONENT_NAME;ADD_TO_COMPONENT"
     ""
     ${ARGN})
-  add_llvm_library(${name} COMPONENT_LIB ${ARG_UNPARSED_ARGUMENTS})
+  add_llvm_library(${name} COMPONENT_LIB OBJECT ${ARG_UNPARSED_ARGUMENTS})
   string(REGEX REPLACE "^LLVM" "" component_name ${name})
   set_property(TARGET ${name} PROPERTY LLVM_COMPONENT_NAME ${component_name})
 
@@ -1358,8 +1359,11 @@ function(process_llvm_pass_plugins)
 
   # Add static plugins to the Extension component
   foreach(llvm_extension ${LLVM_STATIC_EXTENSIONS})
-      set_property(TARGET LLVMExtensions APPEND PROPERTY LINK_LIBRARIES ${llvm_extension})
-      set_property(TARGET LLVMExtensions APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${llvm_extension})
+      # Update the properties for the normal library and the object library.
+      foreach (lib "LLVMExtensions;obj.LLVMExtensions")
+         set_property(TARGET ${lib} APPEND PROPERTY LINK_LIBRARIES ${llvm_extension})
+         set_property(TARGET ${lib} APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${llvm_extension})
+      endforeach()
   endforeach()
 
   # Eventually generate the extension headers, and store config to a cmake file

--- a/llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Interpreter/CMakeLists.txt
@@ -1,3 +1,7 @@
+if( LLVM_ENABLE_FFI )
+  set(link_libs FFI::ffi)
+endif()
+
 add_llvm_component_library(LLVMInterpreter
   Execution.cpp
   ExternalFunctions.cpp
@@ -6,13 +10,10 @@ add_llvm_component_library(LLVMInterpreter
   DEPENDS
   intrinsics_gen
 
+  LINK_LIBS PRIVATE ${link_libs}
   LINK_COMPONENTS
   CodeGen
   Core
   ExecutionEngine
   Support
   )
-
-if( LLVM_ENABLE_FFI )
-  target_link_libraries( LLVMInterpreter PRIVATE FFI::ffi )
-endif()

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -298,7 +298,6 @@ add_llvm_component_library(LLVMSupport
   Z3Solver.cpp
 
   ${ALLOCATOR_FILES}
-  $<TARGET_OBJECTS:LLVMSupportBlake3>
 
 # System
   Atomic.cpp
@@ -328,6 +327,7 @@ add_llvm_component_library(LLVMSupport
 
   LINK_LIBS
   ${system_libs} ${imported_libs} ${delayload_flags}
+  $<TARGET_OBJECTS:LLVMSupportBlake3>
 
   LINK_COMPONENTS
   Demangle

--- a/llvm/tools/llvm-archive/CMakeLists.txt
+++ b/llvm/tools/llvm-archive/CMakeLists.txt
@@ -1,0 +1,23 @@
+# This tool creates a static library from the LLVM libraries.
+
+option(LLVM_BUILD_LLVM_ARCHIVE "Build libllvm static library" OFF)
+
+if(LLVM_BUILD_LLVM_ARCHIVE)
+  set(LLVM_ARCHIVE_COMPONENTS "all" CACHE STRING "Libraries to include in libLLVM archive")
+  
+  llvm_map_components_to_libnames(LIB_NAMES ${LLVM_ARCHIVE_COMPONENTS})
+
+  list(REMOVE_ITEM LIB_NAMES "LLVMTableGen")
+
+  list(REMOVE_DUPLICATES LIB_NAMES)
+  # Link against the object libraries instead of static libraries.
+  list(TRANSFORM LIB_NAMES PREPEND "obj.")
+
+  add_llvm_library(LLVM_static STATIC
+    LINK_LIBS ${LIB_NAMES}
+    OUTPUT_NAME "LLVM"
+    NO_EXPORT
+    )
+endif()
+
+

--- a/llvm/tools/llvm-shlib/CMakeLists.txt
+++ b/llvm/tools/llvm-shlib/CMakeLists.txt
@@ -51,6 +51,10 @@ if(LLVM_BUILD_LLVM_DYLIB)
   endif()
 
   list(REMOVE_DUPLICATES LIB_NAMES)
+
+  # Link against the object libraries instead of static libraries.
+  list(TRANSFORM LIB_NAMES PREPEND "obj.")
+
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     set(LIB_NAMES -Wl,-all_load ${LIB_NAMES})
   else()


### PR DESCRIPTION
This is a rebased copy of https://reviews.llvm.org/D95727. We would like to enable building libLLVM as a static archive which was originally proposed in https://reviews.llvm.org/D99155 via archive merging, but using object libraries is cleaner and simpler approach.

This change also additionally includes a new tool, llvm-archive, for building LLVM as a single static archive, as an alternative approach to https://reviews.llvm.org/D99155. This demonstrates another use case object libraries.