### PR TITLE
[lldb] Prioritize the MAKE_NO_DEBUG_INFO flag

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -248,8 +248,7 @@ CFLAGS ?= $(DEBUG_INFO_FLAG) -O0
 # it adds `-gdwarf-{version}` to the CFLAGS environment variable which causes those tests
 # to fail. Strip any existing debug flags from CFLAGS and force -g0 to prevent this.
 ifeq "$(MAKE_NO_DEBUG_INFO)" "YES"
-    CFLAGS := $(filter-out -g%,$(CFLAGS))
-    CFLAGS += -g0
+    CFLAGS := $(filter-out -g%,$(CFLAGS)) -g0
 endif
 CFLAGS += $(SYSROOT_FLAGS)
 

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -240,13 +240,17 @@ ifeq "$(OS)" "Windows_NT"
 	DEBUG_INFO_FLAG ?= -gdwarf
 endif
 
-ifeq "$(MAKE_NO_DEBUG_INFO)" "YES"
-	DEBUG_INFO_FLAG := -g0
-endif
-
 DEBUG_INFO_FLAG ?= -g
 
 CFLAGS ?= $(DEBUG_INFO_FLAG) -O0
+
+# Some tests require no debug information. When lldb-dotest specifies a DWARF version,
+# it adds `-gdwarf-{version}` to the CFLAGS environment variable which causes those tests
+# to fail. Strip any existing debug flags from CFLAGS and force -g0 to prevent this.
+ifeq "$(MAKE_NO_DEBUG_INFO)" "YES"
+    CFLAGS := $(filter-out -g%,$(CFLAGS))
+    CFLAGS += -g0
+endif
 CFLAGS += $(SYSROOT_FLAGS)
 
 ifeq "$(OS)" "Darwin"


### PR DESCRIPTION
Some tests require an executable with no debug information. When `lldb-dotest` is run with `--dwarf-version`, that flag currently takes precedence over the debug info type specified in the test. This is incorrect when the test explicitly expects the executable to have no debug information.

Ensure `MAKE_NO_DEBUG_INFO` takes priority over `--dwarf-version` so that tests requiring stripped executables behave correctly regardless of how the test suite is invoked.