### PR TITLE
Use existing encoding when writing to an existing file

### DIFF
--- a/llvm/include/llvm/Support/AutoConvert.h
+++ b/llvm/include/llvm/Support/AutoConvert.h
@@ -32,6 +32,7 @@ extern "C" {
 #endif /* __cplusplus */
 
 int enablezOSAutoConversion(int FD);
+int enablezOSAutoConversionCcsid(int FD, int ccsid);
 int disablezOSAutoConversion(int FD);
 int restorezOSStdHandleAutoConversion(int FD);
 
@@ -45,7 +46,7 @@ namespace llvm {
 #ifdef __MVS__
 
 /** \brief Set the tag information for a file descriptor. */
-std::error_code setzOSFileTag(int FD, int CCSID, bool Text);
+std::error_code setzOSFileTag(int FD, int CCSID, bool IsText);
 
 /** \brief Get the the tag ccsid for a file name or a file descriptor. */
 ErrorOr<__ccsid_t> getzOSFileTag(const Twine &FileName, const int FD = -1);
@@ -83,6 +84,14 @@ inline std::error_code enableAutoConversion(int FD) {
   return std::error_code();
 }
 
+inline std::error_code enableAutoConversion(int FD, int ccsid) {
+#ifdef __MVS__
+  if (::enablezOSAutoConversionCcsid(FD, ccsid) == -1)
+    return errnoAsErrorCode();
+#endif
+  return std::error_code();
+}
+
 inline std::error_code restoreStdHandleAutoConversion(int FD) {
 #ifdef __MVS__
   if (::restorezOSStdHandleAutoConversion(FD) == -1)
@@ -91,9 +100,9 @@ inline std::error_code restoreStdHandleAutoConversion(int FD) {
   return std::error_code();
 }
 
-inline std::error_code setFileTag(int FD, int CCSID, bool Text) {
+inline std::error_code setFileTag(int FD, int CCSID, bool IsText) {
 #ifdef __MVS__
-  return setzOSFileTag(FD, CCSID, Text);
+  return setzOSFileTag(FD, CCSID, IsText);
 #endif
   return std::error_code();
 }

--- a/llvm/lib/Support/AutoConvert.cpp
+++ b/llvm/lib/Support/AutoConvert.cpp
@@ -82,12 +82,24 @@ int enablezOSAutoConversion(int FD) {
   return fcntl(FD, F_CONTROL_CVT, &Query);
 }
 
-std::error_code llvm::setzOSFileTag(int FD, int CCSID, bool Text) {
-  assert((!Text || (CCSID != FT_UNTAGGED && CCSID != FT_BINARY)) &&
+int enablezOSAutoConversionCcsid(int FD, int ccsid) {
+  struct f_cnvrt cvt = {
+      SETCVTALL,    // cvtcmd
+      CCSID_UTF_8,  // pccsid
+      0,            // fccsid
+  };
+  if (ccsid == FT_UNTAGGED)
+    return -1;
+  cvt.fccsid = ccsid;
+  return fcntl(FD, F_CONTROL_CVT, &cvt);
+}
+
+std::error_code llvm::setzOSFileTag(int FD, int CCSID, bool IsText) {
+  assert((!IsText || (CCSID != FT_UNTAGGED && CCSID != FT_BINARY)) &&
          "FT_UNTAGGED and FT_BINARY are not allowed for text files");
   struct file_tag Tag;
   Tag.ft_ccsid = CCSID;
-  Tag.ft_txtflag = Text;
+  Tag.ft_txtflag = IsText;
   Tag.ft_deferred = 0;
   Tag.ft_rsvflags = 0;
 
@@ -143,6 +155,10 @@ std::error_code llvm::copyFileTagAttributes(const std::string &Source,
   struct stat SourceAttributes;
   if (stat(Source.c_str(), &SourceAttributes) == -1)
     return std::error_code(errno, std::generic_category());
+
+  if (SourceAttributes.st_tag.ft_txtflag)
+    if (enablezOSAutoConversionCcsid(DestinationFD, SourceAttributes.st_tag.ft_ccsid) == -1)
+      return errnoAsErrorCode();
 
   return setzOSFileTag(DestinationFD, SourceAttributes.st_tag.ft_ccsid,
                        SourceAttributes.st_tag.ft_txtflag);

--- a/llvm/lib/Support/AutoConvert.cpp
+++ b/llvm/lib/Support/AutoConvert.cpp
@@ -84,9 +84,9 @@ int enablezOSAutoConversion(int FD) {
 
 int enablezOSAutoConversionCcsid(int FD, int ccsid) {
   struct f_cnvrt cvt = {
-      SETCVTALL,    // cvtcmd
-      CCSID_UTF_8,  // pccsid
-      0,            // fccsid
+      SETCVTALL,   // cvtcmd
+      CCSID_UTF_8, // pccsid
+      0,           // fccsid
   };
   if (ccsid == FT_UNTAGGED)
     return -1;
@@ -157,7 +157,8 @@ std::error_code llvm::copyFileTagAttributes(const std::string &Source,
     return std::error_code(errno, std::generic_category());
 
   if (SourceAttributes.st_tag.ft_txtflag)
-    if (enablezOSAutoConversionCcsid(DestinationFD, SourceAttributes.st_tag.ft_ccsid) == -1)
+    if (enablezOSAutoConversionCcsid(DestinationFD,
+                                     SourceAttributes.st_tag.ft_ccsid) == -1)
       return errnoAsErrorCode();
 
   return setzOSFileTag(DestinationFD, SourceAttributes.st_tag.ft_ccsid,

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1160,17 +1160,23 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
                     !Stat.st_tag.ft_txtflag && !Stat.st_tag.ft_ccsid &&
                     Stat.st_size == 0;
     if (Flags & OF_Text) {
-      if (auto EC = llvm::enableAutoConversion(ResultFD))
-        return EC;
-      if (DoSetTag) {
-        if (auto EC = llvm::setzOSFileTag(ResultFD, CCSID_IBM_1047, true))
+      if ((Access & FA_Write) && (Disp != CD_OpenExisting)) {
+        int ccsid = CCSID_IBM_1047;
+        if (Stat.st_tag.ft_txtflag && Stat.st_tag.ft_ccsid != FT_UNTAGGED)
+          ccsid = Stat.st_tag.ft_ccsid;
+        if (auto EC = llvm::enableAutoConversion(ResultFD, ccsid))
           return EC;
-      }
+        if (DoSetTag) {
+          if (auto EC = llvm::setzOSFileTag(ResultFD, ccsid, /*IsText=*/true))
+            return EC;
+        }
+      } else if (auto EC = llvm::enableAutoConversion(ResultFD))
+        return EC;
     } else {
       if (auto EC = llvm::disableAutoConversion(ResultFD))
         return EC;
       if (DoSetTag) {
-        if (auto EC = llvm::setzOSFileTag(ResultFD, FT_BINARY, false))
+        if (auto EC = llvm::setzOSFileTag(ResultFD, FT_BINARY, /*IsText=*/false))
           return EC;
       }
     }

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1176,7 +1176,8 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
       if (auto EC = llvm::disableAutoConversion(ResultFD))
         return EC;
       if (DoSetTag) {
-        if (auto EC = llvm::setzOSFileTag(ResultFD, FT_BINARY, /*IsText=*/false))
+        if (auto EC =
+                 llvm::setzOSFileTag(ResultFD, FT_BINARY, /*IsText=*/false))
           return EC;
       }
     }

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -1177,7 +1177,7 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
         return EC;
       if (DoSetTag) {
         if (auto EC =
-                 llvm::setzOSFileTag(ResultFD, FT_BINARY, /*IsText=*/false))
+                llvm::setzOSFileTag(ResultFD, FT_BINARY, /*IsText=*/false))
           return EC;
       }
     }

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -1023,14 +1023,14 @@ Error llvm::writeToOutput(StringRef OutputFileName,
   if (!Temp)
     return createFileError(OutputFileName, Temp.takeError());
 
-  raw_fd_ostream Out(Temp->FD, false);
-
 #if defined(__MVS__)
   if (auto EC = llvm::copyFileTagAttributes(OutputFileName.str(), Temp->FD)) {
     if (EC != std::errc::no_such_file_or_directory)
       return createFileError(OutputFileName, EC);
   }
 #endif
+
+  raw_fd_ostream Out(Temp->FD, false);
 
   if (Error E = Write(Out)) {
     if (Error DiscardError = Temp->discard())

--- a/llvm/lib/Support/raw_ostream.cpp
+++ b/llvm/lib/Support/raw_ostream.cpp
@@ -1024,6 +1024,9 @@ Error llvm::writeToOutput(StringRef OutputFileName,
     return createFileError(OutputFileName, Temp.takeError());
 
 #if defined(__MVS__)
+  // The file tag needs to be set before any output can be written to the file.
+  // Do this before creating the raw_fd_ostream to ensure the correct
+  // sequence.
   if (auto EC = llvm::copyFileTagAttributes(OutputFileName.str(), Temp->FD)) {
     if (EC != std::errc::no_such_file_or_directory)
       return createFileError(OutputFileName, EC);

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -433,7 +433,8 @@ TEST(raw_ostreamTest, flush_tied_to_stream_on_write) {
 
   SmallString<64> Path;
   int FD;
-  ASSERT_FALSE(sys::fs::createTemporaryFile("tietest", "", FD, Path, sys::fs::OF_Text));
+  ASSERT_FALSE(
+      sys::fs::createTemporaryFile("tietest", "", FD, Path, sys::fs::OF_Text));
   FileRemover Cleanup(Path);
   raw_fd_ostream TiedStream(FD, /*ShouldClose=*/false);
   TiedStream.SetUnbuffered();
@@ -558,7 +559,8 @@ TEST(raw_ostreamTest, reserve_stream) {
 TEST(raw_ostreamTest, writeToOutputFile) {
   SmallString<64> Path;
   int FD;
-  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
+  ASSERT_FALSE(
+      sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
   FileRemover Cleanup(Path);
 
   ASSERT_THAT_ERROR(writeToOutput(Path,
@@ -579,7 +581,8 @@ TEST(raw_ostreamTest, writeToOutputFileEncoding) {
   // the tag on the file.
   SmallString<64> Path;
   int FD=0;
-  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
+  ASSERT_FALSE(
+      sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
   setzOSFileTag(FD,819, true);
   FileRemover Cleanup(Path);
 

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
+#include "llvm/Support/AutoConvert.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
@@ -432,7 +433,7 @@ TEST(raw_ostreamTest, flush_tied_to_stream_on_write) {
 
   SmallString<64> Path;
   int FD;
-  ASSERT_FALSE(sys::fs::createTemporaryFile("tietest", "", FD, Path));
+  ASSERT_FALSE(sys::fs::createTemporaryFile("tietest", "", FD, Path, sys::fs::OF_Text));
   FileRemover Cleanup(Path);
   raw_fd_ostream TiedStream(FD, /*ShouldClose=*/false);
   TiedStream.SetUnbuffered();
@@ -495,7 +496,7 @@ TEST(raw_ostreamTest, flush_tied_to_stream_on_write) {
 
 static void checkFileData(StringRef FileName, StringRef GoldenData) {
   ErrorOr<std::unique_ptr<MemoryBuffer>> BufOrErr =
-      MemoryBuffer::getFileOrSTDIN(FileName);
+      MemoryBuffer::getFileOrSTDIN(FileName, /*IsText=*/true);
   EXPECT_FALSE(BufOrErr.getError());
 
   EXPECT_EQ((*BufOrErr)->getBufferSize(), GoldenData.size());
@@ -508,14 +509,14 @@ TEST(raw_ostreamTest, raw_fd_ostream_mutual_ties) {
   SmallString<64> PathTiedTo;
   int FDTiedTo;
   ASSERT_FALSE(
-      sys::fs::createTemporaryFile("tietest1", "", FDTiedTo, PathTiedTo));
+      sys::fs::createTemporaryFile("tietest1", "", FDTiedTo, PathTiedTo, sys::fs::OF_Text));
   FileRemover CleanupTiedTo(PathTiedTo);
   raw_fd_ostream TiedTo(FDTiedTo, /*ShouldClose=*/false);
 
   SmallString<64> PathTiedStream;
   int FDTiedStream;
   ASSERT_FALSE(sys::fs::createTemporaryFile("tietest2", "", FDTiedStream,
-                                            PathTiedStream));
+                                            PathTiedStream, sys::fs::OF_Text));
   FileRemover CleanupTiedStream(PathTiedStream);
   raw_fd_ostream TiedStream(FDTiedStream, /*ShouldClose=*/false);
 
@@ -557,7 +558,7 @@ TEST(raw_ostreamTest, reserve_stream) {
 TEST(raw_ostreamTest, writeToOutputFile) {
   SmallString<64> Path;
   int FD;
-  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path));
+  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
   FileRemover Cleanup(Path);
 
   ASSERT_THAT_ERROR(writeToOutput(Path,
@@ -568,6 +569,39 @@ TEST(raw_ostreamTest, writeToOutputFile) {
                     Succeeded());
   checkFileData(Path, "HelloWorld");
 }
+
+#ifdef __MVS__
+TEST(raw_ostreamTest, writeToOutputFileEncoding) {
+  // Create the temp file with that has ISO8859-1 encoding
+  // Then update the file.  The new file should have ISO8859-1
+  // characters and be tagged as ISO8859-1.  This test will
+  // check to make sure that the encoding used in the file matches
+  // the tag on the file.
+  SmallString<64> Path;
+  int FD=0;
+  ASSERT_FALSE(sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
+  setzOSFileTag(FD,819, true);
+  FileRemover Cleanup(Path);
+
+  {
+    raw_fd_ostream out(FD, true);
+    out << "01234";
+  }
+
+  // Now update the file.
+  ASSERT_THAT_ERROR(writeToOutput(Path,
+                                  [](raw_ostream &Out) -> Error {
+                                    Out << "6789";
+                                    return Error::success();
+                                  }),
+                    Succeeded());
+
+  ErrorOr<__ccsid_t> Cssid = getzOSFileTag(Path, -1);
+  ASSERT_TRUE(Cssid);
+  EXPECT_EQ(Cssid.get(), 819);
+  checkFileData(Path, "6789");
+}
+#endif
 
 #ifndef _WIN32
 TEST(raw_ostreamTest, filePermissions) {

--- a/llvm/unittests/Support/raw_ostream_test.cpp
+++ b/llvm/unittests/Support/raw_ostream_test.cpp
@@ -509,8 +509,8 @@ static void checkFileData(StringRef FileName, StringRef GoldenData) {
 TEST(raw_ostreamTest, raw_fd_ostream_mutual_ties) {
   SmallString<64> PathTiedTo;
   int FDTiedTo;
-  ASSERT_FALSE(
-      sys::fs::createTemporaryFile("tietest1", "", FDTiedTo, PathTiedTo, sys::fs::OF_Text));
+  ASSERT_FALSE(sys::fs::createTemporaryFile("tietest1", "", FDTiedTo,
+                                            PathTiedTo, sys::fs::OF_Text));
   FileRemover CleanupTiedTo(PathTiedTo);
   raw_fd_ostream TiedTo(FDTiedTo, /*ShouldClose=*/false);
 
@@ -580,10 +580,10 @@ TEST(raw_ostreamTest, writeToOutputFileEncoding) {
   // check to make sure that the encoding used in the file matches
   // the tag on the file.
   SmallString<64> Path;
-  int FD=0;
+  int FD = 0;
   ASSERT_FALSE(
       sys::fs::createTemporaryFile("foo", "bar", FD, Path, sys::fs::OF_Text));
-  setzOSFileTag(FD,819, true);
+  setzOSFileTag(FD, 819, true);
   FileRemover Cleanup(Path);
 
   {


### PR DESCRIPTION
Clang lit test `Sema/warn-lifetime-safety-suggestions.cpp` is failing because the encoding for the new contents of the source file don't match the file tag on the file.

This change ensures the contents of a file are written in the same code page as the existing file.

- The copyFileTagAttributes() function will change the auto conversion to the code page of the file tag when writing a new version of a file.
- When writing to an existing file (eg. appending), use the file tag as the code page for auto conversion.  Don't assume 1047.