### PR TITLE
[AArch64][GlobalISel] Do not clamp s16 G_FCONSTANT.

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64LegalizerInfo.cpp
@@ -735,8 +735,7 @@ AArch64LegalizerInfo::AArch64LegalizerInfo(const AArch64Subtarget &ST)
       .widenScalarToNextPow2(0)
       .clampScalar(0, s8, s64);
   getActionDefinitionsBuilder(G_FCONSTANT)
-      .legalFor({s16, s32, s64, s128})
-      .clampScalar(0, MinFPScalar, s128);
+      .legalFor({s16, s32, s64, s128});
 
   // FIXME: fix moreElementsToNextPow2
   getActionDefinitionsBuilder(G_ICMP)


### PR DESCRIPTION
This should be an NFC as s16 FCONSTANT is already legal and handled later
whether fp16 is available or not.