### PR TITLE
[NFC][mlir][bufferization] Remove getMemRefType() helper

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
+++ b/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h
@@ -660,23 +660,6 @@ OpTy replaceOpWithNewBufferizedOp(RewriterBase &rewriter, Operation *op,
   return newOp;
 }
 
-/// Return a MemRefType to which the TensorType can be bufferized.
-///
-/// If possible, op bufferization implementations should not use this function
-/// and instead infer precise memref types for tensor results by themselves.
-///
-/// Unless a layout map was specified, `options.unknownTypeConverterFn`
-/// determines what kind of layout map will be used. For best composability
-/// (without copies), the fully dynamic layout map is used by default.
-///
-/// Note: Canonicalization patterns could clean up layout maps and infer more
-/// precise layout maps after bufferization. However, many possible
-/// canonicalizations are currently not implemented.
-BaseMemRefType getMemRefType(TensorType tensorType,
-                             const BufferizationOptions &options,
-                             MemRefLayoutAttrInterface layout = {},
-                             Attribute memorySpace = nullptr);
-
 /// Return a MemRef type with fully dynamic layout. If the given tensor type
 /// is unranked, return an unranked MemRef type.
 BaseMemRefType

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizableOpInterface.cpp
@@ -812,29 +812,6 @@ LogicalResult BufferizationOptions::createMemCpy(OpBuilder &b, Location loc,
 // Bufferization-specific IRMapping support with debugging.
 //===----------------------------------------------------------------------===//
 
-BaseMemRefType bufferization::getMemRefType(TensorType tensorType,
-                                            const BufferizationOptions &options,
-                                            MemRefLayoutAttrInterface layout,
-                                            Attribute memorySpace) {
-  // Case 1: Unranked memref type.
-  if (auto unrankedTensorType =
-          llvm::dyn_cast<UnrankedTensorType>(tensorType)) {
-    assert(!layout && "UnrankedTensorType cannot have a layout map");
-    return UnrankedMemRefType::get(unrankedTensorType.getElementType(),
-                                   memorySpace);
-  }
-
-  // Case 2: Ranked memref type with specified layout.
-  auto rankedTensorType = llvm::cast<RankedTensorType>(tensorType);
-  if (layout) {
-    return MemRefType::get(rankedTensorType.getShape(),
-                           rankedTensorType.getElementType(), layout,
-                           memorySpace);
-  }
-
-  return options.unknownTypeConverterFn(tensorType, memorySpace, options);
-}
-
 BaseMemRefType
 bufferization::getMemRefTypeWithFullyDynamicLayout(TensorType tensorType,
                                                    Attribute memorySpace) {
@@ -980,8 +957,8 @@ FailureOr<BufferLikeType> bufferization::detail::defaultGetBufferType(
 
   // No further analysis is possible for a block argument.
   if (llvm::isa<BlockArgument>(value)) {
-    return cast<BufferLikeType>(
-        bufferization::getMemRefType(tensorType, options));
+    return cast<BufferLikeType>(options.unknownTypeConverterFn(
+        tensorType, /*memorySpace=*/nullptr, options));
   }
 
   // Value is an OpResult.
@@ -1006,7 +983,7 @@ FailureOr<BufferLikeType> bufferization::detail::defaultGetBufferType(
     return op->emitError("could not infer memory space");
 
   return cast<BufferLikeType>(
-      getMemRefType(tensorType, options, /*layout=*/{}, *memSpace));
+      options.unknownTypeConverterFn(tensorType, *memSpace, options));
 }
 
 bool bufferization::detail::defaultIsRepetitiveRegion(

--- a/mlir/lib/Dialect/Bufferization/IR/BufferizationDialect.cpp
+++ b/mlir/lib/Dialect/Bufferization/IR/BufferizationDialect.cpp
@@ -48,7 +48,7 @@ struct BuiltinTensorExternalModel
       return emitError() << "could not infer memory space";
 
     return cast<BufferLikeType>(
-        getMemRefType(tensorType, options, /*layout=*/{}, *memSpace));
+        options.unknownTypeConverterFn(tensorType, *memSpace, options));
   }
 
   mlir::LogicalResult verifyCompatibleBufferType(


### PR DESCRIPTION
Replace getMemRefType() helper with a direct usage of options.unknownTypeConverterFn() hook. This does not change any behaviour since all the existing call-sites would already implicitly call the hook. The major difference could have been in the handling of the memref layout but this does not seem to be properly handled anyhow.

As the `getMemRefType()` helper is removed, there are two cases to keep in mind for downstream users that need to adjust the code accordingly:
1. For creating memrefs without layouts, call `options.unknownTypeConverterFn` hook directly (the same way this patch is doing for upstream)
2. For creating memrefs with layouts (assuming, custom ones), please (re)implement the same helper. As only ranked memrefs can have a layout, a call to `mlir::MemRefType::get(shape, elementType, /*your custom layout=*/myLayout, memorySpace)` should be sufficient.