### PR TITLE
[compiler-rt][builtins] A few fixes cpu_model files

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/AArch64CPUFeatures.inc
+++ b/compiler-rt/lib/builtins/cpu_model/AArch64CPUFeatures.inc
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef AARCH64_CPU_FEATURS_INC_H
-#define AARCH64_CPU_FEATURS_INC_H
+#ifndef AARCH64_CPU_FEATURES_INC_H
+#define AARCH64_CPU_FEATURES_INC_H
 
 // Function Multi Versioning CPU features.
 enum CPUFeatures {

--- a/compiler-rt/lib/builtins/cpu_model/cpu_model.h
+++ b/compiler-rt/lib/builtins/cpu_model/cpu_model.h
@@ -1,4 +1,4 @@
-//===-- cpu_model_common.c - Utilities for cpu model detection ----*- C -*-===//
+//===-- cpu_model/cpu_model.h - Utilities for cpu model detection -*- C -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef COMPILER_RT_LIB_BUILTINS_CPU_MODEL_COMMON_H
-#define COMPILER_RT_LIB_BUILTINS_CPU_MODEL_COMMON_H
+#ifndef COMPILER_RT_LIB_BUILTINS_CPU_MODEL_CPU_MODEL_H
+#define COMPILER_RT_LIB_BUILTINS_CPU_MODEL_CPU_MODEL_H
 
 #define bool int
 #define true 1

--- a/llvm/include/llvm/TargetParser/AArch64CPUFeatures.inc
+++ b/llvm/include/llvm/TargetParser/AArch64CPUFeatures.inc
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef AARCH64_CPU_FEATURS_INC_H
-#define AARCH64_CPU_FEATURS_INC_H
+#ifndef AARCH64_CPU_FEATURES_INC_H
+#define AARCH64_CPU_FEATURES_INC_H
 
 // Function Multi Versioning CPU features.
 enum CPUFeatures {


### PR DESCRIPTION
- Fix typo in include guard with the word features
- Correct header in cpu_model.h header file and include guard after
  the file has been renamed