### PR TITLE
[lldb] Update TestDelayedBreakpoint test to use the right setting

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/delayed_breakpoints/TestDelayedBreakpoint.py
@@ -9,6 +9,7 @@ import os
 class TestDelayedBreakpoint(TestBase):
     def test(self):
         self.build()
+        self.runCmd("settings set target.process.use-delayed-breakpoints true")
         logfile = os.path.join(self.getBuildDir(), "log.txt")
         self.runCmd(f"log enable -f {logfile} gdb-remote packets")
 
@@ -45,6 +46,7 @@ class TestDelayedBreakpoint(TestBase):
 
     def test_eager_breakpoints(self):
         self.build()
+        self.runCmd("settings set target.process.use-delayed-breakpoints true")
         logfile = os.path.join(self.getBuildDir(), "log.txt")
         self.runCmd(f"log enable -f {logfile} gdb-remote packets")
 


### PR DESCRIPTION
This test should regardless of which setting is the default for delayed breakpoints.