### PR TITLE
[Github] Add timeouts to libc tests

### DIFF
--- a/.github/workflows/libc-freebsd-vm-tests.yml
+++ b/.github/workflows/libc-freebsd-vm-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     if: github.repository_owner == 'llvm'
+    timeout-minutes: 120
     runs-on: ubuntu-24.04
     
     steps:

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     if: github.repository_owner == 'llvm'
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     container:
       image: ${{ (startsWith(matrix.os, 'ubuntu-24.04-arm') && 'ghcr.io/llvm/arm64v8/libc-ubuntu-24.04') || 'ghcr.io/llvm/libc-ubuntu-24.04'}}

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     if: github.repository_owner == 'llvm'
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations.

--- a/.github/workflows/libc-shared-tests.yml
+++ b/.github/workflows/libc-shared-tests.yml
@@ -11,6 +11,7 @@ jobs:
   windows-msvc-shared:
     name: libc-shared-test with MSVC (${{ matrix.arch }})
     if: github.repository_owner == 'llvm'
+    timeout-minutes: 20
     strategy:
       fail-fast: false # If one arch fails, let the other finish
       matrix:
@@ -49,6 +50,7 @@ jobs:
   linux-cross-arch-shared:
     name: libc-shared-tests on (${{ matrix.arch }})
     if: github.repository_owner == 'llvm'
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false # If one arch fails, let the other finish


### PR DESCRIPTION
None of these jobs do not take anywhere close to the six hour timeout that Github uses by default. Set timeouts that are 2-3x the typical job runtime so that if there is a test/build step that hangs indefinitely, the job times out in a reasonable amount of time and does not hold any resources that could be used elsewhere.

This should not impact any jobs that do not hang, will not change the result of jobs that do hang, and means we can more effectively deal with cases like today where tests were hanging, from a resource perspective.

This is also standard in some other workflows like the main premerge workflow definition.