### PR TITLE
[mlir][SPIRVToLLVM] Add missing conversions for GL ops

### DIFF
--- a/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
@@ -1544,6 +1544,26 @@ public:
   }
 };
 
+// `llvm.intr.abs` requires an `is_int_min_poison` immarg that `spirv.GL.SAbs`
+// does not carry; default to `false` to preserve SPIR-V's well-defined
+// behavior on INT_MIN.
+class SAbsPattern : public SPIRVToLLVMConversion<spirv::GLSAbsOp> {
+public:
+  using SPIRVToLLVMConversion<spirv::GLSAbsOp>::SPIRVToLLVMConversion;
+
+  LogicalResult
+  matchAndRewrite(spirv::GLSAbsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto dstType = getTypeConverter()->convertType(op.getType());
+    if (!dstType)
+      return rewriter.notifyMatchFailure(op, "type conversion failed");
+
+    rewriter.replaceOpWithNewOp<LLVM::AbsOp>(op, dstType, adaptor.getOperand(),
+                                             /*is_int_min_poison=*/false);
+    return success();
+  }
+};
+
 class VariablePattern : public SPIRVToLLVMConversion<spirv::VariableOp> {
 public:
   using SPIRVToLLVMConversion<spirv::VariableOp>::SPIRVToLLVMConversion;
@@ -1867,14 +1887,18 @@ void mlir::populateSPIRVToLLVMConversionPatterns(
       DirectConversionPattern<spirv::GLExpOp, LLVM::ExpOp>,
       DirectConversionPattern<spirv::GLFAbsOp, LLVM::FAbsOp>,
       DirectConversionPattern<spirv::GLFloorOp, LLVM::FFloorOp>,
+      DirectConversionPattern<spirv::GLFmaOp, LLVM::FMAOp>,
       DirectConversionPattern<spirv::GLFMaxOp, LLVM::MaxNumOp>,
       DirectConversionPattern<spirv::GLFMinOp, LLVM::MinNumOp>,
       DirectConversionPattern<spirv::GLLogOp, LLVM::LogOp>,
+      DirectConversionPattern<spirv::GLPowOp, LLVM::PowOp>,
       DirectConversionPattern<spirv::GLSinOp, LLVM::SinOp>,
       DirectConversionPattern<spirv::GLSMaxOp, LLVM::SMaxOp>,
       DirectConversionPattern<spirv::GLSMinOp, LLVM::SMinOp>,
       DirectConversionPattern<spirv::GLSqrtOp, LLVM::SqrtOp>,
-      InverseSqrtPattern, TanPattern, TanhPattern,
+      DirectConversionPattern<spirv::GLUMaxOp, LLVM::UMaxOp>,
+      DirectConversionPattern<spirv::GLUMinOp, LLVM::UMinOp>,
+      InverseSqrtPattern, SAbsPattern, TanPattern, TanhPattern,
 
       // Logical ops
       DirectConversionPattern<spirv::LogicalAndOp, LLVM::AndOp>,

--- a/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
@@ -1554,7 +1554,7 @@ public:
   LogicalResult
   matchAndRewrite(spirv::GLSAbsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto dstType = getTypeConverter()->convertType(op.getType());
+    Type dstType = getTypeConverter()->convertType(op.getType());
     if (!dstType)
       return rewriter.notifyMatchFailure(op, "type conversion failed");
 

--- a/mlir/test/Conversion/SPIRVToLLVM/gl-ops-to-llvm.mlir
+++ b/mlir/test/Conversion/SPIRVToLLVM/gl-ops-to-llvm.mlir
@@ -118,6 +118,45 @@ spirv.func @sin(%arg0: f32, %arg1: vector<3xf16>) "None" {
 }
 
 //===----------------------------------------------------------------------===//
+// spirv.GL.Pow
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @pow
+spirv.func @pow(%arg0: f32, %arg1: vector<3xf16>) "None" {
+  // CHECK: llvm.intr.pow(%{{.*}}, %{{.*}}) : (f32, f32) -> f32
+  %0 = spirv.GL.Pow %arg0, %arg0 : f32
+  // CHECK: llvm.intr.pow(%{{.*}}, %{{.*}}) : (vector<3xf16>, vector<3xf16>) -> vector<3xf16>
+  %1 = spirv.GL.Pow %arg1, %arg1 : vector<3xf16>
+  spirv.Return
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.GL.Fma
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @fma
+spirv.func @fma(%arg0: f32, %arg1: vector<3xf16>) "None" {
+  // CHECK: llvm.intr.fma(%{{.*}}, %{{.*}}, %{{.*}}) : (f32, f32, f32) -> f32
+  %0 = spirv.GL.Fma %arg0, %arg0, %arg0 : f32
+  // CHECK: llvm.intr.fma(%{{.*}}, %{{.*}}, %{{.*}}) : (vector<3xf16>, vector<3xf16>, vector<3xf16>) -> vector<3xf16>
+  %1 = spirv.GL.Fma %arg1, %arg1, %arg1 : vector<3xf16>
+  spirv.Return
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.GL.SAbs
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @sabs
+spirv.func @sabs(%arg0: i16, %arg1: vector<3xi32>) "None" {
+  // CHECK: "llvm.intr.abs"(%{{.*}}) <{is_int_min_poison = false}> : (i16) -> i16
+  %0 = spirv.GL.SAbs %arg0 : i16
+  // CHECK: "llvm.intr.abs"(%{{.*}}) <{is_int_min_poison = false}> : (vector<3xi32>) -> vector<3xi32>
+  %1 = spirv.GL.SAbs %arg1 : vector<3xi32>
+  spirv.Return
+}
+
+//===----------------------------------------------------------------------===//
 // spirv.GL.SMax
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Conversion/SPIRVToLLVM/gl-ops-to-llvm.mlir
+++ b/mlir/test/Conversion/SPIRVToLLVM/gl-ops-to-llvm.mlir
@@ -183,6 +183,32 @@ spirv.func @smin(%arg0: i16, %arg1: vector<3xi32>) "None" {
 }
 
 //===----------------------------------------------------------------------===//
+// spirv.GL.UMax
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @umax
+spirv.func @umax(%arg0: i16, %arg1: vector<3xi32>) "None" {
+  // CHECK: llvm.intr.umax(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
+  %0 = spirv.GL.UMax %arg0, %arg0 : i16
+  // CHECK: llvm.intr.umax(%{{.*}}, %{{.*}}) : (vector<3xi32>, vector<3xi32>) -> vector<3xi32>
+  %1 = spirv.GL.UMax %arg1, %arg1 : vector<3xi32>
+  spirv.Return
+}
+
+//===----------------------------------------------------------------------===//
+// spirv.GL.UMin
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: @umin
+spirv.func @umin(%arg0: i16, %arg1: vector<3xi32>) "None" {
+  // CHECK: llvm.intr.umin(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
+  %0 = spirv.GL.UMin %arg0, %arg0 : i16
+  // CHECK: llvm.intr.umin(%{{.*}}, %{{.*}}) : (vector<3xi32>, vector<3xi32>) -> vector<3xi32>
+  %1 = spirv.GL.UMin %arg1, %arg1 : vector<3xi32>
+  spirv.Return
+}
+
+//===----------------------------------------------------------------------===//
 // spirv.GL.Sqrt
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Add direct LLVM intrinsic lowerings for spirv.GL.Pow, spirv.GL.Fma, spirv.GL.UMax, spirv.GL.UMin, and spirv.GL.SAbs