### PR TITLE
[flang-rt] Remove library dependency from flang-rt to offload

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -111,6 +111,8 @@ set(host_sources
 )
 if (TARGET llvm-libc-common-utilities)
   list(APPEND host_sources io-api-server.cpp)
+  set_property(SOURCE environment.cpp APPEND PROPERTY
+    COMPILE_DEFINITIONS FLANG_RT_HAS_RPC_SERVER)
 endif()
 
 # Sources that can be compiled directly for the GPU.

--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -111,7 +111,7 @@ set(host_sources
 )
 if (TARGET llvm-libc-common-utilities)
   list(APPEND host_sources io-api-server.cpp)
-  set_property(SOURCE environment.cpp APPEND PROPERTY
+  set_property(SOURCE main.cpp APPEND PROPERTY
     COMPILE_DEFINITIONS FLANG_RT_HAS_RPC_SERVER)
 endif()
 

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -8,6 +8,7 @@
 
 #include "flang-rt/runtime/environment.h"
 #include "environment-default-list.h"
+#include "io-api-gpu.h"
 #include "flang-rt/runtime/memory.h"
 #include "flang-rt/runtime/tools.h"
 #include <cstdio>
@@ -267,6 +268,11 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
       PostConfigEnvCallback[i](ac, av, env, envDefaults);
     }
   }
+
+  // Registers the IO handlers with the offloading runtime only if present.
+#ifdef FLANG_RT_HAS_RPC_SERVER
+  Fortran::runtime::io::RegisterRPCHandlers();
+#endif
 }
 
 const char *ExecutionEnvironment::GetEnv(

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -8,7 +8,6 @@
 
 #include "flang-rt/runtime/environment.h"
 #include "environment-default-list.h"
-#include "io-api-gpu.h"
 #include "flang-rt/runtime/memory.h"
 #include "flang-rt/runtime/tools.h"
 #include <cstdio>
@@ -268,11 +267,6 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
       PostConfigEnvCallback[i](ac, av, env, envDefaults);
     }
   }
