### PR TITLE
[SPIR][SPIRV] Mark AS3 as having an unstable pointer representation

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -282,7 +282,8 @@ public:
     // Take the maximum because it's possible the Host supports wider types.
     MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 64);
     resetDataLayout("e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1");
+                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+                    "-pu3:32:32");
   }
 
   void getTargetDefines(const LangOptions &Opts,
@@ -302,7 +303,8 @@ public:
     // Take the maximum because it's possible the Host supports wider types.
     MaxAtomicInlineWidth = std::max<unsigned char>(MaxAtomicInlineWidth, 64);
     resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-"
-                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1");
+                    "v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+                    "-pu3:64:64");
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -265,6 +265,14 @@
 // RUN: FileCheck %s -check-prefix=SPIRVVULKAN
 // SPIRVVULKAN: target datalayout = "e-ve-i64:64-n8:16:32:64-G10"
 
+// RUN: %clang_cc1 -triple spirv32-unknown-unknown -o - -emit-llvm %s | \
+// RUN: FileCheck %s -check-prefix=SPIRV32UNKNOWN
+// SPIRV32UNKNOWN: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:32:32"
+
+// RUN: %clang_cc1 -triple spirv64-unknown-unknown -o - -emit-llvm %s | \
+// RUN: FileCheck %s -check-prefix=SPIRV64UNKNOWN
+// SPIRV64UNKNOWN: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
+
 // RUN: %clang_cc1 -triple spirv32-unknown-vulkan -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIRV32VULKAN
 // SPIRV32VULKAN: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -239,11 +239,11 @@
 
 // RUN: %clang_cc1 -triple spir-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIR
-// SPIR: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+// SPIR: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1-pu3:32:32"
 
 // RUN: %clang_cc1 -triple spir64-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIR64
-// SPIR64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+// SPIR64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1-pu3:64:64"
 
 // RUN: %clang_cc1 -triple bpfel -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=BPFEL

--- a/clang/test/Driver/Inputs/SYCL/bar.ll
+++ b/clang/test/Driver/Inputs/SYCL/bar.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_func i32 @bar_func1(i32 %a, i32 %b) {

--- a/clang/test/Driver/Inputs/SYCL/baz.ll
+++ b/clang/test/Driver/Inputs/SYCL/baz.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_func i32 @bar_func1(i32 %a, i32 %b) {

--- a/clang/test/Driver/Inputs/SYCL/foo.ll
+++ b/clang/test/Driver/Inputs/SYCL/foo.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_func i32 @foo_func1(i32 %a, i32 %b) {

--- a/clang/test/Driver/Inputs/SYCL/libLLVMSYCL.ll
+++ b/clang/test/Driver/Inputs/SYCL/libLLVMSYCL.ll
@@ -1,4 +1,4 @@
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_func i32 @addFive(i32 %a) {

--- a/clang/test/Tooling/clang-sycl-linker-split-mode.ll
+++ b/clang/test/Tooling/clang-sycl-linker-split-mode.ll
@@ -47,7 +47,7 @@
 ; SPLIT-SRC-NEXT: LLVM backend: input: [[S1]].bc, output: {{.*}}_1.spv
 ; SPLIT-SRC-NOT:  {{.+}}
 
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_func i32 @helper() {

--- a/clang/test/Tooling/clang-sycl-linker-triple.ll
+++ b/clang/test/Tooling/clang-sycl-linker-triple.ll
@@ -34,7 +34,7 @@
 ; NO-TRIPLE: Target triple must be specified or inferable from inputs
 
 ;--- input1.ll
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_kernel void @kernel_a() #0 {
@@ -44,7 +44,7 @@ define spir_kernel void @kernel_a() #0 {
 attributes #0 = { "sycl-module-id"="TU1.cpp" }
 
 ;--- input2.ll
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_kernel void @kernel_b() #0 {

--- a/clang/test/Tooling/clang-sycl-linker.ll
+++ b/clang/test/Tooling/clang-sycl-linker.ll
@@ -81,7 +81,7 @@
 ; NO-ENTRY-POINTS: producer        sycl
 
 ;--- input1.ll
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_kernel void @kernel_a() #0 {
@@ -91,7 +91,7 @@ define spir_kernel void @kernel_a() #0 {
 attributes #0 = { "sycl-module-id"="TU1.cpp" }
 
 ;--- input2.ll
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_kernel void @kernel_b() #0 {
@@ -101,7 +101,7 @@ define spir_kernel void @kernel_b() #0 {
 attributes #0 = { "sycl-module-id"="TU2.cpp" }
 
 ;--- no-entry-points.ll
-target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1-pu3:64:64"
 target triple = "spirv64"
 
 define spir_func i32 @helper() {

--- a/llvm/lib/TargetParser/TargetDataLayout.cpp
+++ b/llvm/lib/TargetParser/TargetDataLayout.cpp
@@ -476,14 +476,23 @@ static std::string computeNVPTXDataLayout(const Triple &T, StringRef ABIName) {
 
 static std::string computeSPIRVDataLayout(const Triple &TT) {
   const auto Arch = TT.getArch();
+  const bool IsUnknownTriple =
+      TT.getVendor() == Triple::UnknownVendor &&
+      TT.getOS() == Triple::UnknownOS &&
+      TT.getEnvironment() == Triple::UnknownEnvironment;
   // TODO: this probably needs to be revisited:
   // Logical SPIR-V has no pointer size, so any fixed pointer size would be
   // wrong. The choice to default to 32 or 64 is just motivated by another
   // memory model used for graphics: PhysicalStorageBuffer64. But it shouldn't
   // mean anything.
-  if (Arch == Triple::spirv32)
-    return "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-"
-           "v256:256-v512:512-v1024:1024-n8:16:32:64-G1";
+  if (Arch == Triple::spirv32) {
+    std::string Ret =
+        "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:"
+        "256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1";
+    if (IsUnknownTriple)
+      Ret += "-pu3:32:32";
+    return Ret;
+  }
   if (Arch == Triple::spirv)
     return "e-ve-i64:64-n8:16:32:64-G10";
   if (TT.getVendor() == Triple::VendorType::AMD &&
@@ -493,8 +502,12 @@ static std::string computeSPIRVDataLayout(const Triple &TT) {
   if (TT.getVendor() == Triple::VendorType::Intel)
     return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
            "v512:512-v1024:1024-n8:16:32:64-G1-P9-A0";
-  return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
-         "v512:512-v1024:1024-n8:16:32:64-G1";
+  std::string Ret =
+      "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:"
+      "256-v512:512-v1024:1024-n8:16:32:64-G1";
+  if (IsUnknownTriple)
+    Ret += "-pu3:64:64";
+  return Ret;
 }
 
 static std::string computeLanaiDataLayout() {


### PR DESCRIPTION
Intel GPU backend uses a non-zero sentinel for null in OpenCL local address space. DataLayout::mustNotIntroducePtrToInt returns true when AS3 has unstable pointer representation, preventing optimization passes (e.g. SROA) from creating invalid ptrtoint/inttoptr round-trip:
```
  %1 = ptrtoint ptr addrspace(3) addrspacecast (ptr addrspace(4) null to ptr addrspace(3)) to i64
  %2 = inttoptr i64 %1 to ptr addrspace(3)
  %3 = addrspacecast ptr addrspace(3) %2 to ptr addrspace(4)
```
EarlyCSEPass further folds the sequence to `ptr addrspace(4) null`, which doesn't preserve null in local address space.

`spir-unknown-unknown`, `spir64-unknown-unknown`, `spirv32-unknown-unknown` and `spirv64-unknown-unknown`  are generic virtual triples. Marking AS3 as unstable pointer is a conservative approach to preserve local-address-space null semantics.

This fixes a SYCL test on Intel GPU.