### PR TITLE
[RISCV] NFC: Use the new "let append" TableGen feature to reduce duplication

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -295,7 +295,7 @@ def C_LW_INX : CLoad_ri<0b010, "c.lw", GPRF32C, uimm7_lsb00>,
   let Inst{5} = imm{6};
 }
 
-let Predicates = [HasStdExtZca, IsRV64] in
+let append Predicates = [IsRV64] in
 def C_LD : CLoad_ri<0b011, "c.ld", GPRC, uimm8_lsb000>,
            Sched<[WriteLDD, ReadMemBase]> {
   bits<8> imm;
@@ -320,7 +320,7 @@ def C_SW_INX : CStore_rri<0b110, "c.sw", GPRF32C, uimm7_lsb00>,
   let Inst{5} = imm{6};
 }
 
-let Predicates = [HasStdExtZca, IsRV64] in
+let append Predicates = [IsRV64] in
 def C_SD : CStore_rri<0b111, "c.sd", GPRC, uimm8_lsb000>,
            Sched<[WriteSTD, ReadStoreData, ReadMemBase]> {
   bits<8> imm;
@@ -352,12 +352,12 @@ def PseudoC_ADDI_NOP : Pseudo<(outs GPRX0:$rd), (ins GPRX0:$rs1, simm6:$imm),
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCall = 1,
     DecoderNamespace = "RV32Only", Defs = [X1],
-    Predicates = [HasStdExtZca, IsRV32]  in
+    append Predicates = [IsRV32]  in
 def C_JAL : RVInst16CJ<0b001, OPC_C1, (outs), (ins bare_simm12_lsb0:$offset),
                        "c.jal", "$offset">, Sched<[WriteJal]>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0,
-    Predicates = [HasStdExtZca, IsRV64] in
+    append Predicates = [IsRV64] in
 def C_ADDIW : RVInst16CI<0b001, OPC_C1, (outs GPRNoX0:$rd_wb),
                          (ins GPRNoX0:$rd, simm6:$imm),
                          "c.addiw", "$rd, $imm">,
@@ -498,7 +498,7 @@ def C_SWSP_INX : CStackStore<0b110, "c.swsp", GPRF32, uimm8_lsb00>,
   let Inst{8-7}  = imm{7-6};
 }
 
-let Predicates = [HasStdExtZca, IsRV64] in
+let append Predicates = [IsRV64] in
 def C_SDSP : CStackStore<0b111, "c.sdsp", GPR, uimm9_lsb000>,
              Sched<[WriteSTD, ReadStoreData, ReadMemBase]> {
   let Inst{9-7}   = imm{8-6};
@@ -567,7 +567,7 @@ let Predicates = [HasStdExtZcd] in {
                  Sched<[WriteFST64, ReadFStoreData, ReadFMemBase]> {
     let Inst{9-7}   = imm{8-6};
   }
-} // Predicates = [HasStdExtZcd] in {
+} // Predicates = [HasStdExtZcd]
 
 //===----------------------------------------------------------------------===//
 // HINT Instructions