-
-  // Registers the IO handlers with the offloading runtime only if present.
-#ifdef FLANG_RT_HAS_RPC_SERVER
-  Fortran::runtime::io::RegisterRPCHandlers();
-#endif
 }
 
 const char *ExecutionEnvironment::GetEnv(

--- a/flang-rt/lib/runtime/io-api-gpu.h
+++ b/flang-rt/lib/runtime/io-api-gpu.h
@@ -12,6 +12,10 @@
 #include <cstdint>
 
 namespace Fortran::runtime::io {
+
+// Registers the callbacks with the offloading runtime.
+void RegisterRPCHandlers();
+
 // We reserve the RPC opcodes with 'f' in the MSB for Fortran usage.
 constexpr std::uint32_t MakeOpcode(std::uint32_t base) {
   return ('f' << 24) | base;

--- a/flang-rt/lib/runtime/io-api-server.cpp
+++ b/flang-rt/lib/runtime/io-api-server.cpp
@@ -299,12 +299,15 @@ using RPCCallbackTy = std::uint32_t (*)(void *, std::uint32_t);
 
 // COFF workaround for the lack of weak symbols, copied from the sanitizers.
 #if defined(_MSC_VER)
-extern "C" void register_rpc_callback_stub(RPCCallbackTy) {}
+extern "C" void register_rpc_callback_stub(RPCCallbackTy) {
+  // Stub function to be replaced with __tgt_register_rpc_callback if present.
+}
 #pragma comment(linker, \
     "/alternatename:__tgt_register_rpc_callback=" \
     "register_rpc_callback_stub")
 #endif
 
+// Used for I/O from the offloading device runtime.
 static std::uint32_t HandleRPCOpcodes(void *raw, std::uint32_t numLanes) {
   rpc::Server::Port &port = *reinterpret_cast<rpc::Server::Port *>(raw);
   switch (numLanes) {

--- a/flang-rt/lib/runtime/io-api-server.cpp
+++ b/flang-rt/lib/runtime/io-api-server.cpp
@@ -292,10 +292,20 @@ rpc::RPCStatus HandleOpcodesImpl(rpc::Server::Port &port) {
 
   return rpc::RPC_SUCCESS;
 }
-} // namespace
 
-RT_EXT_API_GROUP_BEGIN
-std::uint32_t IODEF(HandleRPCOpcodes)(void *raw, std::uint32_t numLanes) {
+} // anonymous namespace
+
+using RPCCallbackTy = std::uint32_t (*)(void *, std::uint32_t);
+
+// COFF workaround for the lack of weak symbols, copied from the sanitizers.
+#if defined(_MSC_VER)
+extern "C" void register_rpc_callback_stub(RPCCallbackTy) {}
+#pragma comment(linker, \
+    "/alternatename:__tgt_register_rpc_callback=" \
+    "register_rpc_callback_stub")
+#endif
+
+static std::uint32_t HandleRPCOpcodes(void *raw, std::uint32_t numLanes) {
   rpc::Server::Port &port = *reinterpret_cast<rpc::Server::Port *>(raw);
   switch (numLanes) {
   case 1:
@@ -308,5 +318,23 @@ std::uint32_t IODEF(HandleRPCOpcodes)(void *raw, std::uint32_t numLanes) {
     return rpc::RPC_ERROR;
   }
 }
-RT_EXT_API_GROUP_END
+
+#if defined(__ELF__)
+extern "C" void __tgt_register_rpc_callback(RPCCallbackTy)
+    __attribute__((weak));
+#elif defined(__APPLE__)
+extern "C" void __tgt_register_rpc_callback(RPCCallbackTy)
+    __attribute__((weak_import));
+#else
+extern "C" void __tgt_register_rpc_callback(RPCCallbackTy);
+#endif
+
+void RegisterRPCHandlers() {
+#if defined(__ELF__) || defined(__APPLE__)
+  if (__tgt_register_rpc_callback)
+    __tgt_register_rpc_callback(HandleRPCOpcodes);
+#elif defined(_MSC_VER)
+  __tgt_register_rpc_callback(HandleRPCOpcodes);
+#endif
+}
 } // namespace Fortran::runtime::io

--- a/flang-rt/lib/runtime/main.cpp
+++ b/flang-rt/lib/runtime/main.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Runtime/main.h"
+#include "io-api-gpu.h"
 #include "flang-rt/runtime/environment.h"
 #include "flang-rt/runtime/terminator.h"
 #include <cfenv>
@@ -32,6 +33,10 @@ void RTNAME(ProgramStart)(int argc, const char *argv[], const char *envp[],
   Fortran::runtime::executionEnvironment.Configure(
       argc, argv, envp, envDefaults);
   ConfigureFloatingPoint();
+  // Register the IO handlers with the offloading runtime only if present.
+#ifdef FLANG_RT_HAS_RPC_SERVER
+  Fortran::runtime::io::RegisterRPCHandlers();
+#endif
   // I/O is initialized on demand so that it works for non-Fortran main().
 }
 

--- a/flang/include/flang/Runtime/io-api.h
+++ b/flang/include/flang/Runtime/io-api.h
@@ -366,8 +366,6 @@ bool IODECL(InquireInteger64)(
 // rather than by terminating the image.
 enum Iostat IODECL(EndIoStatement)(Cookie);
 
-// Used for I/O from the offloading device.
-std::uint32_t IODECL(HandleRPCOpcodes)(void *raw, std::uint32_t numLanes);
 } // extern "C"
 } // namespace Fortran::runtime::io
 

--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -36,11 +36,6 @@ endif()
 include(FindLibcCommonUtils)
 target_link_libraries(PluginCommon PRIVATE llvm-libc-common-utilities)
 
-if (TARGET flang_rt.runtime.static)
-  target_link_libraries(PluginCommon PRIVATE flang_rt.runtime.static)
-  target_compile_definitions(PluginCommon PRIVATE OFFLOAD_HAS_FLANG_RT)
-endif()
-
 # Define the TARGET_NAME and DEBUG_PREFIX.
 target_compile_definitions(PluginCommon PRIVATE
   TARGET_NAME=PluginInterface

--- a/offload/plugins-nextgen/common/src/RPC.cpp
+++ b/offload/plugins-nextgen/common/src/RPC.cpp
@@ -17,10 +17,6 @@
 #include "shared/rpc_opcodes.h"
 #include "shared/rpc_server.h"
 
-#ifdef OFFLOAD_HAS_FLANG_RT
-#include "flang/Runtime/io-api.h"
-#endif
-
 using namespace llvm;
 using namespace omp;
 using namespace target;
@@ -114,12 +110,6 @@ runServer(plugin::GenericDeviceTy &Device, void *Buffer,
 
   if (Status == rpc::RPC_UNHANDLED_OPCODE)
     Status = rpc::handle_libc_opcodes(*Port, NumLanes);
-
-#ifdef OFFLOAD_HAS_FLANG_RT
-  if (Status == rpc::RPC_UNHANDLED_OPCODE)
-    Status = static_cast<rpc::RPCStatus>(
-        Fortran::runtime::io::IONAME(HandleRPCOpcodes)(&*Port, NumLanes));
-#endif
 
   return Status;
 }


### PR DESCRIPTION
Summary:
We need the offload project's RPC thread to handle the IO requests
originating from the GPU. Previously we did the 'easy' solution and just
linked this handler directly into the offload proejct. This is not ideal
because it prevents people's ability to build and configure libraries
separately.

This PR inverts the dependency, flang-rt now conditionally enables
support using the existing RPC callback mechanism. The cost is that
every flang-rt program now pays the cost of a boolean compare, the
benefit is the libraries are now independent of each-other.
