### PR TITLE
[flang][Semantics] Warn on repeated do-variable in nested I/O implied DO

### DIFF
--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -86,7 +86,8 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
     MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure,
-    IgnoredNoReallocateLHS, CLoc, ExperimentalOption, AccImplicitScalar)
+    IgnoredNoReallocateLHS, CLoc, ExperimentalOption, AccImplicitScalar,
+    IoImpliedDoIndexConflict)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/include/flang/Support/Fortran-features.h
+++ b/flang/include/flang/Support/Fortran-features.h
@@ -86,7 +86,7 @@ ENUM_CLASS(UsageWarning, Portability, PointerToUndefinable,
     RealConstantWidening, VolatileOrAsynchronousTemporary, UnusedVariable,
     UsedUndefinedVariable, BadValueInDeadCode, AssumedTypeSizeDummy,
     MisplacedIgnoreTKR, NamelistParameter, ImpureFinalInPure,
-    IgnoredNoReallocateLHS, ExperimentalOption)
+    IgnoredNoReallocateLHS, ExperimentalOption, IoImpliedDoIndexConflict)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 using UsageWarnings = EnumSet<UsageWarning, UsageWarning_enumSize>;

--- a/flang/lib/Semantics/check-do-forall.cpp
+++ b/flang/lib/Semantics/check-do-forall.cpp
@@ -1195,16 +1195,70 @@ static void CheckIoImpliedDoIndex(
   }
 }
 
+// F2023 12.6.3p7: The do-variable of an io-implied-do that is in another
+// io-implied-do shall not appear as, nor be associated with, the do-variable
+// of the containing io-implied-do.
+void DoForallChecker::CheckActiveIoImpliedDoVar(const parser::Name &name) {
+  if (!name.symbol) {
+    return;
+  }
+  const Symbol &resolved{ResolveAssociations(*name.symbol)};
+  const EquivalenceSet *equivSet{FindEquivalenceSet(resolved)};
+  for (const Symbol *active : activeIoImpliedDoVars_) {
+    const Symbol &activeResolved{ResolveAssociations(*active)};
+    bool associated{&resolved == &activeResolved};
+    if (!associated && equivSet) {
+      for (const EquivalenceObject &obj : *equivSet) {
+        if (obj.symbol == activeResolved) {
+          associated = true;
+          break;
+        }
+      }
+    }
+    if (associated) {
+      if (name.symbol == active) {
+        context_.Warn(common::UsageWarning::IoImpliedDoIndexConflict,
+            name.source,
+            "I/O implied DO index '%s' appears in an enclosing I/O implied DO loop and should not have the same name"_warn_en_US,
+            name.source);
+      } else {
+        context_.Warn(common::UsageWarning::IoImpliedDoIndexConflict,
+            name.source,
+            "I/O implied DO index '%s' should not be associated with do-variable '%s' of an enclosing I/O implied DO loop"_warn_en_US,
+            name.source, active->name());
+      }
+      break;
+    }
+  }
+  activeIoImpliedDoVars_.insert(name.symbol);
+}
+
+void DoForallChecker::Enter(const parser::OutputImpliedDo &outputImpliedDo) {
+  CheckActiveIoImpliedDoVar(parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(outputImpliedDo.t).Name()));
+}
+
+void DoForallChecker::Enter(const parser::InputImpliedDo &inputImpliedDo) {
+  CheckActiveIoImpliedDoVar(parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(inputImpliedDo.t).Name()));
+}
+
 void DoForallChecker::Leave(const parser::OutputImpliedDo &outputImpliedDo) {
-  CheckIoImpliedDoIndex(context_,
-      parser::UnwrapRef<parser::Name>(
-          std::get<parser::IoImpliedDoControl>(outputImpliedDo.t).Name()));
+  const auto &name{parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(outputImpliedDo.t).Name())};
+  CheckIoImpliedDoIndex(context_, name);
+  if (name.symbol) {
+    activeIoImpliedDoVars_.erase(name.symbol);
+  }
 }
 
 void DoForallChecker::Leave(const parser::InputImpliedDo &inputImpliedDo) {
-  CheckIoImpliedDoIndex(context_,
-      parser::UnwrapRef<parser::Name>(
-          std::get<parser::IoImpliedDoControl>(inputImpliedDo.t).Name()));
+  const auto &name{parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(inputImpliedDo.t).Name())};
+  CheckIoImpliedDoIndex(context_, name);
+  if (name.symbol) {
+    activeIoImpliedDoVars_.erase(name.symbol);
+  }
 }
 
 void DoForallChecker::Leave(const parser::StatVariable &statVariable) {

--- a/flang/lib/Semantics/check-do-forall.cpp
+++ b/flang/lib/Semantics/check-do-forall.cpp
@@ -1191,16 +1191,70 @@ static void CheckIoImpliedDoIndex(
   }
 }
 
