### PR TITLE
[CIR] Fix problem with multiple references to an alloca in a cleanup

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCleanup.cpp
@@ -131,10 +131,22 @@ static void hoistAllocaOutOfCleanupScope(CIRGenFunction &cgf, Address addr,
   if (!alloca)
     return;
 
-  // If the alloca is not contained within the cleanup scope's body region,
+  // If the alloca is not contained within a cleanup scope or the cleanup scope
+  // containing the alloca is not the cleanup scope we're currently proccessing
   // we don't need to hoist it.
-  if (!scope.getBodyRegion().isAncestor(alloca->getParentRegion()))
+  if (alloca->getParentOfType<cir::CleanupScopeOp>() != scope) {
+    // It shouldn't be possible to get here with a nested cleanup scope.
+    assert(![&]() {
+      auto cur = alloca->getParentOfType<cir::CleanupScopeOp>();
+      while (cur) {
+        if (cur == scope)
+          return true;
+        cur = cur->getParentOfType<cir::CleanupScopeOp>();
+      }
+      return false;
+    }() && "alloca is nested within the current cleanup scope");
     return;
+  }
 
   // Place the alloca at the canonical alloca insertion point of the block
   // containing the cleanup scope op, so it groups with any preceding

--- a/clang/test/CIR/CodeGen/cleanup-conditional-with-wrapper-eh.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-conditional-with-wrapper-eh.cpp
@@ -171,3 +171,163 @@ Wrapper makeWrapper() {
 // OGCG:   br label %[[EH_DONE]]
 // OGCG: [[EH_DONE]]:
 // OGCG:   resume
+
+struct APInt {
+  ~APInt();
+  APInt uadd_sat();
+};
+
+struct APFixedPoint {
+  void add(int x) const;
+};
+
+// A conditional expression whose two arms both materialize into the same
+// aggregate temporary pushes two deferred conditional cleanups that share
+// the same underlying alloca.
+void APFixedPoint::add(int x) const {
+  APInt ThisVal;
+  if (x)
+    x ? ThisVal : ThisVal.uadd_sat();
+}
+
+// CIR: cir.func {{.*}} @_ZNK12APFixedPoint3addEi(%{{.*}}: !cir.ptr<!rec_APFixedPoint>{{.*}}, %{{.*}}: !s32i{{.*}})
+// CIR:   %[[X_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]
+// CIR:   %[[THISVAL:.*]] = cir.alloca !rec_APInt, !cir.ptr<!rec_APInt>, ["ThisVal"]
+// CIR:   %[[CLEANUP_COND_TRUE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
+// CIR:   %[[CLEANUP_COND_FALSE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
+// CIR:   cir.cleanup.scope {
+// CIR:     cir.scope {
+// CIR:       %[[X:.*]] = cir.load{{.*}} %[[X_ADDR]]
+// CIR:       %[[X_BOOL:.*]] = cir.cast int_to_bool %[[X]]
+// CIR:       cir.if %[[X_BOOL]] {
+// CIR:         %[[AGG_TMP:.*]] = cir.alloca !rec_APInt, !cir.ptr<!rec_APInt>, ["agg.tmp.ensured"]
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[X2:.*]] = cir.load{{.*}} %[[X_ADDR]]
+// CIR:           %[[X2_BOOL:.*]] = cir.cast int_to_bool %[[X2]]
+// CIR:           %[[FALSE:.*]] = cir.const #false
+// CIR:           cir.store{{.*}} %[[FALSE]], %[[CLEANUP_COND_TRUE]]
+// CIR:           %[[FALSE:.*]] = cir.const #false
+// CIR:           cir.store{{.*}} %[[FALSE]], %[[CLEANUP_COND_FALSE]]
+// CIR:           cir.if %[[X2_BOOL]] {
+// CIR:             %[[TRUE:.*]] = cir.const #true
+// CIR:             cir.store %[[TRUE]], %[[CLEANUP_COND_TRUE]]
+// CIR:           } else {
+// CIR:             %[[CALL_RES:.*]] = cir.call @_ZN5APInt8uadd_satEv(%[[THISVAL]])
+// CIR:             cir.store{{.*}} %[[CALL_RES]], %[[AGG_TMP]]
+// CIR:             %[[TRUE:.*]] = cir.const #true
+// CIR:             cir.store %[[TRUE]], %[[CLEANUP_COND_FALSE]]
+// CIR:           }
+// CIR:         } cleanup all {
+// CIR:           %[[F_FLAG:.*]] = cir.load{{.*}} %[[CLEANUP_COND_FALSE]]
+// CIR:           cir.if %[[F_FLAG]] {
+// CIR:             cir.call @_ZN5APIntD1Ev(%[[AGG_TMP]])
+// CIR:           }
+// CIR:           %[[T_FLAG:.*]] = cir.load{{.*}} %[[CLEANUP_COND_TRUE]]
+// CIR:           cir.if %[[T_FLAG]] {
+// CIR:             cir.call @_ZN5APIntD1Ev(%[[AGG_TMP]])
+// CIR:           }
+// CIR:         }
+// CIR:       }
+// CIR:     }
+// CIR:   } cleanup all {
+// CIR:     cir.call @_ZN5APIntD1Ev(%[[THISVAL]])
+// CIR:   }
+// CIR:   cir.return
+
+// LLVM: define {{.*}} void @_ZNK12APFixedPoint3addEi(ptr {{.*}} %{{.*}}, i32 {{.*}} %{{.*}}){{.*}} personality ptr @__gxx_personality_v0
+// LLVM:   %[[AGG_TMP:.*]] = alloca %struct.APInt
+// LLVM:   %[[THIS_ADDR:.*]] = alloca ptr
+// LLVM:   %[[X_ADDR:.*]] = alloca i32
+// LLVM:   %[[THISVAL:.*]] = alloca %struct.APInt
+// LLVM:   %[[CLEANUP_COND_TRUE:.*]] = alloca i8
+// LLVM:   %[[CLEANUP_COND_FALSE:.*]] = alloca i8
+// LLVM:   br i1 %{{.*}}, label %[[OUTER_TRUE:.*]], label %[[OUTER_END:.*]]
+// LLVM: [[OUTER_TRUE]]:
+// LLVM:   br i1 %{{.*}}, label %[[COND_TRUE:.*]], label %[[COND_FALSE:.*]]
+// LLVM: [[COND_TRUE]]:
+// LLVM:   store i8 1, ptr %[[CLEANUP_COND_TRUE]]
+// LLVM: [[COND_FALSE]]:
+// LLVM:   %[[CALL_RES:.*]] = invoke %struct.APInt @_ZN5APInt8uadd_satEv(ptr {{.*}} %[[THISVAL]])
+// LLVM:           to label %[[INVOKE_CONT:.*]] unwind label %[[LPAD:.*]]
+// LLVM: [[INVOKE_CONT]]:
+// LLVM:   store %struct.APInt %[[CALL_RES]], ptr %[[AGG_TMP]]
+// LLVM:   store i8 1, ptr %[[CLEANUP_COND_FALSE]]
+// LLVM:   %[[FF:.*]] = load i8, ptr %[[CLEANUP_COND_FALSE]]
+// LLVM:   %[[FF_B:.*]] = trunc i8 %[[FF]] to i1
+// LLVM:   br i1 %[[FF_B]], label %[[CLEANUP_F:.*]], label %[[AFTER_F:.*]]
+// LLVM: [[CLEANUP_F]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// LLVM: [[AFTER_F]]:
+// LLVM:   %[[TF:.*]] = load i8, ptr %[[CLEANUP_COND_TRUE]]
+// LLVM:   %[[TF_B:.*]] = trunc i8 %[[TF]] to i1
+// LLVM:   br i1 %[[TF_B]], label %[[CLEANUP_T:.*]], label %[[AFTER_T:.*]]
+// LLVM: [[CLEANUP_T]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// LLVM: [[AFTER_T]]:
+// LLVM: [[LPAD]]:
+// LLVM:   landingpad { ptr, i32 }
+// LLVM:     cleanup
+// LLVM:   %[[FF_EH:.*]] = load i8, ptr %[[CLEANUP_COND_FALSE]]
+// LLVM:   %[[FF_EH_B:.*]] = trunc i8 %[[FF_EH]] to i1
+// LLVM:   br i1 %[[FF_EH_B]], label %[[EH_CLEANUP_F:.*]], label %[[EH_AFTER_F:.*]]
+// LLVM: [[EH_CLEANUP_F]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// LLVM: [[EH_AFTER_F]]:
+// LLVM:   %[[TF_EH:.*]] = load i8, ptr %[[CLEANUP_COND_TRUE]]
+// LLVM:   %[[TF_EH_B:.*]] = trunc i8 %[[TF_EH]] to i1
+// LLVM:   br i1 %[[TF_EH_B]], label %[[EH_CLEANUP_T:.*]], label %[[EH_AFTER_T:.*]]
+// LLVM: [[EH_CLEANUP_T]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// LLVM: [[EH_AFTER_T]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[THISVAL]])
+// LLVM:   resume
+
+// OGCG: define {{.*}} void @_ZNK12APFixedPoint3addEi(ptr {{.*}} %[[THIS:.*]], i32 {{.*}} %[[X:.*]]){{.*}} personality ptr @__gxx_personality_v0
+// OGCG:   %[[THIS_ADDR:.*]] = alloca ptr
+// OGCG:   %[[X_ADDR:.*]] = alloca i32
+// OGCG:   %[[THISVAL:.*]] = alloca %struct.APInt
+// OGCG:   %[[AGG_TMP:.*]] = alloca %struct.APInt
+// OGCG:   %[[CLEANUP_COND_TRUE:.*]] = alloca i1
+// OGCG:   %[[EXN_SLOT:.*]] = alloca ptr
+// OGCG:   %[[EHSEL_SLOT:.*]] = alloca i32
+// OGCG:   %[[CLEANUP_COND_FALSE:.*]] = alloca i1
+// OGCG:   br i1 %{{.*}}, label %[[IF_THEN:.*]], label %[[IF_END:.*]]
+// OGCG: [[IF_THEN]]:
+// OGCG:   br i1 %{{.*}}, label %[[COND_TRUE:.*]], label %[[COND_FALSE:.*]]
+// OGCG: [[COND_TRUE]]:
+// OGCG:   store i1 true, ptr %[[CLEANUP_COND_TRUE]]
+// OGCG: [[COND_FALSE]]:
+// OGCG:   invoke void @_ZN5APInt8uadd_satEv(ptr {{.*}} sret(%struct.APInt) {{.*}} %[[AGG_TMP]], ptr {{.*}} %[[THISVAL]])
+// OGCG:           to label %[[INVOKE_CONT:.*]] unwind label %[[LPAD:.*]]
+// OGCG: [[INVOKE_CONT]]:
+// OGCG:   store i1 true, ptr %[[CLEANUP_COND_FALSE]]
+// OGCG: [[COND_END:.*]]:
+// OGCG:   %[[FF:.*]] = load i1, ptr %[[CLEANUP_COND_FALSE]]
+// OGCG:   br i1 %[[FF]], label %[[CLEANUP_F:.*]], label %[[AFTER_F:.*]]
+// OGCG: [[CLEANUP_F]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// OGCG:   br label %[[AFTER_F]]
+// OGCG: [[AFTER_F]]:
+// OGCG:   %[[TF:.*]] = load i1, ptr %[[CLEANUP_COND_TRUE]]
+// OGCG:   br i1 %[[TF]], label %[[CLEANUP_T:.*]], label %[[AFTER_T:.*]]
+// OGCG: [[CLEANUP_T]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// OGCG:   br label %[[AFTER_T]]
+// OGCG: [[AFTER_T]]:
+// OGCG:   br label %[[IF_END]]
+// OGCG: [[LPAD]]:
+// OGCG:   landingpad { ptr, i32 }
+// OGCG:     cleanup
+// OGCG:   %[[TF_EH:.*]] = load i1, ptr %[[CLEANUP_COND_TRUE]]
+// OGCG:   br i1 %[[TF_EH]], label %[[EH_CLEANUP_T:.*]], label %[[EH_AFTER_T:.*]]
+// OGCG: [[EH_CLEANUP_T]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// OGCG:   br label %[[EH_AFTER_T]]
+// OGCG: [[EH_AFTER_T]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[THISVAL]])
+// OGCG:   br label %[[EH_RESUME:.*]]
+// OGCG: [[IF_END]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[THISVAL]])
+// OGCG:   ret void
+// OGCG: [[EH_RESUME]]:
+// OGCG:   resume

--- a/clang/test/CIR/CodeGen/cleanup-conditional-with-wrapper.cpp
+++ b/clang/test/CIR/CodeGen/cleanup-conditional-with-wrapper.cpp
@@ -124,3 +124,131 @@ Wrapper makeWrapper() {
 // OGCG:   br label %[[DONE]]
 // OGCG: [[DONE]]:
 // OGCG:   ret void
+
+struct APInt {
+  ~APInt();
+  APInt uadd_sat();
+};
+
+struct APFixedPoint {
+  void add(int x) const;
+};
+
+// A conditional expression whose two arms both materialize into the same
+// aggregate temporary pushes two deferred conditional cleanups that share
+// the same underlying alloca.
+void APFixedPoint::add(int x) const {
+  APInt ThisVal;
+  if (x)
+    x ? ThisVal : ThisVal.uadd_sat();
+}
+
+// CIR: cir.func {{.*}} @_ZNK12APFixedPoint3addEi(%{{.*}}: !cir.ptr<!rec_APFixedPoint>{{.*}}, %{{.*}}: !s32i{{.*}})
+// CIR:   %[[X_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x", init]
+// CIR:   %[[THISVAL:.*]] = cir.alloca !rec_APInt, !cir.ptr<!rec_APInt>, ["ThisVal"]
+// CIR:   %[[CLEANUP_COND_TRUE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
+// CIR:   %[[CLEANUP_COND_FALSE:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cleanup.cond"]
+// CIR:   cir.cleanup.scope {
+// CIR:     cir.scope {
+// CIR:       %[[X:.*]] = cir.load{{.*}} %[[X_ADDR]]
+// CIR:       %[[X_BOOL:.*]] = cir.cast int_to_bool %[[X]]
+// CIR:       cir.if %[[X_BOOL]] {
+// CIR:         %[[AGG_TMP:.*]] = cir.alloca !rec_APInt, !cir.ptr<!rec_APInt>, ["agg.tmp.ensured"]
+// CIR:         cir.cleanup.scope {
+// CIR:           %[[X2:.*]] = cir.load{{.*}} %[[X_ADDR]]
+// CIR:           %[[X2_BOOL:.*]] = cir.cast int_to_bool %[[X2]]
+// CIR:           %[[FALSE:.*]] = cir.const #false
+// CIR:           cir.store{{.*}} %[[FALSE]], %[[CLEANUP_COND_TRUE]]
+// CIR:           %[[FALSE:.*]] = cir.const #false
+// CIR:           cir.store{{.*}} %[[FALSE]], %[[CLEANUP_COND_FALSE]]
+// CIR:           cir.if %[[X2_BOOL]] {
+// CIR:             %[[TRUE:.*]] = cir.const #true
+// CIR:             cir.store %[[TRUE]], %[[CLEANUP_COND_TRUE]]
+// CIR:           } else {
+// CIR:             %[[CALL_RES:.*]] = cir.call @_ZN5APInt8uadd_satEv(%[[THISVAL]])
+// CIR:             cir.store{{.*}} %[[CALL_RES]], %[[AGG_TMP]]
+// CIR:             %[[TRUE:.*]] = cir.const #true
+// CIR:             cir.store %[[TRUE]], %[[CLEANUP_COND_FALSE]]
+// CIR:           }
+// CIR:         } cleanup normal {
+// CIR:           %[[F_FLAG:.*]] = cir.load{{.*}} %[[CLEANUP_COND_FALSE]]
+// CIR:           cir.if %[[F_FLAG]] {
+// CIR:             cir.call @_ZN5APIntD1Ev(%[[AGG_TMP]])
+// CIR:           }
+// CIR:           %[[T_FLAG:.*]] = cir.load{{.*}} %[[CLEANUP_COND_TRUE]]
+// CIR:           cir.if %[[T_FLAG]] {
+// CIR:             cir.call @_ZN5APIntD1Ev(%[[AGG_TMP]])
+// CIR:           }
+// CIR:         }
+// CIR:       }
+// CIR:     }
+// CIR:   } cleanup normal {
+// CIR:     cir.call @_ZN5APIntD1Ev(%[[THISVAL]])
+// CIR:   }
+// CIR:   cir.return
+
+// LLVM: define {{.*}} void @_ZNK12APFixedPoint3addEi(ptr {{.*}} %{{.*}}, i32 {{.*}} %{{.*}})
+// LLVM:   %[[AGG_TMP:.*]] = alloca %struct.APInt
+// LLVM:   %[[THIS_ADDR:.*]] = alloca ptr
+// LLVM:   %[[X_ADDR:.*]] = alloca i32
+// LLVM:   %[[THISVAL:.*]] = alloca %struct.APInt
+// LLVM:   %[[CLEANUP_COND_TRUE:.*]] = alloca i8
+// LLVM:   %[[CLEANUP_COND_FALSE:.*]] = alloca i8
+// LLVM:   br i1 %{{.*}}, label %[[OUTER_TRUE:.*]], label %[[OUTER_END:.*]]
+// LLVM: [[OUTER_TRUE]]:
+// LLVM:   br i1 %{{.*}}, label %[[COND_TRUE:.*]], label %[[COND_FALSE:.*]]
+// LLVM: [[COND_TRUE]]:
+// LLVM:   store i8 1, ptr %[[CLEANUP_COND_TRUE]]
+// LLVM: [[COND_FALSE]]:
+// LLVM:   %[[CALL_RES:.*]] = call %struct.APInt @_ZN5APInt8uadd_satEv(ptr {{.*}} %[[THISVAL]])
+// LLVM:   store %struct.APInt %[[CALL_RES]], ptr %[[AGG_TMP]]
+// LLVM:   store i8 1, ptr %[[CLEANUP_COND_FALSE]]
+// LLVM:   %[[FF:.*]] = load i8, ptr %[[CLEANUP_COND_FALSE]]
+// LLVM:   %[[FF_B:.*]] = trunc i8 %[[FF]] to i1
+// LLVM:   br i1 %[[FF_B]], label %[[CLEANUP_F:.*]], label %[[AFTER_F:.*]]
+// LLVM: [[CLEANUP_F]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// LLVM: [[AFTER_F]]:
+// LLVM:   %[[TF:.*]] = load i8, ptr %[[CLEANUP_COND_TRUE]]
+// LLVM:   %[[TF_B:.*]] = trunc i8 %[[TF]] to i1
+// LLVM:   br i1 %[[TF_B]], label %[[CLEANUP_T:.*]], label %[[AFTER_T:.*]]
+// LLVM: [[CLEANUP_T]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// LLVM: [[AFTER_T]]:
+// LLVM:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[THISVAL]])
+// LLVM:   ret void
+
+// OGCG: define {{.*}} void @_ZNK12APFixedPoint3addEi(ptr {{.*}} %[[THIS:.*]], i32 {{.*}} %[[X:.*]])
+// OGCG:   %[[THIS_ADDR:.*]] = alloca ptr
+// OGCG:   %[[X_ADDR:.*]] = alloca i32
+// OGCG:   %[[THISVAL:.*]] = alloca %struct.APInt
+// OGCG:   %[[AGG_TMP:.*]] = alloca %struct.APInt
+// OGCG:   %[[CLEANUP_COND_TRUE:.*]] = alloca i1
+// OGCG:   %[[CLEANUP_COND_FALSE:.*]] = alloca i1
+// OGCG:   br i1 %{{.*}}, label %[[IF_THEN:.*]], label %[[IF_END:.*]]
+// OGCG: [[IF_THEN]]:
+// OGCG:   br i1 %{{.*}}, label %[[COND_TRUE:.*]], label %[[COND_FALSE:.*]]
+// OGCG: [[COND_TRUE]]:
+// OGCG:   store i1 true, ptr %[[CLEANUP_COND_TRUE]]
+// OGCG: [[COND_FALSE]]:
+// OGCG:   call void @_ZN5APInt8uadd_satEv(ptr {{.*}} sret(%struct.APInt) {{.*}} %[[AGG_TMP]], ptr {{.*}} %[[THISVAL]])
+// OGCG:   store i1 true, ptr %[[CLEANUP_COND_FALSE]]
+// Both arms of the conditional share the same agg.tmp.ensured slot, so
+// each cleanup branch destructs %[[AGG_TMP]].
+// OGCG: [[COND_END:.*]]:
+// OGCG:   %[[FF:.*]] = load i1, ptr %[[CLEANUP_COND_FALSE]]
+// OGCG:   br i1 %[[FF]], label %[[CLEANUP_F:.*]], label %[[AFTER_F:.*]]
+// OGCG: [[CLEANUP_F]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// OGCG:   br label %[[AFTER_F]]
+// OGCG: [[AFTER_F]]:
+// OGCG:   %[[TF:.*]] = load i1, ptr %[[CLEANUP_COND_TRUE]]
+// OGCG:   br i1 %[[TF]], label %[[CLEANUP_T:.*]], label %[[AFTER_T:.*]]
+// OGCG: [[CLEANUP_T]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[AGG_TMP]])
+// OGCG:   br label %[[AFTER_T]]
+// OGCG: [[AFTER_T]]:
+// OGCG:   br label %[[IF_END]]
+// OGCG: [[IF_END]]:
+// OGCG:   call void @_ZN5APIntD1Ev(ptr {{.*}} %[[THISVAL]])
+// OGCG:   ret void


### PR DESCRIPTION
A recent change to hoist allocas out of a deferred cleanup scope had a bug wherein if multiple entries in the deferred cleanup stack referenced the same alloca, the second attempt to see if it needed to be hoisted would assert in the MLIR region code. This was happening because when we hoist the alloca, we hoist it to a block that is still under construction. On the second encounter when we're walking its parent chain to see if it is contained within the cleanup scope we're processing, our call to get the parent region of the block containing the alloca would assert because the alloca is in an unlinked block (it gets added to a region after we're done constructing it).

To fix this problem, I changed the way we're checking for the alloca being nested within the cleanup scope, using a more robust implementation that will tolerate encountering unlinked operations.

Assisted-by: Cursor / claude-opus-4.7-thinking-xhigh