### PR TITLE
[alpha.webkit.UncountedLocalVarsChecker] Some forms of mutating a guardian variable is ignored

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLocalVarsChecker.cpp
@@ -67,41 +67,65 @@ struct GuardianVisitor : DynamicRecursiveASTVisitor {
   }
 
   bool VisitCXXConstructExpr(CXXConstructExpr *CE) override {
-    if (auto *Ctor = CE->getConstructor()) {
-      if (Ctor->isMoveConstructor() && CE->getNumArgs() == 1) {
-        auto *Arg = CE->getArg(0)->IgnoreParenCasts();
-        if (auto *VarRef = dyn_cast<DeclRefExpr>(Arg)) {
-          if (VarRef->getDecl() == Guardian)
-            return false;
-        }
+    auto *Ctor = CE->getConstructor();
+    if (!Ctor)
+      return false;
+    unsigned ArgIndex = 0;
+    for (auto *Arg : CE->arguments()) {
+      ParmVarDecl *Parm = nullptr;
+      if (ArgIndex < Ctor->getNumParams())
+        Parm = Ctor->getParamDecl(ArgIndex);
+      if (mutatesGuardian(Arg, Parm))
+        return false;
+      ArgIndex++;
+    }
+    return true;
+  }
+
+  bool VisitCallExpr(CallExpr *CE) override {
+    auto *Callee = CE->getDirectCallee();
+    if (!Callee)
+      return false;
+    unsigned ArgIndex = 0;
+    unsigned ArgOffset = isa<CXXOperatorCallExpr>(CE);
+    for (auto *Arg : CE->arguments()) {
+      ParmVarDecl *Parm = nullptr;
+      if (ArgIndex >= ArgOffset) {
+        unsigned ParmIndex = ArgIndex - ArgOffset;
+        if (ParmIndex < Callee->getNumParams())
+          Parm = Callee->getParamDecl(ParmIndex);
       }
+      if (mutatesGuardian(Arg, Parm))
+        return false;
+      ArgIndex++;
     }
     return true;
   }
 
   bool VisitCXXMemberCallExpr(CXXMemberCallExpr *MCE) override {
-    auto MethodName = safeGetName(MCE->getMethodDecl());
-    if (MethodName == "swap" || MethodName == "leakRef" ||
-        MethodName == "releaseNonNull" || MethodName == "clear") {
-      auto *ThisArg = MCE->getImplicitObjectArgument()->IgnoreParenCasts();
-      if (auto *VarRef = dyn_cast<DeclRefExpr>(ThisArg)) {
-        if (VarRef->getDecl() == Guardian)
-          return false;
-      }
+    auto *Method = MCE->getMethodDecl();
+    auto ObjType = MCE->getObjectType();
+    if (ObjType.isConstQualified())
+      return true;
+    auto *ThisArg = MCE->getImplicitObjectArgument()->IgnoreParenCasts();
+    if (auto *VarRef = dyn_cast<DeclRefExpr>(ThisArg)) {
+      if (!isa<CXXConversionDecl>(Method) && VarRef->getDecl() == Guardian)
+        return false;
     }
     return true;
   }
 
-  bool VisitCXXOperatorCallExpr(CXXOperatorCallExpr *OCE) override {
-    if (OCE->isAssignmentOp()) {
-      assert(OCE->getNumArgs() == 2);
-      auto *ThisArg = OCE->getArg(0)->IgnoreParenCasts();
-      if (auto *VarRef = dyn_cast<DeclRefExpr>(ThisArg)) {
-        if (VarRef->getDecl() == Guardian)
-          return false;
+private:
+  bool mutatesGuardian(const Expr *Arg, const ParmVarDecl *ParmDecl) {
+    Arg = Arg->IgnoreParenCasts();
+    if (auto *VarRef = dyn_cast<DeclRefExpr>(Arg)) {
+      if (VarRef->getDecl() == Guardian) {
+        auto ArgType = ParmDecl ? ParmDecl->getType() : Arg->getType();
+        if (!ArgType.isConstQualified())
+          return true;
       }
     }
-    return true;
+    return false;
   }
 };
 

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -13,6 +13,22 @@ typedef T type;
 
 template<typename T> typename remove_reference<T>::type&& move(T&& t);
 
+template<typename T, typename U>
+T exchange(T& t, U&& u)
+{
+  T r = static_cast<T&&>(t);
+  t = static_cast<U&&>(u);
+  return r;
+}
+
+template<typename T>
+T exchange(T& t, decltype(nullptr))
+{
+  T r = static_cast<T&&>(t);
+  t = static_cast<T>(t);
+  return r;
+}
+
 }
 
 #endif

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-local-vars.cpp
@@ -132,6 +132,14 @@ void foo8(RefCountable* obj) {
   }
 }
 
+void consumeRef(Ref<RefCountable>&);
+struct Consumer {
+  Consumer();
+  Consumer(Ref<RefCountable>&);
+  void mutate(Ref<RefCountable>&);
+};
+Consumer operator<<(Consumer, Ref<RefCountable>&);
+
 void foo9(RefCountable& o) {
   Ref<RefCountable> guardian(o);
   {
@@ -163,6 +171,40 @@ void foo9(RefCountable& o) {
     RefCountable *bar = guardian.ptr();
     // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
     guardian = o.trivial() ? o : *bar;
+    bar->method();
+  }
+  {
+    RefCountable *bar = guardian.ptr();
+    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    {
+      Ref<RefCountable> oldGuardian = std::exchange(guardian, nullptr);
+    }
+    bar->method();
+  }
+  {
+    RefCountable *bar = guardian.ptr();
+    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    consumeRef(guardian);
+    bar->method();
+  }
+  {
+    RefCountable *bar = guardian.ptr();
+    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    Consumer consumer(guardian);
+    bar->method();
+  }
+  {
+    RefCountable *bar = guardian.ptr();
+    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    Consumer consumer;
+    consumer.mutate(guardian);
+    bar->method();
+  }
+  {
+    RefCountable *bar = guardian.ptr();
+    // expected-warning@-1{{Local variable 'bar' is uncounted and unsafe [alpha.webkit.UncountedLocalVarsChecker]}}
+    Consumer consumer;
+    consumer << guardian;
     bar->method();
   }
 }


### PR DESCRIPTION
This PR fixes a bug in UncountedLocalVarsChecker that it was allowing mutations to guardian variables within the same scope of a guarded raw pointer/reference. Since mutating a guardian can affect the lifetime of a guarded object, we must not consider it as a guardian variable for the scope.

VisitCXXConstructExpr was just looking for smart pointer's move constructor but any constructor which takes a guardian smart pointer using a non-const function argument is problematic so detect all those cases. Also add VisitCallExpr to detect all forms of function calls to which a guardian variable is passed via a non-const argument. For VisitCXXMemberCallExpr, we consider calling any non-const member function on a guardian variable to be dangerous except conversion operators (e.g. operator T()).