+// F2023 12.6.3p7: The do-variable of an io-implied-do that is in another
+// io-implied-do shall not appear as, nor be associated with, the do-variable
+// of the containing io-implied-do.
+void DoForallChecker::CheckActiveIoImpliedDoVar(const parser::Name &name) {
+  if (!name.symbol) {
+    return;
+  }
+  const Symbol &resolved{ResolveAssociations(*name.symbol)};
+  const EquivalenceSet *equivSet{FindEquivalenceSet(resolved)};
+  for (const Symbol *active : activeIoImpliedDoVars_) {
+    const Symbol &activeResolved{ResolveAssociations(*active)};
+    bool associated{&resolved == &activeResolved};
+    if (!associated && equivSet) {
+      for (const EquivalenceObject &obj : *equivSet) {
+        if (obj.symbol == activeResolved) {
+          associated = true;
+          break;
+        }
+      }
+    }
+    if (associated) {
+      if (name.symbol == active) {
+        context_.Warn(common::UsageWarning::IoImpliedDoIndexConflict,
+            name.source,
+            "I/O implied DO index '%s' appears in an enclosing I/O implied DO loop and should not have the same name"_warn_en_US,
+            name.source);
+      } else {
+        context_.Warn(common::UsageWarning::IoImpliedDoIndexConflict,
+            name.source,
+            "I/O implied DO index '%s' should not be associated with do-variable '%s' of an enclosing I/O implied DO loop"_warn_en_US,
+            name.source, active->name());
+      }
+      break;
+    }
+  }
+  activeIoImpliedDoVars_.insert(name.symbol);
+}
+
+void DoForallChecker::Enter(const parser::OutputImpliedDo &outputImpliedDo) {
+  CheckActiveIoImpliedDoVar(parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(outputImpliedDo.t).Name()));
+}
+
+void DoForallChecker::Enter(const parser::InputImpliedDo &inputImpliedDo) {
+  CheckActiveIoImpliedDoVar(parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(inputImpliedDo.t).Name()));
+}
+
 void DoForallChecker::Leave(const parser::OutputImpliedDo &outputImpliedDo) {
-  CheckIoImpliedDoIndex(context_,
-      parser::UnwrapRef<parser::Name>(
-          std::get<parser::IoImpliedDoControl>(outputImpliedDo.t).Name()));
+  const auto &name{parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(outputImpliedDo.t).Name())};
+  CheckIoImpliedDoIndex(context_, name);
+  if (name.symbol) {
+    activeIoImpliedDoVars_.erase(name.symbol);
+  }
 }
 
 void DoForallChecker::Leave(const parser::InputImpliedDo &inputImpliedDo) {
-  CheckIoImpliedDoIndex(context_,
-      parser::UnwrapRef<parser::Name>(
-          std::get<parser::IoImpliedDoControl>(inputImpliedDo.t).Name()));
+  const auto &name{parser::UnwrapRef<parser::Name>(
+      std::get<parser::IoImpliedDoControl>(inputImpliedDo.t).Name())};
+  CheckIoImpliedDoIndex(context_, name);
+  if (name.symbol) {
+    activeIoImpliedDoVars_.erase(name.symbol);
+  }
 }
 
 void DoForallChecker::Leave(const parser::StatVariable &statVariable) {

--- a/flang/lib/Semantics/check-do-forall.h
+++ b/flang/lib/Semantics/check-do-forall.h
@@ -55,7 +55,9 @@ public:
   void Leave(const parser::Expr &);
   void Leave(const parser::InquireSpec &);
   void Leave(const parser::IoControlSpec &);
+  void Enter(const parser::OutputImpliedDo &);
   void Leave(const parser::OutputImpliedDo &);
+  void Enter(const parser::InputImpliedDo &);
   void Leave(const parser::InputImpliedDo &);
   void Leave(const parser::StatVariable &);
 
@@ -63,7 +65,9 @@ private:
   SemanticsContext &context_;
   int exprDepth_{0};
   std::list<SemanticsContext::IndexVarKind> nestedWithinConcurrent_;
+  std::set<const Symbol *> activeIoImpliedDoVars_;
 
+  void CheckActiveIoImpliedDoVar(const parser::Name &);
   void SayBadLeave(
       StmtType, const char *enclosingStmt, const ConstructNode &) const;
   void CheckDoConcurrentExit(StmtType, const ConstructNode &) const;

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -218,6 +218,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnUsage_.set(UsageWarning::ImpureFinalInPure);
   warnUsage_.set(UsageWarning::IgnoredNoReallocateLHS);
   warnUsage_.set(UsageWarning::CLoc);
+  warnUsage_.set(UsageWarning::IoImpliedDoIndexConflict);
   warnLanguage_.set(LanguageFeature::OpenMPThreadprivateEquivalence);
 }
 

