### PR TITLE
[lldb][windows] Fix HostThreadWindows::Join dead-code on GetExitCodeThread failure

### DIFF
--- a/lldb/source/Host/windows/HostThreadWindows.cpp
+++ b/lldb/source/Host/windows/HostThreadWindows.cpp
@@ -31,18 +31,22 @@ HostThreadWindows::~HostThreadWindows() { Reset(); }
 void HostThreadWindows::SetOwnsHandle(bool owns) { m_owns_handle = owns; }
 
 Status HostThreadWindows::Join(lldb::thread_result_t *result) {
+  if (!IsJoinable())
+    return Status(ERROR_INVALID_HANDLE, eErrorTypeWin32);
+
   Status error;
-  if (IsJoinable()) {
-    DWORD wait_result = ::WaitForSingleObject(m_thread, INFINITE);
-    if (WAIT_OBJECT_0 == wait_result && result) {
+  DWORD wait_result = ::WaitForSingleObject(m_thread, INFINITE);
+  if (wait_result == WAIT_OBJECT_0) {
+    if (result) {
       DWORD exit_code = 0;
-      if (!::GetExitCodeThread(m_thread, &exit_code))
+      if (::GetExitCodeThread(m_thread, &exit_code))
+        *result = exit_code;
+      else
         *result = 0;
-      *result = exit_code;
-    } else if (WAIT_OBJECT_0 != wait_result)
-      error = Status(::GetLastError(), eErrorTypeWin32);
-  } else
-    error = Status(ERROR_INVALID_HANDLE, eErrorTypeWin32);
+    }
+  } else {
+    error = Status(::GetLastError(), eErrorTypeWin32);
+  }
 
   Reset();
   return error;


### PR DESCRIPTION
The old code unconditionally assigned `exit_code` to `*result` after the `GetExitCodeThread` check, so the failure branch assignment of 0 was overwritten. We never returned the `exit_code` value. `exit_code` happens to be zero-initialized so the bug was masked, but the structure was wrong.