### PR TITLE
[RISCV][P-ext] Return SDValue() instead of calling DAG.UnrollVectorOp for non-splat shift amounts. NFCI

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -8962,7 +8962,7 @@ SDValue RISCVTargetLowering::LowerOperation(SDValue Op,
           SplatVal = cast<BuildVectorSDNode>(ShAmtVec)->getSplatValue();
 
         if (!SplatVal)
-          return DAG.UnrollVectorOp(Op.getNode());
+          return SDValue();
 
         unsigned Opc;
         switch (Op.getOpcode()) {


### PR DESCRIPTION
The generic legalizer can call DAG.UnrollVectorOp itself.