### PR TITLE
[OFFLOAD][L0] Remove support for non-immediate command lists

### DIFF
--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -75,18 +75,6 @@ struct L0DeviceIdTy {
 };
 
 class L0DeviceTLSTy {
-  /// Command list for each device.
-  ze_command_list_handle_t CmdList = nullptr;
-
-  /// Main copy command list for each device.
-  ze_command_list_handle_t CopyCmdList = nullptr;
-
-  /// Command queue for each device.
-  ze_command_queue_handle_t CmdQueue = nullptr;
-
-  /// Main copy command queue for each device.
-  ze_command_queue_handle_t CopyCmdQueue = nullptr;
-
   /// Immediate command list for each device.
   ze_command_list_handle_t ImmCmdList = nullptr;
 
@@ -96,41 +84,22 @@ class L0DeviceTLSTy {
 public:
   L0DeviceTLSTy() = default;
   ~L0DeviceTLSTy() {
-    // assert all fields are nullptr on destruction.
-    assert(!CmdList && !CopyCmdList && !CmdQueue && !CopyCmdQueue &&
-           !ImmCmdList && !ImmCopyCmdList &&
+    assert(!ImmCmdList && !ImmCopyCmdList &&
            "L0DeviceTLSTy destroyed without clearing resources");
   }
 
   L0DeviceTLSTy(const L0DeviceTLSTy &) = delete;
   L0DeviceTLSTy(L0DeviceTLSTy &&Other) {
-    CmdList = std::exchange(Other.CmdList, nullptr);
-    CopyCmdList = std::exchange(Other.CopyCmdList, nullptr);
-    CmdQueue = std::exchange(Other.CmdQueue, nullptr);
-    CopyCmdQueue = std::exchange(Other.CopyCmdQueue, nullptr);
     ImmCmdList = std::exchange(Other.ImmCmdList, nullptr);
     ImmCopyCmdList = std::exchange(Other.ImmCopyCmdList, nullptr);
   }
 
   Error deinit() {
-    // destroy all lists and queues.
-    if (CmdList)
-      CALL_ZE_RET_ERROR(zeCommandListDestroy, CmdList);
-    if (CopyCmdList)
-      CALL_ZE_RET_ERROR(zeCommandListDestroy, CopyCmdList);
     if (ImmCmdList)
       CALL_ZE_RET_ERROR(zeCommandListDestroy, ImmCmdList);
     if (ImmCopyCmdList)
       CALL_ZE_RET_ERROR(zeCommandListDestroy, ImmCopyCmdList);
-    if (CmdQueue)
-      CALL_ZE_RET_ERROR(zeCommandQueueDestroy, CmdQueue);
-    if (CopyCmdQueue)
-      CALL_ZE_RET_ERROR(zeCommandQueueDestroy, CopyCmdQueue);
 
-    CmdList = nullptr;
-    CopyCmdList = nullptr;
-    CmdQueue = nullptr;
-    CopyCmdQueue = nullptr;
     ImmCmdList = nullptr;
     ImmCopyCmdList = nullptr;
 
@@ -140,14 +109,6 @@ public:
   L0DeviceTLSTy &operator=(const L0DeviceTLSTy &) = delete;
   L0DeviceTLSTy &operator=(L0DeviceTLSTy &&) = delete;
 
-  ze_command_list_handle_t getCmdList() const { return CmdList; }
-  void setCmdList(ze_command_list_handle_t _CmdList) { CmdList = _CmdList; }
-
-  ze_command_list_handle_t getCopyCmdList() const { return CopyCmdList; }
-  void setCopyCmdList(ze_command_list_handle_t _CopyCmdList) {
-    CopyCmdList = _CopyCmdList;
-  }
-
   ze_command_list_handle_t getImmCmdList() const { return ImmCmdList; }
   void setImmCmdList(ze_command_list_handle_t ImmCmdListIn) {
     ImmCmdList = ImmCmdListIn;
@@ -156,16 +117,6 @@ public:
   ze_command_list_handle_t getImmCopyCmdList() const { return ImmCopyCmdList; }
   void setImmCopyCmdList(ze_command_list_handle_t ImmCopyCmdListIn) {
     ImmCopyCmdList = ImmCopyCmdListIn;
-  }
-
-  ze_command_queue_handle_t getCmdQueue() const { return CmdQueue; }
-  void setCmdQueue(ze_command_queue_handle_t CmdQueueIn) {
-    CmdQueue = CmdQueueIn;
-  }
-
-  ze_command_queue_handle_t getCopyCmdQueue() const { return CopyCmdQueue; }
-  void setCopyCmdQueue(ze_command_queue_handle_t CopyCmdQueueIn) {
-    CopyCmdQueue = CopyCmdQueueIn;
   }
 };
 
@@ -452,14 +403,7 @@ public:
   bool hasMainCopyEngine() const { return CopyOrdinal.first != MaxOrdinal; }
   uint32_t getMainCopyEngine() const { return CopyOrdinal.first; }
 
-  bool deviceRequiresImmCmdList() const {
-    constexpr uint32_t BMGIP = 0x05004000;
-    return isDeviceIPorNewer(BMGIP);
-  }
   bool asyncEnabled() const { return IsAsyncEnabled; }
-  bool useImmForCompute() const { return true; }
-  bool useImmForCopy() const { return true; }
-  bool useImmForInterop() const { return true; }
 
   void reportDeviceInfo() const;
 
@@ -475,24 +419,6 @@ public:
   createCmdList(ze_context_handle_t Context, ze_device_handle_t Device,
                 uint32_t Ordinal, const std::string_view DeviceIdStr);
 
-  Expected<ze_command_list_handle_t> getCmdList();
-
-  /// Create a command queue with given ordinal and flags.
-  Expected<ze_command_queue_handle_t>
-  createCmdQueue(ze_context_handle_t Context, ze_device_handle_t Device,
-                 uint32_t Ordinal, uint32_t Index,
-                 ze_command_queue_flags_t Flags,
-                 const std::string_view DeviceIdStr);
-
-  /// Create a command queue with default flags.
-  Expected<ze_command_queue_handle_t>
-  createCmdQueue(ze_context_handle_t Context, ze_device_handle_t Device,
-                 uint32_t Ordinal, uint32_t Index,
-                 const std::string_view DeviceIdStr, bool InOrder = false);
-
-  /// Create a new command queue for the given OpenMP device ID.
-  Expected<ze_command_queue_handle_t> createCommandQueue(bool InOrder = false);
-
   /// Create an immediate command list.
   Expected<ze_command_list_handle_t>
   createImmCmdList(uint32_t Ordinal, uint32_t Index, bool InOrder = false);
@@ -504,9 +430,6 @@ public:
 
   /// Create an immediate command list for copying.
   Expected<ze_command_list_handle_t> createImmCopyCmdList();
-  Expected<ze_command_queue_handle_t> getCmdQueue();
-  Expected<ze_command_list_handle_t> getCopyCmdList();
-  Expected<ze_command_queue_handle_t> getCopyCmdQueue();
   Expected<ze_command_list_handle_t> getImmCmdList();
   Expected<ze_command_list_handle_t> getImmCopyCmdList();
 

--- a/offload/plugins-nextgen/level_zero/include/L0Device.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Device.h
@@ -407,18 +407,6 @@ public:
 
   void reportDeviceInfo() const;
 
-  // Command queues related functions.
-  /// Create a command list with given ordinal and flags.
-  Expected<ze_command_list_handle_t>
-  createCmdList(ze_context_handle_t Context, ze_device_handle_t Device,
-                uint32_t Ordinal, ze_command_list_flags_t Flags,
-                const std::string_view DeviceIdStr);
-
-  /// Create a command list with default flags.
-  Expected<ze_command_list_handle_t>
-  createCmdList(ze_context_handle_t Context, ze_device_handle_t Device,
-                uint32_t Ordinal, const std::string_view DeviceIdStr);
-
   /// Create an immediate command list.
   Expected<ze_command_list_handle_t>
   createImmCmdList(uint32_t Ordinal, uint32_t Index, bool InOrder = false);

--- a/offload/plugins-nextgen/level_zero/include/L0Interop.h
+++ b/offload/plugins-nextgen/level_zero/include/L0Interop.h
@@ -17,9 +17,6 @@ namespace llvm::omp::target::plugin::L0Interop {
 
 /// Level Zero interop property.
 struct Property {
-  // Use this when command queue needs to be accessed as
-  // the targetsync field in interop will be changed if preferred type is sycl.
-  ze_command_queue_handle_t CommandQueue;
   ze_command_list_handle_t ImmCmdList;
 };
 

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -811,20 +811,11 @@ Expected<OmpInteropTy> L0DeviceTy::createInterop(int32_t InteropContext,
 
     bool InOrder = InteropSpec.attrs.inorder;
     Ret->attrs.inorder = InOrder;
-    if (useImmForInterop()) {
-      auto CmdListOrErr = createImmCmdList(InOrder);
-      if (!CmdListOrErr)
-        return CmdListOrErr.takeError();
-      Ret->async_info->Queue = *CmdListOrErr;
-      L0->ImmCmdList = *CmdListOrErr;
-    } else {
-      auto QueueOrErr = createCommandQueue(InOrder);
-      if (!QueueOrErr)
-        return QueueOrErr.takeError();
-      Ret->async_info->Queue = *QueueOrErr;
-      L0->CommandQueue =
-          static_cast<ze_command_queue_handle_t>(Ret->async_info->Queue);
-    }
+    auto CmdListOrErr = createImmCmdList(InOrder);
+    if (!CmdListOrErr)
+      return CmdListOrErr.takeError();
+    Ret->async_info->Queue = *CmdListOrErr;
+    L0->ImmCmdList = *CmdListOrErr;
 
     CleanupOnError.release();
   }
@@ -842,13 +833,8 @@ Error L0DeviceTy::releaseInterop(OmpInteropTy Interop) {
   }
   auto L0 = static_cast<L0Interop::Property *>(Interop->rtl_property);
   if (Interop->async_info && Interop->async_info->Queue) {
-    if (useImmForInterop()) {
-      auto ImmCmdList = L0->ImmCmdList;
-      CALL_ZE_RET_ERROR(zeCommandListDestroy, ImmCmdList);
-    } else {
-      auto CmdQueue = L0->CommandQueue;
-      CALL_ZE_RET_ERROR(zeCommandQueueDestroy, CmdQueue);
-    }
+    auto ImmCmdList = L0->ImmCmdList;
+    CALL_ZE_RET_ERROR(zeCommandListDestroy, ImmCmdList);
   }
   delete L0;
   delete Interop;
@@ -859,49 +845,15 @@ Error L0DeviceTy::releaseInterop(OmpInteropTy Interop) {
 Error L0DeviceTy::enqueueMemCopy(void *Dst, const void *Src, size_t Size,
                                  __tgt_async_info *AsyncInfo,
                                  bool UseCopyEngine) {
-  ze_command_list_handle_t CmdList = nullptr;
-  ze_command_queue_handle_t CmdQueue = nullptr;
+  auto CmdListOrErr = UseCopyEngine ? getImmCopyCmdList() : getImmCmdList();
+  if (!CmdListOrErr)
+    return CmdListOrErr.takeError();
+  ze_command_list_handle_t CmdList = *CmdListOrErr;
 
-  if (useImmForCopy()) {
-    auto CmdListOrErr = UseCopyEngine ? getImmCopyCmdList() : getImmCmdList();
-    if (!CmdListOrErr)
-      return CmdListOrErr.takeError();
-    CmdList = *CmdListOrErr;
-    CALL_ZE_RET_ERROR(zeCommandListAppendMemoryCopy, CmdList, Dst, Src, Size,
-                      nullptr, 0, nullptr);
-    CALL_ZE_RET_ERROR(zeCommandListHostSynchronize, CmdList, L0DefaultTimeout);
-  } else {
-    if (UseCopyEngine) {
-      auto CmdListOrErr = getCopyCmdList();
-      if (!CmdListOrErr)
-        return CmdListOrErr.takeError();
-      CmdList = *CmdListOrErr;
-      auto CmdQueueOrErr = getCopyCmdQueue();
-      if (!CmdQueueOrErr)
-        return CmdQueueOrErr.takeError();
-      CmdQueue = *CmdQueueOrErr;
-    } else {
-      auto CmdListOrErr = getCmdList();
-      if (!CmdListOrErr)
-        return CmdListOrErr.takeError();
-      CmdList = *CmdListOrErr;
-      auto CmdQueueOrErr = getCmdQueue();
-      if (!CmdQueueOrErr)
-        return CmdQueueOrErr.takeError();
-      CmdQueue = *CmdQueueOrErr;
-    }
+  CALL_ZE_RET_ERROR(zeCommandListAppendMemoryCopy, CmdList, Dst, Src, Size,
+                    nullptr, 0, nullptr);
+  CALL_ZE_RET_ERROR(zeCommandListHostSynchronize, CmdList, L0DefaultTimeout);
 
-    CALL_ZE_RET_ERROR(zeCommandListAppendMemoryCopy, CmdList, Dst, Src, Size,
-                      nullptr, 0, nullptr);
-    CALL_ZE_RET_ERROR(zeCommandListClose, CmdList);
-    llvm::scope_exit ResetOnExit(
-        [&]() { CALL_ZE_SILENT(zeCommandListReset, CmdList); });
-    CALL_ZE_RET_ERROR_MTX(zeCommandQueueExecuteCommandLists, getMutex(),
-                          CmdQueue, 1, &CmdList, nullptr);
-    CALL_ZE_RET_ERROR(zeCommandQueueSynchronize, CmdQueue, L0DefaultTimeout);
-    ResetOnExit.release();
-    CALL_ZE_RET_ERROR(zeCommandListReset, CmdList);
-  }
   return Plugin::success();
 }
 
@@ -951,42 +903,23 @@ Error L0DeviceTy::enqueueMemCopyAsync(void *Dst, const void *Src, size_t Size,
 /// Enqueue memory fill.
 Error L0DeviceTy::enqueueMemFill(void *Ptr, const void *Pattern,
                                  size_t PatternSize, size_t Size) {
-  if (useImmForCopy()) {
-    auto CmdListOrErr = getImmCopyCmdList();
-    if (!CmdListOrErr)
-      return CmdListOrErr.takeError();
-    const auto CmdList = *CmdListOrErr;
-    auto EventOrErr = getEvent();
-    if (!EventOrErr)
-      return EventOrErr.takeError();
-    Error AllErrors = Error::success();
-    ze_event_handle_t Event = *EventOrErr;
-    CALL_ZE_ACCUM_ERROR(AllErrors, zeCommandListAppendMemoryFill, CmdList, Ptr,
-                        Pattern, PatternSize, Size, Event, 0, nullptr);
-    if (!AllErrors)
-      CALL_ZE_ACCUM_ERROR(AllErrors, zeEventHostSynchronize, Event,
-                          L0DefaultTimeout);
-    if (auto Err = releaseEvent(Event))
-      AllErrors = joinErrors(std::move(AllErrors), std::move(Err));
-    return AllErrors;
-  } else {
-    auto CmdListOrErr = getCopyCmdList();
-    if (!CmdListOrErr)
-      return CmdListOrErr.takeError();
-    auto CmdList = *CmdListOrErr;
-    auto CmdQueueOrErr = getCopyCmdQueue();
-    if (!CmdQueueOrErr)
-      return CmdQueueOrErr.takeError();
-    const auto CmdQueue = *CmdQueueOrErr;
-    CALL_ZE_RET_ERROR(zeCommandListAppendMemoryFill, CmdList, Ptr, Pattern,
-                      PatternSize, Size, nullptr, 0, nullptr);
-    CALL_ZE_RET_ERROR(zeCommandListClose, CmdList);
-    CALL_ZE_RET_ERROR(zeCommandQueueExecuteCommandLists, CmdQueue, 1, &CmdList,
-                      nullptr);
-    CALL_ZE_RET_ERROR(zeCommandQueueSynchronize, CmdQueue, L0DefaultTimeout);
-    CALL_ZE_RET_ERROR(zeCommandListReset, CmdList);
-  }
-  return Plugin::success();
+  auto CmdListOrErr = getImmCopyCmdList();
+  if (!CmdListOrErr)
+    return CmdListOrErr.takeError();
+  const auto CmdList = *CmdListOrErr;
+  auto EventOrErr = getEvent();
+  if (!EventOrErr)
+    return EventOrErr.takeError();
+  Error AllErrors = Error::success();
+  ze_event_handle_t Event = *EventOrErr;
+  CALL_ZE_ACCUM_ERROR(AllErrors, zeCommandListAppendMemoryFill, CmdList, Ptr,
+                      Pattern, PatternSize, Size, Event, 0, nullptr);
+  if (!AllErrors)
+    CALL_ZE_ACCUM_ERROR(AllErrors, zeEventHostSynchronize, Event,
+                        L0DefaultTimeout);
+  if (auto Err = releaseEvent(Event))
+    AllErrors = joinErrors(std::move(AllErrors), std::move(Err));
+  return AllErrors;
 }
 
 Error L0DeviceTy::dataFillImpl(void *TgtPtr, const void *PatternPtr,
@@ -1057,62 +990,6 @@ L0DeviceTy::createCmdList(ze_context_handle_t Context,
              : createCmdList(Context, Device, Ordinal, 0, DeviceIdStr);
 }
 
-Expected<ze_command_list_handle_t> L0DeviceTy::getCmdList() {
-  auto &TLS = getTLS();
-  auto CmdList = TLS.getCmdList();
-  if (!CmdList) {
-    auto CmdListOrErr = createCmdList(getZeContext(), getZeDevice(),
-                                      getComputeEngine(), getZeId());
-    if (!CmdListOrErr)
-      return CmdListOrErr.takeError();
-    CmdList = *CmdListOrErr;
-    TLS.setCmdList(CmdList);
-  }
-  return CmdList;
-}
-
-/// Create a command queue with given ordinal and flags.
-Expected<ze_command_queue_handle_t>
-L0DeviceTy::createCmdQueue(ze_context_handle_t Context,
-                           ze_device_handle_t Device, uint32_t Ordinal,
-                           uint32_t Index, ze_command_queue_flags_t Flags,
-                           const std::string_view DeviceIdStr) {
-  ze_command_queue_desc_t cmdQueueDesc = {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
-                                          nullptr, // Extension.
-                                          Ordinal,
-                                          Index,
-                                          Flags,
-                                          ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
-                                          ZE_COMMAND_QUEUE_PRIORITY_NORMAL};
-  ze_command_queue_handle_t cmdQueue;
-  CALL_ZE_RET_ERROR(zeCommandQueueCreate, Context, Device, &cmdQueueDesc,
-                    &cmdQueue);
-  ODBG(OLDT_Device) << "Created a command queue " << cmdQueue
-                    << " (Ordinal: " << Ordinal << ", Index: " << Index
-                    << ", Flags: " << Flags << ") for device "
-                    << DeviceIdStr.data() << ".";
-  return cmdQueue;
-}
-
-/// Create a command queue with default flags.
-Expected<ze_command_queue_handle_t> L0DeviceTy::createCmdQueue(
-    ze_context_handle_t Context, ze_device_handle_t Device, uint32_t Ordinal,
-    uint32_t Index, const std::string_view DeviceIdStr, bool InOrder) {
-  ze_command_queue_flags_t Flags = InOrder ? ZE_COMMAND_QUEUE_FLAG_IN_ORDER : 0;
-  return (Ordinal == MaxOrdinal) ? nullptr
-                                 : createCmdQueue(Context, Device, Ordinal,
-                                                  Index, Flags, DeviceIdStr);
-}
-
-/// Create a new command queue for the given OpenMP device ID.
-Expected<ze_command_queue_handle_t>
-L0DeviceTy::createCommandQueue(bool InOrder) {
-  auto cmdQueue =
-      createCmdQueue(getZeContext(), getZeDevice(), getComputeEngine(),
-                     getComputeIndex(), getZeId(), InOrder);
-  return cmdQueue;
-}
-
 /// Create an immediate command list.
 Expected<ze_command_list_handle_t>
 L0DeviceTy::createImmCmdList(uint32_t Ordinal, uint32_t Index, bool InOrder) {
@@ -1141,56 +1018,6 @@ Expected<ze_command_list_handle_t> L0DeviceTy::createImmCopyCmdList() {
   return createImmCmdList(Ordinal, /*Index*/ 0);
 }
 
-Expected<ze_command_queue_handle_t> L0DeviceTy::getCmdQueue() {
-  auto &TLS = getTLS();
-  auto CmdQueue = TLS.getCmdQueue();
-  if (!CmdQueue) {
-    auto CmdQueueOrErr = createCommandQueue();
-    if (!CmdQueueOrErr)
-      return CmdQueueOrErr.takeError();
-    CmdQueue = *CmdQueueOrErr;
-    TLS.setCmdQueue(CmdQueue);
-  }
-  return CmdQueue;
-}
-
-Expected<ze_command_list_handle_t> L0DeviceTy::getCopyCmdList() {
-  // Use main copy engine if available.
-  if (hasMainCopyEngine()) {
-    auto &TLS = getTLS();
-    auto CmdList = TLS.getCopyCmdList();
-    if (!CmdList) {
-      auto CmdListOrErr = createCmdList(getZeContext(), getZeDevice(),
-                                        getMainCopyEngine(), getZeId());
-      if (!CmdListOrErr)
-        return CmdListOrErr.takeError();
-      CmdList = *CmdListOrErr;
-      TLS.setCopyCmdList(CmdList);
-    }
-    return CmdList;
-  }
-  // Use compute engine otherwise.
-  return getCmdList();
-}
-
-Expected<ze_command_queue_handle_t> L0DeviceTy::getCopyCmdQueue() {
-  // Use main copy engine if available.
-  if (hasMainCopyEngine()) {
-    auto &TLS = getTLS();
-    auto CmdQueue = TLS.getCopyCmdQueue();
-    if (!CmdQueue) {
-      auto CmdQueueOrErr = createCmdQueue(getZeContext(), getZeDevice(),
-                                          getMainCopyEngine(), 0, getZeId());
-      if (!CmdQueueOrErr)
-        return CmdQueueOrErr.takeError();
-      CmdQueue = *CmdQueueOrErr;
-      TLS.setCopyCmdQueue(CmdQueue);
-    }
-    return CmdQueue;
-  }
-  // Use compute engine otherwise.
-  return getCmdQueue();
-}
 
 Expected<ze_command_list_handle_t> L0DeviceTy::getImmCmdList() {
   auto &TLS = getTLS();
@@ -1226,35 +1053,11 @@ Error L0DeviceTy::dataFence(__tgt_async_info *Async) {
   if (Ordered)
     return Plugin::success();
 
-  ze_command_list_handle_t CmdList = nullptr;
-  ze_command_queue_handle_t CmdQueue = nullptr;
-
-  if (useImmForCopy()) {
-    auto CmdListOrErr = getImmCopyCmdList();
-    if (!CmdListOrErr)
-      return CmdListOrErr.takeError();
-    auto CmdList = *CmdListOrErr;
-    CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, nullptr, 0, nullptr);
-  } else {
-    auto CmdListOrErr = getCopyCmdList();
-    if (!CmdListOrErr)
-      return CmdListOrErr.takeError();
-    auto CmdQueueOrerr = getCopyCmdQueue();
-    if (!CmdQueueOrerr)
-      return CmdQueueOrerr.takeError();
-
-    CmdList = *CmdListOrErr;
-    CmdQueue = *CmdQueueOrerr;
-    CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, nullptr, 0, nullptr);
-    CALL_ZE_RET_ERROR(zeCommandListClose, CmdList);
-    llvm::scope_exit ResetOnExit(
-        [&]() { CALL_ZE_SILENT(zeCommandListReset, CmdList); });
-    CALL_ZE_RET_ERROR(zeCommandQueueExecuteCommandLists, CmdQueue, 1, &CmdList,
-                      nullptr);
-    CALL_ZE_RET_ERROR(zeCommandQueueSynchronize, CmdQueue, L0DefaultTimeout);
-    ResetOnExit.release();
-    CALL_ZE_RET_ERROR(zeCommandListReset, CmdList);
-  }
+  auto CmdListOrErr = getImmCopyCmdList();
+  if (!CmdListOrErr)
+    return CmdListOrErr.takeError();
+  auto CmdList = *CmdListOrErr;
+  CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, nullptr, 0, nullptr);
 
   return Plugin::success();
 }

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -1018,7 +1018,6 @@ Expected<ze_command_list_handle_t> L0DeviceTy::createImmCopyCmdList() {
   return createImmCmdList(Ordinal, /*Index*/ 0);
 }
 
-
 Expected<ze_command_list_handle_t> L0DeviceTy::getImmCmdList() {
   auto &TLS = getTLS();
   auto CmdList = TLS.getImmCmdList();

--- a/offload/plugins-nextgen/level_zero/src/L0Device.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Device.cpp
@@ -963,33 +963,6 @@ Error L0DeviceTy::makeMemoryResident(void *Mem, size_t Size) {
   return Plugin::success();
 }
 
-// Command queues related functions.
-/// Create a command list with given ordinal and flags.
-Expected<ze_command_list_handle_t> L0DeviceTy::createCmdList(
-    ze_context_handle_t Context, ze_device_handle_t Device, uint32_t Ordinal,
-    ze_command_list_flags_t Flags, const std::string_view DeviceIdStr) {
-  ze_command_list_desc_t cmdListDesc = {ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC,
-                                        nullptr, // Extension.
-                                        Ordinal, Flags};
-  ze_command_list_handle_t cmdList;
-  CALL_ZE_RET_ERROR(zeCommandListCreate, Context, Device, &cmdListDesc,
-                    &cmdList);
-  ODBG(OLDT_Device) << "Created a command list " << cmdList
-                    << " (Ordinal: " << Ordinal << ") for device "
-                    << DeviceIdStr.data() << ".";
-  return cmdList;
-}
-
-/// Create a command list with default flags.
-Expected<ze_command_list_handle_t>
-L0DeviceTy::createCmdList(ze_context_handle_t Context,
-                          ze_device_handle_t Device, uint32_t Ordinal,
-                          const std::string_view DeviceIdStr) {
-  return (Ordinal == MaxOrdinal)
-             ? nullptr
-             : createCmdList(Context, Device, Ordinal, 0, DeviceIdStr);
-}
-
 /// Create an immediate command list.
 Expected<ze_command_list_handle_t>
 L0DeviceTy::createImmCmdList(uint32_t Ordinal, uint32_t Index, bool InOrder) {

--- a/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Kernel.cpp
@@ -159,58 +159,6 @@ static Error launchKernelWithImmCmdList(L0DeviceTy &l0Device,
   return Plugin::success();
 }
 
-static Error launchKernelWithCmdQueue(L0DeviceTy &l0Device,
-                                      ze_kernel_handle_t zeKernel,
-                                      L0LaunchEnvTy &KEnv) {
-  const auto DeviceId = l0Device.getDeviceId();
-  const auto *IdStr = l0Device.getZeIdCStr();
-
-  auto CmdListOrErr = l0Device.getCmdList();
-  if (!CmdListOrErr)
-    return CmdListOrErr.takeError();
-  ze_command_list_handle_t CmdList = *CmdListOrErr;
-  auto CmdQueueOrErr = l0Device.getCmdQueue();
-  if (!CmdQueueOrErr)
-    return CmdQueueOrErr.takeError();
-  const ze_command_queue_handle_t CmdQueue = *CmdQueueOrErr;
-
-  INFO(OMP_INFOTYPE_PLUGIN_KERNEL, DeviceId,
-       "Using regular command list for kernel submission.\n");
-
-  ze_event_handle_t Event = nullptr;
-
-  if (KEnv.IsCooperative) {
-    INFO(OMP_INFOTYPE_PLUGIN_KERNEL, DeviceId,
-         "Launching cooperative kernel " DPxMOD "\n", DPxPTR(zeKernel));
-    CALL_ZE_RET_ERROR(zeCommandListAppendLaunchCooperativeKernel, CmdList,
-                      zeKernel, &KEnv.GroupCounts, Event, 0, nullptr);
-  } else {
-    CALL_ZE_RET_ERROR(zeCommandListAppendLaunchKernel, CmdList, zeKernel,
-                      &KEnv.GroupCounts, Event, 0, nullptr);
-  }
-  KEnv.Lock.unlock();
-  CALL_ZE_RET_ERROR(zeCommandListClose, CmdList);
-
-  // Ensure command list is reset even on errors after this point.
-  llvm::scope_exit ResetOnExit(
-      [&]() { CALL_ZE_SILENT(zeCommandListReset, CmdList); });
-
-  CALL_ZE_RET_ERROR_MTX(zeCommandQueueExecuteCommandLists, l0Device.getMutex(),
-                        CmdQueue, 1, &CmdList, nullptr);
-  INFO(OMP_INFOTYPE_PLUGIN_KERNEL, DeviceId,
-       "Submitted kernel " DPxMOD " to device %s\n", DPxPTR(zeKernel), IdStr);
-  CALL_ZE_RET_ERROR(zeCommandQueueSynchronize, CmdQueue, L0DefaultTimeout);
-  if (Event) {
-    if (auto Err = l0Device.releaseEvent(Event))
-      return Err;
-  }
-  INFO(OMP_INFOTYPE_PLUGIN_KERNEL, DeviceId,
-       "Executed kernel entry " DPxMOD " on device %s\n", DPxPTR(zeKernel),
-       IdStr);
-
-  return Plugin::success();
-}
-
 Error L0KernelTy::setKernelGroups(L0DeviceTy &l0Device, L0LaunchEnvTy &KEnv,
                                   uint32_t NumThreads[3],
                                   uint32_t NumBlocks[3]) const {
@@ -355,13 +303,9 @@ Error L0KernelTy::launchImpl(GenericDeviceTy &GenericDevice,
   if (auto Err = setIndirectFlags(l0Device, KEnv))
     return Err;
 
-  // The next calls should unlock the KernelLock internally.
-  const bool UseImmCmdList = l0Device.useImmForCompute();
-  if (UseImmCmdList)
-    return launchKernelWithImmCmdList(l0Device, zeKernel, KEnv,
-                                      Options.CommandMode);
-
-  return launchKernelWithCmdQueue(l0Device, zeKernel, KEnv);
+  // The next call should unlock the KernelLock internally.
+  return launchKernelWithImmCmdList(l0Device, zeKernel, KEnv,
+                                    Options.CommandMode);
 }
 
 Expected<uint32_t>

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -212,23 +212,13 @@ Error LevelZeroPluginTy::syncBarrierImpl(omp_interop_val_t *Interop) {
     return Plugin::success();
 
   const auto L0 = static_cast<L0Interop::Property *>(Interop->rtl_property);
-  const auto device_id = Interop->device_id;
-  auto &l0Device = getDeviceFromId(device_id);
 
-  // We can synchronize both L0 & SYCL objects with the same ze command.
-  if (l0Device.useImmForInterop()) {
-    ODBG(OLDT_Sync) << "LevelZeroPluginTy::sync_barrier: Synchronizing "
-                    << Interop << " with ImmCmdList barrier";
-    auto ImmCmdList = L0->ImmCmdList;
+  ODBG(OLDT_Sync) << "LevelZeroPluginTy::sync_barrier: Synchronizing "
+                  << Interop << " with ImmCmdList barrier";
+  auto ImmCmdList = L0->ImmCmdList;
 
-    CALL_ZE_RET_ERROR(zeCommandListHostSynchronize, ImmCmdList,
-                      L0DefaultTimeout);
-  } else {
-    ODBG(OLDT_Sync) << "LevelZeroPluginTy::sync_barrier: Synchronizing "
-                    << Interop << " with queue synchronize";
-    auto CmdQueue = L0->CommandQueue;
-    CALL_ZE_RET_ERROR(zeCommandQueueSynchronize, CmdQueue, L0DefaultTimeout);
-  }
+  CALL_ZE_RET_ERROR(zeCommandListHostSynchronize, ImmCmdList,
+                    L0DefaultTimeout);
 
   return Plugin::success();
 }
@@ -243,33 +233,14 @@ Error LevelZeroPluginTy::asyncBarrierImpl(omp_interop_val_t *Interop) {
     return Plugin::success();
 
   const auto L0 = static_cast<L0Interop::Property *>(Interop->rtl_property);
-  const auto device_id = Interop->device_id;
   if (Interop->attrs.inorder)
     return Plugin::success();
 
-  auto &l0Device = getDeviceFromId(device_id);
-  if (l0Device.useImmForInterop()) {
-    ODBG(OLDT_Sync) << "LevelZeroPluginTy::async_barrier: Appending ImmCmdList "
-                    << "barrier to " << Interop;
-    auto ImmCmdList = L0->ImmCmdList;
-    CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, ImmCmdList, nullptr, 0,
-                      nullptr);
-  } else {
-#if 0
-    // TODO: re-enable once we have a way to delay the CmdList reset .
-    ODBG(OLDT_Sync) << "LevelZeroPluginTy::async_barrier: Appending CmdList "
-                   << "barrier to " << Interop;
-    auto CmdQueue = L0->CommandQueue;
-    ze_command_list_handle_t CmdList = l0Device.getCmdList();
-    CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, CmdList, nullptr, 0, nullptr);
-    CALL_ZE_RET_ERROR(zeCommandListClose, CmdList);
-    CALL_ZE_RET_ERROR(zeCommandQueueExecuteCommandLists, CmdQueue, 1, &CmdList,
-                      nullptr);
-    CALL_ZE_RET_ERROR(zeCommandListReset, CmdList);
-#else
-    return syncBarrierImpl(Interop);
-#endif
-  }
+  ODBG(OLDT_Sync) << "LevelZeroPluginTy::async_barrier: Appending ImmCmdList "
+                  << "barrier to " << Interop;
+  auto ImmCmdList = L0->ImmCmdList;
+  CALL_ZE_RET_ERROR(zeCommandListAppendBarrier, ImmCmdList, nullptr, 0,
+                    nullptr);
 
   return Plugin::success();
 }

--- a/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
+++ b/offload/plugins-nextgen/level_zero/src/L0Plugin.cpp
@@ -217,8 +217,7 @@ Error LevelZeroPluginTy::syncBarrierImpl(omp_interop_val_t *Interop) {
                   << Interop << " with ImmCmdList barrier";
   auto ImmCmdList = L0->ImmCmdList;
 
-  CALL_ZE_RET_ERROR(zeCommandListHostSynchronize, ImmCmdList,
-                    L0DefaultTimeout);
+  CALL_ZE_RET_ERROR(zeCommandListHostSynchronize, ImmCmdList, L0DefaultTimeout);
 
   return Plugin::success();
 }


### PR DESCRIPTION
The code was in a dead path as immediate command lists are always used.