### PR TITLE
[lldb][test] Make dependent-modules-nodupe-windows case-insensitive

### DIFF
--- a/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
+++ b/lldb/test/Shell/Target/dependent-modules-nodupe-windows.test
@@ -9,7 +9,7 @@
 # RUN: %clang_host -g0 -O0 %S/Inputs/main.c %t.shlib.lib -o %t.main.exe \
 # RUN:             %if windows-msvc %{-Wl,-debug:none%}
 # RUN: %lldb -b -o "#before" -o "target modules list" -o "b main" -o run \
-# RUN:       -o "#after" -o "target modules list" %t.main.exe | FileCheck %s
+# RUN:       -o "#after" -o "target modules list" %t.main.exe | FileCheck --ignore-case %s
 
 # CHECK-LABEL: #before
 # CHECK-NEXT: target modules list


### PR DESCRIPTION
Running the test in containers returns `KERNEL32.DLL` instead of `kernel32.dll`, which causes the test to fail. Both names point to the same file. Windows path comparison is case-insensitive. The test is asserting an OS-level behavior, not a casing convention, so it should not be case-sensitive.