### PR TITLE
[libc] Enable baremetal float printf using modular format

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -13,9 +13,6 @@
     "LIBC_CONF_PRINTF_DISABLE_FIXED_POINT": {
       "value": true
     },
-    "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
-      "value": true
-    },
     "LIBC_CONF_PRINTF_DISABLE_INDEX_MODE": {
       "value": true
     },
@@ -32,6 +29,9 @@
       "value": true
     },
     "LIBC_COPT_PRINTF_DISABLE_BITINT": {
+      "value": true
+    },
+    "LIBC_COPT_PRINTF_MODULAR": {
       "value": true
     }
   },

--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -31,7 +31,7 @@
     "LIBC_COPT_PRINTF_DISABLE_BITINT": {
       "value": true
     },
-    "LIBC_COPT_PRINTF_MODULAR": {
+    "LIBC_CONF_PRINTF_MODULAR": {
       "value": true
     }
   },


### PR DESCRIPTION
The most best configuration for llvm-libc is for it to be used with a recent clang. Accordingly, this patch enables floating point type support in printf for baremetal without inflating code size by also enabling modular printf support. This is safe for older clang and other compilers, but it would increase code size for the default baremetal configuration on such targets.