### PR TITLE
[lldb][windows] try to resolve module path if info.hFile is null

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -540,16 +540,67 @@ static std::optional<std::string> GetFileNameFromHandleFallback(HANDLE hFile) {
   return ConvertNtDevicePathToDosPath(mapped_filename);
 }
 
+static std::optional<std::string> GetFileNameByLoadAddress(HANDLE hProcess,
+                                                           LPVOID base_addr) {
+  std::array<wchar_t, MAX_PATH + 1> module_filename;
+  DWORD len =
+      ::GetModuleFileNameExW(hProcess, reinterpret_cast<HMODULE>(base_addr),
+                             module_filename.data(), module_filename.size());
+  if (len > 0 && len < module_filename.size()) {
+    std::string path_utf8;
+    llvm::convertWideToUTF8(std::wstring(module_filename.data(), len),
+                            path_utf8);
+    return path_utf8;
+  }
+
+  // Fallback: ask the kernel for the file backing the mapping at this address.
+  std::array<wchar_t, MAX_PATH + 1> mapped_filename;
+  if (!::GetMappedFileNameW(hProcess, base_addr, mapped_filename.data(),
+                            mapped_filename.size()))
+    return std::nullopt;
+  return ConvertNtDevicePathToDosPath(mapped_filename);
+}
+
+// Resolve the LOAD_DLL_DEBUG_INFO::lpImageName field.
+static std::optional<std::string>
+GetFileNameFromImageNameField(HANDLE hProcess,
+                              const LOAD_DLL_DEBUG_INFO &info) {
+  if (info.lpImageName == nullptr)
+    return std::nullopt;
+
+  LPVOID name_addr = nullptr;
+  SIZE_T bytes_read = 0;
+  if (!::ReadProcessMemory(hProcess, info.lpImageName, &name_addr,
+                           sizeof(name_addr), &bytes_read) ||
+      bytes_read != sizeof(name_addr) || name_addr == nullptr)
+    return std::nullopt;
+
+  if (info.fUnicode) {
+    std::array<wchar_t, MAX_PATH + 1> wbuf{};
+    if (!::ReadProcessMemory(hProcess, name_addr, wbuf.data(),
+                             (wbuf.size() - 1) * sizeof(wchar_t), &bytes_read))
+      return std::nullopt;
+    std::string path_utf8;
+    llvm::convertWideToUTF8(wbuf.data(), path_utf8);
+    if (path_utf8.empty())
+      return std::nullopt;
+    return path_utf8;
+  }
+
+  std::array<char, MAX_PATH + 1> abuf{};
+  if (!::ReadProcessMemory(hProcess, name_addr, abuf.data(), abuf.size() - 1,
+                           &bytes_read))
+    return std::nullopt;
+  std::string path(abuf.data());
+  if (path.empty())
+    return std::nullopt;
+  return path;
+}
+
 DWORD
 DebuggerThread::HandleLoadDllEvent(const LOAD_DLL_DEBUG_INFO &info,
                                    DWORD thread_id) {
   Log *log = GetLog(WindowsLog::Event);
-  if (info.hFile == nullptr) {
-    // Not sure what this is, so just ignore it.
-    LLDB_LOG(log, "Warning: Inferior {0} has a NULL file handle, returning...",
-             m_process.GetProcessId());
-    return DBG_CONTINUE;
-  }
 
   auto on_load_dll = [&](llvm::StringRef path) {
     FileSpec file_spec(path);
@@ -562,32 +613,43 @@ DebuggerThread::HandleLoadDllEvent(const LOAD_DLL_DEBUG_INFO &info,
     m_debug_delegate->OnLoadDll(module_spec, load_addr);
   };
 
-  std::vector<wchar_t> buffer(1);
-  DWORD required_size =
-      GetFinalPathNameByHandleW(info.hFile, &buffer[0], 0, VOLUME_NAME_DOS);
-  if (required_size > 0) {
-    buffer.resize(required_size + 1);
-    required_size = GetFinalPathNameByHandleW(info.hFile, &buffer[0],
-                                              required_size, VOLUME_NAME_DOS);
-    std::string path_str_utf8;
-    llvm::convertWideToUTF8(buffer.data(), path_str_utf8);
-    llvm::StringRef path_str = path_str_utf8;
-    const char *path = path_str.data();
-    if (path_str.starts_with("\\\\?\\"))
-      path += 4;
-
-    on_load_dll(path);
-  } else if (std::optional<std::string> path =
-                 GetFileNameFromHandleFallback(info.hFile)) {
-    on_load_dll(*path);
-  } else {
-    LLDB_LOG(
-        log,
-        "Inferior {0} - Error {1} occurred calling GetFinalPathNameByHandle",
-        m_process.GetProcessId(), ::GetLastError());
+  std::optional<std::string> resolved_path;
+  if (info.hFile != nullptr) {
+    std::vector<wchar_t> buffer(1);
+    DWORD required_size =
+        GetFinalPathNameByHandleW(info.hFile, &buffer[0], 0, VOLUME_NAME_DOS);
+    if (required_size > 0) {
+      buffer.resize(required_size + 1);
+      GetFinalPathNameByHandleW(info.hFile, &buffer[0], required_size,
+                                VOLUME_NAME_DOS);
+      std::string path_str_utf8;
+      llvm::convertWideToUTF8(buffer.data(), path_str_utf8);
+      llvm::StringRef path_str = path_str_utf8;
+      path_str.consume_front("\\\\?\\");
+      resolved_path = path_str.str();
+    } else {
+      resolved_path = GetFileNameFromHandleFallback(info.hFile);
+    }
   }
+
+  HANDLE hProcess = m_process.GetNativeProcess().GetSystemHandle();
+  if (!resolved_path)
+    resolved_path = GetFileNameFromImageNameField(hProcess, info);
+  if (!resolved_path)
+    resolved_path = GetFileNameByLoadAddress(hProcess, info.lpBaseOfDll);
+
+  if (resolved_path)
+    on_load_dll(*resolved_path);
+  else
+    LLDB_LOG(log,
+             "Inferior {0} - could not resolve path for LOAD_DLL_DEBUG_EVENT "
+             "(hFile={1}, base={2:x}, last error={3})",
+             m_process.GetProcessId(), info.hFile, info.lpBaseOfDll,
+             ::GetLastError());
+
   // Windows does not automatically close info.hFile, so we need to do it.
-  ::CloseHandle(info.hFile);
+  if (info.hFile != nullptr)
+    ::CloseHandle(info.hFile);
   return DBG_CONTINUE;
 }
 

--- a/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/DebuggerThread.cpp
@@ -578,7 +578,9 @@ GetFileNameFromImageNameField(HANDLE hProcess,
   if (info.fUnicode) {
     std::array<wchar_t, MAX_PATH + 1> wbuf{};
     if (!::ReadProcessMemory(hProcess, name_addr, wbuf.data(),
-                             (wbuf.size() - 1) * sizeof(wchar_t), &bytes_read))
+                             wbuf.size() * sizeof(wchar_t), &bytes_read))
+      return std::nullopt;
+    if (wbuf[MAX_PATH] != L'\0')
       return std::nullopt;
     std::string path_utf8;
     llvm::convertWideToUTF8(wbuf.data(), path_utf8);
@@ -588,8 +590,10 @@ GetFileNameFromImageNameField(HANDLE hProcess,
   }
 
   std::array<char, MAX_PATH + 1> abuf{};
-  if (!::ReadProcessMemory(hProcess, name_addr, abuf.data(), abuf.size() - 1,
+  if (!::ReadProcessMemory(hProcess, name_addr, abuf.data(), abuf.size(),
                            &bytes_read))
+    return std::nullopt;
+  if (abuf[MAX_PATH] != '\0')
     return std::nullopt;
   std::string path(abuf.data());
   if (path.empty())


### PR DESCRIPTION
The Windows API can deliver `LOAD_DLL_DEBUG_EVENT` with `hFile` set to NULL. In practice, this happens in practice
inside Windows Server Core containers for system DLLs like `kernel32.dll`, `KernelBase.dll` and `ucrtbase.dll`. This is the issue described by @Nerixyz in https://github.com/llvm/llvm-project/issues/132800.
    
`DebuggerThread::HandleLoadDllEvent` previously dropped any such event.
    
This patch improves the module path resolution with the 2 following methods:
- `GetFileNameByLoadAddress`: resolve the module path given its base load address.
- `GetFileNameFromImageNameField`: resolve the module path given the `LOAD_DLL_DEBUG_INFO::lpImageName` field.

This requires:
- https://github.com/llvm/llvm-project/pull/198794