### PR TITLE
[CI] Pass label name to script using env var in pr-subscriber workflow

### DIFF
--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -42,10 +42,11 @@ jobs:
       - name: Update watchers
         working-directory: ./llvm/utils/git/
         env:
+          LABEL_NAME: ${{ github.event.label.name }}
           PR_SUBSCRIBER_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           python3 ./github-automation.py \
             --token "$PR_SUBSCRIBER_TOKEN" \
             pr-subscriber \
             --issue-number "${{ github.event.number }}" \
-            --label-name "${{ github.event.label.name }}"
+            --label-name "$LABEL_NAME"


### PR DESCRIPTION
As is done in issue-subscriber.yml already.

This addresses the problem described in
https://docs.github.com/en/actions/concepts/security/script-injections using the solution recommended by
https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable.