### PR TITLE
[TySan] Expose __tysan_set_type_unknown interface

### DIFF
--- a/compiler-rt/include/sanitizer/tysan_interface.h
+++ b/compiler-rt/include/sanitizer/tysan_interface.h
@@ -20,7 +20,15 @@
 extern "C" {
 #endif
 
-// No interfaces currently
+/// Marks a memory region (<c>[addr, addr+size)</c>) as not yet having a type.
+///
+/// TySan will take the next read/write to the memory region to be the correct
+/// type for the memory, and use that for its checks from then on.
+///
+/// \param addr Start of memory region.
+/// \param size Size of memory region.
+void SANITIZER_CDECL __tysan_set_type_unknown(void const *addr,
+                                                 size_t size);
 
 #ifdef __cplusplus
 }

--- a/compiler-rt/include/sanitizer/tysan_interface.h
+++ b/compiler-rt/include/sanitizer/tysan_interface.h
@@ -27,8 +27,7 @@ extern "C" {
 ///
 /// \param addr Start of memory region.
 /// \param size Size of memory region.
-void SANITIZER_CDECL __tysan_set_type_unknown(void const *addr,
-                                                 size_t size);
+void SANITIZER_CDECL __tysan_set_type_unknown(void const *addr, size_t size);
 
 #ifdef __cplusplus
 }

