### PR TITLE
[NFC][AArch64][Cyclone] Model WriteSTP with a local SchedWriteRes

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SchedCyclone.td
+++ b/llvm/lib/Target/AArch64/AArch64SchedCyclone.td
@@ -274,7 +274,12 @@ def : WriteRes<WriteLDHi, []> {
 }
 
 // STP is a vector op and store, except for QQ, which is just two stores.
-def : SchedAlias<WriteSTP, WriteVSTShuffle>;
+def CyWriteSTP : SchedWriteRes<[CyUnitV, CyUnitLS]> {
+  let Latency = 6;
+  let NumMicroOps = 2;
+}
+
+def : SchedAlias<WriteSTP, CyWriteSTP>;
 def : InstRW<[WriteST, WriteST], (instrs STPQi)>;
 
 //---


### PR DESCRIPTION
Cyclone scheduling model uses SchedAlias between 2 SchedWriteRes definitions from AArch64Schedule.td.
This prevents other scheduling models from aliasing WriteSTP. This patch address the issue by defining a new CyWriteSTP and using that instead.