### PR TITLE
[libc++] Add Android assertion handler

### DIFF
--- a/libcxx/cmake/caches/AndroidNDK.cmake
+++ b/libcxx/cmake/caches/AndroidNDK.cmake
@@ -35,3 +35,4 @@ set(CMAKE_CXX_COMPILER_WORKS ON CACHE BOOL "")
 # them.
 set(LIBCXX_TEST_CONFIG "llvm-libc++-android.cfg.in" CACHE STRING "")
 set(LIBCXXABI_TEST_CONFIG "llvm-libc++abi-android.cfg.in" CACHE STRING "")
+set(LIBCXX_ASSERTION_HANDLER_FILE "vendor/android/android_assertion_handler.in" CACHE STRING "")

--- a/libcxx/vendor/android/android_assertion_handler.in
+++ b/libcxx/vendor/android/android_assertion_handler.in
@@ -1,0 +1,58 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __LIBCPP_ANDROID_ASSERTION_HANDLER
+#define __LIBCPP_ANDROID_ASSERTION_HANDLER
+
+#include <__config>
+#include <__log_hardening_failure>
+#include <__verbose_abort>
+#include <__verbose_trap>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_IGNORE
+#  define _LIBCPP_ASSERTION_HANDLER(message) ((void)0)
+
+#elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_OBSERVE
+#  define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_LOG_HARDENING_FAILURE(message)
+
+#elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_QUICK_ENFORCE
+
+// Require `nomerge` for better crash attribution.
+#  define _LIBCPP_ASSERTION_HANDLER(message) \
+  ({ [[clang::nomerge]] _LIBCPP_VERBOSE_TRAP(message); })
+
+#elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_ENFORCE
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+// Calling a `void(const char *)` takes fewer bytes than calling a
+// `void(const char *, ...)`.
+[[__noreturn__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_NOINLINE
+inline void __libcpp_android_verbose_abort(const char *__message) {
+  _LIBCPP_VERBOSE_ABORT("%s", __message);
+}
+_LIBCPP_END_NAMESPACE_STD
+
+#  define _LIBCPP_ASSERTION_HANDLER(message) \
+  ({ [[clang::nomerge]] ::std::__libcpp_android_verbose_abort(message); })
+
+#else
+
+#  error _LIBCPP_ASSERTION_SEMANTIC must be set to one of the following values: \
+_LIBCPP_ASSERTION_SEMANTIC_IGNORE, \
+_LIBCPP_ASSERTION_SEMANTIC_OBSERVE, \
+_LIBCPP_ASSERTION_SEMANTIC_QUICK_ENFORCE, \
+_LIBCPP_ASSERTION_SEMANTIC_ENFORCE
+
+#endif // _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_IGNORE
+
+#endif // __LIBCPP_ANDROID_ASSERTION_HANDLER

--- a/libcxx/vendor/android/android_assertion_handler.in
+++ b/libcxx/vendor/android/android_assertion_handler.in
@@ -34,8 +34,8 @@
 #elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_ENFORCE
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-// Calling a `void(const char *)` takes fewer bytes than calling a
-// `void(const char *, ...)`.
+// Calling this saves code size compared to
+// `__libcpp_verbose_abort("%s", "error message")`.
 [[__noreturn__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_NOINLINE
 inline void __libcpp_android_verbose_abort(const char *__message) {
   _LIBCPP_VERBOSE_ABORT("%s", __message);

--- a/libcxx/vendor/android/android_assertion_handler.in
+++ b/libcxx/vendor/android/android_assertion_handler.in
@@ -29,21 +29,23 @@
 
 // Require `nomerge` for better crash attribution.
 #  define _LIBCPP_ASSERTION_HANDLER(message) \
-  ({ [[clang::nomerge]] _LIBCPP_VERBOSE_TRAP(message); })
+  ({ [[clang::__nomerge__]] _LIBCPP_VERBOSE_TRAP(message); })
 
 #elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_ENFORCE
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // Calling this saves code size compared to
 // `__libcpp_verbose_abort("%s", "error message")`.
-[[__noreturn__]] _LIBCPP_HIDE_FROM_ABI _LIBCPP_NOINLINE
+// Force it to be `hidden` so we also don't have to pay for runtime
+// relocations.
+[[clang::__nomerge__]] [[__noreturn__]] _LIBCPP_HIDDEN
 inline void __libcpp_android_verbose_abort(const char *__message) {
   _LIBCPP_VERBOSE_ABORT("%s", __message);
 }
 _LIBCPP_END_NAMESPACE_STD
 
 #  define _LIBCPP_ASSERTION_HANDLER(message) \
-  ({ [[clang::nomerge]] ::std::__libcpp_android_verbose_abort(message); })
+  ::std::__libcpp_android_verbose_abort(message)
 
 #else
 

--- a/libcxx/vendor/android/android_assertion_handler.in
+++ b/libcxx/vendor/android/android_assertion_handler.in
@@ -29,16 +29,14 @@
 
 // Require `nomerge` for better crash attribution.
 #  define _LIBCPP_ASSERTION_HANDLER(message) \
-  ({ [[clang::__nomerge__]] _LIBCPP_VERBOSE_TRAP(message); })
+  ({ [[_Clang::__nomerge__]] _LIBCPP_VERBOSE_TRAP(message); })
 
 #elif _LIBCPP_ASSERTION_SEMANTIC == _LIBCPP_ASSERTION_SEMANTIC_ENFORCE
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // Calling this saves code size compared to
 // `__libcpp_verbose_abort("%s", "error message")`.
-// Force it to be `hidden` so we also don't have to pay for runtime
-// relocations.
-[[clang::__nomerge__]] [[__noreturn__]] _LIBCPP_HIDDEN
+[[_Clang::__nomerge__]] [[__noreturn__]]
 inline void __libcpp_android_verbose_abort(const char *__message) {
   _LIBCPP_VERBOSE_ABORT("%s", __message);
 }


### PR DESCRIPTION
We're in the process of increasing the use of libcxx hardening in
Android. The handlers we're using deviate from the defaults in two ways:

- All handlers are `nomerge` for better postmortem crash attribution
- `_LIBCPP_VERBOSE_ABORT` is wrapped by a `NOINLINE` function to reduce
  binary size overhead slightly (on x86_64, the diff is ~9B per call
  to _LIBCPP_VERBOSE_ABORT).

-----

Meta: I _assume_ the `vendor/` dir here is an invitation for folks to upstream our own solutions here? If so, I'd appreciate a thoughts on how to best test this outside of Android. Locally, I've been running `cmake` with `-DLIBCXX_ASSERTION_HANDLER_FILE=vendor/android/android_assertion_handler.in`, but that's hardly a viable CI story ;)