### PR TITLE
[CI] Pass script args using env var in merged PRs workflow

### DIFF
--- a/.github/workflows/merged-prs.yml
+++ b/.github/workflows/merged-prs.yml
@@ -40,7 +40,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           python3 ./github-automation.py \
-            --token "$GITHUB_TOKEN" \
+            --token "$GH_TOKEN" \
             pr-buildbot-information \
             --issue-number "$ISSUE_NUMBER" \
             --author "$PR_AUTHOR"

--- a/.github/workflows/merged-prs.yml
+++ b/.github/workflows/merged-prs.yml
@@ -34,9 +34,13 @@ jobs:
 
       - name: Add Buildbot information comment
         working-directory: ./llvm/utils/git/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           python3 ./github-automation.py \
-            --token '${{ secrets.GITHUB_TOKEN }}' \
+            --token "$GITHUB_TOKEN" \
             pr-buildbot-information \
-            --issue-number "${{ github.event.pull_request.number }}" \
-            --author "${{ github.event.pull_request.user.login }}"
+            --issue-number "$ISSUE_NUMBER" \
+            --author "$PR_AUTHOR"


### PR DESCRIPTION
As was done in #198160, address the problem described in
https://docs.github.com/en/actions/concepts/security/script-injections using the solution recommended by
https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable.

Not all these inputs are untrusted, but I've applied it to all of them just to be consistent.