### PR TITLE
[PowerPC][NFC] Change arguments of PPCPostRAExpPseudo/PseudoXFormMemOp

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -358,7 +358,6 @@ let Defs = [X8, X9, X10], Uses = [X9, X10] in
 def LDAT_CSNE_PSEUDO : PPCPostRAExpPseudo<
     (outs g8rc:$dst),
     (ins ptr_rc_nor0:$ptr),
-    "#LDAT_CSNE_PSEUDO",
     [(set i64:$dst, (int_ppc_amo_ldat_csne ptr_rc_nor0:$ptr, X9, X10))]>;
 
 let Defs = [CR0], mayStore = 1, mayLoad = 1, hasSideEffects = 1 in {
@@ -377,7 +376,7 @@ def SPLIT_QUADWORD : PPCCustomInserterPseudo<(outs g8rc:$lo, g8rc:$hi),
 class AtomicRMW128<string asmstr>
   : PPCPostRAExpPseudo<(outs g8prc:$RTp, g8prc:$scratch),
                        (ins memrr:$ptr, g8rc:$incr_lo, g8rc:$incr_hi),
-                       asmstr, []>;
+                       [], asmstr>;
 // We have to keep values in MI's uses during LL/SC looping as they are,
 // so set both $RTp and $scratch earlyclobber.
 let mayStore = 1, mayLoad = 1,
@@ -395,8 +394,7 @@ def ATOMIC_LOAD_NAND_I128 : AtomicRMW128<"#ATOMIC_LOAD_NAND_I128">;
 def ATOMIC_CMP_SWAP_I128 : PPCPostRAExpPseudo<
                               (outs g8prc:$RTp, g8prc:$scratch),
                               (ins memrr:$ptr, g8rc:$cmp_lo, g8rc:$cmp_hi,
-                                   g8rc:$new_lo, g8rc:$new_hi),
-                              "#ATOMIC_CMP_SWAP_I128", []>;
+                                   g8rc:$new_lo, g8rc:$new_hi)>;
 }
 
 class PatAtomicRMWI128<SDPatternOperator OpNode, AtomicRMW128 Inst> :
