### PR TITLE
[lldb] Unify ObjectFile and SymbolFile locking on the Module mutex

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -24,6 +24,7 @@
 #include "lldb/lldb-private.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VersionTuple.h"
+#include <mutex>
 #include <optional>
 
 namespace lldb_private {
@@ -576,7 +577,10 @@ public:
   /// In cases where the type can't be calculated (elf files), this routine
   /// allows someone to explicitly set it. As an example, SymbolVendorELF uses
   /// this routine to set eTypeDebugInfo when loading debug link files.
-  virtual void SetType(Type type) { m_type = type; }
+  virtual void SetType(Type type) {
+    std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
+    m_type = type;
+  }
 
   /// The object file should be able to calculate the strata of the object
   /// file.
@@ -636,12 +640,14 @@ public:
 
   // Member Functions
   Type GetType() {
+    std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
     if (m_type == eTypeInvalid)
       m_type = CalculateType();
     return m_type;
   }
 
   Strata GetStrata() {
+    std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
     if (m_strata == eStrataInvalid)
       m_strata = CalculateStrata();
     return m_strata;
@@ -752,6 +758,12 @@ public:
                                         uint64_t Offset);
   std::string GetObjectName() const;
 
+  /// Returns the recursive mutex owned by this ObjectFile's Module.
+  ///
+  /// Methods that mutate or lazily initialize ObjectFile state acquire this
+  /// to serialize concurrent access across Targets that share the Module.
+  std::recursive_mutex &GetModuleMutex() const;
+
 protected:
   typedef NonNullSharedPtr<lldb_private::DataExtractor> DataExtractorNSP;
 
@@ -773,6 +785,8 @@ protected:
   const lldb::addr_t m_memory_addr;
 
   std::unique_ptr<lldb_private::SectionList> m_sections_up;
+  /// Guards lazy section-list construction, which nests the Module mutex
+  /// inside it. Acquired around the Module mutex, never under it.
   std::recursive_mutex m_sections_mutex;
 
   std::unique_ptr<lldb_private::Symtab> m_symtab_up;

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -803,12 +803,19 @@ Symtab *ObjectFile::GetSymtab(bool can_create) {
 }
 
 uint32_t ObjectFile::GetCacheHash() {
+  std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   if (m_cache_hash)
     return *m_cache_hash;
   StreamString strm;
   strm.Format("{0}-{1}-{2}", m_file, GetType(), GetStrata());
   m_cache_hash = llvm::djbHash(strm.GetString());
   return *m_cache_hash;
+}
+
+std::recursive_mutex &ObjectFile::GetModuleMutex() const {
+  ModuleSP module_sp = GetModule();
+  assert(module_sp && "ObjectFile has no Module");
+  return module_sp->GetMutex();
 }
 
 std::string ObjectFile::GetObjectName() const {

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -35,7 +35,9 @@ void SymbolFile::PreloadSymbols() {
 }
 
 std::recursive_mutex &SymbolFile::GetModuleMutex() const {
-  return GetObjectFile()->GetModule()->GetMutex();
+  const ObjectFile *obj_file = GetObjectFile();
+  assert(obj_file && "SymbolFile has no ObjectFile");
+  return obj_file->GetModuleMutex();
 }
 
 SymbolFile *SymbolFile::FindPlugin(ObjectFileSP objfile_sp) {


### PR DESCRIPTION
SymbolFile already treats the Module mutex as its synchronization point: it exposes a GetModuleMutex() helper and takes that lock in its cache-on-first-use accessors. ObjectFile had no such convention, leaving lazy properties like m_type, m_strata, and m_cache_hash to read and write under no lock at all. A Module is shared across Target instances through the global ModuleList, so two threads can enter those accessors concurrently and observe a half-written value.

Mirror SymbolFile's pattern on ObjectFile. Add a GetModuleMutex() helper that asserts the Module is non-null, take it inside the cache-on-first-use accessors, and route the existing module_sp->GetMutex() call sites through it for consistency. SymbolFile's helper delegates to ObjectFile's so the Module dereference and its null check live in one place.

The exception is ObjectFile::m_sections_mutex, which nests the Module mutex inside it because CreateSections builds the local section list and merges into the Module-owned unified list in a single pass. Document its position relative to the Module mutex.