### PR TITLE
[coro] Use C calling convention for C++20 coroutines

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -107,6 +107,12 @@ ABI Changes in This Version
 - Clang now uses MSVC-compatible manglings for supported AArch64 SVE builtin
   types when targeting the Microsoft ABI. This changes symbol names for
   affected declarations compared to previous Clang releases. (#GH196170)
+- The resume and destroy functions of C++20 coroutines now use the platform C
+  calling convention instead of LLVM's internal ``fastcc``. This makes the
+  coroutine ABI stable across LLVM versions and interoperable with other
+  compilers. On most targets this is not a breaking change because ``fastcc``
+  and the platform C calling convention agree for ``void(ptr)``. It is an ABI
+  break on i686, MIPS O32, PowerPC64 ELFv1, and Lanai.
 
 AST Dumping Potentially Breaking Changes
 ----------------------------------------

--- a/clang/test/CodeGenCoroutines/coro-gro4.cpp
+++ b/clang/test/CodeGenCoroutines/coro-gro4.cpp
@@ -44,8 +44,8 @@ wrapper fn() { co_return; }
 // CHECK: call void @gro_destroy()
 // CHECK: ret void
 
-// CHECK: define internal fastcc void @_Z2fnv.resume
+// CHECK: define internal void @_Z2fnv.resume
 // CHECK-NOT: call void @gro_destroy()
 
-// CHECK: define internal fastcc void @_Z2fnv.destroy
+// CHECK: define internal void @_Z2fnv.destroy
 // CHECK-NOT: call void @gro_destroy()

--- a/clang/test/CodeGenCoroutines/coro-symmetric-transfer-03.cpp
+++ b/clang/test/CodeGenCoroutines/coro-symmetric-transfer-03.cpp
@@ -64,5 +64,5 @@ Task task0() {
 // CHECK-LABEL: define{{.*}} void @_Z5task0v.resume
 // This checks we are still in the scope of the current function.
 // CHECK-NOT: {{^}}}
-// CHECK: musttail call fastcc void
+// CHECK: musttail call void
 // CHECK-NEXT: ret void

--- a/clang/test/CodeGenCoroutines/coro-symmetric-transfer-04.cpp
+++ b/clang/test/CodeGenCoroutines/coro-symmetric-transfer-04.cpp
@@ -62,5 +62,5 @@ Task task0() {
 // CHECK-LABEL: define{{.*}} void @_Z5task0v.resume
 // This checks we are still in the scope of the current function.
 // CHECK-NOT: {{^}}}
-// CHECK: musttail call fastcc void
+// CHECK: musttail call void
 // CHECK-NEXT: ret void

--- a/clang/test/CodeGenCoroutines/pr65018.cpp
+++ b/clang/test/CodeGenCoroutines/pr65018.cpp
@@ -45,6 +45,6 @@ MyTask FooBar() {
 
 // CHECK: %[[RET:.+]] = {{.*}}call{{.*}}@_ZN7Awaiter13await_suspendESt16coroutine_handleIvE
 // CHECK: %[[RESUME_ADDR:.+]] = load ptr, ptr %[[RET]],
-// CHECK: musttail call fastcc void %[[RESUME_ADDR]]({{.*}}%[[RET]]
+// CHECK: musttail call void %[[RESUME_ADDR]]({{.*}}%[[RET]]
 // CHECK: ret
 

--- a/llvm/docs/Coroutines.rst
+++ b/llvm/docs/Coroutines.rst
@@ -382,7 +382,7 @@ Outlined resume part of the coroutine will reside in function `f.resume`:
 
 .. code-block:: llvm
 
-  define internal fastcc void @f.resume(ptr %frame.ptr.resume) {
+  define internal void @f.resume(ptr %frame.ptr.resume) {
   entry:
     %inc.spill.addr = getelementptr %f.frame, ptr %frame.ptr.resume, i64 0, i32 2
     %inc.spill = load i32, ptr %inc.spill.addr, align 4
@@ -396,7 +396,7 @@ Whereas function `f.destroy` will contain the cleanup code for the coroutine:
 
 .. code-block:: llvm
 
-  define internal fastcc void @f.destroy(ptr %frame.ptr.destroy) {
+  define internal void @f.destroy(ptr %frame.ptr.destroy) {
   entry:
     tail call void @free(ptr %frame.ptr.destroy)
     ret void
@@ -506,7 +506,7 @@ as follows:
 
 .. code-block:: llvm
 
-  define internal fastcc void @f.Resume(ptr %FramePtr) {
+  define internal void @f.Resume(ptr %FramePtr) {
   entry.Resume:
     %index.addr = getelementptr inbounds %f.Frame, ptr %FramePtr, i64 0, i32 2
     %index = load i8, ptr %index.addr, align 1

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -80,6 +80,13 @@ Makes programs 10x faster by doing Special New Thing.
 * The standard textual output for floating-point literals is changed to take
   advantage of the new floating-point literals formats.
 
+* The resume/destroy functions emitted for the switch-resume ABI (C++20
+  coroutines) now use `CallingConv::C` instead of `CallingConv::Fast`. This
+  stabilizes the coroutine ABI across LLVM versions and aligns it with other
+  vendors. The change is observationally identical on targets where `fastcc`
+  and `ccc` agree for `void(ptr)` (x86_64, AArch64, RISC-V, ...) but is an ABI
+  break on i686, MIPS O32, PowerPC64 ELFv1, and Lanai.
+
 ### Changes to LLVM infrastructure
 
 * Removed ``Constant::isZeroValue``. It was functionally identical to

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -211,7 +211,10 @@ struct Shape {
   CallingConv::ID getResumeFunctionCC() const {
     switch (ABI) {
     case coro::ABI::Switch:
-      return CallingConv::Fast;
+      // Use the platform C calling convention so that resume/destroy
+      // function pointers stored in the coroutine frame are
+      // interoperable with other compilers.
+      return CallingConv::C;
 
     case coro::ABI::Retcon:
     case coro::ABI::RetconOnce:

--- a/llvm/lib/Transforms/Coroutines/CoroCleanup.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroCleanup.cpp
@@ -183,7 +183,6 @@ void Lowerer::lowerCoroNoop(IntrinsicInst *II) {
         FnTy, GlobalValue::LinkageTypes::InternalLinkage,
         M.getDataLayout().getProgramAddressSpace(), "__NoopCoro_ResumeDestroy",
         &M);
-    NoopFn->setCallingConv(CallingConv::Fast);
     buildDebugInfoForNoopResumeDestroyFunc(NoopFn);
     auto *Entry = BasicBlock::Create(C, "entry", NoopFn);
     ReturnInst::Create(C, Entry);

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -44,7 +44,6 @@ void Lowerer::lowerResumeOrDestroy(CallBase &CB,
                                    CoroSubFnInst::ResumeKind Index) {
   Value *ResumeAddr = makeSubFnCall(CB.getArgOperand(0), Index, &CB);
   CB.setCalledOperand(ResumeAddr);
-  CB.setCallingConv(CallingConv::Fast);
 }
 
 // Coroutine promise field is always at the fixed offset from the beginning of

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -136,7 +136,6 @@ static void lowerAwaitSuspend(IRBuilder<> &Builder, CoroAwaitSuspendInst *CB,
     FunctionType *ResumeTy = FunctionType::get(
         Type::getVoidTy(Ctx), PointerType::getUnqual(Ctx), false);
     auto *ResumeCall = Builder.CreateCall(ResumeTy, ResumeAddr, {NewCall});
-    ResumeCall->setCallingConv(CallingConv::Fast);
 
     // We can't insert the 'ret' instruction and adjust the cc until the
     // function has been split, so remember this for later.

--- a/llvm/test/Transforms/Coroutines/coro-alloc-with-param-O0.ll
+++ b/llvm/test/Transforms/Coroutines/coro-alloc-with-param-O0.ll
@@ -63,7 +63,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f_copy.resume(
+; CHECK-LABEL: define internal void @f_copy.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[THIS_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -74,7 +74,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f_copy.destroy(
+; CHECK-LABEL: define internal void @f_copy.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -82,7 +82,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f_copy.cleanup(
+; CHECK-LABEL: define internal void @f_copy.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-alloc-with-param-O2.ll
+++ b/llvm/test/Transforms/Coroutines/coro-alloc-with-param-O2.ll
@@ -58,7 +58,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f_direct.resume(
+; CHECK-LABEL: define internal void @f_direct.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[THIS_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -69,7 +69,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f_direct.destroy(
+; CHECK-LABEL: define internal void @f_direct.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -77,7 +77,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f_direct.cleanup(
+; CHECK-LABEL: define internal void @f_direct.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-alloca-07.ll
+++ b/llvm/test/Transforms/Coroutines/coro-alloca-07.ll
@@ -84,7 +84,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(48) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[ALIAS_PHI_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 32
@@ -95,7 +95,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(48) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -103,7 +103,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(48) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-await-suspend-handle-in-ramp.ll
+++ b/llvm/test/Transforms/Coroutines/coro-await-suspend-handle-in-ramp.ll
@@ -17,12 +17,13 @@ entry:
     i8 1, label %cleanup
   ]
 
-; Check the calling convention for resuming function is fastcc
-; CHECK:     define {{[^@]*}} @f()
+; The `call void` below uses the default calling convention. This must match
+; the calling convention of the `@f.resume` function, tested further down.
+; CHECK:      define void @f() {
 ; CHECK:      entry:
 ; CHECK:        %[[NEXT_HDL:.+]] = call ptr @await_suspend_wrapper_handle(
 ; CHECK-NEXT:   %[[CONT:.+]] = call ptr @llvm.coro.subfn.addr(ptr %[[NEXT_HDL]], i8 0)
-; CHECK-NEXT:   call fastcc void %[[CONT]](ptr %[[NEXT_HDL]])
+; CHECK-NEXT:   call void %[[CONT]](ptr %[[NEXT_HDL]])
 step:
   br label %cleanup
 
@@ -36,10 +37,11 @@ ret:
   ret void
 }
 
-; check that we were haven't accidentally went out of @f body
-; CHECK-LABEL: @f.resume(
-; CHECK-LABEL: @f.destroy(
-; CHECK-LABEL: @f.cleanup(
+; Check that the clones use the same calling convention as the ramp's resuming
+; call (i.e. the default as there is no specifc calling convention mentioned).
+; CHECK-LABEL: define internal void @f.resume(
+; CHECK-LABEL: define internal void @f.destroy(
+; CHECK-LABEL: define internal void @f.cleanup(
 
 declare ptr @await_suspend_wrapper_handle(ptr, ptr)
 

--- a/llvm/test/Transforms/Coroutines/coro-await-suspend-lower-invoke.ll
+++ b/llvm/test/Transforms/Coroutines/coro-await-suspend-lower-invoke.ll
@@ -117,7 +117,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*]]:
 ; CHECK-NEXT:    [[AWAITER_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 0
@@ -156,7 +156,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:            to label %[[STEP2_CONTINUE:.*]] unwind label %[[PAD]]
 ; CHECK:       [[STEP2_CONTINUE]]:
 ; CHECK-NEXT:    [[TMP4:%.*]] = call ptr @llvm.coro.subfn.addr(ptr [[TMP3]], i8 0)
-; CHECK-NEXT:    musttail call fastcc void [[TMP4]](ptr [[TMP3]])
+; CHECK-NEXT:    musttail call void [[TMP4]](ptr [[TMP3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[PAD]]:
 ; CHECK-NEXT:    [[LP:%.*]] = landingpad { ptr, i32 }
@@ -175,7 +175,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    unreachable
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[AWAITER_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 0
@@ -184,7 +184,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[AWAITER_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 0

--- a/llvm/test/Transforms/Coroutines/coro-await-suspend-lower.ll
+++ b/llvm/test/Transforms/Coroutines/coro-await-suspend-lower.ll
@@ -94,7 +94,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*]]:
 ; CHECK-NEXT:    [[AWAITER_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 0
@@ -129,7 +129,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    store i2 -1, ptr [[INDEX_ADDR15]], align 1
 ; CHECK-NEXT:    [[TMP3:%.*]] = call ptr @await_suspend_wrapper_handle(ptr [[AWAITER_RELOAD_ADDR]], ptr [[HDL]])
 ; CHECK-NEXT:    [[TMP4:%.*]] = call ptr @llvm.coro.subfn.addr(ptr [[TMP3]], i8 0)
-; CHECK-NEXT:    musttail call fastcc void [[TMP4]](ptr [[TMP3]])
+; CHECK-NEXT:    musttail call void [[TMP4]](ptr [[TMP3]])
 ; CHECK-NEXT:    ret void
 ; CHECK:       [[CLEANUP]]:
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -141,7 +141,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    unreachable
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[AWAITER_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 0
@@ -150,7 +150,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[AWAITER_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 0

--- a/llvm/test/Transforms/Coroutines/coro-debug-O2.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-O2.ll
@@ -2,7 +2,7 @@
 
 ; Checks the dbg informations about promise and coroutine frames under O2.
 
-; CHECK-LABEL: define internal fastcc void @f.resume({{.*}})
+; CHECK-LABEL: define internal void @f.resume({{.*}})
 ; CHECK:       entry.resume:
 ; CHECK:        #dbg_value(ptr poison, ![[PROMISEVAR_RESUME:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 16
 ; CHECK:        #dbg_value(ptr %begin, ![[CORO_FRAME:[0-9]+]], !DIExpression(DW_OP_deref)

--- a/llvm/test/Transforms/Coroutines/coro-debug-coro-frame.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-coro-frame.ll
@@ -7,7 +7,7 @@
 ; CHECK:        %[[begin:.*]] = call noalias nonnull ptr @llvm.coro.begin(
 ; CHECK:        #dbg_declare(ptr %[[begin]], ![[CORO_FRAME:[0-9]+]], !DIExpression(),
 ;
-; CHECK:       define internal fastcc void @f.resume(
+; CHECK:       define internal void @f.resume(
 ; CHECK:       entry.resume:
 ; CHECK:            %[[FramePtr_RESUME:.*]] = alloca ptr
 ; CHECK:            #dbg_declare(ptr %[[FramePtr_RESUME]], ![[CORO_FRAME_IN_RESUME:[0-9]+]], !DIExpression(DW_OP_deref)

--- a/llvm/test/Transforms/Coroutines/coro-debug-dbg.values-not_used_in_frame.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-dbg.values-not_used_in_frame.ll
@@ -2,7 +2,7 @@
 ; RUN: opt < %s -passes='module(coro-early),cgscc(coro-split,coro-split)' -S | FileCheck %s
 ;
 ; This file is based on coro-debug-frame-variable.ll.
-; CHECK:  define internal fastcc void @_Z3foov.resume(ptr noundef nonnull align 16 dereferenceable(80) %begin) !dbg ![[RESUME_FN_DBG_NUM:[0-9]+]]
+; CHECK:  define internal void @_Z3foov.resume(ptr noundef nonnull align 16 dereferenceable(80) %begin) !dbg ![[RESUME_FN_DBG_NUM:[0-9]+]]
 ; CHECK:       await.ready:
 ; CHECK:         #dbg_value(i32 poison, ![[IVAR_RESUME:[0-9]+]], !DIExpression(
 ; CHECK:         #dbg_value(i32 poison, ![[JVAR_RESUME:[0-9]+]], !DIExpression(

--- a/llvm/test/Transforms/Coroutines/coro-debug-frame-variable.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-frame-variable.ll
@@ -36,7 +36,7 @@
 ; CHECK:         #dbg_declare(ptr %[[MEMORY]], ![[IVAR:[0-9]+]], !DIExpression(DW_OP_plus_uconst, 20), ![[IDBGLOC]]
 ; CHECK:       await.ready:
 ;
-; CHECK-LABEL: define internal fastcc void @_Z3foov.resume({{.*}}) {{.*}} {
+; CHECK-LABEL: define internal void @_Z3foov.resume({{.*}}) {{.*}} {
 ; CHECK:       entry.resume:
 ; CHECK-NEXT:    %[[DBG_PTR:.*]] = alloca ptr
 ; CHECK-NEXT:    #dbg_declare(ptr %[[DBG_PTR]], ![[XVAR_RESUME:[0-9]+]],   !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32),

--- a/llvm/test/Transforms/Coroutines/coro-debug-spill-dbg.declare.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug-spill-dbg.declare.ll
@@ -17,17 +17,17 @@
 ;
 ; We want to make sure that the "this" pointer is accessable in debugger before and after the suspension point.
 ;
-; CHECK: define internal fastcc void @foo.resume(ptr noundef nonnull align 8 dereferenceable(32) %[[HDL:.*]])
+; CHECK: define internal void @foo.resume(ptr noundef nonnull align 8 dereferenceable(32) %[[HDL:.*]])
 ; CHECK-NEXT: entry.resume:
 ; CHECK-NEXT:   %[[HDL]].debug = alloca ptr, align 8
 ; CHECK-NEXT:   #dbg_declare(ptr %[[HDL]].debug, ![[THIS_RESUME:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24),
 ;
-; CHECK: define internal fastcc void @foo.destroy(ptr noundef nonnull align 8 dereferenceable(32) %[[HDL]])
+; CHECK: define internal void @foo.destroy(ptr noundef nonnull align 8 dereferenceable(32) %[[HDL]])
 ; CHECK-NEXT: entry.destroy:
 ; CHECK-NEXT:   %[[HDL]].debug = alloca ptr, align 8
 ; CHECK-NEXT:   #dbg_declare(ptr %[[HDL]].debug, ![[THIS_DESTROY:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24),
 ;
-; CHECK: define internal fastcc void @foo.cleanup(ptr noundef nonnull align 8 dereferenceable(32) %[[HDL]])
+; CHECK: define internal void @foo.cleanup(ptr noundef nonnull align 8 dereferenceable(32) %[[HDL]])
 ; CHECK-NEXT: entry.cleanup:
 ; CHECK-NEXT:   %[[HDL]].debug = alloca ptr, align 8
 ; CHECK-NEXT:   #dbg_declare(ptr %[[HDL]].debug, ![[THIS_CLEANUP:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24),

--- a/llvm/test/Transforms/Coroutines/coro-debug.ll
+++ b/llvm/test/Transforms/Coroutines/coro-debug.ll
@@ -162,7 +162,7 @@ attributes #0 = { noinline nounwind presplitcoroutine }
 ; Also check that it contains `#dbg_declare` and `#dbg_value` debug instructions
 ; making the debug variables available to the debugger.
 ;
-; CHECK: define internal fastcc void @flink.resume(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 personality i32 0 !dbg ![[RESUME:[0-9]+]]
+; CHECK: define internal void @flink.resume(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 personality i32 0 !dbg ![[RESUME:[0-9]+]]
 ; CHECK: entry.resume:
 ; CHECK: %[[DBG_PTR:.*]] = alloca ptr
 ; CHECK-NEXT: #dbg_declare(ptr %[[DBG_PTR]], ![[RESUME_X:[0-9]+]], !DIExpression(DW_OP_deref, DW_OP_plus_uconst, [[EXPR_TAIL:.*]])
@@ -186,8 +186,8 @@ attributes #0 = { noinline nounwind presplitcoroutine }
 
 ; Check that the destroy and cleanup functions are present and capture their debug info id.
 ;
-; CHECK: define internal fastcc void @flink.destroy(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 personality i32 0 !dbg ![[DESTROY:[0-9]+]]
-; CHECK: define internal fastcc void @flink.cleanup(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 personality i32 0 !dbg ![[CLEANUP:[0-9]+]]
+; CHECK: define internal void @flink.destroy(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 personality i32 0 !dbg ![[DESTROY:[0-9]+]]
+; CHECK: define internal void @flink.cleanup(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 personality i32 0 !dbg ![[CLEANUP:[0-9]+]]
 
 ; Check that the linkage name of the original function is set correctly.
 ;

--- a/llvm/test/Transforms/Coroutines/coro-eh-aware-edge-split-00.ll
+++ b/llvm/test/Transforms/Coroutines/coro-eh-aware-edge-split-00.ll
@@ -4,7 +4,7 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
 
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 define void @f(i1 %cond) presplitcoroutine personality i32 0 {
 entry:
   %id = call token @llvm.coro.id(i32 16, ptr null, ptr @f, ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-eh-aware-edge-split-01.ll
+++ b/llvm/test/Transforms/Coroutines/coro-eh-aware-edge-split-01.ll
@@ -90,7 +90,7 @@ declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @g.resume(
+; CHECK-LABEL: define internal void @g.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[COND_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 25
@@ -121,7 +121,7 @@ declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 ; CHECK-NEXT:    unreachable
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @g.destroy(
+; CHECK-LABEL: define internal void @g.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -129,7 +129,7 @@ declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @g.cleanup(
+; CHECK-LABEL: define internal void @g.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-eh-aware-edge-split-02.ll
+++ b/llvm/test/Transforms/Coroutines/coro-eh-aware-edge-split-02.ll
@@ -90,7 +90,7 @@ declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @h.resume(
+; CHECK-LABEL: define internal void @h.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[COND_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 25
@@ -123,7 +123,7 @@ declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @h.destroy(
+; CHECK-LABEL: define internal void @h.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -131,7 +131,7 @@ declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @h.cleanup(
+; CHECK-LABEL: define internal void @h.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-frame-arrayalloca.ll
+++ b/llvm/test/Transforms/Coroutines/coro-frame-arrayalloca.ll
@@ -72,7 +72,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(56) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[PREFIX_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -86,7 +86,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(56) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -94,7 +94,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(56) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-frame.ll
+++ b/llvm/test/Transforms/Coroutines/coro-frame.ll
@@ -72,7 +72,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(40) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[R_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -86,7 +86,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(40) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -94,7 +94,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(40) [[HDL:%.*]]) personality i32 0 {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-noop-pacbti.ll
+++ b/llvm/test/Transforms/Coroutines/coro-noop-pacbti.ll
@@ -1,7 +1,7 @@
 
 ; RUN: opt < %s -S -passes=coro-cleanup | FileCheck %s
 
-; CHECK:      define internal fastcc void @__NoopCoro_ResumeDestroy(ptr %0) #1 {
+; CHECK:      define internal void @__NoopCoro_ResumeDestroy(ptr %0) #1 {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/llvm/test/Transforms/Coroutines/coro-noop.ll
+++ b/llvm/test/Transforms/Coroutines/coro-noop.ll
@@ -25,7 +25,7 @@ declare ptr @llvm.coro.noop()
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 
 
-; CHECK: define internal fastcc void @__NoopCoro_ResumeDestroy(ptr %0) !dbg ![[RESUME:[0-9]+]] {
+; CHECK: define internal void @__NoopCoro_ResumeDestroy(ptr %0) !dbg ![[RESUME:[0-9]+]] {
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:    ret void
 

--- a/llvm/test/Transforms/Coroutines/coro-padding.ll
+++ b/llvm/test/Transforms/Coroutines/coro-padding.ll
@@ -61,7 +61,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 32 dereferenceable(64) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[DATA_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 32
@@ -71,7 +71,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 32 dereferenceable(64) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -79,7 +79,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 32 dereferenceable(64) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-resume-destroy.ll
+++ b/llvm/test/Transforms/Coroutines/coro-resume-destroy.ll
@@ -6,11 +6,11 @@ define void @callResume(ptr %hdl) {
 ; CHECK-NEXT: entry
 entry:
 ; CHECK-NEXT: %0 = call ptr @llvm.coro.subfn.addr(ptr %hdl, i8 0)
-; CHECK-NEXT: call fastcc void %0(ptr %hdl)
+; CHECK-NEXT: call void %0(ptr %hdl)
   call void @llvm.coro.resume(ptr %hdl)
 
 ; CHECK-NEXT: %1 = call ptr @llvm.coro.subfn.addr(ptr %hdl, i8 1)
-; CHECK-NEXT: call fastcc void %1(ptr %hdl)
+; CHECK-NEXT: call void %1(ptr %hdl)
   call void @llvm.coro.destroy(ptr %hdl)
 
   ret void
@@ -22,7 +22,7 @@ define void @eh(ptr %hdl) personality ptr null {
 ; CHECK-NEXT: entry
 entry:
 ;  CHECK-NEXT: %0 = call ptr @llvm.coro.subfn.addr(ptr %hdl, i8 0)
-;  CHECK-NEXT: invoke fastcc void %0(ptr %hdl)
+;  CHECK-NEXT: invoke void %0(ptr %hdl)
   invoke void @llvm.coro.resume(ptr %hdl)
           to label %cont unwind label %ehcleanup
 cont:

--- a/llvm/test/Transforms/Coroutines/coro-spill-corobegin.ll
+++ b/llvm/test/Transforms/Coroutines/coro-spill-corobegin.ll
@@ -69,7 +69,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[INNERHDL_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -82,7 +82,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -90,7 +90,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(32) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-spill-promise-02.ll
+++ b/llvm/test/Transforms/Coroutines/coro-spill-promise-02.ll
@@ -71,7 +71,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 64 dereferenceable(128) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[DATA_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -83,7 +83,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 64 dereferenceable(128) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -91,7 +91,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 64 dereferenceable(128) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-spill-promise.ll
+++ b/llvm/test/Transforms/Coroutines/coro-spill-promise.ll
@@ -65,7 +65,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 64 dereferenceable(128) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[DATA_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -77,7 +77,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 64 dereferenceable(128) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -85,7 +85,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 64 dereferenceable(128) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)

--- a/llvm/test/Transforms/Coroutines/coro-spill-suspend.ll
+++ b/llvm/test/Transforms/Coroutines/coro-spill-suspend.ll
@@ -59,7 +59,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*]]:
 ; CHECK-NEXT:    [[INDEX_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -90,7 +90,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    unreachable
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[INDEX_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -114,7 +114,7 @@ declare void @free(ptr)
 ; CHECK-NEXT:    unreachable
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[INDEX_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16

--- a/llvm/test/Transforms/Coroutines/coro-split-dbg-labels-inlined.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-dbg-labels-inlined.ll
@@ -33,13 +33,13 @@ coro_Suspend:
 }
 
 ; Check that the resume function contains the `#dbg_label` instructions.
-; CHECK-LABEL:   define internal fastcc void @f.resume({{.*}})
+; CHECK-LABEL:   define internal void @f.resume({{.*}})
 ; CHECK-SAME:      !dbg ![[RESUME_SUBPROGRAM:[0-9]+]]
 ; CHECK:         resume.0:
 ; CHECK-NEXT:        #dbg_label(![[RESUME_0:[0-9]+]], ![[RESUME_LABEL_LOC:[0-9]+]])
 
 ; Check that the destroy function contains the `#dbg_label` instructions.
-; CHECK-LABEL:   define internal fastcc void @f.destroy({{.*}})
+; CHECK-LABEL:   define internal void @f.destroy({{.*}})
 ; CHECK-SAME:      !dbg ![[DESTROY_SUBPROGRAM:[0-9]+]]
 ; CHECK:         resume.0:
 ; CHECK-NEXT:        #dbg_label(![[DESTROY_0:[0-9]+]], ![[DESTROY_LABEL_LOC:[0-9]+]])

--- a/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
@@ -76,7 +76,7 @@ coro_Suspend:                                     ; preds = %for.cond, %if.then,
 ; CHECK-NEXT:        #dbg_label(![[RESUME_1:[0-9]+]], !{{[0-9]+}})
 
 ; Check that the destroy function contains the `#dbg_label` instructions.
-; CHECK-LABEL:   define internal fastcc void @f.destroy({{.*}}) #1 !dbg !38 {
+; CHECK-LABEL:   define internal void @f.destroy({{.*}}) #1 !dbg !38 {
 ; CHECK:         resume.0:        ; preds = %resume.entry
 ; CHECK-NEXT:        #dbg_label(![[DESTROY_0:[0-9]+]], !{{[0-9]+}})
 ; CHECK:         resume.1:        ; preds = %resume.entry

--- a/llvm/test/Transforms/Coroutines/coro-split-eh-00.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-eh-00.ll
@@ -57,7 +57,7 @@ eh.resume:
 ; VERIFY Resume Parts
 
 ; Verify that resume function does not contains both print calls appearing after coro.end
-; CHECK-LABEL: define internal fastcc void @f.resume
+; CHECK-LABEL: define internal void @f.resume
 ; CHECK: invoke void @print(i32 1)
 ; CHECK:   to label %CoroEnd unwind label %lpad
 

--- a/llvm/test/Transforms/Coroutines/coro-split-eh-01.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-eh-01.ll
@@ -51,7 +51,7 @@ cleanup.cont:
 ; VERIFY Resume Parts
 
 ; Verify that resume function does not contains both print calls appearing after coro.end
-; CHECK-LABEL: define internal fastcc void @f2.resume
+; CHECK-LABEL: define internal void @f2.resume
 ; CHECK: invoke void @print(i32 1)
 ; CHECK:   to label %CoroEnd unwind label %lpad
 

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail-chain-pgo-counter-promo.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail-chain-pgo-counter-promo.ll
@@ -1,12 +1,12 @@
 ; REQUIRES: x86-registered-target
 ; RUN: opt -passes='pgo-instr-gen,instrprof,coro-split' -do-counter-promotion=true -S < %s | FileCheck %s
 
-; CHECK-LABEL: define internal fastcc void @f.resume
-; CHECK: musttail call fastcc void 
+; CHECK-LABEL: define internal void @f.resume
+; CHECK: musttail call void 
 ; CHECK-NEXT: ret void
-; CHECK: musttail call fastcc void 
+; CHECK: musttail call void 
 ; CHECK-NEXT: ret void
-; CHECK-LABEL: define internal fastcc void @f.destroy
+; CHECK-LABEL: define internal void @f.destroy
 target triple = "x86_64-grtev4-linux-gnu"
 
 %CoroutinePromise = type { ptr, i64, [8 x i8], ptr} 
@@ -131,7 +131,7 @@ define ptr @f(i32 %0) presplitcoroutine align 32 {
   %48 = inttoptr i64 %40 to ptr
   %49 = call ptr @llvm.coro.subfn.addr(ptr %48, i8 0)
   %50 = ptrtoint ptr %49 to i64
-  call fastcc void %49(ptr %48) #9
+  call void %49(ptr %48) #9
   %51 = call i8 @llvm.coro.suspend(token %37, i1 true) #28
   switch i8 %51, label %61 [
     i8 0, label %53

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail.ll
@@ -10,7 +10,7 @@ entry:
 
   %save = call token @llvm.coro.save(ptr null)
   %addr1 = call ptr @llvm.coro.subfn.addr(ptr null, i8 0)
-  call fastcc void %addr1(ptr null)
+  call void %addr1(ptr null)
 
   %suspend = call i8 @llvm.coro.suspend(token %save, i1 false)
   switch i8 %suspend, label %exit [
@@ -34,12 +34,12 @@ exit:
 ; Verify that in the initial function resume is not marked with musttail.
 ; CHECK-LABEL: @f(
 ; CHECK: %[[addr1:.+]] = call ptr @llvm.coro.subfn.addr(ptr null, i8 0)
-; CHECK-NOT: musttail call fastcc void %[[addr1]](ptr null)
+; CHECK-NOT: musttail call void %[[addr1]](ptr null)
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @f.resume(
 ; CHECK: %[[addr2:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr2]]
+; CHECK-NEXT: musttail call void %[[addr2]]
 ; CHECK-NEXT: ret void
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #1

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail1.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail1.ll
@@ -10,7 +10,7 @@ entry:
 
   %save = call token @llvm.coro.save(ptr null)
   %addr1 = call ptr @llvm.coro.subfn.addr(ptr null, i8 0)
-  call fastcc void %addr1(ptr null)
+  call void %addr1(ptr null)
 
   %suspend = call i8 @llvm.coro.suspend(token %save, i1 false)
   switch i8 %suspend, label %exit [
@@ -54,23 +54,23 @@ unreach:
 ; Verify that in the initial function resume is not marked with musttail.
 ; CHECK-LABEL: @f(
 ; CHECK: %[[addr1:.+]] = call ptr @llvm.coro.subfn.addr(ptr null, i8 0)
-; CHECK-NOT: musttail call fastcc void %[[addr1]](ptr null)
+; CHECK-NOT: musttail call void %[[addr1]](ptr null)
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @f.resume(
 ; CHECK: %[[hdl:.+]] = call ptr @g()
 ; CHECK-NEXT: call ptr @await_suspend_function
 ; CHECK-NEXT: %[[addr2:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr2]]
+; CHECK-NEXT: musttail call void %[[addr2]]
 ; CHECK-NEXT: ret void
 ; CHECK: %[[hdl2:.+]] = call ptr @h()
 ; CHECK-NEXT: call ptr @await_suspend_function
 ; CHECK-NEXT: %[[addr3:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr3]]
+; CHECK-NEXT: musttail call void %[[addr3]]
 ; CHECK-NEXT: ret void
 ; CHECK: call ptr @await_suspend_function
 ; CHECK: %[[addr4:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr4]]
+; CHECK-NEXT: musttail call void %[[addr4]]
 ; CHECK-NEXT: ret void
 
 

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail2.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail2.ll
@@ -14,7 +14,7 @@ entry:
   %vFrame = call noalias nonnull ptr @llvm.coro.begin(token %id, ptr %alloc)
 
   %save = call token @llvm.coro.save(ptr null)
-  call fastcc void @fakeresume1(ptr null)
+  call void @fakeresume1(ptr null)
 
   %suspend = call i8 @llvm.coro.suspend(token %save, i1 false)
   switch i8 %suspend, label %exit [
@@ -37,13 +37,13 @@ exit:
 
 ; Verify that in the initial function resume is not marked with musttail.
 ; CHECK-LABEL: @g(
-; CHECK-NOT: musttail call fastcc void @fakeresume1(ptr null)
+; CHECK-NOT: musttail call void @fakeresume1(ptr null)
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @g.resume(
 ; CHECK: call ptr @await_suspend_function
 ; CHECK-NEXT: call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void
+; CHECK-NEXT: musttail call void
 ; CHECK-NEXT: ret void
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #1

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail3.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail3.ll
@@ -10,7 +10,7 @@ entry:
 
   %save = call token @llvm.coro.save(ptr null)
   %addr1 = call ptr @llvm.coro.subfn.addr(ptr null, i8 0)
-  call fastcc void %addr1(ptr null)
+  call void %addr1(ptr null)
 
   %suspend = call i8 @llvm.coro.suspend(token %save, i1 false)
   %cmp = icmp eq i8 %suspend, 0
@@ -50,23 +50,23 @@ unreach:
 ; Verify that in the initial function resume is not marked with musttail.
 ; CHECK-LABEL: @f(
 ; CHECK: %[[addr1:.+]] = call ptr @llvm.coro.subfn.addr(ptr null, i8 0)
-; CHECK-NOT: musttail call fastcc void %[[addr1]](ptr null)
+; CHECK-NOT: musttail call void %[[addr1]](ptr null)
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @f.resume(
 ; CHECK: %[[hdl:.+]] = call ptr @g()
 ; CHECK-NEXT: call ptr @await_suspend_function
 ; CHECK-NEXT: %[[addr2:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr2]]
+; CHECK-NEXT: musttail call void %[[addr2]]
 ; CHECK-NEXT: ret void
 ; CHECK: %[[hdl2:.+]] = call ptr @h()
 ; CHECK-NEXT: call ptr @await_suspend_function
 ; CHECK-NEXT: %[[addr3:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr3]]
+; CHECK-NEXT: musttail call void %[[addr3]]
 ; CHECK-NEXT: ret void
 ; CHECK: call ptr @await_suspend_function
 ; CHECK: %[[addr4:.+]] = call ptr @llvm.coro.subfn.addr
-; CHECK-NEXT: musttail call fastcc void %[[addr4]]
+; CHECK-NEXT: musttail call void %[[addr4]]
 ; CHECK-NEXT: ret void
 
 

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail4.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail4.ll
@@ -43,7 +43,7 @@ coro.end:
 }
 
 ; CHECK-LABEL: @f.resume(
-; CHECK:          musttail call fastcc void
+; CHECK:          musttail call void
 ; CHECK-NEXT:     ret void
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #1

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail5.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail5.ll
@@ -38,7 +38,7 @@ exit:
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @g.resume(
-; CHECK:          musttail call fastcc void
+; CHECK:          musttail call void
 ; CHECK-NEXT:     ret void
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #1

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail6.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail6.ll
@@ -42,7 +42,7 @@ exit:
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @g.resume(
-; CHECK:      musttail call fastcc void
+; CHECK:      musttail call void
 ; CHECK-NEXT: ret void
 
 ; It has a cleanup bb.
@@ -90,7 +90,7 @@ exit:
 
 ; Verify that in the resume part resume call is marked with musttail.
 ; CHECK-LABEL: @f.resume(
-; CHECK:      musttail call fastcc void
+; CHECK:      musttail call void
 ; CHECK-NEXT: ret void
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #1

--- a/llvm/test/Transforms/Coroutines/coro-split-musttail7.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-musttail7.ll
@@ -48,7 +48,7 @@ exit:
 ; CHECK-LABEL: @g.resume(
 ; CHECK:         %[[FRAME:[0-9]+]] = call ptr @await_suspend_function(ptr null, ptr null)
 ; CHECK:         %[[RESUMEADDR:[0-9]+]] = call ptr @llvm.coro.subfn.addr(ptr %[[FRAME]], i8 0)
-; CHECK:         musttail call fastcc void %[[RESUMEADDR]](ptr %[[FRAME]])
+; CHECK:         musttail call void %[[RESUMEADDR]](ptr %[[FRAME]])
 ; CHECK-NEXT:    ret void
 
 ; It has a cleanup bb.
@@ -98,7 +98,7 @@ exit:
 ; CHECK-LABEL: @f.resume(
 ; CHECK:         %[[FRAME:[0-9]+]] = call ptr @await_suspend_function(ptr null, ptr null)
 ; CHECK:         %[[RESUMEADDR:[0-9]+]] = call ptr @llvm.coro.subfn.addr(ptr %[[FRAME]], i8 0)
-; CHECK:         musttail call fastcc void %[[RESUMEADDR]](ptr %[[FRAME]])
+; CHECK:         musttail call void %[[RESUMEADDR]](ptr %[[FRAME]])
 ; CHECK-NEXT:    ret void
 
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #1

--- a/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-01.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-01.ll
@@ -142,7 +142,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.resume(
+; CHECK-LABEL: define internal void @a.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca i32, align 4
@@ -156,7 +156,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.destroy(
+; CHECK-LABEL: define internal void @a.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca i32, align 4
@@ -165,7 +165,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.cleanup(
+; CHECK-LABEL: define internal void @a.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca i32, align 4
@@ -174,7 +174,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a_optnone.resume(
+; CHECK-LABEL: define internal void @a_optnone.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[REF_TMP7:%.*]] = alloca %"struct.lean_future<int>::Awaiter", align 8
@@ -201,7 +201,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a_optnone.destroy(
+; CHECK-LABEL: define internal void @a_optnone.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[REF_TMP7:%.*]] = alloca %"struct.lean_future<int>::Awaiter", align 8
@@ -228,7 +228,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a_optnone.cleanup(
+; CHECK-LABEL: define internal void @a_optnone.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) #[[ATTR0]] {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[REF_TMP7:%.*]] = alloca %"struct.lean_future<int>::Awaiter", align 8

--- a/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-02.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-02.ll
@@ -100,7 +100,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.resume(
+; CHECK-LABEL: define internal void @a.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[REF_TMP7:%.*]] = alloca %"struct.lean_future<int>::Awaiter", align 8
@@ -118,7 +118,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.destroy(
+; CHECK-LABEL: define internal void @a.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[REF_TMP7:%.*]] = alloca %"struct.lean_future<int>::Awaiter", align 8
@@ -136,7 +136,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.cleanup(
+; CHECK-LABEL: define internal void @a.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[REF_TMP7:%.*]] = alloca %"struct.lean_future<int>::Awaiter", align 8

--- a/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-03.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-03.ll
@@ -73,7 +73,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.gep.resume(
+; CHECK-LABEL: define internal void @a.gep.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca [[I8_ARRAY:%.*]], align 8
@@ -86,7 +86,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.gep.destroy(
+; CHECK-LABEL: define internal void @a.gep.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca [[I8_ARRAY:%.*]], align 8
@@ -95,7 +95,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.gep.cleanup(
+; CHECK-LABEL: define internal void @a.gep.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca [[I8_ARRAY:%.*]], align 8

--- a/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-04.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-sink-lifetime-04.ll
@@ -74,7 +74,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.resume(
+; CHECK-LABEL: define internal void @a.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca i8, align 1
@@ -88,7 +88,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.destroy(
+; CHECK-LABEL: define internal void @a.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca i8, align 1
@@ -97,7 +97,7 @@ declare void @llvm.lifetime.end.p0(ptr nocapture) #4
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @a.cleanup(
+; CHECK-LABEL: define internal void @a.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[VFRAME:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    [[TESTVAL:%.*]] = alloca i8, align 1

--- a/llvm/test/Transforms/Coroutines/coro-split-tbaa-md.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-tbaa-md.ll
@@ -81,7 +81,7 @@ declare void @free(ptr) willreturn allockind("free") "alloc-family"="malloc"
 ; CHECK-NEXT:    ret ptr [[HDL]]
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.resume(
+; CHECK-LABEL: define internal void @f.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[X_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[HDL]], i64 16
@@ -92,7 +92,7 @@ declare void @free(ptr) willreturn allockind("free") "alloc-family"="malloc"
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.destroy(
+; CHECK-LABEL: define internal void @f.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[MEM:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[HDL]])
@@ -100,7 +100,7 @@ declare void @free(ptr) willreturn allockind("free") "alloc-family"="malloc"
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @f.cleanup(
+; CHECK-LABEL: define internal void @f.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[HDL:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    ret void

--- a/llvm/test/Transforms/Coroutines/coro-zero-alloca.ll
+++ b/llvm/test/Transforms/Coroutines/coro-zero-alloca.ll
@@ -67,7 +67,7 @@ cleanup:                                          ; preds = %wakeup, %entry
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @foo.resume(
+; CHECK-LABEL: define internal void @foo.resume(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[CORO_STATE:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_RESUME:.*:]]
 ; CHECK-NEXT:    [[A1_RELOAD_ADDR:%.*]] = getelementptr inbounds i8, ptr [[CORO_STATE]], i64 16
@@ -83,7 +83,7 @@ cleanup:                                          ; preds = %wakeup, %entry
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @foo.destroy(
+; CHECK-LABEL: define internal void @foo.destroy(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[CORO_STATE:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_DESTROY:.*:]]
 ; CHECK-NEXT:    [[CORO_MEMFREE:%.*]] = call ptr @llvm.coro.free(token poison, ptr [[CORO_STATE]])
@@ -91,7 +91,7 @@ cleanup:                                          ; preds = %wakeup, %entry
 ; CHECK-NEXT:    ret void
 ;
 ;
-; CHECK-LABEL: define internal fastcc void @foo.cleanup(
+; CHECK-LABEL: define internal void @foo.cleanup(
 ; CHECK-SAME: ptr noundef nonnull align 8 dereferenceable(24) [[CORO_STATE:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY_CLEANUP:.*:]]
 ; CHECK-NEXT:    call void @free(ptr null)


### PR DESCRIPTION
Change the calling convention for resume / destroy functions of C++ coroutines from `fastcc` to the C calling convention.

The resume / destroy functions are exposed as part of the coroutine ABI and must be compatible with other compilers and other versions of LLVM. fastcc is an LLVM-internal, unstable calling convention, though.

In practice, fastcc and the C calling convention are in sync for `void func(void*)` function signatures on almost all platforms. Therefore, I think we can still do this change without widespread ABI breakage.

`fastcc` and `ccc` do differ for i686 (x86-32), MIPS O32, PowerPC64 ELFv1 and Lanai. Afaik, those are all legacy ABIs and a recent feature like C++20 coroutines is unlikely to be used by projects still targeting legacy ABIs.

Historical context: I tried to figure out why `fastcc` was used. It is around since the original commit f93082e71a94 from 2016, predating the cross-vendor coroutine ABI work. I could not find any discussion of whether this should use `fastcc` on the review or on the mailing list.

As a side-effect, this also fixes #91123.

Co-authored-by: Cursor <cursoragent@cursor.com>