### PR TITLE
[AArch64][GlobalISel] Add support for scalar sqdmulh intrinsic

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -635,6 +635,7 @@ static bool isFPIntrinsic(const MachineRegisterInfo &MRI,
   case Intrinsic::aarch64_neon_sqadd:
   case Intrinsic::aarch64_neon_uqsub:
   case Intrinsic::aarch64_neon_sqsub:
+  case Intrinsic::aarch64_neon_sqdmulh:
   case Intrinsic::aarch64_neon_sqdmulls_scalar:
   case Intrinsic::aarch64_neon_srshl:
   case Intrinsic::aarch64_neon_urshl:

--- a/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-int-neon.ll
@@ -2,8 +2,7 @@
 ; RUN: llc < %s -mtriple aarch64-unknown-unknown -mattr=+fprcvt,+fullfp16 | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc < %s -mtriple aarch64-unknown-unknown -global-isel -global-isel-abort=2 -mattr=+fprcvt,+fullfp16 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:    warning: Instruction selection used fallback path for test_sqdmulh_scalar
-; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s32
+; CHECK-GI:    warning: Instruction selection used fallback path for test_sqabs_s32
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqabs_s64
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqneg_s32
 ; CHECK-GI-NEXT:    warning: Instruction selection used fallback path for test_sqneg_s64

--- a/llvm/test/CodeGen/AArch64/arm64-vmul.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-vmul.ll
@@ -2,8 +2,7 @@
 ; RUN: llc -mtriple=aarch64-none-elf -mattr=+aes < %s | FileCheck %s --check-prefixes=CHECK,CHECK-SD
 ; RUN: llc -mtriple=aarch64-none-elf -mattr=+aes -global-isel -global-isel-abort=2 2>&1 < %s | FileCheck %s --check-prefixes=CHECK,CHECK-GI
 
-; CHECK-GI:       warning: Instruction selection used fallback path for sqdmulh_1s
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmls_2s
+; CHECK-GI:  warning: Instruction selection used fallback path for fmls_2s
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmls_4s
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmls_2d
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmls_commuted_neg_2s
@@ -18,7 +17,6 @@
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmla_indexed_scalar_2s_strict
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmla_indexed_scalar_4s_strict
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for fmla_indexed_scalar_2d_strict
-; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for sqdmulh_lane_1s
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for scalar_fmls_from_extract_v4f32
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for scalar_fmls_from_extract_v2f32
 ; CHECK-GI-NEXT:  warning: Instruction selection used fallback path for scalar_fmls_from_extract_v2f64


### PR DESCRIPTION
SQDMULH - Signed Saturated MUltiply, with result being Lower Half of the calculated value.

Previously, the scalar version of this intrinsic was failing to lower, because the RegBankSelect phase was attempting to put the source and destination values (i32s) on general purpose register banks. As NEON intrinsics aren't supported on GPR, change RegBankInfo to place all source and destination values onto FPR.