### PR TITLE
[Offload] Fix LLVM_LINK_LLVM_DYLIB linking liboffload

### DIFF
--- a/offload/liboffload/CMakeLists.txt
+++ b/offload/liboffload/CMakeLists.txt
@@ -6,7 +6,11 @@ add_library(LLVMOffload SHARED
 )
 add_dependencies(LLVMOffload OffloadAPI PluginErrcodes)
 
-llvm_map_components_to_libnames(llvm_libs FrontendOpenMP Support)
+if(LLVM_LINK_LLVM_DYLIB)
+  set(llvm_libs LLVM)
+else()
+  llvm_map_components_to_libnames(llvm_libs FrontendOpenMP Support)
+endif()
 target_link_libraries(LLVMOffload PRIVATE ${llvm_libs})
 
 foreach(plugin IN LISTS LIBOMPTARGET_PLUGINS_TO_BUILD)

--- a/offload/libomptarget/CMakeLists.txt
+++ b/offload/libomptarget/CMakeLists.txt
@@ -21,7 +21,11 @@ add_library(omptarget SHARED
   KernelLanguage/API.cpp
 )
 
-llvm_map_components_to_libnames(llvm_libs FrontendOpenMP Support Object)
+if(LLVM_LINK_LLVM_DYLIB)
+  set(llvm_libs LLVM)
+else()
+  llvm_map_components_to_libnames(llvm_libs FrontendOpenMP Support Object)
+endif()
 target_link_libraries(omptarget PRIVATE omp ${llvm_libs})
 target_include_directories(omptarget PRIVATE
   ${LIBOMPTARGET_INCLUDE_DIR} ${LIBOMPTARGET_BINARY_INCLUDE_DIR}

--- a/offload/plugins-nextgen/CMakeLists.txt
+++ b/offload/plugins-nextgen/CMakeLists.txt
@@ -5,11 +5,15 @@ add_subdirectory(common)
 function(add_target_library target_name lib_name)
   add_library(${target_name} STATIC)
 
-  llvm_map_components_to_libnames(llvm_libs
-    AggressiveInstCombine Analysis BinaryFormat BitReader BitWriter CodeGen
-    Core Extensions FrontendOffloading InstCombine Instrumentation IPO IRReader
-    Linker MC Object Passes ProfileData Remarks ScalarOpts Support Target
-    TargetParser TransformUtils Vectorize)
+  if(LLVM_LINK_LLVM_DYLIB)
+    set(llvm_libs LLVM)
+  else()
+    llvm_map_components_to_libnames(llvm_libs
+      AggressiveInstCombine Analysis BinaryFormat BitReader BitWriter CodeGen
+      Core Extensions FrontendOffloading InstCombine Instrumentation IPO IRReader
+      Linker MC Object Passes ProfileData Remarks ScalarOpts Support Target
+      TargetParser TransformUtils Vectorize)
+  endif()
   llvm_update_compile_flags(${target_name})
   target_include_directories(${target_name} PUBLIC ${common_dir}/include
                              ${common_bin_dir}/include)


### PR DESCRIPTION
Summary:
When this is set you can only link against `LLVM`. The previous patch
did not respect this because I did not realize that internally in the
add_llvm_library that this was required.
