### PR TITLE
[Clang] [Docs] Remove stray release note

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -541,9 +541,6 @@ Improvements to Clang's diagnostics
 - Clang now errors when a function declaration aliases a variable or vice versa. (#GH195550)
 
 - Added ``-Wattribute-alias`` to diagnose type mismatches between an alias and its aliased function. (#GH195550)
-
-- Added warnings for floating-point exception function calls (fenv.h) without enabling
-  floating-point exception behavior via the appropriate flags or pragmas. (#GH128239)
   
 - The diagnostics around ``__block`` now explain why a variable cannot be marked ``__block``. (#GH197213)
 


### PR DESCRIPTION
The patch that added this release note was reverted (#198341), but then (#198167) accidentally added it back.