--- a/flang/lib/Support/Fortran-features.cpp
+++ b/flang/lib/Support/Fortran-features.cpp
@@ -215,6 +215,7 @@ LanguageFeatureControl::LanguageFeatureControl() {
   warnUsage_.set(UsageWarning::MisplacedIgnoreTKR);
   warnUsage_.set(UsageWarning::ImpureFinalInPure);
   warnUsage_.set(UsageWarning::IgnoredNoReallocateLHS);
+  warnUsage_.set(UsageWarning::IoImpliedDoIndexConflict);
   warnLanguage_.set(LanguageFeature::OpenMPThreadprivateEquivalence);
   warnLanguage_.set(LanguageFeature::OpenACCMultipleNamesInRoutine);
 }

--- a/flang/test/Semantics/io-implied-do01.f90
+++ b/flang/test/Semantics/io-implied-do01.f90
@@ -1,0 +1,64 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror
+!
+! Check that repeated do-variable names in nested io-implied-do are diagnosed.
+! Section 12.6.3 paragraph 7: The do-variable of an io-implied-do that is in
+! another io-implied-do shall not appear as, nor be associated with, the
+! do-variable of the containing io-implied-do.
+
+module m
+  integer :: mk
+end module
+
+program test
+  use m, only: mk, mk_alias => mk
+  implicit none
+  integer :: matrix(10,10), vec(10), cube(5,5,5)
+  integer :: i, j, k, ei
+  equivalence(j, ei)
+
+  do i = 1, 10
+    do j = 1, 10
+      matrix(i,j) = 10*(i - 1) + j
+    end do
+  end do
+  vec = [(i, i=1,10)]
+
+  ! OK: different do-variables
+  write(*,'(10i5)') ((matrix(i,j), j=1,10), i=1,10)
+
+  ! Bad: j repeated in nested io-implied-do
+  !WARNING: I/O implied DO index 'j' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+  write(*,'(10i5)') ((matrix(i,j), j=1,10), j=1,10)
+
+  ! Bad: i repeated in nested io-implied-do
+  !WARNING: I/O implied DO index 'i' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+  write(*,'(10i5)') ((matrix(i,j), i=1,10), i=1,10)
+
+  ! OK: single (non-nested) io-implied-do
+  write(*,'(10i5)') (vec(j), j=1,10)
+
+  ! OK: sibling (non-nested) implied-DOs reusing the same variable
+  write(*,'(10i5)') (vec(i), i=1,5), (vec(i), i=6,10)
+
+  ! Bad: j repeated in nested io-implied-do (READ)
+  !WARNING: I/O implied DO index 'j' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+  read(*,*) ((matrix(i,j), j=1,10), j=1,10)
+
+  ! Bad: ei is associated with j via EQUIVALENCE
+  !WARNING: I/O implied DO index 'ei' should not be associated with do-variable 'j' of an enclosing I/O implied DO loop [-Wio-implied-do-index-conflict]
+  write(*,'(10i5)') ((matrix(i,ei), ei=1,10), j=1,10)
+
+  ! Bad: USE-renamed mk_alias is the same variable as mk
+  !WARNING: I/O implied DO index 'mk_alias' should not be associated with do-variable 'mk' of an enclosing I/O implied DO loop [-Wio-implied-do-index-conflict]
+  write(*,'(10i5)') ((matrix(i,mk_alias), mk_alias=1,10), mk=1,10)
+
+  ! Bad: triple nesting, k repeated at innermost level
+  !WARNING: I/O implied DO index 'k' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+  write(*,*) (((cube(i,j,k), k=1,5), j=1,5), k=1,5)
+
+  ! Bad: ASSOCIATE — x is associated with j
+  associate(x => j)
+    !WARNING: I/O implied DO index 'x' should not be associated with do-variable 'j' of an enclosing I/O implied DO loop [-Wio-implied-do-index-conflict]
+    write(*,'(10i5)') ((matrix(i,x), x=1,10), j=1,10)
+  end associate
+end program test

