### PR TITLE
[libc++] Remove ios_base::__xindex_ from the ABI

### DIFF
--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -235,10 +235,6 @@ storage-class-specifier const error_category& iostream_category() noexcept;
 #    include <__verbose_abort>
 #    include <version>
 
-#    if _LIBCPP_HAS_ATOMIC_HEADER
-#      include <__atomic/atomic.h> // for __xindex_
-#    endif
-
 #    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #      pragma GCC system_header
 #    endif
@@ -406,13 +402,6 @@ private:
   int* __index_;
   size_t __event_size_;
   size_t __event_cap_;
-// TODO(EricWF): Enable this for both Clang and GCC. Currently it is only
-// enabled with clang.
-#    if _LIBCPP_HAS_C_ATOMIC_IMP && _LIBCPP_HAS_THREADS
-  static atomic<int> __xindex_;
-#    else
-  static int __xindex_;
-#    endif
   long* __iarray_;
   size_t __iarray_size_;
   size_t __iarray_cap_;
@@ -885,6 +874,11 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #  endif // _LIBCPP_HAS_LOCALIZATION
+
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#    include <ctime>
+#    include <ratio>
+#  endif
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>

--- a/libcxx/lib/abi/CHANGELOG.TXT
+++ b/libcxx/lib/abi/CHANGELOG.TXT
@@ -13,12 +13,26 @@ To generate a summary, re-generate the new ABI list using the
 New entries should be added directly below the "Version" header.
 
 ------------
+Version 23.0
+------------
+
+* [libc++] Remove ios_base::__xindex_ from the ABI
+
+  `__xindex_` is only ever used from the dylib from a single function. We can simplify the code a bit by making the
+  variable function-local and avoiding exposing it to the ABI at all. This also fixes a TODO about whether it's safe to
+  use `atomic` with the GCC ABI: yes, since it's not actually part of our ABI.
+
+  All platforms
+  -------------
+  Symbol removed: __ZNSt3__18ios_base9__xindex_E
+
+------------
 Version 22.0
 ------------
 
 * [libc++] Allows any types of size 4 and 8 to use native platform ulock_wait
 
-  This patch added symbols for platform wait functions with the size of the type 
+  This patch added symbols for platform wait functions with the size of the type
 
   All platforms
   -------------

--- a/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1869,7 +1869,6 @@
 {'is_defined': True, 'name': '__ZNSt3__18ios_base7unitbufE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base8internalE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base8showbaseE', 'size': 0, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '__ZNSt3__18ios_base9__xindex_E', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base9basefieldE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base9boolalphaE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base9showpointE', 'size': 0, 'type': 'OBJECT'}

--- a/libcxx/lib/abi/i686-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/i686-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1507,7 +1507,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base7unitbufE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base8internalE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base8showbaseE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9__xindex_E', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9basefieldE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9boolalphaE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9showpointE', 'size': 4, 'type': 'OBJECT'}

--- a/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -826,7 +826,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base7unitbufE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base8internalE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base8showbaseE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9__xindex_E', 'storage_mapping_class': 'RW', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9basefieldE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9boolalphaE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9showpointE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}

--- a/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -826,7 +826,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base7unitbufE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base8internalE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base8showbaseE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9__xindex_E', 'storage_mapping_class': 'RW', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9basefieldE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9boolalphaE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__18ios_base9showpointE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}

--- a/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1859,7 +1859,6 @@
 {'is_defined': True, 'name': '__ZNSt3__18ios_base7unitbufE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base8internalE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base8showbaseE', 'size': 0, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '__ZNSt3__18ios_base9__xindex_E', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base9basefieldE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base9boolalphaE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__18ios_base9showpointE', 'size': 0, 'type': 'OBJECT'}

--- a/libcxx/lib/abi/x86_64-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1507,7 +1507,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base7unitbufE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base8internalE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base8showbaseE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9__xindex_E', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9basefieldE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9boolalphaE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk18ios_base9showpointE', 'size': 4, 'type': 'OBJECT'}

