### PR TITLE
[lldb][windows] Fix HostThreadWindows::Cancel inverted error reporting

### DIFF
--- a/lldb/source/Host/windows/HostThreadWindows.cpp
+++ b/lldb/source/Host/windows/HostThreadWindows.cpp
@@ -49,11 +49,9 @@ Status HostThreadWindows::Join(lldb::thread_result_t *result) {
 }
 
 Status HostThreadWindows::Cancel() {
-  Status error;
-
-  DWORD result = ::QueueUserAPC(::ExitThreadProxy, m_thread, 0);
-  error = Status(result, eErrorTypeWin32);
-  return error;
+  if (!::QueueUserAPC(&ExitThreadProxy, m_thread, 0))
+    return Status(::GetLastError(), eErrorTypeWin32);
+  return Status();
 }
 
 lldb::tid_t HostThreadWindows::GetThreadId() const {


### PR DESCRIPTION
QueueUserAPC returns non-zero on success and zero on failure. The old code stored the return value and unconditionally constructed a Status from it, so a successful call reported a phantom Win32 error code and a real failure reported success.

Check the return and read GetLastError() on failure.