### PR TITLE
[libc][semaphore] Add post and wait operations for internal semaphore

### DIFF
--- a/libc/src/semaphore/linux/CMakeLists.txt
+++ b/libc/src/semaphore/linux/CMakeLists.txt
@@ -11,6 +11,7 @@ add_header_library(
     libc.src.__support.CPP.atomic
     libc.src.__support.CPP.limits
     libc.src.__support.error_or
+    libc.src.__support.libc_assert
     libc.src.__support.threads.futex_utils
     libc.src.__support.time.abs_timeout
 )

--- a/libc/src/semaphore/linux/CMakeLists.txt
+++ b/libc/src/semaphore/linux/CMakeLists.txt
@@ -4,11 +4,15 @@ add_header_library(
     semaphore.h
   DEPENDS
     libc.hdr.errno_macros
+    libc.hdr.time_macros
+    libc.hdr.types.clockid_t
     libc.hdr.types.mode_t
+    libc.hdr.types.struct_timespec
     libc.src.__support.CPP.atomic
     libc.src.__support.CPP.limits
     libc.src.__support.error_or
     libc.src.__support.threads.futex_utils
+    libc.src.__support.time.abs_timeout
 )
 
 add_object_library(

--- a/libc/src/semaphore/linux/CMakeLists.txt
+++ b/libc/src/semaphore/linux/CMakeLists.txt
@@ -3,8 +3,10 @@ add_header_library(
   HDRS
     semaphore.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.hdr.types.mode_t
     libc.src.__support.CPP.atomic
+    libc.src.__support.CPP.limits
     libc.src.__support.error_or
     libc.src.__support.threads.futex_utils
 )
@@ -20,7 +22,6 @@ add_object_library(
     libc.hdr.errno_macros
     libc.hdr.fcntl_macros
     libc.src.__support.CPP.array
-    libc.src.__support.CPP.limits
     libc.src.__support.CPP.new
     libc.src.__support.CPP.string_view
     libc.src.__support.ctype_utils

--- a/libc/src/semaphore/linux/named_semaphore.cpp
+++ b/libc/src/semaphore/linux/named_semaphore.cpp
@@ -147,7 +147,10 @@ ErrorOr<Semaphore *> Semaphore::open(const char *name, int oflag, mode_t mode,
   }
 
   Semaphore *sem = sem_or.value();
-  new (sem) Semaphore(value);
+
+  // Named semaphores are backed by MAP_SHARED memory and used across
+  // processes, so they use shared futex addressing mode.
+  new (sem) Semaphore(value, /*is_shared=*/true);
 
   // atomically publish the fully initialized semaphore.
   auto link_or = linux_syscalls::link(tmp_or->data(), path_or->data());

--- a/libc/src/semaphore/linux/named_semaphore.cpp
+++ b/libc/src/semaphore/linux/named_semaphore.cpp
@@ -11,7 +11,6 @@
 #include "hdr/errno_macros.h"
 #include "hdr/fcntl_macros.h"
 #include "src/__support/CPP/array.h"
-#include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/new.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/OSUtil/linux/syscall_wrappers/close.h"
@@ -33,10 +32,6 @@
 namespace LIBC_NAMESPACE_DECL {
 
 namespace {
-
-// define SEM_VALUE_MAX as INT_MAX
-constexpr unsigned int SEM_VALUE_MAX =
-    static_cast<unsigned int>(cpp::numeric_limits<int>::max());
 
 // Named semaphores are backed by files in /dev/shm/.
 // a prefix "sem." is added to avoid name collision.

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -18,6 +18,7 @@
 #include "src/__support/CPP/limits.h"
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
+#include "src/__support/libc_assert.h"
 #include "src/__support/threads/futex_utils.h"
 #include "src/__support/time/abs_timeout.h"
 
@@ -31,6 +32,9 @@ class Semaphore {
   Futex value;
   unsigned int canary;
 
+  // Whether the semaphore is shared between processes.
+  bool is_shared;
+
   // A private constant canary used to detect use of uninitialized or
   // destroyed semaphores. Chose "SEM1" in ASCII (0x53='S', 0x45='E',
   // 0x4D='M', 0x31='1').
@@ -43,7 +47,7 @@ class Semaphore {
       if (trywait() == 0)
         return 0;
 
-      auto wait_or = value.wait(/*expected=*/0, timeout, /*is_shared=*/true);
+      auto wait_or = value.wait(/*expected=*/0, timeout, is_shared);
       if (!wait_or.has_value() && wait_or.error() == ETIMEDOUT) {
         // Final attempt in case a post() raced with the timeout.
         if (trywait() == 0)
@@ -54,8 +58,8 @@ class Semaphore {
   }
 
 public:
-  LIBC_INLINE constexpr Semaphore(unsigned int value)
-      : value(value), canary(SEM_CANARY) {}
+  LIBC_INLINE constexpr Semaphore(unsigned int value, bool shared)
+      : value(value), canary(SEM_CANARY), is_shared(shared) {}
 
   // Sanity check to detect use of uninitialized or destroyed semaphores.
   LIBC_INLINE bool is_valid() const { return canary == SEM_CANARY; }
@@ -92,9 +96,7 @@ public:
 
     // Wake one waiter if any,
     // waiter selection is left to linux futex implementation.
-    // Named semaphores live in MAP_SHARED memory and may be shared across
-    // processes, so use a shared wake.
-    value.notify_one(/*is_shared=*/true);
+    value.notify_one(is_shared);
     return 0;
   }
 
@@ -123,8 +125,7 @@ public:
       // Futex wait re-checks the value atomically,
       // so a racing post() before sleep is not lost.
       // Spurious wakeups just send back to trywait().
-      (void)value.wait(/*expected=*/0, /*timeout=*/cpp::nullopt,
-                       /*is_shared=*/true);
+      (void)value.wait(/*expected=*/0, /*timeout=*/cpp::nullopt, is_shared);
     }
   }
 
@@ -145,7 +146,10 @@ public:
     if (LIBC_LIKELY(timeout.has_value()))
       return wait_until(timeout.value());
 
-    switch (timeout.error()) {
+    internal::AbsTimeout::Error err = timeout.error();
+    LIBC_ASSERT(err == internal::AbsTimeout::Error::Invalid ||
+                err == internal::AbsTimeout::Error::BeforeEpoch);
+    switch (err) {
     case internal::AbsTimeout::Error::Invalid:
       return EINVAL;
     case internal::AbsTimeout::Error::BeforeEpoch:

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -10,12 +10,16 @@
 #define LLVM_LIBC_SRC_SEMAPHORE_LINUX_SEMAPHORE_H
 
 #include "hdr/errno_macros.h"
+#include "hdr/time_macros.h"
+#include "hdr/types/clockid_t.h"
 #include "hdr/types/mode_t.h"
+#include "hdr/types/struct_timespec.h"
 #include "src/__support/CPP/atomic.h"
 #include "src/__support/CPP/limits.h"
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
 #include "src/__support/threads/futex_utils.h"
+#include "src/__support/time/abs_timeout.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -32,11 +36,24 @@ class Semaphore {
   // 0x4D='M', 0x31='1').
   static constexpr unsigned int SEM_CANARY = 0x53454D31U;
 
-public:
-  // TODO:
-  // Add the blocking waiting operations: sem_wait, sem_timedwait,
-  //    sem_clockwait.
+  // Helper function for timed blocking wait, wait for a required
+  // absolute timeout.
+  LIBC_INLINE int wait_until(internal::AbsTimeout timeout) {
+    for (;;) {
+      if (trywait() == 0)
+        return 0;
 
+      auto wait_or = value.wait(/*expected=*/0, timeout, /*is_shared=*/true);
+      if (!wait_or.has_value() && wait_or.error() == ETIMEDOUT) {
+        // Final attempt in case a post() raced with the timeout.
+        if (trywait() == 0)
+          return 0;
+        return ETIMEDOUT;
+      }
+    }
+  }
+
+public:
   LIBC_INLINE constexpr Semaphore(unsigned int value)
       : value(value), canary(SEM_CANARY) {}
 
@@ -107,6 +124,32 @@ public:
       (void)value.wait(/*expected=*/0, /*timeout=*/cpp::nullopt,
                        /*is_shared=*/true);
     }
+  }
+
+  // Blocking wait against an absolute CLOCK_REALTIME deadline.
+  LIBC_INLINE int timedwait(const timespec *abstime) {
+    return clockwait(CLOCK_REALTIME, abstime);
+  }
+
+  // Blocking wait against a deadline on the given clock:
+  // CLOCK_REALTIME or CLOCK_MONOTONIC
+  LIBC_INLINE int clockwait(clockid_t clock_id, const timespec *abstime) {
+    if (clock_id != CLOCK_MONOTONIC && clock_id != CLOCK_REALTIME)
+      return EINVAL;
+
+    bool is_realtime = (clock_id == CLOCK_REALTIME);
+    auto timeout =
+        internal::AbsTimeout::from_timespec(*abstime, /*realtime=*/is_realtime);
+    if (LIBC_LIKELY(timeout.has_value()))
+      return wait_until(timeout.value());
+
+    switch (timeout.error()) {
+    case internal::AbsTimeout::Error::Invalid:
+      return EINVAL;
+    case internal::AbsTimeout::Error::BeforeEpoch:
+      return ETIMEDOUT;
+    }
+    __builtin_unreachable();
   }
 
   // Named semaphore operations.

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -86,10 +86,12 @@ public:
       if (v >= SEM_VALUE_MAX)
         return EOVERFLOW;
       // RELEASE on success, since post should publish prior writes
-      // RELAXED on failture, since no synchronization event occurs
+      // RELAXED on failure, since no synchronization event occurs
     } while (!value.compare_exchange_weak(v, v + 1, cpp::MemoryOrder::RELEASE,
                                           cpp::MemoryOrder::RELAXED));
 
+    // Wake one waiter if any,
+    // waiter selection is left to linux futex implementation.
     // Named semaphores live in MAP_SHARED memory and may be shared across
     // processes, so use a shared wake.
     value.notify_one(/*is_shared=*/true);

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -9,13 +9,19 @@
 #ifndef LLVM_LIBC_SRC_SEMAPHORE_LINUX_SEMAPHORE_H
 #define LLVM_LIBC_SRC_SEMAPHORE_LINUX_SEMAPHORE_H
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/mode_t.h"
 #include "src/__support/CPP/atomic.h"
+#include "src/__support/CPP/limits.h"
 #include "src/__support/common.h"
 #include "src/__support/error_or.h"
 #include "src/__support/threads/futex_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
+
+// Define SEM_VALUE_MAX as INT_MAX
+constexpr unsigned int SEM_VALUE_MAX =
+    static_cast<unsigned int>(cpp::numeric_limits<int>::max());
 
 class Semaphore {
   Futex value;
@@ -28,8 +34,8 @@ class Semaphore {
 
 public:
   // TODO:
-  // Add the posting and waiting operations: sem_post, sem_wait,
-  //    sem_trywait, sem_timedwait, sem_clockwait.
+  // Add the blocking waiting operations: sem_wait, sem_timedwait,
+  //    sem_clockwait.
 
   LIBC_INLINE constexpr Semaphore(unsigned int value)
       : value(value), canary(SEM_CANARY) {}
@@ -52,6 +58,39 @@ public:
     // TODO: handle the case where the semaphore is locked.
     return static_cast<int>(
         const_cast<Futex &>(value).load(cpp::MemoryOrder::RELAXED));
+  }
+
+  // Atomically increments the semaphore value and
+  // wakes one blocked waiter if any.
+  LIBC_INLINE int post() {
+    FutexWordType v = value.load(cpp::MemoryOrder::RELAXED);
+
+    do {
+      if (v >= SEM_VALUE_MAX)
+        return EOVERFLOW;
+      // RELEASE on success, since post should publish prior writes
+      // RELAXED on failture, since no synchronization event occurs
+    } while (!value.compare_exchange_weak(v, v + 1, cpp::MemoryOrder::RELEASE,
+                                          cpp::MemoryOrder::RELAXED));
+
+    // Named semaphores live in MAP_SHARED memory and may be shared across
+    // processes, so use a shared wake.
+    value.notify_one(/*is_shared=*/true);
+    return 0;
+  }
+
+  // Attempts to decrement the semaphore value without blocking.
+  LIBC_INLINE int trywait() {
+    FutexWordType v = value.load(cpp::MemoryOrder::RELAXED);
+
+    while (v > 0) {
+      // ACQUIRE on success to synchronize with the matching post().
+      if (value.compare_exchange_weak(v, v - 1, cpp::MemoryOrder::ACQUIRE,
+                                      cpp::MemoryOrder::RELAXED))
+        return 0;
+    }
+
+    return EAGAIN;
   }
 
   // Named semaphore operations.

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -93,6 +93,22 @@ public:
     return EAGAIN;
   }
 
+  // Blocking wait, decrements the value when positive, or blocks until a
+  // post() makes it positive again.
+  LIBC_INLINE int wait() {
+    for (;;) {
+      if (trywait() == 0)
+        return 0;
+
+      // Blocks when value was zero.
+      // Futex wait re-checks the value atomically,
+      // so a racing post() before sleep is not lost.
+      // Spurious wakeups just send back to trywait().
+      (void)value.wait(/*expected=*/0, /*timeout=*/cpp::nullopt,
+                       /*is_shared=*/true);
+    }
+  }
+
   // Named semaphore operations.
   // creates or opens a named semaphore backed by a file in /dev/shm/.
   // When O_CREAT is specified in oflag, mode and value are used for

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -45,21 +45,18 @@ class Semaphore {
   LIBC_INLINE int wait_until(internal::AbsTimeout timeout) {
     while (trywait() != 0) {
       auto wait_or = value.wait(/*expected=*/0, timeout, is_shared);
-      if (wait_or.has_value())
-        continue;
 
-      if (wait_or.error() == EAGAIN)
-        continue;
+      // returned error is not a benign race EAGAIN
+      if (!wait_or.has_value() && wait_or.error() != EAGAIN) {
 
-      if (wait_or.error() == ETIMEDOUT) {
-        // Final attempt in case a post() raced with the timeout.
-        if (trywait() == 0)
+        // ETIMEDOUT still needs a final trywait() in case a post() raced with
+        // the deadline
+        if (wait_or.error() == ETIMEDOUT && trywait() == 0)
           return 0;
-        return ETIMEDOUT;
-      }
 
-      // Any other error is unexpected (e.g. EINVAL/EFAULT).
-      return wait_or.error();
+        // Any other error (e.g. EINVAL/EFAULT)
+        return wait_or.error();
+      }
     }
     return 0;
   }

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -43,18 +43,25 @@ class Semaphore {
   // Helper function for timed blocking wait, wait for a required
   // absolute timeout.
   LIBC_INLINE int wait_until(internal::AbsTimeout timeout) {
-    for (;;) {
-      if (trywait() == 0)
-        return 0;
-
+    while (trywait() != 0) {
       auto wait_or = value.wait(/*expected=*/0, timeout, is_shared);
-      if (!wait_or.has_value() && wait_or.error() == ETIMEDOUT) {
+      if (wait_or.has_value())
+        continue;
+
+      if (wait_or.error() == EAGAIN)
+        continue;
+
+      if (wait_or.error() == ETIMEDOUT) {
         // Final attempt in case a post() raced with the timeout.
         if (trywait() == 0)
           return 0;
         return ETIMEDOUT;
       }
+
+      // Any other error is unexpected (e.g. EINVAL/EFAULT).
+      return wait_or.error();
     }
+    return 0;
   }
 
 public:
@@ -117,16 +124,20 @@ public:
   // Blocking wait, decrements the value when positive, or blocks until a
   // post() makes it positive again.
   LIBC_INLINE int wait() {
-    for (;;) {
-      if (trywait() == 0)
-        return 0;
-
+    while (trywait() != 0) {
       // Blocks when value was zero.
       // Futex wait re-checks the value atomically,
       // so a racing post() before sleep is not lost.
       // Spurious wakeups just send back to trywait().
-      (void)value.wait(/*expected=*/0, /*timeout=*/cpp::nullopt, is_shared);
+      auto wait_or =
+          value.wait(/*expected=*/0, /*timeout=*/cpp::nullopt, is_shared);
+
+      // A successful wake or EAGAIN both just send it back to trywait().
+      // Any other error is unexpected.
+      if (!wait_or.has_value() && wait_or.error() != EAGAIN)
+        return wait_or.error();
     }
+    return 0;
   }
 
   // Blocking wait against an absolute CLOCK_REALTIME deadline.

--- a/libc/src/semaphore/linux/semaphore.h
+++ b/libc/src/semaphore/linux/semaphore.h
@@ -148,6 +148,11 @@ public:
     if (clock_id != CLOCK_MONOTONIC && clock_id != CLOCK_REALTIME)
       return EINVAL;
 
+    // If the semaphore can be locked immediately, succeed without consulting
+    // the clock or dereferencing abstime.
+    if (trywait() == 0)
+      return 0;
+
     bool is_realtime = (clock_id == CLOCK_REALTIME);
     auto timeout =
         internal::AbsTimeout::from_timespec(*abstime, /*realtime=*/is_realtime);
@@ -163,7 +168,8 @@ public:
     case internal::AbsTimeout::Error::BeforeEpoch:
       return ETIMEDOUT;
     }
-    __builtin_unreachable();
+
+    __builtin_trap();
   }
 
   // Named semaphore operations.

--- a/libc/test/src/semaphore/linux/CMakeLists.txt
+++ b/libc/test/src/semaphore/linux/CMakeLists.txt
@@ -9,6 +9,9 @@ add_libc_unittest(
   DEPENDS
     libc.hdr.errno_macros
     libc.hdr.fcntl_macros
+    libc.hdr.time_macros
+    libc.hdr.types.struct_timespec
+    libc.src.__support.time.clock_gettime
     libc.src.semaphore.linux.semaphore
     libc.src.semaphore.linux.named_semaphore
 )

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -17,20 +17,20 @@
 using LIBC_NAMESPACE::Semaphore;
 
 TEST(LlvmLibcSemaphoreTest, InitAndGetValue) {
-  Semaphore sem(3);
+  Semaphore sem(3, /*is_shared=*/false);
   ASSERT_TRUE(sem.is_valid());
   ASSERT_EQ(sem.getvalue(), 3);
 }
 
 TEST(LlvmLibcSemaphoreTest, Destroy) {
-  Semaphore sem(5);
+  Semaphore sem(5, /*is_shared=*/false);
   ASSERT_TRUE(sem.is_valid());
   sem.destroy();
   ASSERT_FALSE(sem.is_valid());
 }
 
 TEST(LlvmLibcSemaphoreTest, TryWait) {
-  Semaphore sem(2);
+  Semaphore sem(2, /*is_shared=*/false);
 
   // two successful non-blocking decrements.
   ASSERT_EQ(sem.trywait(), 0);
@@ -43,7 +43,7 @@ TEST(LlvmLibcSemaphoreTest, TryWait) {
 }
 
 TEST(LlvmLibcSemaphoreTest, Post) {
-  Semaphore sem(0);
+  Semaphore sem(0, /*is_shared=*/false);
   ASSERT_EQ(sem.getvalue(), 0);
 
   ASSERT_EQ(sem.post(), 0);
@@ -55,7 +55,7 @@ TEST(LlvmLibcSemaphoreTest, Post) {
 }
 
 TEST(LlvmLibcSemaphoreTest, WaitNonBlocking) {
-  Semaphore sem(2);
+  Semaphore sem(2, /*is_shared=*/false);
 
   // value is positive: wait() should decrement without blocking.
   ASSERT_EQ(sem.wait(), 0);
@@ -65,7 +65,7 @@ TEST(LlvmLibcSemaphoreTest, WaitNonBlocking) {
 }
 
 TEST(LlvmLibcSemaphoreTest, TimedWaitNonBlocking) {
-  Semaphore sem(2);
+  Semaphore sem(2, /*is_shared=*/false);
   timespec ts{};
   LIBC_NAMESPACE::internal::clock_gettime(CLOCK_REALTIME, &ts);
   ts.tv_sec += 60;
@@ -77,7 +77,7 @@ TEST(LlvmLibcSemaphoreTest, TimedWaitNonBlocking) {
 }
 
 TEST(LlvmLibcSemaphoreTest, TimedWaitTimeout) {
-  Semaphore sem(0);
+  Semaphore sem(0, /*is_shared=*/false);
   timespec ts{};
   LIBC_NAMESPACE::internal::clock_gettime(CLOCK_REALTIME, &ts);
   // a few milliseconds in the future.
@@ -92,7 +92,7 @@ TEST(LlvmLibcSemaphoreTest, TimedWaitTimeout) {
 }
 
 TEST(LlvmLibcSemaphoreTest, TimedWaitBeforeEpoch) {
-  Semaphore sem(0);
+  Semaphore sem(0, /*is_shared=*/false);
   // tv_sec < 0 is treated as an already expired deadline.
   timespec ts{};
   ts.tv_sec = -1;
@@ -101,7 +101,7 @@ TEST(LlvmLibcSemaphoreTest, TimedWaitBeforeEpoch) {
 }
 
 TEST(LlvmLibcSemaphoreTest, TimedWaitInvalidTimespec) {
-  Semaphore sem(0);
+  Semaphore sem(0, /*is_shared=*/false);
   // tv_nsec out of [0, 1e9) is malformed.
   timespec ts{};
   ts.tv_sec = 1;
@@ -110,7 +110,7 @@ TEST(LlvmLibcSemaphoreTest, TimedWaitInvalidTimespec) {
 }
 
 TEST(LlvmLibcSemaphoreTest, ClockWaitMonotonicTimeout) {
-  Semaphore sem(0);
+  Semaphore sem(0, /*is_shared=*/false);
   timespec ts{};
   LIBC_NAMESPACE::internal::clock_gettime(CLOCK_MONOTONIC, &ts);
   ts.tv_nsec += 10'000'000;
@@ -123,7 +123,7 @@ TEST(LlvmLibcSemaphoreTest, ClockWaitMonotonicTimeout) {
 }
 
 TEST(LlvmLibcSemaphoreTest, ClockWaitUnsupportedClock) {
-  Semaphore sem(0);
+  Semaphore sem(0, /*is_shared=*/false);
   timespec ts{};
   ts.tv_sec = 1;
   ts.tv_nsec = 0;

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -8,6 +8,9 @@
 
 #include "hdr/errno_macros.h"
 #include "hdr/fcntl_macros.h"
+#include "hdr/time_macros.h"
+#include "hdr/types/struct_timespec.h"
+#include "src/__support/time/clock_gettime.h"
 #include "src/semaphore/linux/semaphore.h"
 #include "test/UnitTest/Test.h"
 
@@ -59,6 +62,73 @@ TEST(LlvmLibcSemaphoreTest, WaitNonBlocking) {
   ASSERT_EQ(sem.getvalue(), 1);
   ASSERT_EQ(sem.wait(), 0);
   ASSERT_EQ(sem.getvalue(), 0);
+}
+
+TEST(LlvmLibcSemaphoreTest, TimedWaitNonBlocking) {
+  Semaphore sem(2);
+  timespec ts{};
+  LIBC_NAMESPACE::internal::clock_gettime(CLOCK_REALTIME, &ts);
+  ts.tv_sec += 60;
+
+  // value is positive: timedwait should decrement without consulting the
+  // clock.
+  ASSERT_EQ(sem.timedwait(&ts), 0);
+  ASSERT_EQ(sem.getvalue(), 1);
+}
+
+TEST(LlvmLibcSemaphoreTest, TimedWaitTimeout) {
+  Semaphore sem(0);
+  timespec ts{};
+  LIBC_NAMESPACE::internal::clock_gettime(CLOCK_REALTIME, &ts);
+  // a few milliseconds in the future.
+  ts.tv_nsec += 10'000'000;
+  if (ts.tv_nsec >= 1'000'000'000) {
+    ts.tv_sec += 1;
+    ts.tv_nsec -= 1'000'000'000;
+  }
+
+  // value is zero and no post() arrives: must time out.
+  ASSERT_EQ(sem.timedwait(&ts), ETIMEDOUT);
+}
+
+TEST(LlvmLibcSemaphoreTest, TimedWaitBeforeEpoch) {
+  Semaphore sem(0);
+  // tv_sec < 0 is treated as an already expired deadline.
+  timespec ts{};
+  ts.tv_sec = -1;
+  ts.tv_nsec = 0;
+  ASSERT_EQ(sem.timedwait(&ts), ETIMEDOUT);
+}
+
+TEST(LlvmLibcSemaphoreTest, TimedWaitInvalidTimespec) {
+  Semaphore sem(0);
+  // tv_nsec out of [0, 1e9) is malformed.
+  timespec ts{};
+  ts.tv_sec = 1;
+  ts.tv_nsec = 1'000'000'001;
+  ASSERT_EQ(sem.timedwait(&ts), EINVAL);
+}
+
+TEST(LlvmLibcSemaphoreTest, ClockWaitMonotonicTimeout) {
+  Semaphore sem(0);
+  timespec ts{};
+  LIBC_NAMESPACE::internal::clock_gettime(CLOCK_MONOTONIC, &ts);
+  ts.tv_nsec += 10'000'000;
+  if (ts.tv_nsec >= 1'000'000'000) {
+    ts.tv_sec += 1;
+    ts.tv_nsec -= 1'000'000'000;
+  }
+
+  ASSERT_EQ(sem.clockwait(CLOCK_MONOTONIC, &ts), ETIMEDOUT);
+}
+
+TEST(LlvmLibcSemaphoreTest, ClockWaitUnsupportedClock) {
+  Semaphore sem(0);
+  timespec ts{};
+  ts.tv_sec = 1;
+  ts.tv_nsec = 0;
+  // any clock other than CLOCK_MONOTONIC / CLOCK_REALTIME is rejected.
+  ASSERT_EQ(sem.clockwait(static_cast<clockid_t>(99), &ts), EINVAL);
 }
 
 // Named semaphore tests.

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -26,6 +26,31 @@ TEST(LlvmLibcSemaphoreTest, Destroy) {
   ASSERT_FALSE(sem.is_valid());
 }
 
+TEST(LlvmLibcSemaphoreTest, TryWait) {
+  Semaphore sem(2);
+
+  // two successful non-blocking decrements.
+  ASSERT_EQ(sem.trywait(), 0);
+  ASSERT_EQ(sem.trywait(), 0);
+  ASSERT_EQ(sem.getvalue(), 0);
+
+  // value is now zero, trywait must fail with EAGAIN.
+  ASSERT_EQ(sem.trywait(), EAGAIN);
+  ASSERT_EQ(sem.getvalue(), 0);
+}
+
+TEST(LlvmLibcSemaphoreTest, Post) {
+  Semaphore sem(0);
+  ASSERT_EQ(sem.getvalue(), 0);
+
+  ASSERT_EQ(sem.post(), 0);
+  ASSERT_EQ(sem.getvalue(), 1);
+
+  // the posted value can be consumed by trywait.
+  ASSERT_EQ(sem.trywait(), 0);
+  ASSERT_EQ(sem.getvalue(), 0);
+}
+
 // Named semaphore tests.
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenCloseUnlink) {

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -51,6 +51,16 @@ TEST(LlvmLibcSemaphoreTest, Post) {
   ASSERT_EQ(sem.getvalue(), 0);
 }
 
+TEST(LlvmLibcSemaphoreTest, WaitNonBlocking) {
+  Semaphore sem(2);
+
+  // value is positive: wait() should decrement without blocking.
+  ASSERT_EQ(sem.wait(), 0);
+  ASSERT_EQ(sem.getvalue(), 1);
+  ASSERT_EQ(sem.wait(), 0);
+  ASSERT_EQ(sem.getvalue(), 0);
+}
+
 // Named semaphore tests.
 
 TEST(LlvmLibcSemaphoreTest, NamedOpenCloseUnlink) {

--- a/libc/test/src/semaphore/linux/semaphore_test.cpp
+++ b/libc/test/src/semaphore/linux/semaphore_test.cpp
@@ -76,6 +76,25 @@ TEST(LlvmLibcSemaphoreTest, TimedWaitNonBlocking) {
   ASSERT_EQ(sem.getvalue(), 1);
 }
 
+TEST(LlvmLibcSemaphoreTest, TimedWaitNullTime) {
+  // When the semaphore can be locked immediately, abstime must not be
+  // dereferenced.
+  Semaphore sem(1, /*is_shared=*/false);
+  ASSERT_EQ(sem.timedwait(nullptr), 0);
+  ASSERT_EQ(sem.getvalue(), 0);
+
+  Semaphore sem2(1, /*is_shared=*/false);
+  ASSERT_EQ(sem2.clockwait(CLOCK_MONOTONIC, nullptr), 0);
+  ASSERT_EQ(sem2.getvalue(), 0);
+}
+
+TEST(LlvmLibcSemaphoreTest, PostOverflow) {
+  // The value exceeds maximum, post() must fail with EOVERFLOW
+  Semaphore sem(LIBC_NAMESPACE::SEM_VALUE_MAX, /*is_shared=*/false);
+  ASSERT_EQ(sem.post(), EOVERFLOW);
+  ASSERT_EQ(sem.getvalue(), static_cast<int>(LIBC_NAMESPACE::SEM_VALUE_MAX));
+}
+
 TEST(LlvmLibcSemaphoreTest, TimedWaitTimeout) {
   Semaphore sem(0, /*is_shared=*/false);
   timespec ts{};


### PR DESCRIPTION
This pr implements https://github.com/llvm/llvm-project/issues/190847, adding the post and wait operations in posix semaphore for linux using futex. 

Particularly, 
`sem_post`: https://pubs.opengroup.org/onlinepubs/9799919799/functions/sem_post.html
`sem_trywait`, `sem_wait`: https://pubs.opengroup.org/onlinepubs/9799919799/functions/sem_wait.html
`sem_timedwait`, `sem_clockwait`: https://pubs.opengroup.org/onlinepubs/9799919799/functions/sem_clockwait.html#

The implementation is assisted by Claude Code Opus 4.7, specifically for the unit tests generations.