### PR TITLE
IR: Move `simplify_type<(const) Use *>` to Use.h and fix a bug.

### DIFF
--- a/llvm/include/llvm/IR/Use.h
+++ b/llvm/include/llvm/IR/Use.h
@@ -118,6 +118,21 @@ template <> struct simplify_type<const Use> {
   static SimpleType getSimplifiedValue(const Use &Val) { return Val.get(); }
 };
 
+template<> struct simplify_type<Use *> {
+  using SimpleType = Value*;
+
+  static SimpleType getSimplifiedValue(Use *Val) {
+    return Val ? Val->get() : nullptr;
+  }
+};
+template<> struct simplify_type<const Use *> {
+  using SimpleType = /*const*/ Value*;
+
+  static SimpleType getSimplifiedValue(const Use *Val) {
+    return Val ? Val->get() : nullptr;
+  }
+};
+
 // Create wrappers for C Binding types (see CBindingWrapping.h).
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(Use, LLVMUseRef)
 

--- a/llvm/include/llvm/IR/Use.h
+++ b/llvm/include/llvm/IR/Use.h
@@ -118,15 +118,15 @@ template <> struct simplify_type<const Use> {
   static SimpleType getSimplifiedValue(const Use &Val) { return Val.get(); }
 };
 
-template<> struct simplify_type<Use *> {
-  using SimpleType = Value*;
+template <> struct simplify_type<Use *> {
+  using SimpleType = Value *;
 
   static SimpleType getSimplifiedValue(Use *Val) {
     return Val ? Val->get() : nullptr;
   }
 };
-template<> struct simplify_type<const Use *> {
-  using SimpleType = /*const*/ Value*;
+template <> struct simplify_type<const Use *> {
+  using SimpleType = /*const*/ Value *;
 
   static SimpleType getSimplifiedValue(const Use *Val) {
     return Val ? Val->get() : nullptr;

--- a/llvm/include/llvm/IR/User.h
+++ b/llvm/include/llvm/IR/User.h
@@ -344,21 +344,6 @@ static_assert(alignof(Use) >= alignof(User),
 static_assert(alignof(Use *) >= alignof(User),
               "Alignment is insufficient after objects prepended to User");
 
-template<> struct simplify_type<User::op_iterator> {
-  using SimpleType = Value*;
-
-  static SimpleType getSimplifiedValue(User::op_iterator &Val) {
-    return Val->get();
-  }
-};
-template<> struct simplify_type<User::const_op_iterator> {
-  using SimpleType = /*const*/ Value*;
-
-  static SimpleType getSimplifiedValue(User::const_op_iterator &Val) {
-    return Val->get();
-  }
-};
-
 } // end namespace llvm
 
 #endif // LLVM_IR_USER_H


### PR DESCRIPTION
These overloads live in User.h because the type of
`User::(const_)op_iterator` is `(const) Use *`, but they do not
necessarily need to be used together with `User`, so let's move them to
Use.h with the canonical type used in the overload for clarity.

There's also a bug where `dyn_cast_or_null` with a `Use *` argument
crashes if the argument is null. Fix it by adding a null check to
these overloads. The null check is expected to be optimized out of the
implementation of `isa`/`cast`/`dyn_cast` because these functions will
unconditionally load from the result of `getSimplifiedValue`.
