### PR TITLE
[lldb][windows] enable CI tests

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -201,12 +201,7 @@ SKIP_PROJECTS = ["docs", "gn"]
 # where a project can be built but its tests are not yet stable on that
 # platform, so we still want a compile-time signal.
 PROJECT_CHECK_TARGETS_OVERRIDE = {
-    "Windows": {
-        # TODO(issues/132800): LLDB tests need environment setup on Windows.
-        # In the meantime, at least compile lldb and lldb-dap to catch
-        # breakage.
-        "lldb": "lldb lldb-dap",
-    },
+    "Windows": {},
 }
 
 

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -123,6 +123,8 @@ EXCLUDE_WINDOWS = {
 # enabled on changes to dependencies.
 EXCLUDE_DEPENDENTS_WINDOWS = {
     "flang",
+    # TODO: Re-enable once Windows CI timings allow it (daemonized testing).
+    "lldb",
 }
 
 EXCLUDE_MAC = {
@@ -195,16 +197,6 @@ SKIP_BUILD_PROJECTS = ["CIR", "lit", "libc-shared"]
 # Projects that should not run any tests. These need to be metaprojects.
 SKIP_PROJECTS = ["docs", "gn"]
 
-# Overrides for PROJECT_CHECK_TARGETS on a per-platform basis. If a platform
-# has an entry for a given project here, its value is used as the ninja
-# target(s) instead of the default check target. This is intended for cases
-# where a project can be built but its tests are not yet stable on that
-# platform, so we still want a compile-time signal.
-PROJECT_CHECK_TARGETS_OVERRIDE = {
-    "Windows": {},
-}
-
-
 def _add_dependencies(projects: Set[str], runtimes: Set[str]) -> Set[str]:
     projects_with_dependents = set(projects)
     current_projects_count = 0
@@ -262,11 +254,8 @@ def _compute_project_check_targets(
     projects_to_test: Set[str], platform: str
 ) -> Set[str]:
     check_targets = set()
-    platform_overrides = PROJECT_CHECK_TARGETS_OVERRIDE.get(platform, {})
     for project_to_test in projects_to_test:
-        if project_to_test in platform_overrides:
-            check_targets.add(platform_overrides[project_to_test])
-        elif project_to_test in PROJECT_CHECK_TARGETS:
+        if project_to_test in PROJECT_CHECK_TARGETS:
             check_targets.add(PROJECT_CHECK_TARGETS[project_to_test])
     return check_targets
 

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -191,6 +191,16 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
 
+    def test_lldb(self):
+        env_variables = compute_projects.get_env_variables(
+            ["lldb/CMakeLists.txt"], "Linux"
+        )
+        self.assertEqual(env_variables["projects_to_build"], "clang;lldb;llvm")
+        self.assertEqual(env_variables["project_check_targets"], "check-lldb")
+        self.assertEqual(env_variables["runtimes_to_build"], "")
+        self.assertEqual(env_variables["runtimes_check_targets"], "")
+        self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+
     def test_mlir(self):
         env_variables = compute_projects.get_env_variables(
             ["mlir/CMakeLists.txt"], "Linux"

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -39,11 +39,11 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;lldb;llvm;mlir;polly",
+            "clang;clang-tools-extra;lld;llvm;mlir;polly",
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-tools check-lld check-llvm check-mlir check-polly lldb lldb-dap",
+            "check-clang check-clang-tools check-lld check-llvm check-mlir check-polly",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(
@@ -112,11 +112,11 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;lldb;llvm",
+            "clang;clang-tools-extra;lld;llvm",
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-tools lldb lldb-dap",
+            "check-clang check-clang-tools",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "compiler-rt")
         self.assertEqual(
@@ -187,16 +187,6 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["projects_to_build"], "bolt;clang;lld;llvm")
         self.assertEqual(env_variables["project_check_targets"], "check-bolt")
-        self.assertEqual(env_variables["runtimes_to_build"], "")
-        self.assertEqual(env_variables["runtimes_check_targets"], "")
-        self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
-
-    def test_lldb(self):
-        env_variables = compute_projects.get_env_variables(
-            ["lldb/CMakeLists.txt"], "Linux"
-        )
-        self.assertEqual(env_variables["projects_to_build"], "clang;lldb;llvm")
-        self.assertEqual(env_variables["project_check_targets"], "check-lldb")
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
@@ -327,11 +317,11 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;lldb;llvm;mlir;polly",
+            "clang;clang-tools-extra;lld;llvm;mlir;polly",
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-cir check-clang-tools check-lld check-llvm check-mlir check-polly lldb lldb-dap",
+            "check-clang check-clang-cir check-clang-tools check-lld check-llvm check-mlir check-polly",
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
@@ -472,7 +462,7 @@ class TestComputeProjects(unittest.TestCase):
             ["lldb/CMakeLists.txt"], "Windows"
         )
         self.assertEqual(env_variables["projects_to_build"], "clang;lld;lldb;llvm")
-        self.assertEqual(env_variables["project_check_targets"], "lldb lldb-dap")
+        self.assertEqual(env_variables["project_check_targets"], "check-lldb")
         self.assertEqual(env_variables["runtimes_to_build"], "compiler-rt")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")


### PR DESCRIPTION
This patch enables CI testing for lldb on Windows. It skips dependent PR testing for now until we enable daemonized testing.

This patch also skips `TestDAP_restart_console` on Windows because it's failing on the bots and is unresolved in the docker container. See https://github.com/llvm/llvm-project/issues/200840 fore more details.

fix https://github.com/llvm/llvm-project/issues/132800.