### PR TITLE
[CIR] Fix cast kind to support bool in builtin_*_overflow

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -2148,10 +2148,19 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
     Address resultPtr = emitPointerWithAlignment(resultArg);
 
     // Extend each operand to the encompassing type, if necessary.
-    if (x.getType() != encompassingCIRTy)
-      x = builder.createCast(cir::CastKind::integral, x, encompassingCIRTy);
-    if (y.getType() != encompassingCIRTy)
-      y = builder.createCast(cir::CastKind::integral, y, encompassingCIRTy);
+    if (x.getType() != encompassingCIRTy) {
+      x = builder.createCast(mlir::isa<cir::BoolType>(x.getType())
+                                 ? cir::CastKind::bool_to_int
+                                 : cir::CastKind::integral,
+                             x, encompassingCIRTy);
+    }
+
+    if (y.getType() != encompassingCIRTy) {
+      y = builder.createCast(mlir::isa<cir::BoolType>(y.getType())
+                                 ? cir::CastKind::bool_to_int
+                                 : cir::CastKind::integral,
+                             y, encompassingCIRTy);
+    }
 
     // Perform the operation on the extended values.
     mlir::Location loc = getLoc(e->getSourceRange());

--- a/clang/test/CIR/CodeGenBuiltins/builtins-overflow.cpp
+++ b/clang/test/CIR/CodeGenBuiltins/builtins-overflow.cpp
@@ -370,3 +370,21 @@ bool test_smulll_overflow(long long x, long long y, long long *res) {
 // CIR-NEXT:   %[[RES:.+]], %{{.+}} = cir.mul.overflow %[[#X]], %[[#Y]] : !s64i -> !s64i
 // CIR-NEXT:   cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !s64i, !cir.ptr<!s64i>
 //      CIR: }
+
+bool test_bool_math_overflow(bool x, bool y, int *res) {
+  return __builtin_add_overflow(x, y, res);
+// CIR-LABEL: test_bool_math_overflow
+//      CIR: %[[LOAD_X:.*]] = cir.load align(1) %{{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT: %[[LOAD_Y:.*]] = cir.load align(1) %{{.*}} : !cir.ptr<!cir.bool>, !cir.bool
+// CIR-NEXT: %[[#RES_PTR:]] = cir.load align(8) %{{.*}} : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
+// CIR-NEXT: %[[X_CAST:.*]] = cir.cast bool_to_int %[[LOAD_X]] : !cir.bool -> !s32i
+// CIR-NEXT: %[[Y_CAST:.*]] = cir.cast bool_to_int %[[LOAD_Y]] : !cir.bool -> !s32i
+// CIR-NEXT: %[[RES:.*]], %{{.*}} = cir.add.overflow %[[X_CAST]], %[[Y_CAST]] : !s32i -> !s32i
+// CIR-NEXT: cir.store{{.*}} %[[RES]], %[[#RES_PTR]] : !s32i, !cir.ptr<!s32i>
+
+// LLVM-LABEL: test_bool_math_overflow
+// LLVM: %[[X_CAST:.*]] = zext i1 %{{.*}} to i32
+// LLVM: %[[Y_CAST:.*]] = zext i1 %{{.*}} to i32
+// LLVM: call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %[[X_CAST]], i32 %[[Y_CAST]])
+}
+


### PR DESCRIPTION
'bool' is an acceptable type to the __builtin_*_overflow functions, but we were unconditionally doing an integral cast. This adds some logic to do a bool-to-int cast if necessary.