### PR TITLE
[CIR] Handle atomic-fetch lowering of pointer types.

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -570,6 +570,28 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   cir::AtomicFetchKindAttr fetchAttr;
   bool fetchFirst = true;
 
+  bool fetchRequiredIntCast = false;
+  mlir::Type pointeeType = ptr.getElementType();
+  auto handleFetchOp = [&](cir::AtomicFetchKind kind) {
+    opName = cir::AtomicFetchOp::getOperationName();
+    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(), kind);
+
+    // The fetch operation only takes int/float as its element type, so
+    // pointer-to-pointer needs to just be cast to a intptr type. Do the first
+    // part here, and we can cast the rest later. Classic codegen has to do a
+    // bit more to handle floating point types for exchange, but this isn't
+    // really necessary for CIR. This mirrors the logic in CIRGenBuiltin for
+    // binary atomic values. Clang type checking enforces that 'val' is a
+    // PtrDiffT, so we cast to that.
+    if (mlir::isa<cir::PointerType>(pointeeType)) {
+      fetchRequiredIntCast = true;
+      mlir::Type ptrSizeInt =
+          cgf.convertType(cgf.getContext().getPointerDiffType());
+
+      ptr = ptr.withElementType(builder, ptrSizeInt);
+    }
+  };
+
   switch (expr->getOp()) {
   case AtomicExpr::AO__c11_atomic_init:
     llvm_unreachable("already handled!");
@@ -644,9 +666,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_add:
   case AtomicExpr::AO__atomic_fetch_add:
   case AtomicExpr::AO__scoped_atomic_fetch_add:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Add);
+    handleFetchOp(cir::AtomicFetchKind::Add);
     break;
 
   case AtomicExpr::AO__atomic_sub_fetch:
@@ -656,9 +676,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_sub:
   case AtomicExpr::AO__atomic_fetch_sub:
   case AtomicExpr::AO__scoped_atomic_fetch_sub:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Sub);
+    handleFetchOp(cir::AtomicFetchKind::Sub);
     break;
 
   case AtomicExpr::AO__atomic_min_fetch:
@@ -668,9 +686,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_min:
   case AtomicExpr::AO__atomic_fetch_min:
   case AtomicExpr::AO__scoped_atomic_fetch_min:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Min);
+    handleFetchOp(cir::AtomicFetchKind::Min);
     break;
 
   case AtomicExpr::AO__atomic_max_fetch:
@@ -680,9 +696,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_max:
   case AtomicExpr::AO__atomic_fetch_max:
   case AtomicExpr::AO__scoped_atomic_fetch_max:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Max);
+    handleFetchOp(cir::AtomicFetchKind::Max);
     break;
 
   case AtomicExpr::AO__atomic_and_fetch:
@@ -692,9 +706,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_and:
   case AtomicExpr::AO__atomic_fetch_and:
   case AtomicExpr::AO__scoped_atomic_fetch_and:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::And);
+    handleFetchOp(cir::AtomicFetchKind::And);
     break;
 
   case AtomicExpr::AO__atomic_or_fetch:
@@ -704,9 +716,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_or:
   case AtomicExpr::AO__atomic_fetch_or:
   case AtomicExpr::AO__scoped_atomic_fetch_or:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Or);
+    handleFetchOp(cir::AtomicFetchKind::Or);
     break;
 
   case AtomicExpr::AO__atomic_xor_fetch:
@@ -716,9 +726,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_xor:
   case AtomicExpr::AO__atomic_fetch_xor:
   case AtomicExpr::AO__scoped_atomic_fetch_xor:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Xor);
+    handleFetchOp(cir::AtomicFetchKind::Xor);
     break;
 
   case AtomicExpr::AO__atomic_nand_fetch:
@@ -728,9 +736,7 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   case AtomicExpr::AO__c11_atomic_fetch_nand:
   case AtomicExpr::AO__atomic_fetch_nand:
   case AtomicExpr::AO__scoped_atomic_fetch_nand:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::Nand);
+    handleFetchOp(cir::AtomicFetchKind::Nand);
     break;
 
   case AtomicExpr::AO__atomic_test_and_set: {
@@ -752,16 +758,12 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
 
   case AtomicExpr::AO__atomic_fetch_uinc:
   case AtomicExpr::AO__scoped_atomic_fetch_uinc:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::UIncWrap);
+    handleFetchOp(cir::AtomicFetchKind::UIncWrap);
     break;
 
   case AtomicExpr::AO__atomic_fetch_udec:
   case AtomicExpr::AO__scoped_atomic_fetch_udec:
-    opName = cir::AtomicFetchOp::getOperationName();
-    fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(),
-                                              cir::AtomicFetchKind::UDecWrap);
+    handleFetchOp(cir::AtomicFetchKind::UDecWrap);
     break;
 
   case AtomicExpr::AO__opencl_atomic_init:
@@ -823,6 +825,10 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
     rmwOp->setAttr("fetch_first", builder.getUnitAttr());
 
   mlir::Value result = rmwOp->getResult(0);
+
+  if (fetchRequiredIntCast)
+    result = builder.createIntToPtr(result, pointeeType);
+
   builder.createStore(loc, result, dest);
 }
 

--- a/clang/test/CIR/CodeGen/atomic.c
+++ b/clang/test/CIR/CodeGen/atomic.c
@@ -921,6 +921,53 @@ void clear_volatile(volatile void *p) {
   // OGCG: store atomic volatile i8 0, ptr %{{.+}} seq_cst, align 1
 }
 
