### PR TITLE
[Flang][OpenMP] Allow workdistribute inside 'target teams'

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1138,7 +1138,7 @@ void OmpStructureChecker::Enter(const parser::OmpBlockConstruct &x) {
           "directives outside of the TEAMS construct"_err_en_US);
     }
     if (GetContext().directive == llvm::omp::Directive::OMPD_workdistribute &&
-        GetContextParent().directive != llvm::omp::Directive::OMPD_teams) {
+        !llvm::omp::bottomTeamsSet.test(GetContextParent().directive)) {
       context_.Say(x.BeginDir().DirName().source,
           "%s region can only be strictly nested within TEAMS region"_err_en_US,
           ContextDirectiveAsFortran());

--- a/flang/test/Semantics/OpenMP/workdistribute05.f90
+++ b/flang/test/Semantics/OpenMP/workdistribute05.f90
@@ -1,0 +1,25 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -fopenmp-version=60
+! OpenMP Version 6.0
+! workdistribute Construct
+! Make sure that standalone workdistribute doesn't trigger errors when used in
+! supported contexts.
+
+subroutine teams_workdistribute()
+  use iso_fortran_env
+  real(kind=real32) :: a
+  !$omp teams
+  !$omp workdistribute
+  a = 1
+  !$omp end workdistribute
+  !$omp end teams
+end subroutine teams_workdistribute
+
+subroutine target_teams_workdistribute()
+  use iso_fortran_env
+  real(kind=real32) :: a
+  !$omp target teams
+  !$omp workdistribute
+  a = 1
+  !$omp end workdistribute
+  !$omp end target teams
+end subroutine target_teams_workdistribute

--- a/flang/test/Semantics/OpenMP/workdistribute05.f90
+++ b/flang/test/Semantics/OpenMP/workdistribute05.f90
@@ -5,8 +5,7 @@
 ! supported contexts.
 
 subroutine teams_workdistribute()
-  use iso_fortran_env
-  real(kind=real32) :: a
+  integer :: a
   !$omp teams
   !$omp workdistribute
   a = 1
@@ -15,8 +14,7 @@ subroutine teams_workdistribute()
 end subroutine teams_workdistribute
 
 subroutine target_teams_workdistribute()
-  use iso_fortran_env
-  real(kind=real32) :: a
+  integer :: a
   !$omp target teams
   !$omp workdistribute
   a = 1


### PR DESCRIPTION
Currently, a `workdistribute` construct nested inside of a combined `target teams` is incorrectly reported as an error. This patch fixes that.