### PR TITLE
[llvm][Instrumentor] Fix non-determinism in Instrumentor

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/EnumeratedArray.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -447,7 +448,7 @@ struct InstrumentationConfig {
   /// the instrumentation location kind and then by the opportunity name. Notice
   /// that an instrumentation location may have more than one instrumentation
   /// opportunity registered.
-  EnumeratedArray<StringMap<InstrumentationOpportunity *>,
+  EnumeratedArray<MapVector<StringRef, InstrumentationOpportunity *>,
                   InstrumentationLocation::KindTy>
       IChoices;
 

--- a/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
@@ -86,14 +86,14 @@ void writeConfigToJSON(InstrumentationConfig &IConf, StringRef OutputFile,
 
     J.attributeBegin(InstrumentationLocation::getKindStr(Kind));
     J.objectBegin();
-    for (auto &ChoiceIt : KindChoices) {
-      J.attributeBegin(ChoiceIt.getKey());
+    for (auto &[Name, Choice] : KindChoices) {
+      J.attributeBegin(Name);
       J.objectBegin();
-      J.attribute("enabled", ChoiceIt.second->Enabled);
-      J.attribute("filter", ChoiceIt.second->Filter);
+      J.attribute("enabled", Choice->Enabled);
+      J.attribute("filter", Choice->Filter);
       J.attribute("filter.description",
                   "Static property filter to exclude instrumentation.");
-      for (auto &ArgIt : ChoiceIt.second->IRTArgs) {
+      for (auto &ArgIt : Choice->IRTArgs) {
         J.attribute(ArgIt.Name, ArgIt.Enabled);
         if ((ArgIt.Flags & IRTArg::REPLACABLE) ||
             (ArgIt.Flags & IRTArg::REPLACABLE_CUSTOM))
@@ -200,7 +200,8 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
             "malformed JSON configuration, expected an object", DS_Warning));
         continue;
       }
-      auto *IO = IChoiceMap.lookup(ObjIt.first);
+      auto *ChoiceIt = IChoiceMap.find(ObjIt.first);
+      auto *IO = (ChoiceIt != IChoiceMap.end()) ? ChoiceIt->second : nullptr;
       if (!IO) {
         Ctx.diagnose(DiagnosticInfoInstrumentation(
             Twine("malformed JSON configuration, expected an object matching "

--- a/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorConfigFile.cpp
@@ -200,8 +200,7 @@ bool readConfigFromJSON(InstrumentationConfig &IConf, StringRef InputFile,
             "malformed JSON configuration, expected an object", DS_Warning));
         continue;
       }
-      auto *ChoiceIt = IChoiceMap.find(ObjIt.first);
-      auto *IO = (ChoiceIt != IChoiceMap.end()) ? ChoiceIt->second : nullptr;
+      auto *IO = IChoiceMap.lookup(ObjIt.first);
       if (!IO) {
         Ctx.diagnose(DiagnosticInfoInstrumentation(
             Twine("malformed JSON configuration, expected an object matching "

--- a/llvm/test/Instrumentation/Instrumentor/default_config.json
+++ b/llvm/test/Instrumentation/Instrumentor/default_config.json
@@ -132,6 +132,18 @@
     }
   },
   "instruction_pre": {
+    "alloca": {
+      "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
+      "size": true,
+      "size.replace": true,
+      "size.description": "The allocation size.",
+      "alignment": true,
+      "alignment.description": "The allocation alignment.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
+    },
     "unreachable": {
       "enabled": true,
       "filter": "",
@@ -163,18 +175,6 @@
       "id": true,
       "id.description": "A unique ID associated with the given instrumentor call"
     },
-    "alloca": {
-      "enabled": true,
-      "filter": "",
-      "filter.description": "Static property filter to exclude instrumentation.",
-      "size": true,
-      "size.replace": true,
-      "size.description": "The allocation size.",
-      "alignment": true,
-      "alignment.description": "The allocation alignment.",
-      "id": true,
-      "id.description": "A unique ID associated with the given instrumentor call"
-    },
     "store": {
       "enabled": true,
       "filter": "",
@@ -203,6 +203,20 @@
     }
   },
   "instruction_post": {
+    "alloca": {
+      "enabled": true,
+      "filter": "",
+      "filter.description": "Static property filter to exclude instrumentation.",
+      "address": true,
+      "address.replace": true,
+      "address.description": "The allocated memory address.",
+      "size": true,
+      "size.description": "The allocation size.",
+      "alignment": true,
+      "alignment.description": "The allocation alignment.",
+      "id": true,
+      "id.description": "A unique ID associated with the given instrumentor call"
+    },
     "load": {
       "enabled": true,
       "filter": "",
@@ -226,20 +240,6 @@
       "sync_scope_id.description": "The sync scope id of the load.",
       "is_volatile": true,
       "is_volatile.description": "Flag indicating a volatile load.",
-      "id": true,
-      "id.description": "A unique ID associated with the given instrumentor call"
-    },
-    "alloca": {
-      "enabled": true,
-      "filter": "",
-      "filter.description": "Static property filter to exclude instrumentation.",
-      "address": true,
-      "address.replace": true,
-      "address.description": "The allocated memory address.",
-      "size": true,
-      "size.description": "The allocation size.",
-      "alignment": true,
-      "alignment.description": "The allocation alignment.",
       "id": true,
       "id.description": "A unique ID associated with the given instrumentor call"
     },


### PR DESCRIPTION
In InstrumentorStubPrinter the StringMap was being iterated over, which
broke the Instrumentation/Instrumentor/write_config.ll test under
LLVM_REVERSE_ITERATION builds. We can use a MapVector to ensure the
order is stable. We only need to update the test json ordering to match
the stable order for with and without LLVM_REVERSE_ITERATION.