### PR TITLE
[Github] Do not restrict branches for CI workflows

### DIFF
--- a/.github/workflows/libc-freebsd-vm-tests.yml
+++ b/.github/workflows/libc-freebsd-vm-tests.yml
@@ -4,7 +4,6 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'libc/**'
       - '.github/workflows/libc-freebsd-vm-tests.yml'

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -4,7 +4,6 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'libc/**'
       - '.github/workflows/libc-fullbuild-tests.yml'

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -4,7 +4,6 @@ permissions:
   contents: read
 on:
   pull_request:
-    branches: [ "main" ]
     paths:
       - 'libc/**'
       - '.github/workflows/libc-overlay-tests.yml'


### PR DESCRIPTION
This is covered in our CI best practices document in https://llvm.org/docs/CIBestPractices.html#ensuring-workflows-run-on-the-correct-events.

Otherwise we cannot run libc CI workflows on stacked pull requests.