### PR TITLE
[libc] Make FreeListHeap::free ignore null pointers.

### DIFF
--- a/libc/src/__support/freelist_heap.h
+++ b/libc/src/__support/freelist_heap.h
@@ -128,6 +128,9 @@ LIBC_INLINE void *FreeListHeap::aligned_allocate(size_t alignment,
 }
 
 LIBC_INLINE void FreeListHeap::free(void *ptr) {
+  if (ptr == nullptr)
+    return;
+
   cpp::byte *bytes = static_cast<cpp::byte *>(ptr);
 
   LIBC_ASSERT(is_valid_ptr(bytes) && "Invalid pointer");


### PR DESCRIPTION
Update `FreeListHeap::free` to return immediately when passed `nullptr`.

This matches the expected `free(nullptr)` behaviour as per the C standard and avoids running pointer validation on a null pointer allowing the hermetic malloc test libc/test/src/stdlib/malloc_test.cpp to pass.

As per standard:
The free function, paragraph:
```
  The free function causes the space pointed to by
  ptr to be deallocated, that is, made available for
  further allocation. If ptr is a null pointer,
  no action occurs.
```