### PR TITLE
[CI] Remove unused env var from commit-access-greeter

### DIFF
--- a/.github/workflows/commit-access-greeter.yml
+++ b/.github/workflows/commit-access-greeter.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Add comments to issue
         working-directory: ./llvm/utils/git/
         env:
-          LABEL_NAME: ${{ github.event.label.name }}
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |


### PR DESCRIPTION
LABEL_NAME has been there since the workflow's introduction in f8ef2699d860aea97750953f1b79db8ef7574e82, but has never been used.