+float *atomic_fetch_ptr_to_ptr(float **ptr, int value) {
+  // CIR-LABEL: @atomic_fetch_ptr_to_ptr
+  // LLVM-LABEL: @atomic_fetch_ptr_to_ptr
+  // OGCG-LABEL: @atomic_fetch_ptr_to_ptr
+
+  return __atomic_fetch_add(ptr, value, __ATOMIC_SEQ_CST);
+  // CIR: %[[PTR:.*]] = cir.alloca !cir.ptr<!cir.ptr<!cir.float>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.float>>>, ["ptr", init]
+  // CIR: %[[ATOMIC_TEMP:.*]] = cir.alloca !cir.ptr<!cir.float>, !cir.ptr<!cir.ptr<!cir.float>>, ["atomic-temp"] {alignment = 8 : i64}
+  // CIR: %[[PTR_LOAD:.*]] = cir.load align(8) %[[PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.float>>>, !cir.ptr<!cir.ptr<!cir.float>>
+  // CIR: %[[PTR_CAST:.*]] = cir.cast bitcast %[[PTR_LOAD]] : !cir.ptr<!cir.ptr<!cir.float>> -> !cir.ptr<!s64i>
+  // CIR: %[[RESULT:.*]] = cir.atomic.fetch add seq_cst syncscope(system) fetch_first %[[PTR_CAST]], %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+  // CIR: %[[RESULT_CAST:.*]] = cir.cast int_to_ptr %[[RESULT]] : !s64i -> !cir.ptr<!cir.float>
+  // CIR: cir.store align(8) %[[RESULT_CAST]], %[[ATOMIC_TEMP]] : !cir.ptr<!cir.float>, !cir.ptr<!cir.ptr<!cir.float>>
+
+  // LLVM: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %{{.*}} seq_cst, align 8
+  // LLVM: %[[RESULT_CAST:.*]] = inttoptr i64 %[[RESULT]] to ptr
+  // LLVM: store ptr %[[RESULT_CAST]], ptr %{{.*}}, align 8
+
+  // OGCG: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %{{.*}} seq_cst, align 8
+  // OGCG Skips the cast and just stores it directly.
+  // OGCG: store i64 %[[RESULT]], ptr %{{.*}}, align 8
+}
+
+float *atomic_fetch_ptr_to_ptr2(float **ptr, int value) {
+  // CIR-LABEL: @atomic_fetch_ptr_to_ptr2
+  // LLVM-LABEL: @atomic_fetch_ptr_to_ptr2
+  // OGCG-LABEL: @atomic_fetch_ptr_to_ptr2
+  return __atomic_add_fetch(ptr, value, __ATOMIC_SEQ_CST);
+  // CIR: %[[PTR:.*]] = cir.alloca !cir.ptr<!cir.ptr<!cir.float>>, !cir.ptr<!cir.ptr<!cir.ptr<!cir.float>>>, ["ptr", init]
+  // CIR: %[[ATOMIC_TEMP:.*]] = cir.alloca !cir.ptr<!cir.float>, !cir.ptr<!cir.ptr<!cir.float>>, ["atomic-temp"] {alignment = 8 : i64}
+  // CIR: %[[PTR_LOAD:.*]] = cir.load align(8) %[[PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.float>>>, !cir.ptr<!cir.ptr<!cir.float>>
+  // CIR: %[[PTR_CAST:.*]] = cir.cast bitcast %[[PTR_LOAD]] : !cir.ptr<!cir.ptr<!cir.float>> -> !cir.ptr<!s64i>
+  // CIR: %[[RESULT:.*]] = cir.atomic.fetch add seq_cst syncscope(system) %[[PTR_CAST]], %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
+  // CIR: %[[RESULT_CAST:.*]] = cir.cast int_to_ptr %[[RESULT]] : !s64i -> !cir.ptr<!cir.float>
+  // CIR: cir.store align(8) %[[RESULT_CAST]], %[[ATOMIC_TEMP]] : !cir.ptr<!cir.float>, !cir.ptr<!cir.ptr<!cir.float>>
+
+  // LLVM: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %[[VAL:.*]] seq_cst, align 8
+  // LLVM: %[[ADD_RES:.*]] = add i64 %[[RESULT]], %[[VAL]]
+  // LLVM: %[[RESULT_CAST:.*]] = inttoptr i64 %[[ADD_RES]] to ptr
+  // LLVM: store ptr %[[RESULT_CAST]], ptr %{{.*}}, align 8
+
+  // OGCG: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %[[VAL:.*]] seq_cst, align 8
+  // OGCG: %[[ADD_RES:.*]] = add i64 %[[RESULT]], %[[VAL]]
+  // OGCG Skips the cast and just stores it directly.
+  // OGCG: store i64 %[[ADD_RES]], ptr %{{.*}}, align 8
+}
+
 int atomic_fetch_add(int *ptr, int value) {
   // CIR-LABEL: @atomic_fetch_add
   // LLVM-LABEL: @atomic_fetch_add


### PR DESCRIPTION
We previously didn't properly handle the pointer type conversions, which resulted in a verifier error.  This patch does what classic codegen does for these: casts them to an integer type.  The rest of the logic around this in classic codegen isn't necessary as the llvm intrinsics now handle those types properly.