### PR TITLE
[CIR] Lower member-pointer casts in constant emitter

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -543,9 +543,12 @@ def CIR_DataMemberAttr : CIR_ValueLikeAttr<"DataMember", "data_member"> {
     A data member attribute is a literal attribute that represents a constant
     pointer-to-data-member value.
 
-    The `member_index` parameter represents the index of the pointed-to member
-    within its containing record. It is an optional parameter; lack of this
-    parameter indicates a null pointer-to-data-member value.
+    The `member_index` parameter is the index of the pointed-to member within
+    its containing record (the attribute's `classTy`).  It is an optional
+    parameter; lack of this parameter indicates a null pointer-to-data-member
+    value.  A non-null pointer to a member of a base class subobject in a
+    derived class is represented by a leaf attribute in the base class type
+    wrapped in `cir.derived_data_member` operations.
 
     Example:
     ```

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -472,13 +472,13 @@ public:
   //===--------------------------------------------------------------------===//
   // UnaryOp creation helpers
   //===--------------------------------------------------------------------===//
-  mlir::Value createNeg(mlir::Value value) {
+  mlir::Value createNeg(mlir::Value value, bool nsw = false) {
 
     if (auto intTy = mlir::dyn_cast<cir::IntType>(value.getType())) {
       // Source is a unsigned integer: first cast it to signed.
       if (intTy.isUnsigned())
         value = createIntCast(value, getSIntNTy(intTy.getWidth()));
-      return createMinus(value.getLoc(), value);
+      return createMinus(value.getLoc(), value, nsw);
     }
 
     llvm_unreachable("negation for the given type is NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -472,13 +472,13 @@ public:
   //===--------------------------------------------------------------------===//
   // UnaryOp creation helpers
   //===--------------------------------------------------------------------===//
-  mlir::Value createNeg(mlir::Value value, bool nsw = false) {
+  mlir::Value createNeg(mlir::Value value) {
 
     if (auto intTy = mlir::dyn_cast<cir::IntType>(value.getType())) {
       // Source is a unsigned integer: first cast it to signed.
       if (intTy.isUnsigned())
         value = createIntCast(value, getSIntNTy(intTy.getWidth()));
-      return createMinus(value.getLoc(), value, nsw);
+      return createMinus(value.getLoc(), value);
     }
 
     llvm_unreachable("negation for the given type is NYI");

--- a/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
+++ b/clang/lib/CIR/CodeGen/CIRGenCXXABI.h
@@ -64,6 +64,13 @@ public:
   virtual cir::MethodAttr buildVirtualMethodAttr(cir::MethodType methodTy,
                                                  const CXXMethodDecl *md) = 0;
 
+  virtual mlir::Attribute emitMemberPointerConversion(const CastExpr *e,
+                                                      mlir::Attribute src) = 0;
+
+  virtual mlir::Value emitMemberPointerConversion(CIRGenFunction &cgf,
+                                                  const CastExpr *e,
+                                                  mlir::Value src) = 0;
+
 public:
   /// Similar to AddedStructorArgs, but only notes the number of additional
   /// arguments.

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -933,11 +933,18 @@ public:
     switch (e->getCastKind()) {
     case CK_ToUnion:
     case CK_AddressSpaceConversion:
-    case CK_ReinterpretMemberPointer:
-    case CK_DerivedToBaseMemberPointer:
-    case CK_BaseToDerivedMemberPointer:
       cgm.errorNYI(e->getBeginLoc(), "ConstExprEmitter::VisitCastExpr");
       return {};
+
+    case CK_ReinterpretMemberPointer:
+    case CK_DerivedToBaseMemberPointer:
+    case CK_BaseToDerivedMemberPointer: {
+      mlir::Attribute srcAttr =
+          emitter.tryEmitPrivate(subExpr, subExpr->getType());
+      if (!srcAttr)
+        return {};
+      return cgm.getCXXABI().emitMemberPointerConversion(e, srcAttr);
+    }
 
     case CK_LValueToRValue:
     case CK_AtomicToNonAtomic:

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -1926,11 +1926,6 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
 
     const auto *fieldDecl = cast<FieldDecl>(memberDecl);
     const auto *mpt = destType->castAs<MemberPointerType>();
-    const CXXRecordDecl *pointerClass = mpt->getMostRecentCXXRecordDecl();
-    const auto *fieldParent = cast<CXXRecordDecl>(fieldDecl->getParent());
-    if (fieldParent != pointerClass)
-      return {};
-
     return cgm.getDataMemberAttrForField(mpt, fieldDecl);
   }
   case APValue::LValue:

--- a/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprConstant.cpp
@@ -1907,12 +1907,6 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
     if (!memberDecl)
       return builder.getZeroInitAttr(cgm.convertType(destType));
 
-    if (value.isMemberPointerToDerivedMember()) {
-      cgm.errorNYI(
-          "ConstExprEmitter::tryEmitPrivate member pointer to derived member");
-      return {};
-    }
-
     if (auto const *cxxDecl = dyn_cast<CXXMethodDecl>(memberDecl)) {
       auto ty = mlir::cast<cir::MethodType>(cgm.convertType(destType));
       if (cxxDecl->isVirtual())
@@ -1923,10 +1917,14 @@ mlir::Attribute ConstantEmitter::tryEmitPrivate(const APValue &value,
       return cgm.getBuilder().getMethodAttr(ty, methodFuncOp);
     }
 
-    auto cirTy = mlir::cast<cir::DataMemberType>(cgm.convertType(destType));
-
     const auto *fieldDecl = cast<FieldDecl>(memberDecl);
-    return builder.getDataMemberAttr(cirTy, fieldDecl->getFieldIndex());
+    const auto *mpt = destType->castAs<MemberPointerType>();
+    const CXXRecordDecl *pointerClass = mpt->getMostRecentCXXRecordDecl();
+    const auto *fieldParent = cast<CXXRecordDecl>(fieldDecl->getParent());
+    if (fieldParent != pointerClass)
+      return {};
+
+    return cgm.getDataMemberAttrForField(mpt, fieldDecl);
   }
   case APValue::LValue:
     return ConstantLValueEmitter(*this, value, destType).tryEmit();

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -679,7 +679,7 @@ public:
         mlir::Location loc = cgf.getLoc(e->getSourceRange());
         mlir::Value numElts = cgf.getVLASize(vla).numElts;
         if (!e->isIncrementOp())
-          numElts = cgf.getBuilder().createNeg(numElts);
+          numElts = cgf.getBuilder().createNeg(numElts, /*nsw=*/true);
         assert(!cir::MissingFeatures::sanitizers());
         value = cgf.getBuilder().createPtrStride(loc, value, numElts);
       } else {

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -679,7 +679,7 @@ public:
         mlir::Location loc = cgf.getLoc(e->getSourceRange());
         mlir::Value numElts = cgf.getVLASize(vla).numElts;
         if (!e->isIncrementOp())
-          numElts = cgf.getBuilder().createNeg(numElts, /*nsw=*/true);
+          numElts = cgf.getBuilder().createNeg(numElts);
         assert(!cir::MissingFeatures::sanitizers());
         value = cgf.getBuilder().createPtrStride(loc, value, numElts);
       } else {

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CIRGenCXXABI.h"
 #include "CIRGenConstantEmitter.h"
 #include "CIRGenFunction.h"
 #include "CIRGenValue.h"
@@ -2329,44 +2330,11 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
         loc, cgf.cgm.emitNullMemberAttr(destTy, mpt));
   }
 
-  case CK_ReinterpretMemberPointer: {
-    mlir::Value src = Visit(subExpr);
-    return builder.createBitcast(cgf.getLoc(subExpr->getExprLoc()), src,
-                                 cgf.convertType(destTy));
-  }
+  case CK_ReinterpretMemberPointer:
   case CK_BaseToDerivedMemberPointer:
   case CK_DerivedToBaseMemberPointer: {
     mlir::Value src = Visit(subExpr);
-
-    assert(!cir::MissingFeatures::memberFuncPtrAuthInfo());
-
-    QualType derivedTy =
-        kind == CK_DerivedToBaseMemberPointer ? subExpr->getType() : destTy;
-    const auto *mpType = derivedTy->castAs<MemberPointerType>();
-    NestedNameSpecifier qualifier = mpType->getQualifier();
-    assert(qualifier && "member pointer without class qualifier");
-    const Type *qualifierType = qualifier.getAsType();
-    assert(qualifierType && "member pointer qualifier is not a type");
-    const CXXRecordDecl *derivedClass = qualifierType->getAsCXXRecordDecl();
-    CharUnits offset =
-        cgf.cgm.computeNonVirtualBaseClassOffset(derivedClass, ce->path());
-
-    mlir::Location loc = cgf.getLoc(subExpr->getExprLoc());
-    mlir::Type resultTy = cgf.convertType(destTy);
-    mlir::IntegerAttr offsetAttr = builder.getIndexAttr(offset.getQuantity());
-
-    if (subExpr->getType()->isMemberFunctionPointerType()) {
-      if (kind == CK_BaseToDerivedMemberPointer)
-        return cir::DerivedMethodOp::create(builder, loc, resultTy, src,
-                                            offsetAttr);
-      return cir::BaseMethodOp::create(builder, loc, resultTy, src, offsetAttr);
-    }
-
-    if (kind == CK_BaseToDerivedMemberPointer)
-      return cir::DerivedDataMemberOp::create(builder, loc, resultTy, src,
-                                              offsetAttr);
-    return cir::BaseDataMemberOp::create(builder, loc, resultTy, src,
-                                         offsetAttr);
+    return cgf.cgm.getCXXABI().emitMemberPointerConversion(cgf, ce, src);
   }
 
   case CK_LValueToRValue:

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -2416,14 +2416,13 @@ static const FieldDecl *getDataMemberFieldFromExpr(const Expr *e) {
   e = e->IgnoreParenImpCasts();
   if (const auto *declRef = dyn_cast<DeclRefExpr>(e))
     return dyn_cast<FieldDecl>(declRef->getDecl());
-  if (const auto *memberExpr = dyn_cast<MemberExpr>(e))
+  else if (const auto *memberExpr = dyn_cast<MemberExpr>(e))
     return dyn_cast<FieldDecl>(memberExpr->getMemberDecl());
-  if (const auto *unaryOp = dyn_cast<UnaryOperator>(e)) {
+  else if (const auto *castExpr = dyn_cast<CastExpr>(e))
+    return getDataMemberFieldFromExpr(castExpr->getSubExpr());
+  else if (const auto *unaryOp = dyn_cast<UnaryOperator>(e))
     if (unaryOp->getOpcode() == UO_AddrOf)
       return getDataMemberFieldFromExpr(unaryOp->getSubExpr());
-  }
-  if (const auto *castExpr = dyn_cast<CastExpr>(e))
-    return getDataMemberFieldFromExpr(castExpr->getSubExpr());
   return nullptr;
 }
 
@@ -2464,12 +2463,8 @@ CIRGenItaniumCXXABI::emitMemberPointerConversion(const CastExpr *e,
     return cgm.getDataMemberAttrForField(destMpt, field);
   }
 
-  if (const FieldDecl *field = getDataMemberFieldFromExpr(e->getSubExpr())) {
-    const auto *fieldParent = cast<CXXRecordDecl>(field->getParent());
-    if (fieldParent == destMpt->getMostRecentCXXRecordDecl())
-      return cgm.getDataMemberAttrForField(destMpt, field);
-    return {};
-  }
+  if (const FieldDecl *field = getDataMemberFieldFromExpr(e->getSubExpr()))
+    return cgm.getDataMemberAttrForField(destMpt, field);
 
   cgm.errorNYI(e->getBeginLoc(),
                "member-pointer cast without underlying field decl");

--- a/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenItaniumCXXABI.cpp
@@ -190,6 +190,13 @@ public:
   cir::MethodAttr buildVirtualMethodAttr(cir::MethodType methodTy,
                                          const CXXMethodDecl *md) override;
 
+  mlir::Attribute emitMemberPointerConversion(const CastExpr *e,
+                                              mlir::Attribute src) override;
+
+  mlir::Value emitMemberPointerConversion(CIRGenFunction &cgf,
+                                          const CastExpr *e,
+                                          mlir::Value src) override;
+
   Address initializeArrayCookie(CIRGenFunction &cgf, Address newPtr,
                                 mlir::Value numElements, const CXXNewExpr *e,
                                 QualType elementType) override;
@@ -2402,6 +2409,120 @@ CIRGenItaniumCXXABI::buildVirtualMethodAttr(cir::MethodType methodTy,
 
   return cir::MethodAttr::get(methodTy, vtableOffset);
 }
+
+/// Peel casts and return the field decl for a constant member-data-pointer
+/// initializer rooted at a member expression.
+static const FieldDecl *getDataMemberFieldFromExpr(const Expr *e) {
+  e = e->IgnoreParenImpCasts();
+  if (const auto *declRef = dyn_cast<DeclRefExpr>(e))
+    return dyn_cast<FieldDecl>(declRef->getDecl());
+  if (const auto *memberExpr = dyn_cast<MemberExpr>(e))
+    return dyn_cast<FieldDecl>(memberExpr->getMemberDecl());
+  if (const auto *unaryOp = dyn_cast<UnaryOperator>(e)) {
+    if (unaryOp->getOpcode() == UO_AddrOf)
+      return getDataMemberFieldFromExpr(unaryOp->getSubExpr());
+  }
+  if (const auto *castExpr = dyn_cast<CastExpr>(e))
+    return getDataMemberFieldFromExpr(castExpr->getSubExpr());
+  return nullptr;
+}
+
+mlir::Attribute
+CIRGenItaniumCXXABI::emitMemberPointerConversion(const CastExpr *e,
+                                                 mlir::Attribute src) {
+  assert(e->getCastKind() == CK_DerivedToBaseMemberPointer ||
+         e->getCastKind() == CK_BaseToDerivedMemberPointer ||
+         e->getCastKind() == CK_ReinterpretMemberPointer);
+
+  if (mlir::isa<cir::MethodAttr>(src)) {
+    cgm.errorNYI(e->getBeginLoc(),
+                 "emitMemberPointerConversion for member function pointer");
+    return {};
+  }
+
+  auto destTy = mlir::cast<cir::DataMemberType>(cgm.convertType(e->getType()));
+  auto dataMember = mlir::cast<cir::DataMemberAttr>(src);
+
+  if (dataMember.isNullPtr())
+    return cgm.getBuilder().getNullDataMemberAttr(destTy);
+
+  const auto *destMpt = e->getType()->getAs<MemberPointerType>();
+
+  if (e->getCastKind() == CK_ReinterpretMemberPointer) {
+    if (dataMember.getType().getClassTy() == destTy.getClassTy())
+      return cgm.getBuilder().getDataMemberAttr(
+          destTy, dataMember.getMemberIndex().value());
+
+    CharUnits offset = cgm.computeDataMemberOffset(dataMember);
+    const FieldDecl *field = cgm.findDataMemberFieldAtOffset(
+        destMpt->getMostRecentCXXRecordDecl(), offset);
+    if (!field) {
+      cgm.errorNYI(e->getBeginLoc(),
+                   "reinterpret member pointer with unmapped offset");
+      return {};
+    }
+    return cgm.getDataMemberAttrForField(destMpt, field);
+  }
+
+  if (const FieldDecl *field = getDataMemberFieldFromExpr(e->getSubExpr())) {
+    const auto *fieldParent = cast<CXXRecordDecl>(field->getParent());
+    if (fieldParent == destMpt->getMostRecentCXXRecordDecl())
+      return cgm.getDataMemberAttrForField(destMpt, field);
+    return {};
+  }
+
+  cgm.errorNYI(e->getBeginLoc(),
+               "member-pointer cast without underlying field decl");
+  return {};
+}
+
+mlir::Value CIRGenItaniumCXXABI::emitMemberPointerConversion(
+    CIRGenFunction &cgf, const CastExpr *e, mlir::Value src) {
+  assert(e->getCastKind() == CK_DerivedToBaseMemberPointer ||
+         e->getCastKind() == CK_BaseToDerivedMemberPointer ||
+         e->getCastKind() == CK_ReinterpretMemberPointer);
+
+  CastKind kind = e->getCastKind();
+  const Expr *subExpr = e->getSubExpr();
+  QualType destTy = e->getType();
+
+  if (kind == CK_ReinterpretMemberPointer)
+    return cgf.getBuilder().createBitcast(cgf.getLoc(subExpr->getExprLoc()),
+                                          src, cgf.convertType(destTy));
+
+  assert(!cir::MissingFeatures::memberFuncPtrAuthInfo());
+
+  QualType derivedTy =
+      kind == CK_DerivedToBaseMemberPointer ? subExpr->getType() : destTy;
+  const auto *mpType = derivedTy->castAs<MemberPointerType>();
+  NestedNameSpecifier qualifier = mpType->getQualifier();
+  assert(qualifier && "member pointer without class qualifier");
+  const Type *qualifierType = qualifier.getAsType();
+  assert(qualifierType && "member pointer qualifier is not a type");
+  const CXXRecordDecl *derivedClass = qualifierType->getAsCXXRecordDecl();
+  CharUnits offset =
+      cgm.computeNonVirtualBaseClassOffset(derivedClass, e->path());
+
+  mlir::Location loc = cgf.getLoc(subExpr->getExprLoc());
+  mlir::Type resultTy = cgf.convertType(destTy);
+  mlir::IntegerAttr offsetAttr =
+      cgf.getBuilder().getIndexAttr(offset.getQuantity());
+
+  if (subExpr->getType()->isMemberFunctionPointerType()) {
+    if (kind == CK_BaseToDerivedMemberPointer)
+      return cir::DerivedMethodOp::create(cgf.getBuilder(), loc, resultTy, src,
+                                          offsetAttr);
+    return cir::BaseMethodOp::create(cgf.getBuilder(), loc, resultTy, src,
+                                     offsetAttr);
+  }
+
+  if (kind == CK_BaseToDerivedMemberPointer)
+    return cir::DerivedDataMemberOp::create(cgf.getBuilder(), loc, resultTy,
+                                            src, offsetAttr);
+  return cir::BaseDataMemberOp::create(cgf.getBuilder(), loc, resultTy, src,
+                                       offsetAttr);
+}
+
 /// The Itanium ABI always places an offset to the complete object
 /// at entry -2 in the vtable.
 void CIRGenItaniumCXXABI::emitVirtualObjectDelete(

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1202,7 +1202,6 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef mangledName, mlir::Type ty,
       if (const SectionAttr *sa = d->getAttr<SectionAttr>())
         gv.setSectionAttr(builder.getStringAttr(sa->getName()));
     }
-    gv.setGlobalVisibility(getGlobalVisibilityAttrFromDecl(d).getValue());
 
     // Handle XCore specific ABI requirements.
     if (getTriple().getArch() == llvm::Triple::xcore)
@@ -2226,9 +2225,11 @@ mlir::Value CIRGenModule::emitDataMemberPointer(mlir::Location loc,
       builder, loc,
       builder.getDataMemberAttr(leafTy, fieldLayout.getCIRFieldNo(field)));
 
-  llvm::SmallVector<const CXXRecordDecl *, 4> chain;
-  if (!buildDataMemberBaseChain(pointerClass, fieldParent, chain))
-    llvm_unreachable("could not find base path to data member parent");
+  llvm::SmallVector<const CXXRecordDecl *> chain;
+  if (!buildDataMemberBaseChain(pointerClass, fieldParent, chain)) {
+    errorNYI(loc, "data member pointer through virtual or ambiguous base");
+    return mlir::Value();
+  }
 
   for (int i = static_cast<int>(chain.size()) - 2; i >= 0; --i) {
     const CXXRecordDecl *derived = chain[i];
@@ -2255,11 +2256,8 @@ CIRGenModule::getDataMemberAttrForField(const MemberPointerType *destMpt,
       mlir::cast<cir::DataMemberType>(convertType(QualType(destMpt, 0)));
   unsigned memberIndex =
       getTypes().getCIRGenRecordLayout(fieldParent).getCIRFieldNo(field);
-  if (fieldParent != destClass) {
-    errorNYI(field->getLocation(),
-             "constexpr data member attr requires field in dest class");
+  if (fieldParent != destClass)
     return {};
-  }
   return builder.getDataMemberAttr(destTy, memberIndex);
 }
 
@@ -2889,9 +2887,69 @@ static bool shouldAssumeDSOLocal(const CIRGenModule &cgm,
   return false;
 }
 
-void CIRGenModule::setGlobalVisibility(mlir::Operation *gv,
+void CIRGenModule::setGlobalVisibility(mlir::Operation *op,
                                        const NamedDecl *d) const {
-  assert(!cir::MissingFeatures::opGlobalVisibility());
+  auto gv = dyn_cast<cir::CIRGlobalValueInterface>(op);
+  if (!gv)
+    return;
+
+  // Internal definitions always have default visibility.
+  if (gv.hasLocalLinkage()) {
+    gv.setGlobalVisibility(cir::VisibilityKind::Default);
+    return;
+  }
+  if (!d)
+    return;
+
+  // Set visibility for definitions, and for declarations if requested globally
+  // or set explicitly.
+  LinkageInfo lv = d->getLinkageAndVisibility();
+
+  // OpenMP declare target variables must be visible to the host so they can
+  // be registered. We require protected visibility unless the variable has
+  // the DT_nohost modifier and does not need to be registered.
+  if (getASTContext().getLangOpts().OpenMP &&
+      getASTContext().getLangOpts().OpenMPIsTargetDevice && isa<VarDecl>(d) &&
+      d->hasAttr<OMPDeclareTargetDeclAttr>() &&
+      d->getAttr<OMPDeclareTargetDeclAttr>()->getDevType() !=
+          OMPDeclareTargetDeclAttr::DT_NoHost &&
+      lv.getVisibility() == HiddenVisibility) {
+    llvm_unreachable("setGlobalVisibility: OpenMP is NYI");
+    return;
+  }
+
+  // CUDA/HIP device kernels and global variables must be visible to the host
+  // so they can be registered / initialized. We require protected visibility
+  // unless the user explicitly requested hidden via an attribute.
+  if (getASTContext().getLangOpts().CUDAIsDevice &&
+      lv.getVisibility() == HiddenVisibility && !lv.isVisibilityExplicit() &&
+      !d->hasAttr<OMPDeclareTargetDeclAttr>()) {
+    bool needsProtected = false;
+    if (isa<FunctionDecl>(d)) {
+      needsProtected =
+          d->hasAttr<CUDAGlobalAttr>() || d->hasAttr<DeviceKernelAttr>();
+    } else if (const auto *vd = dyn_cast<VarDecl>(d)) {
+      needsProtected = vd->hasAttr<CUDADeviceAttr>() ||
+                       vd->hasAttr<CUDAConstantAttr>() ||
+                       vd->getType()->isCUDADeviceBuiltinSurfaceType() ||
+                       vd->getType()->isCUDADeviceBuiltinTextureType();
+    }
+    if (needsProtected) {
+      gv.setGlobalVisibility(cir::VisibilityKind::Protected);
+      return;
+    }
+  }
+
+  if (getASTContext().getLangOpts().HLSL && !d->isInExportDeclContext()) {
+    gv.setGlobalVisibility(cir::VisibilityKind::Hidden);
+    return;
+  }
+
+  assert(!cir::MissingFeatures::opGlobalDLLImportExport());
+
+  if (lv.isVisibilityExplicit() || getLangOpts().SetVisibilityForExternDecls ||
+      !gv.isDeclarationForLinker())
+    gv.setGlobalVisibility(getCIRVisibilityKind(lv.getVisibility()));
 }
 
 void CIRGenModule::setDSOLocal(cir::CIRGlobalValueInterface gv) const {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -34,10 +34,8 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Interfaces/CIROpInterfaces.h"
 #include "clang/CIR/MissingFeatures.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include "CIRGenFunctionInfo.h"
 #include "TargetInfo.h"
@@ -806,47 +804,7 @@ bool CIRGenModule::getCPUAndFeaturesAttributes(
   const auto *tc = fd ? fd->getAttr<TargetClonesAttr>() : nullptr;
   bool addedAttr = false;
   if (td || tv || sd || tc) {
-    llvm::StringMap<bool> featureMap;
-    astContext.getFunctionFeatureMap(featureMap, gd);
-
-    // Now add the target-cpu and target-features to the function.
-    // While we populated the feature map above, we still need to
-    // get and parse the target/target_clones attribute so we can
-    // get the cpu for the function.
-    llvm::StringRef featureStr = td ? td->getFeaturesStr() : llvm::StringRef();
-    if (tc && (getTriple().isOSAIX() || getTriple().isX86()))
-      featureStr = tc->getFeatureStr(gd.getMultiVersionIndex());
-    if (!featureStr.empty()) {
-      clang::ParsedTargetAttr parsedAttr =
-          getTarget().parseTargetAttr(featureStr);
-      if (!parsedAttr.CPU.empty() &&
-          getTarget().isValidCPUName(parsedAttr.CPU)) {
-        targetCPU = parsedAttr.CPU;
-        tuneCPU = ""; // Clear the tune CPU.
-      }
-      if (!parsedAttr.Tune.empty() &&
-          getTarget().isValidCPUName(parsedAttr.Tune))
-        tuneCPU = parsedAttr.Tune;
-    }
-
-    if (sd) {
-      // Apply the given CPU name as the 'tune-cpu' so that the optimizer can
-      // favor this processor.
-      tuneCPU = sd->getCPUName(gd.getMultiVersionIndex())->getName();
-    }
-
-    // For AMDGPU, only emit delta features (features that differ from the
-    // target CPU's defaults). Other targets might want to follow a similar
-    // pattern.
-    if (getTarget().getTriple().isAMDGPU()) {
-      features = getFeatureDeltaFromDefault(*this, targetCPU, featureMap);
-    } else {
-      // Produce the canonical string for this set of features.
-      features.reserve(features.size() + featureMap.size());
-      for (const auto &entry : featureMap)
-        features.push_back((entry.getValue() ? "+" : "-") +
-                           entry.getKey().str());
-    }
+    assert(!cir::MissingFeatures::opFuncMultiVersioning());
   } else {
     // Just add the existing target cpu and target features to the function.
     if (setTargetFeatures && getTarget().getTriple().isAMDGPU()) {
@@ -1244,6 +1202,7 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef mangledName, mlir::Type ty,
       if (const SectionAttr *sa = d->getAttr<SectionAttr>())
         gv.setSectionAttr(builder.getStringAttr(sa->getName()));
     }
+    gv.setGlobalVisibility(getGlobalVisibilityAttrFromDecl(d).getValue());
 
     // Handle XCore specific ABI requirements.
     if (getTriple().getArch() == llvm::Triple::xcore)
@@ -2205,11 +2164,9 @@ LangAS CIRGenModule::getLangTempAllocaAddressSpace() const {
   if (getLangOpts().CUDAIsDevice)
     return LangAS::Default;
 
-  if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice)
-    assert(!cir::MissingFeatures::openMP());
-  if (getLangOpts().SYCLIsDevice)
-    errorNYI("SYCL temp address space");
-
+  if (getLangOpts().SYCLIsDevice ||
+      (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice))
+    errorNYI("SYCL or OpenMP temp address space");
   return LangAS::Default;
 }
 
@@ -2220,6 +2177,90 @@ void CIRGenModule::emitExplicitCastExprType(const ExplicitCastExpr *e,
 
   assert(!cir::MissingFeatures::generateDebugInfo() &&
          "emitExplicitCastExprType");
+}
+
+bool CIRGenModule::buildDataMemberBaseChain(
+    const CXXRecordDecl *pointerClass, const CXXRecordDecl *fieldParent,
+    llvm::SmallVectorImpl<const CXXRecordDecl *> &chain) {
+  chain.clear();
+  chain.push_back(pointerClass);
+
+  if (fieldParent == pointerClass)
+    return true;
+
+  const CXXRecordDecl *current = pointerClass;
+  while (current != fieldParent) {
+    const CXXRecordDecl *nextBase = nullptr;
+    for (const CXXBaseSpecifier &base : current->bases()) {
+      if (base.isVirtual())
+        continue;
+
+      const auto *baseDecl =
+          cast<CXXRecordDecl>(base.getType()->getAsCXXRecordDecl());
+      if (fieldParent->isDerivedFrom(baseDecl) || baseDecl == fieldParent) {
+        current = baseDecl;
+        nextBase = baseDecl;
+        chain.push_back(current);
+        break;
+      }
+    }
+    if (!nextBase)
+      return false;
+  }
+
+  return true;
+}
+
+mlir::Value CIRGenModule::emitDataMemberPointer(mlir::Location loc,
+                                                const MemberPointerType *mpt,
+                                                const FieldDecl *field) {
+  const CXXRecordDecl *pointerClass = mpt->getMostRecentCXXRecordDecl();
+  const auto *fieldParent = cast<CXXRecordDecl>(field->getParent());
+
+  QualType leafMpt = getASTContext().getMemberPointerType(
+      field->getType(), std::nullopt, fieldParent);
+  auto leafTy = mlir::cast<cir::DataMemberType>(convertType(leafMpt));
+  const CIRGenRecordLayout &fieldLayout =
+      getTypes().getCIRGenRecordLayout(fieldParent);
+  mlir::Value memberPtr = cir::ConstantOp::create(
+      builder, loc,
+      builder.getDataMemberAttr(leafTy, fieldLayout.getCIRFieldNo(field)));
+
+  llvm::SmallVector<const CXXRecordDecl *, 4> chain;
+  if (!buildDataMemberBaseChain(pointerClass, fieldParent, chain))
+    llvm_unreachable("could not find base path to data member parent");
+
+  for (int i = static_cast<int>(chain.size()) - 2; i >= 0; --i) {
+    const CXXRecordDecl *derived = chain[i];
+    const CXXRecordDecl *base = chain[i + 1];
+    QualType derivedMpt = getASTContext().getMemberPointerType(
+        field->getType(), std::nullopt, derived);
+    auto derivedTy = mlir::cast<cir::DataMemberType>(convertType(derivedMpt));
+    CharUnits offset =
+        getASTContext().getASTRecordLayout(derived).getBaseClassOffset(base);
+    memberPtr = cir::DerivedDataMemberOp::create(
+        builder, loc, derivedTy, memberPtr,
+        builder.getIndexAttr(offset.getQuantity()));
+  }
+
+  return memberPtr;
+}
+
+mlir::TypedAttr
+CIRGenModule::getDataMemberAttrForField(const MemberPointerType *destMpt,
+                                        const FieldDecl *field) {
+  const CXXRecordDecl *destClass = destMpt->getMostRecentCXXRecordDecl();
+  const auto *fieldParent = cast<CXXRecordDecl>(field->getParent());
+  auto destTy =
+      mlir::cast<cir::DataMemberType>(convertType(QualType(destMpt, 0)));
+  unsigned memberIndex =
+      getTypes().getCIRGenRecordLayout(fieldParent).getCIRFieldNo(field);
+  if (fieldParent != destClass) {
+    errorNYI(field->getLocation(),
+             "constexpr data member attr requires field in dest class");
+    return {};
+  }
+  return builder.getDataMemberAttr(destTy, memberIndex);
 }
 
 mlir::TypedAttr CIRGenModule::emitNullMemberAttr(QualType destTy,
@@ -2256,10 +2297,9 @@ mlir::Value CIRGenModule::emitMemberPointerConstant(const UnaryOperator *e) {
   }
 
   // Otherwise, a member data pointer.
-  auto ty = mlir::cast<cir::DataMemberType>(convertType(e->getType()));
   const auto *fieldDecl = cast<FieldDecl>(decl);
-  return cir::ConstantOp::create(
-      builder, loc, builder.getDataMemberAttr(ty, fieldDecl->getFieldIndex()));
+  const auto *mpt = cast<MemberPointerType>(e->getType().getTypePtr());
+  return emitDataMemberPointer(loc, mpt, fieldDecl);
 }
 
 void CIRGenModule::emitDeclContext(const DeclContext *dc) {
@@ -2811,65 +2851,9 @@ static bool shouldAssumeDSOLocal(const CIRGenModule &cgm,
   return false;
 }
 
-void CIRGenModule::setGlobalVisibility(cir::CIRGlobalValueInterface gv,
+void CIRGenModule::setGlobalVisibility(mlir::Operation *gv,
                                        const NamedDecl *d) const {
-  // Internal definitions always have default visibility.
-  if (gv.hasLocalLinkage()) {
-    gv.setGlobalVisibility(cir::VisibilityKind::Default);
-    return;
-  }
-  if (!d)
-    return;
-
-  // Set visibility for definitions, and for declarations if requested globally
-  // or set explicitly.
-  LinkageInfo lv = d->getLinkageAndVisibility();
-
-  // OpenMP declare target variables must be visible to the host so they can
-  // be registered. We require protected visibility unless the variable has
-  // the DT_nohost modifier and does not need to be registered.
-  if (getASTContext().getLangOpts().OpenMP &&
-      getASTContext().getLangOpts().OpenMPIsTargetDevice && isa<VarDecl>(d) &&
-      d->hasAttr<OMPDeclareTargetDeclAttr>() &&
-      d->getAttr<OMPDeclareTargetDeclAttr>()->getDevType() !=
-          OMPDeclareTargetDeclAttr::DT_NoHost &&
-      lv.getVisibility() == HiddenVisibility) {
-    llvm_unreachable("setGlobalVisibility: OpenMP is NYI");
-    return;
-  }
-
-  // CUDA/HIP device kernels and global variables must be visible to the host
-  // so they can be registered / initialized. We require protected visibility
-  // unless the user explicitly requested hidden via an attribute.
-  if (getASTContext().getLangOpts().CUDAIsDevice &&
-      lv.getVisibility() == HiddenVisibility && !lv.isVisibilityExplicit() &&
-      !d->hasAttr<OMPDeclareTargetDeclAttr>()) {
-    bool needsProtected = false;
-    if (isa<FunctionDecl>(d)) {
-      needsProtected =
-          d->hasAttr<CUDAGlobalAttr>() || d->hasAttr<DeviceKernelAttr>();
-    } else if (const auto *vd = dyn_cast<VarDecl>(d)) {
-      needsProtected = vd->hasAttr<CUDADeviceAttr>() ||
-                       vd->hasAttr<CUDAConstantAttr>() ||
-                       vd->getType()->isCUDADeviceBuiltinSurfaceType() ||
-                       vd->getType()->isCUDADeviceBuiltinTextureType();
-    }
-    if (needsProtected) {
-      gv.setGlobalVisibility(cir::VisibilityKind::Protected);
-      return;
-    }
-  }
-
-  if (getASTContext().getLangOpts().HLSL && !d->isInExportDeclContext()) {
-    gv.setGlobalVisibility(cir::VisibilityKind::Hidden);
-    return;
-  }
-
-  assert(!cir::MissingFeatures::opGlobalDLLImportExport());
-
-  if (lv.isVisibilityExplicit() || getLangOpts().SetVisibilityForExternDecls ||
-      !gv.isDeclarationForLinker())
-    gv.setGlobalVisibility(getCIRVisibilityKind(lv.getVisibility()));
+  assert(!cir::MissingFeatures::opGlobalVisibility());
 }
 
 void CIRGenModule::setDSOLocal(cir::CIRGlobalValueInterface gv) const {
@@ -2889,7 +2873,7 @@ void CIRGenModule::setGVProperties(mlir::Operation *op,
 
 void CIRGenModule::setGVPropertiesAux(mlir::Operation *op,
                                       const NamedDecl *d) const {
-  setGlobalVisibility(cast<cir::CIRGlobalValueInterface>(op), d);
+  setGlobalVisibility(op, d);
   setDSOLocal(op);
   assert(!cir::MissingFeatures::opGlobalPartition());
 }
@@ -2992,6 +2976,15 @@ void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
 
   if (!isIncompleteFunction && func.isDeclaration())
     getTargetCIRGenInfo().setTargetAttributes(funcDecl, func, *this);
+
+  // TODO(cir): This needs a lot of work to better match CodeGen. That
+  // ultimately ends up in setGlobalVisibility, which already has the linkage of
+  // the LLVM GV (corresponding to our FuncOp) computed, so it doesn't have to
+  // recompute it here. This is a minimal fix for now.
+  if (!isLocalLinkage(getFunctionLinkage(globalDecl))) {
+    const Decl *decl = globalDecl.getDecl();
+    func.setGlobalVisibility(getGlobalVisibilityAttrFromDecl(decl).getValue());
+  }
 
   // If we plan on emitting this inline builtin, we can't treat it as a builtin.
   if (funcDecl->isInlineBuiltinDeclaration()) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -2263,6 +2263,44 @@ CIRGenModule::getDataMemberAttrForField(const MemberPointerType *destMpt,
   return builder.getDataMemberAttr(destTy, memberIndex);
 }
 
+CharUnits CIRGenModule::computeDataMemberOffset(cir::DataMemberAttr attr) {
+  if (attr.isNullPtr())
+    return CharUnits::fromQuantity(-1);
+
+  const mlir::DataLayout &dataLayout = getDataLayout().layout;
+  cir::RecordType recTy = attr.getType().getClassTy();
+  return CharUnits::fromQuantity(
+      recTy.getElementOffset(dataLayout, attr.getMemberIndex().value()));
+}
+
+const FieldDecl *
+CIRGenModule::findDataMemberFieldAtOffset(const CXXRecordDecl *record,
+                                          CharUnits offset) {
+  const ASTContext &astContext = getASTContext();
+  for (const FieldDecl *field : record->fields()) {
+    CharUnits fieldOffset =
+        astContext.toCharUnitsFromBits(astContext.getFieldOffset(field));
+    if (fieldOffset == offset)
+      return field;
+  }
+
+  const ASTRecordLayout &layout = astContext.getASTRecordLayout(record);
+  for (const CXXBaseSpecifier &base : record->bases()) {
+    if (base.isVirtual())
+      continue;
+    const auto *baseDecl =
+        cast<CXXRecordDecl>(base.getType()->castAsCXXRecordDecl());
+    CharUnits baseOffset = layout.getBaseClassOffset(baseDecl);
+    if (offset < baseOffset)
+      continue;
+    if (const FieldDecl *field =
+            findDataMemberFieldAtOffset(baseDecl, offset - baseOffset))
+      return field;
+  }
+
+  return nullptr;
+}
+
 mlir::TypedAttr CIRGenModule::emitNullMemberAttr(QualType destTy,
                                                  const MemberPointerType *mpt) {
   if (mpt->isMemberFunctionPointerType()) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -804,7 +804,47 @@ bool CIRGenModule::getCPUAndFeaturesAttributes(
   const auto *tc = fd ? fd->getAttr<TargetClonesAttr>() : nullptr;
   bool addedAttr = false;
   if (td || tv || sd || tc) {
-    assert(!cir::MissingFeatures::opFuncMultiVersioning());
+    llvm::StringMap<bool> featureMap;
+    astContext.getFunctionFeatureMap(featureMap, gd);
+
+    // Now add the target-cpu and target-features to the function.
+    // While we populated the feature map above, we still need to
+    // get and parse the target/target_clones attribute so we can
+    // get the cpu for the function.
+    llvm::StringRef featureStr = td ? td->getFeaturesStr() : llvm::StringRef();
+    if (tc && (getTriple().isOSAIX() || getTriple().isX86()))
+      featureStr = tc->getFeatureStr(gd.getMultiVersionIndex());
+    if (!featureStr.empty()) {
+      clang::ParsedTargetAttr parsedAttr =
+          getTarget().parseTargetAttr(featureStr);
+      if (!parsedAttr.CPU.empty() &&
+          getTarget().isValidCPUName(parsedAttr.CPU)) {
+        targetCPU = parsedAttr.CPU;
+        tuneCPU = ""; // Clear the tune CPU.
+      }
+      if (!parsedAttr.Tune.empty() &&
+          getTarget().isValidCPUName(parsedAttr.Tune))
+        tuneCPU = parsedAttr.Tune;
+    }
+
+    if (sd) {
+      // Apply the given CPU name as the 'tune-cpu' so that the optimizer can
+      // favor this processor.
+      tuneCPU = sd->getCPUName(gd.getMultiVersionIndex())->getName();
+    }
+
+    // For AMDGPU, only emit delta features (features that differ from the
+    // target CPU's defaults). Other targets might want to follow a similar
+    // pattern.
+    if (getTarget().getTriple().isAMDGPU()) {
+      features = getFeatureDeltaFromDefault(*this, targetCPU, featureMap);
+    } else {
+      // Produce the canonical string for this set of features.
+      features.reserve(features.size() + featureMap.size());
+      for (const auto &entry : featureMap)
+        features.push_back((entry.getValue() ? "+" : "-") +
+                           entry.getKey().str());
+    }
   } else {
     // Just add the existing target cpu and target features to the function.
     if (setTargetFeatures && getTarget().getTriple().isAMDGPU()) {
@@ -2163,9 +2203,10 @@ LangAS CIRGenModule::getLangTempAllocaAddressSpace() const {
   if (getLangOpts().CUDAIsDevice)
     return LangAS::Default;
 
-  if (getLangOpts().SYCLIsDevice ||
-      (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice))
-    errorNYI("SYCL or OpenMP temp address space");
+  if (getLangOpts().OpenMP && getLangOpts().OpenMPIsTargetDevice)
+    assert(!cir::MissingFeatures::openMP());
+  if (getLangOpts().SYCLIsDevice)
+    errorNYI("SYCL temp address space");
   return LangAS::Default;
 }
 
@@ -2887,12 +2928,8 @@ static bool shouldAssumeDSOLocal(const CIRGenModule &cgm,
   return false;
 }
 
-void CIRGenModule::setGlobalVisibility(mlir::Operation *op,
+void CIRGenModule::setGlobalVisibility(cir::CIRGlobalValueInterface gv,
                                        const NamedDecl *d) const {
-  auto gv = dyn_cast<cir::CIRGlobalValueInterface>(op);
-  if (!gv)
-    return;
-
   // Internal definitions always have default visibility.
   if (gv.hasLocalLinkage()) {
     gv.setGlobalVisibility(cir::VisibilityKind::Default);
@@ -2906,7 +2943,7 @@ void CIRGenModule::setGlobalVisibility(mlir::Operation *op,
   LinkageInfo lv = d->getLinkageAndVisibility();
 
   // OpenMP declare target variables must be visible to the host so they can
-  // be registered. We require protected visibility unless the variable has
+  // be registered.  We require protected visibility unless the variable has
   // the DT_nohost modifier and does not need to be registered.
   if (getASTContext().getLangOpts().OpenMP &&
       getASTContext().getLangOpts().OpenMPIsTargetDevice && isa<VarDecl>(d) &&
@@ -2919,7 +2956,7 @@ void CIRGenModule::setGlobalVisibility(mlir::Operation *op,
   }
 
   // CUDA/HIP device kernels and global variables must be visible to the host
-  // so they can be registered / initialized. We require protected visibility
+  // so they can be registered / initialized.  We require protected visibility
   // unless the user explicitly requested hidden via an attribute.
   if (getASTContext().getLangOpts().CUDAIsDevice &&
       lv.getVisibility() == HiddenVisibility && !lv.isVisibilityExplicit() &&
@@ -2969,7 +3006,7 @@ void CIRGenModule::setGVProperties(mlir::Operation *op,
 
 void CIRGenModule::setGVPropertiesAux(mlir::Operation *op,
                                       const NamedDecl *d) const {
-  setGlobalVisibility(op, d);
+  setGlobalVisibility(cast<cir::CIRGlobalValueInterface>(op), d);
   setDSOLocal(op);
   assert(!cir::MissingFeatures::opGlobalPartition());
 }
@@ -3072,15 +3109,6 @@ void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
 
   if (!isIncompleteFunction && func.isDeclaration())
     getTargetCIRGenInfo().setTargetAttributes(funcDecl, func, *this);
-
-  // TODO(cir): This needs a lot of work to better match CodeGen. That
-  // ultimately ends up in setGlobalVisibility, which already has the linkage of
-  // the LLVM GV (corresponding to our FuncOp) computed, so it doesn't have to
-  // recompute it here. This is a minimal fix for now.
-  if (!isLocalLinkage(getFunctionLinkage(globalDecl))) {
-    const Decl *decl = globalDecl.getDecl();
-    func.setGlobalVisibility(getGlobalVisibilityAttrFromDecl(decl).getValue());
-  }
 
   // If we plan on emitting this inline builtin, we can't treat it as a builtin.
   if (funcDecl->isInlineBuiltinDeclaration()) {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -431,19 +431,6 @@ public:
     llvm_unreachable("unknown visibility!");
   }
 
-  static cir::VisibilityKind getCIRVisibilityKind(Visibility v) {
-    switch (v) {
-    case DefaultVisibility:
-      return cir::VisibilityKind::Default;
-    case HiddenVisibility:
-      return cir::VisibilityKind::Hidden;
-    case ProtectedVisibility:
-      return cir::VisibilityKind::Protected;
-    }
-
-    llvm_unreachable("unknown visibility!");
-  }
-
   llvm::DenseMap<mlir::Attribute, cir::GlobalOp> constantStringMap;
   llvm::DenseMap<const UnnamedGlobalConstantDecl *, cir::GlobalOp>
       unnamedGlobalConstantDeclMap;
@@ -615,8 +602,7 @@ public:
   mlir::Type convertType(clang::QualType type);
 
   /// Set the visibility for the given global.
-  void setGlobalVisibility(cir::CIRGlobalValueInterface gv,
-                           const NamedDecl *d) const;
+  void setGlobalVisibility(mlir::Operation *op, const NamedDecl *d) const;
   void setDSOLocal(mlir::Operation *op) const;
   void setDSOLocal(cir::CIRGlobalValueInterface gv) const;
 
@@ -704,6 +690,19 @@ public:
   mlir::TypedAttr emitNullConstantForBase(const CXXRecordDecl *record);
 
   mlir::Value emitMemberPointerConstant(const UnaryOperator *e);
+
+  bool
+  buildDataMemberBaseChain(const CXXRecordDecl *pointerClass,
+                           const CXXRecordDecl *fieldParent,
+                           llvm::SmallVectorImpl<const CXXRecordDecl *> &chain);
+
+  mlir::Value emitDataMemberPointer(mlir::Location loc,
+                                    const MemberPointerType *mpt,
+                                    const FieldDecl *field);
+
+  mlir::TypedAttr getDataMemberAttrForField(const MemberPointerType *destMpt,
+                                            const FieldDecl *field);
+
   /// Returns a null attribute to represent either a null method or null data
   /// member, depending on the type of mpt.
   mlir::TypedAttr emitNullMemberAttr(QualType t, const MemberPointerType *mpt);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -440,7 +440,6 @@ public:
     case ProtectedVisibility:
       return cir::VisibilityKind::Protected;
     }
-
     llvm_unreachable("unknown visibility!");
   }
 
@@ -615,7 +614,8 @@ public:
   mlir::Type convertType(clang::QualType type);
 
   /// Set the visibility for the given global.
-  void setGlobalVisibility(mlir::Operation *op, const NamedDecl *d) const;
+  void setGlobalVisibility(cir::CIRGlobalValueInterface gv,
+                           const NamedDecl *d) const;
   void setDSOLocal(mlir::Operation *op) const;
   void setDSOLocal(cir::CIRGlobalValueInterface gv) const;
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -703,6 +703,11 @@ public:
   mlir::TypedAttr getDataMemberAttrForField(const MemberPointerType *destMpt,
                                             const FieldDecl *field);
 
+  CharUnits computeDataMemberOffset(cir::DataMemberAttr attr);
+
+  const FieldDecl *findDataMemberFieldAtOffset(const CXXRecordDecl *record,
+                                               CharUnits offset);
+
   /// Returns a null attribute to represent either a null method or null data
   /// member, depending on the type of mpt.
   mlir::TypedAttr emitNullMemberAttr(QualType t, const MemberPointerType *mpt);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -431,6 +431,19 @@ public:
     llvm_unreachable("unknown visibility!");
   }
 
+  static cir::VisibilityKind getCIRVisibilityKind(Visibility v) {
+    switch (v) {
+    case DefaultVisibility:
+      return cir::VisibilityKind::Default;
+    case HiddenVisibility:
+      return cir::VisibilityKind::Hidden;
+    case ProtectedVisibility:
+      return cir::VisibilityKind::Protected;
+    }
+
+    llvm_unreachable("unknown visibility!");
+  }
+
   llvm::DenseMap<mlir::Attribute, cir::GlobalOp> constantStringMap;
   llvm::DenseMap<const UnnamedGlobalConstantDecl *, cir::GlobalOp>
       unnamedGlobalConstantDeclMap;

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -194,20 +194,16 @@ mlir::Type LowerItaniumCXXABI::lowerMethodType(
 mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
     cir::DataMemberAttr attr, const mlir::DataLayout &layout,
     const mlir::TypeConverter &typeConverter) const {
-  int64_t memberOffset;
-  if (attr.isNullPtr()) {
-    // Itanium C++ ABI 2.3:
-    //   A NULL pointer is represented as -1.
-    memberOffset = -1;
-  } else {
-    // Itanium C++ ABI 2.3:
-    //   A pointer to data member is an offset from the base address of
-    //   the class object containing it, represented as a ptrdiff_t
-    unsigned memberIndex = attr.getMemberIndex().value();
+  // Itanium C++ ABI 2.3:
+  //   A pointer to data member is an offset from the base address of the
+  //   class object containing it, represented as a ptrdiff_t.  A NULL
+  //   pointer is represented as -1.
+  int64_t memberOffset = -1;
+  if (!attr.isNullPtr()) {
+    cir::RecordType recTy = attr.getType().getClassTy();
     memberOffset =
-        attr.getType().getClassTy().getElementOffset(layout, memberIndex);
+        recTy.getElementOffset(layout, attr.getMemberIndex().value());
   }
-
   mlir::Type abiTy = lowerDataMemberType(attr.getType(), typeConverter);
   return cir::IntAttr::get(abiTy, memberOffset);
 }

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-conversions.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-conversions.cpp
@@ -36,6 +36,7 @@ int M::*b2d_multi = &M::b;
 int B::*d2b = (int B::*)&M::b;
 // CIR-BEFORE: cir.global external @d2b = #cir.data_member<0> : !cir.data_member<!s32i in !rec_B>
 // CIR-AFTER: cir.global external @d2b = #cir.int<0> : !s64i
+// LLVM-DAG: @d2b = global i64 0
 // OGCG: @d2b = global i64 0
 
 struct Foo { int x; int y; };
@@ -44,6 +45,7 @@ struct Bar { float a; int b; };
 int Foo::*reint = reinterpret_cast<int Foo::*>(&Bar::b);
 // CIR-BEFORE: cir.global external @reint = #cir.data_member<1> : !cir.data_member<!s32i in !rec_Foo>
 // CIR-AFTER: cir.global external @reint = #cir.int<4> : !s64i
+// LLVM-DAG: @reint = global i64 4
 // OGCG: @reint = global i64 4
 
 int Derived::*b2d_null = (int Derived::*)(int Base::*)nullptr;

--- a/clang/test/CIR/CodeGen/pointer-to-data-member-conversions.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member-conversions.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-cir -mmlir -mlir-print-ir-before=cir-cxxabi-lowering %s -o %t.cir 2> %t-before.cir
+// RUN: FileCheck --check-prefix=CIR-BEFORE --input-file=%t-before.cir %s
+// RUN: FileCheck --check-prefix=CIR-AFTER --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -fclangir -Wno-unused-value -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++17 -Wno-unused-value -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+struct Base { int x; };
+struct Derived : Base { double y; };
+
+int Derived::*b2d_simple = &Derived::x;
+// CIR-BEFORE: cir.global external @b2d_simple = ctor
+// CIR-BEFORE: cir.const #cir.data_member<0> : !cir.data_member<!s32i in !rec_Base>
+// CIR-BEFORE: cir.derived_data_member %{{.*}}[0] : !cir.data_member<!s32i in !rec_Base> -> !cir.data_member<!s32i in !rec_Derived>
+// CIR-AFTER: cir.func{{.*}}@__cxx_global_var_init
+// CIR-AFTER: cir.const #cir.int<0> : !s64i
+// LLVM-DAG: define internal void @__cxx_global_var_init()
+// LLVM-DAG: store i64 0
+// OGCG: @b2d_simple = global i64 0
+
+struct A { double a; };
+struct B { int b; };
+struct M : A, B { };
+
+int M::*b2d_multi = &M::b;
+// CIR-BEFORE: cir.global external @b2d_multi = ctor
+// CIR-BEFORE: cir.const #cir.data_member<0> : !cir.data_member<!s32i in !rec_B>
+// CIR-BEFORE: cir.derived_data_member %{{.*}}[8] : !cir.data_member<!s32i in !rec_B> -> !cir.data_member<!s32i in !rec_M>
+// CIR-AFTER: cir.func{{.*}}@__cxx_global_var_init.1
+// CIR-AFTER: cir.const #cir.int<8> : !s64i
+// LLVM-DAG: define internal void @__cxx_global_var_init.1()
+// LLVM-DAG: store i64 8
+// OGCG: @b2d_multi = global i64 8
+
+int B::*d2b = (int B::*)&M::b;
+// CIR-BEFORE: cir.global external @d2b = #cir.data_member<0> : !cir.data_member<!s32i in !rec_B>
+// CIR-AFTER: cir.global external @d2b = #cir.int<0> : !s64i
+// OGCG: @d2b = global i64 0
+
+struct Foo { int x; int y; };
+struct Bar { float a; int b; };
+
+int Foo::*reint = reinterpret_cast<int Foo::*>(&Bar::b);
+// CIR-BEFORE: cir.global external @reint = #cir.data_member<1> : !cir.data_member<!s32i in !rec_Foo>
+// CIR-AFTER: cir.global external @reint = #cir.int<4> : !s64i
+// OGCG: @reint = global i64 4
+
+int Derived::*b2d_null = (int Derived::*)(int Base::*)nullptr;
+// CIR-BEFORE: cir.global external @b2d_null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_Derived>
+// CIR-AFTER: cir.global external @b2d_null = #cir.int<-1> : !s64i
+// LLVM-DAG: @b2d_null = global i64 -1
+// OGCG: @b2d_null = global i64 -1
+
+int B::*d2b_null = (int B::*)(int M::*)nullptr;
+// CIR-BEFORE: cir.global external @d2b_null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_B>
+// CIR-AFTER: cir.global external @d2b_null = #cir.int<-1> : !s64i
+// LLVM-DAG: @d2b_null = global i64 -1
+// OGCG: @d2b_null = global i64 -1
+
+int Foo::*reint_null = reinterpret_cast<int Foo::*>((int Bar::*)nullptr);
+// CIR-BEFORE: cir.global external @reint_null = #cir.data_member<null> : !cir.data_member<!s32i in !rec_Foo>
+// CIR-AFTER: cir.global external @reint_null = #cir.int<-1> : !s64i
+// LLVM-DAG: @reint_null = global i64 -1
+// OGCG: @reint_null = global i64 -1

--- a/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
+++ b/clang/test/CIR/CodeGen/pointer-to-data-member.cpp
@@ -349,3 +349,25 @@ auto test_null_incomplete() -> int Incomplete::* {
 
 // OGCG: define {{.*}} i64 @_Z20test_null_incompletev()
 // OGCG:   ret i64 -1
+
+struct BaseMember {
+  int b;
+};
+
+struct DerivedMember : BaseMember {
+  int d;
+};
+
+auto take_base_member() -> int DerivedMember::* {
+  return &DerivedMember::b;
+}
+
+// CIR-BEFORE: cir.func {{.*}} @_Z16take_base_memberv() -> !cir.data_member<!s32i in !rec_DerivedMember>
+// CIR-BEFORE:   %[[MEMBER:.*]] = cir.const #cir.data_member<0> : !cir.data_member<!s32i in !rec_BaseMember>
+// CIR-BEFORE:   %[[CAST:.*]] = cir.derived_data_member %[[MEMBER]][0] : !cir.data_member<!s32i in !rec_BaseMember> -> !cir.data_member<!s32i in !rec_DerivedMember>
+// CIR-BEFORE:   cir.store %[[CAST]], %{{.*}} : !cir.data_member<!s32i in !rec_DerivedMember>
+// CIR-AFTER:   %[[OFFSET:.*]] = cir.const #cir.int<0> : !s64i
+// LLVM: define {{.*}} i64 @_Z16take_base_memberv()
+// LLVM:   store i64 0
+// OGCG: define {{.*}} i64 @_Z16take_base_memberv()
+// OGCG:   ret i64 0

--- a/clang/test/CIR/IR/data-member-attr.cir
+++ b/clang/test/CIR/IR/data-member-attr.cir
@@ -1,0 +1,18 @@
+// RUN: cir-opt %s -split-input-file | FileCheck %s
+
+// -----
+
+!u32i = !cir.int<u, 32>
+!rec = !cir.record<struct "S" {!u32i}>
+
+module {
+  cir.global external @gv = #cir.data_member<0> : !cir.data_member<!u32i in !rec>
+  cir.global external @null_gv = #cir.data_member<null>
+      : !cir.data_member<!u32i in !rec>
+  cir.func @roundtrip() {
+    cir.return
+  }
+}
+
+// CHECK: cir.global external @gv = #cir.data_member<0>
+// CHECK: cir.global external @null_gv = #cir.data_member<null>

--- a/clang/test/CIR/IR/invalid-data-member.cir
+++ b/clang/test/CIR/IR/invalid-data-member.cir
@@ -2,8 +2,25 @@
 
 // -----
 
-!u32i = !cir.int<u, 32>
 !u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
+
+// expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
+#invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!incomplete_struct = !cir.record<struct "Incomplete" incomplete>
+
+// expected-error@+1 {{incomplete 'cir.record' cannot be used to build a non-null data member pointer}}
+#incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
 !struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
 
 // expected-error@+1 {{member index of a #cir.data_member attribute is out of range}}

--- a/clang/test/CIR/IR/invalid-data-member.cir
+++ b/clang/test/CIR/IR/invalid-data-member.cir
@@ -2,29 +2,22 @@
 
 // -----
 
-!u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
-
-// expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
-#invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
-
-// -----
-
 !u16i = !cir.int<u, 16>
-!incomplete_struct = !cir.record<struct "Incomplete" incomplete>
-
-// expected-error@+1 {{incomplete 'cir.record' cannot be used to build a non-null data member pointer}}
-#incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>
-
-// -----
-
-!u16i = !cir.int<u, 16>
-!u32i = !cir.int<u, 32>
 !struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
 
 // expected-error@+1 {{member index of a #cir.data_member attribute is out of range}}
-#invalid_member_ty = #cir.data_member<2> : !cir.data_member<!u32i in !struct1>
+#out_of_range_index = #cir.data_member<99> : !cir.data_member<!u32i in !struct1>
+
+// -----
+
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!base = !cir.record<struct "Base" {!u32i}>
+!derived = !cir.record<struct "Derived" {!base, !u32i}>
+
+// expected-error@+1 {{member index of a #cir.data_member attribute is out of range}}
+#out_of_range_nested = #cir.data_member<1> : !cir.data_member<!u32i in !base>
 
 // -----
 


### PR DESCRIPTION
Depends on [#197555](https://github.com/llvm/llvm-project/pull/197555).

Base branch is `cir-data-member-offset-nfc` on the fork. The diff is only the two cast commits on top of that member_path work.

ConstExprEmitter and CIRGenItaniumCXXABI lower `CK_BaseToDerivedMemberPointer`, `CK_DerivedToBaseMemberPointer`, and `CK_ReinterpretMemberPointer` for data-member pointers using GEP-like `member_path` attributes. Runtime scalar casts use `emitMemberPointerConversion` on the CXXABI, matching classic CodeGen.

Supersedes closed [#197582](https://github.com/llvm/llvm-project/pull/197582) (`cir-data-member-cast` on `main`, offset-based).