### PR TITLE
llvm: Fix most LLVM_ABI annotations in Analysis

### DIFF
--- a/llvm/include/llvm/Analysis/AssumptionCache.h
+++ b/llvm/include/llvm/Analysis/AssumptionCache.h
@@ -168,7 +168,7 @@ public:
   }
 
   /// Determine which values are affected by this assume operand bundle.
-  static void
+  LLVM_ABI static void
   findValuesAffectedByOperandBundle(OperandBundleUse Bundle,
                                     function_ref<void(Value *)> InsertAffected);
 };

--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -52,11 +52,11 @@
 #define DEBUG_TYPE "block-freq"
 
 namespace llvm {
-extern llvm::cl::opt<bool> CheckBFIUnknownBlockQueries;
+extern LLVM_ABI llvm::cl::opt<bool> CheckBFIUnknownBlockQueries;
 
-extern llvm::cl::opt<bool> UseIterativeBFIInference;
-extern llvm::cl::opt<unsigned> IterativeBFIMaxIterationsPerBlock;
-extern llvm::cl::opt<double> IterativeBFIPrecision;
+extern LLVM_ABI llvm::cl::opt<bool> UseIterativeBFIInference;
+extern LLVM_ABI llvm::cl::opt<unsigned> IterativeBFIMaxIterationsPerBlock;
+extern LLVM_ABI llvm::cl::opt<double> IterativeBFIPrecision;
 
 class BranchProbabilityInfo;
 class Function;
@@ -141,10 +141,10 @@ public:
   ///
   /// Convert to \a ScaledNumber.  \a isFull() gives 1.0, while \a isEmpty()
   /// gives slightly above 0.0.
-  ScaledNumber<uint64_t> toScaled() const;
+  LLVM_ABI ScaledNumber<uint64_t> toScaled() const;
 
-  void dump() const;
-  raw_ostream &print(raw_ostream &OS) const;
+  LLVM_ABI void dump() const;
+  LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 };
 
 inline BlockMass operator+(BlockMass L, BlockMass R) {
@@ -174,7 +174,7 @@ inline raw_ostream &operator<<(raw_ostream &OS, BlockMass X) {
 ///
 /// Nevertheless, the majority of the overall algorithm documentation lives with
 /// BlockFrequencyInfoImpl.  See there for details.
-class BlockFrequencyInfoImplBase {
+class LLVM_ABI BlockFrequencyInfoImplBase {
 public:
   using Scaled64 = ScaledNumber<uint64_t>;
   using BlockMass = bfi_detail::BlockMass;
@@ -409,10 +409,11 @@ public:
     /// cases, adjacent edge weights are combined by sorting WeightList and
     /// combining adjacent weights.  However, for very large edge lists an
     /// auxiliary hash table is used.
-    void normalize();
+    LLVM_ABI void normalize();
 
   private:
-    void add(const BlockNode &Node, uint64_t Amount, Weight::DistType Type);
+    LLVM_ABI void add(const BlockNode &Node, uint64_t Amount,
+                      Weight::DistType Type);
   };
 
   /// Data about each block.  This is used downstream.
@@ -631,20 +632,20 @@ struct IrreducibleGraph {
   template <class BlockEdgesAdder>
   void initialize(const BFIBase::LoopData *OuterLoop,
                   BlockEdgesAdder addBlockEdges);
-  void addNodesInLoop(const BFIBase::LoopData &OuterLoop);
-  void addNodesInFunction();
+  LLVM_ABI void addNodesInLoop(const BFIBase::LoopData &OuterLoop);
+  LLVM_ABI void addNodesInFunction();
 
   void addNode(const BlockNode &Node) {
     Nodes.emplace_back(Node);
     BFI.Working[Node.Index].getMass() = BlockMass::getEmpty();
   }
 
-  void indexNodes();
+  LLVM_ABI void indexNodes();
   template <class BlockEdgesAdder>
   void addEdges(const BlockNode &Node, const BFIBase::LoopData *OuterLoop,
                 BlockEdgesAdder addBlockEdges);
-  void addEdge(IrrNode &Irr, const BlockNode &Succ,
-               const BFIBase::LoopData *OuterLoop);
+  LLVM_ABI void addEdge(IrrNode &Irr, const BlockNode &Succ,
+                        const BFIBase::LoopData *OuterLoop);
 };
 
 template <class BlockEdgesAdder>

--- a/llvm/include/llvm/Analysis/CFGSCCPrinter.h
+++ b/llvm/include/llvm/Analysis/CFGSCCPrinter.h
@@ -18,7 +18,7 @@ class CFGSCCPrinterPass : public RequiredPassInfoMixin<CFGSCCPrinterPass> {
 
 public:
   explicit CFGSCCPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Analysis/CmpInstAnalysis.h
+++ b/llvm/include/llvm/Analysis/CmpInstAnalysis.h
@@ -44,7 +44,7 @@ namespace llvm {
   /// 110     6   A <= B
   /// 111     7   Always true
   ///
-  unsigned getICmpCode(CmpInst::Predicate Pred);
+  LLVM_ABI unsigned getICmpCode(CmpInst::Predicate Pred);
 
   /// This is the complement of getICmpCode. It turns a predicate code into
   /// either a constant true or false or the predicate for a new ICmp.
@@ -52,12 +52,13 @@ namespace llvm {
   /// new ICmp instruction.
   /// Non-NULL return value will be a true or false constant.
   /// NULL return means a new ICmp is needed. The predicate is output in Pred.
-  Constant *getPredForICmpCode(unsigned Code, bool Sign, Type *OpTy,
-                               CmpInst::Predicate &Pred);
+  LLVM_ABI Constant *getPredForICmpCode(unsigned Code, bool Sign, Type *OpTy,
+                                        CmpInst::Predicate &Pred);
 
   /// Return true if both predicates match sign or if at least one of them is an
   /// equality comparison (which is signless).
-  bool predicatesFoldable(CmpInst::Predicate P1, CmpInst::Predicate P2);
+  LLVM_ABI bool predicatesFoldable(CmpInst::Predicate P1,
+                                   CmpInst::Predicate P2);
 
   /// Similar to getICmpCode but for FCmpInst. This encodes a fcmp predicate
   /// into a four bit mask.
@@ -89,8 +90,8 @@ namespace llvm {
   /// either a constant true or false or the predicate for a new FCmp.
   /// Non-NULL return value will be a true or false constant.
   /// NULL return means a new ICmp is needed. The predicate is output in Pred.
-  Constant *getPredForFCmpCode(unsigned Code, Type *OpTy,
-                               CmpInst::Predicate &Pred);
+  LLVM_ABI Constant *getPredForFCmpCode(unsigned Code, Type *OpTy,
+                                        CmpInst::Predicate &Pred);
 
   /// Represents the operation icmp (X & Mask) pred C, where pred can only be
   /// eq or ne.
@@ -105,7 +106,7 @@ namespace llvm {
   /// Unless \p AllowNonZeroC is true, C will always be 0. If \p
   /// DecomposeAnd is specified, then, for equality predicates, this will
   /// decompose bitmasking via `and`.
-  std::optional<DecomposedBitTest>
+  LLVM_ABI std::optional<DecomposedBitTest>
   decomposeBitTestICmp(Value *LHS, Value *RHS, CmpInst::Predicate Pred,
                        bool LookThroughTrunc = true, bool AllowNonZeroC = false,
                        bool DecomposeAnd = false);
@@ -114,7 +115,7 @@ namespace llvm {
   /// possible. Unless \p AllowNonZeroC is true, C will always be 0.
   /// If \p DecomposeAnd is specified, then, for equality predicates, this
   /// will decompose bitmasking via `and`.
-  std::optional<DecomposedBitTest>
+  LLVM_ABI std::optional<DecomposedBitTest>
   decomposeBitTest(Value *Cond, bool LookThroughTrunc = true,
                    bool AllowNonZeroC = false, bool DecomposeAnd = false);
 

--- a/llvm/include/llvm/Analysis/CostModel.h
+++ b/llvm/include/llvm/Analysis/CostModel.h
@@ -20,7 +20,7 @@ class CostModelPrinterPass
 public:
   explicit CostModelPrinterPass(raw_ostream &OS) : OS(OS) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Analysis/CycleAnalysis.h
+++ b/llvm/include/llvm/Analysis/CycleAnalysis.h
@@ -22,7 +22,7 @@
 namespace llvm {
 
 /// Legacy analysis pass which computes a \ref CycleInfo.
-class CycleInfoWrapperPass : public FunctionPass {
+class LLVM_ABI CycleInfoWrapperPass : public FunctionPass {
   Function *F = nullptr;
   CycleInfo CI;
 
@@ -54,10 +54,10 @@ public:
   using LegacyWrapper = CycleInfoWrapperPass;
 
   /// Run the analysis pass over a function and produce a dominator tree.
-  CycleInfo run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI CycleInfo run(Function &F, FunctionAnalysisManager &);
 
-  bool invalidate(Function &F, const PreservedAnalyses &PA,
-                  FunctionAnalysisManager::Invalidator &);
+  LLVM_ABI bool invalidate(Function &F, const PreservedAnalyses &PA,
+                           FunctionAnalysisManager::Invalidator &);
 
   // TODO: verify analysis?
 };
@@ -67,13 +67,13 @@ class CycleInfoPrinterPass
   raw_ostream &OS;
 
 public:
-  explicit CycleInfoPrinterPass(raw_ostream &OS);
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI explicit CycleInfoPrinterPass(raw_ostream &OS);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 struct CycleInfoVerifierPass
     : public RequiredPassInfoMixin<CycleInfoVerifierPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/DDGPrinter.h
+++ b/llvm/include/llvm/Analysis/DDGPrinter.h
@@ -27,8 +27,9 @@ class Loop;
 //===--------------------------------------------------------------------===//
 class DDGDotPrinterPass : public RequiredPassInfoMixin<DDGDotPrinterPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 //===--------------------------------------------------------------------===//
@@ -48,24 +49,24 @@ struct DOTGraphTraits<const DataDependenceGraph *>
 
   /// Print a DDG node either in concise form (-ddg-dot-only) or
   /// verbose mode (-ddg-dot).
-  std::string getNodeLabel(const DDGNode *Node,
-                           const DataDependenceGraph *Graph);
+  LLVM_ABI std::string getNodeLabel(const DDGNode *Node,
+                                    const DataDependenceGraph *Graph);
 
   /// Print attributes of an edge in the DDG graph. If the edge
   /// is a MemoryDependence edge, then detailed dependence info
   /// available from DependenceAnalysis is displayed.
-  std::string
+  LLVM_ABI std::string
   getEdgeAttributes(const DDGNode *Node,
                     GraphTraits<const DDGNode *>::ChildIteratorType I,
                     const DataDependenceGraph *G);
 
   /// Do not print nodes that are part of a pi-block separately. They
   /// will be printed when their containing pi-block is being printed.
-  bool isNodeHidden(const DDGNode *Node, const DataDependenceGraph *G);
+  LLVM_ABI bool isNodeHidden(const DDGNode *Node, const DataDependenceGraph *G);
 
   /// Return DOT attributes for a node (e.g. border and fill for pi-blocks).
-  static std::string getNodeAttributes(const DDGNode *Node,
-                                       const DataDependenceGraph *G);
+  LLVM_ABI static std::string getNodeAttributes(const DDGNode *Node,
+                                                const DataDependenceGraph *G);
 
 private:
   /// Print a DDG node in concise form.

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -40,7 +40,7 @@ struct ModuleMetadataInfo {
   Triple::EnvironmentType ShaderProfile{Triple::UnknownEnvironment};
   VersionTuple ValidatorVersion{};
   SmallVector<EntryProperties> EntryPropertyVec{};
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 };
 
 } // namespace dxil
@@ -54,7 +54,7 @@ class DXILMetadataAnalysis : public AnalysisInfoMixin<DXILMetadataAnalysis> {
 public:
   using Result = dxil::ModuleMetadataInfo;
   /// Gather module metadata info for the module \c M.
-  dxil::ModuleMetadataInfo run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI dxil::ModuleMetadataInfo run(Module &M, ModuleAnalysisManager &AM);
 };
 
 /// Printer pass for the \c DXILMetadataAnalysis results.
@@ -65,11 +65,11 @@ class DXILMetadataAnalysisPrinterPass
 public:
   explicit DXILMetadataAnalysisPrinterPass(raw_ostream &OS) : OS(OS) {}
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 /// Legacy pass
-class DXILMetadataAnalysisWrapperPass : public ModulePass {
+class LLVM_ABI DXILMetadataAnalysisWrapperPass : public ModulePass {
   std::unique_ptr<dxil::ModuleMetadataInfo> MetadataInfo;
 
 public:

--- a/llvm/include/llvm/Analysis/Delinearization.h
+++ b/llvm/include/llvm/Analysis/Delinearization.h
@@ -28,21 +28,21 @@ class SCEV;
 /// Compute the array dimensions Sizes from the set of Terms extracted from
 /// the memory access function of this SCEVAddRecExpr (second step of
 /// delinearization).
-void findArrayDimensions(ScalarEvolution &SE,
-                         SmallVectorImpl<const SCEV *> &Terms,
-                         SmallVectorImpl<const SCEV *> &Sizes,
-                         const SCEV *ElementSize);
+LLVM_ABI void findArrayDimensions(ScalarEvolution &SE,
+                                  SmallVectorImpl<const SCEV *> &Terms,
+                                  SmallVectorImpl<const SCEV *> &Sizes,
+                                  const SCEV *ElementSize);
 
 /// Collect parametric terms occurring in step expressions (first step of
 /// delinearization).
-void collectParametricTerms(ScalarEvolution &SE, const SCEV *Expr,
-                            SmallVectorImpl<const SCEV *> &Terms);
+LLVM_ABI void collectParametricTerms(ScalarEvolution &SE, const SCEV *Expr,
+                                     SmallVectorImpl<const SCEV *> &Terms);
 
 /// Return in Subscripts the access functions for each dimension in Sizes
 /// (third step of delinearization).
-void computeAccessFunctions(ScalarEvolution &SE, const SCEV *Expr,
-                            SmallVectorImpl<const SCEV *> &Subscripts,
-                            SmallVectorImpl<const SCEV *> &Sizes);
+LLVM_ABI void computeAccessFunctions(ScalarEvolution &SE, const SCEV *Expr,
+                                     SmallVectorImpl<const SCEV *> &Subscripts,
+                                     SmallVectorImpl<const SCEV *> &Sizes);
 /// Split this SCEVAddRecExpr into two vectors of SCEVs representing the
 /// subscripts and sizes of an array access.
 ///
@@ -107,15 +107,17 @@ void computeAccessFunctions(ScalarEvolution &SE, const SCEV *Expr,
 /// The subscript of the outermost dimension is the Quotient: [j+k].
 ///
 /// Overall, we have: A[][n][m], and the access function: A[j+k][2i][5i].
-void delinearize(ScalarEvolution &SE, const SCEV *Expr,
-                 SmallVectorImpl<const SCEV *> &Subscripts,
-                 SmallVectorImpl<const SCEV *> &Sizes, const SCEV *ElementSize);
+LLVM_ABI void delinearize(ScalarEvolution &SE, const SCEV *Expr,
+                          SmallVectorImpl<const SCEV *> &Subscripts,
+                          SmallVectorImpl<const SCEV *> &Sizes,
+                          const SCEV *ElementSize);
 
 /// Compute the dimensions of fixed size array from \Expr and save the results
 /// in \p Sizes.
-bool findFixedSizeArrayDimensions(ScalarEvolution &SE, const SCEV *Expr,
-                                  SmallVectorImpl<uint64_t> &Sizes,
-                                  const SCEV *ElementSize);
+LLVM_ABI bool findFixedSizeArrayDimensions(ScalarEvolution &SE,
+                                           const SCEV *Expr,
+                                           SmallVectorImpl<uint64_t> &Sizes,
+                                           const SCEV *ElementSize);
 
 /// Split this SCEVAddRecExpr into two vectors of SCEVs representing the
 /// subscripts and sizes of an access to a fixed size array. This is a special
@@ -134,17 +136,18 @@ bool findFixedSizeArrayDimensions(ScalarEvolution &SE, const SCEV *Expr,
 ///
 /// This function is intended to replace getIndexExpressionsFromGEP. They rely
 /// on the GEP source element type so that will be removed in the future.
-bool delinearizeFixedSizeArray(ScalarEvolution &SE, const SCEV *Expr,
-                               SmallVectorImpl<const SCEV *> &Subscripts,
-                               SmallVectorImpl<const SCEV *> &Sizes,
-                               const SCEV *ElementSize);
+LLVM_ABI bool
+delinearizeFixedSizeArray(ScalarEvolution &SE, const SCEV *Expr,
+                          SmallVectorImpl<const SCEV *> &Subscripts,
+                          SmallVectorImpl<const SCEV *> &Sizes,
+                          const SCEV *ElementSize);
 
 /// Check that each subscript in \p Subscripts is within the corresponding size
 /// in \p Sizes. For the outermost dimension, the subscript being negative is
 /// allowed.
-bool validateDelinearizationResult(ScalarEvolution &SE,
-                                   ArrayRef<const SCEV *> Sizes,
-                                   ArrayRef<const SCEV *> Subscripts);
+LLVM_ABI bool validateDelinearizationResult(ScalarEvolution &SE,
+                                            ArrayRef<const SCEV *> Sizes,
+                                            ArrayRef<const SCEV *> Subscripts);
 
 /// Gathers the individual index expressions from a GEP instruction.
 ///
@@ -155,15 +158,15 @@ bool validateDelinearizationResult(ScalarEvolution &SE,
 /// lists have either equal length or the size list is one element shorter in
 /// case there is no known size available for the outermost array dimension.
 /// Returns true if successful and false otherwise.
-bool getIndexExpressionsFromGEP(ScalarEvolution &SE,
-                                const GetElementPtrInst *GEP,
-                                SmallVectorImpl<const SCEV *> &Subscripts,
-                                SmallVectorImpl<const SCEV *> &Sizes);
+LLVM_ABI bool
+getIndexExpressionsFromGEP(ScalarEvolution &SE, const GetElementPtrInst *GEP,
+                           SmallVectorImpl<const SCEV *> &Subscripts,
+                           SmallVectorImpl<const SCEV *> &Sizes);
 
 struct DelinearizationPrinterPass
     : public RequiredPassInfoMixin<DelinearizationPrinterPass> {
-  explicit DelinearizationPrinterPass(raw_ostream &OS);
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI explicit DelinearizationPrinterPass(raw_ostream &OS);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
 private:
   raw_ostream &OS;

--- a/llvm/include/llvm/Analysis/DomConditionCache.h
+++ b/llvm/include/llvm/Analysis/DomConditionCache.h
@@ -34,7 +34,7 @@ private:
 
 public:
   /// Add a branch condition to the cache.
-  void registerBranch(CondBrInst *BI);
+  LLVM_ABI void registerBranch(CondBrInst *BI);
 
   /// Remove a value from the cache, e.g. because it will be erased.
   void removeValue(Value *V) { AffectedValues.erase(V); }

--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -126,8 +126,9 @@ public:
   void dump() const;
 };
 
-extern template class DominanceFrontierBase<BasicBlock, false>;
-extern template class DominanceFrontierBase<BasicBlock, true>;
+extern template class LLVM_TEMPLATE_ABI
+    DominanceFrontierBase<BasicBlock, false>;
+extern template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, true>;
 
 /// Analysis pass which computes a \c DominanceFrontier.
 class DominanceFrontierAnalysis

--- a/llvm/include/llvm/Analysis/DominanceFrontier.h
+++ b/llvm/include/llvm/Analysis/DominanceFrontier.h
@@ -100,11 +100,11 @@ public:
   using const_iterator = DominanceFrontier::const_iterator;
 
   /// Handle invalidation explicitly.
-  bool invalidate(Function &F, const PreservedAnalyses &PA,
-                  FunctionAnalysisManager::Invalidator &);
+  LLVM_ABI bool invalidate(Function &F, const PreservedAnalyses &PA,
+                           FunctionAnalysisManager::Invalidator &);
 };
 
-class DominanceFrontierWrapperPass : public FunctionPass {
+class LLVM_ABI DominanceFrontierWrapperPass : public FunctionPass {
   DominanceFrontier DF;
 
 public:
@@ -141,7 +141,7 @@ public:
   using Result = DominanceFrontier;
 
   /// Run the analysis pass over a function and produce a dominator tree.
-  DominanceFrontier run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI DominanceFrontier run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Printer pass for the \c DominanceFrontier.
@@ -150,9 +150,9 @@ class DominanceFrontierPrinterPass
   raw_ostream &OS;
 
 public:
-  explicit DominanceFrontierPrinterPass(raw_ostream &OS);
+  LLVM_ABI explicit DominanceFrontierPrinterPass(raw_ostream &OS);
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
+++ b/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
@@ -189,7 +189,7 @@ class FunctionPropertiesStatisticsPass
 public:
   explicit FunctionPropertiesStatisticsPass() {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 /// Correctly update FunctionPropertiesInfo post-inlining. A

--- a/llvm/include/llvm/Analysis/GuardUtils.h
+++ b/llvm/include/llvm/Analysis/GuardUtils.h
@@ -12,6 +12,8 @@
 #ifndef LLVM_ANALYSIS_GUARDUTILS_H
 #define LLVM_ANALYSIS_GUARDUTILS_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class BasicBlock;
@@ -22,19 +24,19 @@ template <typename T> class SmallVectorImpl;
 
 /// Returns true iff \p U has semantics of a guard expressed in a form of call
 /// of llvm.experimental.guard intrinsic.
-bool isGuard(const User *U);
+LLVM_ABI bool isGuard(const User *U);
 
 /// Returns true iff \p V has semantics of llvm.experimental.widenable.condition
 /// call
-bool isWidenableCondition(const Value *V);
+LLVM_ABI bool isWidenableCondition(const Value *V);
 
 /// Returns true iff \p U is a widenable branch (that is,
 /// extractWidenableCondition returns widenable condition).
-bool isWidenableBranch(const User *U);
+LLVM_ABI bool isWidenableBranch(const User *U);
 
 /// Returns true iff \p U has semantics of a guard expressed in a form of a
 /// widenable conditional branch to deopt block.
-bool isGuardAsWidenableBranch(const User *U);
+LLVM_ABI bool isGuardAsWidenableBranch(const User *U);
 
 /// If U is widenable branch looking like:
 ///   %cond = ...
@@ -45,25 +47,28 @@ bool isGuardAsWidenableBranch(const User *U);
 /// %if_true_bb, if_false_bb are returned in
 /// the parameters (Condition, WidenableCondition, IfTrueBB and IfFalseFF)
 /// respectively. If \p U does not match this pattern, return false.
-bool parseWidenableBranch(const User *U, Value *&Condition,
-                          Value *&WidenableCondition, BasicBlock *&IfTrueBB,
-                          BasicBlock *&IfFalseBB);
+LLVM_ABI bool parseWidenableBranch(const User *U, Value *&Condition,
+                                   Value *&WidenableCondition,
+                                   BasicBlock *&IfTrueBB,
+                                   BasicBlock *&IfFalseBB);
 
 /// Analogous to the above, but return the Uses so that they can be
 /// modified. Unlike previous version, Condition is optional and may be null.
-bool parseWidenableBranch(User *U, Use *&Cond, Use *&WC, BasicBlock *&IfTrueBB,
-                          BasicBlock *&IfFalseBB);
+LLVM_ABI bool parseWidenableBranch(User *U, Use *&Cond, Use *&WC,
+                                   BasicBlock *&IfTrueBB,
+                                   BasicBlock *&IfFalseBB);
 
 // The guard condition is expected to be in form of:
 //   cond1 && cond2 && cond3 ...
 // or in case of widenable branch:
 //   cond1 && cond2 && cond3 && widenable_contidion ...
 // Method collects the list of checks, but skips widenable_condition.
-void parseWidenableGuard(const User *U, llvm::SmallVectorImpl<Value *> &Checks);
+LLVM_ABI void parseWidenableGuard(const User *U,
+                                  llvm::SmallVectorImpl<Value *> &Checks);
 
 // Returns widenable_condition if it exists in the expression tree rooting from
 // \p U and has only one use.
-Value *extractWidenableCondition(const User *U);
+LLVM_ABI Value *extractWidenableCondition(const User *U);
 } // llvm
 
 #endif // LLVM_ANALYSIS_GUARDUTILS_H

--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -31,7 +31,7 @@ struct CRCTable : public std::array<APInt, 256> {
   LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 #endif
 };
 

--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -28,7 +28,7 @@ class LPMUpdater;
 
 /// A custom std::array with 256 entries, that also has a print function.
 struct CRCTable : public std::array<APInt, 256> {
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
@@ -65,9 +65,9 @@ struct PolynomialInfo {
   // zero.
   Value *LHSAux;
 
-  PolynomialInfo(unsigned TripCount, Value *LHS, const APInt &RHS,
-                 Value *ComputedValue, bool ByteOrderSwapped,
-                 Value *LHSAux = nullptr);
+  LLVM_ABI PolynomialInfo(unsigned TripCount, Value *LHS, const APInt &RHS,
+                          Value *ComputedValue, bool ByteOrderSwapped,
+                          Value *LHSAux = nullptr);
 };
 
 /// The analysis.
@@ -76,17 +76,18 @@ class HashRecognize {
   ScalarEvolution &SE;
 
 public:
-  HashRecognize(const Loop &L, ScalarEvolution &SE);
+  LLVM_ABI HashRecognize(const Loop &L, ScalarEvolution &SE);
 
   // The main analysis entry points.
-  std::variant<PolynomialInfo, StringRef> recognizeCRC() const;
-  std::optional<PolynomialInfo> getResult() const;
+  LLVM_ABI std::variant<PolynomialInfo, StringRef> recognizeCRC() const;
+  LLVM_ABI std::optional<PolynomialInfo> getResult() const;
 
   // Auxilary entry point after analysis to interleave the generating polynomial
   // and return a 256-entry CRC table.
-  static CRCTable genSarwateTable(const APInt &GenPoly, bool ByteOrderSwapped);
+  LLVM_ABI static CRCTable genSarwateTable(const APInt &GenPoly,
+                                           bool ByteOrderSwapped);
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const;
@@ -99,8 +100,8 @@ class HashRecognizePrinterPass
 
 public:
   explicit HashRecognizePrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR, LPMUpdater &);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -223,9 +223,9 @@ public:
   using VocabMap = std::map<std::string, Embedding>;
   /// Parse a vocabulary section from JSON and populate the target vocabulary
   /// map.
-  static Error parseVocabSection(StringRef Key,
-                                 const json::Value &ParsedVocabValue,
-                                 VocabMap &TargetVocab, unsigned &Dim);
+  LLVM_ABI static Error parseVocabSection(StringRef Key,
+                                          const json::Value &ParsedVocabValue,
+                                          VocabMap &TargetVocab, unsigned &Dim);
 };
 
 /// Class for storing and accessing the IR2Vec vocabulary.
@@ -326,7 +326,7 @@ public:
       NumICmpPredicates + NumFCmpPredicates;
 
   Vocabulary() = default;
-  LLVM_ABI Vocabulary(VocabStorage &&Storage) : Storage(std::move(Storage)) {}
+  Vocabulary(VocabStorage &&Storage) : Storage(std::move(Storage)) {}
 
   Vocabulary(const Vocabulary &) = delete;
   Vocabulary &operator=(const Vocabulary &) = delete;
@@ -344,11 +344,9 @@ public:
                                                 float TypeWeight = 0.5,
                                                 float ArgWeight = 0.2);
 
-  LLVM_ABI bool isValid() const {
-    return Storage.size() == NumCanonicalEntries;
-  }
+  bool isValid() const { return Storage.size() == NumCanonicalEntries; }
 
-  LLVM_ABI unsigned getDimension() const {
+  unsigned getDimension() const {
     assert(isValid() && "IR2Vec Vocabulary is invalid");
     return Storage.getDimension();
   }
@@ -361,12 +359,12 @@ public:
   LLVM_ABI static StringRef getVocabKeyForOpcode(unsigned Opcode);
 
   /// Function to get vocabulary key for a given TypeID
-  LLVM_ABI static StringRef getVocabKeyForTypeID(Type::TypeID TypeID) {
+  static StringRef getVocabKeyForTypeID(Type::TypeID TypeID) {
     return getVocabKeyForCanonicalTypeID(getCanonicalTypeID(TypeID));
   }
 
   /// Function to get vocabulary key for a given OperandKind
-  LLVM_ABI static StringRef getVocabKeyForOperandKind(OperandKind Kind) {
+  static StringRef getVocabKeyForOperandKind(OperandKind Kind) {
     unsigned Index = static_cast<unsigned>(Kind);
     assert(Index < MaxOperandKinds && "Invalid OperandKind");
     return OperandKindNames[Index];
@@ -379,45 +377,45 @@ public:
   LLVM_ABI static StringRef getVocabKeyForPredicate(CmpInst::Predicate P);
 
   /// Functions to return flat index
-  LLVM_ABI static unsigned getIndex(unsigned Opcode) {
+  static unsigned getIndex(unsigned Opcode) {
     assert(Opcode >= 1 && Opcode <= MaxOpcodes && "Invalid opcode");
     return Opcode - 1; // Convert to zero-based index
   }
 
-  LLVM_ABI static unsigned getIndex(Type::TypeID TypeID) {
+  static unsigned getIndex(Type::TypeID TypeID) {
     assert(static_cast<unsigned>(TypeID) < MaxTypeIDs && "Invalid type ID");
     return MaxOpcodes + static_cast<unsigned>(getCanonicalTypeID(TypeID));
   }
 
-  LLVM_ABI static unsigned getIndex(const Value &Op) {
+  static unsigned getIndex(const Value &Op) {
     unsigned Index = static_cast<unsigned>(getOperandKind(&Op));
     assert(Index < MaxOperandKinds && "Invalid OperandKind");
     return OperandBaseOffset + Index;
   }
 
-  LLVM_ABI static unsigned getIndex(CmpInst::Predicate P) {
+  static unsigned getIndex(CmpInst::Predicate P) {
     return PredicateBaseOffset + getPredicateLocalIndex(P);
   }
 
   /// Accessors to get the embedding for a given entity.
-  LLVM_ABI const ir2vec::Embedding &operator[](unsigned Opcode) const {
+  const ir2vec::Embedding &operator[](unsigned Opcode) const {
     assert(Opcode >= 1 && Opcode <= MaxOpcodes && "Invalid opcode");
     return Storage[static_cast<unsigned>(Section::Opcodes)][Opcode - 1];
   }
 
-  LLVM_ABI const ir2vec::Embedding &operator[](Type::TypeID TypeID) const {
+  const ir2vec::Embedding &operator[](Type::TypeID TypeID) const {
     assert(static_cast<unsigned>(TypeID) < MaxTypeIDs && "Invalid type ID");
     unsigned LocalIndex = static_cast<unsigned>(getCanonicalTypeID(TypeID));
     return Storage[static_cast<unsigned>(Section::CanonicalTypes)][LocalIndex];
   }
 
-  LLVM_ABI const ir2vec::Embedding &operator[](const Value &Arg) const {
+  const ir2vec::Embedding &operator[](const Value &Arg) const {
     unsigned LocalIndex = static_cast<unsigned>(getOperandKind(&Arg));
     assert(LocalIndex < MaxOperandKinds && "Invalid OperandKind");
     return Storage[static_cast<unsigned>(Section::Operands)][LocalIndex];
   }
 
-  LLVM_ABI const ir2vec::Embedding &operator[](CmpInst::Predicate P) const {
+  const ir2vec::Embedding &operator[](CmpInst::Predicate P) const {
     unsigned LocalIndex = getPredicateLocalIndex(P);
     return Storage[static_cast<unsigned>(Section::Predicates)][LocalIndex];
   }
@@ -461,8 +459,9 @@ private:
       OperandBaseOffset + MaxOperandKinds;
 
   /// Functions for predicate index calculations
-  static unsigned getPredicateLocalIndex(CmpInst::Predicate P);
-  static CmpInst::Predicate getPredicateFromLocalIndex(unsigned LocalIndex);
+  LLVM_ABI static unsigned getPredicateLocalIndex(CmpInst::Predicate P);
+  LLVM_ABI static CmpInst::Predicate
+  getPredicateFromLocalIndex(unsigned LocalIndex);
 
   /// String mappings for CanonicalTypeID values
   static constexpr StringLiteral CanonicalTypeNames[] = {
@@ -510,15 +509,14 @@ private:
                 "TypeIDMapping must cover all Type::TypeID values");
 
   /// Function to get vocabulary key for canonical type by enum
-  LLVM_ABI static StringRef
-  getVocabKeyForCanonicalTypeID(CanonicalTypeID CType) {
+  static StringRef getVocabKeyForCanonicalTypeID(CanonicalTypeID CType) {
     unsigned Index = static_cast<unsigned>(CType);
     assert(Index < MaxCanonicalTypeIDs && "Invalid CanonicalTypeID");
     return CanonicalTypeNames[Index];
   }
 
   /// Function to convert TypeID to CanonicalTypeID
-  LLVM_ABI static CanonicalTypeID getCanonicalTypeID(Type::TypeID TypeID) {
+  static CanonicalTypeID getCanonicalTypeID(Type::TypeID TypeID) {
     unsigned Index = static_cast<unsigned>(TypeID);
     assert(Index < MaxTypeIDs && "Invalid TypeID");
     return TypeIDMapping[Index];
@@ -558,16 +556,16 @@ protected:
   /// in the IR instructions to generate the vector representation.
   const float OpcWeight, TypeWeight, ArgWeight;
 
-  LLVM_ABI Embedder(const Function &F, const Vocabulary &Vocab)
+  Embedder(const Function &F, const Vocabulary &Vocab)
       : F(F), Vocab(Vocab), Dimension(Vocab.getDimension()),
         OpcWeight(ir2vec::OpcWeight), TypeWeight(ir2vec::TypeWeight),
         ArgWeight(ir2vec::ArgWeight) {}
 
   /// Function to compute embeddings.
-  Embedding computeEmbeddings() const;
+  LLVM_ABI Embedding computeEmbeddings() const;
 
   /// Function to compute the embedding for a given basic block.
-  Embedding computeEmbeddings(const BasicBlock &BB) const;
+  LLVM_ABI Embedding computeEmbeddings(const BasicBlock &BB) const;
 
   /// Function to compute the embedding for a given instruction.
   /// Specific to the kind of embeddings being computed.
@@ -582,18 +580,18 @@ public:
 
   /// Computes and returns the embedding for a given instruction in the function
   /// F
-  LLVM_ABI Embedding getInstVector(const Instruction &I) const {
+  Embedding getInstVector(const Instruction &I) const {
     return computeEmbeddings(I);
   }
 
   /// Computes and returns the embedding for a given basic block in the function
   /// F
-  LLVM_ABI Embedding getBBVector(const BasicBlock &BB) const {
+  Embedding getBBVector(const BasicBlock &BB) const {
     return computeEmbeddings(BB);
   }
 
   /// Computes and returns the embedding for the current function.
-  LLVM_ABI Embedding getFunctionVector() const { return computeEmbeddings(); }
+  Embedding getFunctionVector() const { return computeEmbeddings(); }
 
   /// Invalidate embeddings if cached. The embeddings may not be relevant
   /// anymore when the IR changes due to transformations. In such cases, the
@@ -644,7 +642,7 @@ class IR2VecVocabAnalysis : public AnalysisInfoMixin<IR2VecVocabAnalysis> {
 public:
   LLVM_ABI static AnalysisKey Key;
   IR2VecVocabAnalysis() = default;
-  LLVM_ABI explicit IR2VecVocabAnalysis(ir2vec::VocabStorage &&Vocab)
+  explicit IR2VecVocabAnalysis(ir2vec::VocabStorage &&Vocab)
       : Vocab(std::move(Vocab)) {}
   using Result = ir2vec::Vocabulary;
   LLVM_ABI Result run(Module &M, ModuleAnalysisManager &MAM);

--- a/llvm/include/llvm/Analysis/IVUsers.h
+++ b/llvm/include/llvm/Analysis/IVUsers.h
@@ -32,7 +32,8 @@ class IVUsers;
 /// The Expr member keeps track of the expression, User is the actual user
 /// instruction of the operand, and 'OperandValToReplace' is the operand of
 /// the User that is the use.
-class IVStrideUse final : public CallbackVH, public ilist_node<IVStrideUse> {
+class LLVM_ABI IVStrideUse final : public CallbackVH,
+                                   public ilist_node<IVStrideUse> {
   friend class IVUsers;
 public:
   IVStrideUse(IVUsers *P, Instruction* U, Value *O)
@@ -105,8 +106,8 @@ class IVUsers {
   SmallPtrSet<const Value *, 32> EphValues;
 
 public:
-  IVUsers(Loop *L, AssumptionCache *AC, LoopInfo *LI, DominatorTree *DT,
-          ScalarEvolution *SE);
+  LLVM_ABI IVUsers(Loop *L, AssumptionCache *AC, LoopInfo *LI,
+                   DominatorTree *DT, ScalarEvolution *SE);
 
   IVUsers(IVUsers &&X)
       : L(std::move(X.L)), AC(std::move(X.AC)), DT(std::move(X.DT)),
@@ -124,19 +125,19 @@ public:
   /// AddUsersIfInteresting - Inspect the specified Instruction.  If it is a
   /// reducible SCEV, recursively add its users to the IVUsesByStride set and
   /// return true.  Otherwise, return false.
-  bool AddUsersIfInteresting(Instruction *I);
+  LLVM_ABI bool AddUsersIfInteresting(Instruction *I);
 
-  IVStrideUse &AddUser(Instruction *User, Value *Operand);
+  LLVM_ABI IVStrideUse &AddUser(Instruction *User, Value *Operand);
 
   /// getReplacementExpr - Return a SCEV expression which computes the
   /// value of the OperandValToReplace of the given IVStrideUse.
-  const SCEV *getReplacementExpr(const IVStrideUse &IU) const;
+  LLVM_ABI const SCEV *getReplacementExpr(const IVStrideUse &IU) const;
 
   /// getExpr - Return the expression for the use. Returns nullptr if the result
   /// is not invertible.
-  const SCEV *getExpr(const IVStrideUse &IU) const;
+  LLVM_ABI const SCEV *getExpr(const IVStrideUse &IU) const;
 
-  const SCEV *getStride(const IVStrideUse &IU, const Loop *L) const;
+  LLVM_ABI const SCEV *getStride(const IVStrideUse &IU, const Loop *L) const;
 
   typedef ilist<IVStrideUse>::iterator iterator;
   typedef ilist<IVStrideUse>::const_iterator const_iterator;
@@ -152,17 +153,17 @@ public:
 
   bool isEphemeral(const Value *V) const { return EphValues.count(V); }
 
-  void releaseMemory();
+  LLVM_ABI void releaseMemory();
 
-  void print(raw_ostream &OS, const Module * = nullptr) const;
+  LLVM_ABI void print(raw_ostream &OS, const Module * = nullptr) const;
 
   /// dump - This method is used for debugging.
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
-Pass *createIVUsersPass();
+LLVM_ABI Pass *createIVUsersPass();
 
-class IVUsersWrapperPass : public LoopPass {
+class LLVM_ABI IVUsersWrapperPass : public LoopPass {
   std::unique_ptr<IVUsers> IU;
 
 public:
@@ -190,8 +191,8 @@ class IVUsersAnalysis : public AnalysisInfoMixin<IVUsersAnalysis> {
 public:
   typedef IVUsers Result;
 
-  IVUsers run(Loop &L, LoopAnalysisManager &AM,
-              LoopStandardAnalysisResults &AR);
+  LLVM_ABI IVUsers run(Loop &L, LoopAnalysisManager &AM,
+                       LoopStandardAnalysisResults &AR);
 };
 
 }

--- a/llvm/include/llvm/Analysis/IndirectCallPromotionAnalysis.h
+++ b/llvm/include/llvm/Analysis/IndirectCallPromotionAnalysis.h
@@ -57,9 +57,11 @@ public:
   ///
   /// The returned array space is owned by this class, and overwritten on
   /// subsequent calls.
-  MutableArrayRef<InstrProfValueData> getPromotionCandidatesForInstruction(
-      const Instruction *I, uint64_t &TotalCount, uint32_t &NumCandidates,
-      unsigned MaxNumValueData = 0);
+  LLVM_ABI MutableArrayRef<InstrProfValueData>
+  getPromotionCandidatesForInstruction(const Instruction *I,
+                                       uint64_t &TotalCount,
+                                       uint32_t &NumCandidates,
+                                       unsigned MaxNumValueData = 0);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/InstCount.h
+++ b/llvm/include/llvm/Analysis/InstCount.h
@@ -23,7 +23,7 @@ class InstCountPass : public RequiredPassInfoMixin<InstCountPass> {
 public:
   explicit InstCountPass() {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/KernelInfo.h
+++ b/llvm/include/llvm/Analysis/KernelInfo.h
@@ -27,7 +27,7 @@ class KernelInfoPrinter : public RequiredPassInfoMixin<KernelInfoPrinter> {
 public:
   explicit KernelInfoPrinter(TargetMachine *TM) : TM(TM) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 #endif // LLVM_ANALYSIS_KERNELINFO_H

--- a/llvm/include/llvm/Analysis/LazyBlockFrequencyInfo.h
+++ b/llvm/include/llvm/Analysis/LazyBlockFrequencyInfo.h
@@ -94,7 +94,7 @@ private:
 /// Note that it is expected that we wouldn't need this functionality for the
 /// new PM since with the new PM, analyses are executed on demand.
 
-class LazyBlockFrequencyInfoPass : public FunctionPass {
+class LLVM_ABI LazyBlockFrequencyInfoPass : public FunctionPass {
 private:
   LazyBlockFrequencyInfo<Function, LazyBranchProbabilityInfoPass, LoopInfo,
                          BlockFrequencyInfo>

--- a/llvm/include/llvm/Analysis/LazyBranchProbabilityInfo.h
+++ b/llvm/include/llvm/Analysis/LazyBranchProbabilityInfo.h
@@ -46,7 +46,7 @@ class TargetLibraryInfo;
 ///
 /// Note that it is expected that we wouldn't need this functionality for the
 /// new PM since with the new PM, analyses are executed on demand.
-class LazyBranchProbabilityInfoPass : public FunctionPass {
+class LLVM_ABI LazyBranchProbabilityInfoPass : public FunctionPass {
 
   /// Wraps a BPI to allow lazy computation of the branch probabilities.
   ///
@@ -105,7 +105,7 @@ public:
 };
 
 /// Helper for client passes to initialize dependent passes for LBPI.
-void initializeLazyBPIPassPass(PassRegistry &Registry);
+LLVM_ABI void initializeLazyBPIPassPass(PassRegistry &Registry);
 
 /// Simple trait class that provides a mapping between BPI passes and the
 /// corresponding BPInfo.

--- a/llvm/include/llvm/Analysis/LazyValueInfo.h
+++ b/llvm/include/llvm/Analysis/LazyValueInfo.h
@@ -41,7 +41,7 @@ namespace llvm {
     LazyValueInfoImpl &getOrCreateImpl();
 
   public:
-    ~LazyValueInfo();
+    LLVM_ABI ~LazyValueInfo();
     LazyValueInfo() = default;
     LazyValueInfo(Function *F, AssumptionCache *AC) : F(F), AC(AC) {}
     LazyValueInfo(LazyValueInfo &&Arg)
@@ -62,83 +62,88 @@ namespace llvm {
     /// Determine whether the specified value comparison with a constant is
     /// known to be true or false on the specified CFG edge. Pred is a CmpInst
     /// predicate.
-    Constant *getPredicateOnEdge(CmpInst::Predicate Pred, Value *V, Constant *C,
-                                 BasicBlock *FromBB, BasicBlock *ToBB,
-                                 Instruction *CxtI = nullptr);
+    LLVM_ABI Constant *getPredicateOnEdge(CmpInst::Predicate Pred, Value *V,
+                                          Constant *C, BasicBlock *FromBB,
+                                          BasicBlock *ToBB,
+                                          Instruction *CxtI = nullptr);
 
     /// Determine whether the specified value comparison with a constant is
     /// known to be true or false at the specified instruction. \p Pred is a
     /// CmpInst predicate. If \p UseBlockValue is true, the block value is also
     /// taken into account.
-    Constant *getPredicateAt(CmpInst::Predicate Pred, Value *V, Constant *C,
-                             Instruction *CxtI, bool UseBlockValue);
+    LLVM_ABI Constant *getPredicateAt(CmpInst::Predicate Pred, Value *V,
+                                      Constant *C, Instruction *CxtI,
+                                      bool UseBlockValue);
 
     /// Determine whether the specified value comparison is known to be true
     /// or false at the specified instruction. While this takes two Value's,
     /// it still requires that one of them is a constant.
     /// \p Pred is a CmpInst predicate.
     /// If \p UseBlockValue is true, the block value is also taken into account.
-    Constant *getPredicateAt(CmpInst::Predicate Pred, Value *LHS, Value *RHS,
-                             Instruction *CxtI, bool UseBlockValue);
+    LLVM_ABI Constant *getPredicateAt(CmpInst::Predicate Pred, Value *LHS,
+                                      Value *RHS, Instruction *CxtI,
+                                      bool UseBlockValue);
 
     /// Determine whether the specified value is known to be a constant at the
     /// specified instruction. Return null if not.
-    Constant *getConstant(Value *V, Instruction *CxtI);
+    LLVM_ABI Constant *getConstant(Value *V, Instruction *CxtI);
 
     /// Return the ConstantRange constraint that is known to hold for the
     /// specified value at the specified instruction. This may only be called
     /// on integer-typed Values.
-    ConstantRange getConstantRange(Value *V, Instruction *CxtI,
-                                   bool UndefAllowed);
+    LLVM_ABI ConstantRange getConstantRange(Value *V, Instruction *CxtI,
+                                            bool UndefAllowed);
 
     /// Return the ConstantRange constraint that is known to hold for the value
     /// at a specific use-site.
-    ConstantRange getConstantRangeAtUse(const Use &U, bool UndefAllowed);
+    LLVM_ABI ConstantRange getConstantRangeAtUse(const Use &U,
+                                                 bool UndefAllowed);
 
     /// Determine whether the specified value is known to be a
     /// constant on the specified edge.  Return null if not.
-    Constant *getConstantOnEdge(Value *V, BasicBlock *FromBB, BasicBlock *ToBB,
-                                Instruction *CxtI = nullptr);
+    LLVM_ABI Constant *getConstantOnEdge(Value *V, BasicBlock *FromBB,
+                                         BasicBlock *ToBB,
+                                         Instruction *CxtI = nullptr);
 
     /// Return the ConstantRage constraint that is known to hold for the
     /// specified value on the specified edge. This may be only be called
     /// on integer-typed Values.
-    ConstantRange getConstantRangeOnEdge(Value *V, BasicBlock *FromBB,
-                                         BasicBlock *ToBB,
-                                         Instruction *CxtI = nullptr);
+    LLVM_ABI ConstantRange getConstantRangeOnEdge(Value *V, BasicBlock *FromBB,
+                                                  BasicBlock *ToBB,
+                                                  Instruction *CxtI = nullptr);
 
     /// Inform the analysis cache that we have threaded an edge from
     /// PredBB to OldSucc to be from PredBB to NewSucc instead.
-    void threadEdge(BasicBlock *PredBB, BasicBlock *OldSucc,
-                    BasicBlock *NewSucc);
+    LLVM_ABI void threadEdge(BasicBlock *PredBB, BasicBlock *OldSucc,
+                             BasicBlock *NewSucc);
 
     /// Remove information related to this value from the cache.
-    void forgetValue(Value *V);
+    LLVM_ABI void forgetValue(Value *V);
 
     /// Inform the analysis cache that we have erased a block.
-    void eraseBlock(BasicBlock *BB);
+    LLVM_ABI void eraseBlock(BasicBlock *BB);
 
     /// Complete flush all previously computed values
-    void clear();
+    LLVM_ABI void clear();
 
     /// Print the \LazyValueInfo Analysis.
     /// We pass in the DTree that is required for identifying which basic blocks
     /// we can solve/print for, in the LVIPrinter.
-    void printLVI(Function &F, DominatorTree &DTree, raw_ostream &OS);
+    LLVM_ABI void printLVI(Function &F, DominatorTree &DTree, raw_ostream &OS);
 
     // For old PM pass. Delete once LazyValueInfoWrapperPass is gone.
-    void releaseMemory();
+    LLVM_ABI void releaseMemory();
 
     /// Handle invalidation events in the new pass manager.
-    bool invalidate(Function &F, const PreservedAnalyses &PA,
-                    FunctionAnalysisManager::Invalidator &Inv);
+    LLVM_ABI bool invalidate(Function &F, const PreservedAnalyses &PA,
+                             FunctionAnalysisManager::Invalidator &Inv);
   };
 
 /// Analysis to compute lazy value information.
 class LazyValueAnalysis : public AnalysisInfoMixin<LazyValueAnalysis> {
 public:
   typedef LazyValueInfo Result;
-  Result run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI Result run(Function &F, FunctionAnalysisManager &FAM);
 
 private:
   static AnalysisKey Key;
@@ -153,11 +158,11 @@ class LazyValueInfoPrinterPass
 public:
   explicit LazyValueInfoPrinterPass(raw_ostream &OS) : OS(OS) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Wrapper around LazyValueInfo.
-class LazyValueInfoWrapperPass : public FunctionPass {
+class LLVM_ABI LazyValueInfoWrapperPass : public FunctionPass {
   LazyValueInfoWrapperPass(const LazyValueInfoWrapperPass&) = delete;
   void operator=(const LazyValueInfoWrapperPass&) = delete;
 public:

--- a/llvm/include/llvm/Analysis/Lint.h
+++ b/llvm/include/llvm/Analysis/Lint.h
@@ -29,20 +29,21 @@ class Function;
 ///
 /// This should only be used for debugging, because it plays games with
 /// PassManagers and stuff.
-void lintModule(const Module &M, bool AbortOnError = false);
+LLVM_ABI void lintModule(const Module &M, bool AbortOnError = false);
 
 // Lint a function.
-void lintFunction(const Function &F, bool AbortOnError = false);
+LLVM_ABI void lintFunction(const Function &F, bool AbortOnError = false);
 
 class LintPass : public RequiredPassInfoMixin<LintPass> {
   const bool AbortOnError;
 
 public:
   LintPass(bool AbortOnError) : AbortOnError(AbortOnError) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Analysis/LoopCacheAnalysis.h
+++ b/llvm/include/llvm/Analysis/LoopCacheAnalysis.h
@@ -47,12 +47,13 @@ using LoopVectorTy = SmallVector<Loop *, 8>;
 ///   Subscripts -> [{0,+,1}<%for.i>][{1,+,2}<%for.j>][{2,+,3}<%for.k>]
 ///   Sizes -> [m][o][4]
 class IndexedReference {
-  friend raw_ostream &operator<<(raw_ostream &OS, const IndexedReference &R);
+  friend LLVM_ABI raw_ostream &operator<<(raw_ostream &OS,
+                                          const IndexedReference &R);
 
 public:
   /// Construct an indexed reference given a \p StoreOrLoadInst instruction.
-  IndexedReference(Instruction &StoreOrLoadInst, const LoopInfo &LI,
-                   ScalarEvolution &SE);
+  LLVM_ABI IndexedReference(Instruction &StoreOrLoadInst, const LoopInfo &LI,
+                            ScalarEvolution &SE);
 
   bool isValid() const { return IsValid; }
   const SCEV *getBasePointer() const { return BasePointer; }
@@ -74,16 +75,17 @@ public:
   /// are/aren't in the same cache line of size \p CLS. Two references are in
   /// the same chace line iff the distance between them in the innermost
   /// dimension is less than the cache line size. Return std::nullopt if unsure.
-  std::optional<bool> hasSpacialReuse(const IndexedReference &Other,
-                                      unsigned CLS, AAResults &AA) const;
+  LLVM_ABI std::optional<bool> hasSpacialReuse(const IndexedReference &Other,
+                                               unsigned CLS,
+                                               AAResults &AA) const;
 
   /// Return true if the current object and the indexed reference \p Other
   /// have distance smaller than \p MaxDistance in the dimension associated with
   /// the given loop \p L. Return false if the distance is not smaller than \p
   /// MaxDistance and std::nullopt if unsure.
-  std::optional<bool> hasTemporalReuse(const IndexedReference &Other,
-                                       unsigned MaxDistance, const Loop &L,
-                                       DependenceInfo &DI, AAResults &AA) const;
+  LLVM_ABI std::optional<bool>
+  hasTemporalReuse(const IndexedReference &Other, unsigned MaxDistance,
+                   const Loop &L, DependenceInfo &DI, AAResults &AA) const;
 
   /// Compute the cost of the reference w.r.t. the given loop \p L when it is
   /// considered in the innermost position in the loop nest.
@@ -94,7 +96,7 @@ public:
   ///     + the coefficient of this loop's index variable used in all other
   ///       subscripts is zero
   ///   - or otherwise equal to 'TripCount'.
-  CacheCostTy computeRefCost(const Loop &L, unsigned CLS) const;
+  LLVM_ABI CacheCostTy computeRefCost(const Loop &L, unsigned CLS) const;
 
 private:
   /// Attempt to delinearize the indexed reference.
@@ -184,7 +186,7 @@ using ReferenceGroupsTy = SmallVector<ReferenceGroupTy, 8>;
 ///  - equal to the innermost loop trip count if the reference stride is greater
 ///    or equal to the cache line size CLS.
 class CacheCost {
-  friend raw_ostream &operator<<(raw_ostream &OS, const CacheCost &CC);
+  friend LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CacheCost &CC);
   using LoopTripCountTy = std::pair<const Loop *, unsigned>;
   using LoopCacheCostTy = std::pair<const Loop *, CacheCostTy>;
 
@@ -193,15 +195,16 @@ public:
   /// The optional parameter \p TRT can be used to specify the max. distance
   /// between array elements accessed in a loop so that the elements are
   /// classified to have temporal reuse.
-  CacheCost(const LoopVectorTy &Loops, const LoopInfo &LI, ScalarEvolution &SE,
-            TargetTransformInfo &TTI, AAResults &AA, DependenceInfo &DI,
-            std::optional<unsigned> TRT = std::nullopt);
+  LLVM_ABI CacheCost(const LoopVectorTy &Loops, const LoopInfo &LI,
+                     ScalarEvolution &SE, TargetTransformInfo &TTI,
+                     AAResults &AA, DependenceInfo &DI,
+                     std::optional<unsigned> TRT = std::nullopt);
 
   /// Create a CacheCost for the loop nest rooted by \p Root.
   /// The optional parameter \p TRT can be used to specify the max. distance
   /// between array elements accessed in a loop so that the elements are
   /// classified to have temporal reuse.
-  static std::unique_ptr<CacheCost>
+  LLVM_ABI static std::unique_ptr<CacheCost>
   getCacheCost(Loop &Root, LoopStandardAnalysisResults &AR, DependenceInfo &DI,
                std::optional<unsigned> TRT = std::nullopt);
 
@@ -274,8 +277,8 @@ private:
   DependenceInfo &DI;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const IndexedReference &R);
-raw_ostream &operator<<(raw_ostream &OS, const CacheCost &CC);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const IndexedReference &R);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const CacheCost &CC);
 
 /// Printer pass for the \c CacheCost results.
 class LoopCachePrinterPass
@@ -285,8 +288,9 @@ class LoopCachePrinterPass
 public:
   explicit LoopCachePrinterPass(raw_ostream &OS) : OS(OS) {}
 
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Analysis/LoopIterator.h
+++ b/llvm/include/llvm/Analysis/LoopIterator.h
@@ -120,7 +120,7 @@ public:
   Loop *getLoop() const { return L; }
 
   /// Traverse the loop blocks and store the DFS result.
-  void perform(const LoopInfo *LI);
+  LLVM_ABI void perform(const LoopInfo *LI);
 
   /// Return true if postorder numbers are assigned to all loop blocks.
   bool isComplete() const { return PostBlocks.size() == L->getNumBlocks(); }

--- a/llvm/include/llvm/Analysis/MLInlineAdvisor.h
+++ b/llvm/include/llvm/Analysis/MLInlineAdvisor.h
@@ -25,7 +25,7 @@ class Module;
 class MLInlineAdvice;
 class ProfileSummaryInfo;
 
-class MLInlineAdvisor : public InlineAdvisor {
+class LLVM_ABI MLInlineAdvisor : public InlineAdvisor {
 public:
   MLInlineAdvisor(Module &M, ModuleAnalysisManager &MAM,
                   std::function<std::unique_ptr<MLModelRunner>(
@@ -101,7 +101,7 @@ private:
 
 /// InlineAdvice that tracks changes post inlining. For that reason, it only
 /// overrides the "successful inlining" extension points.
-class MLInlineAdvice : public InlineAdvice {
+class LLVM_ABI MLInlineAdvice : public InlineAdvice {
 public:
   MLInlineAdvice(MLInlineAdvisor *Advisor, CallBase &CB,
                  OptimizationRemarkEmitter &ORE, bool Recommendation);

--- a/llvm/include/llvm/Analysis/MemDerefPrinter.h
+++ b/llvm/include/llvm/Analysis/MemDerefPrinter.h
@@ -17,7 +17,7 @@ class MemDerefPrinterPass : public RequiredPassInfoMixin<MemDerefPrinterPass> {
 
 public:
   MemDerefPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Analysis/MemoryDependenceAnalysis.h
+++ b/llvm/include/llvm/Analysis/MemoryDependenceAnalysis.h
@@ -377,19 +377,19 @@ public:
         DefaultBlockScanLimit(DefaultBlockScanLimit) {}
 
   /// Handle invalidation in the new PM.
-  bool invalidate(Function &F, const PreservedAnalyses &PA,
-                  FunctionAnalysisManager::Invalidator &Inv);
+  LLVM_ABI bool invalidate(Function &F, const PreservedAnalyses &PA,
+                           FunctionAnalysisManager::Invalidator &Inv);
 
   /// Some methods limit the number of instructions they will examine.
   /// The return value of this method is the default limit that will be
   /// used if no limit is explicitly passed in.
-  unsigned getDefaultBlockScanLimit() const;
+  LLVM_ABI unsigned getDefaultBlockScanLimit() const;
 
   /// Returns the instruction on which a memory operation depends.
   ///
   /// See the class comment for more details. It is illegal to call this on
   /// non-memory instructions.
-  MemDepResult getDependency(Instruction *QueryInst);
+  LLVM_ABI MemDepResult getDependency(Instruction *QueryInst);
 
   /// Perform a full dependency query for the specified call, returning the set
   /// of blocks that the value is potentially live across.
@@ -404,7 +404,8 @@ public:
   /// invalidated on the next non-local query or when an instruction is
   /// removed.  Clients must copy this data if they want it around longer than
   /// that.
-  const NonLocalDepInfo &getNonLocalCallDependency(CallBase *QueryCall);
+  LLVM_ABI const NonLocalDepInfo &
+  getNonLocalCallDependency(CallBase *QueryCall);
 
   /// Perform a full dependency query for an access to the QueryInst's
   /// specified memory location, returning the set of instructions that either
@@ -416,12 +417,13 @@ public:
   ///
   /// This method assumes the pointer has a "NonLocal" dependency within
   /// QueryInst's parent basic block.
-  void getNonLocalPointerDependency(Instruction *QueryInst,
-                                    SmallVectorImpl<NonLocalDepResult> &Result);
+  LLVM_ABI void
+  getNonLocalPointerDependency(Instruction *QueryInst,
+                               SmallVectorImpl<NonLocalDepResult> &Result);
 
   /// Removes an instruction from the dependence analysis, updating the
   /// dependence of instructions that previously depended on it.
-  void removeInstruction(Instruction *InstToRemove);
+  LLVM_ABI void removeInstruction(Instruction *InstToRemove);
 
   /// Invalidates cached information about the specified pointer, because it
   /// may be too conservative in memdep.
@@ -430,13 +432,13 @@ public:
   /// equivalence between the pointer and some other value and replaces the
   /// other value with ptr. This can make Ptr available in more places that
   /// cached info does not necessarily keep.
-  void invalidateCachedPointerInfo(Value *Ptr);
+  LLVM_ABI void invalidateCachedPointerInfo(Value *Ptr);
 
   /// Clears the PredIteratorCache info.
   ///
   /// This needs to be done when the CFG changes, e.g., due to splitting
   /// critical edges.
-  void invalidateCachedPredecessors();
+  LLVM_ABI void invalidateCachedPredecessors();
 
   /// Returns the instruction on which a memory location depends.
   ///
@@ -451,24 +453,20 @@ public:
   /// in, the limit will default to the value of -memdep-block-scan-limit.
   ///
   /// Note that this is an uncached query, and thus may be inefficient.
-  MemDepResult getPointerDependencyFrom(const MemoryLocation &Loc, bool isLoad,
-                                        BasicBlock::iterator ScanIt,
-                                        BasicBlock *BB,
-                                        Instruction *QueryInst = nullptr,
-                                        unsigned *Limit = nullptr);
+  LLVM_ABI MemDepResult getPointerDependencyFrom(
+      const MemoryLocation &Loc, bool isLoad, BasicBlock::iterator ScanIt,
+      BasicBlock *BB, Instruction *QueryInst = nullptr,
+      unsigned *Limit = nullptr);
 
-  MemDepResult getPointerDependencyFrom(const MemoryLocation &Loc, bool isLoad,
-                                        BasicBlock::iterator ScanIt,
-                                        BasicBlock *BB,
-                                        Instruction *QueryInst,
-                                        unsigned *Limit,
-                                        BatchAAResults &BatchAA);
+  LLVM_ABI MemDepResult getPointerDependencyFrom(
+      const MemoryLocation &Loc, bool isLoad, BasicBlock::iterator ScanIt,
+      BasicBlock *BB, Instruction *QueryInst, unsigned *Limit,
+      BatchAAResults &BatchAA);
 
-  MemDepResult
-  getSimplePointerDependencyFrom(const MemoryLocation &MemLoc, bool isLoad,
-                                 BasicBlock::iterator ScanIt, BasicBlock *BB,
-                                 Instruction *QueryInst, unsigned *Limit,
-                                 BatchAAResults &BatchAA);
+  LLVM_ABI MemDepResult getSimplePointerDependencyFrom(
+      const MemoryLocation &MemLoc, bool isLoad, BasicBlock::iterator ScanIt,
+      BasicBlock *BB, Instruction *QueryInst, unsigned *Limit,
+      BatchAAResults &BatchAA);
 
   /// This analysis looks for other loads and stores with invariant.group
   /// metadata and the same pointer operand. Returns Unknown if it does not
@@ -476,10 +474,11 @@ public:
   /// store the same value and NonLocal which indicate that non-local Def was
   /// found, which can be retrieved by calling getNonLocalPointerDependency
   /// with the same queried instruction.
-  MemDepResult getInvariantGroupPointerDependency(LoadInst *LI, BasicBlock *BB);
+  LLVM_ABI MemDepResult getInvariantGroupPointerDependency(LoadInst *LI,
+                                                           BasicBlock *BB);
 
   /// Release memory in caches.
-  void releaseMemory();
+  LLVM_ABI void releaseMemory();
 
   /// Return the clobber offset to dependent instruction.
   std::optional<int32_t> getClobberOffset(LoadInst *DepInst) const {
@@ -529,15 +528,16 @@ class MemoryDependenceAnalysis
 public:
   using Result = MemoryDependenceResults;
 
-  MemoryDependenceAnalysis();
+  LLVM_ABI MemoryDependenceAnalysis();
   MemoryDependenceAnalysis(unsigned DefaultBlockScanLimit) : DefaultBlockScanLimit(DefaultBlockScanLimit) { }
 
-  MemoryDependenceResults run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI MemoryDependenceResults run(Function &F,
+                                       FunctionAnalysisManager &AM);
 };
 
 /// A wrapper analysis pass for the legacy pass manager that exposes a \c
 /// MemoryDepnedenceResults instance.
-class MemoryDependenceWrapperPass : public FunctionPass {
+class LLVM_ABI MemoryDependenceWrapperPass : public FunctionPass {
   std::optional<MemoryDependenceResults> MemDep;
 
 public:

--- a/llvm/include/llvm/Analysis/ModuleDebugInfoPrinter.h
+++ b/llvm/include/llvm/Analysis/ModuleDebugInfoPrinter.h
@@ -21,8 +21,8 @@ class ModuleDebugInfoPrinterPass
   raw_ostream &OS;
 
 public:
-  explicit ModuleDebugInfoPrinterPass(raw_ostream &OS);
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI explicit ModuleDebugInfoPrinterPass(raw_ostream &OS);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Analysis/ObjCARCAliasAnalysis.h
+++ b/llvm/include/llvm/Analysis/ObjCARCAliasAnalysis.h
@@ -49,17 +49,19 @@ public:
     return false;
   }
 
-  AliasResult alias(const MemoryLocation &LocA, const MemoryLocation &LocB,
-                    AAQueryInfo &AAQI, const Instruction *CtxI);
-  ModRefInfo getModRefInfoMask(const MemoryLocation &Loc, AAQueryInfo &AAQI,
-                               bool IgnoreLocals);
+  LLVM_ABI AliasResult alias(const MemoryLocation &LocA,
+                             const MemoryLocation &LocB, AAQueryInfo &AAQI,
+                             const Instruction *CtxI);
+  LLVM_ABI ModRefInfo getModRefInfoMask(const MemoryLocation &Loc,
+                                        AAQueryInfo &AAQI, bool IgnoreLocals);
 
   using AAResultBase::getMemoryEffects;
-  MemoryEffects getMemoryEffects(const Function *F);
+  LLVM_ABI MemoryEffects getMemoryEffects(const Function *F);
 
   using AAResultBase::getModRefInfo;
-  ModRefInfo getModRefInfo(const CallBase *Call, const MemoryLocation &Loc,
-                           AAQueryInfo &AAQI);
+  LLVM_ABI ModRefInfo getModRefInfo(const CallBase *Call,
+                                    const MemoryLocation &Loc,
+                                    AAQueryInfo &AAQI);
 };
 
 /// Analysis pass providing a never-invalidated alias analysis result.
@@ -70,7 +72,7 @@ class ObjCARCAA : public AnalysisInfoMixin<ObjCARCAA> {
 public:
   typedef ObjCARCAAResult Result;
 
-  ObjCARCAAResult run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI ObjCARCAAResult run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // namespace objcarc

--- a/llvm/include/llvm/Analysis/ObjCARCAnalysisUtils.h
+++ b/llvm/include/llvm/Analysis/ObjCARCAnalysisUtils.h
@@ -36,7 +36,7 @@ class AAResults;
 namespace objcarc {
 
 /// A handy option to enable/disable all ARC Optimizations.
-extern bool EnableARCOpts;
+extern LLVM_ABI bool EnableARCOpts;
 
 /// Test if the given module looks interesting to run ARC optimization
 /// on.
@@ -174,7 +174,7 @@ inline bool IsPotentialRetainableObjPtr(const Value *Op) {
   return true;
 }
 
-bool IsPotentialRetainableObjPtr(const Value *Op, AAResults &AA);
+LLVM_ABI bool IsPotentialRetainableObjPtr(const Value *Op, AAResults &AA);
 
 /// Helper for GetARCInstKind. Determines what kind of construct CS
 /// is.

--- a/llvm/include/llvm/Analysis/ObjCARCInstKind.h
+++ b/llvm/include/llvm/Analysis/ObjCARCInstKind.h
@@ -53,48 +53,48 @@ enum class ARCInstKind {
   None                      ///< anything that is inert from an ARC perspective.
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const ARCInstKind Class);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const ARCInstKind Class);
 
 /// Test if the given class is a kind of user.
-bool IsUser(ARCInstKind Class);
+LLVM_ABI bool IsUser(ARCInstKind Class);
 
 /// Test if the given class is objc_retain or equivalent.
-bool IsRetain(ARCInstKind Class);
+LLVM_ABI bool IsRetain(ARCInstKind Class);
 
 /// Test if the given class is objc_autorelease or equivalent.
-bool IsAutorelease(ARCInstKind Class);
+LLVM_ABI bool IsAutorelease(ARCInstKind Class);
 
 /// Test if the given class represents instructions which return their
 /// argument verbatim.
-bool IsForwarding(ARCInstKind Class);
+LLVM_ABI bool IsForwarding(ARCInstKind Class);
 
 /// Test if the given class represents instructions which do nothing if
 /// passed a null pointer.
-bool IsNoopOnNull(ARCInstKind Class);
+LLVM_ABI bool IsNoopOnNull(ARCInstKind Class);
 
 /// Test if the given class represents instructions which do nothing if
 /// passed a global variable.
-bool IsNoopOnGlobal(ARCInstKind Class);
+LLVM_ABI bool IsNoopOnGlobal(ARCInstKind Class);
 
 /// Test if the given class represents instructions which are always safe
 /// to mark with the "tail" keyword.
-bool IsAlwaysTail(ARCInstKind Class);
+LLVM_ABI bool IsAlwaysTail(ARCInstKind Class);
 
 /// Test if the given class represents instructions which are never safe
 /// to mark with the "tail" keyword.
-bool IsNeverTail(ARCInstKind Class);
+LLVM_ABI bool IsNeverTail(ARCInstKind Class);
 
 /// Test if the given class represents instructions which are always safe
 /// to mark with the nounwind attribute.
-bool IsNoThrow(ARCInstKind Class);
+LLVM_ABI bool IsNoThrow(ARCInstKind Class);
 
 /// Test whether the given instruction can autorelease any pointer or cause an
 /// autoreleasepool pop.
-bool CanInterruptRV(ARCInstKind Class);
+LLVM_ABI bool CanInterruptRV(ARCInstKind Class);
 
 /// Determine if F is one of the special known Functions.  If it isn't,
 /// return ARCInstKind::CallOrUser.
-ARCInstKind GetFunctionClass(const Function *F);
+LLVM_ABI ARCInstKind GetFunctionClass(const Function *F);
 
 /// Determine which objc runtime call instruction class V belongs to.
 ///
@@ -114,11 +114,11 @@ inline ARCInstKind GetBasicARCInstKind(const Value *V) {
 }
 
 /// Map V to its ARCInstKind equivalence class.
-ARCInstKind GetARCInstKind(const Value *V);
+LLVM_ABI ARCInstKind GetARCInstKind(const Value *V);
 
 /// Returns false if conservatively we can prove that any instruction mapped to
 /// this kind can not decrement ref counts. Returns true otherwise.
-bool CanDecrementRefCount(ARCInstKind Kind);
+LLVM_ABI bool CanDecrementRefCount(ARCInstKind Kind);
 
 } // end namespace objcarc
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/OverflowInstAnalysis.h
+++ b/llvm/include/llvm/Analysis/OverflowInstAnalysis.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_ANALYSIS_OVERFLOWINSTANALYSIS_H
 #define LLVM_ANALYSIS_OVERFLOWINSTANALYSIS_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Use;
 class Value;
@@ -35,9 +37,10 @@ class Value;
 /// If Op0 and Op1 match one of the patterns above, return true and fill Y's
 /// use.
 
-bool isCheckForZeroAndMulWithOverflow(Value *Op0, Value *Op1, bool IsAnd,
-                                      Use *&Y);
-bool isCheckForZeroAndMulWithOverflow(Value *Op0, Value *Op1, bool IsAnd);
+LLVM_ABI bool isCheckForZeroAndMulWithOverflow(Value *Op0, Value *Op1,
+                                               bool IsAnd, Use *&Y);
+LLVM_ABI bool isCheckForZeroAndMulWithOverflow(Value *Op0, Value *Op1,
+                                               bool IsAnd);
 } // end namespace llvm
 
 #endif

--- a/llvm/include/llvm/Analysis/PtrUseVisitor.h
+++ b/llvm/include/llvm/Analysis/PtrUseVisitor.h
@@ -168,13 +168,13 @@ protected:
   ///
   /// This will visit the users with the same offset of the current visit
   /// (including an unknown offset if that is the current state).
-  void enqueueUsers(Value &I);
+  LLVM_ABI void enqueueUsers(Value &I);
 
   /// Walk the operands of a GEP and adjust the offset as appropriate.
   ///
   /// This routine does the heavy lifting of the pointer walk by computing
   /// offsets and looking through GEPs.
-  bool adjustOffsetForGEP(GetElementPtrInst &GEPI);
+  LLVM_ABI bool adjustOffsetForGEP(GetElementPtrInst &GEPI);
 };
 
 } // end namespace detail

--- a/llvm/include/llvm/Analysis/RegionInfo.h
+++ b/llvm/include/llvm/Analysis/RegionInfo.h
@@ -985,7 +985,7 @@ class RegionInfoPrinterPass
 public:
   LLVM_ABI explicit RegionInfoPrinterPass(raw_ostream &OS);
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Verifier pass for the \c RegionInfo.

--- a/llvm/include/llvm/Analysis/RegionInfo.h
+++ b/llvm/include/llvm/Analysis/RegionInfo.h
@@ -886,16 +886,20 @@ public:
 
 class Region : public RegionBase<RegionTraits<Function>> {
 public:
-  Region(BasicBlock *Entry, BasicBlock *Exit, RegionInfo *RI, DominatorTree *DT,
-         Region *Parent = nullptr);
-  ~Region();
+  LLVM_ABI Region(BasicBlock *Entry, BasicBlock *Exit, RegionInfo *RI,
+                  DominatorTree *DT, Region *Parent = nullptr);
+  LLVM_ABI ~Region();
 
   bool operator==(const RegionNode &RN) const {
     return &RN == reinterpret_cast<const RegionNode *>(this);
   }
 };
 
-class RegionInfo : public RegionInfoBase<RegionTraits<Function>> {
+extern template class LLVM_TEMPLATE_ABI RegionBase<RegionTraits<Function>>;
+extern template class LLVM_TEMPLATE_ABI RegionNodeBase<RegionTraits<Function>>;
+extern template class LLVM_TEMPLATE_ABI RegionInfoBase<RegionTraits<Function>>;
+
+class LLVM_ABI RegionInfo : public RegionInfoBase<RegionTraits<Function>> {
 public:
   using Base = RegionInfoBase<RegionTraits<Function>>;
 
@@ -937,7 +941,7 @@ public:
 #endif
 };
 
-class RegionInfoPass : public FunctionPass {
+class LLVM_ABI RegionInfoPass : public FunctionPass {
   RegionInfo RI;
 
 public:
@@ -970,7 +974,7 @@ class RegionInfoAnalysis : public AnalysisInfoMixin<RegionInfoAnalysis> {
 public:
   using Result = RegionInfo;
 
-  RegionInfo run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI RegionInfo run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Printer pass for the \c RegionInfo.
@@ -979,14 +983,14 @@ class RegionInfoPrinterPass
   raw_ostream &OS;
 
 public:
-  explicit RegionInfoPrinterPass(raw_ostream &OS);
+  LLVM_ABI explicit RegionInfoPrinterPass(raw_ostream &OS);
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Verifier pass for the \c RegionInfo.
 struct RegionInfoVerifierPass : RequiredPassInfoMixin<RegionInfoVerifierPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 template <>
@@ -1017,10 +1021,6 @@ inline raw_ostream &operator<<(raw_ostream &OS,
   else
     return OS << Node.template getNodeAs<BlockT>()->getName();
 }
-
-extern template class RegionBase<RegionTraits<Function>>;
-extern template class RegionNodeBase<RegionTraits<Function>>;
-extern template class RegionInfoBase<RegionTraits<Function>>;
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Analysis/ReplayInlineAdvisor.h
+++ b/llvm/include/llvm/Analysis/ReplayInlineAdvisor.h
@@ -50,9 +50,10 @@ struct ReplayInlinerSettings {
 };
 
 /// Get call site location as a string with the given format
-std::string formatCallSiteLocation(DebugLoc DLoc, const CallSiteFormat &Format);
+LLVM_ABI std::string formatCallSiteLocation(DebugLoc DLoc,
+                                            const CallSiteFormat &Format);
 
-std::unique_ptr<InlineAdvisor>
+LLVM_ABI std::unique_ptr<InlineAdvisor>
 getReplayInlineAdvisor(Module &M, FunctionAnalysisManager &FAM,
                        LLVMContext &Context,
                        std::unique_ptr<InlineAdvisor> OriginalAdvisor,
@@ -61,7 +62,7 @@ getReplayInlineAdvisor(Module &M, FunctionAnalysisManager &FAM,
 
 /// Replay inline advisor that uses optimization remarks from inlining of
 /// previous build to guide current inlining. This is useful for inliner tuning.
-class ReplayInlineAdvisor : public InlineAdvisor {
+class LLVM_ABI ReplayInlineAdvisor : public InlineAdvisor {
 public:
   ReplayInlineAdvisor(Module &M, FunctionAnalysisManager &FAM,
                       LLVMContext &Context,

--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -336,7 +336,7 @@ public:
   LLVM_ABI void computeAndSetCanonical(ScalarEvolution &SE);
 
   /// Return the canonical SCEV.
-  LLVM_ABI const SCEV *getCanonical() const {
+  const SCEV *getCanonical() const {
     assert(CanonicalSCEV && "canonical SCEV not yet computed");
     return CanonicalSCEV;
   }

--- a/llvm/include/llvm/Analysis/ScalarEvolutionDivision.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolutionDivision.h
@@ -40,9 +40,9 @@ public:
   /// * Division of constants is performed as signed.
   /// * The multiplication of Quotient and Denominator may wrap.
   /// * The addition of Quotient*Denominator and Remainder may wrap.
-  static void divide(ScalarEvolution &SE, const SCEV *Numerator,
-                     const SCEV *Denominator, const SCEV **Quotient,
-                     const SCEV **Remainder);
+  LLVM_ABI static void divide(ScalarEvolution &SE, const SCEV *Numerator,
+                              const SCEV *Denominator, const SCEV **Quotient,
+                              const SCEV **Remainder);
 
   // Except in the trivial case described above, we do not know how to divide
   // Expr by Denominator for the following functions with empty implementation.
@@ -60,15 +60,15 @@ public:
   void visitUnknown(const SCEVUnknown *Numerator) {}
   void visitCouldNotCompute(const SCEVCouldNotCompute *Numerator) {}
 
-  void visitConstant(const SCEVConstant *Numerator);
+  LLVM_ABI void visitConstant(const SCEVConstant *Numerator);
 
-  void visitVScale(const SCEVVScale *Numerator);
+  LLVM_ABI void visitVScale(const SCEVVScale *Numerator);
 
-  void visitAddRecExpr(const SCEVAddRecExpr *Numerator);
+  LLVM_ABI void visitAddRecExpr(const SCEVAddRecExpr *Numerator);
 
-  void visitAddExpr(const SCEVAddExpr *Numerator);
+  LLVM_ABI void visitAddExpr(const SCEVAddExpr *Numerator);
 
-  void visitMulExpr(const SCEVMulExpr *Numerator);
+  LLVM_ABI void visitMulExpr(const SCEVMulExpr *Numerator);
 
 private:
   SCEVDivision(ScalarEvolution &S, const SCEV *Numerator,
@@ -89,7 +89,7 @@ class SCEVDivisionPrinterPass
 
 public:
   explicit SCEVDivisionPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/StackLifetime.h
+++ b/llvm/include/llvm/Analysis/StackLifetime.h
@@ -130,10 +130,11 @@ private:
   void calculateLiveIntervals();
 
 public:
-  StackLifetime(const Function &F, ArrayRef<const AllocaInst *> Allocas,
-                LivenessType Type);
+  LLVM_ABI StackLifetime(const Function &F,
+                         ArrayRef<const AllocaInst *> Allocas,
+                         LivenessType Type);
 
-  void run();
+  LLVM_ABI void run();
 
   iterator_range<
       filter_iterator<ArrayRef<const IntrinsicInst *>::const_iterator,
@@ -147,13 +148,13 @@ public:
   /// Returns a set of "interesting" instructions where the given alloca is
   /// live. Not all instructions in a function are interesting: we pick a set
   /// that is large enough for LiveRange::Overlaps to be correct.
-  const LiveRange &getLiveRange(const AllocaInst *AI) const;
+  LLVM_ABI const LiveRange &getLiveRange(const AllocaInst *AI) const;
 
   /// Returns true if instruction is reachable from entry.
-  bool isReachable(const Instruction *I) const;
+  LLVM_ABI bool isReachable(const Instruction *I) const;
 
   /// Returns true if the alloca is alive after the instruction.
-  bool isAliveAfter(const AllocaInst *AI, const Instruction *I) const;
+  LLVM_ABI bool isAliveAfter(const AllocaInst *AI, const Instruction *I) const;
 
   /// Returns a live range that represents an alloca that is live throughout the
   /// entire function.
@@ -161,7 +162,7 @@ public:
     return LiveRange(Instructions.size(), true);
   }
 
-  void print(raw_ostream &O);
+  LLVM_ABI void print(raw_ostream &O);
 };
 
 static inline raw_ostream &operator<<(raw_ostream &OS, const BitVector &V) {
@@ -187,10 +188,11 @@ class StackLifetimePrinterPass
 public:
   StackLifetimePrinterPass(raw_ostream &OS, StackLifetime::LivenessType Type)
       : Type(Type), OS(OS) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
+++ b/llvm/include/llvm/Analysis/StackSafetyAnalysis.h
@@ -33,16 +33,17 @@ private:
   mutable std::unique_ptr<InfoTy> Info;
 
 public:
-  StackSafetyInfo();
-  StackSafetyInfo(Function *F, std::function<ScalarEvolution &()> GetSE);
-  StackSafetyInfo(StackSafetyInfo &&);
-  StackSafetyInfo &operator=(StackSafetyInfo &&);
-  ~StackSafetyInfo();
+  LLVM_ABI StackSafetyInfo();
+  LLVM_ABI StackSafetyInfo(Function *F,
+                           std::function<ScalarEvolution &()> GetSE);
+  LLVM_ABI StackSafetyInfo(StackSafetyInfo &&);
+  LLVM_ABI StackSafetyInfo &operator=(StackSafetyInfo &&);
+  LLVM_ABI ~StackSafetyInfo();
 
-  const InfoTy &getInfo() const;
+  LLVM_ABI const InfoTy &getInfo() const;
 
   // TODO: Add useful for client methods.
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 
   /// Parameters use for a FunctionSummary.
   /// Function collects access information of all pointer parameters.
@@ -51,7 +52,7 @@ public:
   /// StackSafety assumes that missing parameter information means possibility
   /// of access to the parameter with any offset, so we can correctly link
   /// code without StackSafety information, e.g. non-ThinLTO.
-  std::vector<FunctionSummary::ParamAccess>
+  LLVM_ABI std::vector<FunctionSummary::ParamAccess>
   getParamAccesses(ModuleSummaryIndex &Index) const;
 };
 
@@ -67,25 +68,25 @@ private:
   const InfoTy &getInfo() const;
 
 public:
-  StackSafetyGlobalInfo();
-  StackSafetyGlobalInfo(
+  LLVM_ABI StackSafetyGlobalInfo();
+  LLVM_ABI StackSafetyGlobalInfo(
       Module *M, std::function<const StackSafetyInfo &(Function &F)> GetSSI,
       const ModuleSummaryIndex *Index);
-  StackSafetyGlobalInfo(StackSafetyGlobalInfo &&);
-  StackSafetyGlobalInfo &operator=(StackSafetyGlobalInfo &&);
-  ~StackSafetyGlobalInfo();
+  LLVM_ABI StackSafetyGlobalInfo(StackSafetyGlobalInfo &&);
+  LLVM_ABI StackSafetyGlobalInfo &operator=(StackSafetyGlobalInfo &&);
+  LLVM_ABI ~StackSafetyGlobalInfo();
 
   // Whether we can prove that all accesses to this Alloca are in-range and
   // during its lifetime.
-  bool isSafe(const AllocaInst &AI) const;
+  LLVM_ABI bool isSafe(const AllocaInst &AI) const;
 
   // Returns true if the instruction can be proven to do only two types of
   // memory accesses:
   //  (1) live stack locations in-bounds or
   //  (2) non-stack locations.
-  bool stackAccessIsSafe(const Instruction &I) const;
-  void print(raw_ostream &O) const;
-  void dump() const;
+  LLVM_ABI bool stackAccessIsSafe(const Instruction &I) const;
+  LLVM_ABI void print(raw_ostream &O) const;
+  LLVM_ABI void dump() const;
 };
 
 /// StackSafetyInfo wrapper for the new pass manager.
@@ -95,7 +96,7 @@ class StackSafetyAnalysis : public AnalysisInfoMixin<StackSafetyAnalysis> {
 
 public:
   using Result = StackSafetyInfo;
-  StackSafetyInfo run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI StackSafetyInfo run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Printer pass for the \c StackSafetyAnalysis results.
@@ -105,11 +106,11 @@ class StackSafetyPrinterPass
 
 public:
   explicit StackSafetyPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// StackSafetyInfo wrapper for the legacy pass manager
-class StackSafetyInfoWrapperPass : public FunctionPass {
+class LLVM_ABI StackSafetyInfoWrapperPass : public FunctionPass {
   StackSafetyInfo SSI;
 
 public:
@@ -133,7 +134,7 @@ class StackSafetyGlobalAnalysis
 
 public:
   using Result = StackSafetyGlobalInfo;
-  Result run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI Result run(Module &M, ModuleAnalysisManager &AM);
 };
 
 /// Printer pass for the \c StackSafetyGlobalAnalysis results.
@@ -143,12 +144,12 @@ class StackSafetyGlobalPrinterPass
 
 public:
   explicit StackSafetyGlobalPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 /// This pass performs the global (interprocedural) stack safety analysis
 /// (legacy pass manager).
-class StackSafetyGlobalInfoWrapperPass : public ModulePass {
+class LLVM_ABI StackSafetyGlobalInfoWrapperPass : public ModulePass {
   StackSafetyGlobalInfo SSGI;
 
 public:
@@ -165,9 +166,9 @@ public:
   bool runOnModule(Module &M) override;
 };
 
-bool needsParamAccessSummary(const Module &M);
+LLVM_ABI bool needsParamAccessSummary(const Module &M);
 
-void generateParamAccessSummary(ModuleSummaryIndex &Index);
+LLVM_ABI void generateParamAccessSummary(ModuleSummaryIndex &Index);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
+++ b/llvm/include/llvm/Analysis/StaticDataProfileInfo.h
@@ -21,11 +21,11 @@ enum class AnnotationKind : uint8_t {
   ReservedName,
 };
 /// Returns the annotation kind of the global variable \p GV.
-AnnotationKind getAnnotationKind(const GlobalVariable &GV);
+LLVM_ABI AnnotationKind getAnnotationKind(const GlobalVariable &GV);
 
 /// Returns true if the annotation kind of the global variable \p GV is
 /// AnnotationOK.
-bool IsAnnotationOK(const GlobalVariable &GV);
+LLVM_ABI bool IsAnnotationOK(const GlobalVariable &GV);
 } // namespace memprof
 
 /// A class that holds the constants that represent static data and their

--- a/llvm/include/llvm/Analysis/StructuralHash.h
+++ b/llvm/include/llvm/Analysis/StructuralHash.h
@@ -30,7 +30,7 @@ public:
                                      StructuralHashOptions Options)
       : OS(OS), Options(Options) {}
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -150,22 +150,19 @@ class MemIntrinsicCostAttributes {
   Align Alignment;
 
 public:
-  LLVM_ABI MemIntrinsicCostAttributes(Intrinsic::ID Id, Type *DataTy,
-                                      const Value *Ptr, bool VariableMask,
-                                      Align Alignment,
-                                      const Instruction *I = nullptr)
+  MemIntrinsicCostAttributes(Intrinsic::ID Id, Type *DataTy, const Value *Ptr,
+                             bool VariableMask, Align Alignment,
+                             const Instruction *I = nullptr)
       : I(I), Ptr(Ptr), DataTy(DataTy), IID(Id), VariableMask(VariableMask),
         Alignment(Alignment) {}
 
-  LLVM_ABI MemIntrinsicCostAttributes(Intrinsic::ID Id, Type *DataTy,
-                                      Align Alignment,
-                                      unsigned AddressSpace = 0)
+  MemIntrinsicCostAttributes(Intrinsic::ID Id, Type *DataTy, Align Alignment,
+                             unsigned AddressSpace = 0)
       : DataTy(DataTy), IID(Id), AddressSpace(AddressSpace),
         Alignment(Alignment) {}
 
-  LLVM_ABI MemIntrinsicCostAttributes(Intrinsic::ID Id, Type *DataTy,
-                                      bool VariableMask, Align Alignment,
-                                      const Instruction *I = nullptr)
+  MemIntrinsicCostAttributes(Intrinsic::ID Id, Type *DataTy, bool VariableMask,
+                             Align Alignment, const Instruction *I = nullptr)
       : I(I), DataTy(DataTy), IID(Id), VariableMask(VariableMask),
         Alignment(Alignment) {}
 
@@ -1071,7 +1068,8 @@ public:
   };
 
   /// Calculates a VectorInstrContext from \p I.
-  static VectorInstrContext getVectorInstrContextHint(const Instruction *I);
+  LLVM_ABI static VectorInstrContext
+  getVectorInstrContextHint(const Instruction *I);
 
   /// Estimate the overhead of scalarizing an instruction. Insert and Extract
   /// are set if the demanded result elements need to be inserted and/or

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -32,7 +32,7 @@ class Function;
 
 /// Base class for use as a mix-in that aids implementing
 /// a TargetTransformInfo-compatible class.
-class TargetTransformInfoImplBase {
+class LLVM_ABI TargetTransformInfoImplBase {
 
 protected:
   typedef TargetTransformInfo TTI;

--- a/llvm/include/llvm/Analysis/Trace.h
+++ b/llvm/include/llvm/Analysis/Trace.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_ANALYSIS_TRACE_H
 #define LLVM_ANALYSIS_TRACE_H
 
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <vector>
 
@@ -47,11 +48,11 @@ public:
   BasicBlock *getBlock(unsigned i)   const { return BasicBlocks[i]; }
 
   /// getFunction - Return this trace's parent function.
-  Function *getFunction () const;
+  LLVM_ABI Function *getFunction() const;
 
   /// getModule - Return this Module that contains this trace's parent
   /// function.
-  Module *getModule () const;
+  LLVM_ABI Module *getModule() const;
 
   /// getBlockIndex - Return the index of the specified basic block in the
   /// trace, or -1 if it is not in the trace.
@@ -99,11 +100,11 @@ public:
   iterator erase(iterator q1, iterator q2) { return BasicBlocks.erase (q1, q2); }
 
   /// print - Write trace to output stream.
-  void print(raw_ostream &O) const;
+  LLVM_ABI void print(raw_ostream &O) const;
 
   /// dump - Debugger convenience method; writes trace to standard error
   /// output stream.
-  void dump() const;
+  LLVM_ABI void dump() const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Analysis/TypeMetadataUtils.h
+++ b/llvm/include/llvm/Analysis/TypeMetadataUtils.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ANALYSIS_TYPEMETADATAUTILS_H
 #define LLVM_ANALYSIS_TYPEMETADATAUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <utility>
 
@@ -46,14 +47,14 @@ struct DevirtCallSite {
 
 /// Given a call to the intrinsic \@llvm.type.test, find all devirtualizable
 /// call sites based on the call and return them in DevirtCalls.
-void findDevirtualizableCallsForTypeTest(
+LLVM_ABI void findDevirtualizableCallsForTypeTest(
     SmallVectorImpl<DevirtCallSite> &DevirtCalls,
     SmallVectorImpl<CallInst *> &Assumes, const CallInst *CI,
     DominatorTree &DT);
 
 /// Given a call to the intrinsic \@llvm.type.checked.load, find all
 /// devirtualizable call sites based on the call and return them in DevirtCalls.
-void findDevirtualizableCallsForTypeCheckedLoad(
+LLVM_ABI void findDevirtualizableCallsForTypeCheckedLoad(
     SmallVectorImpl<DevirtCallSite> &DevirtCalls,
     SmallVectorImpl<Instruction *> &LoadedPtrs,
     SmallVectorImpl<Instruction *> &Preds, bool &HasNonCallUses,
@@ -76,19 +77,19 @@ void findDevirtualizableCallsForTypeCheckedLoad(
 /// }
 ///
 /// For such (sub-)expressions, getPointerAtOffset returns the @target pointer.
-Constant *getPointerAtOffset(Constant *I, uint64_t Offset, Module &M,
-                             Constant *TopLevelGlobal = nullptr);
+LLVM_ABI Constant *getPointerAtOffset(Constant *I, uint64_t Offset, Module &M,
+                                      Constant *TopLevelGlobal = nullptr);
 
 /// Given a vtable and a specified offset, returns the function and the trivial
 /// pointer at the specified offset in pair iff the pointer at the specified
 /// offset is a function or an alias to a function. Returns a pair of nullptr
 /// otherwise.
-std::pair<Function *, Constant *>
+LLVM_ABI std::pair<Function *, Constant *>
 getFunctionAtVTableOffset(GlobalVariable *GV, uint64_t Offset, Module &M);
 
 /// Finds the same "relative pointer" pattern as described above, where the
 /// target is `C`, and replaces the entire pattern with a constant zero.
-void replaceRelativePointerUsersWithZero(Constant *C);
+LLVM_ABI void replaceRelativePointerUsersWithZero(Constant *C);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Analysis/UniformityAnalysis.h
+++ b/llvm/include/llvm/Analysis/UniformityAnalysis.h
@@ -35,7 +35,7 @@ public:
   using Result = UniformityInfo;
 
   /// Run the analysis pass over a function and produce a dominator tree.
-  UniformityInfo run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI UniformityInfo run(Function &F, FunctionAnalysisManager &);
 
   // TODO: verify analysis
 };
@@ -46,13 +46,13 @@ class UniformityInfoPrinterPass
   raw_ostream &OS;
 
 public:
-  explicit UniformityInfoPrinterPass(raw_ostream &OS);
+  LLVM_ABI explicit UniformityInfoPrinterPass(raw_ostream &OS);
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 /// Legacy analysis pass which computes a \ref CycleInfo.
-class UniformityInfoWrapperPass : public FunctionPass {
+class LLVM_ABI UniformityInfoWrapperPass : public FunctionPass {
   Function *Fn = nullptr;
   UniformityInfo UI;
 

--- a/llvm/include/llvm/Analysis/ValueLatticeUtils.h
+++ b/llvm/include/llvm/Analysis/ValueLatticeUtils.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_ANALYSIS_VALUELATTICEUTILS_H
 #define LLVM_ANALYSIS_VALUELATTICEUTILS_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class Function;
@@ -22,18 +24,18 @@ class GlobalVariable;
 /// Determine if the values of the given function's arguments can be tracked
 /// interprocedurally. The value of an argument can be tracked if the function
 /// has local linkage and its address is not taken.
-bool canTrackArgumentsInterprocedurally(Function *F);
+LLVM_ABI bool canTrackArgumentsInterprocedurally(Function *F);
 
 /// Determine if the values of the given function's returns can be tracked
 /// interprocedurally. Return values can be tracked if the function has an
 /// exact definition and it doesn't have the "naked" attribute. Naked functions
 /// may contain assembly code that returns untrackable values.
-bool canTrackReturnsInterprocedurally(Function *F);
+LLVM_ABI bool canTrackReturnsInterprocedurally(Function *F);
 
 /// Determine if the value maintained in the given global variable can be
 /// tracked interprocedurally. A value can be tracked if the global variable
 /// has local linkage and is only used by non-volatile loads and stores.
-bool canTrackGlobalVariableInterprocedurally(GlobalVariable *GV);
+LLVM_ABI bool canTrackGlobalVariableInterprocedurally(GlobalVariable *GV);
 
 } // end namespace llvm
 

--- a/llvm/lib/Analysis/DominanceFrontier.cpp
+++ b/llvm/lib/Analysis/DominanceFrontier.cpp
@@ -21,8 +21,8 @@ using namespace llvm;
 
 namespace llvm {
 
-template class DominanceFrontierBase<BasicBlock, false>;
-template class DominanceFrontierBase<BasicBlock, true>;
+template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, false>;
+template class LLVM_TEMPLATE_ABI DominanceFrontierBase<BasicBlock, true>;
 
 } // end namespace llvm
 

--- a/llvm/lib/Analysis/RegionInfo.cpp
+++ b/llvm/lib/Analysis/RegionInfo.cpp
@@ -28,9 +28,9 @@ using namespace llvm;
 
 namespace llvm {
 
-template class RegionBase<RegionTraits<Function>>;
-template class RegionNodeBase<RegionTraits<Function>>;
-template class RegionInfoBase<RegionTraits<Function>>;
+template class LLVM_TEMPLATE_ABI RegionBase<RegionTraits<Function>>;
+template class LLVM_TEMPLATE_ABI RegionNodeBase<RegionTraits<Function>>;
+template class LLVM_TEMPLATE_ABI RegionInfoBase<RegionTraits<Function>>;
 
 } // end namespace llvm
 


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the Analysis headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.