### PR TITLE
[libc][nfc] Include header for EFIAPI macro

### DIFF
--- a/libc/include/llvm-libc-types/CMakeLists.txt
+++ b/libc/include/llvm-libc-types/CMakeLists.txt
@@ -570,6 +570,7 @@ add_header(EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL
   HDR
     EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h
   DEPENDS
+    libc.include.llvm-libc-macros.EFIAPI_macros
     libc.include.llvm-libc-macros.stdint_macros
     .EFI_STATUS
     .size_t

--- a/libc/include/llvm-libc-types/EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h
+++ b/libc/include/llvm-libc-types/EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_H
 #define LLVM_LIBC_TYPES_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_H
 
+#include "../llvm-libc-macros/EFIAPI-macros.h"
 #include "../llvm-libc-macros/stdint-macros.h"
 #include "EFI_STATUS.h"
 #include "size_t.h"


### PR DESCRIPTION
This file uses `EFIAPI`, but it's not included. It looks like compilation currently succeeds because `EFI_SYSTEM_TABLE.h` is the only header that includes `EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.h`, and it happens to include `EFIAPI-macros.h` indirectly.

We will be adding Bazel rules for this file, and Bazel typically requires all headers to be compilable on their own. This build error is theoretically reproducable by running cmake build with `-DCMAKE_VERIFY_INTERFACE_HEADER_SETS` if we had the appropriate FILE_SETs defined.