--- a/compiler-rt/lib/tysan/tysan.cpp
+++ b/compiler-rt/lib/tysan/tysan.cpp
@@ -30,7 +30,7 @@ using namespace __sanitizer;
 using namespace __tysan;
 
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE void
-tysan_set_type_unknown(const void *addr, uptr size) {
+__tysan_set_type_unknown(const void *addr, uptr size) {
   if (tysan_inited)
     internal_memset(shadow_for(addr), 0, size * sizeof(uptr));
 }

--- a/compiler-rt/lib/tysan/tysan.h
+++ b/compiler-rt/lib/tysan/tysan.h
@@ -23,7 +23,7 @@ using __sanitizer::uptr;
 #include "tysan_platform.h"
 
 extern "C" {
-void tysan_set_type_unknown(const void *addr, uptr size);
+void __tysan_set_type_unknown(const void *addr, uptr size);
 void tysan_copy_types(const void *daddr, const void *saddr, uptr size);
 }
 

--- a/compiler-rt/lib/tysan/tysan_interceptors.cpp
+++ b/compiler-rt/lib/tysan/tysan_interceptors.cpp
@@ -40,7 +40,7 @@ INTERCEPTOR(void *, memset, void *dst, int v, uptr size) {
     return internal_memset(dst, v, size);
 
   void *res = REAL(memset)(dst, v, size);
-  tysan_set_type_unknown(dst, size);
+  __tysan_set_type_unknown(dst, size);
   return res;
 }
 
@@ -69,7 +69,7 @@ INTERCEPTOR(void *, mmap, void *addr, SIZE_T length, int prot, int flags,
             int fd, OFF_T offset) {
   void *res = REAL(mmap)(addr, length, prot, flags, fd, offset);
   if (res != (void *)-1)
-    tysan_set_type_unknown(res, RoundUpTo(length, GetPageSize()));
+    __tysan_set_type_unknown(res, RoundUpTo(length, GetPageSize()));
   return res;
 }
 
@@ -78,7 +78,7 @@ INTERCEPTOR(void *, mmap64, void *addr, SIZE_T length, int prot, int flags,
             int fd, OFF64_T offset) {
   void *res = REAL(mmap64)(addr, length, prot, flags, fd, offset);
   if (res != (void *)-1)
-    tysan_set_type_unknown(res, RoundUpTo(length, GetPageSize()));
+    __tysan_set_type_unknown(res, RoundUpTo(length, GetPageSize()));
   return res;
 }
 #endif
@@ -104,7 +104,7 @@ INTERCEPTOR(void *, malloc, uptr size) {
     return DlsymAlloc::Allocate(size);
   void *res = REAL(malloc)(size);
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 
@@ -123,7 +123,7 @@ INTERCEPTOR(void *, realloc, void *ptr, uptr size) {
   // We might want to copy the types from the original allocation (although
   // that would require that we knew its size).
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 
@@ -132,7 +132,7 @@ INTERCEPTOR(void *, calloc, uptr nmemb, uptr size) {
     return DlsymAlloc::Callocate(nmemb, size);
   void *res = REAL(calloc)(nmemb, size);
   if (res)
-    tysan_set_type_unknown(res, nmemb * size);
+    __tysan_set_type_unknown(res, nmemb * size);
   return res;
 }
 
@@ -145,7 +145,7 @@ INTERCEPTOR(void, free, void *ptr) {
 INTERCEPTOR(void *, valloc, uptr size) {
   void *res = REAL(valloc)(size);
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 
@@ -153,7 +153,7 @@ INTERCEPTOR(void *, valloc, uptr size) {
 INTERCEPTOR(void *, memalign, uptr alignment, uptr size) {
   void *res = REAL(memalign)(alignment, size);
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 #define TYSAN_MAYBE_INTERCEPT_MEMALIGN INTERCEPT_FUNCTION(memalign)
@@ -165,7 +165,7 @@ INTERCEPTOR(void *, memalign, uptr alignment, uptr size) {
 INTERCEPTOR(void *, __libc_memalign, uptr alignment, uptr size) {
   void *res = REAL(__libc_memalign)(alignment, size);
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 #define TYSAN_MAYBE_INTERCEPT___LIBC_MEMALIGN                                  \
@@ -178,7 +178,7 @@ INTERCEPTOR(void *, __libc_memalign, uptr alignment, uptr size) {
 INTERCEPTOR(void *, pvalloc, uptr size) {
   void *res = REAL(pvalloc)(size);
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 #define TYSAN_MAYBE_INTERCEPT_PVALLOC INTERCEPT_FUNCTION(pvalloc)
@@ -190,7 +190,7 @@ INTERCEPTOR(void *, pvalloc, uptr size) {
 INTERCEPTOR(void *, aligned_alloc, uptr alignment, uptr size) {
   void *res = REAL(aligned_alloc)(alignment, size);
   if (res)
-    tysan_set_type_unknown(res, size);
+    __tysan_set_type_unknown(res, size);
   return res;
 }
 #define TYSAN_MAYBE_INTERCEPT_ALIGNED_ALLOC INTERCEPT_FUNCTION(aligned_alloc)
@@ -201,7 +201,7 @@ INTERCEPTOR(void *, aligned_alloc, uptr alignment, uptr size) {
 INTERCEPTOR(int, posix_memalign, void **memptr, uptr alignment, uptr size) {
   int res = REAL(posix_memalign)(memptr, alignment, size);
   if (res == 0 && *memptr)
-    tysan_set_type_unknown(*memptr, size);
+    __tysan_set_type_unknown(*memptr, size);
   return res;
 }
 

--- a/compiler-rt/test/tysan/set_type_unknown-interface.c
+++ b/compiler-rt/test/tysan/set_type_unknown-interface.c
@@ -4,18 +4,18 @@
 #include <sanitizer/tysan_interface.h>
 
 int main(){
-    int i = 0;
-    int* iPtr = &i;
-    float* fPtr = (float*)iPtr;
+  int i = 0;
+  int *iPtr = &i;
+  float *fPtr = (float *)iPtr;
 
-    *fPtr = 5.0f;
-    // CHECK: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
-    __tysan_set_type_unknown(iPtr, sizeof(int));
-    *fPtr += 5.0f;
-    // CHECK-NOT: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+  *fPtr = 5.0f;
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+  __tysan_set_type_unknown(iPtr, sizeof(int));
+  *fPtr += 5.0f;
+  // CHECK-NOT: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
 
-    *iPtr = 0;
-    // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
+  *iPtr = 0;
+  // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
 
-    return 0;
+return 0;
 }

--- a/compiler-rt/test/tysan/set_type_unknown-interface.c
+++ b/compiler-rt/test/tysan/set_type_unknown-interface.c
@@ -1,0 +1,21 @@
+// RUN: %clang_tysan -O0 %s -o %t && %run %t >%t.out 2>&1
+// RUN: FileCheck %s < %t.out
+
+#include <sanitizer/tysan_interface.h>
+
+int main(){
+    int i = 0;
+    int* iPtr = &i;
+    float* fPtr = (float*)iPtr;
+
+    *fPtr = 5.0f;
+    // CHECK: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+    __tysan_set_type_unknown(iPtr, sizeof(int));
+    *fPtr += 5.0f;
+    // CHECK-NOT: WRITE of size 4 at 0x{{.*}} with type float accesses an existing object of type int
+
+    *iPtr = 0;
+    // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
+
+    return 0;
+}

--- a/compiler-rt/test/tysan/set_type_unknown-interface.c
+++ b/compiler-rt/test/tysan/set_type_unknown-interface.c
@@ -3,7 +3,7 @@
 
 #include <sanitizer/tysan_interface.h>
 
-int main(){
+int main() {
   int i = 0;
   int *iPtr = &i;
   float *fPtr = (float *)iPtr;
@@ -17,5 +17,5 @@ int main(){
   *iPtr = 0;
   // CHECK: WRITE of size 4 at 0x{{.*}} with type int accesses an existing object of type float
 
-return 0;
+  return 0;
 }


### PR DESCRIPTION
This can help work around issues like [#143587](https://github.com/llvm/llvm-project/issues/143587)
The function is renamed with two trailing underscores to match the naming scheme of the other sanitizers.