### PR TITLE
[MC] Create new MCScheduleOptions cl::opt category

### DIFF
--- a/llvm/include/llvm/MC/MCSchedule.h
+++ b/llvm/include/llvm/MC/MCSchedule.h
@@ -32,6 +32,12 @@ class MCInst;
 class MCInstrDesc;
 class InstrItineraryData;
 
+namespace cl {
+class OptionCategory;
+}
+
+extern cl::OptionCategory MCScheduleOptions;
+
 /// Define a kind of processor resource that will be modeled by the scheduler.
 struct MCProcResourceDesc {
   const char *Name;

--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -23,11 +23,13 @@
 
 using namespace llvm;
 
+cl::OptionCategory llvm::MCScheduleOptions("Machine model options");
+
 static constexpr float DefaultReservationStationScaleFactor = 1.0f;
 
 static cl::opt<float> ReservationStationScaleFactor(
     "sched-model-reservation-station-scale-factor", cl::Hidden,
-    cl::init(DefaultReservationStationScaleFactor),
+    cl::init(DefaultReservationStationScaleFactor), cl::cat(MCScheduleOptions),
     cl::desc("Scale the buffer size of all reservation stations by a positive "
              "factor. Buffer sizes of -1/0/1 (unlimited/unbuffered/in-order) "
              "are preserved. Likewise, if the scaled result is <= 1, the "

--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -23,7 +23,7 @@
 
 using namespace llvm;
 
-cl::OptionCategory llvm::MCScheduleOptions("Machine model options");
+cl::OptionCategory llvm::MCScheduleOptions("Machine scheduling model options");
 
 static constexpr float DefaultReservationStationScaleFactor = 1.0f;
 

--- a/llvm/test/tools/llvm-mca/mc-schedule-options-help.test
+++ b/llvm/test/tools/llvm-mca/mc-schedule-options-help.test
@@ -1,0 +1,8 @@
+# RUN: llvm-mca --help-hidden | FileCheck %s --check-prefix=HIDDEN
+# RUN: llvm-mca --help | FileCheck %s --check-prefix=HELP
+
+# HIDDEN: Machine model options:
+# HIDDEN:   --sched-model-reservation-station-scale-factor=<number>
+
+# HELP-NOT: Machine model options:
+# HELP-NOT: sched-model-reservation-station-scale-factor

--- a/llvm/test/tools/llvm-mca/mc-schedule-options-help.test
+++ b/llvm/test/tools/llvm-mca/mc-schedule-options-help.test
@@ -1,8 +1,8 @@
 # RUN: llvm-mca --help-hidden | FileCheck %s --check-prefix=HIDDEN
 # RUN: llvm-mca --help | FileCheck %s --check-prefix=HELP
 
-# HIDDEN: Machine model options:
+# HIDDEN: Machine scheduling model options:
 # HIDDEN:   --sched-model-reservation-station-scale-factor=<number>
 
-# HELP-NOT: Machine model options:
+# HELP-NOT: Machine scheduling model options:
 # HELP-NOT: sched-model-reservation-station-scale-factor

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -38,6 +38,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSchedule.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/MCTargetOptionsCommandFlags.h"
 #include "llvm/MC/TargetRegistry.h"
@@ -374,7 +375,7 @@ int main(int argc, char **argv) {
   // Enable printing of available targets when flag --version is specified.
   cl::AddExtraVersionPrinter(TargetRegistry::printRegisteredTargetsForVersion);
 
-  cl::HideUnrelatedOptions({&ToolOptions, &ViewOptions});
+  cl::HideUnrelatedOptions({&ToolOptions, &ViewOptions, &MCScheduleOptions});
 
   // Parse flags and initialize target options.
   cl::ParseCommandLineOptions(argc, argv,


### PR DESCRIPTION
This patch creates a new cl::opt category for MCSchedule options. It enables tools to filter MCSchedule options based on category. Specifically, llvm-mca now filters them in, and displays them under `--help-hidden`, which wasnt the case before.