### PR TITLE
Revert "[AArch64] Use ADDP tree for v16i8 to i16 bitmask extraction (#192974)"

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -26148,12 +26148,9 @@ static SDValue vectorToScalarBitmask(SDNode *N, SelectionDAG &DAG) {
   SmallVector<SDValue, 16> MaskConstants;
   if (DAG.getSubtarget<AArch64Subtarget>().isNeonAvailable() &&
       VecVT == MVT::v16i8) {
-    // v16i8 is a special case: we have 16 entries but only 8 positional bits
-    // per i16 of bitmask. ANDing with a mask whose two 8-byte halves both
-    // hold the powers-of-two 1,2,...,128 leaves at most one bit set per byte
-    // lane within each 8-byte group, so pairwise addition equals OR and
-    // cannot carry. Three levels of ADDP then losslessly pack the 16
-    // per-lane bits into the low i16 of the result vector.
+    // v16i8 is a special case, as we have 16 entries but only 8 positional bits
+    // per entry. We split it into two halves, apply the mask, zip the halves to
+    // create 8x 16-bit values, and the perform the vector reduce.
     for (unsigned Half = 0; Half < 2; ++Half) {
       for (unsigned I = 0; I < 8; ++I) {
         // On big-endian targets, the lane order in sub-byte vector elements
@@ -26166,13 +26163,13 @@ static SDValue vectorToScalarBitmask(SDNode *N, SelectionDAG &DAG) {
     SDValue RepresentativeBits =
         DAG.getNode(ISD::AND, DL, VecVT, ComparisonResult, Mask);
 
-    SDValue V = RepresentativeBits;
-    V = DAG.getNode(AArch64ISD::ADDP, DL, VecVT, V, V);
-    V = DAG.getNode(AArch64ISD::ADDP, DL, VecVT, V, V);
-    V = DAG.getNode(AArch64ISD::ADDP, DL, VecVT, V, V);
-    V = DAG.getNode(ISD::BITCAST, DL, MVT::v8i16, V);
-    return DAG.getNode(ISD::EXTRACT_VECTOR_ELT, DL, MVT::i16, V,
-                       DAG.getConstant(0, DL, MVT::i64));
+    SDValue UpperRepresentativeBits =
+        DAG.getNode(AArch64ISD::EXT, DL, VecVT, RepresentativeBits,
+                    RepresentativeBits, DAG.getConstant(8, DL, MVT::i32));
+    SDValue Zipped = DAG.getNode(AArch64ISD::ZIP1, DL, VecVT,
+                                 RepresentativeBits, UpperRepresentativeBits);
+    Zipped = DAG.getNode(ISD::BITCAST, DL, MVT::v8i16, Zipped);
+    return DAG.getNode(ISD::VECREDUCE_ADD, DL, MVT::i16, Zipped);
   }
 
   // All other vector sizes.

--- a/llvm/test/CodeGen/AArch64/alias_mask.ll
+++ b/llvm/test/CodeGen/AArch64/alias_mask.ll
@@ -112,12 +112,12 @@ define <32 x i1> @whilewr_8_split(i64 %a, i64 %b) {
 ; CHECK-NEXT:    mov z1.b, p1/z, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    and v0.16b, v0.16b, v2.16b
 ; CHECK-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
+; CHECK-NEXT:    ext v2.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v3.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v2.16b
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    addv h1, v1.8h
 ; CHECK-NEXT:    str h0, [x8]
 ; CHECK-NEXT:    str h1, [x8, #2]
 ; CHECK-NEXT:    ret
@@ -129,43 +129,42 @@ entry:
 define <64 x i1> @whilewr_8_split2(i64 %a, i64 %b) {
 ; CHECK-LABEL: whilewr_8_split2:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    sub x10, x1, x0
-; CHECK-NEXT:    mov w9, #32 // =0x20
-; CHECK-NEXT:    mov w11, #48 // =0x30
-; CHECK-NEXT:    cmp x10, #1
-; CHECK-NEXT:    csinv x10, x10, xzr, ge
-; CHECK-NEXT:    whilelo p0.b, x9, x10
-; CHECK-NEXT:    mov w9, #16 // =0x10
-; CHECK-NEXT:    whilelo p1.b, x11, x10
-; CHECK-NEXT:    adrp x11, .LCPI9_0
+; CHECK-NEXT:    sub x9, x1, x0
+; CHECK-NEXT:    mov w10, #48 // =0x30
+; CHECK-NEXT:    mov w11, #16 // =0x10
+; CHECK-NEXT:    cmp x9, #1
+; CHECK-NEXT:    mov w12, #32 // =0x20
+; CHECK-NEXT:    csinv x9, x9, xzr, ge
+; CHECK-NEXT:    whilewr p0.b, x0, x1
+; CHECK-NEXT:    whilelo p1.b, x10, x9
+; CHECK-NEXT:    adrp x10, .LCPI9_0
 ; CHECK-NEXT:    mov z0.b, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    ldr q2, [x11, :lo12:.LCPI9_0]
-; CHECK-NEXT:    whilelo p0.b, x9, x10
-; CHECK-NEXT:    mov z1.b, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    whilewr p1.b, x0, x1
+; CHECK-NEXT:    whilelo p0.b, x12, x9
+; CHECK-NEXT:    ldr q1, [x10, :lo12:.LCPI9_0]
+; CHECK-NEXT:    mov z2.b, p1/z, #-1 // =0xffffffffffffffff
+; CHECK-NEXT:    whilelo p1.b, x11, x9
 ; CHECK-NEXT:    mov z3.b, p0/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    and v0.16b, v0.16b, v2.16b
 ; CHECK-NEXT:    mov z4.b, p1/z, #-1 // =0xffffffffffffffff
-; CHECK-NEXT:    and v1.16b, v1.16b, v2.16b
-; CHECK-NEXT:    and v3.16b, v3.16b, v2.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    and v2.16b, v4.16b, v2.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v3.16b, v3.16b, v3.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v2.16b, v2.16b, v2.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v3.16b, v3.16b, v3.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v2.16b, v2.16b, v2.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v3.16b, v3.16b, v3.16b
-; CHECK-NEXT:    addp v2.16b, v2.16b, v2.16b
-; CHECK-NEXT:    zip1 v1.4h, v0.4h, v1.4h
-; CHECK-NEXT:    ext v0.8b, v0.8b, v1.8b, #4
-; CHECK-NEXT:    zip1 v1.4h, v2.4h, v3.4h
-; CHECK-NEXT:    mov v1.s[1], v0.s[1]
-; CHECK-NEXT:    str d1, [x8]
+; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    and v2.16b, v2.16b, v1.16b
+; CHECK-NEXT:    and v3.16b, v3.16b, v1.16b
+; CHECK-NEXT:    and v1.16b, v4.16b, v1.16b
+; CHECK-NEXT:    ext v4.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v5.16b, v2.16b, v2.16b, #8
+; CHECK-NEXT:    ext v6.16b, v3.16b, v3.16b, #8
+; CHECK-NEXT:    ext v7.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v4.16b
+; CHECK-NEXT:    zip1 v2.16b, v2.16b, v5.16b
+; CHECK-NEXT:    zip1 v3.16b, v3.16b, v6.16b
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v7.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    addv h2, v2.8h
+; CHECK-NEXT:    addv h3, v3.8h
+; CHECK-NEXT:    addv h1, v1.8h
+; CHECK-NEXT:    str h0, [x8]
+; CHECK-NEXT:    str h2, [x8, #6]
+; CHECK-NEXT:    str h3, [x8, #4]
+; CHECK-NEXT:    str h1, [x8, #2]
 ; CHECK-NEXT:    ret
 entry:
   %0 = call <64 x i1> @llvm.loop.dependence.war.mask.v64i1.i64(i64 %a, i64 %b, i64 1)
@@ -206,12 +205,12 @@ define <32 x i1> @whilewr_16_expand2(i64 %a, i64 %b) {
 ; CHECK-NEXT:    mov z2.b, p1/z, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEXT:    and v1.16b, v2.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
+; CHECK-NEXT:    ext v2.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v3.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v2.16b
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    addv h1, v1.8h
 ; CHECK-NEXT:    str h0, [x8, #2]
 ; CHECK-NEXT:    str h1, [x8]
 ; CHECK-NEXT:    ret
@@ -274,12 +273,12 @@ define <32 x i1> @whilewr_32_expand3(i64 %a, i64 %b) {
 ; CHECK-NEXT:    mov z2.b, p1/z, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEXT:    and v1.16b, v2.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
+; CHECK-NEXT:    ext v2.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v3.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v2.16b
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    addv h1, v1.8h
 ; CHECK-NEXT:    str h0, [x8, #2]
 ; CHECK-NEXT:    str h1, [x8]
 ; CHECK-NEXT:    ret
@@ -360,12 +359,12 @@ define <32 x i1> @whilewr_64_expand4(i64 %a, i64 %b) {
 ; CHECK-NEXT:    mov z2.b, p1/z, #-1 // =0xffffffffffffffff
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
 ; CHECK-NEXT:    and v1.16b, v2.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
+; CHECK-NEXT:    ext v2.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    ext v3.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v2.16b
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v3.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    addv h1, v1.8h
 ; CHECK-NEXT:    str h0, [x8, #2]
 ; CHECK-NEXT:    str h1, [x8]
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/dag-combine-setcc.ll
+++ b/llvm/test/CodeGen/AArch64/dag-combine-setcc.ll
@@ -338,10 +338,10 @@ define i16 @combine_setcc_slt_add_nsw(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NEXT:    cmgt v0.16b, v1.16b, v0.16b
 ; CHECK-NEXT:    ldr q1, [x8, :lo12:.LCPI20_0]
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w0, v0.h[0]
+; CHECK-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w0, s0
 ; CHECK-NEXT:    ret
   %add0 = sub nsw <16 x i8> %a, %b
   %cmp1 = icmp slt <16 x i8> %add0, zeroinitializer
@@ -356,10 +356,10 @@ define i16 @combine_setcc_sgt_add_nsw(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NEXT:    cmgt v0.16b, v0.16b, v1.16b
 ; CHECK-NEXT:    ldr q1, [x8, :lo12:.LCPI21_0]
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w0, v0.h[0]
+; CHECK-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w0, s0
 ; CHECK-NEXT:    ret
   %add0 = sub nsw <16 x i8> %a, %b
   %cmp1 = icmp sgt <16 x i8> %add0, zeroinitializer
@@ -374,10 +374,10 @@ define i16 @combine_setcc_sle_add_nsw(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NEXT:    cmge v0.16b, v1.16b, v0.16b
 ; CHECK-NEXT:    ldr q1, [x8, :lo12:.LCPI22_0]
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w0, v0.h[0]
+; CHECK-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w0, s0
 ; CHECK-NEXT:    ret
   %add0 = sub nsw <16 x i8> %a, %b
   %cmp1 = icmp sle <16 x i8> %add0, zeroinitializer
@@ -391,10 +391,10 @@ define i16 @combine_setcc_sge_add_nsw(<16 x i8> %a, <16 x i8> %b) {
 ; CHECK-NEXT:    cmge v0.16b, v0.16b, v1.16b
 ; CHECK-NEXT:    ldr q1, [x8, :lo12:.LCPI23_0]
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w0, v0.h[0]
+; CHECK-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w0, s0
 ; CHECK-NEXT:    ret
   %add0 = sub nsw <16 x i8> %a, %b
   %cmp1 = icmp sge <16 x i8> %add0, zeroinitializer

--- a/llvm/test/CodeGen/AArch64/fixed_masked_deinterleaved_loads.ll
+++ b/llvm/test/CodeGen/AArch64/fixed_masked_deinterleaved_loads.ll
@@ -15,14 +15,14 @@ define { <16 x i8>, <16 x i8> } @foo_ld2_v16i8(<16 x i1> %mask, ptr %p) {
 ; CHECK-NEXT:    cmlt v0.16b, v0.16b, #0
 ; CHECK-NEXT:    and v1.16b, v1.16b, v2.16b
 ; CHECK-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w9, v1.h[0]
-; CHECK-NEXT:    umov w8, v0.h[0]
+; CHECK-NEXT:    ext v2.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    ext v3.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v2.16b
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v3.16b
+; CHECK-NEXT:    addv h1, v1.8h
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w9, s1
+; CHECK-NEXT:    fmov w8, s0
 ; CHECK-NEXT:    bfi w8, w9, #16, #16
 ; CHECK-NEXT:    tbz w8, #0, .LBB0_2
 ; CHECK-NEXT:  // %bb.1: // %cond.load
@@ -236,10 +236,10 @@ define { <8 x i16>, <8 x i16> } @foo_ld2_v8i16(<8 x i1> %mask, ptr %p) {
 ; CHECK-NEXT:    shl v0.16b, v0.16b, #7
 ; CHECK-NEXT:    cmlt v0.16b, v0.16b, #0
 ; CHECK-NEXT:    and v0.16b, v0.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w8, v0.h[0]
+; CHECK-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w8, s0
 ; CHECK-NEXT:    tbz w8, #0, .LBB1_2
 ; CHECK-NEXT:  // %bb.1: // %cond.load
 ; CHECK-NEXT:    ldr h1, [x0]

--- a/llvm/test/CodeGen/AArch64/fixed_masked_interleaved_stores.ll
+++ b/llvm/test/CodeGen/AArch64/fixed_masked_interleaved_stores.ll
@@ -15,14 +15,14 @@ define void @foo_st2_v16i8(<16 x i1> %mask, <16 x i8> %val1, <16 x i8> %val2, pt
 ; CHECK-NEXT:    cmlt v0.16b, v0.16b, #0
 ; CHECK-NEXT:    and v3.16b, v3.16b, v4.16b
 ; CHECK-NEXT:    and v0.16b, v0.16b, v4.16b
-; CHECK-NEXT:    addp v3.16b, v3.16b, v3.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v3.16b, v3.16b, v3.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v3.16b, v3.16b, v3.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w9, v3.h[0]
-; CHECK-NEXT:    umov w8, v0.h[0]
+; CHECK-NEXT:    ext v4.16b, v3.16b, v3.16b, #8
+; CHECK-NEXT:    ext v5.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v3.16b, v3.16b, v4.16b
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v5.16b
+; CHECK-NEXT:    addv h3, v3.8h
+; CHECK-NEXT:    addv h0, v0.8h
+; CHECK-NEXT:    fmov w9, s3
+; CHECK-NEXT:    fmov w8, s0
 ; CHECK-NEXT:    zip1 v0.16b, v1.16b, v2.16b
 ; CHECK-NEXT:    bfi w8, w9, #16, #16
 ; CHECK-NEXT:    tbnz w8, #0, .LBB0_33
@@ -234,11 +234,11 @@ define void @foo_st2_v8i16(<8 x i1> %mask, <8 x i16> %val1, <8 x i16> %val2, ptr
 ; CHECK-NEXT:    shl v0.16b, v0.16b, #7
 ; CHECK-NEXT:    cmlt v0.16b, v0.16b, #0
 ; CHECK-NEXT:    and v0.16b, v0.16b, v3.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    umov w8, v0.h[0]
+; CHECK-NEXT:    ext v3.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v3.16b
+; CHECK-NEXT:    addv h3, v0.8h
 ; CHECK-NEXT:    zip1 v0.8h, v1.8h, v2.8h
+; CHECK-NEXT:    fmov w8, s3
 ; CHECK-NEXT:    tbnz w8, #0, .LBB1_17
 ; CHECK-NEXT:  // %bb.1: // %else
 ; CHECK-NEXT:    tbnz w8, #1, .LBB1_18

--- a/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-expandloads.ll
+++ b/llvm/test/CodeGen/AArch64/sve-fixed-length-masked-expandloads.ll
@@ -357,11 +357,11 @@ define void @masked_load_v16f32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
 ; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI4_0]
 ; VBITS_GE_256-NEXT:    and v0.16b, v1.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w9, v0.h[0]
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w9, s0
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w9, #0, .LBB4_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ldr s0, [x0], #4
@@ -5338,8 +5338,6 @@ define void @masked_load_v16i32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    .cfi_def_cfa_offset 16
 ; VBITS_GE_256-NEXT:    ptrue p0.s, vl8
 ; VBITS_GE_256-NEXT:    mov x8, #8 // =0x8
-; VBITS_GE_256-NEXT:    adrp x10, .LCPI9_1
-; VBITS_GE_256-NEXT:    add x10, x10, :lo12:.LCPI9_1
 ; VBITS_GE_256-NEXT:    ld1w { z0.s }, p0/z, [x0, x8, lsl #2]
 ; VBITS_GE_256-NEXT:    ld1w { z1.s }, p0/z, [x0]
 ; VBITS_GE_256-NEXT:    ld1w { z2.s }, p0/z, [x1, x8, lsl #2]
@@ -5356,13 +5354,15 @@ define void @masked_load_v16i32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    uzp1 z1.b, z1.b, z1.b
 ; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
 ; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI9_0]
+; VBITS_GE_256-NEXT:    adrp x8, .LCPI9_1
+; VBITS_GE_256-NEXT:    add x8, x8, :lo12:.LCPI9_1
 ; VBITS_GE_256-NEXT:    and v0.16b, v1.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w9, v0.h[0]
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
-; VBITS_GE_256-NEXT:    ld1w { z0.s }, p0/z, [x10]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h1, v0.8h
+; VBITS_GE_256-NEXT:    ld1w { z0.s }, p0/z, [x8]
+; VBITS_GE_256-NEXT:    fmov w9, s1
+; VBITS_GE_256-NEXT:    fmov w8, s1
 ; VBITS_GE_256-NEXT:    tbz w9, #0, .LBB9_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ld1rw { z2.s }, p1/z, [x0]
@@ -7627,10 +7627,10 @@ define void @masked_load_sext_v16i8i32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    ldr q1, [x8, :lo12:.LCPI14_0]
 ; VBITS_GE_256-NEXT:    cmeq v0.16b, v0.16b, #0
 ; VBITS_GE_256-NEXT:    and v0.16b, v0.16b, v1.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w8, #0, .LBB14_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ldrb w9, [x0], #1
@@ -7731,10 +7731,10 @@ define void @masked_load_sext_v16i8i32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_512-NEXT:    ldr q1, [x8, :lo12:.LCPI14_0]
 ; VBITS_GE_512-NEXT:    cmeq v0.16b, v0.16b, #0
 ; VBITS_GE_512-NEXT:    and v0.16b, v0.16b, v1.16b
-; VBITS_GE_512-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_512-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_512-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_512-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_512-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_512-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_512-NEXT:    addv h0, v0.8h
+; VBITS_GE_512-NEXT:    fmov w8, s0
 ; VBITS_GE_512-NEXT:    tbz w8, #0, .LBB14_2
 ; VBITS_GE_512-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_512-NEXT:    ldrb w9, [x0], #1
@@ -9833,10 +9833,10 @@ define void @masked_load_zext_v16i8i32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    ldr q1, [x8, :lo12:.LCPI20_0]
 ; VBITS_GE_256-NEXT:    cmeq v0.16b, v0.16b, #0
 ; VBITS_GE_256-NEXT:    and v0.16b, v0.16b, v1.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w8, #0, .LBB20_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ldrb w9, [x0], #1
@@ -9937,10 +9937,10 @@ define void @masked_load_zext_v16i8i32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_512-NEXT:    ldr q1, [x8, :lo12:.LCPI20_0]
 ; VBITS_GE_512-NEXT:    cmeq v0.16b, v0.16b, #0
 ; VBITS_GE_512-NEXT:    and v0.16b, v0.16b, v1.16b
-; VBITS_GE_512-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_512-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_512-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_512-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_512-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_512-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_512-NEXT:    addv h0, v0.8h
+; VBITS_GE_512-NEXT:    fmov w8, s0
 ; VBITS_GE_512-NEXT:    tbz w8, #0, .LBB20_2
 ; VBITS_GE_512-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_512-NEXT:    ldrb w9, [x0], #1
@@ -12030,11 +12030,11 @@ define void @masked_load_sext_v16i8i32_m32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
 ; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI26_0]
 ; VBITS_GE_256-NEXT:    and v0.16b, v1.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w9, v0.h[0]
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w9, s0
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w9, #0, .LBB26_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ldrb w9, [x0], #1
@@ -12532,11 +12532,11 @@ define void @masked_load_sext_v16i16i32_m32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
 ; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI28_0]
 ; VBITS_GE_256-NEXT:    and v0.16b, v1.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w9, v0.h[0]
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w9, s0
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w9, #0, .LBB28_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ld1rh { z0.h }, p1/z, [x0]
@@ -14394,11 +14394,11 @@ define void @masked_load_zext_v16i8i32_m32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
 ; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI32_0]
 ; VBITS_GE_256-NEXT:    and v0.16b, v1.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w9, v0.h[0]
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w9, s0
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w9, #0, .LBB32_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ldrb w9, [x0], #1
@@ -14896,11 +14896,11 @@ define void @masked_load_zext_v16i16i32_m32(ptr %ap, ptr %bp, ptr %c) #0 {
 ; VBITS_GE_256-NEXT:    mov v1.d[1], v0.d[0]
 ; VBITS_GE_256-NEXT:    ldr q0, [x8, :lo12:.LCPI34_0]
 ; VBITS_GE_256-NEXT:    and v0.16b, v1.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    addp v0.16b, v0.16b, v0.16b
-; VBITS_GE_256-NEXT:    umov w9, v0.h[0]
-; VBITS_GE_256-NEXT:    umov w8, v0.h[0]
+; VBITS_GE_256-NEXT:    ext v1.16b, v0.16b, v0.16b, #8
+; VBITS_GE_256-NEXT:    zip1 v0.16b, v0.16b, v1.16b
+; VBITS_GE_256-NEXT:    addv h0, v0.8h
+; VBITS_GE_256-NEXT:    fmov w9, s0
+; VBITS_GE_256-NEXT:    fmov w8, s0
 ; VBITS_GE_256-NEXT:    tbz w9, #0, .LBB34_2
 ; VBITS_GE_256-NEXT:  // %bb.1: // %cond.load
 ; VBITS_GE_256-NEXT:    ld1rh { z0.h }, p1/z, [x0]

--- a/llvm/test/CodeGen/AArch64/sve-mask-partition.ll
+++ b/llvm/test/CodeGen/AArch64/sve-mask-partition.ll
@@ -381,12 +381,12 @@ define <32 x i1> @mask_exclude_active_v32(<32 x i1> %mask.in) {
 ; CHECK-NEXT:    cmlt v0.16b, v0.16b, #0
 ; CHECK-NEXT:    and v1.16b, v1.16b, v2.16b
 ; CHECK-NEXT:    and v0.16b, v0.16b, v2.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
-; CHECK-NEXT:    addp v1.16b, v1.16b, v1.16b
-; CHECK-NEXT:    addp v0.16b, v0.16b, v0.16b
+; CHECK-NEXT:    ext v2.16b, v1.16b, v1.16b, #8
+; CHECK-NEXT:    ext v3.16b, v0.16b, v0.16b, #8
+; CHECK-NEXT:    zip1 v1.16b, v1.16b, v2.16b
+; CHECK-NEXT:    zip1 v0.16b, v0.16b, v3.16b
+; CHECK-NEXT:    addv h1, v1.8h
+; CHECK-NEXT:    addv h0, v0.8h
 ; CHECK-NEXT:    str h1, [x8, #2]
 ; CHECK-NEXT:    str h0, [x8]
 ; CHECK-NEXT:    ret

--- a/llvm/test/CodeGen/AArch64/vec-combine-compare-to-bitmask.ll
+++ b/llvm/test/CodeGen/AArch64/vec-combine-compare-to-bitmask.ll
@@ -17,10 +17,10 @@ define i16 @convert_to_bitmask16(<16 x i8> %vec) {
 ; CHECK-SD-NEXT:    cmeq.16b v0, v0, #0
 ; CHECK-SD-NEXT:    ldr q1, [x8, lCPI0_0@PAGEOFF]
 ; CHECK-SD-NEXT:    bic.16b v0, v1, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    umov.h w0, v0[0]
+; CHECK-SD-NEXT:    ext.16b v1, v0, v0, #8
+; CHECK-SD-NEXT:    zip1.16b v0, v0, v1
+; CHECK-SD-NEXT:    addv.8h h0, v0
+; CHECK-SD-NEXT:    fmov w0, s0
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: convert_to_bitmask16:
@@ -521,10 +521,10 @@ define i16 @convert_to_bitmask_without_knowing_type(<16 x i1> %vec) {
 ; CHECK-SD-NEXT:    ldr q1, [x8, lCPI10_0@PAGEOFF]
 ; CHECK-SD-NEXT:    cmlt.16b v0, v0, #0
 ; CHECK-SD-NEXT:    and.16b v0, v0, v1
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    umov.h w0, v0[0]
+; CHECK-SD-NEXT:    ext.16b v1, v0, v0, #8
+; CHECK-SD-NEXT:    zip1.16b v0, v0, v1
+; CHECK-SD-NEXT:    addv.8h h0, v0
+; CHECK-SD-NEXT:    fmov w0, s0
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: convert_to_bitmask_without_knowing_type:
@@ -992,9 +992,9 @@ define <2 x i8> @vector_to_vector_cast(<16 x i1> %arg) nounwind {
 ; CHECK-SD-NEXT:    ldr q1, [x8, lCPI20_0@PAGEOFF]
 ; CHECK-SD-NEXT:    cmlt.16b v0, v0, #0
 ; CHECK-SD-NEXT:    and.16b v0, v0, v1
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
-; CHECK-SD-NEXT:    addp.16b v0, v0, v0
+; CHECK-SD-NEXT:    ext.16b v1, v0, v0, #8
+; CHECK-SD-NEXT:    zip1.16b v0, v0, v1
+; CHECK-SD-NEXT:    addv.8h h0, v0
 ; CHECK-SD-NEXT:    ushll.8h v0, v0, #0
 ; CHECK-SD-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-SD-NEXT:    ; kill: def $d0 killed $d0 killed $q0

--- a/llvm/test/CodeGen/AArch64/vec-combine-compare-truncate-store.ll
+++ b/llvm/test/CodeGen/AArch64/vec-combine-compare-truncate-store.ll
@@ -11,9 +11,9 @@ define void @store_16_elements(<16 x i8> %vec, ptr %out) {
 ; CHECK-NEXT:  Lloh1:
 ; CHECK-NEXT:    ldr q1, [x8, lCPI0_0@PAGEOFF]
 ; CHECK-NEXT:    bic.16b v0, v1, v0
-; CHECK-NEXT:    addp.16b v0, v0, v0
-; CHECK-NEXT:    addp.16b v0, v0, v0
-; CHECK-NEXT:    addp.16b v0, v0, v0
+; CHECK-NEXT:    ext.16b v1, v0, v0, #8
+; CHECK-NEXT:    zip1.16b v0, v0, v1
+; CHECK-NEXT:    addv.8h h0, v0
 ; CHECK-NEXT:    str h0, [x0]
 ; CHECK-NEXT:    ret
 ; CHECK-NEXT:    .loh AdrpLdr Lloh0, Lloh1


### PR DESCRIPTION
This reverts commit 42cc9b53bf83ebb778755fd51a9b277cb71740d5 as it is
tripping up on type legalization.