### PR TITLE
[RISCV] Ensure AVL dominates True in vmerge peephole

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVectorPeephole.cpp
@@ -71,7 +71,8 @@ private:
   bool hasSameEEW(const MachineInstr &User, const MachineInstr &Src) const;
   bool isAllOnesMask(const MachineInstr *MaskDef) const;
   std::optional<unsigned> getConstant(const MachineOperand &VL) const;
-  bool ensureDominates(const MachineOperand &Use, MachineInstr &Src) const;
+  bool ensureDominates(ArrayRef<const MachineOperand> Defs,
+                       MachineInstr &Use) const;
   Register
   lookThruCopies(Register Reg, bool OneUseOnly = false,
                  SmallVectorImpl<MachineInstr *> *Copies = nullptr) const;
@@ -462,21 +463,28 @@ static bool dominates(MachineBasicBlock::const_iterator A,
   return &*I == A;
 }
 
-/// If the register in \p MO doesn't dominate \p Src, try to move \p Src so it
+/// If a register in \p Uses doesn't dominate \p Src, try to move \p Src so it
 /// does. Returns false if doesn't dominate and we can't move. \p MO must be in
 /// the same basic block as \Src.
-bool RISCVVectorPeephole::ensureDominates(const MachineOperand &MO,
-                                          MachineInstr &Src) const {
-  assert(MO.getParent()->getParent() == Src.getParent());
-  if (!MO.isReg() || !MO.getReg().isValid())
-    return true;
+bool RISCVVectorPeephole::ensureDominates(ArrayRef<const MachineOperand> Defs,
+                                          MachineInstr &Use) const {
+  MachineInstr *Dest = &Use;
 
-  MachineInstr *Def = MRI->getVRegDef(MO.getReg());
-  if (Def->getParent() == Src.getParent() && !dominates(Def, Src)) {
-    if (!RISCVInstrInfo::isSafeToMove(Src, *Def->getNextNode()))
-      return false;
-    Src.moveBefore(Def->getNextNode());
+  for (const MachineOperand &MO : Defs) {
+    assert(MO.getParent()->getParent() == Use.getParent());
+    if (!MO.isReg() || !MO.getReg().isValid())
+      continue;
+
+    MachineInstr *Def = MRI->getVRegDef(MO.getReg());
+    if (Def->getParent() == Dest->getParent() && !dominates(Def, *Dest)) {
+      if (!RISCVInstrInfo::isSafeToMove(*Dest, *Def->getNextNode()))
+        return false;
+      Dest = Def->getNextNode();
+    }
   }
+
+  if (Dest != &Use)
+    Use.moveBefore(Dest);
 
   return true;
 }
@@ -721,15 +729,9 @@ bool RISCVVectorPeephole::foldVMergeToMask(MachineInstr &MI) const {
   assert(RISCVII::hasVecPolicyOp(True.getDesc().TSFlags) &&
          "Foldable unmasked pseudo should have a policy op already");
 
-  // Make sure both mask and false dominate True and its copies, otherwise move
-  // down True so it does. VL will always dominate since if it's a register they
-  // need to be the same.
-  const MachineOperand *DomOp = &MaskOp;
-  MachineInstr *False = MRI->getUniqueVRegDef(FalseReg);
-  if (False && False->getParent() == Mask->getParent() &&
-      dominates(Mask, False))
-    DomOp = &FalseOp;
-  if (!ensureDominates(*DomOp, True))
+  // Make sure Mask, False and MinVL dominate True and its copies, otherwise
+  // move down True so it does.
+  if (!ensureDominates({MaskOp, FalseOp, MinVL}, True))
     return false;
 
   if (NeedsCommute) {

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-vops.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-vops.ll
@@ -1173,6 +1173,17 @@ define <vscale x 2 x float> @commute_vfmadd(<vscale x 2 x float> %passthru, <vsc
 
 ; Test for crash where we didn't sink to ensure AVL dominated
 define i32 @pr198733(<vscale x 16 x i32> %0, <vscale x 16 x i1> %1, i32 %2) {
+; CHECK-LABEL: pr198733:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    slli a0, a0, 32
+; CHECK-NEXT:    srli a0, a0, 32
+; CHECK-NEXT:    vsetvli zero, a0, e32, m8, ta, mu
+; CHECK-NEXT:    vor.vi v8, v8, 1, v0.t
+; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    vsetivli zero, 1, e32, m8, ta, ma
+; CHECK-NEXT:    vslidedown.vx v8, v8, a0
+; CHECK-NEXT:    vmv.x.s a0, v8
+; CHECK-NEXT:    ret
 entry:
   %3 = zext <vscale x 16 x i1> %1 to <vscale x 16 x i32>
   %4 = or <vscale x 16 x i32> %0, %3

--- a/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-vops.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/rvv-peephole-vmerge-vops.ll
@@ -1170,3 +1170,14 @@ define <vscale x 2 x float> @commute_vfmadd(<vscale x 2 x float> %passthru, <vsc
   %merge = call <vscale x 2 x float> @llvm.vp.merge(<vscale x 2 x i1> %mask, <vscale x 2 x float> %fadd, <vscale x 2 x float> %passthru, i32 %evl)
   ret <vscale x 2 x float> %merge
 }
+
+; Test for crash where we didn't sink to ensure AVL dominated
+define i32 @pr198733(<vscale x 16 x i32> %0, <vscale x 16 x i1> %1, i32 %2) {
+entry:
+  %3 = zext <vscale x 16 x i1> %1 to <vscale x 16 x i32>
+  %4 = or <vscale x 16 x i32> %0, %3
+  %5 = zext i32 %2 to i64
+  %6 = add i64 %5, -1
+  %7 = extractelement <vscale x 16 x i32> %4, i64 %6
+  ret i32 %7
+}

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -256,3 +256,16 @@ body: |
     %y:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
     %z:vrnov0 = PseudoVMERGE_VVM_M1 $noreg, %y:vrnov0, %x:vrnov0, %mask, -1, 5
 ...
+---
+name: sink_past_avl
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: sink_past_avl
+    ; CHECK: %mask:vmv0 = COPY $v0
+    ; CHECK-NEXT: %z:vrnov0 = PseudoVADD_VV_M1_MASK %y:vrnov0, $noreg, $noreg, %mask, %avl /* vl */, 5 /* e32 */, 1 /* ta, mu */
+    ; CHECK-NEXT: %avl:gprnox0 = ADDI $noreg, 1
+    %mask:vmv0 = COPY $v0
+    %x:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
+    %avl:gprnox0 = ADDI $noreg, 1
+    %z:vrnov0 = PseudoVMERGE_VVM_M1 $noreg, $noreg, %x:vrnov0, %mask, %avl, 5
+...

--- a/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vmerge-peephole.mir
@@ -262,8 +262,8 @@ body: |
   bb.0:
     ; CHECK-LABEL: name: sink_past_avl
     ; CHECK: %mask:vmv0 = COPY $v0
-    ; CHECK-NEXT: %z:vrnov0 = PseudoVADD_VV_M1_MASK %y:vrnov0, $noreg, $noreg, %mask, %avl /* vl */, 5 /* e32 */, 1 /* ta, mu */
     ; CHECK-NEXT: %avl:gprnox0 = ADDI $noreg, 1
+    ; CHECK-NEXT: %z:vrnov0 = PseudoVADD_VV_M1_MASK $noreg, $noreg, $noreg, %mask, %avl /* vl */, 5 /* e32 */, 1 /* ta, mu */
     %mask:vmv0 = COPY $v0
     %x:vrnov0 = PseudoVADD_VV_M1 $noreg, $noreg, $noreg, -1, 5, 3
     %avl:gprnox0 = ADDI $noreg, 1


### PR DESCRIPTION
When folding vmerge into its true operand, if vmerge has an AVL defined by a register and true has VLMAX, then the minimum AVL will be the register. In this case it's not guaranteed to dominate true, so we need to potentially sink true so it does.

This teaches ensureDominates to check multiple definitions at the same time, since we want the sinking to be atomic.

Fixes #198733