### PR TITLE
[flang][FIRToMemRef] Fixed array_coor with box/shape/slice.

### DIFF
--- a/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
@@ -710,8 +710,8 @@ FIRToMemRef::convertArrayCoorOp(Operation *memOp, fir::ArrayCoorOp arrayCoorOp,
   //         compute strides (e.g. rebox sourced array_coor).
   const bool descriptorOwnsLayout =
       sliceInfo.hasProjectedSlice || shapeVec.empty() ||
-      (isDescriptor && sliceInfo.shiftVec.empty() &&
-       arrayCoorOp.getShape() && arrayCoorOp.getSlice());
+      (isDescriptor && sliceInfo.shiftVec.empty() && arrayCoorOp.getShape() &&
+       arrayCoorOp.getSlice());
   if (descriptorOwnsLayout) {
     // Projected slices carry their physical layout in the descriptor. Rebuild
     // the MemRef view from box metadata instead of from slice triplets.

--- a/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
@@ -694,7 +694,25 @@ FIRToMemRef::convertArrayCoorOp(Operation *memOp, fir::ArrayCoorOp arrayCoorOp,
   strides.reserve(rank);
 
   SmallVector<Value> &shapeVec = sliceInfo.shapeVec;
-  if (sliceInfo.hasProjectedSlice || shapeVec.empty()) {
+  // Pick how to derive sizes/strides for the reinterpret_cast view:
+  //
+  //   shapeVec path: use the collected fir.shape extents and synthesize
+  //     row-major strides. Valid when those extents describe the underlying
+  //     memref's layout -- shape from a defining embox, a shape_shift that
+  //     carries lower bounds, or no slicing at all.
+  //
+  //   box_dims path: query the descriptor at runtime. Required when:
+  //     (a) the slice is projected (physical layout is owned by the box);
+  //     (b) we have no shape information at all; or
+  //     (c) the array_coor itself carries fir.shape + fir.slice on a
+  //         descriptor-backed memref with no shift -- those extents describe
+  //         the post-slice view, not the source, so they cannot be used to
+  //         compute strides (e.g. rebox sourced array_coor).
+  const bool descriptorOwnsLayout =
+      sliceInfo.hasProjectedSlice || shapeVec.empty() ||
+      (isDescriptor && sliceInfo.shiftVec.empty() &&
+       arrayCoorOp.getShape() && arrayCoorOp.getSlice());
+  if (descriptorOwnsLayout) {
     // Projected slices carry their physical layout in the descriptor. Rebuild
     // the MemRef view from box metadata instead of from slice triplets.
     auto boxElementSize =

--- a/flang/test/Transforms/FIRToMemRef/array-coor-rebox-slice-shape.mlir
+++ b/flang/test/Transforms/FIRToMemRef/array-coor-rebox-slice-shape.mlir
@@ -1,0 +1,70 @@
+// RUN: fir-opt %s --fir-to-memref --allow-unregistered-dialect | FileCheck %s
+
+// Descriptor-backed array_coor with fir.shape (extents only, no shift) and a
+// rebox slice must rebuild the memref view from fir.box_dims strides. This
+// mirrors assign-inlined loops for VP(:,K) on a rebox-sourced box.
+//
+// Without useBoxDescriptorLayout, FIRToMemRef used fir.shape extents to
+// synthesize strides and mis-addressed column sections of non-contiguous boxes.
+
+// CHECK-LABEL: func.func @array_coor_box_slice_shape_no_shift
+// CHECK:       fir.box_addr %[[BOX:arg[0-9]+]]
+// CHECK:       fir.box_elesize %[[BOX]]
+// CHECK:       fir.box_dims %[[BOX]]
+// CHECK:       arith.divsi
+// CHECK:       fir.box_dims %[[BOX]]
+// CHECK:       arith.divsi
+// CHECK:       memref.reinterpret_cast %{{.+}} to offset:
+// CHECK-SAME:  sizes: [{{%.+}}, {{%.+}}], strides: [{{%.+}}, {{%.+}}]
+// CHECK:       memref.load %{{.+}}[{{%.+}}, {{%.+}}]
+// CHECK-NOT:   fir.array_coor
+func.func @array_coor_box_slice_shape_no_shift(%arg0: !fir.box<!fir.array<?x?xi32>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %undef = fir.undefined index
+  %rebox = fir.rebox %arg0 : (!fir.box<!fir.array<?x?xi32>>) -> !fir.box<!fir.array<?x?xi32>>
+  %slice = fir.slice %c1, %c2, %c1, %c2, %undef, %undef :
+      (index, index, index, index, index, index) -> !fir.slice<2>
+  %dim0:3 = fir.box_dims %rebox, %c0 : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+  %dim1:3 = fir.box_dims %rebox, %c1 : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+  %shape = fir.shape %dim0#1, %dim1#1 : (index, index) -> !fir.shape<2>
+  %addr = fir.array_coor %arg0(%shape) [%slice] %c1, %c2 :
+      (!fir.box<!fir.array<?x?xi32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+  %val = fir.load %addr : !fir.ref<i32>
+  return
+}
+
+// Row loop: load VP(I,2) for I=1..2 using the same slice+shape pattern.
+// CHECK-LABEL: func.func @array_coor_box_slice_shape_row_loop
+// CHECK:       scf.for
+// CHECK:         fir.box_elesize %[[BOX:arg[0-9]+]]
+// CHECK:         fir.box_dims %[[BOX]]
+// CHECK:         arith.divsi
+// CHECK:         fir.box_dims %[[BOX]]
+// CHECK:         arith.divsi
+// CHECK:         memref.reinterpret_cast
+// CHECK-SAME:        sizes: [{{%.+}}, {{%.+}}], strides: [{{%.+}}, {{%.+}}]
+// CHECK:         memref.load %{{.+}}[{{%.+}}, {{%.+}}]
+// CHECK-NOT:     fir.array_coor
+func.func @array_coor_box_slice_shape_row_loop(%arg0: !fir.box<!fir.array<?x?xi32>>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %undef = fir.undefined index
+  %rebox = fir.rebox %arg0 : (!fir.box<!fir.array<?x?xi32>>) -> !fir.box<!fir.array<?x?xi32>>
+  %slice = fir.slice %c1, %c2, %c1, %c2, %undef, %undef :
+      (index, index, index, index, index, index) -> !fir.slice<2>
+  %c0 = arith.constant 0 : index
+  %trip = arith.subi %c2, %c1 : index
+  %ub = arith.addi %trip, %c1 : index
+  scf.for %i = %c0 to %ub step %c1 {
+    %row = arith.addi %c1, %i : index
+    %dim0:3 = fir.box_dims %rebox, %c0 : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+    %dim1:3 = fir.box_dims %rebox, %c1 : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+    %shape = fir.shape %dim0#1, %dim1#1 : (index, index) -> !fir.shape<2>
+    %addr = fir.array_coor %arg0(%shape) [%slice] %row, %c2 :
+        (!fir.box<!fir.array<?x?xi32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+    %val = fir.load %addr : !fir.ref<i32>
+  }
+  return
+}

--- a/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
+++ b/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
@@ -75,10 +75,8 @@ func.func @array_coor_slice_shift_section() {
   return
 }
 
-// Descriptor-backed array_coor with shape_shift + slice. Even though the
-// memref is a fir.box, the explicit shape_shift carries lower bounds, so the
-// shapeVec path (synthesize row-major strides from extents) must be taken,
-// not the box_dims descriptor path.
+// Descriptor-backed array_coor with shape_shift + slice.
+// TODO: the strides must still be taken from the descriptor.
 // CHECK-LABEL: func.func @array_coor_box_shape_shift_slice
 // CHECK:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK:       %[[C5:.*]] = arith.constant 5 : index

--- a/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
+++ b/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
@@ -74,3 +74,30 @@ func.func @array_coor_slice_shift_section() {
   fir.store %c1_i32 to %4 : !fir.ref<i32>
   return
 }
+
+// Descriptor-backed array_coor with shape_shift + slice. Even though the
+// memref is a fir.box, the explicit shape_shift carries lower bounds, so the
+// shapeVec path (synthesize row-major strides from extents) must be taken,
+// not the box_dims descriptor path.
+// CHECK-LABEL: func.func @array_coor_box_shape_shift_slice
+// CHECK:       %[[C1:.*]] = arith.constant 1 : index
+// CHECK:       %[[C5:.*]] = arith.constant 5 : index
+// CHECK:       %[[C10:.*]] = arith.constant 10 : index
+// CHECK:       fir.box_addr %arg0
+// CHECK:       memref.reinterpret_cast %{{.+}} to offset: [%{{.+}}], sizes: [%[[C5]], %[[C10]]], strides: [%[[C10]], %{{.+}}]
+// CHECK:       memref.load
+// CHECK-NOT:   fir.box_dims
+// CHECK-NOT:   fir.box_elesize
+// CHECK-NOT:   fir.array_coor
+func.func @array_coor_box_shape_shift_slice(%arg0: !fir.box<!fir.array<?x?xi32>>) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c5 = arith.constant 5 : index
+  %c10 = arith.constant 10 : index
+  %undef = fir.undefined index
+  %ss = fir.shape_shift %c1, %c10, %c1, %c5 : (index, index, index, index) -> !fir.shapeshift<2>
+  %slice = fir.slice %c1, %c2, %c1, %c2, %undef, %undef : (index, index, index, index, index, index) -> !fir.slice<2>
+  %addr = fir.array_coor %arg0(%ss) [%slice] %c1, %c2 : (!fir.box<!fir.array<?x?xi32>>, !fir.shapeshift<2>, !fir.slice<2>, index, index) -> !fir.ref<i32>
+  %val = fir.load %addr : !fir.ref<i32>
+  return
+}


### PR DESCRIPTION
A `fir.array_coor` with box input, a slice and a shape without
a shift, should also be converted using dimensions information
stored in the input box (case (c) in the updated code).
