### PR TITLE
[lldb] Call SetSyntheticChildrenGenerated on GetSyntheticChildAtOffset

### DIFF
--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1954,6 +1954,7 @@ ValueObjectSP ValueObject::GetSyntheticChildAtOffset(
     synthetic_child_sp = synthetic_child->GetSP();
     synthetic_child_sp->SetName(name_const_str);
     synthetic_child_sp->m_flags.m_is_child_at_offset = true;
+    synthetic_child_sp->SetSyntheticChildrenGenerated(true);
   }
   return synthetic_child_sp;
 }

--- a/lldb/test/API/python_api/sbvalue_get_parent/MyContainer_synthetic.py
+++ b/lldb/test/API/python_api/sbvalue_get_parent/MyContainer_synthetic.py
@@ -1,0 +1,29 @@
+import lldb
+
+
+@lldb.synthetic("MyContainer")
+class MyContainerSynthetic:
+    """Formatter that mimicks libstdc++ std::vector use of CreateChildAtOffset."""
+
+    valobj: lldb.SBValue
+
+    def __init__(self, valobj: lldb.SBValue, _) -> None:
+        self.valobj = valobj
+
+    def update(self) -> bool:
+        self.data = self.valobj.GetChildMemberWithName("data")
+        self.element_type = self.data.GetType().GetPointeeType()
+        self.element_size = self.element_type.GetByteSize()
+        self.count = self.valobj.GetChildMemberWithName("count").GetValueAsUnsigned(0)
+        return True
+
+    def num_children(self) -> int:
+        return self.count
+
+    def get_child_at_index(self, index: int) -> lldb.SBValue:
+        if 0 <= index < self.count:
+            offset = index * self.element_size
+            return self.data.CreateChildAtOffset(
+                f"[{index}]", offset, self.element_type
+            )
+        return lldb.SBValue()

--- a/lldb/test/API/python_api/sbvalue_get_parent/TestSBValueGetParent.py
+++ b/lldb/test/API/python_api/sbvalue_get_parent/TestSBValueGetParent.py
@@ -17,7 +17,18 @@ class TestCase(TestBase):
         frame = thread.GetFrameAtIndex(0)
 
         self._do_test(frame, "parent", "child")
-        self._do_test(frame, "vec", 0)
+        self._do_test(frame, "vec", 1)
+
+    def test_create_child_at_offset(self):
+        """Values returned by CreateChildAtOffset should return the synthetic parent from GetParent."""
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+        frame = thread.GetFrameAtIndex(0)
+
+        self.runCmd("command script import MyContainer_synthetic.py")
+        self._do_test(frame, "container", 1)
 
     def _do_test(
         self, frame: lldb.SBFrame, parent_name: str, child_key: Union[str, int]

--- a/lldb/test/API/python_api/sbvalue_get_parent/TestSBValueGetParent.py
+++ b/lldb/test/API/python_api/sbvalue_get_parent/TestSBValueGetParent.py
@@ -17,18 +17,11 @@ class TestCase(TestBase):
         frame = thread.GetFrameAtIndex(0)
 
         self._do_test(frame, "parent", "child")
-        self._do_test(frame, "vec", 1)
+        self._do_test(frame, "vec", 0)
 
-    def test_create_child_at_offset(self):
-        """Values returned by CreateChildAtOffset should return the synthetic parent from GetParent."""
-        self.build()
-        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.cpp")
-        )
-        frame = thread.GetFrameAtIndex(0)
-
+        # Test Python synthetic formatters using CreateChildAtOffset.
         self.runCmd("command script import MyContainer_synthetic.py")
-        self._do_test(frame, "container", 1)
+        self._do_test(frame, "container", 0)
 
     def _do_test(
         self, frame: lldb.SBFrame, parent_name: str, child_key: Union[str, int]
@@ -43,7 +36,7 @@ class TestCase(TestBase):
             child = parent.GetChildMemberWithName(child_key)
         self.assertTrue(child.IsValid())
 
-        # GetParent of child should be the parent struct.
+        # GetParent of child should be the original parent.
         child_parent = child.GetParent()
         self.assertTrue(child_parent.IsValid())
         self.assertEqual(child_parent.name, parent_name)

--- a/lldb/test/API/python_api/sbvalue_get_parent/main.cpp
+++ b/lldb/test/API/python_api/sbvalue_get_parent/main.cpp
@@ -8,8 +8,15 @@ struct Parent {
   Child child;
 };
 
+struct MyContainer {
+  int *data;
+  unsigned count;
+};
+
 int main() {
   Parent parent = {{1}};
   std::vector<int> vec = {10, 20, 30};
+  int arr[] = {100, 200, 300};
+  MyContainer container = {arr, 3};
   return 0; // break here
 }


### PR DESCRIPTION
Follow up to #197311 and based on the feedback on that PR.

One way a Python synthetic formatter can construct a child is with `SBValue::GetSyntheticChildAtOffset`. However those values were are not marked as having been generated by `SyntheticChildren`. This means the previous PR (#197311) did not apply to them as would be expected. The fix is to call `SetSyntheticChildrenGenerated(true)` on the child values created in `GetSyntheticChildAtOffset`.

Assisted-by: claude (tests and review)