### PR TITLE
[lldb][test] Set explicit C standard for tests that require an older one

### DIFF
--- a/lldb/test/API/lang/c/cpp_keyword_identifiers/Makefile
+++ b/lldb/test/API/lang/c/cpp_keyword_identifiers/Makefile
@@ -1,3 +1,4 @@
 C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
 
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/struct_with_keyword_name/Makefile
+++ b/lldb/test/API/lang/cpp/struct_with_keyword_name/Makefile
@@ -1,3 +1,4 @@
 C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
 
 include Makefile.rules


### PR DESCRIPTION
These use identifiers which are keywords since C23. Once the default standard is changed we'd have to be explicit anyway.