### PR TITLE
[X86] LowerVECREDUCE - don't attempt to handle vectors with non-pow2 element counts

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -29718,7 +29718,9 @@ static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
   const TargetLowering &TLI = DAG.getTargetLoweringInfo();
   SDLoc DL(Op);
 
-  if (SrcSVT != ExtractVT || (SrcVT.getSizeInBits() % 128) != 0)
+  // TODO: Pad non-pow2 vectors with identity constants.
+  if (SrcSVT != ExtractVT || SrcVT.getSizeInBits() < 128 ||
+      !isPowerOf2_32(SrcVT.getVectorNumElements()))
     return SDValue();
 
   // Split vector down to 128-bits, performing bin to lo/hi subvectors.
@@ -29960,8 +29962,9 @@ static SDValue LowerMINMAX_REDUCE(SDValue Op, const X86Subtarget &Subtarget,
   EVT SrcVT = Src.getValueType();
   EVT SrcSVT = SrcVT.getScalarType();
   ISD::NodeType BinOp = ISD::getVecReduceBaseOpcode(Op.getOpcode());
-  if (SrcSVT != ExtractVT || (SrcVT.getSizeInBits() % 128) != 0)
-    return LowerVECREDUCE(Op, Subtarget, DAG, AllowScalarization);
+  if (SrcSVT != ExtractVT || SrcVT.getSizeInBits() < 128 ||
+      !isPowerOf2_32(SrcVT.getVectorNumElements()))
+    return SDValue();
 
   // Bail if at least the upper half elements are identity.
   APInt HiElts = APInt::getHighBitsSet(SrcVT.getVectorNumElements(),

--- a/llvm/test/CodeGen/X86/vector-reduce-smax.ll
+++ b/llvm/test/CodeGen/X86/vector-reduce-smax.ll
@@ -3550,6 +3550,349 @@ define i8 @test_v128i8(<128 x i8> %a0) nounwind {
   ret i8 %1
 }
 
+; Special Cases
+
+define i64 @test_v6i64(<6 x i64> %a0) nounwind {
+; X86-SSE2-LABEL: test_v6i64:
+; X86-SSE2:       # %bb.0:
+; X86-SSE2-NEXT:    pushl %edi
+; X86-SSE2-NEXT:    pushl %esi
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-SSE2-NEXT:    cmpl %ecx, %eax
+; X86-SSE2-NEXT:    movl %edx, %edi
+; X86-SSE2-NEXT:    sbbl %esi, %edi
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-SSE2-NEXT:    cmovll %esi, %edx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    cmovll %ecx, %eax
+; X86-SSE2-NEXT:    cmpl %eax, %edi
+; X86-SSE2-NEXT:    movl %esi, %ecx
+; X86-SSE2-NEXT:    sbbl %edx, %ecx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE2-NEXT:    cmovgel %esi, %edx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    cmovgel %edi, %eax
+; X86-SSE2-NEXT:    cmpl %eax, %ecx
+; X86-SSE2-NEXT:    movl %esi, %edi
+; X86-SSE2-NEXT:    sbbl %edx, %edi
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-SSE2-NEXT:    cmovgel %esi, %edx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    cmovgel %ecx, %eax
+; X86-SSE2-NEXT:    cmpl %eax, %edi
+; X86-SSE2-NEXT:    movl %esi, %ecx
+; X86-SSE2-NEXT:    sbbl %edx, %ecx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE2-NEXT:    cmovgel %esi, %edx
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE2-NEXT:    cmovgel %edi, %eax
+; X86-SSE2-NEXT:    cmpl %eax, %ecx
+; X86-SSE2-NEXT:    movl %esi, %edi
+; X86-SSE2-NEXT:    sbbl %edx, %edi
+; X86-SSE2-NEXT:    cmovgel %ecx, %eax
+; X86-SSE2-NEXT:    cmovgel %esi, %edx
+; X86-SSE2-NEXT:    popl %esi
+; X86-SSE2-NEXT:    popl %edi
+; X86-SSE2-NEXT:    retl
+;
+; X64-SSE2-LABEL: test_v6i64:
+; X64-SSE2:       # %bb.0:
+; X64-SSE2-NEXT:    movq %rcx, %xmm1
+; X64-SSE2-NEXT:    movq %rdx, %xmm0
+; X64-SSE2-NEXT:    punpcklqdq {{.*#+}} xmm0 = xmm0[0],xmm1[0]
+; X64-SSE2-NEXT:    movq %rsi, %xmm1
+; X64-SSE2-NEXT:    movq %rdi, %xmm2
+; X64-SSE2-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm1[0]
+; X64-SSE2-NEXT:    movq %r9, %xmm1
+; X64-SSE2-NEXT:    movq %r8, %xmm3
+; X64-SSE2-NEXT:    punpcklqdq {{.*#+}} xmm3 = xmm3[0],xmm1[0]
+; X64-SSE2-NEXT:    movdqa {{.*#+}} xmm1 = [2147483648,2147483648]
+; X64-SSE2-NEXT:    movdqa %xmm3, %xmm4
+; X64-SSE2-NEXT:    pxor %xmm1, %xmm4
+; X64-SSE2-NEXT:    movdqa %xmm2, %xmm5
+; X64-SSE2-NEXT:    pxor %xmm1, %xmm5
+; X64-SSE2-NEXT:    movdqa %xmm5, %xmm6
+; X64-SSE2-NEXT:    pcmpgtd %xmm4, %xmm6
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm7 = xmm6[0,0,2,2]
+; X64-SSE2-NEXT:    pcmpeqd %xmm4, %xmm5
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm5[1,1,3,3]
+; X64-SSE2-NEXT:    pand %xmm7, %xmm4
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm5 = xmm6[1,1,3,3]
+; X64-SSE2-NEXT:    por %xmm4, %xmm5
+; X64-SSE2-NEXT:    pand %xmm5, %xmm2
+; X64-SSE2-NEXT:    pandn %xmm3, %xmm5
+; X64-SSE2-NEXT:    por %xmm2, %xmm5
+; X64-SSE2-NEXT:    movdqa %xmm5, %xmm2
+; X64-SSE2-NEXT:    pxor %xmm1, %xmm2
+; X64-SSE2-NEXT:    pxor %xmm0, %xmm1
+; X64-SSE2-NEXT:    movdqa %xmm2, %xmm3
+; X64-SSE2-NEXT:    pcmpgtd %xmm1, %xmm3
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm4 = xmm3[0,0,2,2]
+; X64-SSE2-NEXT:    pcmpeqd %xmm2, %xmm1
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm1 = xmm1[1,1,3,3]
+; X64-SSE2-NEXT:    pand %xmm4, %xmm1
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm2 = xmm3[1,1,3,3]
+; X64-SSE2-NEXT:    por %xmm1, %xmm2
+; X64-SSE2-NEXT:    pand %xmm2, %xmm5
+; X64-SSE2-NEXT:    pandn %xmm0, %xmm2
+; X64-SSE2-NEXT:    por %xmm5, %xmm2
+; X64-SSE2-NEXT:    movq %xmm2, %rcx
+; X64-SSE2-NEXT:    pshufd {{.*#+}} xmm0 = xmm2[2,3,2,3]
+; X64-SSE2-NEXT:    movq %xmm0, %rax
+; X64-SSE2-NEXT:    cmpq %rax, %rcx
+; X64-SSE2-NEXT:    cmovgq %rcx, %rax
+; X64-SSE2-NEXT:    retq
+;
+; X86-SSE4-LABEL: test_v6i64:
+; X86-SSE4:       # %bb.0:
+; X86-SSE4-NEXT:    pushl %edi
+; X86-SSE4-NEXT:    pushl %esi
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-SSE4-NEXT:    cmpl %ecx, %eax
+; X86-SSE4-NEXT:    movl %edx, %edi
+; X86-SSE4-NEXT:    sbbl %esi, %edi
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-SSE4-NEXT:    cmovll %esi, %edx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE4-NEXT:    cmovll %ecx, %eax
+; X86-SSE4-NEXT:    cmpl %eax, %edi
+; X86-SSE4-NEXT:    movl %esi, %ecx
+; X86-SSE4-NEXT:    sbbl %edx, %ecx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE4-NEXT:    cmovgel %esi, %edx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE4-NEXT:    cmovgel %edi, %eax
+; X86-SSE4-NEXT:    cmpl %eax, %ecx
+; X86-SSE4-NEXT:    movl %esi, %edi
+; X86-SSE4-NEXT:    sbbl %edx, %edi
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-SSE4-NEXT:    cmovgel %esi, %edx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE4-NEXT:    cmovgel %ecx, %eax
+; X86-SSE4-NEXT:    cmpl %eax, %edi
+; X86-SSE4-NEXT:    movl %esi, %ecx
+; X86-SSE4-NEXT:    sbbl %edx, %ecx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE4-NEXT:    cmovgel %esi, %edx
+; X86-SSE4-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SSE4-NEXT:    cmovgel %edi, %eax
+; X86-SSE4-NEXT:    cmpl %eax, %ecx
+; X86-SSE4-NEXT:    movl %esi, %edi
+; X86-SSE4-NEXT:    sbbl %edx, %edi
+; X86-SSE4-NEXT:    cmovgel %ecx, %eax
+; X86-SSE4-NEXT:    cmovgel %esi, %edx
+; X86-SSE4-NEXT:    popl %esi
+; X86-SSE4-NEXT:    popl %edi
+; X86-SSE4-NEXT:    retl
+;
+; X64-SSE41-LABEL: test_v6i64:
+; X64-SSE41:       # %bb.0:
+; X64-SSE41-NEXT:    movq %rcx, %xmm0
+; X64-SSE41-NEXT:    movq %rdx, %xmm1
+; X64-SSE41-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
+; X64-SSE41-NEXT:    movq %rsi, %xmm0
+; X64-SSE41-NEXT:    movq %rdi, %xmm3
+; X64-SSE41-NEXT:    punpcklqdq {{.*#+}} xmm3 = xmm3[0],xmm0[0]
+; X64-SSE41-NEXT:    movq %r9, %xmm0
+; X64-SSE41-NEXT:    movq %r8, %xmm2
+; X64-SSE41-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm0[0]
+; X64-SSE41-NEXT:    pmovzxdq {{.*#+}} xmm4 = [2147483648,2147483648]
+; X64-SSE41-NEXT:    movdqa %xmm2, %xmm0
+; X64-SSE41-NEXT:    pxor %xmm4, %xmm0
+; X64-SSE41-NEXT:    movdqa %xmm3, %xmm5
+; X64-SSE41-NEXT:    pxor %xmm4, %xmm5
+; X64-SSE41-NEXT:    movdqa %xmm5, %xmm6
+; X64-SSE41-NEXT:    pcmpgtd %xmm0, %xmm6
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm7 = xmm6[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm5
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm5[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm7, %xmm5
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm6[1,1,3,3]
+; X64-SSE41-NEXT:    por %xmm5, %xmm0
+; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
+; X64-SSE41-NEXT:    movapd %xmm2, %xmm0
+; X64-SSE41-NEXT:    xorpd %xmm4, %xmm0
+; X64-SSE41-NEXT:    pxor %xmm1, %xmm4
+; X64-SSE41-NEXT:    movapd %xmm0, %xmm3
+; X64-SSE41-NEXT:    pcmpgtd %xmm4, %xmm3
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm5 = xmm3[0,0,2,2]
+; X64-SSE41-NEXT:    pcmpeqd %xmm0, %xmm4
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm4 = xmm4[1,1,3,3]
+; X64-SSE41-NEXT:    pand %xmm5, %xmm4
+; X64-SSE41-NEXT:    pshufd {{.*#+}} xmm0 = xmm3[1,1,3,3]
+; X64-SSE41-NEXT:    por %xmm4, %xmm0
+; X64-SSE41-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE41-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE41-NEXT:    movq %xmm1, %rcx
+; X64-SSE41-NEXT:    cmpq %rax, %rcx
+; X64-SSE41-NEXT:    cmovgq %rcx, %rax
+; X64-SSE41-NEXT:    retq
+;
+; X64-SSE42-LABEL: test_v6i64:
+; X64-SSE42:       # %bb.0:
+; X64-SSE42-NEXT:    movq %rcx, %xmm0
+; X64-SSE42-NEXT:    movq %rdx, %xmm1
+; X64-SSE42-NEXT:    punpcklqdq {{.*#+}} xmm1 = xmm1[0],xmm0[0]
+; X64-SSE42-NEXT:    movq %r9, %xmm0
+; X64-SSE42-NEXT:    movq %r8, %xmm2
+; X64-SSE42-NEXT:    punpcklqdq {{.*#+}} xmm2 = xmm2[0],xmm0[0]
+; X64-SSE42-NEXT:    movq %rsi, %xmm0
+; X64-SSE42-NEXT:    movq %rdi, %xmm3
+; X64-SSE42-NEXT:    punpcklqdq {{.*#+}} xmm3 = xmm3[0],xmm0[0]
+; X64-SSE42-NEXT:    movdqa %xmm3, %xmm0
+; X64-SSE42-NEXT:    pcmpgtq %xmm2, %xmm0
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm3, %xmm2
+; X64-SSE42-NEXT:    movapd %xmm2, %xmm0
+; X64-SSE42-NEXT:    pcmpgtq %xmm1, %xmm0
+; X64-SSE42-NEXT:    blendvpd %xmm0, %xmm2, %xmm1
+; X64-SSE42-NEXT:    pextrq $1, %xmm1, %rax
+; X64-SSE42-NEXT:    movq %xmm1, %rcx
+; X64-SSE42-NEXT:    cmpq %rax, %rcx
+; X64-SSE42-NEXT:    cmovgq %rcx, %rax
+; X64-SSE42-NEXT:    retq
+;
+; X86-AVX-LABEL: test_v6i64:
+; X86-AVX:       # %bb.0:
+; X86-AVX-NEXT:    pushl %edi
+; X86-AVX-NEXT:    pushl %esi
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-AVX-NEXT:    cmpl %ecx, %eax
+; X86-AVX-NEXT:    movl %edx, %edi
+; X86-AVX-NEXT:    sbbl %esi, %edi
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-AVX-NEXT:    cmovll %esi, %edx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-AVX-NEXT:    cmovll %ecx, %eax
+; X86-AVX-NEXT:    cmpl %eax, %edi
+; X86-AVX-NEXT:    movl %esi, %ecx
+; X86-AVX-NEXT:    sbbl %edx, %ecx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-AVX-NEXT:    cmovgel %esi, %edx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-AVX-NEXT:    cmovgel %edi, %eax
+; X86-AVX-NEXT:    cmpl %eax, %ecx
+; X86-AVX-NEXT:    movl %esi, %edi
+; X86-AVX-NEXT:    sbbl %edx, %edi
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %edi
+; X86-AVX-NEXT:    cmovgel %esi, %edx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-AVX-NEXT:    cmovgel %ecx, %eax
+; X86-AVX-NEXT:    cmpl %eax, %edi
+; X86-AVX-NEXT:    movl %esi, %ecx
+; X86-AVX-NEXT:    sbbl %edx, %ecx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-AVX-NEXT:    cmovgel %esi, %edx
+; X86-AVX-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-AVX-NEXT:    cmovgel %edi, %eax
+; X86-AVX-NEXT:    cmpl %eax, %ecx
+; X86-AVX-NEXT:    movl %esi, %edi
+; X86-AVX-NEXT:    sbbl %edx, %edi
+; X86-AVX-NEXT:    cmovgel %ecx, %eax
+; X86-AVX-NEXT:    cmovgel %esi, %edx
+; X86-AVX-NEXT:    popl %esi
+; X86-AVX-NEXT:    popl %edi
+; X86-AVX-NEXT:    retl
+;
+; X64-AVX1-LABEL: test_v6i64:
+; X64-AVX1:       # %bb.0:
+; X64-AVX1-NEXT:    vmovq %rcx, %xmm0
+; X64-AVX1-NEXT:    vmovq %rdx, %xmm1
+; X64-AVX1-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm1[0],xmm0[0]
+; X64-AVX1-NEXT:    vmovddup {{.*#+}} xmm1 = [9223372036854775808,9223372036854775808]
+; X64-AVX1-NEXT:    # xmm1 = mem[0,0]
+; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
+; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX1-NEXT:    vmovq %r9, %xmm1
+; X64-AVX1-NEXT:    vmovq %r8, %xmm2
+; X64-AVX1-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
+; X64-AVX1-NEXT:    vmovq %rsi, %xmm2
+; X64-AVX1-NEXT:    vmovq %rdi, %xmm3
+; X64-AVX1-NEXT:    vpunpcklqdq {{.*#+}} xmm2 = xmm3[0],xmm2[0]
+; X64-AVX1-NEXT:    vpcmpgtq %xmm1, %xmm2, %xmm3
+; X64-AVX1-NEXT:    vblendvpd %xmm3, %xmm2, %xmm1, %xmm1
+; X64-AVX1-NEXT:    vpcmpgtq %xmm0, %xmm1, %xmm2
+; X64-AVX1-NEXT:    vblendvpd %xmm2, %xmm1, %xmm0, %xmm0
+; X64-AVX1-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX1-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX1-NEXT:    cmpq %rax, %rcx
+; X64-AVX1-NEXT:    cmovgq %rcx, %rax
+; X64-AVX1-NEXT:    retq
+;
+; X64-AVX2-LABEL: test_v6i64:
+; X64-AVX2:       # %bb.0:
+; X64-AVX2-NEXT:    vmovq %rcx, %xmm0
+; X64-AVX2-NEXT:    vmovq %rdx, %xmm1
+; X64-AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm0 = xmm1[0],xmm0[0]
+; X64-AVX2-NEXT:    vmovq %rsi, %xmm1
+; X64-AVX2-NEXT:    vmovq %rdi, %xmm2
+; X64-AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
+; X64-AVX2-NEXT:    vinserti128 $1, %xmm0, %ymm1, %ymm0
+; X64-AVX2-NEXT:    vmovq %r9, %xmm1
+; X64-AVX2-NEXT:    vmovq %r8, %xmm2
+; X64-AVX2-NEXT:    vpunpcklqdq {{.*#+}} xmm1 = xmm2[0],xmm1[0]
+; X64-AVX2-NEXT:    vinserti128 $1, {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %ymm1, %ymm1
+; X64-AVX2-NEXT:    vpcmpgtq %ymm1, %ymm0, %ymm2
+; X64-AVX2-NEXT:    vblendvpd %ymm2, %ymm0, %ymm1, %ymm0
+; X64-AVX2-NEXT:    vextractf128 $1, %ymm0, %xmm1
+; X64-AVX2-NEXT:    vpcmpgtq %xmm1, %xmm0, %xmm2
+; X64-AVX2-NEXT:    vblendvpd %xmm2, %xmm0, %xmm1, %xmm0
+; X64-AVX2-NEXT:    vpextrq $1, %xmm0, %rax
+; X64-AVX2-NEXT:    vmovq %xmm0, %rcx
+; X64-AVX2-NEXT:    cmpq %rax, %rcx
+; X64-AVX2-NEXT:    cmovgq %rcx, %rax
+; X64-AVX2-NEXT:    vzeroupper
+; X64-AVX2-NEXT:    retq
+;
+; AVX512BW-LABEL: test_v6i64:
+; AVX512BW:       # %bb.0:
+; AVX512BW-NEXT:    vpbroadcastq {{.*#+}} zmm1 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
+; AVX512BW-NEXT:    movb $64, %al
+; AVX512BW-NEXT:    kmovd %eax, %k1
+; AVX512BW-NEXT:    vmovdqa64 %zmm1, %zmm0 {%k1}
+; AVX512BW-NEXT:    movb $-128, %al
+; AVX512BW-NEXT:    kmovd %eax, %k1
+; AVX512BW-NEXT:    vmovdqa64 %zmm1, %zmm0 {%k1}
+; AVX512BW-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
+; AVX512BW-NEXT:    vpmaxsq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vextracti128 $1, %ymm0, %xmm1
+; AVX512BW-NEXT:    vpmaxsq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; AVX512BW-NEXT:    vpmaxsq %zmm1, %zmm0, %zmm0
+; AVX512BW-NEXT:    vmovq %xmm0, %rax
+; AVX512BW-NEXT:    vzeroupper
+; AVX512BW-NEXT:    retq
+;
+; AVX512VL-LABEL: test_v6i64:
+; AVX512VL:       # %bb.0:
+; AVX512VL-NEXT:    vpbroadcastq {{.*#+}} zmm1 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
+; AVX512VL-NEXT:    movb $64, %al
+; AVX512VL-NEXT:    kmovd %eax, %k1
+; AVX512VL-NEXT:    vmovdqa64 %zmm1, %zmm0 {%k1}
+; AVX512VL-NEXT:    movb $-128, %al
+; AVX512VL-NEXT:    kmovd %eax, %k1
+; AVX512VL-NEXT:    vmovdqa64 %zmm1, %zmm0 {%k1}
+; AVX512VL-NEXT:    vextracti64x4 $1, %zmm0, %ymm1
+; AVX512VL-NEXT:    vpmaxsq %ymm1, %ymm0, %ymm0
+; AVX512VL-NEXT:    vextracti128 $1, %ymm0, %xmm1
+; AVX512VL-NEXT:    vpmaxsq %xmm1, %xmm0, %xmm0
+; AVX512VL-NEXT:    vpshufd {{.*#+}} xmm1 = xmm0[2,3,2,3]
+; AVX512VL-NEXT:    vpmaxsq %xmm1, %xmm0, %xmm0
+; AVX512VL-NEXT:    vmovq %xmm0, %rax
+; AVX512VL-NEXT:    vzeroupper
+; AVX512VL-NEXT:    retq
+  %r = call i64 @llvm.vector.reduce.smax.v6i64(<6 x i64> %a0)
+  ret i64 %r
+}
+
 declare i64 @llvm.vector.reduce.smax.v2i64(<2 x i64>)
 declare i64 @llvm.vector.reduce.smax.v4i64(<4 x i64>)
 declare i64 @llvm.vector.reduce.smax.v8i64(<8 x i64>)


### PR DESCRIPTION
32-bit targets will attempt to lower vXi64 reductions prior to argtype legalization

Crash fix - we can improve the handling in a future commit