### PR TITLE
[LLDB] Add a progress event to xcrun invocations

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/macosx/HostInfoMacOSX.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
@@ -24,6 +25,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/RWMutex.h"
@@ -433,6 +435,12 @@ FileSpec HostInfoMacOSX::GetCurrentCommandLineToolsDirectory() {
 static llvm::Expected<std::string>
 xcrun(const std::string &sdk, llvm::ArrayRef<llvm::StringRef> arguments,
       llvm::StringRef developer_dir = "") {
+  std::string details;
+  llvm::raw_string_ostream os(details);
+  os << "xcrun --sdk " << sdk << llvm::join(arguments, " ")
+     << " (DEVELOPER_DIR=" << developer_dir << ')';
+  Progress progress("Running xcrun", details);
+
   Args args;
   if (!developer_dir.empty()) {
     args.AppendArgument("/usr/bin/env");


### PR DESCRIPTION
LLDB invokes xcrun to find SDKs on disk. This is usually very fast, but sometimes (after an Xcode update, or when the searched SDK does not exist) it can take very long (10s or more). The progress event provides user feedback to explain the hang.