### PR TITLE
[lldb][windows] Fix HostProcessWindows::Terminate clobbering error

### DIFF
--- a/lldb/source/Host/windows/HostProcessWindows.cpp
+++ b/lldb/source/Host/windows/HostProcessWindows.cpp
@@ -38,14 +38,13 @@ HostProcessWindows::~HostProcessWindows() { Close(); }
 void HostProcessWindows::SetOwnsHandle(bool owns) { m_owns_handle = owns; }
 
 Status HostProcessWindows::Terminate() {
-  Status error;
   if (m_process == nullptr)
-    error = Status(ERROR_INVALID_HANDLE, lldb::eErrorTypeWin32);
+    return Status(ERROR_INVALID_HANDLE, lldb::eErrorTypeWin32);
 
   if (!::TerminateProcess(m_process, 0))
-    error = Status(::GetLastError(), lldb::eErrorTypeWin32);
+    return Status(::GetLastError(), lldb::eErrorTypeWin32);
 
-  return error;
+  return Status();
 }
 
 lldb::pid_t HostProcessWindows::GetProcessId() const {


### PR DESCRIPTION
When `m_process` is `nullptr` the function sets `ERROR_INVALID_HANDLE` then fell through to call `TerminateProcess(nullptr, 0)`, which clobbers the error.

Return early instead.