### PR TITLE
[CIR] Emit globals for declarations that force externally visible defs

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -536,11 +536,13 @@ void CIRGenModule::emitGlobal(clang::GlobalDecl gd) {
         deferredAnnotations[mangledName] = fd;
     }
     if (!fd->doesThisDeclarationHaveABody()) {
-      if (!fd->doesDeclarationForceExternallyVisibleDefinition())
+      if (!fd->doesDeclarationForceExternallyVisibleDefinition() &&
+          (!fd->isMultiVersion() || !getTarget().getTriple().isAArch64()))
         return;
 
-      errorNYI(fd->getSourceRange(),
-               "function declaration that forces code gen");
+      const CIRGenFunctionInfo &fi = getTypes().arrangeGlobalDeclaration(gd);
+      cir::FuncType ty = getTypes().getFunctionType(fi);
+      getAddrOfFunction(gd, ty, /*ForVTable=*/false, /*DontDefer=*/false);
       return;
     }
   } else {

--- a/clang/test/CIR/CodeGen/inline-extern-force-codegen.c
+++ b/clang/test/CIR/CodeGen/inline-extern-force-codegen.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c17 -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c17 -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c17 -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+// C99 inline definition followed by an extern declaration that forces an
+// externally visible declaration of the same symbol (berkeley-abc if.h shape).
+
+inline int cut_copy(int *dst, int *src) { return *dst = *src; }
+extern int cut_copy(int *dst, int *src);
+
+int driver(void) { return 0; }
+
+// CIR: cir.func{{.*}} @cut_copy(
+// CIR: cir.return
+
+// LLVM: define{{.*}} @cut_copy(
+// LLVM: define{{.*}} @driver(
+
+// OGCG: define{{.*}} @cut_copy(
+// OGCG: define{{.*}} @driver(

--- a/clang/test/CIR/CodeGen/inline-extern-force-codegen.c
+++ b/clang/test/CIR/CodeGen/inline-extern-force-codegen.c
@@ -3,10 +3,10 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c17 -fclangir -emit-llvm %s -o %t-cir.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c17 -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
 
 // C99 inline definition followed by an extern declaration that forces an
-// externally visible declaration of the same symbol (berkeley-abc if.h shape).
+// externally visible declaration of the same symbol.
 
 inline int cut_copy(int *dst, int *src) { return *dst = *src; }
 extern int cut_copy(int *dst, int *src);
@@ -18,6 +18,3 @@ int driver(void) { return 0; }
 
 // LLVM: define{{.*}} @cut_copy(
 // LLVM: define{{.*}} @driver(
-
-// OGCG: define{{.*}} @cut_copy(
-// OGCG: define{{.*}} @driver(


### PR DESCRIPTION
CIRGenModule::emitGlobal reported NYI for forward declarations that
force an externally visible definition under C99 inline rules (inline
definition in the TU, then a later extern declaration). Classic
CodeGenModule already materializes these with GetOrCreateLLVMFunction;
wire the same path through getAddrOfFunction, including the AArch64
multiversion guard from OGCG.

This pattern shows up in SPEC CPU 2026 berkeley-abc `if.h` when
compiling `abcIf.c` for 729.abc_r / 829.abc_s (`If_CutCopy` at line 527).

Test: `inline-extern-force-codegen.c` with CIR, LLVM, and OGCG checks.
