### PR TITLE
[clang][OpenMP] Add OMP 6.0 prefer_type({fr,attr}) parsing for interop

### DIFF
--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -9013,10 +9013,10 @@ public:
     ArrayRef<unsigned> Ends = getAttrEnds();
     return llvm::map_range(llvm::seq<unsigned>(0, N), [=](unsigned I) {
       unsigned Start = (I == 0) ? 0 : Ends[I - 1];
-      return PrefView{const_cast<Expr *>(E[1 + I]),
-                      ArrayRef<Expr *>(const_cast<Expr **>(E) + varlist_size() +
-                                           Start,
-                                       Ends[I] - Start)};
+      return PrefView{
+          const_cast<Expr *>(E[1 + I]),
+          ArrayRef<Expr *>(const_cast<Expr **>(E) + varlist_size() + Start,
+                           Ends[I] - Start)};
     });
   }
 

--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -8863,8 +8863,8 @@ class OMPInitClause final
   bool IsTargetSync = false;
   bool HasPreferAttrs = false;
 
-  /// Total number of attr() exprs across all pref-specs (sum of the
-  /// per-pref-spec counts in the trailing unsigned[]).
+  /// Total number of attr() exprs across all pref-specs; equals the last entry
+  /// of the trailing unsigned[] of cumulative end offsets (or 0 if no prefs).
   unsigned NumAttrs = 0;
 
   /// Trailing-objects layout (single contiguous Expr* array):
@@ -8874,7 +8874,10 @@ class OMPInitClause final
   ///     [varlist_size() ..]    = flat list of attr exprs, concatenated in
   ///                              pref-spec order
   ///   unsigned[ NumPrefs ]:
-  ///     [i]                    = number of attr() exprs in pref-spec i
+  ///     [i]                    = end offset of pref-spec i's attrs in the flat
+  ///                              attr block (inclusive cumulative attr count);
+  ///                              spec i's attrs are [ends[i-1], ends[i]), with
+  ///                              an implicit 0 before ends[0]
   ///
   /// varlist_size() = 1 + NumPrefs, so OMPVarListClause iteration covers
   /// InteropVar + the Fr block.
@@ -8976,20 +8979,26 @@ public:
   /// Total attrs across all pref-specs.
   unsigned getNumAttrs() const { return NumAttrs; }
 
