### PR TITLE
[libc][NFC] Lowercase standard identifiers in YAML files

### DIFF
--- a/libc/include/arpa/inet.yaml
+++ b/libc/include/arpa/inet.yaml
@@ -10,19 +10,19 @@ objects: []
 functions:
   - name: htonl
     standards:
-      - POSIX
+      - posix
     return_type: uint32_t
     arguments:
       - type: uint32_t
   - name: htons
     standards:
-      - POSIX
+      - posix
     return_type: uint16_t
     arguments:
       - type: uint16_t
   - name: inet_addr
     standards:
-      - POSIX
+      - posix
     return_type: in_addr_t
     arguments:
       - type: const char *
@@ -35,13 +35,13 @@ functions:
       - type: struct in_addr *
   - name: ntohl
     standards:
-      - POSIX
+      - posix
     return_type: uint32_t
     arguments:
       - type: uint32_t
   - name: ntohs
     standards:
-      - POSIX
+      - posix
     return_type: uint16_t
     arguments:
       - type: uint16_t

--- a/libc/include/ctype.yaml
+++ b/libc/include/ctype.yaml
@@ -18,7 +18,7 @@ functions:
       - type: int
   - name: isascii
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -84,7 +84,7 @@ functions:
       - type: int
   - name: toascii
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: int

--- a/libc/include/dlfcn.yaml
+++ b/libc/include/dlfcn.yaml
@@ -91,25 +91,25 @@ types:
 functions:
   - name: dlclose
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
   - name: dlerror
     standards:
-      - POSIX
+      - posix
     return_type: char *
     arguments: []
   - name: dlopen
     standards:
-      - POSIX
+      - posix
     return_type: void *
     arguments:
       - type: const char *
       - type: int
   - name: dlsym
     standards:
-      - POSIX
+      - posix
     return_type: void *
     arguments:
       - type: void *__restrict
@@ -124,7 +124,7 @@ functions:
       - type: void *__restrict
   - name: dladdr
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const void *__restrict

--- a/libc/include/errno.yaml
+++ b/libc/include/errno.yaml
@@ -2,8 +2,8 @@ header: errno.h
 header_template: errno.h.def
 standards:
   - stdc
-  - Linux
-  - POSIX
+  - linux
+  - posix
 macros: []
 types:
   - type_name: errno_t

--- a/libc/include/fcntl.yaml
+++ b/libc/include/fcntl.yaml
@@ -18,14 +18,14 @@ objects: []
 functions:
   - name: creat
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
       - type: mode_t
   - name: fcntl
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -33,7 +33,7 @@ functions:
       - type: '...'
   - name: open
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
@@ -41,7 +41,7 @@ functions:
       - type: '...'
   - name: openat
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int

--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -1590,19 +1590,19 @@ functions:
       - type: long double
   - name: isnan
     standards:
-      - BSDExtensions
+      - bsd
     return_type: int
     arguments:
       - type: double
   - name: isnanf
     standards:
-      - BSDExtensions
+      - bsd
     return_type: int
     arguments:
       - type: float
   - name: isnanl
     standards:
-      - BSDExtensions
+      - bsd
     return_type: int
     arguments:
       - type: long double

--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -50,26 +50,26 @@ functions:
       - type: cpu_set_t *
   - name: getcpu
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: unsigned int *
       - type: unsigned int *
   - name: sched_get_priority_max
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: sched_get_priority_min
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: sched_getaffinity
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: pid_t
@@ -77,33 +77,33 @@ functions:
       - type: cpu_set_t *
   - name: sched_getcpu
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: void
   - name: sched_getparam
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: pid_t
       - type: struct sched_param *
   - name: sched_getscheduler
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: pid_t
   - name: sched_rr_get_interval
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: pid_t
       - type: struct timespec *
   - name: sched_setaffinity
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: pid_t
@@ -111,14 +111,14 @@ functions:
       - type: const cpu_set_t *
   - name: sched_setparam
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: pid_t
       - type: const struct sched_param *
   - name: sched_setscheduler
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: pid_t
@@ -126,7 +126,7 @@ functions:
       - type: const struct sched_param *
   - name: sched_yield
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void

