### PR TITLE
[docs] Rename SphinxQuickstartTemplate.{rst|md} for blame

### DIFF
--- a/llvm/docs/MarkdownQuickstartTemplate.md
+++ b/llvm/docs/MarkdownQuickstartTemplate.md
@@ -158,4 +158,4 @@ integration documentation can be found in the [myst-parser docs].
 
 ## Generating the documentation
 
-see [Sphinx Quickstart Template](project:SphinxQuickstartTemplate.rst#Generating the documentation)
+see [Sphinx Quickstart Template](project:SphinxQuickstartTemplate.md#Generating the documentation)

--- a/llvm/docs/README.txt
+++ b/llvm/docs/README.txt
@@ -20,7 +20,7 @@ The mapping between reStructuredText files and generated documentation is
 `docs/Foo.rst` <-> `<build-dir>/docs//html/Foo.html` <-> `https://llvm.org/docs/Foo.html`.
 
 If you are interested in writing new documentation, you will want to read
-`SphinxQuickstartTemplate.rst` which will get you writing documentation
+`SphinxQuickstartTemplate.md` which will get you writing documentation
 very fast and includes examples of the most important reStructuredText
 markup syntax.
 

--- a/llvm/docs/SphinxQuickstartTemplate.md
+++ b/llvm/docs/SphinxQuickstartTemplate.md
@@ -18,7 +18,7 @@ LLVM documentation is written in `reStructuredText`_, a markup syntax similar to
 How to use this template
 ========================
 
-This article is located in ``docs/SphinxQuickstartTemplate.rst``. To use it as a template, make a copy and open it in a text editor. You can then write your docs, and then send the new article to llvm-commits for review.
+This article is located in ``docs/SphinxQuickstartTemplate.md``. To use it as a template, make a copy and open it in a text editor. You can then write your docs, and then send the new article to llvm-commits for review.
 
 To view the restructuredText source file for this article, click **Show Source** on the right sidebar.
 

--- a/openmp/docs/README.txt
+++ b/openmp/docs/README.txt
@@ -21,7 +21,7 @@ The mapping between reStructuredText files and generated documentation is
 `https://openmp.llvm.org/docs/Foo.html`.
 
 If you are interested in writing new documentation, you will want to read
-`llvm/docs/SphinxQuickstartTemplate.rst` which will get you writing
+`llvm/docs/SphinxQuickstartTemplate.md` which will get you writing
 documentation very fast and includes examples of the most important
 reStructuredText markup syntax.
 


### PR DESCRIPTION
Renames SphinxQuickstartTemplate.rst to SphinxQuickstartTemplate.md as an isolated commit to preserve blame history. The file content is not yet valid Markdown; the rewrite follows in a stacked PR. Cross-references in MarkdownQuickstartTemplate.md, README.txt, and openmp/docs/README.txt are updated accordingly.