### PR TITLE
[NFC][lldb][windows] Replace typedef with using

### DIFF
--- a/lldb/source/Host/windows/PseudoConsole.cpp
+++ b/lldb/source/Host/windows/PseudoConsole.cpp
@@ -18,11 +18,11 @@
 
 using namespace lldb_private;
 
-typedef HRESULT(WINAPI *CreatePseudoConsole_t)(COORD size, HANDLE hInput,
-                                               HANDLE hOutput, DWORD dwFlags,
-                                               HPCON *phPC);
+using CreatePseudoConsole_t = HRESULT(WINAPI *)(COORD size, HANDLE hInput,
+                                                HANDLE hOutput, DWORD dwFlags,
+                                                HPCON *phPC);
 
-typedef VOID(WINAPI *ClosePseudoConsole_t)(HPCON hPC);
+using ClosePseudoConsole_t = VOID(WINAPI *)(HPCON hPC);
 
 static constexpr DWORD PSEUDOCONSOLE_INHERIT_CURSOR = 0x1;
 

--- a/lldb/source/Plugins/Process/Windows/Common/ForwardDecl.h
+++ b/lldb/source/Plugins/Process/Windows/Common/ForwardDecl.h
@@ -32,10 +32,10 @@ class IDebugDelegate;
 class DebuggerThread;
 class ExceptionRecord;
 
-typedef std::shared_ptr<IDebugDelegate> DebugDelegateSP;
-typedef std::shared_ptr<DebuggerThread> DebuggerThreadSP;
-typedef std::shared_ptr<ExceptionRecord> ExceptionRecordSP;
-typedef std::unique_ptr<ExceptionRecord> ExceptionRecordUP;
+using DebugDelegateSP = std::shared_ptr<IDebugDelegate>;
+using DebuggerThreadSP = std::shared_ptr<DebuggerThread>;
+using ExceptionRecordSP = std::shared_ptr<ExceptionRecord>;
+using ExceptionRecordUP = std::unique_ptr<ExceptionRecord>;
 }
 
 #endif

--- a/lldb/source/Plugins/Process/Windows/Common/LocalDebugDelegate.h
+++ b/lldb/source/Plugins/Process/Windows/Common/LocalDebugDelegate.h
@@ -18,7 +18,7 @@
 namespace lldb_private {
 
 class ProcessWindows;
-typedef std::shared_ptr<ProcessWindows> ProcessWindowsSP;
+using ProcessWindowsSP = std::shared_ptr<ProcessWindows>;
 
 // LocalDebugDelegate
 //

--- a/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeProcessWindows.h
@@ -22,7 +22,7 @@ class NativeProcessWindows;
 class NativeThreadWindows;
 class NativeDebugDelegate;
 
-typedef std::shared_ptr<NativeDebugDelegate> NativeDebugDelegateSP;
+using NativeDebugDelegateSP = std::shared_ptr<NativeDebugDelegate>;
 
 //------------------------------------------------------------------
 // NativeProcessWindows


### PR DESCRIPTION
Convert C-style typedefs in the Windows process plugin and Host runtime to C++11 `using`.