### PR TITLE
DebugInfo: Shrink-to-fit some containers to reduce peak memory usage

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
@@ -50,6 +50,7 @@ Error DWARFAbbreviationDeclarationSet::extract(DataExtractor Data,
     PrevAbbrCode = AbbrDecl.getCode();
     Decls.push_back(std::move(AbbrDecl));
   }
+  Decls.shrink_to_fit();
   return Error::success();
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1269,6 +1269,9 @@ Error DWARFDebugLine::LineTable::parse(
         " is not terminated",
         DebugLineOffset));
 
+  Rows.shrink_to_fit();
+  Sequences.shrink_to_fit();
+
   // Sort all sequences so that address lookup will work faster.
   if (!Sequences.empty()) {
     llvm::stable_sort(Sequences, Sequence::orderByHighPC);

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -496,6 +496,7 @@ void DWARFUnit::extractDIEsToVector(
 
     // Stop when compile unit die is removed from the parents stack.
   } while (Parents.size() > 1);
+  Dies.shrink_to_fit();
 }
 
 void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {


### PR DESCRIPTION
Changes originally by Tipp Moseley (tipp@google.com)