-  /// Per-pref-spec attr counts (one entry per pref-spec).
-  ArrayRef<unsigned> getAttrCounts() const {
+  /// All attr() exprs across every pref-spec, in pref-spec order (flat block).
+  ArrayRef<Expr *> getAttrs() const {
+    return ArrayRef<Expr *>(getTrailingObjects<Expr *>() + varlist_size(),
+                            NumAttrs);
+  }
+
+  /// Per-pref-spec attr end offsets: entry i is the inclusive cumulative attr
+  /// count through pref-spec i (one past its last attr in the flat attr block).
+  ArrayRef<unsigned> getAttrEnds() const {
     return getTrailingObjects<unsigned>(getNumPrefs());
   }
 
   PrefView getPref(unsigned I) {
     assert(I < getNumPrefs() && "pref-spec index out of range");
     Expr **E = getTrailingObjects<Expr *>();
-    ArrayRef<unsigned> Counts = getAttrCounts();
-    unsigned AttrStart = 0;
-    for (unsigned K = 0; K < I; ++K)
-      AttrStart += Counts[K];
-    return PrefView{
-        E[1 + I], ArrayRef<Expr *>(E + varlist_size() + AttrStart, Counts[I])};
+    ArrayRef<unsigned> AttrEnds = getAttrEnds();
+    unsigned Start = (I == 0) ? 0 : AttrEnds[I - 1];
+    unsigned Count = AttrEnds[I] - Start;
+    return PrefView{E[1 + I],
+                    ArrayRef<Expr *>(E + varlist_size() + Start, Count)};
   }
   PrefView getPref(unsigned I) const {
     return const_cast<OMPInitClause *>(this)->getPref(I);

--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -8899,6 +8899,15 @@ class OMPInitClause final
 
   void setAttrs(ArrayRef<unsigned> Counts, ArrayRef<Expr *> Attrs);
 
+  /// Number of pref-specs in prefer_type(...).
+  unsigned getNumPrefs() const { return varlist_size() - 1; }
+
+  /// Per-pref-spec attr end offsets: entry i is the inclusive cumulative attr
+  /// count through pref-spec i (one past its last attr in the flat attr block).
+  ArrayRef<unsigned> getAttrEnds() const {
+    return getTrailingObjects<unsigned>(getNumPrefs());
+  }
+
   /// Sets the location of the interop variable.
   void setVarLoc(SourceLocation Loc) { VarLoc = Loc; }
 
@@ -8971,37 +8980,12 @@ public:
   bool getIsTargetSync() const { return IsTargetSync; }
 
   /// Returns true if OMP 6.0 {fr/attr} syntax is used.
-  bool getHasPreferAttrs() const { return HasPreferAttrs; }
-
-  /// Number of pref-specs in prefer_type(...).
-  unsigned getNumPrefs() const { return varlist_size() - 1; }
-
-  /// Total attrs across all pref-specs.
-  unsigned getNumAttrs() const { return NumAttrs; }
+  bool hasPreferAttrs() const { return HasPreferAttrs; }
 
   /// All attr() exprs across every pref-spec, in pref-spec order (flat block).
-  ArrayRef<Expr *> getAttrs() const {
+  ArrayRef<Expr *> attrs() const {
     return ArrayRef<Expr *>(getTrailingObjects<Expr *>() + varlist_size(),
                             NumAttrs);
-  }
-
-  /// Per-pref-spec attr end offsets: entry i is the inclusive cumulative attr
-  /// count through pref-spec i (one past its last attr in the flat attr block).
-  ArrayRef<unsigned> getAttrEnds() const {
-    return getTrailingObjects<unsigned>(getNumPrefs());
-  }
-
-  PrefView getPref(unsigned I) {
-    assert(I < getNumPrefs() && "pref-spec index out of range");
-    Expr **E = getTrailingObjects<Expr *>();
-    ArrayRef<unsigned> AttrEnds = getAttrEnds();
-    unsigned Start = (I == 0) ? 0 : AttrEnds[I - 1];
-    unsigned Count = AttrEnds[I] - Start;
-    return PrefView{E[1 + I],
-                    ArrayRef<Expr *>(E + varlist_size() + Start, Count)};
-  }
-  PrefView getPref(unsigned I) const {
-    return const_cast<OMPInitClause *>(this)->getPref(I);
   }
 
   child_range children() {
@@ -9021,18 +9005,19 @@ public:
     return const_child_range(const_child_iterator(), const_child_iterator());
   }
 
-  using prefs_iterator = MutableArrayRef<Expr *>::iterator;
-  using const_prefs_iterator = ArrayRef<const Expr *>::iterator;
-  using prefs_range = llvm::iterator_range<prefs_iterator>;
-  using const_prefs_range = llvm::iterator_range<const_prefs_iterator>;
-
-  prefs_range prefs() {
-    return prefs_range(reinterpret_cast<Expr **>(std::next(varlist_begin())),
-                       reinterpret_cast<Expr **>(varlist_end()));
-  }
-
-  const_prefs_range prefs() const {
-    return const_prefs_range(const_cast<OMPInitClause *>(this)->prefs());
+  /// Returns a range of PrefView objects, one per preference-specification,
+  /// each carrying the fr() expression (or null) and the attr() exprs.
+  auto prefs() const {
+    unsigned N = getNumPrefs();
+    Expr *const *E = getTrailingObjects<Expr *>();
+    ArrayRef<unsigned> Ends = getAttrEnds();
+    return llvm::map_range(llvm::seq<unsigned>(0, N), [=](unsigned I) {
+      unsigned Start = (I == 0) ? 0 : Ends[I - 1];
+      return PrefView{const_cast<Expr *>(E[1 + I]),
+                      ArrayRef<Expr *>(const_cast<Expr **>(E) + varlist_size() +
+                                           Start,
+                                       Ends[I] - Start)};
+    });
   }
 
   static bool classof(const OMPClause *T) {

--- a/clang/include/clang/AST/OpenMPClause.h
+++ b/clang/include/clang/AST/OpenMPClause.h
@@ -8851,7 +8851,7 @@ public:
 /// \endcode
 class OMPInitClause final
     : public OMPVarListClause<OMPInitClause>,
-      private llvm::TrailingObjects<OMPInitClause, Expr *> {
+      private llvm::TrailingObjects<OMPInitClause, Expr *, unsigned> {
   friend class OMPClauseReader;
   friend OMPVarListClause;
   friend TrailingObjects;
@@ -8861,12 +8861,40 @@ class OMPInitClause final
 
   bool IsTarget = false;
   bool IsTargetSync = false;
+  bool HasPreferAttrs = false;
+
+  /// Total number of attr() exprs across all pref-specs (sum of the
+  /// per-pref-spec counts in the trailing unsigned[]).
+  unsigned NumAttrs = 0;
+
+  /// Trailing-objects layout (single contiguous Expr* array):
+  ///   Expr*[ varlist_size() + NumAttrs ]:
+  ///     [0]                    = InteropVar
+  ///     [1 .. NumPrefs]        = Fr expr per pref-spec (null if attr-only)
+  ///     [varlist_size() ..]    = flat list of attr exprs, concatenated in
+  ///                              pref-spec order
+  ///   unsigned[ NumPrefs ]:
+  ///     [i]                    = number of attr() exprs in pref-spec i
+  ///
+  /// varlist_size() = 1 + NumPrefs, so OMPVarListClause iteration covers
+  /// InteropVar + the Fr block.
+
+  size_t numTrailingObjects(OverloadToken<Expr *>) const {
+    return varlist_size() + NumAttrs;
+  }
+  size_t numTrailingObjects(OverloadToken<unsigned>) const {
+    return getNumPrefs();
+  }
 
   void setInteropVar(Expr *E) { varlist_begin()[0] = E; }
 
   void setIsTarget(bool V) { IsTarget = V; }
 
   void setIsTargetSync(bool V) { IsTargetSync = V; }
+
+  void setHasPreferAttrs(bool V) { HasPreferAttrs = V; }
+
+  void setAttrs(ArrayRef<unsigned> Counts, ArrayRef<Expr *> Attrs);
 
   /// Sets the location of the interop variable.
   void setVarLoc(SourceLocation Loc) { VarLoc = Loc; }
@@ -8879,7 +8907,7 @@ class OMPInitClause final
   /// \param LParenLoc Location of '('.
   /// \param VarLoc Location of the interop variable.
   /// \param EndLoc Ending location of the clause.
-  /// \param N Number of expressions.
+  /// \param N Number of varlist entries (1 + NumPrefs).
   OMPInitClause(bool IsTarget, bool IsTargetSync, SourceLocation StartLoc,
                 SourceLocation LParenLoc, SourceLocation VarLoc,
                 SourceLocation EndLoc, unsigned N)
@@ -8894,6 +8922,14 @@ class OMPInitClause final
   }
 
 public:
+  struct PrefView {
+    /// Foreign-runtime-id expression. Null for attr-only specs.
+    Expr *Fr;
+    /// attr() string-literal expressions. Empty for fr-only or OMP 5.1
+    /// flat specs.
+    ArrayRef<Expr *> Attrs;
+  };
+
   /// Creates a fully specified clause.
   ///
   /// \param C AST context.
@@ -8909,11 +8945,14 @@ public:
                                SourceLocation LParenLoc, SourceLocation VarLoc,
                                SourceLocation EndLoc);
 
-  /// Creates an empty clause with \a N expressions.
+  /// Creates an empty clause sized for \a NumPrefs pref-specs and \a NumAttrs
+  /// total attr() exprs across them.
   ///
   /// \param C AST context.
-  /// \param N Number of expression items.
-  static OMPInitClause *CreateEmpty(const ASTContext &C, unsigned N);
+  /// \param NumPrefs Number of pref-specs (length of the Fr block).
+  /// \param NumAttrs Total attr() exprs across all pref-specs.
+  static OMPInitClause *CreateEmpty(const ASTContext &C, unsigned NumPrefs,
+                                    unsigned NumAttrs);
 
   /// Returns the location of the interop variable.
   SourceLocation getVarLoc() const { return VarLoc; }
@@ -8928,9 +8967,38 @@ public:
   /// Returns true is interop-type 'targetsync' is used.
   bool getIsTargetSync() const { return IsTargetSync; }
 
+  /// Returns true if OMP 6.0 {fr/attr} syntax is used.
+  bool getHasPreferAttrs() const { return HasPreferAttrs; }
+
+  /// Number of pref-specs in prefer_type(...).
+  unsigned getNumPrefs() const { return varlist_size() - 1; }
+
+  /// Total attrs across all pref-specs.
+  unsigned getNumAttrs() const { return NumAttrs; }
+
+  /// Per-pref-spec attr counts (one entry per pref-spec).
+  ArrayRef<unsigned> getAttrCounts() const {
+    return getTrailingObjects<unsigned>(getNumPrefs());
+  }
+
+  PrefView getPref(unsigned I) {
+    assert(I < getNumPrefs() && "pref-spec index out of range");
+    Expr **E = getTrailingObjects<Expr *>();
+    ArrayRef<unsigned> Counts = getAttrCounts();
+    unsigned AttrStart = 0;
+    for (unsigned K = 0; K < I; ++K)
+      AttrStart += Counts[K];
+    return PrefView{
+        E[1 + I], ArrayRef<Expr *>(E + varlist_size() + AttrStart, Counts[I])};
+  }
+  PrefView getPref(unsigned I) const {
+    return const_cast<OMPInitClause *>(this)->getPref(I);
+  }
+
   child_range children() {
-    return child_range(reinterpret_cast<Stmt **>(varlist_begin()),
-                       reinterpret_cast<Stmt **>(varlist_end()));
+    return child_range(
+        reinterpret_cast<Stmt **>(varlist_begin()),
+        reinterpret_cast<Stmt **>(varlist_begin() + varlist_size() + NumAttrs));
   }
 
   const_child_range children() const {

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -3799,7 +3799,7 @@ bool RecursiveASTVisitor<Derived>::VisitOMPInitClause(OMPInitClause *C) {
   TRY_TO(VisitOMPClauseList(C));
   // VisitOMPClauseList covers the interop var and the per-pref-spec fr exprs
   // (the varlist); the prefer_type attr() exprs live outside it.
-  for (Expr *A : C->getAttrs())
+  for (Expr *A : C->attrs())
     TRY_TO(TraverseStmt(A));
   return true;
 }

--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -3797,6 +3797,10 @@ bool RecursiveASTVisitor<Derived>::VisitOMPNogroupClause(OMPNogroupClause *) {
 template <typename Derived>
 bool RecursiveASTVisitor<Derived>::VisitOMPInitClause(OMPInitClause *C) {
   TRY_TO(VisitOMPClauseList(C));
+  // VisitOMPClauseList covers the interop var and the per-pref-spec fr exprs
+  // (the varlist); the prefer_type attr() exprs live outside it.
+  for (Expr *A : C->getAttrs())
+    TRY_TO(TraverseStmt(A));
   return true;
 }
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1693,6 +1693,12 @@ def warn_omp_more_one_interop_type
     InGroup<OpenMPClauses>;
 def err_omp_interop_multiple_fr : Error<
   "only one 'fr' selector allowed per preference-specification">;
+def err_omp_prefer_type_brace_60 : Error<
+  "brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later">;
+def err_omp_expected_fr_or_attr_selector : Error<
+  "expected 'fr' or 'attr' selector in 'prefer_type'">;
+def err_omp_expected_pref_spec : Error<
+  "expected preference-specification in 'prefer_type'">;
 def err_expected_sequence_or_directive : Error<
   "expected an OpenMP 'directive' or 'sequence' attribute argument">;
 def ext_omp_attributes : ExtWarn<

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1691,6 +1691,8 @@ def err_omp_expected_interop_type : Error<
 def warn_omp_more_one_interop_type
   : Warning<"interop type '%0' cannot be specified more than once">,
     InGroup<OpenMPClauses>;
+def err_omp_interop_multiple_fr : Error<
+  "only one 'fr' selector allowed per preference-specification">;
 def err_expected_sequence_or_directive : Error<
   "expected an OpenMP 'directive' or 'sequence' attribute argument">;
 def ext_omp_attributes : ExtWarn<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12713,6 +12713,12 @@ def err_omp_interop_variable_wrong_type : Error<
 def err_omp_interop_prefer_type : Error<
   "prefer_list item must be a string literal or constant integral "
   "expression">;
+def err_omp_interop_attr_not_string : Error<
+  "attr() argument must be a string literal">;
+def err_omp_interop_attr_missing_ompx_prefix : Error<
+  "attr() argument '%0' must start with the 'ompx_' prefix">;
+def err_omp_interop_attr_contains_comma : Error<
+  "attr() argument '%0' must not contain a comma">;
 def err_omp_interop_bad_depend_clause : Error<
   "'depend' clause requires the 'targetsync' interop type">;
 def err_omp_interop_var_multiple_actions : Error<

--- a/clang/include/clang/Basic/OpenMPKinds.h
+++ b/clang/include/clang/Basic/OpenMPKinds.h
@@ -296,6 +296,8 @@ class Expr;
 /// foreign-runtime-id expression and zero or more attr() ext-string-literal
 /// expressions. Fr is nullptr for attr-only specs.
 struct OMPInteropPref final {
+  OMPInteropPref(Expr *Fr, llvm::SmallVector<Expr *, 2> Attrs)
+      : Fr(Fr), Attrs(std::move(Attrs)) {}
   Expr *Fr = nullptr;
   llvm::SmallVector<Expr *, 2> Attrs;
 };

--- a/clang/include/clang/Basic/OpenMPKinds.h
+++ b/clang/include/clang/Basic/OpenMPKinds.h
@@ -292,12 +292,20 @@ static constexpr unsigned NumberOfOMPAllocateClauseModifiers =
 
 /// Contains 'interop' data for 'append_args' and 'init' clauses.
 class Expr;
+/// One entry of a prefer_type list. Each pref-spec carries an optional fr()
+/// foreign-runtime-id expression and zero or more attr() ext-string-literal
+/// expressions. Fr is nullptr for attr-only specs.
+struct OMPInteropPref final {
+  Expr *Fr = nullptr;
+  llvm::SmallVector<Expr *, 2> Attrs;
+};
 struct OMPInteropInfo final {
   OMPInteropInfo(bool IsTarget = false, bool IsTargetSync = false)
       : IsTarget(IsTarget), IsTargetSync(IsTargetSync) {}
   bool IsTarget;
   bool IsTargetSync;
-  llvm::SmallVector<Expr *, 4> PreferTypes;
+  bool HasPreferAttrs = false;
+  llvm::SmallVector<OMPInteropPref, 4> Prefs;
 };
 
 OpenMPDefaultClauseVariableCategory

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -7001,6 +7001,12 @@ private:
   /// Parses the 'interop' parts of the 'append_args' and 'init' clauses.
   bool ParseOMPInteropInfo(OMPInteropInfo &InteropInfo, OpenMPClauseKind Kind);
 
+  /// Parses 'fr(<foreign-runtime-id>)'.
+  ExprResult ParseOMPInteropFrSelector();
+
+  /// Parses 'attr(<string-literal>[, ...])', appending to \p Attrs.
+  bool ParseOMPInteropAttrSelector(SmallVectorImpl<Expr *> &Attrs);
+
   /// Parses clause with an interop variable of kind \a Kind.
   ///
   /// \verbatim

--- a/clang/lib/AST/OpenMPClause.cpp
+++ b/clang/lib/AST/OpenMPClause.cpp
@@ -1823,12 +1823,13 @@ OMPInitClause *OMPInitClause::Create(const ASTContext &C, Expr *InteropVar,
   E[0] = InteropVar;
   for (unsigned I = 0; I < NumPrefs; ++I)
     E[1 + I] = InteropInfo.Prefs[I].Fr;
-  unsigned *Counts = Clause->getTrailingObjects<unsigned>();
-  unsigned AttrPos = 1 + NumPrefs;
+  unsigned *AttrEnds = Clause->getTrailingObjects<unsigned>();
+  unsigned AttrBase = 1 + NumPrefs; 
+  unsigned AttrPos = AttrBase;
   for (unsigned I = 0; I < NumPrefs; ++I) {
-    Counts[I] = InteropInfo.Prefs[I].Attrs.size();
     for (Expr *A : InteropInfo.Prefs[I].Attrs)
       E[AttrPos++] = A;
+    AttrEnds[I] = AttrPos - AttrBase; 
   }
   return Clause;
 }
@@ -1849,7 +1850,13 @@ void OMPInitClause::setAttrs(ArrayRef<unsigned> Counts,
          "attr-count vector size must match number of pref-specs");
   assert(Attrs.size() == NumAttrs &&
          "attr-expr count must match preallocated NumAttrs");
-  llvm::copy(Counts, getTrailingObjects<unsigned>());
+  // Store inclusive cumulative counts (end offsets)
+  unsigned *AttrEnds = getTrailingObjects<unsigned>();
+  unsigned Run = 0;
+  for (unsigned I = 0, E = Counts.size(); I < E; ++I) {
+    Run += Counts[I];
+    AttrEnds[I] = Run;
+  }
   llvm::copy(Attrs, getTrailingObjects<Expr *>() + varlist_size());
 }
 

--- a/clang/lib/AST/OpenMPClause.cpp
+++ b/clang/lib/AST/OpenMPClause.cpp
@@ -2428,37 +2428,34 @@ void OMPClausePrinter::VisitOMPHintClause(OMPHintClause *Node) {
 
 void OMPClausePrinter::VisitOMPInitClause(OMPInitClause *Node) {
   OS << "init(";
-  unsigned NumPrefs = Node->getNumPrefs();
-  if (NumPrefs > 0) {
+  if (!Node->prefs().empty()) {
     OS << "prefer_type(";
-    if (Node->getHasPreferAttrs()) {
+    if (Node->hasPreferAttrs()) {
       // OMP 6.0 brace-grouped form
-      llvm::interleaveComma(
-          llvm::seq<unsigned>(0, NumPrefs), OS, [&](unsigned I) {
-            OMPInitClause::PrefView P = Node->getPref(I);
-            OS << "{";
-            if (P.Fr) {
-              OS << "fr(";
-              P.Fr->printPretty(OS, nullptr, Policy);
-              OS << ")";
-              if (!P.Attrs.empty())
-                OS << ", ";
-            }
-            if (!P.Attrs.empty()) {
-              OS << "attr(";
-              llvm::interleaveComma(P.Attrs, OS, [&](const Expr *A) {
-                A->printPretty(OS, nullptr, Policy);
-              });
-              OS << ")";
-            }
-            OS << "}";
+      llvm::interleaveComma(Node->prefs(), OS, [&](OMPInitClause::PrefView P) {
+        OS << "{";
+        if (P.Fr) {
+          OS << "fr(";
+          P.Fr->printPretty(OS, nullptr, Policy);
+          OS << ")";
+          if (!P.Attrs.empty())
+            OS << ", ";
+        }
+        if (!P.Attrs.empty()) {
+          OS << "attr(";
+          llvm::interleaveComma(P.Attrs, OS, [&](const Expr *A) {
+            A->printPretty(OS, nullptr, Policy);
           });
+          OS << ")";
+        }
+        OS << "}";
+      });
     } else {
       llvm::interleave(
-          llvm::seq<unsigned>(0, NumPrefs), OS,
-          [&](unsigned I) {
-            if (Expr *Fr = Node->getPref(I).Fr)
-              Fr->printPretty(OS, nullptr, Policy);
+          Node->prefs(), OS,
+          [&](OMPInitClause::PrefView P) {
+            if (P.Fr)
+              P.Fr->printPretty(OS, nullptr, Policy);
           },
           ",");
     }

--- a/clang/lib/AST/OpenMPClause.cpp
+++ b/clang/lib/AST/OpenMPClause.cpp
@@ -1824,12 +1824,12 @@ OMPInitClause *OMPInitClause::Create(const ASTContext &C, Expr *InteropVar,
   for (unsigned I = 0; I < NumPrefs; ++I)
     E[1 + I] = InteropInfo.Prefs[I].Fr;
   unsigned *AttrEnds = Clause->getTrailingObjects<unsigned>();
-  unsigned AttrBase = 1 + NumPrefs; 
+  unsigned AttrBase = 1 + NumPrefs;
   unsigned AttrPos = AttrBase;
   for (unsigned I = 0; I < NumPrefs; ++I) {
     for (Expr *A : InteropInfo.Prefs[I].Attrs)
       E[AttrPos++] = A;
-    AttrEnds[I] = AttrPos - AttrBase; 
+    AttrEnds[I] = AttrPos - AttrBase;
   }
   return Clause;
 }

--- a/clang/lib/AST/OpenMPClause.cpp
+++ b/clang/lib/AST/OpenMPClause.cpp
@@ -1805,19 +1805,52 @@ OMPInitClause *OMPInitClause::Create(const ASTContext &C, Expr *InteropVar,
                                      SourceLocation VarLoc,
                                      SourceLocation EndLoc) {
 
-  void *Mem =
-      C.Allocate(totalSizeToAlloc<Expr *>(InteropInfo.PreferTypes.size() + 1));
-  auto *Clause = new (Mem) OMPInitClause(
-      InteropInfo.IsTarget, InteropInfo.IsTargetSync, StartLoc, LParenLoc,
-      VarLoc, EndLoc, InteropInfo.PreferTypes.size() + 1);
-  Clause->setInteropVar(InteropVar);
-  llvm::copy(InteropInfo.PreferTypes, Clause->getTrailingObjects() + 1);
+  unsigned NumPrefs = InteropInfo.Prefs.size();
+  unsigned NumAttrs = 0;
+  for (const OMPInteropPref &P : InteropInfo.Prefs)
+    NumAttrs += P.Attrs.size();
+
+  // Trailing layout: Expr*[1 + NumPrefs + NumAttrs], unsigned[NumPrefs].
+  void *Mem = C.Allocate(
+      totalSizeToAlloc<Expr *, unsigned>(1 + NumPrefs + NumAttrs, NumPrefs));
+  auto *Clause = new (Mem)
+      OMPInitClause(InteropInfo.IsTarget, InteropInfo.IsTargetSync, StartLoc,
+                    LParenLoc, VarLoc, EndLoc, /*VarListN=*/1 + NumPrefs);
+  Clause->NumAttrs = NumAttrs;
+  Clause->HasPreferAttrs = InteropInfo.HasPreferAttrs;
+
+  Expr **E = Clause->getTrailingObjects<Expr *>();
+  E[0] = InteropVar;
+  for (unsigned I = 0; I < NumPrefs; ++I)
+    E[1 + I] = InteropInfo.Prefs[I].Fr;
+  unsigned *Counts = Clause->getTrailingObjects<unsigned>();
+  unsigned AttrPos = 1 + NumPrefs;
+  for (unsigned I = 0; I < NumPrefs; ++I) {
+    Counts[I] = InteropInfo.Prefs[I].Attrs.size();
+    for (Expr *A : InteropInfo.Prefs[I].Attrs)
+      E[AttrPos++] = A;
+  }
   return Clause;
 }
 
-OMPInitClause *OMPInitClause::CreateEmpty(const ASTContext &C, unsigned N) {
-  void *Mem = C.Allocate(totalSizeToAlloc<Expr *>(N));
-  return new (Mem) OMPInitClause(N);
+OMPInitClause *OMPInitClause::CreateEmpty(const ASTContext &C,
+                                          unsigned NumPrefs,
+                                          unsigned NumAttrs) {
+  void *Mem = C.Allocate(
+      totalSizeToAlloc<Expr *, unsigned>(1 + NumPrefs + NumAttrs, NumPrefs));
+  auto *Clause = new (Mem) OMPInitClause(/*VarListN=*/1 + NumPrefs);
+  Clause->NumAttrs = NumAttrs;
+  return Clause;
+}
+
+void OMPInitClause::setAttrs(ArrayRef<unsigned> Counts,
+                             ArrayRef<Expr *> Attrs) {
+  assert(Counts.size() == getNumPrefs() &&
+         "attr-count vector size must match number of pref-specs");
+  assert(Attrs.size() == NumAttrs &&
+         "attr-expr count must match preallocated NumAttrs");
+  llvm::copy(Counts, getTrailingObjects<unsigned>());
+  llvm::copy(Attrs, getTrailingObjects<Expr *>() + varlist_size());
 }
 
 OMPBindClause *
@@ -2388,17 +2421,42 @@ void OMPClausePrinter::VisitOMPHintClause(OMPHintClause *Node) {
 
 void OMPClausePrinter::VisitOMPInitClause(OMPInitClause *Node) {
   OS << "init(";
-  bool First = true;
-  for (const Expr *E : Node->prefs()) {
-    if (First)
-      OS << "prefer_type(";
-    else
-      OS << ",";
-    E->printPretty(OS, nullptr, Policy);
-    First = false;
-  }
-  if (!First)
+  unsigned NumPrefs = Node->getNumPrefs();
+  if (NumPrefs > 0) {
+    OS << "prefer_type(";
+    if (Node->getHasPreferAttrs()) {
+      // OMP 6.0 brace-grouped form
+      llvm::interleaveComma(
+          llvm::seq<unsigned>(0, NumPrefs), OS, [&](unsigned I) {
+            OMPInitClause::PrefView P = Node->getPref(I);
+            OS << "{";
+            if (P.Fr) {
+              OS << "fr(";
+              P.Fr->printPretty(OS, nullptr, Policy);
+              OS << ")";
+              if (!P.Attrs.empty())
+                OS << ", ";
+            }
+            if (!P.Attrs.empty()) {
+              OS << "attr(";
+              llvm::interleaveComma(P.Attrs, OS, [&](const Expr *A) {
+                A->printPretty(OS, nullptr, Policy);
+              });
+              OS << ")";
+            }
+            OS << "}";
+          });
+    } else {
+      llvm::interleave(
+          llvm::seq<unsigned>(0, NumPrefs), OS,
+          [&](unsigned I) {
+            if (Expr *Fr = Node->getPref(I).Fr)
+              Fr->printPretty(OS, nullptr, Policy);
+          },
+          ",");
+    }
     OS << "), ";
+  }
   if (Node->getIsTarget())
     OS << "target";
   if (Node->getIsTargetSync()) {

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -40,6 +40,9 @@ namespace {
 
     void VisitStmt(const Stmt *S);
 
+    /// Fold a scalar value into the profile
+    void VisitInteger(uint64_t Value) { ID.AddInteger(Value); }
+
     void VisitStmtNoChildren(const Stmt *S) {
       HandleStmtClass(S->getStmtClass());
     }
@@ -658,7 +661,19 @@ void OMPClauseProfiler::VisitOMPSIMDClause(const OMPSIMDClause *) {}
 void OMPClauseProfiler::VisitOMPNogroupClause(const OMPNogroupClause *) {}
 
 void OMPClauseProfiler::VisitOMPInitClause(const OMPInitClause *C) {
-  VisitOMPClauseList(C);
+  // Enumerate per pref-spec so the {fr, attr} grouping is part of the profile.
+  Profiler->VisitStmt(C->getInteropVar());
+  unsigned NumPrefs = C->getNumPrefs();
+  Profiler->VisitInteger(NumPrefs);
+  for (unsigned I = 0; I < NumPrefs; ++I) {
+    OMPInitClause::PrefView P = C->getPref(I);
+    Profiler->VisitInteger(P.Fr ? 1 : 0); // Fr may be null for an attr-only spec
+    if (P.Fr)
+      Profiler->VisitStmt(P.Fr);
+    Profiler->VisitInteger(P.Attrs.size()); // pref-spec boundary
+    for (const Expr *A : P.Attrs)
+      Profiler->VisitStmt(A);
+  }
 }
 
 void OMPClauseProfiler::VisitOMPUseClause(const OMPUseClause *C) {

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -667,7 +667,8 @@ void OMPClauseProfiler::VisitOMPInitClause(const OMPInitClause *C) {
   Profiler->VisitInteger(NumPrefs);
   for (unsigned I = 0; I < NumPrefs; ++I) {
     OMPInitClause::PrefView P = C->getPref(I);
-    Profiler->VisitInteger(P.Fr ? 1 : 0); // Fr may be null for an attr-only spec
+    Profiler->VisitInteger(P.Fr ? 1
+                                : 0); // Fr may be null for an attr-only spec
     if (P.Fr)
       Profiler->VisitStmt(P.Fr);
     Profiler->VisitInteger(P.Attrs.size()); // pref-spec boundary

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -663,15 +663,13 @@ void OMPClauseProfiler::VisitOMPNogroupClause(const OMPNogroupClause *) {}
 void OMPClauseProfiler::VisitOMPInitClause(const OMPInitClause *C) {
   // Enumerate per pref-spec so the {fr, attr} grouping is part of the profile.
   Profiler->VisitStmt(C->getInteropVar());
-  unsigned NumPrefs = C->getNumPrefs();
-  Profiler->VisitInteger(NumPrefs);
-  for (unsigned I = 0; I < NumPrefs; ++I) {
-    OMPInitClause::PrefView P = C->getPref(I);
-    Profiler->VisitInteger(P.Fr ? 1
-                                : 0); // Fr may be null for an attr-only spec
+  Profiler->VisitInteger(C->hasPreferAttrs() ? 1 : 0);
+  Profiler->VisitInteger(C->varlist_size() - 1);
+  for (OMPInitClause::PrefView P : C->prefs()) {
+    Profiler->VisitInteger(P.Fr ? 1 : 0);
     if (P.Fr)
       Profiler->VisitStmt(P.Fr);
-    Profiler->VisitInteger(P.Attrs.size()); // pref-spec boundary
+    Profiler->VisitInteger(P.Attrs.size());
     for (const Expr *A : P.Attrs)
       Profiler->VisitStmt(A);
   }

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3846,7 +3846,8 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
           PTExpr = Actions.ActOnFinishFullExpr(PTExpr.get(), Loc,
                                                /*DiscardedValue=*/false);
           if (PTExpr.isUsable()) {
-            InteropInfo.Prefs.emplace_back(PTExpr.get(), llvm::SmallVector<Expr *, 2>{});
+            InteropInfo.Prefs.emplace_back(PTExpr.get(),
+                                           llvm::SmallVector<Expr *, 2>{});
           } else {
             HasError = true;
             SkipUntil(tok::comma, tok::r_paren, tok::annot_pragma_openmp_end,

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3713,7 +3713,7 @@ bool Parser::ParseOMPInteropAttrSelector(SmallVectorImpl<Expr *> &Attrs) {
   // attr() requires at least one ext-string-literal argument; an empty list is
   // not permitted by the prefer_type grammar.
   if (Tok.is(tok::r_paren)) {
-    Diag(Tok, diag::err_expected) << tok::string_literal;
+    Diag(Tok, diag::err_omp_interop_attr_not_string);
     HasError = true;
   }
   while (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
@@ -3726,7 +3726,7 @@ bool Parser::ParseOMPInteropAttrSelector(SmallVectorImpl<Expr *> &Attrs) {
         HasError = true;
     } else {
       HasError = true;
-      Diag(Tok, diag::err_expected) << tok::string_literal;
+      Diag(Tok, diag::err_omp_interop_attr_not_string);
       ConsumeToken();
     }
     if (Tok.is(tok::comma))
@@ -3833,7 +3833,8 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
           if (BT.consumeClose())
             HasError = true;
 
-          InteropInfo.Prefs.push_back({FrExpr, std::move(AttrExprs)});
+          if (FrExpr || !AttrExprs.empty())
+            InteropInfo.Prefs.emplace_back(FrExpr, AttrExprs);
           InteropInfo.HasPreferAttrs = true;
         } else {
           // OMP 5.1: flat foreign-runtime-id (string or int). Stored as a
@@ -3845,7 +3846,7 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
           PTExpr = Actions.ActOnFinishFullExpr(PTExpr.get(), Loc,
                                                /*DiscardedValue=*/false);
           if (PTExpr.isUsable()) {
-            InteropInfo.Prefs.push_back({PTExpr.get(), {}});
+            InteropInfo.Prefs.emplace_back(PTExpr.get(), llvm::SmallVector<Expr *, 2>{});
           } else {
             HasError = true;
             SkipUntil(tok::comma, tok::r_paren, tok::annot_pragma_openmp_end,

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3710,6 +3710,12 @@ bool Parser::ParseOMPInteropAttrSelector(SmallVectorImpl<Expr *> &Attrs) {
     return true;
   }
   bool HasError = false;
+  // attr() requires at least one ext-string-literal argument; an empty list is
+  // not permitted by the prefer_type grammar.
+  if (Tok.is(tok::r_paren)) {
+    Diag(Tok, diag::err_expected) << tok::string_literal;
+    HasError = true;
+  }
   while (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
          Tok.isNot(tok::annot_pragma_openmp_end)) {
     if (Tok.is(tok::string_literal)) {
@@ -3762,9 +3768,22 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
       if (PT.expectAndConsume(diag::err_expected_lparen_after, "prefer_type"))
         HasError = true;
 
-      while (Tok.isNot(tok::r_paren)) {
+      // prefer_type requires at least one preference-specification.
+      if (Tok.is(tok::r_paren)) {
+        Diag(Tok, diag::err_omp_expected_pref_spec);
+        HasError = true;
+      }
+
+      while (Tok.isNot(tok::r_paren) &&
+             Tok.isNot(tok::annot_pragma_openmp_end)) {
         // OMP 6.0: { fr(...), attr(...) } brace-grouped pref-spec
         if (Tok.is(tok::l_brace)) {
+          // The brace-grouped form was introduced in OpenMP 6.0; earlier
+          // versions only allow the flat foreign-runtime-id list.
+          if (getLangOpts().OpenMP < 60) {
+            Diag(Tok, diag::err_omp_prefer_type_brace_60);
+            HasError = true;
+          }
           BalancedDelimiterTracker BT(*this, tok::l_brace,
                                       tok::annot_pragma_openmp_end);
           BT.consumeOpen();
@@ -3772,13 +3791,17 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
           SmallVector<Expr *, 2> AttrExprs;
           bool SeenFr = false;
 
+          // A pref-spec requires at least one 'fr'/'attr' selector; {} is not
+          // permitted by the grammar.
+          if (Tok.is(tok::r_brace)) {
+            Diag(Tok, diag::err_omp_expected_fr_or_attr_selector);
+            HasError = true;
+          }
+
           while (Tok.isNot(tok::r_brace) &&
                  Tok.isNot(tok::annot_pragma_openmp_end)) {
-            if (!Tok.is(tok::identifier)) {
-              HasError = true;
-              Diag(Tok, diag::err_omp_expected_interop_type);
-              ConsumeToken();
-            } else if (Tok.getIdentifierInfo()->isStr("fr")) {
+            if (Tok.is(tok::identifier) &&
+                Tok.getIdentifierInfo()->isStr("fr")) {
               if (SeenFr) {
                 Diag(Tok, diag::err_omp_interop_multiple_fr);
                 HasError = true;
@@ -3794,12 +3817,14 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
                 FrExpr = Fr.get();
               else
                 HasError = true;
-            } else if (Tok.getIdentifierInfo()->isStr("attr")) {
+            } else if (Tok.is(tok::identifier) &&
+                       Tok.getIdentifierInfo()->isStr("attr")) {
               if (ParseOMPInteropAttrSelector(AttrExprs))
                 HasError = true;
             } else {
+              // Neither 'fr' nor 'attr' (a non-identifier or some other word).
               HasError = true;
-              Diag(Tok, diag::err_omp_expected_interop_type);
+              Diag(Tok, diag::err_omp_expected_fr_or_attr_selector);
               ConsumeToken();
             }
             if (Tok.is(tok::comma))

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3681,6 +3681,55 @@ bool Parser::ParseOpenMPIndirectClause(
   return false;
 }
 
+ExprResult Parser::ParseOMPInteropFrSelector() {
+  ConsumeToken(); // 'fr'
+  BalancedDelimiterTracker FT(*this, tok::l_paren,
+                              tok::annot_pragma_openmp_end);
+  if (FT.expectAndConsume(diag::err_expected_lparen_after, "fr")) {
+    SkipUntil(
+        {tok::comma, tok::r_brace, tok::r_paren, tok::annot_pragma_openmp_end},
+        StopBeforeMatch);
+    return ExprError();
+  }
+  SourceLocation Loc = Tok.getLocation();
+  ExprResult LHS = ParseCastExpression(CastParseKind::AnyCastExpr);
+  ExprResult Arg = ParseRHSOfBinaryExpression(LHS, prec::Conditional);
+  Arg = Actions.ActOnFinishFullExpr(Arg.get(), Loc, /*DiscardedValue=*/false);
+  FT.consumeClose();
+  return Arg;
+}
+
+bool Parser::ParseOMPInteropAttrSelector(SmallVectorImpl<Expr *> &Attrs) {
+  ConsumeToken(); // 'attr'
+  BalancedDelimiterTracker AT(*this, tok::l_paren,
+                              tok::annot_pragma_openmp_end);
+  if (AT.expectAndConsume(diag::err_expected_lparen_after, "attr")) {
+    SkipUntil(
+        {tok::comma, tok::r_brace, tok::r_paren, tok::annot_pragma_openmp_end},
+        StopBeforeMatch);
+    return true;
+  }
+  bool HasError = false;
+  while (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
+         Tok.isNot(tok::annot_pragma_openmp_end)) {
+    if (Tok.is(tok::string_literal)) {
+      ExprResult S = ParseStringLiteralExpression();
+      if (S.isUsable())
+        Attrs.push_back(S.get());
+      else
+        HasError = true;
+    } else {
+      HasError = true;
+      Diag(Tok, diag::err_expected) << tok::string_literal;
+      ConsumeToken();
+    }
+    if (Tok.is(tok::comma))
+      ConsumeToken();
+  }
+  AT.consumeClose();
+  return HasError;
+}
+
 bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
                                  OpenMPClauseKind Kind) {
   const Token &Tok = getCurToken();
@@ -3725,10 +3774,12 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
 
           while (Tok.isNot(tok::r_brace) &&
                  Tok.isNot(tok::annot_pragma_openmp_end)) {
-            if (Tok.is(tok::identifier) &&
-                Tok.getIdentifierInfo()->isStr("fr")) {
+            if (!Tok.is(tok::identifier)) {
+              HasError = true;
+              Diag(Tok, diag::err_omp_expected_interop_type);
+              ConsumeToken();
+            } else if (Tok.getIdentifierInfo()->isStr("fr")) {
               if (SeenFr) {
-                // Diagnose and skip the duplicate fr(...) entirely
                 Diag(Tok, diag::err_omp_interop_multiple_fr);
                 HasError = true;
                 ConsumeToken(); // 'fr'
@@ -3738,56 +3789,14 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
                 continue;
               }
               SeenFr = true;
-              ConsumeToken(); // 'fr'
-              BalancedDelimiterTracker FT(*this, tok::l_paren,
-                                          tok::annot_pragma_openmp_end);
-              if (FT.expectAndConsume(diag::err_expected_lparen_after, "fr")) {
-                HasError = true;
-                SkipUntil({tok::comma, tok::r_brace, tok::r_paren,
-                           tok::annot_pragma_openmp_end},
-                          StopBeforeMatch);
-                continue;
-              }
-              SourceLocation Loc = Tok.getLocation();
-              ExprResult LHS = ParseCastExpression(CastParseKind::AnyCastExpr);
-              ExprResult Arg =
-                  ParseRHSOfBinaryExpression(LHS, prec::Conditional);
-              Arg = Actions.ActOnFinishFullExpr(Arg.get(), Loc, false);
-              if (Arg.isUsable())
-                FrExpr = Arg.get();
+              ExprResult Fr = ParseOMPInteropFrSelector();
+              if (Fr.isUsable())
+                FrExpr = Fr.get();
               else
                 HasError = true;
-              FT.consumeClose();
-            } else if (Tok.is(tok::identifier) &&
-                       Tok.getIdentifierInfo()->isStr("attr")) {
-              ConsumeToken(); // 'attr'
-              BalancedDelimiterTracker AT(*this, tok::l_paren,
-                                          tok::annot_pragma_openmp_end);
-              if (AT.expectAndConsume(diag::err_expected_lparen_after,
-                                      "attr")) {
+            } else if (Tok.getIdentifierInfo()->isStr("attr")) {
+              if (ParseOMPInteropAttrSelector(AttrExprs))
                 HasError = true;
-                SkipUntil({tok::comma, tok::r_brace, tok::r_paren,
-                           tok::annot_pragma_openmp_end},
-                          StopBeforeMatch);
-                continue;
-              }
-              while (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
-                     Tok.isNot(tok::annot_pragma_openmp_end)) {
-                if (Tok.is(tok::string_literal)) {
-                  ExprResult StrRes = ParseStringLiteralExpression();
-                  if (!StrRes.isUsable())
-                    HasError = true;
-                  else
-                    AttrExprs.push_back(StrRes.get());
-                } else {
-                  HasError = true;
-                  Diag(Tok, diag::err_expected) << tok::string_literal;
-                  ConsumeToken();
-                }
-                if (Tok.is(tok::comma))
-                  ConsumeToken();
-              }
-              AT.consumeClose();
             } else {
               HasError = true;
               Diag(Tok, diag::err_omp_expected_interop_type);

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -3690,9 +3690,8 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
 
   while (Tok.is(tok::identifier)) {
     // Currently prefer_type is only allowed with 'init' and it must be first.
-    bool PreferTypeAllowed = Kind == OMPC_init &&
-                             InteropInfo.PreferTypes.empty() && !IsTarget &&
-                             !IsTargetSync;
+    bool PreferTypeAllowed = Kind == OMPC_init && InteropInfo.Prefs.empty() &&
+                             !IsTarget && !IsTargetSync;
     if (Tok.getIdentifierInfo()->isStr("target")) {
       // OpenMP 5.1 [2.15.1, interop Construct, Restrictions]
       // Each interop-type may be specified on an action-clause at most
@@ -3715,17 +3714,109 @@ bool Parser::ParseOMPInteropInfo(OMPInteropInfo &InteropInfo,
         HasError = true;
 
       while (Tok.isNot(tok::r_paren)) {
-        SourceLocation Loc = Tok.getLocation();
-        ExprResult LHS = ParseCastExpression(CastParseKind::AnyCastExpr);
-        ExprResult PTExpr = ParseRHSOfBinaryExpression(LHS, prec::Conditional);
-        PTExpr = Actions.ActOnFinishFullExpr(PTExpr.get(), Loc,
-                                             /*DiscardedValue=*/false);
-        if (PTExpr.isUsable()) {
-          InteropInfo.PreferTypes.push_back(PTExpr.get());
-        } else {
-          HasError = true;
-          SkipUntil(tok::comma, tok::r_paren, tok::annot_pragma_openmp_end,
+        // OMP 6.0: { fr(...), attr(...) } brace-grouped pref-spec
+        if (Tok.is(tok::l_brace)) {
+          BalancedDelimiterTracker BT(*this, tok::l_brace,
+                                      tok::annot_pragma_openmp_end);
+          BT.consumeOpen();
+          Expr *FrExpr = nullptr;
+          SmallVector<Expr *, 2> AttrExprs;
+          bool SeenFr = false;
+
+          while (Tok.isNot(tok::r_brace) &&
+                 Tok.isNot(tok::annot_pragma_openmp_end)) {
+            if (Tok.is(tok::identifier) &&
+                Tok.getIdentifierInfo()->isStr("fr")) {
+              if (SeenFr) {
+                // Diagnose and skip the duplicate fr(...) entirely
+                Diag(Tok, diag::err_omp_interop_multiple_fr);
+                HasError = true;
+                ConsumeToken(); // 'fr'
+                SkipUntil(
+                    {tok::comma, tok::r_brace, tok::annot_pragma_openmp_end},
                     StopBeforeMatch);
+                continue;
+              }
+              SeenFr = true;
+              ConsumeToken(); // 'fr'
+              BalancedDelimiterTracker FT(*this, tok::l_paren,
+                                          tok::annot_pragma_openmp_end);
+              if (FT.expectAndConsume(diag::err_expected_lparen_after, "fr")) {
+                HasError = true;
+                SkipUntil({tok::comma, tok::r_brace, tok::r_paren,
+                           tok::annot_pragma_openmp_end},
+                          StopBeforeMatch);
+                continue;
+              }
+              SourceLocation Loc = Tok.getLocation();
+              ExprResult LHS = ParseCastExpression(CastParseKind::AnyCastExpr);
+              ExprResult Arg =
+                  ParseRHSOfBinaryExpression(LHS, prec::Conditional);
+              Arg = Actions.ActOnFinishFullExpr(Arg.get(), Loc, false);
+              if (Arg.isUsable())
+                FrExpr = Arg.get();
+              else
+                HasError = true;
+              FT.consumeClose();
+            } else if (Tok.is(tok::identifier) &&
+                       Tok.getIdentifierInfo()->isStr("attr")) {
+              ConsumeToken(); // 'attr'
+              BalancedDelimiterTracker AT(*this, tok::l_paren,
+                                          tok::annot_pragma_openmp_end);
+              if (AT.expectAndConsume(diag::err_expected_lparen_after,
+                                      "attr")) {
+                HasError = true;
+                SkipUntil({tok::comma, tok::r_brace, tok::r_paren,
+                           tok::annot_pragma_openmp_end},
+                          StopBeforeMatch);
+                continue;
+              }
+              while (Tok.isNot(tok::r_paren) && Tok.isNot(tok::r_brace) &&
+                     Tok.isNot(tok::annot_pragma_openmp_end)) {
+                if (Tok.is(tok::string_literal)) {
+                  ExprResult StrRes = ParseStringLiteralExpression();
+                  if (!StrRes.isUsable())
+                    HasError = true;
+                  else
+                    AttrExprs.push_back(StrRes.get());
+                } else {
+                  HasError = true;
+                  Diag(Tok, diag::err_expected) << tok::string_literal;
+                  ConsumeToken();
+                }
+                if (Tok.is(tok::comma))
+                  ConsumeToken();
+              }
+              AT.consumeClose();
+            } else {
+              HasError = true;
+              Diag(Tok, diag::err_omp_expected_interop_type);
+              ConsumeToken();
+            }
+            if (Tok.is(tok::comma))
+              ConsumeToken();
+          }
+          if (BT.consumeClose())
+            HasError = true;
+
+          InteropInfo.Prefs.push_back({FrExpr, std::move(AttrExprs)});
+          InteropInfo.HasPreferAttrs = true;
+        } else {
+          // OMP 5.1: flat foreign-runtime-id (string or int). Stored as a
+          // pref-spec with Fr=expr and no attr() entries.
+          SourceLocation Loc = Tok.getLocation();
+          ExprResult LHS = ParseCastExpression(CastParseKind::AnyCastExpr);
+          ExprResult PTExpr =
+              ParseRHSOfBinaryExpression(LHS, prec::Conditional);
+          PTExpr = Actions.ActOnFinishFullExpr(PTExpr.get(), Loc,
+                                               /*DiscardedValue=*/false);
+          if (PTExpr.isUsable()) {
+            InteropInfo.Prefs.push_back({PTExpr.get(), {}});
+          } else {
+            HasError = true;
+            SkipUntil(tok::comma, tok::r_paren, tok::annot_pragma_openmp_end,
+                      StopBeforeMatch);
+          }
         }
 
         if (Tok.is(tok::comma))

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -18968,22 +18968,41 @@ OMPClause *SemaOpenMP::ActOnOpenMPInitClause(
     return nullptr;
 
   // Check prefer_type values. fr() arguments are either string literals or
-  // constant integral expressions; null Fr is only valid in OMP 6.0
+  // constant integral expressions; null Fr is only valid in OMP 6.0.
+  // attr() arguments must be ext-string-literals with the 'ompx_' prefix
+  // (OpenMP 6.0 spec, section 16.1.3).
   for (const OMPInteropPref &P : InteropInfo.Prefs) {
     const Expr *E = P.Fr;
     if (!E) {
       assert(InteropInfo.HasPreferAttrs && "null Fr requires OMP 6.0 syntax");
-      continue;
+    } else if (!E->isValueDependent() && !E->isTypeDependent() &&
+               !E->isInstantiationDependent() &&
+               !E->containsUnexpandedParameterPack()) {
+      if (!E->isIntegerConstantExpr(getASTContext()) && !isa<StringLiteral>(E)) {
+        Diag(E->getExprLoc(), diag::err_omp_interop_prefer_type);
+        return nullptr;
+      }
     }
-    if (E->isValueDependent() || E->isTypeDependent() ||
-        E->isInstantiationDependent() || E->containsUnexpandedParameterPack())
-      continue;
-    if (E->isIntegerConstantExpr(getASTContext()))
-      continue;
-    if (isa<StringLiteral>(E))
-      continue;
-    Diag(E->getExprLoc(), diag::err_omp_interop_prefer_type);
-    return nullptr;
+    for (const Expr *A : P.Attrs) {
+      if (A->isValueDependent() || A->isTypeDependent() ||
+          A->isInstantiationDependent() || A->containsUnexpandedParameterPack())
+        continue;
+      const auto *SL = dyn_cast<StringLiteral>(A);
+      if (!SL) {
+        Diag(A->getExprLoc(), diag::err_omp_interop_attr_not_string);
+        return nullptr;
+      }
+      if (!SL->getString().starts_with("ompx_")) {
+        Diag(A->getExprLoc(), diag::err_omp_interop_attr_missing_ompx_prefix)
+            << SL->getString();
+        return nullptr;
+      }
+      if (SL->getString().contains(',')) {
+        Diag(A->getExprLoc(), diag::err_omp_interop_attr_contains_comma)
+            << SL->getString();
+        return nullptr;
+      }
+    }
   }
 
   return OMPInitClause::Create(getASTContext(), InteropVar, InteropInfo,

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -18978,7 +18978,8 @@ OMPClause *SemaOpenMP::ActOnOpenMPInitClause(
     } else if (!E->isValueDependent() && !E->isTypeDependent() &&
                !E->isInstantiationDependent() &&
                !E->containsUnexpandedParameterPack()) {
-      if (!E->isIntegerConstantExpr(getASTContext()) && !isa<StringLiteral>(E)) {
+      if (!E->isIntegerConstantExpr(getASTContext()) &&
+          !isa<StringLiteral>(E)) {
         Diag(E->getExprLoc(), diag::err_omp_interop_prefer_type);
         return nullptr;
       }

--- a/clang/lib/Sema/SemaOpenMP.cpp
+++ b/clang/lib/Sema/SemaOpenMP.cpp
@@ -18967,9 +18967,14 @@ OMPClause *SemaOpenMP::ActOnOpenMPInitClause(
   if (!isValidInteropVariable(SemaRef, InteropVar, VarLoc, OMPC_init))
     return nullptr;
 
-  // Check prefer_type values.  These foreign-runtime-id values are either
-  // string literals or constant integral expressions.
-  for (const Expr *E : InteropInfo.PreferTypes) {
+  // Check prefer_type values. fr() arguments are either string literals or
+  // constant integral expressions; null Fr is only valid in OMP 6.0
+  for (const OMPInteropPref &P : InteropInfo.Prefs) {
+    const Expr *E = P.Fr;
+    if (!E) {
+      assert(InteropInfo.HasPreferAttrs && "null Fr requires OMP 6.0 syntax");
+      continue;
+    }
     if (E->isValueDependent() || E->isTypeDependent() ||
         E->isInstantiationDependent() || E->containsUnexpandedParameterPack())
       continue;

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -10997,10 +10997,7 @@ OMPClause *TreeTransform<Derived>::TransformOMPInitClause(OMPInitClause *C) {
     return nullptr;
 
   OMPInteropInfo InteropInfo(C->getIsTarget(), C->getIsTargetSync());
-  unsigned NumPrefs = C->getNumPrefs();
-  InteropInfo.Prefs.reserve(NumPrefs);
-  for (unsigned I = 0; I < NumPrefs; ++I) {
-    OMPInitClause::PrefView P = C->getPref(I);
+  for (OMPInitClause::PrefView P : C->prefs()) {
     Expr *NewFr = nullptr;
     if (P.Fr) {
       ExprResult ER = getDerived().TransformExpr(P.Fr);
@@ -11016,9 +11013,9 @@ OMPClause *TreeTransform<Derived>::TransformOMPInitClause(OMPInitClause *C) {
         return nullptr;
       NewAttrs.push_back(ER.get());
     }
-    InteropInfo.Prefs.push_back({NewFr, std::move(NewAttrs)});
+    InteropInfo.Prefs.emplace_back(NewFr, std::move(NewAttrs));
   }
-  InteropInfo.HasPreferAttrs = C->getHasPreferAttrs();
+  InteropInfo.HasPreferAttrs = C->hasPreferAttrs();
   return getDerived().RebuildOMPInitClause(IVR.get(), InteropInfo,
                                            C->getBeginLoc(), C->getLParenLoc(),
                                            C->getVarLoc(), C->getEndLoc());

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -10997,13 +10997,28 @@ OMPClause *TreeTransform<Derived>::TransformOMPInitClause(OMPInitClause *C) {
     return nullptr;
 
   OMPInteropInfo InteropInfo(C->getIsTarget(), C->getIsTargetSync());
-  InteropInfo.PreferTypes.reserve(C->varlist_size() - 1);
-  for (Expr *E : llvm::drop_begin(C->varlist())) {
-    ExprResult ER = getDerived().TransformExpr(cast<Expr>(E));
-    if (ER.isInvalid())
-      return nullptr;
-    InteropInfo.PreferTypes.push_back(ER.get());
+  unsigned NumPrefs = C->getNumPrefs();
+  InteropInfo.Prefs.reserve(NumPrefs);
+  for (unsigned I = 0; I < NumPrefs; ++I) {
+    OMPInitClause::PrefView P = C->getPref(I);
+    Expr *NewFr = nullptr;
+    if (P.Fr) {
+      ExprResult ER = getDerived().TransformExpr(P.Fr);
+      if (ER.isInvalid())
+        return nullptr;
+      NewFr = ER.get();
+    }
+    SmallVector<Expr *, 2> NewAttrs;
+    NewAttrs.reserve(P.Attrs.size());
+    for (Expr *A : P.Attrs) {
+      ExprResult ER = getDerived().TransformExpr(A);
+      if (ER.isInvalid())
+        return nullptr;
+      NewAttrs.push_back(ER.get());
+    }
+    InteropInfo.Prefs.push_back({NewFr, std::move(NewAttrs)});
   }
+  InteropInfo.HasPreferAttrs = C->getHasPreferAttrs();
   return getDerived().RebuildOMPInitClause(IVR.get(), InteropInfo,
                                            C->getBeginLoc(), C->getLParenLoc(),
                                            C->getVarLoc(), C->getEndLoc());

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -12109,7 +12109,7 @@ void OMPClauseReader::VisitOMPInitClause(OMPInitClause *C) {
   C->setIsTargetSync(Record.readBool());
   C->setHasPreferAttrs(Record.readBool());
 
-  unsigned NumPrefs = C->getNumPrefs();
+  unsigned NumPrefs = C->varlist_size() - 1;
   SmallVector<unsigned, 4> Counts;
   SmallVector<Expr *, 8> Attrs;
   Counts.reserve(NumPrefs);

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -11786,9 +11786,13 @@ OMPClause *OMPClauseReader::readClause() {
   case llvm::omp::OMPC_order:
     C = new (Context) OMPOrderClause();
     break;
-  case llvm::omp::OMPC_init:
-    C = OMPInitClause::CreateEmpty(Context, Record.readInt());
+  case llvm::omp::OMPC_init: {
+    unsigned VarListSize = Record.readInt();
+    unsigned NumAttrs = Record.readInt();
+    C = OMPInitClause::CreateEmpty(Context, /*NumPrefs=*/VarListSize - 1,
+                                   NumAttrs);
     break;
+  }
   case llvm::omp::OMPC_use:
     C = new (Context) OMPUseClause();
     break;
@@ -12103,6 +12107,20 @@ void OMPClauseReader::VisitOMPInitClause(OMPInitClause *C) {
   C->setVarRefs(Vars);
   C->setIsTarget(Record.readBool());
   C->setIsTargetSync(Record.readBool());
+  C->setHasPreferAttrs(Record.readBool());
+
+  unsigned NumPrefs = C->getNumPrefs();
+  SmallVector<unsigned, 4> Counts;
+  SmallVector<Expr *, 8> Attrs;
+  Counts.reserve(NumPrefs);
+  for (unsigned I = 0; I < NumPrefs; ++I) {
+    unsigned NA = Record.readInt();
+    Counts.push_back(NA);
+    for (unsigned J = 0; J < NA; ++J)
+      Attrs.push_back(Record.readSubExpr());
+  }
+  C->setAttrs(Counts, Attrs);
+
   C->setLParenLoc(Record.readSourceLocation());
   C->setVarLoc(Record.readSourceLocation());
 }

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -8285,16 +8285,15 @@ void OMPClauseWriter::VisitOMPInitClause(OMPInitClause *C) {
   // Sizes for CreateEmpty on the read side: varlist_size = 1 + NumPrefs, then
   // NumAttrs (total attrs across all pref-specs).
   Record.push_back(C->varlist_size());
-  Record.push_back(C->getNumAttrs());
+  Record.push_back(C->attrs().size());
   // Varlist (interop var + Fr block).
   for (Expr *VE : C->varlist())
     Record.AddStmt(VE);
   Record.writeBool(C->getIsTarget());
   Record.writeBool(C->getIsTargetSync());
-  Record.writeBool(C->getHasPreferAttrs());
+  Record.writeBool(C->hasPreferAttrs());
   // Per-pref-spec: attr count + that many attr exprs, in order.
-  for (unsigned I = 0, E = C->getNumPrefs(); I < E; ++I) {
-    OMPInitClause::PrefView P = C->getPref(I);
+  for (OMPInitClause::PrefView P : C->prefs()) {
     Record.push_back(P.Attrs.size());
     for (Expr *A : P.Attrs)
       Record.AddStmt(A);

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -8282,11 +8282,23 @@ void OMPClauseWriter::VisitOMPSIMDClause(OMPSIMDClause *) {}
 void OMPClauseWriter::VisitOMPNogroupClause(OMPNogroupClause *) {}
 
 void OMPClauseWriter::VisitOMPInitClause(OMPInitClause *C) {
+  // Sizes for CreateEmpty on the read side: varlist_size = 1 + NumPrefs, then
+  // NumAttrs (total attrs across all pref-specs).
   Record.push_back(C->varlist_size());
+  Record.push_back(C->getNumAttrs());
+  // Varlist (interop var + Fr block).
   for (Expr *VE : C->varlist())
     Record.AddStmt(VE);
   Record.writeBool(C->getIsTarget());
   Record.writeBool(C->getIsTargetSync());
+  Record.writeBool(C->getHasPreferAttrs());
+  // Per-pref-spec: attr count + that many attr exprs, in order.
+  for (unsigned I = 0, E = C->getNumPrefs(); I < E; ++I) {
+    OMPInitClause::PrefView P = C->getPref(I);
+    Record.push_back(P.Attrs.size());
+    for (Expr *A : P.Attrs)
+      Record.AddStmt(A);
+  }
   Record.AddSourceLocation(C->getLParenLoc());
   Record.AddSourceLocation(C->getVarLoc());
 }

--- a/clang/test/OpenMP/interop_prefer_type_brace_ast_print.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_ast_print.cpp
@@ -37,7 +37,7 @@ void brace_specs() {
   #pragma omp interop init(prefer_type({fr("sycl"), attr("ompx_propX")}), \
                            targetsync: obj)
 
-  // attr() only (no fr()) — any runtime.
+  // attr() only (no fr()) -- any runtime.
   // PRINT: #pragma omp interop init(prefer_type({attr("ompx_propX", "ompx_propY")}), targetsync : obj)
   #pragma omp interop init(prefer_type({attr("ompx_propX", "ompx_propY")}), \
                            targetsync: obj)

--- a/clang/test/OpenMP/interop_prefer_type_brace_ast_print.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_ast_print.cpp
@@ -1,0 +1,71 @@
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+// RUN:   -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+// RUN:   -ast-print %s | FileCheck %s --check-prefix=PRINT
+
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+// RUN:   -emit-pch -o %t %s
+
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+// RUN:   -include-pch %t -ast-print %s | FileCheck %s --check-prefix=PRINT
+
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+// RUN:   -ast-dump %s | FileCheck %s --check-prefix=DUMP
+
+#ifndef HEADER
+#define HEADER
+
+typedef void *omp_interop_t;
+
+void brace_specs() {
+  omp_interop_t obj;
+
+  // Single brace entry with fr() only.
+  // PRINT: #pragma omp interop init(prefer_type({fr("sycl")}), targetsync : obj)
+  #pragma omp interop init(prefer_type({fr("sycl")}), targetsync: obj)
+
+  // Multiple brace entries, each with fr() only.
+  // PRINT: #pragma omp interop init(prefer_type({fr("sycl")}, {fr("level_zero")}, {fr("opencl")}), targetsync : obj)
+  #pragma omp interop init(prefer_type({fr("sycl")}, {fr("level_zero")}, \
+                                       {fr("opencl")}), targetsync: obj)
+
+  // fr() + attr() on one entry.
+  // PRINT: #pragma omp interop init(prefer_type({fr("sycl"), attr("ompx_propX")}), targetsync : obj)
+  #pragma omp interop init(prefer_type({fr("sycl"), attr("ompx_propX")}), \
+                           targetsync: obj)
+
+  // attr() only (no fr()) — any runtime.
+  // PRINT: #pragma omp interop init(prefer_type({attr("ompx_propX", "ompx_propY")}), targetsync : obj)
+  #pragma omp interop init(prefer_type({attr("ompx_propX", "ompx_propY")}), \
+                           targetsync: obj)
+
+  // Integer expression inside fr() on brace-grouped entry.
+  // PRINT: #pragma omp interop init(prefer_type({fr(4)}, {fr(6)}), targetsync : obj)
+  #pragma omp interop init(prefer_type({fr(4)}, {fr(6)}), targetsync: obj)
+
+  // Mixed flat + brace entries
+  // PRINT: #pragma omp interop init(prefer_type({fr("sycl")}, {fr("opencl")}), targetsync : obj)
+  #pragma omp interop init(prefer_type("sycl", {fr("opencl")}), \
+                           targetsync: obj)
+
+  // Multiple pref-specs mixing fr-only, fr+attr, and attr-only.
+  // PRINT: #pragma omp interop init(prefer_type({fr("sycl"), attr("ompx_propX")}, {fr("level_zero")}, {attr("ompx_propY")}), targetsync : obj)
+  #pragma omp interop init(prefer_type({fr("sycl"), attr("ompx_propX")}, {fr("level_zero")}, {attr("ompx_propY")}), targetsync: obj)
+}
+
+template <int N>
+void tmpl(omp_interop_t obj) {
+  // PRINT: #pragma omp interop init(prefer_type({fr(N), attr("ompx_propX")}), targetsync : obj)
+  #pragma omp interop init(prefer_type({fr(N), attr("ompx_propX")}), targetsync: obj)
+}
+
+// DUMP: FunctionDecl {{.*}} tmpl 'void (omp_interop_t)' explicit_instantiation_definition
+// DUMP: TemplateArgument integral '7'
+// DUMP: OMPInitClause
+// DUMP: IntegerLiteral {{.*}} 'int' 7
+// DUMP: StringLiteral {{.*}} "ompx_propX"
+template void tmpl<7>(omp_interop_t);
+#endif // HEADER

--- a/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
@@ -52,6 +52,19 @@ static void foo() {
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({attr()}), targetsync: obj)
 
+  // attr() argument without the required 'ompx_' prefix.
+  // expected-error@+2 {{attr() argument 'cuda_prop' must start with the 'ompx_' prefix}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr("cuda_prop")}), targetsync: obj)
+
+  // Valid attr() with 'ompx_' prefix — no error expected.
+  #pragma omp interop init(prefer_type({attr("ompx_propX")}), targetsync: obj)
+
+  // attr() argument with a comma — not permitted by the grammar.
+  // expected-error@+2 {{attr() argument 'ompx_a,b' must not contain a comma}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr("ompx_a,b")}), targetsync: obj)
+
   // expected-error@+2 {{expected '(' after 'fr'}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({fr "sycl"}), targetsync: obj)

--- a/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
@@ -27,6 +27,11 @@ static void foo() {
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({attr(1)}), targetsync: obj)
 
+  // Empty attr() — at least one ext-string-literal is required.
+  // expected-error@+2 {{expected <string_literal>}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr()}), targetsync: obj)
+
   // expected-error@+2 {{expected '(' after 'fr'}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({fr "sycl"}), targetsync: obj)
@@ -36,7 +41,22 @@ static void foo() {
   #pragma omp interop init(prefer_type({attr "ompx_propX"}), targetsync: obj)
 
   // Anything that is not 'fr' or 'attr' is rejected by the brace parser.
-  // expected-error@+2 {{expected interop type: 'target' and/or 'targetsync'}}
+  // expected-error@+2 {{expected 'fr' or 'attr' selector in 'prefer_type'}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({foo}), targetsync: obj)
+
+  // A non-identifier where a selector is expected is rejected too.
+  // expected-error@+2 {{expected 'fr' or 'attr' selector in 'prefer_type'}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({42}), targetsync: obj)
+
+  // An empty pref-spec '{}' requires at least one 'fr'/'attr' selector.
+  // expected-error@+2 {{expected 'fr' or 'attr' selector in 'prefer_type'}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({}), targetsync: obj)
+
+  // An empty prefer_type() requires at least one preference-specification.
+  // expected-error@+2 {{expected preference-specification in 'prefer_type'}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type(), targetsync: obj)
 }

--- a/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
@@ -10,7 +10,7 @@ typedef void *omp_interop_t;
 static void foo() {
   omp_interop_t obj;
 
-  // Flat string list — valid before OMP 6.0, no error expected.
+  // Flat string list -- valid before OMP 6.0, no error expected.
   #pragma omp interop init(prefer_type("sycl", "level_zero", "opencl"), targetsync: obj)
 
   // fr() with a string literal.
@@ -42,13 +42,13 @@ static void foo() {
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({fr(1.5)}), targetsync: obj)
 
-  // Integer inside attr() — only string literals allowed.
-  // expected-error@+2 {{expected <string_literal>}}
+  // Integer inside attr() -- only string literals allowed.
+  // expected-error@+2 {{attr() argument must be a string literal}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({attr(1)}), targetsync: obj)
 
-  // Empty attr() — at least one ext-string-literal is required.
-  // expected-error@+2 {{expected <string_literal>}}
+  // Empty attr() -- at least one ext-string-literal is required.
+  // expected-error@+2 {{attr() argument must be a string literal}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({attr()}), targetsync: obj)
 
@@ -57,10 +57,10 @@ static void foo() {
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({attr("cuda_prop")}), targetsync: obj)
 
-  // Valid attr() with 'ompx_' prefix — no error expected.
+  // Valid attr() with 'ompx_' prefix -- no error expected.
   #pragma omp interop init(prefer_type({attr("ompx_propX")}), targetsync: obj)
 
-  // attr() argument with a comma — not permitted by the grammar.
+  // attr() argument with a comma -- not permitted by the grammar.
   // expected-error@+2 {{attr() argument 'ompx_a,b' must not contain a comma}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type({attr("ompx_a,b")}), targetsync: obj)

--- a/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
@@ -5,7 +5,25 @@
 
 typedef void *omp_interop_t;
 
-#ifndef PRE_OMP60
+#ifdef PRE_OMP60
+// Brace-grouped syntax is rejected before OpenMP 6.0.
+static void foo() {
+  omp_interop_t obj;
+
+  // Flat string list — valid before OMP 6.0, no error expected.
+  #pragma omp interop init(prefer_type("sycl", "level_zero", "opencl"), targetsync: obj)
+
+  // fr() with a string literal.
+  // pre-omp60-error@+2 {{brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later}}
+  // pre-omp60-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({fr("cuda")}), targetsync: obj)
+
+  // attr() with a single string literal.
+  // pre-omp60-error@+2 {{brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later}}
+  // pre-omp60-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr("ompx_propX")}), targetsync: obj)
+}
+#else
 static void foo() {
   omp_interop_t obj;
 
@@ -61,25 +79,5 @@ static void foo() {
   // expected-error@+2 {{expected preference-specification in 'prefer_type'}}
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type(), targetsync: obj)
-}
-#endif // PRE_OMP60
-
-// Brace-grouped syntax is rejected before OpenMP 6.0.
-#ifdef PRE_OMP60
-static void foo() {
-  omp_interop_t obj;
-
-  // Flat string list — valid before OMP 6.0, no error expected.
-  #pragma omp interop init(prefer_type("sycl", "level_zero", "opencl"), targetsync: obj)
-
-  // fr() with a string literal.
-  // pre-omp60-error@+2 {{brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later}}
-  // pre-omp60-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
-  #pragma omp interop init(prefer_type({fr("cuda")}), targetsync: obj)
-
-  // attr() with a single string literal.
-  // pre-omp60-error@+2 {{brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later}}
-  // pre-omp60-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
-  #pragma omp interop init(prefer_type({attr("ompx_propX")}), targetsync: obj)
 }
 #endif // PRE_OMP60

--- a/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
@@ -1,9 +1,11 @@
-// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -std=c++11 -o - %s
+// RUN: %clang_cc1 -verify              -fopenmp -fopenmp-version=60 -std=c++11 -o - %s
+// RUN: %clang_cc1 -verify=pre-omp60   -fopenmp -fopenmp-version=51 -std=c++11 -DPRE_OMP60 -o - %s
 
 // Diagnostics for the OMP 6.0 brace-grouped prefer_type syntax.
 
 typedef void *omp_interop_t;
 
+#ifndef PRE_OMP60
 static void foo() {
   omp_interop_t obj;
 
@@ -60,3 +62,24 @@ static void foo() {
   // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
   #pragma omp interop init(prefer_type(), targetsync: obj)
 }
+#endif // PRE_OMP60
+
+// Brace-grouped syntax is rejected before OpenMP 6.0.
+#ifdef PRE_OMP60
+static void foo() {
+  omp_interop_t obj;
+
+  // Flat string list — valid before OMP 6.0, no error expected.
+  #pragma omp interop init(prefer_type("sycl", "level_zero", "opencl"), targetsync: obj)
+
+  // fr() with a string literal.
+  // pre-omp60-error@+2 {{brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later}}
+  // pre-omp60-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({fr("cuda")}), targetsync: obj)
+
+  // attr() with a single string literal.
+  // pre-omp60-error@+2 {{brace-grouped 'prefer_type' argument requires OpenMP version 6.0 or later}}
+  // pre-omp60-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr("ompx_propX")}), targetsync: obj)
+}
+#endif // PRE_OMP60

--- a/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
+++ b/clang/test/OpenMP/interop_prefer_type_brace_messages.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -std=c++11 -o - %s
+
+// Diagnostics for the OMP 6.0 brace-grouped prefer_type syntax.
+
+typedef void *omp_interop_t;
+
+static void foo() {
+  omp_interop_t obj;
+
+  // expected-error@+2 {{only one 'fr' selector allowed per preference-specification}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({fr("sycl"), fr("opencl")}), targetsync: obj)
+
+  // Non-constant variable expression inside fr().
+  int x = 2;
+  // expected-error@+2 {{prefer_list item must be a string literal or constant integral expression}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({fr(x)}), targetsync: obj)
+
+  // Floating-point literal inside fr().
+  // expected-error@+2 {{prefer_list item must be a string literal or constant integral expression}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({fr(1.5)}), targetsync: obj)
+
+  // Integer inside attr() — only string literals allowed.
+  // expected-error@+2 {{expected <string_literal>}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr(1)}), targetsync: obj)
+
+  // expected-error@+2 {{expected '(' after 'fr'}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({fr "sycl"}), targetsync: obj)
+
+  // expected-error@+2 {{expected '(' after 'attr'}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({attr "ompx_propX"}), targetsync: obj)
+
+  // Anything that is not 'fr' or 'attr' is rejected by the brace parser.
+  // expected-error@+2 {{expected interop type: 'target' and/or 'targetsync'}}
+  // expected-error@+1 {{expected at least one 'init', 'use', 'destroy', or 'nowait' clause for '#pragma omp interop'}}
+  #pragma omp interop init(prefer_type({foo}), targetsync: obj)
+}

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -2467,6 +2467,8 @@ void OMPClauseEnqueue::VisitOMPNogroupClause(const OMPNogroupClause *) {}
 
 void OMPClauseEnqueue::VisitOMPInitClause(const OMPInitClause *C) {
   VisitOMPClauseList(C);
+  for (const Expr *A : C->getAttrs())
+    Visitor->AddStmt(A);
 }
 
 void OMPClauseEnqueue::VisitOMPUseClause(const OMPUseClause *C) {

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -2467,7 +2467,7 @@ void OMPClauseEnqueue::VisitOMPNogroupClause(const OMPNogroupClause *) {}
 
 void OMPClauseEnqueue::VisitOMPInitClause(const OMPInitClause *C) {
   VisitOMPClauseList(C);
-  for (const Expr *A : C->getAttrs())
+  for (const Expr *A : C->attrs())
     Visitor->AddStmt(A);
 }
 


### PR DESCRIPTION
This PR adds parsing support for the OpenMP 6.0 brace-grouped prefer_type modifier on the init clause of #pragma omp interop, while preserving the OpenMP 5.1 flat form. Each preference-specification can now carry an optional
  fr(<foreign-runtime-id>) and zero or more attr(<string-literal>...) selectors, eg:

  #pragma omp interop init(prefer_type({fr("sycl"), attr("ompx_propX")}, \
                                       {fr("level_zero")}, \
                                       {attr("ompx_propY")}), targetsync: obj)
