### PR TITLE
[bolt][test] Use non-GNU assembly directive

### DIFF
--- a/bolt/test/AArch64/validate-secondary-entry-point.s
+++ b/bolt/test/AArch64/validate-secondary-entry-point.s
@@ -47,15 +47,16 @@ _bar:
 void _start() {}
 
 __attribute__((naked)) void foo() {
-  asm("ldr x16, .L_fnptr\n"
-      "blr x16\n"
-      "ret\n"
+  __asm(
+    "ldr x16, .L_fnptr\n"
+    "blr x16\n"
+    "ret\n"
 
-      "_rodatx:"
-      ".global _rodatx;"
-      ".quad 0;"
-      ".L_fnptr:"
-      ".quad 0;");
+    "_rodatx:"
+    ".global _rodatx;"
+    ".quad 0;"
+    ".L_fnptr:"
+    ".quad 0;");
 }
 
 ;--- ss.c

--- a/bolt/test/X86/Inputs/double_jump.cpp
+++ b/bolt/test/X86/Inputs/double_jump.cpp
@@ -5,28 +5,26 @@ extern "C" unsigned long bar(unsigned long count) {
 }
 
 unsigned long foo(unsigned long count) {
-  asm(
-      "     cmpq  $1,%0\n"
-      "     je    .L7\n"
-      "     incq  %0\n"
-      "     jmp   .L1\n"
-      ".L1: jmp   .L2\n"
-      ".L2: incq  %0\n"
-      "     cmpq  $2,%0\n"
-      "     jne   .L3\n"
-      "     jmp   .L4\n"
-      ".L3: jmp   .L5\n"
-      ".L5: incq  %0\n"
-      ".L4: movq  %0,%%rdi\n"
-      "     pop   %%rbp\n"
-      "     jmp   .L6\n"
-      ".L7: pop   %%rbp\n"
-      "     incq  %0\n"
-      "     jmp   .L6\n"
-      ".L6: jmp   bar\n"
-      :
-      : "m"(count)
-      );
+  __asm("     cmpq  $1,%0\n"
+        "     je    .L7\n"
+        "     incq  %0\n"
+        "     jmp   .L1\n"
+        ".L1: jmp   .L2\n"
+        ".L2: incq  %0\n"
+        "     cmpq  $2,%0\n"
+        "     jne   .L3\n"
+        "     jmp   .L4\n"
+        ".L3: jmp   .L5\n"
+        ".L5: incq  %0\n"
+        ".L4: movq  %0,%%rdi\n"
+        "     pop   %%rbp\n"
+        "     jmp   .L6\n"
+        ".L7: pop   %%rbp\n"
+        "     incq  %0\n"
+        "     jmp   .L6\n"
+        ".L6: jmp   bar\n"
+        :
+        : "m"(count));
   return count;
 }
 

--- a/bolt/test/X86/Inputs/inlined.cpp
+++ b/bolt/test/X86/Inputs/inlined.cpp
@@ -18,6 +18,6 @@ int main(int argc, char *argv[]) {
     ans += x - y;
   }
   // padding to make sure question() is inlineable
-  asm("nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;");
+  __asm("nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;nop;");
   return ans;
 }

--- a/bolt/test/X86/Inputs/linenumber.cpp
+++ b/bolt/test/X86/Inputs/linenumber.cpp
@@ -1,11 +1,11 @@
 int f() {
   // This will be removed by BOLT but they make sure we have some extra space
   // to insert branches and don't run out of space when rewriting the function.
-  asm("nop");
-  asm("nop");
-  asm("nop");
-  asm("nop");
-  asm("nop");
+  __asm("nop");
+  __asm("nop");
+  __asm("nop");
+  __asm("nop");
+  __asm("nop");
   int x = 0xBEEF;
   if (x & 0x32) {
     x++;

--- a/bolt/test/runtime/bolt-reserved.cpp
+++ b/bolt/test/runtime/bolt-reserved.cpp
@@ -28,13 +28,13 @@
 #define RSIZE "8192 * 1024"
 #endif
 
-asm(".pushsection .text \n\
+__asm(".pushsection .text \n\
        .globl __bolt_reserved_start \n\
        .type __bolt_reserved_start, @object \n\
        __bolt_reserved_start: \n\
        .space " RSIZE " \n\
        .globl __bolt_reserved_end \n\
        __bolt_reserved_end: \n\
-     .popsection");
+       .popsection");
 
 int main() { return 0; }


### PR DESCRIPTION
`asm()` is a GNU extensions `__asm()` is supported in both standard-conforming and GNU mode.