### PR TITLE
[DWARFVerifier] Skip DW_TAG_LLVM_annotation in DWARFVerifier

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1990,9 +1990,9 @@ void DWARFVerifier::verifyNameIndexCompleteness(
   case DW_TAG_member:
     return;
 
-  // DW_TAG_LLVM_annotation DIEs attach metadata to other DIEs. 
-  // Their DW_AT_name carries the annotation kind,
-  // not a globally visible symbol, so they should not be indexed.
+  // DW_TAG_LLVM_annotation DIEs attach metadata to other DIEs.
+  // Their DW_AT_name carries the annotation kind, not a globally visible
+  // symbol, so they should not be indexed.
   case DW_TAG_LLVM_annotation:
     return;
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1990,6 +1990,12 @@ void DWARFVerifier::verifyNameIndexCompleteness(
   case DW_TAG_member:
     return;
 
+  // DW_TAG_LLVM_annotation DIEs attach metadata to other DIEs. 
+  // Their DW_AT_name carries the annotation kind,
+  // not a globally visible symbol, so they should not be indexed.
+  case DW_TAG_LLVM_annotation:
+    return;
+
   // According to a strict reading of the specification, enumerators should not
   // be indexed (and LLVM currently does not do that). However, this causes
   // problems for the debuggers, so we may need to reconsider this.

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-llvm-annotation.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-llvm-annotation.ll
@@ -1,11 +1,20 @@
-; Verify that DW_TAG_LLVM_annotation DIEs are not required to appear in
-; .debug_names. 
+; Verify that DW_TAG_LLVM_annotation DIEs are not emitted into .debug_names,
+; and that the verifier does not require them to be.
 
 ; RUN: llc -mtriple=x86_64-unknown-linux-gnu -accel-tables=Dwarf -filetype=obj -o %t %s
 ; RUN: llvm-dwarfdump -verify %t | FileCheck %s
+; RUN: llvm-dwarfdump --debug-names %t | FileCheck %s --check-prefix=NAMES
 
 ; CHECK: Verifying .debug_names...
 ; CHECK-NEXT: No errors.
+
+; The annotation DIE is present in .debug_info (see DW_AT_name "btf_decl_tag"
+; with DW_AT_const_value "tag1"), but neither the tag nor its strings should
+; appear anywhere in the .debug_names index.
+; NAMES:     .debug_names contents:
+; NAMES-NOT: DW_TAG_LLVM_annotation
+; NAMES-NOT: btf_decl_tag
+; NAMES-NOT: tag1
 
 ; Source:
 ;   #define __tag1 __attribute__((btf_decl_tag("tag1")))

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-llvm-annotation.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-verify-completeness-llvm-annotation.ll
@@ -1,0 +1,28 @@
+; Verify that DW_TAG_LLVM_annotation DIEs are not required to appear in
+; .debug_names. 
+
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -accel-tables=Dwarf -filetype=obj -o %t %s
+; RUN: llvm-dwarfdump -verify %t | FileCheck %s
+
+; CHECK: Verifying .debug_names...
+; CHECK-NEXT: No errors.
+
+; Source:
+;   #define __tag1 __attribute__((btf_decl_tag("tag1")))
+;   int g1 __tag1;
+
+@g1 = dso_local global i32 0, align 4, !dbg !0
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!10, !11}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "g1", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true, annotations: !7)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, globals: !5)
+!3 = !DIFile(filename: "t.c", directory: "/tmp")
+!5 = !{!0}
+!6 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = !{!8}
+!8 = !{!"btf_decl_tag", !"tag1"}
+!10 = !{i32 7, !"Dwarf Version", i32 5}
+!11 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
Annotations are not indexed, so we need to skip them on the verifier.

Assisted by: claude