--- a/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1519,7 +1519,6 @@
 {'is_defined': True, 'name': '_ZNSt3__18ios_base7unitbufE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base8internalE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base8showbaseE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt3__18ios_base9__xindex_E', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9basefieldE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9boolalphaE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9showpointE', 'size': 4, 'type': 'OBJECT'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1518,7 +1518,6 @@
 {'is_defined': True, 'name': '_ZNSt3__18ios_base7unitbufE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base8internalE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base8showbaseE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt3__18ios_base9__xindex_E', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9basefieldE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9boolalphaE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9showpointE', 'size': 4, 'type': 'OBJECT'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
@@ -1489,7 +1489,6 @@
 {'is_defined': True, 'name': '_ZNSt3__18ios_base7unitbufE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base8internalE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base8showbaseE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt3__18ios_base9__xindex_E', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9basefieldE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9boolalphaE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__18ios_base9showpointE', 'size': 4, 'type': 'OBJECT'}

--- a/libcxx/src/ios.cpp
+++ b/libcxx/src/ios.cpp
@@ -9,6 +9,7 @@
 #include <__config>
 #include <__locale>
 #include <algorithm>
+#include <atomic>
 #include <ios>
 #include <limits>
 #include <memory>
@@ -111,13 +112,6 @@ locale ios_base::imbue(const locale& newloc) {
 
 locale ios_base::getloc() const { return __loc_; }
 
-// xalloc
-#if _LIBCPP_HAS_C_ATOMIC_IMP && _LIBCPP_HAS_THREADS
-atomic<int> ios_base::__xindex_{0};
-#else
-int ios_base::__xindex_ = 0;
-#endif
-
 template <typename _Tp>
 static size_t __ios_new_cap(size_t __req_size, size_t __current_cap) { // Precondition: __req_size > __current_cap
   const size_t mx = std::numeric_limits<size_t>::max() / sizeof(_Tp);
@@ -127,7 +121,10 @@ static size_t __ios_new_cap(size_t __req_size, size_t __current_cap) { // Precon
     return mx;
 }
 
-int ios_base::xalloc() { return __xindex_++; }
+int ios_base::xalloc() {
+  constinit static atomic<int> xindex = 0;
+  return xindex++;
+}
 
 long& ios_base::iword(int index) {
   size_t req_size = static_cast<size_t>(index) + 1;

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -72,7 +72,6 @@ ccomplex cstdint
 ccomplex cstdio
 ccomplex cstdlib
 ccomplex cstring
-ccomplex ctime
 ccomplex cwchar
 ccomplex cwctype
 ccomplex initializer_list
@@ -80,7 +79,6 @@ ccomplex ios
 ccomplex iosfwd
 ccomplex istream
 ccomplex limits
-ccomplex ratio
 ccomplex sstream
 ccomplex stdexcept
 ccomplex streambuf
@@ -165,7 +163,6 @@ complex cstdint
 complex cstdio
 complex cstdlib
 complex cstring
-complex ctime
 complex cwchar
 complex cwctype
 complex initializer_list
@@ -173,7 +170,6 @@ complex ios
 complex iosfwd
 complex istream
 complex limits
-complex ratio
 complex sstream
 complex stdexcept
 complex streambuf
@@ -213,7 +209,6 @@ ctgmath cstdint
 ctgmath cstdio
 ctgmath cstdlib
 ctgmath cstring
-ctgmath ctime
 ctgmath cwchar
 ctgmath cwctype
 ctgmath initializer_list
@@ -221,7 +216,6 @@ ctgmath ios
 ctgmath iosfwd
 ctgmath istream
 ctgmath limits
-ctgmath ratio
 ctgmath sstream
 ctgmath stdexcept
 ctgmath streambuf
@@ -263,7 +257,6 @@ experimental/iterator cstdint
 experimental/iterator cstdio
 experimental/iterator cstdlib
 experimental/iterator cstring
-experimental/iterator ctime
 experimental/iterator cwchar
 experimental/iterator cwctype
 experimental/iterator initializer_list
@@ -271,7 +264,6 @@ experimental/iterator ios
 experimental/iterator iosfwd
 experimental/iterator iterator
 experimental/iterator limits
-experimental/iterator ratio
 experimental/iterator stdexcept
 experimental/iterator streambuf
 experimental/iterator string
@@ -392,7 +384,6 @@ fstream cstdint
 fstream cstdio
 fstream cstdlib
 fstream cstring
-fstream ctime
 fstream cwchar
 fstream cwctype
 fstream initializer_list
@@ -401,7 +392,6 @@ fstream ios
 fstream iosfwd
 fstream istream
 fstream limits
-fstream ratio
 fstream stdexcept
 fstream streambuf
 fstream string
@@ -463,14 +453,12 @@ iomanip cstdint
 iomanip cstdio
 iomanip cstdlib
 iomanip cstring
-iomanip ctime
 iomanip cwchar
 iomanip cwctype
 iomanip initializer_list
 iomanip ios
 iomanip iosfwd
 iomanip limits
-iomanip ratio
 iomanip stdexcept
 iomanip string
 iomanip string_view
@@ -487,13 +475,11 @@ ios cstdint
 ios cstdio
 ios cstdlib
 ios cstring
-ios ctime
 ios cwchar
 ios cwctype
 ios initializer_list
 ios iosfwd
 ios limits
-ios ratio
 ios stdexcept
 ios string
 ios string_view
@@ -513,7 +499,6 @@ iostream cstdint
 iostream cstdio
 iostream cstdlib
 iostream cstring
-iostream ctime
 iostream cwchar
 iostream cwctype
 iostream format
@@ -525,7 +510,6 @@ iostream limits
 iostream optional
 iostream ostream
 iostream print
-iostream ratio
 iostream stdexcept
 iostream streambuf
 iostream string
@@ -544,14 +528,12 @@ istream cstdint
 istream cstdio
 istream cstdlib
 istream cstring
-istream ctime
 istream cwchar
 istream cwctype
 istream initializer_list
 istream ios
 istream iosfwd
 istream limits
-istream ratio
 istream stdexcept
 istream streambuf
 istream string
@@ -600,14 +582,12 @@ locale cstdint
 locale cstdio
 locale cstdlib
 locale cstring
-locale ctime
 locale cwchar
 locale cwctype
 locale initializer_list
 locale ios
 locale iosfwd
 locale limits
-locale ratio
 locale stdexcept
 locale streambuf
 locale string
@@ -698,7 +678,6 @@ ostream cstdint
 ostream cstdio
 ostream cstdlib
 ostream cstring
-ostream ctime
 ostream cwchar
 ostream cwctype
 ostream format
@@ -708,7 +687,6 @@ ostream iosfwd
 ostream limits
 ostream optional
 ostream print
-ostream ratio
 ostream stdexcept
 ostream streambuf
 ostream string
@@ -871,7 +849,6 @@ sstream cstdint
 sstream cstdio
 sstream cstdlib
 sstream cstring
-sstream ctime
 sstream cwchar
 sstream cwctype
 sstream initializer_list
@@ -879,7 +856,6 @@ sstream ios
 sstream iosfwd
 sstream istream
 sstream limits
-sstream ratio
 sstream stdexcept
 sstream streambuf
 sstream string
@@ -917,14 +893,12 @@ streambuf cstdint
 streambuf cstdio
 streambuf cstdlib
 streambuf cstring
-streambuf ctime
 streambuf cwchar
 streambuf cwctype
 streambuf initializer_list
 streambuf ios
 streambuf iosfwd
 streambuf limits
-streambuf ratio
 streambuf stdexcept
 streambuf string
 streambuf string_view
@@ -969,7 +943,6 @@ strstream cstdint
 strstream cstdio
 strstream cstdlib
 strstream cstring
-strstream ctime
 strstream cwchar
 strstream cwctype
 strstream initializer_list
@@ -977,7 +950,6 @@ strstream ios
 strstream iosfwd
 strstream istream
 strstream limits
-strstream ratio
 strstream stdexcept
 strstream streambuf
 strstream string


### PR DESCRIPTION
`__xindex_` is only ever used from the dylib from a single function. We can simplify the code a bit by making the variable function-local and avoiding exposing it to the ABI at all. This also fixes a TODO about whether it's safe to use `atomic` with the GCC ABI: yes, since it's not actually part of our ABI.