@@ -1512,7 +1510,7 @@ def LDgotTprelL: PPCEmitTimePseudo<(outs g8rc_nox0:$rD), (ins s16imm64:$disp, g8
                  isPPC64;
 
 let Defs = [CR7], Itinerary = IIC_LdStSync in
-def CFENCE8 : PPCPostRAExpPseudo<(outs), (ins g8rc:$cr), "#CFENCE8", []>;
+def CFENCE8 : PPCPostRAExpPseudo<(outs), (ins g8rc:$cr)>;
 
 def : Pat<(PPCaddTls i64:$in, tglobaltlsaddr:$g),
           (ADD8TLS $in, tglobaltlsaddr:$g)>;
@@ -1700,8 +1698,7 @@ def SPILL_QUADWORD : PPCEmitTimePseudo<(outs), (ins g8prc:$RSp, memrix:$dst),
 
 def BUILD_QUADWORD : PPCPostRAExpPseudo<
                        (outs g8prc:$RTp),
-                       (ins g8rc:$lo, g8rc:$hi),
-                       "#BUILD_QUADWORD", []>;
+                       (ins g8rc:$lo, g8rc:$hi)>;
 
 def : Pat<(int_ppc_atomic_store_i128 i64:$lo, i64:$hi, DSForm:$dst),
           (STQ (BUILD_QUADWORD g8rc:$lo, g8rc:$hi), memrix:$dst)>;

--- a/llvm/lib/Target/PowerPC/PPCInstrFormats.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFormats.td
@@ -2406,11 +2406,13 @@ class PPCCustomInserterPseudo<dag OOL, dag IOL, string asmstr,
 
 // PostRAPseudo will be expanded in expandPostRAPseudo, isPseudo flag in td
 // files is set only for PostRAPseudo
-class PPCPostRAExpPseudo<dag OOL, dag IOL, string asmstr, list<dag> pattern>
+class PPCPostRAExpPseudo<dag OOL, dag IOL, list<dag> pattern = [],
+                         string asmstr = "#" # NAME>
     : PPCEmitTimePseudo<OOL, IOL, asmstr, pattern> {
   let isPseudo = 1;
 }
 
-class PseudoXFormMemOp<dag OOL, dag IOL, string asmstr, list<dag> pattern>
-    : PPCPostRAExpPseudo<OOL, IOL, asmstr, pattern>, XFormMemOp;
+class PseudoXFormMemOp<dag OOL, dag IOL, list<dag> pattern = [],
+                       string asmstr = "#" # NAME>
+    : PPCPostRAExpPseudo<OOL, IOL, pattern, asmstr>, XFormMemOp;
 

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -2151,7 +2151,6 @@ let Defs = [R8, R9, R10], Uses = [R9, R10] in
 def LWAT_CSNE_PSEUDO : PPCPostRAExpPseudo<
     (outs gprc:$dst),
     (ins ptr_rc_nor0:$ptr),
-    "#LWAT_CSNE_PSEUDO",
     [(set i32:$dst, (int_ppc_amo_lwat_csne ptr_rc_nor0:$ptr, R9, R10))]>;
 
 let Defs = [CR0], mayStore = 1, mayLoad = 1, hasSideEffects = 1 in {
@@ -5152,8 +5151,9 @@ def RLWNMbm : PPCAsmPseudo<"rlwnm $rA, $rS, $n, $b",
 def RLWNMbm_rec : PPCAsmPseudo<"rlwnm. $rA, $rS, $n, $b",
                            (ins g8rc:$rA, g8rc:$rS, u5imm:$n, i32imm:$b)>;
 def PPCLdFixedAddr :
-  PPCPostRAExpPseudo<(outs gprc:$rT), (ins i32imm:$imm), "#FA_LOAD",
-                     [(set i32:$rT, (int_ppc_fixed_addr_ld timm:$imm))]>;
+  PPCPostRAExpPseudo<(outs gprc:$rT), (ins i32imm:$imm),
+                     [(set i32:$rT, (int_ppc_fixed_addr_ld timm:$imm))],
+                     "#FA_LOAD">;
 
 // These generic branch instruction forms are used for the assembler parser only.
 // Defs and Uses are conservative, since we don't know the BO value.
@@ -5588,7 +5588,7 @@ def HASHCHKP : XForm_XD6_RA5_RB5<31, 690, (outs),
 }
 
 let Defs = [CR7], Itinerary = IIC_LdStSync in
-def CFENCE : PPCPostRAExpPseudo<(outs), (ins gprc:$cr), "#CFENCE", []>;
+def CFENCE : PPCPostRAExpPseudo<(outs), (ins gprc:$cr)>;
 
 // Now both high word and low word are reversed, next
 // swap the high word and low word.

--- a/llvm/lib/Target/PowerPC/PPCInstrMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrMMA.td
@@ -503,11 +503,10 @@ let Predicates = [MMA, IsNotISAFuture] in {
               IIC_VecGeneral,
               [(set v512i1:$AT, (int_ppc_mma_xxmtacc v512i1:$ATi))]>,
               RegConstraint<"$ATi = $AT">;
-  def KILL_PAIR : PPCPostRAExpPseudo<(outs vsrprc:$XTp), (ins vsrprc:$XSp),
-                                      "#KILL_PAIR", []>,
+  def KILL_PAIR : PPCPostRAExpPseudo<(outs vsrprc:$XTp), (ins vsrprc:$XSp)>,
                                       RegConstraint<"$XTp = $XSp">;
-  def BUILD_UACC : PPCPostRAExpPseudo<(outs acc:$AT), (ins uacc:$AS),
-                                      "#BUILD_UACC $AT, $AS", []>;
+  def BUILD_UACC : PPCPostRAExpPseudo<(outs acc:$AT), (ins uacc:$AS), [],
+                                      "#BUILD_UACC $AT, $AS">;
   // We define XXSETACCZ as rematerializable to undo CSE of that intrinsic in
   // the backend. We avoid CSE here because it generates a copy of the acc
   // register and this copy is more expensive than calling the intrinsic again.

--- a/llvm/lib/Target/PowerPC/PPCInstrVSX.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrVSX.td
@@ -343,7 +343,6 @@ let hasSideEffects = 0 in {
     // Pseudo instruction XFLOADf64 will be expanded to LXSDX or LFDX later
     let CodeSize = 3 in
       def XFLOADf64  : PseudoXFormMemOp<(outs vsfrc:$XT), (ins (memrr $RA, $RB):$addr),
-                              "#XFLOADf64",
                               [(set f64:$XT, (load XForm:$addr))]>;
 
     let Predicates = [HasVSX, HasOnlySwappingMemOps] in
@@ -374,7 +373,6 @@ let hasSideEffects = 0 in {
     // Pseudo instruction XFSTOREf64  will be expanded to STXSDX or STFDX later
     let CodeSize = 3 in
       def XFSTOREf64 : PseudoXFormMemOp<(outs), (ins vsfrc:$XT, (memrr $RA, $RB):$addr),
-                              "#XFSTOREf64",
                               [(store f64:$XT, XForm:$addr)]>;
 
     let Predicates = [HasVSX, HasOnlySwappingMemOps] in {
@@ -1165,15 +1163,12 @@ let Predicates = [HasVSX, HasP8Vector] in {
     // Pseudo instruction XFLOADf32 will be expanded to LXSSPX or LFSX later
     let CodeSize = 3 in
     def XFLOADf32  : PseudoXFormMemOp<(outs vssrc:$XT), (ins memrr:$src),
-                            "#XFLOADf32",
                             [(set f32:$XT, (load XForm:$src))]>;
     // Pseudo instruction LIWAX will be expanded to LXSIWAX or LFIWAX later
     def LIWAX : PseudoXFormMemOp<(outs vsfrc:$XT), (ins memrr:$src),
-                       "#LIWAX",
                        [(set f64:$XT, (PPClfiwax ForceXForm:$src))]>;
     // Pseudo instruction LIWZX will be expanded to LXSIWZX or LFIWZX later
     def LIWZX : PseudoXFormMemOp<(outs vsfrc:$XT), (ins memrr:$src),
-                       "#LIWZX",
                        [(set f64:$XT, (PPClfiwzx ForceXForm:$src))]>;
   } // mayLoad
 
@@ -1188,11 +1183,9 @@ let Predicates = [HasVSX, HasP8Vector] in {
     // Pseudo instruction XFSTOREf32 will be expanded to STXSSPX or STFSX later
     let CodeSize = 3 in
     def XFSTOREf32 : PseudoXFormMemOp<(outs), (ins vssrc:$XT, memrr:$dst),
-                            "#XFSTOREf32",
                             [(store f32:$XT, XForm:$dst)]>;
     // Pseudo instruction STIWX will be expanded to STXSIWX or STFIWX later
     def STIWX : PseudoXFormMemOp<(outs), (ins vsfrc:$XT, memrr:$dst),
-                       "#STIWX",
                       [(PPCstfiwx f64:$XT, ForceXForm:$dst)]>;
   } // mayStore
 
@@ -1793,31 +1786,23 @@ let Predicates = [HasVSX, HasP9Vector] in {
   } // mayStore
 
   def DFLOADf32  : PPCPostRAExpPseudo<(outs vssrc:$XT), (ins memrix:$src),
-                          "#DFLOADf32",
                           [(set f32:$XT, (load DSForm:$src))]>;
   def DFLOADf64  : PPCPostRAExpPseudo<(outs vsfrc:$XT), (ins memrix:$src),
-                          "#DFLOADf64",
                           [(set f64:$XT, (load DSForm:$src))]>;
   def DFSTOREf32 : PPCPostRAExpPseudo<(outs), (ins vssrc:$XT, memrix:$dst),
-                          "#DFSTOREf32",
                           [(store f32:$XT, DSForm:$dst)]>;
   def DFSTOREf64 : PPCPostRAExpPseudo<(outs), (ins vsfrc:$XT, memrix:$dst),
-                          "#DFSTOREf64",
                           [(store f64:$XT, DSForm:$dst)]>;
 
   let mayStore = 1 in {
     def SPILLTOVSR_STX : PseudoXFormMemOp<(outs),
-                                          (ins spilltovsrrc:$XT, memrr:$dst),
-                                          "#SPILLTOVSR_STX", []>;
-    def SPILLTOVSR_ST : PPCPostRAExpPseudo<(outs), (ins spilltovsrrc:$XT, memrix:$dst),
-                              "#SPILLTOVSR_ST", []>;
+                                          (ins spilltovsrrc:$XT, memrr:$dst)>;
+    def SPILLTOVSR_ST : PPCPostRAExpPseudo<(outs), (ins spilltovsrrc:$XT, memrix:$dst)>;
   }
   let mayLoad = 1 in {
     def SPILLTOVSR_LDX : PseudoXFormMemOp<(outs spilltovsrrc:$XT),
-                                          (ins memrr:$src),
-                                          "#SPILLTOVSR_LDX", []>;
-    def SPILLTOVSR_LD : PPCPostRAExpPseudo<(outs spilltovsrrc:$XT), (ins memrix:$src),
-                              "#SPILLTOVSR_LD", []>;
+                                          (ins memrr:$src)>;
+    def SPILLTOVSR_LD : PPCPostRAExpPseudo<(outs spilltovsrrc:$XT), (ins memrix:$src)>;
 
   }
   } // HasP9Vector


### PR DESCRIPTION
The assembler string of the pseudo is almost always a # followed by the name of the pseudo. A good part of the pseudos does not have a pattern. Changing the order of arguments asmstr and pattern in PPCPostRAExpPseudo and PseudoXFormMemOp, and assigning default values, reduces repetitions.