### PR TITLE
[AArch64] Use GPR64commonRegClass for finding callee save regs, not GPR64RegClass

### DIFF
--- a/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
+++ b/llvm/lib/CodeGen/DeadMachineInstructionElim.cpp
@@ -32,7 +32,7 @@ namespace {
 class DeadMachineInstructionElimImpl {
   const MachineRegisterInfo *MRI = nullptr;
   const TargetInstrInfo *TII = nullptr;
-  LiveRegUnits LivePhysRegs;
+  LiveRegUnits LiveRegs;
 
 public:
   bool runImpl(MachineFunction &MF);
@@ -81,7 +81,7 @@ bool DeadMachineInstructionElimImpl::runImpl(MachineFunction &MF) {
 
   const TargetSubtargetInfo &ST = MF.getSubtarget();
   TII = ST.getInstrInfo();
-  LivePhysRegs.init(*ST.getRegisterInfo());
+  LiveRegs.init(*ST.getRegisterInfo());
 
   bool NeedAnotherIteration;
   bool AnyChanges = eliminateDeadMI(MF, NeedAnotherIteration);
@@ -99,7 +99,7 @@ bool DeadMachineInstructionElimImpl::eliminateDeadMI(
   // more likely that chains of dependent but ultimately dead instructions will
   // be cleaned up.
   for (MachineBasicBlock *MBB : post_order(&MF)) {
-    LivePhysRegs.addLiveOuts(*MBB);
+    LiveRegs.addLiveOuts(*MBB);
     NeedsProcessing.erase(MBB);
 
     // Now scan the instructions and delete dead ones, tracking physreg
@@ -108,7 +108,7 @@ bool DeadMachineInstructionElimImpl::eliminateDeadMI(
       if (MI.isDebugInstr())
         continue;
       // If the instruction is dead, delete it!
-      if (MI.isDead(*MRI, &LivePhysRegs)) {
+      if (MI.isDead(*MRI, &LiveRegs)) {
         if (MI.isPHI()) {
           for (MachineBasicBlock *P : MBB->predecessors())
             NeedsProcessing.insert(P);
@@ -122,10 +122,10 @@ bool DeadMachineInstructionElimImpl::eliminateDeadMI(
         ++NumDeletes;
         continue;
       }
-      LivePhysRegs.stepBackward(MI);
+      LiveRegs.stepBackward(MI);
     }
   }
-  LivePhysRegs.clear();
+  LiveRegs.clear();
   NeedAnotherIteration = !NeedsProcessing.empty();
   return AnyChanges;
 }

--- a/llvm/lib/CodeGen/RemoveLoadsIntoFakeUses.cpp
+++ b/llvm/lib/CodeGen/RemoveLoadsIntoFakeUses.cpp
@@ -108,17 +108,17 @@ bool RemoveLoadsIntoFakeUses::run(MachineFunction &MF) {
 
   bool AnyChanges = false;
 
-  LiveRegUnits LivePhysRegs;
+  LiveRegUnits LiveRegs;
   const MachineRegisterInfo *MRI = &MF.getRegInfo();
   const TargetSubtargetInfo &ST = MF.getSubtarget();
   const TargetInstrInfo *TII = ST.getInstrInfo();
   const TargetRegisterInfo *TRI = ST.getRegisterInfo();
 
   SmallVector<MachineInstr *> RegFakeUses;
-  LivePhysRegs.init(*TRI);
+  LiveRegs.init(*TRI);
   for (MachineBasicBlock *MBB : post_order(&MF)) {
     RegFakeUses.clear();
-    LivePhysRegs.addLiveOuts(*MBB);
+    LiveRegs.addLiveOuts(*MBB);
 
     for (MachineInstr &MI : make_early_inc_range(reverse(*MBB))) {
       if (MI.isFakeUse()) {
@@ -127,7 +127,7 @@ bool RemoveLoadsIntoFakeUses::run(MachineFunction &MF) {
         // Track the Fake Uses that use these register units so that we can
         // delete them if we delete the corresponding load.
         RegFakeUses.push_back(&MI);
-        // Do not record FAKE_USE uses in LivePhysRegs so that we can recognize
+        // Do not record FAKE_USE uses in LiveRegs so that we can recognize
         // otherwise-unused loads.
         continue;
       }
@@ -137,7 +137,7 @@ bool RemoveLoadsIntoFakeUses::run(MachineFunction &MF) {
       if (MI.getRestoreSize(TII)) {
         Register Reg = MI.getOperand(0).getReg();
         // Don't delete live physreg defs, or any reserved register defs.
-        if (!LivePhysRegs.available(Reg) || MRI->isReserved(Reg))
+        if (!LiveRegs.available(Reg) || MRI->isReserved(Reg))
           continue;
         // There should typically be an exact match between the loaded register
         // and the FAKE_USE, but sometimes regalloc will choose to load a larger
@@ -171,7 +171,7 @@ bool RemoveLoadsIntoFakeUses::run(MachineFunction &MF) {
         continue;
       }
 
-      // In addition to tracking LivePhysRegs, we need to clear RegFakeUses each
+      // In addition to tracking LiveRegs, we need to clear RegFakeUses each
       // time a register is defined, as existing FAKE_USEs no longer apply to
       // that register.
       if (!RegFakeUses.empty()) {
@@ -188,7 +188,7 @@ bool RemoveLoadsIntoFakeUses::run(MachineFunction &MF) {
         }
       }
       if (!MI.isDebugInstr())
-        LivePhysRegs.stepBackward(MI);
+        LiveRegs.stepBackward(MI);
     }
   }
 

--- a/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
@@ -21,7 +21,6 @@
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/LiveIntervals.h"
-#include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -922,7 +922,9 @@ AArch64FrameLowering::findScratchNonCalleeSaveRegister(MachineBasicBlock *MBB,
   if (LiveRegs.available(MRI, AArch64::X9))
     return AArch64::X9;
 
-  for (unsigned Reg : AArch64::GPR64RegClass) {
+  // GPR64common excludes XZR/WZR and SP/WSP, which are not valid scratch regs
+  // for stack adjustment (GPR64sp) instructions.
+  for (MCPhysReg Reg : AArch64::GPR64commonRegClass) {
     if (LiveRegs.available(MRI, Reg))
       return Reg;
   }
@@ -939,9 +941,8 @@ bool AArch64FrameLowering::canUseAsPrologue(
   const AArch64FunctionInfo *AFI = MF->getInfo<AArch64FunctionInfo>();
 
   if (AFI->hasSwiftAsyncContext()) {
-    const AArch64RegisterInfo &TRI = *Subtarget.getRegisterInfo();
     const MachineRegisterInfo &MRI = MF->getRegInfo();
-    LivePhysRegs LiveRegs(TRI);
+    LivePhysRegs LiveRegs(*RegInfo);
     getLiveRegsForEntryMBB(LiveRegs, MBB);
     // The StoreSwiftAsyncContext clobbers X16 and X17. Make sure they are
     // available.
@@ -3369,15 +3370,13 @@ bool isMergeableStackTaggingInstruction(MachineInstr &MI, int64_t &Offset,
 static size_t countAvailableScavengerSlots(LivePhysRegs &LiveRegs,
                                            MachineRegisterInfo &MRI,
                                            RegScavenger *RS) {
-  auto FreeGPRs =
-      llvm::count_if(AArch64::GPR64RegClass, [&LiveRegs, &MRI](auto Reg) {
+  unsigned FreeGPRs =
+      llvm::count_if(AArch64::GPR64commonRegClass, [&](MCPhysReg Reg) {
         return LiveRegs.available(MRI, Reg);
       });
-
   size_t NumEmergencySlots = 0;
   if (RS)
     NumEmergencySlots = RS->getNumScavengingFrameIndices();
-
   return FreeGPRs + NumEmergencySlots;
 }
 
@@ -3448,7 +3447,7 @@ MachineBasicBlock::iterator tryMergeAdjacentSTG(MachineBasicBlock::iterator II,
   // FIXME : This approach of bailing out from merge is conservative in
   // some ways like even if stg loops are not present after merge the
   // insert list, this liveness check is done (which is not needed).
-  LivePhysRegs LiveRegs(*(MBB->getParent()->getSubtarget().getRegisterInfo()));
+  LivePhysRegs LiveRegs(*MBB->getParent()->getSubtarget().getRegisterInfo());
   LiveRegs.addLiveOuts(*MBB);
   for (auto I = MBB->rbegin();; ++I) {
     MachineInstr &MI = *I;


### PR DESCRIPTION
GPR64RegClass includes XZR/WZR and SP/WSP, which we cannot and should not use.