### PR TITLE
[libc] Allow atexit to be compiled pre-C++20

### DIFF
--- a/libc/src/__support/macros/CMakeLists.txt
+++ b/libc/src/__support/macros/CMakeLists.txt
@@ -13,6 +13,10 @@ add_header_library(
   attributes
   HDRS
     attributes.h
+  DEPENDS
+    .config
+    libc.src.__support.macros.properties.architectures
+    libc.src.__support.macros.properties.compiler
 )
 
 add_header_library(

--- a/libc/src/__support/macros/attributes.h
+++ b/libc/src/__support/macros/attributes.h
@@ -19,6 +19,7 @@
 
 #include "config.h"
 #include "properties/architectures.h"
+#include "properties/compiler.h"
 
 #ifndef __has_attribute
 #define __has_attribute(x) 0
@@ -84,6 +85,8 @@ LIBC_THREAD_MODE_EXTERNAL.
 #define LIBC_CONSTINIT constinit
 #elif __has_attribute(__require_constant_initialization__)
 #define LIBC_CONSTINIT __attribute__((__require_constant_initialization__))
+#elif defined(LIBC_COMPILER_IS_GCC) && (LIBC_COMPILER_GCC_VER >= 1202L)
+#define LIBC_CONSTINIT __constinit
 #else
 #define LIBC_CONSTINIT
 #endif

--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -710,10 +710,12 @@ add_entrypoint_object(
     atexit.cpp
   HDRS
     atexit.h
-  CXX_STANDARD
-    20 # For constinit
   DEPENDS
     .exit_handler
+    libc.hdr.types.atexithandler_t
+    libc.src.__support.common
+    libc.src.__support.macros.attributes
+    libc.src.__support.macros.config
 )
 
 add_entrypoint_object(
@@ -722,11 +724,13 @@ add_entrypoint_object(
     at_quick_exit.cpp
   HDRS
     at_quick_exit.h
-  CXX_STANDARD
-    20 # For constinit
   DEPENDS
-    .exit_handler
     .atexit
+    .exit_handler
+    libc.hdr.types.atexithandler_t
+    libc.src.__support.common
+    libc.src.__support.macros.attributes
+    libc.src.__support.macros.config
 )
 
 list(APPEND exit_deps

--- a/libc/src/stdlib/at_quick_exit.cpp
+++ b/libc/src/stdlib/at_quick_exit.cpp
@@ -9,12 +9,13 @@
 #include "src/stdlib/at_quick_exit.h"
 #include "hdr/types/atexithandler_t.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/stdlib/exit_handler.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constinit ExitCallbackList at_quick_exit_callbacks;
+LIBC_CONSTINIT ExitCallbackList at_quick_exit_callbacks;
 
 LLVM_LIBC_FUNCTION(int, at_quick_exit, (__atexithandler_t callback)) {
   return add_atexit_unit(

--- a/libc/src/stdlib/atexit.cpp
+++ b/libc/src/stdlib/atexit.cpp
@@ -9,12 +9,14 @@
 #include "src/stdlib/atexit.h"
 #include "hdr/types/atexithandler_t.h"
 #include "src/__support/common.h"
+#include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/stdlib/exit_handler.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constinit ExitCallbackList atexit_callbacks;
+LIBC_CONSTINIT ExitCallbackList atexit_callbacks;
+
 Mutex handler_list_mtx(/*is_priority_inherit=*/false, /*is_recursive=*/false,
                        /*is_robust=*/false, /*is_pshared=*/false);
 


### PR DESCRIPTION
Currently, LLVM-libc only supports GCC 12.2+ and Clang 11+, which both have builtin constinit support via `__constinit` and `__require_constant_initialization__`.

This PR updates `LIBC_CONSTINIT` to use the GCC-specific attribute and updates `atexit`/`at_quick_exit` to use this attribute instead of `constinit`, which requires C++20 to compile.