### PR TITLE
[lldb][windows] emit a warning if the test target's path exceeds Windows' limit

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -783,13 +783,28 @@ class Base(unittest.TestCase):
         """Create the test-specific working directory, optionally deleting any
         previous contents."""
         bdir = self.getBuildDir()
+        if sys.platform == "win32" and len(bdir) > 256:
+            import warnings
+
+            warnings.warn(
+                "Test build directory path exceeds 256 characters (Windows "
+                "MAX_PATH limit): {}".format(bdir)
+            )
         if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
             shutil.rmtree(bdir)
         lldbutil.mkdir_p(bdir)
 
     def getBuildArtifact(self, name="a.out"):
         """Return absolute path to an artifact in the test's build directory."""
-        return os.path.join(self.getBuildDir(), name)
+        artifact_path = os.path.join(self.getBuildDir(), name)
+        if sys.platform == "win32" and len(artifact_path) > 256:
+            import warnings
+
+            warnings.warn(
+                "Test artifact path exceeds 256 characters (Windows "
+                "MAX_PATH limit): {}".format(artifact_path)
+            )
+        return artifact_path
 
     def getSourcePath(self, name):
         """Return absolute path to a file in the test's source directory."""

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -55,6 +55,13 @@ class ShTestLldb(ShTest):
         super().__init__(execute_external, extra_substitutions, preamble_commands)
 
     def execute(self, test, litConfig):
+        exec_path = test.getExecPath()
+        if platform.system() == "Windows" and len(exec_path) > 256:
+            litConfig.warning(
+                "Test path exceeds 256 characters (Windows MAX_PATH limit): "
+                + exec_path
+            )
+
         # Run each Shell test in a separate directory (on remote).
 
         # Find directory change command in %lldb substitution.


### PR DESCRIPTION
Windows' `MAX_PATH` is 256 characters. Anything longer than that can cause test failures.

This patch adds a warning when executing API and Shell tests if the build directory of the test target or the test target itself have paths that are longer than 256 characters.

rdar://177509534