### PR TITLE
[LV] Fix dead early exit in test. NFC

### DIFF
--- a/llvm/test/Transforms/LoopVectorize/predicated-single-exit.ll
+++ b/llvm/test/Transforms/LoopVectorize/predicated-single-exit.ll
@@ -192,8 +192,8 @@ define i64 @exit_cond_defined_in_header() {
 ; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, %[[LOOP_HEADER]] ], [ [[INDEX_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
 ; CHECK-NEXT:    [[GEP_A:%.*]] = getelementptr inbounds i8, ptr @A, i64 [[IV]]
 ; CHECK-NEXT:    [[WIDE_LOAD:%.*]] = load <4 x i8>, ptr [[GEP_A]], align 1
-; CHECK-NEXT:    [[TMP1:%.*]] = icmp slt <4 x i8> [[WIDE_LOAD]], zeroinitializer
-; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq <4 x i8> [[WIDE_LOAD]], splat (i8 1)
+; CHECK-NEXT:    [[TMP1:%.*]] = icmp sgt <4 x i8> [[WIDE_LOAD]], zeroinitializer
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp slt <4 x i8> [[WIDE_LOAD]], splat (i8 42)
 ; CHECK-NEXT:    [[TMP3:%.*]] = select <4 x i1> [[TMP1]], <4 x i1> [[TMP2]], <4 x i1> zeroinitializer
 ; CHECK-NEXT:    [[INDEX_NEXT]] = add nuw i64 [[IV]], 4
 ; CHECK-NEXT:    [[TMP4:%.*]] = freeze <4 x i1> [[TMP3]]
@@ -217,8 +217,8 @@ loop.header:
   %iv = phi i64 [ %iv.next, %loop.latch ], [ 0, %entry ]
   %gep.A = getelementptr inbounds i8, ptr @A, i64 %iv
   %l.A = load i8, ptr %gep.A, align 1
-  %branch.cond = icmp slt i8 %l.A, 0
-  %exit.cond = icmp eq i8 %l.A, 1
+  %branch.cond = icmp sgt i8 %l.A, 0
+  %exit.cond = icmp slt i8 %l.A, 42
   br i1 %branch.cond, label %block.a, label %loop.latch
 
 block.a:


### PR DESCRIPTION
The early exit in this test is dead because the predicated block's condition (< 0) means the exit cond (== 1) can't be met.
