### PR TITLE
[CIR] Implement getUndefRValue for scalar, complex, and aggregate

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2244,8 +2244,30 @@ RValue CIRGenFunction::getUndefRValue(QualType ty) {
   if (ty->isVoidType())
     return RValue::get(nullptr);
 
-  cgm.errorNYI("unsupported type for undef rvalue");
-  return RValue::get(nullptr);
+  mlir::Location loc = builder.getUnknownLoc();
+
+  switch (getEvaluationKind(ty)) {
+  case cir::TEK_Complex: {
+    mlir::Type cirTy = convertType(ty);
+    mlir::Value v = builder.getConstant(loc, cir::UndefAttr::get(cirTy));
+    return RValue::getComplex(v);
+  }
+
+  // If this is a use of an undefined aggregate type, the aggregate must have
+  // an identifiable address.  Just because the contents of the value are
+  // undefined doesn't mean that the address can't be taken and compared.
+  case cir::TEK_Aggregate: {
+    Address destPtr = createMemTemp(ty, loc, "undef.agg.tmp");
+    return RValue::getAggregate(destPtr);
+  }
+
+  case cir::TEK_Scalar: {
+    mlir::Type cirTy = convertType(ty);
+    mlir::Value v = builder.getConstant(loc, cir::UndefAttr::get(cirTy));
+    return RValue::get(v);
+  }
+  }
+  llvm_unreachable("bad evaluation kind");
 }
 
 RValue CIRGenFunction::emitCall(clang::QualType calleeTy,

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -2240,6 +2240,11 @@ CIRGenCallee CIRGenFunction::emitDirectCallee(const GlobalDecl &gd) {
   return CIRGenCallee::forDirect(callee, gd);
 }
 
+mlir::Value CIRGenFunction::getUndefConstant(mlir::Location loc,
+                                             mlir::Type cirTy) {
+  return builder.getConstant(loc, cir::UndefAttr::get(cirTy));
+}
+
 RValue CIRGenFunction::getUndefRValue(QualType ty) {
   if (ty->isVoidType())
     return RValue::get(nullptr);
@@ -2248,8 +2253,10 @@ RValue CIRGenFunction::getUndefRValue(QualType ty) {
 
   switch (getEvaluationKind(ty)) {
   case cir::TEK_Complex: {
-    mlir::Type cirTy = convertType(ty);
-    mlir::Value v = builder.getConstant(loc, cir::UndefAttr::get(cirTy));
+    QualType elemTy = ty->castAs<ComplexType>()->getElementType();
+    mlir::Type elemCirTy = convertType(elemTy);
+    mlir::Value undefElem = getUndefConstant(loc, elemCirTy);
+    mlir::Value v = builder.createComplexCreate(loc, undefElem, undefElem);
     return RValue::getComplex(v);
   }
 
@@ -2257,15 +2264,12 @@ RValue CIRGenFunction::getUndefRValue(QualType ty) {
   // an identifiable address.  Just because the contents of the value are
   // undefined doesn't mean that the address can't be taken and compared.
   case cir::TEK_Aggregate: {
-    Address destPtr = createMemTemp(ty, loc, "undef.agg.tmp");
+    Address destPtr = createMemTempWithoutCast(ty, loc, "undef.agg.tmp");
     return RValue::getAggregate(destPtr);
   }
 
-  case cir::TEK_Scalar: {
-    mlir::Type cirTy = convertType(ty);
-    mlir::Value v = builder.getConstant(loc, cir::UndefAttr::get(cirTy));
-    return RValue::get(v);
-  }
+  case cir::TEK_Scalar:
+    return RValue::get(getUndefConstant(loc, convertType(ty)));
   }
   llvm_unreachable("bad evaluation kind");
 }
@@ -2754,6 +2758,13 @@ mlir::Value CIRGenFunction::createDummyValue(mlir::Location loc,
 //===----------------------------------------------------------------------===//
 // CIR builder helpers
 //===----------------------------------------------------------------------===//
+
+Address CIRGenFunction::createMemTempWithoutCast(QualType ty,
+                                                 mlir::Location loc,
+                                                 const Twine &name) {
+  return createTempAllocaWithoutCast(
+      convertTypeForMem(ty), getContext().getTypeAlignInChars(ty), loc, name);
+}
 
 Address CIRGenFunction::createMemTemp(QualType ty, mlir::Location loc,
                                       const Twine &name, Address *alloca,

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -1035,10 +1035,10 @@ public:
                                                 const CXXRecordDecl *baseRD,
                                                 bool isVirtual);
 
+  /// Return a CIR constant for an undefined value of \p cirTy.
+  mlir::Value getUndefConstant(mlir::Location loc, mlir::Type cirTy);
+
   /// Get an appropriate 'undef' rvalue for the given type.
-  /// TODO: What's the equivalent for MLIR? Currently we're only using this for
-  /// void types so it just returns RValue::get(nullptr) but it'll need
-  /// addressed later.
   RValue getUndefRValue(clang::QualType ty);
 
   cir::FuncOp generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
@@ -2303,6 +2303,8 @@ public:
   Address createMemTemp(QualType t, CharUnits align, mlir::Location loc,
                         const Twine &name = "tmp", Address *alloca = nullptr,
                         mlir::OpBuilder::InsertPoint ip = {});
+  Address createMemTempWithoutCast(QualType t, mlir::Location loc,
+                                   const Twine &name = "tmp");
 
   mlir::Value performAddrSpaceCast(mlir::Value v, mlir::Type destTy) const {
     if (cir::GlobalOp globalOp = v.getDefiningOp<cir::GlobalOp>())

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1979,6 +1979,12 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
     return mlir::success();
   }
 
+  if (mlir::isa<cir::UndefAttr>(attr)) {
+    rewriter.replaceOpWithNewOp<mlir::LLVM::UndefOp>(
+        op, getTypeConverter()->convertType(op.getType()));
+    return mlir::success();
+  }
+
   if (mlir::isa<mlir::IntegerType>(op.getType())) {
     // Verified cir.const operations cannot actually be of these types, but the
     // lowering pass may generate temporary cir.const operations with these
@@ -2071,6 +2077,12 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
       mlir::ArrayAttr array = rewriter.getArrayAttr({zeroAttr, zeroAttr});
       rewriter.replaceOpWithNewOp<mlir::LLVM::ConstantOp>(
           op, getTypeConverter()->convertType(op.getType()), array);
+      return mlir::success();
+    }
+
+    if (mlir::isa<cir::UndefAttr>(op.getValue())) {
+      rewriter.replaceOpWithNewOp<mlir::LLVM::UndefOp>(
+          op, getTypeConverter()->convertType(op.getType()));
       return mlir::success();
     }
 

--- a/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -verify %s -o - \
+// RUN:     | FileCheck %s --check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -verify %s -o - \
+// RUN:     | FileCheck %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+
+typedef int v4si __attribute__((vector_size(16)));
+
+int test_builtin_reduce_or_undef_rvalue(v4si x) {
+  // expected-error@+1 {{unimplemented X86 builtin call: __builtin_reduce_or}}
+  return __builtin_reduce_or(x);
+}
+
+// CIR-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
+// CIR:         cir.const #cir.undef : !s32i
+// CIR:         cir.return
+
+// LLVM-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
+// LLVM:         store i32 undef, ptr %{{.+}}, align 4
+// LLVM:         ret i32 %{{.+}}
+
+// OGCG-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
+// OGCG:         call i32 @llvm.vector.reduce.or.v4i32
+// OGCG:         ret i32

--- a/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -verify %s -o - \
-// RUN:     | FileCheck %s --check-prefix=CIR
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -verify %s -o - \
-// RUN:     | FileCheck %s --check-prefix=LLVM
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir -verify %s -o - > %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -verify %s -o - > %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t-ogcg.ll
+// RUN: FileCheck --check-prefix=OGCG --input-file=%t-ogcg.ll %s
 
 typedef int v4si __attribute__((vector_size(16)));
 

--- a/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtin-undef-rvalue.cpp
@@ -2,8 +2,6 @@
 // RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -verify %s -o - > %t.ll
 // RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
-// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t-ogcg.ll
-// RUN: FileCheck --check-prefix=OGCG --input-file=%t-ogcg.ll %s
 
 typedef int v4si __attribute__((vector_size(16)));
 
@@ -19,7 +17,3 @@ int test_builtin_reduce_or_undef_rvalue(v4si x) {
 // LLVM-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
 // LLVM:         store i32 undef, ptr %{{.+}}, align 4
 // LLVM:         ret i32 %{{.+}}
-
-// OGCG-LABEL: @_Z35test_builtin_reduce_or_undef_rvalueDv4_i
-// OGCG:         call i32 @llvm.vector.reduce.or.v4i32
-// OGCG:         ret i32


### PR DESCRIPTION
NYI builtin and call paths in CIR were calling getUndefRValue but the
helper only reported "unsupported type for undef rvalue" and returned
null.  libcxx then hit follow-on failures (including scalar-conversion
crashes) on the same translation units that already had other NYI
diagnostics.

Implement the same three cases as classic CodeGen: #cir.undef for
scalar and complex, and an undef.agg.tmp stack slot for aggregates.
Lower cir.const #cir.undef to llvm.undef in DirectToLLVM so emit-llvm
does not assert in the constant op lowering.  builtin-undef-rvalue.cpp
covers the __builtin_reduce_or NYI stub path with CIR/LLVM/OGCG checks.