### PR TITLE
[docker][windows] install make in Dockerfile

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -45,7 +45,8 @@ RUN regsvr32 /S "C:\BuildTools\DIA SDK\bin\amd64\msdia140.dll" & \
 RUN choco install -y ninja --version 1.13.1 && \
     choco install -y git --version 2.50.1 && \
     choco install -y sccache --version 0.10.0 && \
-    choco install -y python3 --version 3.12.3
+    choco install -y python3 --version 3.12.3 && \
+    choco install -y make --version 4.4.1
 
 # Testing requires psutil
 RUN pip install psutil


### PR DESCRIPTION
The lldb-api test suite builds each test's inferior via GNU make. The current Windows CI container (`ghcr.io/llvm/ci-windows-2022:latest`) does not install make, so LLDB's CMake configure step ends up with `LLDB_DEFAULT_TEST_MAKE-NOTFOUND` and every lldb-api test reports `UNRESOLVED`.
    
This patch adds a step in the Windows Dockerfile to install make with choco.