### PR TITLE
[Flang][tests] Add a missing REQUIRES.

### DIFF
--- a/flang/test/Integration/OpenMP/atomic-compare.f90
+++ b/flang/test/Integration/OpenMP/atomic-compare.f90
@@ -6,6 +6,7 @@
 ! added to this directory and sub-directories.
 !===----------------------------------------------------------------------===!
 
+!REQUIRES: x86-registered-target
 !RUN: %flang_fc1 -triple x86_64-unknown-linux-gnu -emit-llvm -fopenmp -fopenmp-version=51 %s -o - | FileCheck %s
 
 ! Int "==" → cmpxchg, default (monotonic) ordering


### PR DESCRIPTION
A newly added test uses `x86_64-unknown-linux-gnu` as a triple, without a `REQUIRES: x86-registered-target` line, so that it will fail in builds of LLVM specific to other architectures.