--- a/libc/include/signal.yaml
+++ b/libc/include/signal.yaml
@@ -34,7 +34,7 @@ objects: []
 functions:
   - name: kill
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: pid_t
@@ -47,7 +47,7 @@ functions:
       - type: int
   - name: sigaction
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -55,34 +55,34 @@ functions:
       - type: struct sigaction *__restrict
   - name: sigaddset
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: sigset_t *
       - type: int
   - name: sigaltstack
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const stack_t *__restrict
       - type: stack_t *__restrict
   - name: sigdelset
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: sigset_t *
       - type: int
   - name: sigemptyset
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: sigset_t *
   - name: sigfillset
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: sigset_t *
@@ -100,7 +100,7 @@ functions:
       - type: void (*)(int)))(int
   - name: sigprocmask
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int

--- a/libc/include/stdio.yaml
+++ b/libc/include/stdio.yaml
@@ -44,7 +44,7 @@ objects:
 functions:
   - name: asprintf
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: char **__restrict
@@ -60,7 +60,7 @@ functions:
       - type: FILE *
   - name: clearerr_unlocked
     standards:
-      - GNUExtensions
+      - gnu
     return_type: void
     arguments:
       - type: FILE *
@@ -72,7 +72,7 @@ functions:
       - type: FILE *
   - name: fdopen
     standards:
-      - POSIX
+      - posix
     return_type: FILE *
     arguments:
       - type: int
@@ -85,7 +85,7 @@ functions:
       - type: FILE *
   - name: feof_unlocked
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: FILE *
@@ -97,7 +97,7 @@ functions:
       - type: FILE *
   - name: ferror_unlocked
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: FILE *
@@ -115,7 +115,7 @@ functions:
       - type: FILE *
   - name: fgetc_unlocked
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: FILE *
@@ -129,13 +129,13 @@ functions:
       - type: FILE *__restrict
   - name: fileno
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: FILE *
   - name: flockfile
     standards:
-      - POSIX
+      - posix
     return_type: void
     arguments:
       - type: FILE *
@@ -148,7 +148,7 @@ functions:
       - type: const char *
   - name: fopencookie
     standards:
-      - GNUExtensions
+      - gnu
     return_type: FILE *
     arguments:
       - type: void *
@@ -187,7 +187,7 @@ functions:
       - type: FILE *__restrict
   - name: fread_unlocked
     standards:
-      - GNUExtensions
+      - gnu
     return_type: size_t
     arguments:
       - type: void *__restrict
@@ -226,7 +226,7 @@ functions:
       - type: FILE *
   - name: fseeko
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: FILE *
@@ -240,13 +240,13 @@ functions:
       - type: FILE *
   - name: ftello
     standards:
-      - POSIX
+      - posix
     return_type: off_t
     arguments:
       - type: FILE *
   - name: funlockfile
     standards:
-      - POSIX
+      - posix
     return_type: void
     arguments:
       - type: FILE *
@@ -261,7 +261,7 @@ functions:
       - type: FILE *__restrict
   - name: fwrite_unlocked
     standards:
-      - GNUExtensions
+      - gnu
     return_type: size_t
     arguments:
       - type: const void *__restrict
@@ -276,7 +276,7 @@ functions:
       - type: FILE *
   - name: getc_unlocked
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: FILE *
@@ -287,7 +287,7 @@ functions:
     arguments: []
   - name: getchar_unlocked
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments: []
   - name: perror
@@ -405,7 +405,7 @@ functions:
       - type: FILE *
   - name: vasprintf
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: char **__restrict

--- a/libc/include/stdlib.yaml
+++ b/libc/include/stdlib.yaml
@@ -183,7 +183,7 @@ functions:
       - type: __qsortcompare_t
   - name: qsort_r
     standards:
-      - POSIX
+      - posix
     return_type: void
     arguments:
       - type: void *

--- a/libc/include/string.yaml
+++ b/libc/include/string.yaml
@@ -50,7 +50,7 @@ functions:
       - type: size_t
   - name: memmem
     standards:
-      - GNUExtensions
+      - gnu
     return_type: void *
     arguments:
       - type: const void *
@@ -75,7 +75,7 @@ functions:
       - type: size_t
   - name: memrchr
     standards:
-      - GNUExtensions
+      - gnu
     return_type: void *
     arguments:
       - type: const void *
@@ -114,7 +114,7 @@ functions:
       - type: size_t
   - name: strcasestr
     standards:
-      - GNUExtensions
+      - gnu
     return_type: char *
     arguments:
       - type: const char *
@@ -135,7 +135,7 @@ functions:
       - type: int
   - name: strchrnul
     standards:
-      - GNUExtensions
+      - gnu
     return_type: char *
     arguments:
       - type: const char *
@@ -188,7 +188,7 @@ functions:
       - type: int
   - name: strerror_r
     standards:
-      - GNUExtensions
+      - gnu
     return_type: char *
     arguments:
       - type: int
@@ -196,7 +196,7 @@ functions:
       - type: size_t
   - name: strlcat
     standards:
-      - BSDExtensions
+      - bsd
     return_type: size_t
     arguments:
       - type: char *__restrict
@@ -204,7 +204,7 @@ functions:
       - type: size_t
   - name: strlcpy
     standards:
-      - BSDExtensions
+      - bsd
     return_type: size_t
     arguments:
       - type: char *__restrict
@@ -278,7 +278,7 @@ functions:
       - type: int
   - name: strsep
     standards:
-      - BSDExtensions
+      - bsd
     return_type: char *
     arguments:
       - type: char **__restrict

--- a/libc/include/sys/mman.yaml
+++ b/libc/include/sys/mman.yaml
@@ -13,7 +13,7 @@ objects: []
 functions:
   - name: madvise
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
@@ -21,14 +21,14 @@ functions:
       - type: int
   - name: memfd_create
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: const char *
       - type: unsigned int
   - name: mincore
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: void *
@@ -36,14 +36,14 @@ functions:
       - type: unsigned char *
   - name: mlock
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
       - type: size_t
   - name: mlock2
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: void *
@@ -51,13 +51,13 @@ functions:
       - type: unsigned int
   - name: mlockall
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: mmap
     standards:
-      - POSIX
+      - posix
     return_type: void *
     arguments:
       - type: void *
@@ -68,7 +68,7 @@ functions:
       - type: off_t
   - name: mremap
     standards:
-      - POSIX
+      - posix
     return_type: void *
     arguments:
       - type: void *
@@ -78,7 +78,7 @@ functions:
       - type: '...'
   - name: mprotect
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
@@ -86,7 +86,7 @@ functions:
       - type: int
   - name: msync
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
@@ -100,39 +100,39 @@ functions:
       - type: size_t
   - name: munlockall
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void
   - name: munmap
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
       - type: size_t
   - name: pkey_alloc
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: unsigned int
       - type: unsigned int
   - name: pkey_free
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: int
   - name: pkey_get
     standards:
-      - GNU
+      - gnu
     return_type: int
     arguments:
       - type: int
   - name: pkey_mprotect
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: void *
@@ -141,14 +141,14 @@ functions:
       - type: int
   - name: pkey_set
     standards:
-      - GNU
+      - gnu
     return_type: int
     arguments:
       - type: int
       - type: unsigned int
   - name: posix_madvise
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: void *
@@ -156,7 +156,7 @@ functions:
       - type: int
   - name: remap_file_pages
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: void *
@@ -166,7 +166,7 @@ functions:
       - type: int
   - name: shm_open
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *
@@ -174,7 +174,7 @@ functions:
       - type: mode_t
   - name: shm_unlink
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const char *

--- a/libc/include/sys/prctl.yaml
+++ b/libc/include/sys/prctl.yaml
@@ -7,7 +7,7 @@ objects: []
 functions:
   - name: prctl
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: int

--- a/libc/include/sys/resource.yaml
+++ b/libc/include/sys/resource.yaml
@@ -12,14 +12,14 @@ objects: []
 functions:
   - name: getrlimit
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: struct rlimit *
   - name: setrlimit
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int

--- a/libc/include/sys/select.yaml
+++ b/libc/include/sys/select.yaml
@@ -16,7 +16,7 @@ objects: []
 functions:
   - name: select
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int

--- a/libc/include/sys/socket.yaml
+++ b/libc/include/sys/socket.yaml
@@ -20,7 +20,7 @@ objects: []
 functions:
   - name: accept
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -28,7 +28,7 @@ functions:
       - type: socklen_t *__restrict
   - name: accept4
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: int
@@ -37,7 +37,7 @@ functions:
       - type: int
   - name: bind
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -45,7 +45,7 @@ functions:
       - type: socklen_t
   - name: connect
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -53,7 +53,7 @@ functions:
       - type: socklen_t
   - name: getpeername
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -61,7 +61,7 @@ functions:
       - type: socklen_t *__restrict
   - name: getsockname
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -69,7 +69,7 @@ functions:
       - type: socklen_t *__restrict
   - name: getsockopt
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -79,14 +79,14 @@ functions:
       - type: socklen_t *__restrict
   - name: listen
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: int
   - name: recv
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -95,7 +95,7 @@ functions:
       - type: int
   - name: recvfrom
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -106,7 +106,7 @@ functions:
       - type: socklen_t *__restrict
   - name: recvmsg
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -114,7 +114,7 @@ functions:
       - type: int
   - name: send
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -123,7 +123,7 @@ functions:
       - type: int
   - name: sendmsg
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -131,7 +131,7 @@ functions:
       - type: int
   - name: sendto
     standards:
-      - POSIX
+      - posix
     return_type: ssize_t
     arguments:
       - type: int
@@ -142,7 +142,7 @@ functions:
       - type: socklen_t
   - name: setsockopt
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
@@ -152,14 +152,14 @@ functions:
       - type: socklen_t
   - name: shutdown
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: int
   - name: socket
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int

--- a/libc/include/sys/wait.yaml
+++ b/libc/include/sys/wait.yaml
@@ -13,14 +13,14 @@ objects: []
 functions:
   - name: wait
     standards:
-      - POSIX
+      - posix
     return_type: pid_t
     arguments:
       - type: int *
   - name: wait4
     standards:
-      - BSDExtensions
-      - POSIX
+      - bsd
+      - posix
     return_type: pid_t
     arguments:
       - type: pid_t
@@ -29,7 +29,7 @@ functions:
       - type: struct rusage *
   - name: waitpid
     standards:
-      - POSIX
+      - posix
     return_type: pid_t
     arguments:
       - type: pid_t

--- a/libc/include/termios.yaml
+++ b/libc/include/termios.yaml
@@ -15,73 +15,73 @@ objects: []
 functions:
   - name: cfgetispeed
     standards:
-      - POSIX
+      - posix
     return_type: speed_t
     arguments:
       - type: const struct termios *
   - name: cfgetospeed
     standards:
-      - POSIX
+      - posix
     return_type: speed_t
     arguments:
       - type: const struct termios *
   - name: cfsetispeed
     standards:
-      - POSIX
+      - posix
     return_type: speed_t
     arguments:
       - type: struct termios *
       - type: speed_t
   - name: cfsetospeed
     standards:
-      - POSIX
+      - posix
     return_type: speed_t
     arguments:
       - type: struct termios *
       - type: speed_t
   - name: tcdrain
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
   - name: tcflow
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: int
   - name: tcflush
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: int
   - name: tcgetattr
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: struct termios *
   - name: tcgetsid
     standards:
-      - POSIX
+      - posix
     return_type: pid_t
     arguments:
       - type: int
   - name: tcsendbreak
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int
       - type: int
   - name: tcsetattr
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: int

--- a/libc/include/time.yaml
+++ b/libc/include/time.yaml
@@ -67,14 +67,14 @@ functions:
       - type: void
   - name: clock_gettime
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: clockid_t
       - type: struct timespec *
   - name: clock_settime
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: clockid_t
@@ -88,7 +88,7 @@ functions:
       - type: time_t
   - name: gettimeofday
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: struct timeval *
@@ -114,7 +114,7 @@ functions:
       - type: struct tm *
   - name: nanosleep
     standards:
-      - POSIX
+      - posix
     return_type: int
     arguments:
       - type: const struct timespec *

--- a/libc/include/unistd.yaml
+++ b/libc/include/unistd.yaml
@@ -184,7 +184,7 @@ functions:
       - type: size_t
   - name: getentropy
     standards:
-      - GNUExtensions
+      - gnu
     return_type: int
     arguments:
       - type: void *
@@ -204,7 +204,7 @@ functions:
       - type: size_t
   - name: getpagesize
     standards:
-      - BSDExtensions
+      - bsd
     return_type: int
     arguments:
       - type: void
@@ -236,7 +236,7 @@ functions:
       - type: pid_t
   - name: gettid
     standards:
-      - Linux
+      - linux
     return_type: pid_t
     arguments:
       - type: void
@@ -300,7 +300,7 @@ functions:
       - type: int *
   - name: pipe2
     standards:
-      - Linux
+      - linux
     return_type: int
     arguments:
       - type: int *


### PR DESCRIPTION
Update YAML files to use lowercase identifiers for standards.

In header.py, canonical identifiers for standards are explicitly defined in lowercase and mapped to their pretty names for display. This change ensures that all YAML files use the lowercase identifiers (posix, linux, bsd, gnu) expected by the header generation tool.

Assisted-by: Automated tooling, human reviewed.