### PR TITLE
[libc] Change POSIX to posix in unistd.yaml

### DIFF
--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -47,7 +47,7 @@ objects:
 functions:
   - name: __llvm_libc_syscall
     standards:
-      - POSIX
+      - posix
     return_type: long
     arguments:
       - type: long
@@ -59,26 +59,26 @@ functions:
       - type: long
   - name: _exit
     standards:
-      - POSIX
+      - posix
     return_type: _Noreturn void
     arguments:
       - type: int
   - name: access
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
       - type: int
   - name: chdir
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
   - name: chown
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
@@ -86,26 +86,26 @@ functions:
       - type: gid_t
   - name: close
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: dup
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: dup2
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: int
   - name: dup3
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -113,14 +113,14 @@ functions:
       - type: int
   - name: execv
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
       - type: __exec_argv_t
   - name: execve
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
@@ -128,7 +128,7 @@ functions:
       - type: __exec_envp_t
   - name: faccessat
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -137,13 +137,13 @@ functions:
       - type: int
   - name: fchdir
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: fchown
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -151,33 +151,33 @@ functions:
       - type: gid_t
   - name: fpathconf
     standards:
-      - POSIX
+      - posix
     return_type: long
     arguments:
       - type: int
       - type: int
   - name: fork
     standards:
-      - POSIX
+      - posix
     return_type: pid_t
     arguments:
       - type: void
   - name: fsync
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: ftruncate
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: off_t
   - name: getcwd
     standards:
-      - POSIX
+      - posix
     return_type: char *
     arguments:
       - type: char *
@@ -191,13 +191,13 @@ functions:
       - type: size_t
   - name: geteuid
     standards:
-      - POSIX
+      - posix
     return_type: uid_t
     arguments:
       - type: void
   - name: gethostname
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: char *
@@ -210,7 +210,7 @@ functions:
       - type: void
   - name: getopt
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -218,19 +218,19 @@ functions:
       - type: const char *
   - name: getpid
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void
   - name: getppid
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void
   - name: getsid
     standards:
-      - POSIX
+      - posix
     return_type: pid_t
     arguments:
       - type: pid_t
@@ -242,19 +242,19 @@ functions:
       - type: void
   - name: getuid
     standards:
-      - POSIX
+      - posix
     return_type: uid_t
     arguments:
       - type: void
   - name: getgid
     standards:
-      - POSIX
+      - posix
     return_type: gid_t
     arguments:
       - type: void
   - name: isatty
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -262,14 +262,14 @@ functions:
     attributes: []
   - name: link
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
       - type: const char *
   - name: linkat
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -279,7 +279,7 @@ functions:
       - type: int
   - name: lseek
     standards:
-      - POSIX
+      - posix
     return_type: off_t
     arguments:
       - type: int
@@ -287,14 +287,14 @@ functions:
       - type: int
   - name: pathconf
     standards:
-      - POSIX
+      - posix
     return_type: long
     arguments:
       - type: const char *
       - type: int
   - name: pipe
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int *
@@ -307,7 +307,7 @@ functions:
       - type: int
   - name: pread
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -316,7 +316,7 @@ functions:
       - type: off_t
   - name: pwrite
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -325,7 +325,7 @@ functions:
       - type: off_t
   - name: read
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -333,7 +333,7 @@ functions:
       - type: size_t
   - name: readlink
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: const char *__restrict
@@ -341,7 +341,7 @@ functions:
       - type: size_t
   - name: readlinkat
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -350,13 +350,13 @@ functions:
       - type: size_t
   - name: rmdir
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
   - name: swab
     standards:
-      - POSIX
+      - posix
     return_type: void
     arguments:
       - type: const void *__restrict
@@ -364,20 +364,20 @@ functions:
       - type: ssize_t
   - name: setsid
     standards:
-      - POSIX
+      - posix
     return_type: pid_t
     arguments:
       - type: void
   - name: symlink
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
       - type: const char *
   - name: symlinkat
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
@@ -385,26 +385,26 @@ functions:
       - type: const char *
   - name: sysconf
     standards:
-      - POSIX
+      - posix
     return_type: long
     arguments:
       - type: int
   - name: truncate
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
       - type: off_t
   - name: unlink
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
   - name: unlinkat
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -412,7 +412,7 @@ functions:
       - type: int
   - name: write
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int


### PR DESCRIPTION
1. In `header.py`, the canonical identifiers for standards are explicitly defined in lowercase and mapped to their uppercase/pretty names for display:     

```python
    # All the canonical identifiers are in lowercase for easy maintenance.
    # This maps them to the pretty descriptions to generate in header comments.
    LIBRARY_DESCRIPTIONS = {
        "stdc": "Standard C",
        "posix": "POSIX",
        "bsd": "BSD",
        "gnu": "GNU",
        "linux": "Linux",
        "uefi": "UEFI",
        "svid": "SVID",
    }
```  

  3. Later in the same file, when generating library descriptions, it checks for the lowercase string header.py:
    # If the header itself is in POSIX, just call it that.
```python
    if "posix" in self.standards:
        return descriptions["posix"]
```
