### PR TITLE
Silence "switch statement contains default but no case labels"; NFC

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -962,11 +962,8 @@ static llvm::Error addReference(T I, Reference &&R, FieldId F) {
 }
 
 template <> llvm::Error addReference(VarInfo *I, Reference &&R, FieldId F) {
-  switch (F) {
-  default:
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "VarInfo cannot contain this Reference");
-  }
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 "VarInfo cannot contain this Reference");
 }
 
 template <> llvm::Error addReference(TypeInfo *I, Reference &&R, FieldId F) {
@@ -1005,19 +1002,13 @@ llvm::Error addReference(MemberTypeInfo *I, Reference &&R, FieldId F) {
 }
 
 template <> llvm::Error addReference(EnumInfo *I, Reference &&R, FieldId F) {
-  switch (F) {
-  default:
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "invalid type cannot contain Reference");
-  }
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 "invalid type cannot contain Reference");
 }
 
 template <> llvm::Error addReference(TypedefInfo *I, Reference &&R, FieldId F) {
-  switch (F) {
-  default:
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "invalid type cannot contain Reference");
-  }
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 "invalid type cannot contain Reference");
 }
 
 template <>


### PR DESCRIPTION
65f8a7c1c423d96597bdb14062a0d0eb27d7caf4 accidentally introduced some diagnostics from having a switch statement with a default label but no case labels. This removes the switch statements until we have more cases to add.