### PR TITLE
[BOLT] Add support for "--perf-script-events" option

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -610,6 +610,15 @@ private:
     return std::nullopt;
   }
 
+  /// Map to store slices of pre-processed perf text data
+  llvm::StringMap<llvm::StringRef> PerfTextSlices;
+
+  /// Flag to indicate if the pre-processed perf text has been loaded
+  bool PerfTextLoaded{false};
+
+  /// Helper function to load and slice pre-processed perf text data
+  void loadAndSlicePerfText(StringRef Name);
+
 public:
   /// If perf.data was collected without build ids, the buildid-list may contain
   /// incomplete entries. Return true if the buffer containing

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -501,12 +501,71 @@ void DataAggregator::filterBinaryMMapInfo() {
   }
 }
 
+void DataAggregator::loadAndSlicePerfText(StringRef Name) {
+  // Parse the perf text file if not loaded yet, and store the slices for
+  // different event types in a map for later retrieval.
+  if (!PerfTextLoaded) {
+    ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+        MemoryBuffer::getFileOrSTDIN(opts::ReadPerfEvents);
+    if (std::error_code EC = MB.getError()) {
+      errs() << "PERF2BOLT-ERROR: Cannot open " << opts::ReadPerfEvents << ": "
+             << EC.message() << "\n";
+      exit(1);
+    }
+    FileBuf = std::move(*MB);
+    StringRef Buf = FileBuf->getBuffer();
+
+    // Parse the header, length = 133, to get the size of each slice
+    if (Buf.starts_with(PerfTextMagicStr)) {
+      size_t Offset = 133;
+      StringRef Header = Buf.substr(0, 133);
+      SmallVector<StringRef, 8> Fields;
+      Header.split(Fields, ';');
+      for (StringRef Field : Fields) {
+        if (Field.empty() || Field.trim().empty() || Field == PerfTextMagicStr)
+          continue;
+        auto KV = Field.split('=');
+        uint64_t Size = 0;
+        // formatv("{0:x-}", *FsRes)
+        if (!KV.second.getAsInteger(16, Size)) {
+          PerfTextSlices[KV.first] = Buf.substr(Offset, Size);
+          Offset += Size;
+        }
+      }
+    } else {
+      // Fallback, treat the entire file as a single stream
+      PerfTextSlices["ALL"] = Buf;
+    }
+    PerfTextLoaded = true;
+    outs() << "PERF2BOLT: Loaded pre-processed perf events from '"
+           << opts::ReadPerfEvents << "'\n";
+  }
+
+  // Find the corresponding slice for the requested event type
+  StringRef Key;
+  if (Name == "buildid")
+    Key = "BUILDIDS";
+  else if (Name == "mmap events")
+    Key = "MMAP";
+  else if (Name == "events" || Name.contains("branch events"))
+    Key = "MAIN";
+  else if (Name == "task events")
+    Key = "TASK";
+  else if (Name == "mem events")
+    Key = "MEM";
+  else
+    Key = "ALL";
+  ParsingBuf = PerfTextSlices.lookup(Key);
+  Col = 0;
+  Line = 1;
+  outs() << "PERF2BOLT: using pre-processed perf events for '" << Name
+         << "' (Size: " << ParsingBuf.size() << " bytes)\n";
+}
+
 int DataAggregator::prepareToParse(StringRef Name, PerfProcessInfo &Process,
                                    PerfProcessErrorCallbackTy Callback) {
   if (!opts::ReadPerfEvents.empty()) {
-    outs() << "PERF2BOLT: using pre-processed perf events for '" << Name
-           << "' (perf-script-events)\n";
-    ParsingBuf = opts::ReadPerfEvents;
+    loadAndSlicePerfText(Name);
     return 0;
   }
 

--- a/bolt/test/perf-script-text.test
+++ b/bolt/test/perf-script-text.test
@@ -1,0 +1,35 @@
+## Test that perf2bolt correctly parses pre-processed perf-script output 
+## (PERFTEXT format) and slices it into appropriate chunks for processing.
+
+# REQUIRES: system-linux
+
+# RUN: split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple x86_64-unknown-linux %t/main.s -o %t.o
+# RUN: ld.lld %t.o -o %t/main -q --no-rosegment --build-id
+
+## Create a dummy perf.data file with the required "PERFILE" magic bytes
+# RUN: echo -n "PERFILE" > %t.perf.data
+
+# RUN: perf2bolt %t/main -p %t.perf.data -perf-script-events %t/main.perf.script \
+# RUN:   -o %t.fdata --ignore-build-id 2>&1 | FileCheck %s
+
+# CHECK: PERF2BOLT: Loaded pre-processed perf events from
+# CHECK: PERF2BOLT: using pre-processed perf events for 'buildid' (Size: 51 bytes)
+# CHECK: PERF2BOLT: using pre-processed perf events for 'mmap events' (Size: 98 bytes)
+# CHECK: PERF2BOLT: using pre-processed perf events for 'task events' (Size: 118 bytes)
+# CHECK: PERF2BOLT: using pre-processed perf events for 'events' (Size: 27 bytes)
+# CHECK: PERF2BOLT: using pre-processed perf events for 'mem events' (Size: 30 bytes)
+
+#--- main.s
+.globl _start
+_start:
+  ret
+
+#--- main.perf.script
+PERFTEXT;BUILDIDS=33;MMAP=62;MAIN=1b;TASK=76;MEM=1e;                                                                          PAD=0;
+0000000000000000000000000000000000000000 /tmp/main
+main 1000 1000.000: PERF_RECORD_MMAP2 1000/1000: [0x200000(0x1000) @ 0 00:00 0 0]: r-xp /tmp/main
+1000 200010/200000/M/-/-/0
+main 1000 1000.000: PERF_RECORD_COMM exec: main:1000/1000
+main 1000 1000.000: PERF_RECORD_FORK(1001:1001):(1000:1000)
+1000 mem-loads: 200010 200000

--- a/bolt/unittests/Core/MemoryMaps.cpp
+++ b/bolt/unittests/Core/MemoryMaps.cpp
@@ -93,12 +93,22 @@ INSTANTIATE_TEST_SUITE_P(AArch64, MemoryMapsTester,
 TEST_P(MemoryMapsTester, ParseMultipleSegments) {
   const int Pid = 1234;
   StringRef Filename = "BINARY";
-  opts::ReadPerfEvents = formatv(
+  std::string PerfData = formatv(
       "name       0 [000]     0.000000: PERF_RECORD_MMAP2 {0}/{0}: "
       "[0xabc0000000(0x1000000) @ 0x11c0000 103:01 1573523 0]: r-xp {1}\n"
       "name       0 [000]     0.000000: PERF_RECORD_MMAP2 {0}/{0}: "
       "[0xabc2000000(0x8000000) @ 0x31d0000 103:01 1573523 0]: r-xp {1}\n",
       Pid, Filename);
+  std::string Header = "PERFTEXT;MMAP=" + utohexstr(PerfData.size()) + ";";
+  Header.append(132 - Header.size(), ' ');
+  Header += "\n";
+  SmallString<64> TempPath;
+  sys::fs::createTemporaryFile("perf-events", "txt", TempPath);
+  std::error_code EC;
+  raw_fd_ostream OS(TempPath, EC, sys::fs::OF_None);
+  OS << Header << PerfData;
+  OS.close();
+  opts::ReadPerfEvents = std::string(TempPath.str());
 
   BC->SegmentMapInfo[0x11da000] = SegmentInfo{
       0x11da000, 0x10da000, 0x11ca000, 0x10da000, 0x10000, true, false};
@@ -117,6 +127,7 @@ TEST_P(MemoryMapsTester, ParseMultipleSegments) {
   // Check that memory mapping is present and has the expected size.
   ASSERT_NE(El, BinaryMMapInfo.end());
   ASSERT_EQ(El->second.Size, static_cast<uint64_t>(0xb1d0000));
+  sys::fs::remove(TempPath);
 }
 
 /// Check that DataAggregator aborts when pre-processing an input binary
@@ -124,12 +135,24 @@ TEST_P(MemoryMapsTester, ParseMultipleSegments) {
 TEST_P(MemoryMapsTester, MultipleSegmentsMismatchedBaseAddress) {
   const int Pid = 1234;
   StringRef Filename = "BINARY";
-  opts::ReadPerfEvents = formatv(
-      "name       0 [000]     0.000000: PERF_RECORD_MMAP2 {0}/{0}: "
-      "[0xabc0000000(0x1000000) @ 0x11c0000 103:01 1573523 0]: r-xp {1}\n"
-      "name       0 [000]     0.000000: PERF_RECORD_MMAP2 {0}/{0}: "
-      "[0xabc2000000(0x8000000) @ 0x31d0000 103:01 1573523 0]: r-xp {1}\n",
-      Pid, Filename);
+  std::string PerfData =
+      formatv(
+          "name       0 [000]     0.000000: PERF_RECORD_MMAP2 {0}/{0}: "
+          "[0xabc0000000(0x1000000) @ 0x11c0000 103:01 1573523 0]: r-xp {1}\n"
+          "name       0 [000]     0.000000: PERF_RECORD_MMAP2 {0}/{0}: "
+          "[0xabc2000000(0x8000000) @ 0x31d0000 103:01 1573523 0]: r-xp {1}\n",
+          Pid, Filename)
+          .str();
+  std::string Header = "PERFTEXT;MMAP=" + utohexstr(PerfData.size()) + ";";
+  Header.append(132 - Header.size(), ' ');
+  Header += "\n";
+  SmallString<64> TempPath;
+  sys::fs::createTemporaryFile("perf-events", "txt", TempPath);
+  std::error_code EC;
+  raw_fd_ostream OS(TempPath, EC, sys::fs::OF_None);
+  OS << Header << PerfData;
+  OS.close();
+  opts::ReadPerfEvents = std::string(TempPath.str());
 
   BC->SegmentMapInfo[0x11da000] = SegmentInfo{
       0x11da000, 0x10da000, 0x11ca000, 0x10da000, 0x10000, true, false};
@@ -143,4 +166,5 @@ TEST_P(MemoryMapsTester, MultipleSegmentsMismatchedBaseAddress) {
   ASSERT_DEBUG_DEATH(
       { Error Err = DA.preprocessProfile(*BC); },
       "Base address on multiple segment mappings should match");
+  sys::fs::remove(TempPath);
 }


### PR DESCRIPTION
Background: We recently explored applying BOLT optimizations to main binaries along with its dependent dynamic libraries, which requires running perf2bolt individually for each DSO. Since perf.data for all DSOs can be collected in a single run and shared, we found the "--perf-script-events" option to be quite useful in this scenario. By pre-generating a shared perf script text via a single "--generate-perf-script"(introduced in this [patch](https://github.com/llvm/llvm-project/pull/171144)), subsequent perf2bolt invocations can consume it directly. This effectively avoids the redundant overhead of repeatedly invoking "perf script" and writing temporary files for each DSO.

About the patch: This change primarily introduces file reading support for the "--perf-script-events" option (accepting either a file path or "-" to read from stdin). It parses the aggregated perf script format generated by "--generate-perf-script", slicing the data into appropriate chunks based on their respective lengths(helpful to parsing efficiency and prevents parsing errors).