### PR TITLE
[Offload] Make profiling support opt-in on events

### DIFF
--- a/offload/liboffload/API/Event.td
+++ b/offload/liboffload/API/Event.td
@@ -10,14 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
+def ol_event_flags_t : Enum {
+  let desc = "Event creation flags.";
+  let etors = [
+    Etor<"NONE", "Default event behavior (synchronization only).">,
+    Etor<"ENABLE_PROFILING", "Enable timing/profiling for this event.">
+  ];
+}
+
 def olCreateEvent : Function {
     let desc = "Enqueue an event to `Queue` and return it.";
     let details = [
-      "This event can be used with `olSyncEvent`, `olWaitEvents`, and `olGetEventElapsedTime`.",
-      "It will be complete once all enqueued work prior to the `olCreateEvent` call is complete.",
+      "This event can be used with `olSyncEvent` and `olWaitEvents`, and will "
+      "be complete once all enqueued work prior to the `olCreateEvent` call is complete.",
+      "To use this event with `olGetEventElapsedTime`, pass OL_EVENT_FLAG_ENABLE_PROFILING in Flags.",
     ];
     let params = [
         Param<"ol_queue_handle_t", "Queue", "queue to create the event for", PARAM_IN>,
+        Param<"ol_event_flags_t", "Flags", "event creation flags (0 for sync-only)", PARAM_IN>,
         Param<"ol_event_handle_t*", "Event", "output pointer for the created event", PARAM_OUT>
     ];
     let returns = [];
@@ -45,7 +55,8 @@ def olGetEventElapsedTime : Function {
     let desc = "Get the elapsed time in milliseconds between two events.";
     let details = [
         "The elapsed time is returned in milliseconds.",
-        "The queues associated with `StartEvent` and `EndEvent` must belong to the same device."
+        "The queues associated with `StartEvent` and `EndEvent` must belong to the same device.",
+        "Both events must have been created with `OL_EVENT_FLAG_ENABLE_PROFILING`."
     ];
     let params = [
         Param<"ol_event_handle_t", "StartEvent", "handle of the start event", PARAM_IN>,

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -172,9 +172,9 @@ std::atomic<size_t> ol_queue_impl_t::IdCounter(0);
 
 struct ol_event_impl_t {
   ol_event_impl_t(void *EventInfo, ol_device_handle_t Device,
-                  ol_queue_handle_t Queue)
-      : EventInfo(EventInfo), Device(Device), QueueId(Queue->Id), Queue(Queue) {
-  }
+                  ol_queue_handle_t Queue, bool ProfilingEnabled)
+      : EventInfo(EventInfo), Device(Device), QueueId(Queue->Id), Queue(Queue),
+        ProfilingEnabled(ProfilingEnabled) {}
   // Opaque backend-specific event state. This is expected to be non-null for
   // backends that materialize real events.
   void *EventInfo;
@@ -184,6 +184,7 @@ struct ol_event_impl_t {
   // It is provided only to implement OL_EVENT_INFO_QUEUE. Use QueueId to check
   // for queue equality instead.
   ol_queue_handle_t Queue;
+  bool ProfilingEnabled;
 };
 
 struct ol_program_impl_t {
@@ -859,6 +860,12 @@ Error olSyncEvent_impl(ol_event_handle_t Event) {
 Error olGetEventElapsedTime_impl(ol_event_handle_t StartEvent,
                                  ol_event_handle_t EndEvent,
                                  float *ElapsedTime) {
+  if (!StartEvent->ProfilingEnabled || !EndEvent->ProfilingEnabled)
+    return createOffloadError(
+        ErrorCode::INVALID_ARGUMENT,
+        "olGetEventElapsedTime requires both events to be created with "
+        "OL_EVENT_FLAGS_ENABLE_PROFILING");
+
   if (StartEvent->Device != EndEvent->Device)
     return createOffloadError(
         ErrorCode::INVALID_DEVICE,
@@ -875,7 +882,8 @@ Error olGetEventElapsedTime_impl(ol_event_handle_t StartEvent,
 
 Error olDestroyEvent_impl(ol_event_handle_t Event) {
   if (Event->EventInfo)
-    if (auto Res = Event->Device->Device->destroyEvent(Event->EventInfo))
+    if (auto Res = Event->Device->Device->destroyEvent(Event->EventInfo,
+                                                       Event->ProfilingEnabled))
       return Res;
 
   return olDestroy(Event);
@@ -922,17 +930,21 @@ Error olGetEventInfoSize_impl(ol_event_handle_t Event, ol_event_info_t PropName,
   return olGetEventInfoImplDetail(Event, PropName, 0, nullptr, PropSizeRet);
 }
 
-Error olCreateEvent_impl(ol_queue_handle_t Queue, ol_event_handle_t *EventOut) {
-  auto Event = std::make_unique<ol_event_impl_t>(nullptr, Queue->Device, Queue);
+Error olCreateEvent_impl(ol_queue_handle_t Queue, ol_event_flags_t Flags,
+                         ol_event_handle_t *EventOut) {
+  bool EnableProfiling = Flags == OL_EVENT_FLAGS_ENABLE_PROFILING;
+  auto Event = std::make_unique<ol_event_impl_t>(nullptr, Queue->Device, Queue,
+                                                 EnableProfiling);
 
-  if (auto Err = Queue->Device->Device->createEvent(&Event->EventInfo))
+  if (auto Err = Queue->Device->Device->createEvent(&Event->EventInfo,
+                                                    EnableProfiling))
     return Err;
 
-  if (auto Err = Queue->Device->Device->recordEvent(Event->EventInfo,
-                                                    Queue->AsyncInfo)) {
+  if (auto Err = Queue->Device->Device->recordEvent(
+          Event->EventInfo, Queue->AsyncInfo, EnableProfiling)) {
     if (Event->EventInfo) {
-      if (auto DestroyErr =
-              Queue->Device->Device->destroyEvent(Event->EventInfo))
+      if (auto DestroyErr = Queue->Device->Device->destroyEvent(
+              Event->EventInfo, EnableProfiling))
         return joinErrors(std::move(Err), std::move(DestroyErr));
     }
 

--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -1688,12 +1688,22 @@ public:
 
   const AMDGPUQueueTy *getQueue() const { return Queue; }
 
-  /// Record an event by enqueuing a barrier marker packet on the stream.
+  /// Record an event on the stream. If \p EnableProfiling is true, a barrier
+  /// marker packet is enqueued to record timestamps.
   Error recordEvent(AMDGPUEventTy &Event,
-                    AMDGPUSignalTy *ReusedSignal = nullptr);
+                    AMDGPUSignalTy *ReusedSignal = nullptr,
+                    bool EnableProfiling = false);
 
   /// Make the stream wait on an event.
   Error waitEvent(const AMDGPUEventTy &Event);
+
+private:
+  /// Lightweight sync-only recording.
+  Error recordEventSyncOnly(AMDGPUEventTy &Event, AMDGPUSignalTy *ReusedSignal);
+
+  /// Full profiling recording.
+  Error recordEventWithProfiling(AMDGPUEventTy &Event,
+                                 AMDGPUSignalTy *ReusedSignal);
 
   friend struct AMDGPUStreamManagerTy;
 };
@@ -1720,7 +1730,7 @@ struct AMDGPUEventTy {
   }
 
   /// Record the current stream point on the event.
-  Error record(AMDGPUStreamTy &Stream) {
+  Error record(AMDGPUStreamTy &Stream, bool EnableProfiling = false) {
     std::lock_guard<std::mutex> Lock(Mutex);
 
     // Discard the previous recording and retained timing state, reusing the
@@ -1731,7 +1741,7 @@ struct AMDGPUEventTy {
 
     RecordedStream = &Stream;
 
-    if (auto Err = Stream.recordEvent(*this, Signal)) {
+    if (auto Err = Stream.recordEvent(*this, Signal, EnableProfiling)) {
       if (auto ResetErr = resetState())
         return joinErrors(std::move(Err), std::move(ResetErr));
       return Err;
@@ -1805,11 +1815,43 @@ protected:
 };
 
 Error AMDGPUStreamTy::recordEvent(AMDGPUEventTy &Event,
-                                  AMDGPUSignalTy *ReusedSignal) {
+                                  AMDGPUSignalTy *ReusedSignal,
+                                  bool EnableProfiling) {
   if (Queue == nullptr)
     return Plugin::error(ErrorCode::INVALID_NULL_POINTER,
                          "target queue was nullptr");
 
+  if (EnableProfiling)
+    return recordEventWithProfiling(Event, ReusedSignal);
+  return recordEventSyncOnly(Event, ReusedSignal);
+}
+
+Error AMDGPUStreamTy::recordEventSyncOnly(AMDGPUEventTy &Event,
+                                          AMDGPUSignalTy *ReusedSignal) {
+  std::lock_guard<std::mutex> StreamLock(Mutex);
+
+  if (size() > 0) {
+    // Record the synchronize identifier (to detect stale recordings) and
+    // the last valid stream's operation.
+    Event.RecordedSyncCycle = SyncCycle;
+    Event.RecordedSlot = last();
+
+    assert(Event.RecordedSyncCycle >= 0 && "Invalid recorded sync cycle");
+    assert(Event.RecordedSlot >= 0 && "Invalid recorded slot");
+  } else {
+    // The stream is empty, everything already completed, record nothing.
+    Event.RecordedSyncCycle = -1;
+    Event.RecordedSlot = -1;
+  }
+
+  // Return the unused reusable signal back to the manager.
+  if (ReusedSignal)
+    return SignalManager.returnResource(ReusedSignal);
+  return Plugin::success();
+}
+
+Error AMDGPUStreamTy::recordEventWithProfiling(AMDGPUEventTy &Event,
+                                               AMDGPUSignalTy *ReusedSignal) {
   // One use for the stream slot and one for the event timing signal.
   const uint32_t OutputSignalUses = 2;
 
@@ -3015,7 +3057,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   };
 
   /// Create an event.
-  Error createEventImpl(void **EventPtrStorage) override {
+  Error createEventImpl(void **EventPtrStorage, bool EnableProfiling) override {
     AMDGPUEventTy **Event = reinterpret_cast<AMDGPUEventTy **>(EventPtrStorage);
     if (auto Err = AMDGPUEventManager.getResource(*Event))
       return Err;
@@ -3023,7 +3065,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   }
 
   /// Destroy a previously created event.
-  Error destroyEventImpl(void *EventPtr) override {
+  Error destroyEventImpl(void *EventPtr, bool EnableProfiling) override {
     AMDGPUEventTy *Event = reinterpret_cast<AMDGPUEventTy *>(EventPtr);
     assert(Event && "Invalid event");
 
@@ -3034,8 +3076,8 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   }
 
   /// Record the event.
-  Error recordEventImpl(void *EventPtr,
-                        AsyncInfoWrapperTy &AsyncInfoWrapper) override {
+  Error recordEventImpl(void *EventPtr, AsyncInfoWrapperTy &AsyncInfoWrapper,
+                        bool EnableProfiling) override {
     AMDGPUEventTy *Event = reinterpret_cast<AMDGPUEventTy *>(EventPtr);
     assert(Event && "Invalid event");
 
@@ -3043,7 +3085,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
     if (auto Err = getStream(AsyncInfoWrapper, Stream))
       return Err;
 
-    return Event->record(*Stream);
+    return Event->record(*Stream, EnableProfiling);
   }
 
   /// Make the stream wait on the event.

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1055,17 +1055,20 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
                                     AsyncInfoWrapperTy &AsyncInfo) = 0;
 
   /// Create an event.
-  Error createEvent(void **EventPtrStorage);
-  virtual Error createEventImpl(void **EventPtrStorage) = 0;
+  Error createEvent(void **EventPtrStorage, bool EnableProfiling = false);
+  virtual Error createEventImpl(void **EventPtrStorage,
+                                bool EnableProfiling) = 0;
 
   /// Destroy an event.
-  Error destroyEvent(void *Event);
-  virtual Error destroyEventImpl(void *EventPtr) = 0;
+  Error destroyEvent(void *Event, bool EnableProfiling = false);
+  virtual Error destroyEventImpl(void *EventPtr, bool EnableProfiling) = 0;
 
   /// Start the recording of the event.
-  Error recordEvent(void *Event, __tgt_async_info *AsyncInfo);
+  Error recordEvent(void *Event, __tgt_async_info *AsyncInfo,
+                    bool EnableProfiling = false);
   virtual Error recordEventImpl(void *EventPtr,
-                                AsyncInfoWrapperTy &AsyncInfoWrapper) = 0;
+                                AsyncInfoWrapperTy &AsyncInfoWrapper,
+                                bool EnableProfiling) = 0;
 
   /// Wait for an event to finish. Notice this wait is asynchronous if the
   /// __tgt_async_info is not nullptr.

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -1202,19 +1202,20 @@ Error GenericDeviceTy::printInfo() {
   return Plugin::success();
 }
 
-Error GenericDeviceTy::createEvent(void **EventPtrStorage) {
-  return createEventImpl(EventPtrStorage);
+Error GenericDeviceTy::createEvent(void **EventPtrStorage,
+                                   bool EnableProfiling) {
+  return createEventImpl(EventPtrStorage, EnableProfiling);
 }
 
-Error GenericDeviceTy::destroyEvent(void *EventPtr) {
-  return destroyEventImpl(EventPtr);
+Error GenericDeviceTy::destroyEvent(void *EventPtr, bool EnableProfiling) {
+  return destroyEventImpl(EventPtr, EnableProfiling);
 }
 
-Error GenericDeviceTy::recordEvent(void *EventPtr,
-                                   __tgt_async_info *AsyncInfo) {
+Error GenericDeviceTy::recordEvent(void *EventPtr, __tgt_async_info *AsyncInfo,
+                                   bool EnableProfiling) {
   AsyncInfoWrapperTy AsyncInfoWrapper(*this, AsyncInfo);
 
-  auto Err = recordEventImpl(EventPtr, AsyncInfoWrapper);
+  auto Err = recordEventImpl(EventPtr, AsyncInfoWrapper, EnableProfiling);
   AsyncInfoWrapper.finalize(Err);
   return Err;
 }

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -260,7 +260,7 @@ struct CUDAEventRef final : public GenericDeviceResourceRef {
       return Plugin::error(ErrorCode::INVALID_ARGUMENT,
                            "creating an existing event");
 
-    CUresult Res = cuEventCreate(&Event, CU_EVENT_DEFAULT);
+    CUresult Res = cuEventCreate(&Event, CU_EVENT_DISABLE_TIMING);
     if (auto Err = Plugin::check(Res, "error in cuEventCreate: %s"))
       return Err;
 
@@ -968,21 +968,31 @@ struct CUDADeviceTy : public GenericDeviceTy {
     return Plugin::check(Res, "error in cuStreamLaunchHostFunc: %s");
   };
 
-  /// Create an event.
-  Error createEventImpl(void **EventPtrStorage) override {
+  /// Non-profiling events use CU_EVENT_DISABLE_TIMING from the pool.
+  /// Profiling events are created directly with timing and not pooled.
+  Error createEventImpl(void **EventPtrStorage, bool EnableProfiling) override {
     CUevent *Event = reinterpret_cast<CUevent *>(EventPtrStorage);
+    if (EnableProfiling) {
+      CUresult Res = cuEventCreate(Event, CU_EVENT_DEFAULT);
+      return Plugin::check(Res, "error in cuEventCreate: %s");
+    }
     return CUDAEventManager.getResource(*Event);
   }
 
-  /// Destroy a previously created event.
-  Error destroyEventImpl(void *EventPtr) override {
+  /// Profiling events are destroyed directly; non-profiling events return to
+  /// the pool.
+  Error destroyEventImpl(void *EventPtr, bool EnableProfiling) override {
     CUevent Event = reinterpret_cast<CUevent>(EventPtr);
+    if (EnableProfiling) {
+      CUresult Res = cuEventDestroy(Event);
+      return Plugin::check(Res, "error in cuEventDestroy: %s");
+    }
     return CUDAEventManager.returnResource(Event);
   }
 
   /// Record the event.
-  Error recordEventImpl(void *EventPtr,
-                        AsyncInfoWrapperTy &AsyncInfoWrapper) override {
+  Error recordEventImpl(void *EventPtr, AsyncInfoWrapperTy &AsyncInfoWrapper,
+                        bool EnableProfiling) override {
     CUevent Event = reinterpret_cast<CUevent>(EventPtr);
 
     CUstream Stream;

--- a/offload/plugins-nextgen/host/src/rtl.cpp
+++ b/offload/plugins-nextgen/host/src/rtl.cpp
@@ -344,13 +344,15 @@ struct GenELF64DeviceTy : public GenericDeviceTy {
   };
 
   /// This plugin does not support the event API. Do nothing without failing.
-  Error createEventImpl(void **EventPtrStorage) override {
+  Error createEventImpl(void **EventPtrStorage, bool EnableProfiling) override {
     *EventPtrStorage = nullptr;
     return Plugin::success();
   }
-  Error destroyEventImpl(void *EventPtr) override { return Plugin::success(); }
-  Error recordEventImpl(void *EventPtr,
-                        AsyncInfoWrapperTy &AsyncInfoWrapper) override {
+  Error destroyEventImpl(void *EventPtr, bool EnableProfiling) override {
+    return Plugin::success();
+  }
+  Error recordEventImpl(void *EventPtr, AsyncInfoWrapperTy &AsyncInfoWrapper,
+                        bool EnableProfiling) override {
     return Plugin::success();
   }
   Error waitEventImpl(void *EventPtr,

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -641,12 +641,14 @@ public:
     return true;
   }
 
-  Error createEventImpl(void **EventPtrStorage) override {
+  Error createEventImpl(void **EventPtrStorage, bool EnableProfiling) override {
     return Plugin::success();
   }
-  Error destroyEventImpl(void *EventPtr) override { return Plugin::success(); }
-  Error recordEventImpl(void *EventPtr,
-                        AsyncInfoWrapperTy &AsyncInfoWrapper) override {
+  Error destroyEventImpl(void *EventPtr, bool EnableProfiling) override {
+    return Plugin::success();
+  }
+  Error recordEventImpl(void *EventPtr, AsyncInfoWrapperTy &AsyncInfoWrapper,
+                        bool EnableProfiling) override {
     return Plugin::success();
   }
 

--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -110,7 +110,7 @@ struct ManuallyTriggeredTask {
             this))
       return Err;
 
-    return olCreateEvent(Queue, &CompleteEvent);
+    return olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &CompleteEvent);
   }
 
   void wait() {
@@ -241,7 +241,7 @@ struct OffloadQueueTest : OffloadDeviceTest {
 struct OffloadEventTest : OffloadQueueTest {
   void SetUp() override {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
-    ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+    ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
     ASSERT_SUCCESS(olSyncQueue(Queue));
   }
 

--- a/offload/unittests/OffloadAPI/event/olCreateEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olCreateEvent.cpp
@@ -15,15 +15,23 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olCreateEventTest);
 
 TEST_P(olCreateEventTest, Success) {
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
+  ASSERT_NE(Event, nullptr);
+}
+
+TEST_P(olCreateEventTest, SuccessWithProfiling) {
+  ol_event_handle_t Event = nullptr;
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &Event));
   ASSERT_NE(Event, nullptr);
 }
 
 TEST_P(olCreateEventTest, InvalidNullQueue) {
   ol_event_handle_t Event;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olCreateEvent(nullptr, &Event));
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+               olCreateEvent(nullptr, OL_EVENT_FLAGS_NONE, &Event));
 }
 
 TEST_P(olCreateEventTest, InvalidNullDest) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olCreateEvent(Queue, nullptr));
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, nullptr));
 }

--- a/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
@@ -15,7 +15,7 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olDestroyEventTest);
 
 TEST_P(olDestroyEventTest, Success) {
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
   ASSERT_NE(Event, nullptr);
   ASSERT_SUCCESS(olSyncQueue(Queue));
   ASSERT_SUCCESS(olDestroyEvent(Event));

--- a/offload/unittests/OffloadAPI/event/olGetEventElapsedTime.cpp
+++ b/offload/unittests/OffloadAPI/event/olGetEventElapsedTime.cpp
@@ -61,12 +61,14 @@ TEST_P(olGetEventElapsedTimeTest, Success) {
   ol_event_handle_t StartEvent = nullptr;
   ol_event_handle_t EndEvent = nullptr;
 
-  ASSERT_SUCCESS(olCreateEvent(Queue, &StartEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &StartEvent));
   ASSERT_NE(StartEvent, nullptr);
 
   launchFoo();
 
-  ASSERT_SUCCESS(olCreateEvent(Queue, &EndEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &EndEvent));
   ASSERT_NE(EndEvent, nullptr);
 
   ASSERT_SUCCESS(olSyncEvent(EndEvent));
@@ -84,12 +86,14 @@ TEST_P(olGetEventElapsedTimeTest, SuccessMultipleCalls) {
   ol_event_handle_t StartEvent = nullptr;
   ol_event_handle_t EndEvent = nullptr;
 
-  ASSERT_SUCCESS(olCreateEvent(Queue, &StartEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &StartEvent));
   ASSERT_NE(StartEvent, nullptr);
 
   launchFoo();
 
-  ASSERT_SUCCESS(olCreateEvent(Queue, &EndEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &EndEvent));
   ASSERT_NE(EndEvent, nullptr);
 
   ASSERT_SUCCESS(olSyncEvent(EndEvent));
@@ -109,7 +113,8 @@ TEST_P(olGetEventElapsedTimeTest, SuccessMultipleCalls) {
 
 TEST_P(olGetEventElapsedTimeTest, InvalidNullStartEvent) {
   ol_event_handle_t EndEvent = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &EndEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &EndEvent));
 
   float ElapsedTime = 0.0f;
   ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
@@ -120,7 +125,8 @@ TEST_P(olGetEventElapsedTimeTest, InvalidNullStartEvent) {
 
 TEST_P(olGetEventElapsedTimeTest, InvalidNullEndEvent) {
   ol_event_handle_t StartEvent = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &StartEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &StartEvent));
 
   float ElapsedTime = 0.0f;
   ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
@@ -133,11 +139,31 @@ TEST_P(olGetEventElapsedTimeTest, InvalidNullElapsedTime) {
   ol_event_handle_t StartEvent = nullptr;
   ol_event_handle_t EndEvent = nullptr;
 
-  ASSERT_SUCCESS(olCreateEvent(Queue, &StartEvent));
-  ASSERT_SUCCESS(olCreateEvent(Queue, &EndEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &StartEvent));
+  ASSERT_SUCCESS(
+      olCreateEvent(Queue, OL_EVENT_FLAGS_ENABLE_PROFILING, &EndEvent));
 
   ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetEventElapsedTime(StartEvent, EndEvent, nullptr));
+
+  ASSERT_SUCCESS(olDestroyEvent(StartEvent));
+  ASSERT_SUCCESS(olDestroyEvent(EndEvent));
+}
+
+TEST_P(olGetEventElapsedTimeTest, InvalidNonProfilingEvent) {
+  ol_event_handle_t StartEvent = nullptr;
+  ol_event_handle_t EndEvent = nullptr;
+
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &StartEvent));
+  launchFoo();
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &EndEvent));
+
+  ASSERT_SUCCESS(olSyncEvent(EndEvent));
+
+  float ElapsedTime = 0.0f;
+  ASSERT_ERROR(OL_ERRC_INVALID_ARGUMENT,
+               olGetEventElapsedTime(StartEvent, EndEvent, &ElapsedTime));
 
   ASSERT_SUCCESS(olDestroyEvent(StartEvent));
   ASSERT_SUCCESS(olDestroyEvent(EndEvent));

--- a/offload/unittests/OffloadAPI/event/olSyncEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olSyncEvent.cpp
@@ -15,7 +15,7 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olSyncEventTest);
 
 TEST_P(olSyncEventTest, Success) {
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
   ASSERT_NE(Event, nullptr);
   ASSERT_SUCCESS(olSyncEvent(Event));
   ASSERT_SUCCESS(olDestroyEvent(Event));
@@ -27,7 +27,7 @@ TEST_P(olSyncEventTest, InvalidNullEvent) {
 
 TEST_P(olSyncEventTest, SuccessMultipleSync) {
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
   ASSERT_NE(Event, nullptr);
 
   for (size_t I = 0; I < 10; I++)

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -248,7 +248,7 @@ TEST_P(olLaunchKernelSingleCounterSyncEventTest, SuccessSyncEvent) {
   ASSERT_SUCCESS(olMemcpy(Queue, &FinalResVal, Host, ResNum, Device, Size));
 
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
   ASSERT_SUCCESS(olSyncEvent(Event));
 
   ASSERT_EQ(FinalResVal, NumberToAdd * LoopRange);
@@ -298,7 +298,7 @@ TEST_P(olLaunchKernelSingleCounterSyncEventTest, SuccessTwoQueues) {
                                 &LaunchArgs, nullptr));
 
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
+  ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Event));
   ASSERT_SUCCESS(olWaitEvents(Queue2, &Event, 1));
   ArgsSingleCounter Args2{LoopRange, NumberToAdd, (uint32_t *)ResNum1,
                           (uint32_t *)ResNum2};

--- a/offload/unittests/OffloadAPI/queue/olWaitEvents.cpp
+++ b/offload/unittests/OffloadAPI/queue/olWaitEvents.cpp
@@ -53,7 +53,7 @@ TEST_P(olWaitEventsTest, Success) {
 
     ASSERT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
                                   sizeof(Args), &LaunchArgs, nullptr));
-    ASSERT_SUCCESS(olCreateEvent(Queues[I], &Events[I]));
+    ASSERT_SUCCESS(olCreateEvent(Queues[I], OL_EVENT_FLAGS_NONE, &Events[I]));
   }
 
   ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
@@ -87,7 +87,7 @@ TEST_P(olWaitEventsTest, SuccessSingleQueue) {
 
     ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                   &LaunchArgs, nullptr));
-    ASSERT_SUCCESS(olCreateEvent(Queue, &Events[I]));
+    ASSERT_SUCCESS(olCreateEvent(Queue, OL_EVENT_FLAGS_NONE, &Events[I]));
   }
 
   ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
@@ -121,7 +121,7 @@ TEST_P(olWaitEventsTest, SuccessMultipleEvents) {
 
     ASSERT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
                                   sizeof(Args), &LaunchArgs, nullptr));
-    ASSERT_SUCCESS(olCreateEvent(Queues[I], &Events[I]));
+    ASSERT_SUCCESS(olCreateEvent(Queues[I], OL_EVENT_FLAGS_NONE, &Events[I]));
   }
 
   ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));


### PR DESCRIPTION
Summary:
Profiling requires getting time stamp information, which required
actually materializing barriers on the event. This caused performance
regressions in some OpenMP applications. Instead, we want to make this
opt in. This just adds a new argument to `olCreateEvent` which takes
some flags. Right now this is just none and profiling. Pretty mechanical
beyond that. Should revert this to the old behavior for OpenMP.
