### PR TITLE
[CIR] Allow clz/ctz/popcount on u8 and u128 widths

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5902,7 +5902,7 @@ def CIR_BitClrsbOp : CIR_BitOpBase<"clrsb", CIR_SIntOfWidths<[32, 64]>> {
 }
 
 def CIR_BitClzOp : CIR_BitZeroCountOpBase<"clz",
-  CIR_UIntOfWidths<[16, 32, 64]>
+  CIR_UIntOfWidths<[8, 16, 32, 64, 128]>
 > {
   let summary = "Get the number of leading 0-bits in the input";
   let description = [{
@@ -5927,7 +5927,7 @@ def CIR_BitClzOp : CIR_BitZeroCountOpBase<"clz",
 }
 
 def CIR_BitCtzOp : CIR_BitZeroCountOpBase<"ctz",
-  CIR_UIntOfWidths<[16, 32, 64]>
+  CIR_UIntOfWidths<[8, 16, 32, 64, 128]>
 > {
   let summary = "Get the number of trailing 0-bits in the input";
   let description = [{
@@ -5993,7 +5993,7 @@ def CIR_BitParityOp : CIR_BitOpBase<"parity", CIR_UIntOfWidths<[32, 64]>> {
 }
 
 def CIR_BitPopcountOp : CIR_BitOpBase<"popcount",
-  CIR_UIntOfWidths<[16, 32, 64]>
+  CIR_UIntOfWidths<[8, 16, 32, 64, 128]>
 > {
   let summary = "Get the number of 1-bits in input";
   let description = [{

--- a/clang/test/CIR/CodeGenBuiltins/builtin-bit.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-bit.cpp
@@ -414,7 +414,7 @@ unsigned test_builtin_popcountg_u8(unsigned char x) {
 // OGCG:         %{{.+}} = call i8 @llvm.ctpop.i8(i8 %{{.+}})
 
 #if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
-typedef unsigned __int128 u128;
+using u128 = unsigned __int128;
 
 int test_builtin_popcountg_u128(u128 x) {
   return __builtin_popcountg(x);

--- a/clang/test/CIR/CodeGenBuiltins/builtin-bit.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-bit.cpp
@@ -398,6 +398,67 @@ int test_builtin_popcountg(unsigned x) {
 // OGCG-LABEL: _Z22test_builtin_popcountgj
 // OGCG:         %{{.+}} = call i32 @llvm.ctpop.i32(i32 %{{.+}})
 
+unsigned test_builtin_popcountg_u8(unsigned char x) {
+  return __builtin_popcountg(x);
+}
+
+// CIR-LABEL: _Z25test_builtin_popcountg_u8h
+// CIR:         [[TMP:%.+]] = cir.popcount %{{.+}} : !u8i
+// CIR:         {{%.+}} = cir.cast integral [[TMP]] : !u8i -> !s32i
+// CIR:         {{%.+}} = cir.cast integral {{.*}} : !s32i -> !u32i
+
+// LLVM-LABEL: _Z25test_builtin_popcountg_u8h
+// LLVM:         %{{.+}} = call i8 @llvm.ctpop.i8(i8 %{{.+}})
+
+// OGCG-LABEL: _Z25test_builtin_popcountg_u8h
+// OGCG:         %{{.+}} = call i8 @llvm.ctpop.i8(i8 %{{.+}})
+
+#if defined(__SIZEOF_INT128__) && __SIZEOF_INT128__ == 16
+typedef unsigned __int128 u128;
+
+int test_builtin_popcountg_u128(u128 x) {
+  return __builtin_popcountg(x);
+}
+
+// CIR-LABEL: _Z27test_builtin_popcountg_u128o
+// CIR:         [[TMP:%.+]] = cir.popcount %{{.+}} : !u128i
+// CIR:         {{%.+}} = cir.cast integral [[TMP]] : !u128i -> !s32i
+
+// LLVM-LABEL: _Z27test_builtin_popcountg_u128o
+// LLVM:         %{{.+}} = call i128 @llvm.ctpop.i128(i128 %{{.+}})
+
+// OGCG-LABEL: _Z27test_builtin_popcountg_u128o
+// OGCG:         %{{.+}} = call i128 @llvm.ctpop.i128(i128 %{{.+}})
+
+int test_builtin_clzg_u128(u128 x) {
+  return __builtin_clzg(x, 0);
+}
+
+// CIR-LABEL: _Z22test_builtin_clzg_u128o
+// CIR:         [[TMP:%.+]] = cir.clz %{{.+}} poison_zero : !u128i
+// CIR:         {{%.+}} = cir.cast integral [[TMP]] : !u128i -> !s32i
+
+// LLVM-LABEL: _Z22test_builtin_clzg_u128o
+// LLVM:         %{{.+}} = call i128 @llvm.ctlz.i128(i128 %{{.+}}, i1 true)
+
+// OGCG-LABEL: _Z22test_builtin_clzg_u128o
+// OGCG:         %{{.+}} = call i128 @llvm.ctlz.i128(i128 %{{.+}}, i1 true)
+
+int test_builtin_ctzg_u128(u128 x) {
+  return __builtin_ctzg(x, 0);
+}
+
+// CIR-LABEL: _Z22test_builtin_ctzg_u128o
+// CIR:         [[TMP:%.+]] = cir.ctz %{{.+}} poison_zero : !u128i
+// CIR:         {{%.+}} = cir.cast integral [[TMP]] : !u128i -> !s32i
+
+// LLVM-LABEL: _Z22test_builtin_ctzg_u128o
+// LLVM:         %{{.+}} = call i128 @llvm.cttz.i128(i128 %{{.+}}, i1 true)
+
+// OGCG-LABEL: _Z22test_builtin_ctzg_u128o
+// OGCG:         %{{.+}} = call i128 @llvm.cttz.i128(i128 %{{.+}}, i1 true)
+#endif
+
 unsigned char test_builtin_bitreverse8(unsigned char x) {
   return __builtin_bitreverse8(x);
 }


### PR DESCRIPTION
libcxx with `-fclangir` was rejecting `cir.clz`, `cir.ctz`, and
`cir.popcount` when the operand type is `!u8i` or `!u128i` — the
verifier only allowed 16/32/64-bit widths even though codegen already
emits the right `llvm.ctlz` / `llvm.cttz` / `llvm.ctpop` intrinsics for
those sizes.  That shows up heavily in the May 20 upstream-main libcxx
baseline (`verifier-rejects-pre-pass-ir` bucket).

Widen the TableGen width lists on the three ops to match `bitreverse`
(8 through 128).  `builtin-bit.cpp` gains `popcountg` on `unsigned char`,
and `popcountg` / `clzg` / `ctzg` on `unsigned __int128` when
`__SIZEOF_INT128__` is 16, each with CIR/LLVM/OGCG checks.