### PR TITLE
[AMDGPU][GlobalISel] Combine rcp(sqrt(x)) into rsq for pseudo-scalar instructions

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPostLegalizerCombiner.cpp
@@ -264,6 +264,10 @@ bool AMDGPUPostLegalizerCombinerImpl::matchRcpSqrtToRsq(
   auto getSqrtSrc = [=](const MachineInstr &MI) -> MachineInstr * {
     if (!MI.getFlag(MachineInstr::FmContract))
       return nullptr;
+    if (auto *GI = dyn_cast<GIntrinsic>(&MI)) {
+      if (GI->is(Intrinsic::amdgcn_sqrt))
+        return MRI.getVRegDef(MI.getOperand(2).getReg());
+    }
     MachineInstr *SqrtSrcMI = nullptr;
     auto Match =
         mi_match(MI.getOperand(0).getReg(), MRI, m_GFSqrt(m_MInstr(SqrtSrcMI)));

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-rsq.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-rsq.mir
@@ -98,9 +98,8 @@ body:             |
     ; GCN: liveins: $sgpr0
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr0
-    ; GCN-NEXT: [[INT:%[0-9]+]]:_(s32) = contract afn G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), [[COPY]](s32)
-    ; GCN-NEXT: [[INT1:%[0-9]+]]:_(s32) = contract afn G_INTRINSIC intrinsic(@llvm.amdgcn.rcp), [[INT]](s32)
-    ; GCN-NEXT: $vgpr0 = COPY [[INT1]](s32)
+    ; GCN-NEXT: [[INT:%[0-9]+]]:_(s32) = contract afn G_INTRINSIC intrinsic(@llvm.amdgcn.rsq), [[COPY]](s32)
+    ; GCN-NEXT: $vgpr0 = COPY [[INT]](s32)
     ; GCN-NEXT: SI_RETURN_TO_EPILOG implicit $vgpr0
     %0:_(s32) = COPY $sgpr0
     %1:_(s32) = afn contract G_INTRINSIC intrinsic(@llvm.amdgcn.sqrt), %0:_(s32)

--- a/llvm/test/CodeGen/AMDGPU/fdiv_flags.f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdiv_flags.f32.ll
@@ -1620,12 +1620,18 @@ define float @v_recip_sqrt_f32_afn_ulp25_contract(float %x) {
 ; CODEGEN-IEEE-GISEL-NEXT:    v_rsq_f32_e32 v0, v0
 ; CODEGEN-IEEE-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
-; IR-IEEE-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
-; IR-IEEE:       ; %bb.0:
-; IR-IEEE-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; IR-IEEE-NEXT:    v_sqrt_f32_e32 v0, v0
-; IR-IEEE-NEXT:    v_rcp_f32_e32 v0, v0
-; IR-IEEE-NEXT:    s_setpc_b64 s[30:31]
+; IR-IEEE-SDAG-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
+; IR-IEEE-SDAG:       ; %bb.0:
+; IR-IEEE-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; IR-IEEE-SDAG-NEXT:    v_sqrt_f32_e32 v0, v0
+; IR-IEEE-SDAG-NEXT:    v_rcp_f32_e32 v0, v0
+; IR-IEEE-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; IR-IEEE-GISEL-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
+; IR-IEEE-GISEL:       ; %bb.0:
+; IR-IEEE-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; IR-IEEE-GISEL-NEXT:    v_rsq_f32_e32 v0, v0
+; IR-IEEE-GISEL-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; CODEGEN-DAZ-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
 ; CODEGEN-DAZ:       ; %bb.0:
@@ -1633,12 +1639,18 @@ define float @v_recip_sqrt_f32_afn_ulp25_contract(float %x) {
 ; CODEGEN-DAZ-NEXT:    v_rsq_f32_e32 v0, v0
 ; CODEGEN-DAZ-NEXT:    s_setpc_b64 s[30:31]
 ;
-; IR-DAZ-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
-; IR-DAZ:       ; %bb.0:
-; IR-DAZ-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; IR-DAZ-NEXT:    v_sqrt_f32_e32 v0, v0
-; IR-DAZ-NEXT:    v_rcp_f32_e32 v0, v0
-; IR-DAZ-NEXT:    s_setpc_b64 s[30:31]
+; IR-DAZ-SDAG-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
+; IR-DAZ-SDAG:       ; %bb.0:
+; IR-DAZ-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; IR-DAZ-SDAG-NEXT:    v_sqrt_f32_e32 v0, v0
+; IR-DAZ-SDAG-NEXT:    v_rcp_f32_e32 v0, v0
+; IR-DAZ-SDAG-NEXT:    s_setpc_b64 s[30:31]
+;
+; IR-DAZ-GISEL-LABEL: v_recip_sqrt_f32_afn_ulp25_contract:
+; IR-DAZ-GISEL:       ; %bb.0:
+; IR-DAZ-GISEL-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+; IR-DAZ-GISEL-NEXT:    v_rsq_f32_e32 v0, v0
+; IR-DAZ-GISEL-NEXT:    s_setpc_b64 s[30:31]
   %sqrt = call contract afn float @llvm.sqrt.f32(float %x), !fpmath !0
   %fdiv = fdiv contract afn float 1.0, %sqrt, !fpmath !0
   ret float %fdiv

--- a/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
+++ b/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
@@ -388,30 +388,18 @@ define amdgpu_cs double @v_s_rcp_f64(double inreg %src) {
   ret double %result
 }
 
-; TODO: GlobalISel should generate v_s_rsq.
 define amdgpu_cs float @v_s_rsq_f32(float inreg %src) {
-; GFX12-SDAG-LABEL: v_s_rsq_f32:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    v_s_rsq_f32 s0, s0
-; GFX12-SDAG-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: v_s_rsq_f32:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    v_s_sqrt_f32 s0, s0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX12-GISEL-NEXT:    v_s_rcp_f32 s0, s0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: v_s_rsq_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    v_s_rsq_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    ; return to shader part epilog
 ;
 ; GCN-GISEL-LABEL: v_s_rsq_f32:
 ; GCN-GISEL:       ; %bb.0:
-; GCN-GISEL-NEXT:    v_sqrt_f32_e32 v0, s0
-; GCN-GISEL-NEXT:    v_rcp_f32_e32 v0, v0
+; GCN-GISEL-NEXT:    v_rsq_f32_e32 v0, s0
 ; GCN-GISEL-NEXT:    ; return to shader part epilog
   %sqrt = call fast float @llvm.sqrt.f32(float %src)
   %fdiv = fdiv fast float 1.0, %sqrt

--- a/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
+++ b/llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll
@@ -356,30 +356,18 @@ define amdgpu_cs double @v_s_rcp_f64(double inreg %src) {
   ret double %result
 }
 
-; TODO: GlobalISel should generate v_s_rsq.
 define amdgpu_cs float @v_s_rsq_f32(float inreg %src) {
-; GFX12-SDAG-LABEL: v_s_rsq_f32:
-; GFX12-SDAG:       ; %bb.0:
-; GFX12-SDAG-NEXT:    v_s_rsq_f32 s0, s0
-; GFX12-SDAG-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-SDAG-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
-; GFX12-SDAG-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-SDAG-NEXT:    ; return to shader part epilog
-;
-; GFX12-GISEL-LABEL: v_s_rsq_f32:
-; GFX12-GISEL:       ; %bb.0:
-; GFX12-GISEL-NEXT:    v_s_sqrt_f32 s0, s0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-GISEL-NEXT:    s_delay_alu instid0(TRANS32_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_1)
-; GFX12-GISEL-NEXT:    v_s_rcp_f32 s0, s0
-; GFX12-GISEL-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
-; GFX12-GISEL-NEXT:    ; return to shader part epilog
+; GFX12-LABEL: v_s_rsq_f32:
+; GFX12:       ; %bb.0:
+; GFX12-NEXT:    v_s_rsq_f32 s0, s0
+; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-NEXT:    s_delay_alu instid0(TRANS32_DEP_1)
+; GFX12-NEXT:    v_mov_b32_e32 v0, s0
+; GFX12-NEXT:    ; return to shader part epilog
 ;
 ; GCN-GISEL-LABEL: v_s_rsq_f32:
 ; GCN-GISEL:       ; %bb.0:
-; GCN-GISEL-NEXT:    v_sqrt_f32_e32 v0, s0
-; GCN-GISEL-NEXT:    v_rcp_f32_e32 v0, v0
+; GCN-GISEL-NEXT:    v_rsq_f32_e32 v0, s0
 ; GCN-GISEL-NEXT:    ; return to shader part epilog
   %sqrt = call fast float @llvm.sqrt.f32(float %src)
   %fdiv = fdiv fast float 1.0, %sqrt


### PR DESCRIPTION
This fixes "TODO: GlobalISel should generate v_s_rsq." give in file "llvm/test/CodeGen/AMDGPU/pseudo-scalar-transcendental.ll"