### PR TITLE
[lldb] Fix delayed breakpoints on running processes

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -2307,6 +2307,9 @@ protected:
   UpdateBreakpointSites(const BreakpointSiteToActionMap &site_to_action);
 
 public:
+  /// Performs `action` on `site`. If `forbid_delay` is true, the action is
+  /// performed immediately, otherwise the method will delay the breakpoint if
+  /// it is correct to do so.
   llvm::Error ExecuteBreakpointSiteAction(BreakpointSite &site,
                                           Process::BreakpointAction action,
                                           bool forbid_delay);

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1601,6 +1601,9 @@ Status Process::DisableBreakpointSiteByID(lldb::user_id_t break_id) {
 llvm::Error Process::ExecuteBreakpointSiteAction(BreakpointSite &site,
                                                  BreakpointAction action,
                                                  bool forbid_delay) {
+  // Breakpoints immediately affect running processes, so do not delay them.
+  forbid_delay |= IsRunning();
+
   if (forbid_delay)
     if (llvm::Error E = FlushDelayedBreakpoints())
       LLDB_LOG_ERROR(

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/TestBreakpointWhileRunning.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/TestBreakpointWhileRunning.py
@@ -23,4 +23,3 @@ class BreakpointWhileRunning(TestBase):
         lldbutil.expect_state_changes(self, listener, process, [lldb.eStateRunning])
         self.runCmd("break set --source-pattern-regexp 'break here'")
         lldbutil.expect_state_changes(self, listener, process, [lldb.eStateStopped])
-        self.runCmd("process status")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/TestBreakpointWhileRunning.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/TestBreakpointWhileRunning.py
@@ -1,0 +1,26 @@
+"""
+Test inserting a breakpoint while inferior is executing.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test import lldbutil
+
+
+class BreakpointWhileRunning(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_breakpoint_while_running(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "main", lldb.SBFileSpec("main.c")
+        )
+
+        self.dbg.SetAsync(True)
+        listener = self.dbg.GetListener()
+        self.runCmd("break delete --force")
+        self.runCmd("continue")
+        lldbutil.expect_state_changes(self, listener, process, [lldb.eStateRunning])
+        self.runCmd("break set --source-pattern-regexp 'break here'")
+        lldbutil.expect_state_changes(self, listener, process, [lldb.eStateStopped])
+        self.runCmd("process status")

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/main.c
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_while_running/main.c
@@ -1,0 +1,12 @@
+#ifdef _WIN32
+#include <windows.h>
+#define sleep(x) Sleep((x) * 1000)
+#else
+#include <unistd.h>
+#endif
+
+int main() {
+  int count = 100;
+  while (count--)
+    sleep(1); // break here
+}


### PR DESCRIPTION
Breakpoints should never be delayed on a running process, as they can immediately affect program execution.