--- a/flang/test/Semantics/io-implied-do01.f90
+++ b/flang/test/Semantics/io-implied-do01.f90
@@ -56,9 +56,31 @@ program test
   !WARNING: I/O implied DO index 'k' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
   write(*,*) (((cube(i,j,k), k=1,5), j=1,5), k=1,5)
 
+  ! Bad: sibling implied-DOs both conflicting with outer k (first sibling diagnosed)
+  !WARNING: I/O implied DO index 'k' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+  write(*,*) (((cube(i,j,k), k=1,5), (cube(i,j,k), k=1,5), j=1,5), k=1,5)
+
   ! Bad: ASSOCIATE — x is associated with j
   associate(x => j)
     !WARNING: I/O implied DO index 'x' should not be associated with do-variable 'j' of an enclosing I/O implied DO loop [-Wio-implied-do-index-conflict]
     write(*,'(10i5)') ((matrix(i,x), x=1,10), j=1,10)
   end associate
 end program test
+
+subroutine host()
+  implicit none
+  integer :: matrix(10,10), i, j
+contains
+  subroutine nested()
+    ! Bad: j is host-associated from host()
+    !WARNING: I/O implied DO index 'j' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+    write(*,'(10i5)') ((matrix(i,j), j=1,10), j=1,10)
+  end subroutine
+end subroutine
+
+subroutine implicit_test()
+  ! No implicit none — i, j are implicitly integer
+  integer :: matrix(10,10)
+  !WARNING: I/O implied DO index 'j' appears in an enclosing I/O implied DO loop and should not have the same name [-Wio-implied-do-index-conflict]
+  write(*,'(10i5)') ((matrix(i,j), j=1,10), j=1,10)
+end subroutine


### PR DESCRIPTION
Fixes #198528

Add a warning when an io-implied-do's do-variable appears as, or is associated with, the do-variable of a containing io-implied-do. This diagnoses violations of Fortran 2023 12.6.3p7:
>The do-variable of an io-implied-do that is in another io-implied-do shall not appear as, nor be associated with, the do-variable of the containing io-implied-do.

Since this is not a constraint, a warning is emitted rather than an error. As suggested in the associated issue, the warning is on by default and can be suppressed with `-Wno-io-implied-do-index-conflict`.

The check detects:

- Direct name reuse (same symbol in inner and outer implied DO)
- Association via EQUIVALENCE
- Association via USE-renaming
- Association via ASSOCIATE construct

A lit test (Semantics/io-implied-do01.f90) is added covering all of the above cases, plus valid cases (sibling implied-DOs, single implied-DO) that should not trigger the warning.

Example:
```
write(*,*) ((matrix(i,j), j=1,10), j=1,10)
! warning: I/O implied DO index 'j' appears in an enclosing I/O implied DO loop
!          and should not have the same name [-Wio-implied-do-index-conflict]
```

Assisted by: Claude