### PR TITLE
[Offload] fix OffloadAPI unittests discovery

### DIFF
--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -52,6 +52,7 @@ add_offload_testsuite(check-libomptarget
   ARGS ${LIBOMPTARGET_LIT_ARG_LIST})
 
 # Add liboffload unit tests - the test binary will run on all available devices
+set(OFFLOAD_UNITTEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/../unittests)
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/unit/lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/unit/lit.site.cfg

--- a/offload/test/unit/lit.cfg.py
+++ b/offload/test/unit/lit.cfg.py
@@ -15,7 +15,7 @@ config.suffixes = []
 
 # test_source_root: The root path where tests are located.
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.library_dir, "unittests")
+config.test_exec_root = config.unittest_dir
 config.test_source_root = config.test_exec_root
 
 # testFormat: The test format to use to interpret tests.

--- a/offload/test/unit/lit.site.cfg.in
+++ b/offload/test/unit/lit.site.cfg.in
@@ -1,6 +1,7 @@
 @AUTO_GEN_COMMENT@
 
 config.library_dir = "@LIBOMPTARGET_LIBRARY_DIR@"
+config.unittest_dir = "@OFFLOAD_UNITTEST_DIR@"
 config.llvm_build_mode = lit_config.substitute("@LLVM_BUILD_MODE@")
 
 # Let the main config do the real work.


### PR DESCRIPTION
Commit 3383f0d repointed LIBOMPTARGET_LIBRARY_DIR to a different runtimes lib dir, but the unit lit config still derived the unittest binary path from it. Pass the unittest directory explicitly instead.