@@ -747,54 +747,48 @@ def : InstAlias<".insn_cj $opcode, $funct3, $imm11",
 let Predicates = [HasStdExtZca] in {
 def : CompressPat<(ADDI GPRC:$rd, SP:$rs1, uimm10_lsb00nonzero:$imm),
                   (C_ADDI4SPN GPRC:$rd, SP:$rs1, uimm10_lsb00nonzero:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
                   (C_LW GPRC:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
 
 let isCompressOnly = true in
 def : CompressPat<(LW_INX GPRF32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm),
                   (C_LW_INX GPRF32C:$rd, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca, IsRV64] in {
+let append Predicates = [IsRV64] in {
 def : CompressPat<(LD GPRC:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm),
                   (C_LD GPRC:$rd, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
-} // Predicates = [HasStdExtZca, IsRV64]
+} // append Predicates = [IsRV64]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(SW GPRC:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm),
                   (C_SW GPRC:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
 
 let isCompressOnly = true in
 def : CompressPat<(SW_INX GPRF32C:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm),
                   (C_SW_INX GPRF32C:$rs2, GPRCMem:$rs1, uimm7_lsb00:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca, IsRV64] in {
+let append Predicates = [IsRV64] in {
 def : CompressPat<(SD GPRC:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm),
                   (C_SD GPRC:$rs2, GPRCMem:$rs1, uimm8_lsb000:$imm)>;
-} // Predicates = [HasStdExtZca, IsRV64]
+} // append Predicates = [IsRV64]
+} // Predicates = [HasStdExtZca]
 
 // Quadrant 1
 let Predicates = [HasStdExtZca] in {
 def : CompressPat<(ADDI X0, X0, 0), (C_NOP)>;
 def : CompressPat<(ADDI GPRNoX0:$rs1, GPRNoX0:$rs1, simm6nonzero:$imm),
                   (C_ADDI GPRNoX0:$rs1, simm6nonzero:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca, IsRV32] in {
+let append Predicates = [IsRV32] in {
 def : CompressPat<(JAL X1, bare_simm12_lsb0:$offset),
                   (C_JAL bare_simm12_lsb0:$offset)>;
-} // Predicates = [HasStdExtZca, IsRV32]
+} // append Predicates = [IsRV32]
 
-let Predicates = [HasStdExtZca, IsRV64] in {
+let append Predicates = [IsRV64] in {
 def : CompressPat<(ADDIW GPRNoX0:$rs1, GPRNoX0:$rs1, simm6:$imm),
                   (C_ADDIW GPRNoX0:$rs1, simm6:$imm)>;
-} // Predicates = [HasStdExtZca, IsRV64]
+} // append Predicates = [IsRV64]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(ADDI GPRNoX0:$rd, X0, simm6:$imm),
                   (C_LI GPRNoX0:$rd, simm6:$imm)>;
 def : CompressPat<(ADDI X2, X2, simm10_lsb0000nonzero:$imm),
@@ -824,9 +818,8 @@ def : CompressPat<(AND GPRC:$rs1, GPRC:$rs1, GPRC:$rs2),
 let isCompressOnly = true in
 def : CompressPat<(AND GPRC:$rs1, GPRC:$rs2, GPRC:$rs1),
                   (C_AND GPRC:$rs1, GPRC:$rs2)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca, IsRV64] in {
+let append Predicates = [IsRV64] in {
 let isCompressOnly = true in
 def : CompressPat<(ADDIW GPRNoX0:$rd, X0, simm6:$imm),
                   (C_LI GPRNoX0:$rd, simm6:$imm)>;
@@ -837,9 +830,8 @@ def : CompressPat<(ADDW GPRC:$rs1, GPRC:$rs1, GPRC:$rs2),
 let isCompressOnly = true in
 def : CompressPat<(ADDW GPRC:$rs1, GPRC:$rs2, GPRC:$rs1),
                    (C_ADDW GPRC:$rs1, GPRC:$rs2)>;
-} // Predicates = [HasStdExtZca, IsRV64]
+} // append Predicates = [IsRV64]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(JAL X0, bare_simm12_lsb0:$offset),
                   (C_J bare_simm12_lsb0:$offset)>;
 def : CompressPat<(BEQ GPRC:$rs1, X0, bare_simm9_lsb0:$imm),
@@ -858,23 +850,19 @@ def : CompressPat<(BNE X0, GPRC:$rs1, bare_simm9_lsb0:$imm),
 let Predicates = [HasStdExtZca] in {
 def : CompressPat<(SLLI GPRNoX0:$rs1, GPRNoX0:$rs1, uimmlog2xlennonzero:$imm),
                   (C_SLLI GPRNoX0:$rs1, uimmlog2xlennonzero:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(LW GPRNoX0:$rd, SPMem:$rs1,  uimm8_lsb00:$imm),
                   (C_LWSP GPRNoX0:$rd, SPMem:$rs1, uimm8_lsb00:$imm)>;
 
 let isCompressOnly = true in
 def : CompressPat<(LW_INX GPRF32NoX0:$rd, SPMem:$rs1,  uimm8_lsb00:$imm),
                   (C_LWSP_INX GPRF32NoX0:$rd, SPMem:$rs1, uimm8_lsb00:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca, IsRV64] in {
+let append Predicates = [IsRV64] in {
 def : CompressPat<(LD GPRNoX0:$rd, SPMem:$rs1, uimm9_lsb000:$imm),
                   (C_LDSP GPRNoX0:$rd, SPMem:$rs1, uimm9_lsb000:$imm)>;
-} // Predicates = [HasStdExtZca, IsRV64]
+} // append Predicates = [IsRV64]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(JALR X0, GPRNoX0:$rs1, 0),
                   (C_JR GPRNoX0:$rs1)>;
 let isCompressOnly = true in {
@@ -894,21 +882,19 @@ def : CompressPat<(ADD GPRNoX0:$rs1, GPRNoX0:$rs1, GPRNoX0:$rs2),
 let isCompressOnly = true in
 def : CompressPat<(ADD GPRNoX0:$rs1, GPRNoX0:$rs2, GPRNoX0:$rs1),
                   (C_ADD GPRNoX0:$rs1, GPRNoX0:$rs2)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca] in {
 def : CompressPat<(SW GPR:$rs2, SPMem:$rs1, uimm8_lsb00:$imm),
                   (C_SWSP GPR:$rs2, SPMem:$rs1, uimm8_lsb00:$imm)>;
 
 let isCompressOnly = true in
 def : CompressPat<(SW_INX GPRF32:$rs2, SPMem:$rs1, uimm8_lsb00:$imm),
                   (C_SWSP_INX GPRF32:$rs2, SPMem:$rs1, uimm8_lsb00:$imm)>;
-} // Predicates = [HasStdExtZca]
 
-let Predicates = [HasStdExtZca, IsRV64] in {
+let append Predicates = [IsRV64] in {
 def : CompressPat<(SD GPR:$rs2, SPMem:$rs1, uimm9_lsb000:$imm),
                   (C_SDSP GPR:$rs2, SPMem:$rs1, uimm9_lsb000:$imm)>;
-} // Predicates = [HasStdExtZca, IsRV64]
+} // append Predicates = [IsRV64]
+} // Predicates = [HasStdExtZca]
 
 // Zcf Instructions
 let Predicates = [HasStdExtZcf, IsRV32] in {


### PR DESCRIPTION
llvm#182382 introduced a language extension to accumulate field values: “append” concatenates the new value after the current value, whilst "prepend" concatenates before the existing value. This change uses that feature to eliminate repetition in the definition of some of the compressed instructions.

For example, line 267 of RISCVIntrInfoC.td establishes a scope for “`let Predicates = [HasStdExtZca] in {`”; this scope ends on line 515. Meanwhile, line 454 wants to add the `IsRV64` predicate for a single instruction but was forced to duplicate the previous condition as well: “`let Predicates = [HasStdExtZca, IsRV64] in`”. That’s no longer necessary since the addition can now be explicit: “`let append Predicates = [IsRV64] in `”

I‘ve verified that this change has no effect on the TableGen output.

It seems quite likely that this same change could be made in some of the other RISC-V TableGen source files…