### PR TITLE
[NFC][lldb][windows] Default empty user-defined destructors

### DIFF
--- a/lldb/include/lldb/Host/windows/MainLoopWindows.h
+++ b/lldb/include/lldb/Host/windows/MainLoopWindows.h
@@ -36,7 +36,7 @@ public:
   class IOEvent {
   public:
     IOEvent(handle_t event) : m_event(event) {}
-    virtual ~IOEvent() {}
+    virtual ~IOEvent() = default;
     virtual void WillPoll() {}
     virtual void DidPoll() {}
     virtual void Disarm() {}

--- a/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
+++ b/lldb/source/Host/windows/ConnectionConPTYWindows.cpp
@@ -18,7 +18,7 @@ using namespace lldb_private;
 ConnectionConPTY::ConnectionConPTY(std::shared_ptr<PseudoConsole> pty)
     : ConnectionGenericFile(pty->GetSTDOUTHandle(), false), m_pty(pty) {}
 
-ConnectionConPTY::~ConnectionConPTY() {}
+ConnectionConPTY::~ConnectionConPTY() = default;
 
 lldb::ConnectionStatus ConnectionConPTY::Connect(llvm::StringRef s,
                                                  Status *error_ptr) {

--- a/lldb/source/Plugins/Process/Windows/Common/ExceptionRecord.h
+++ b/lldb/source/Plugins/Process/Windows/Common/ExceptionRecord.h
@@ -50,7 +50,7 @@ public:
         m_arguments(record.ExceptionInformation,
                     record.ExceptionInformation + record.NumberParameters) {}
 
-  virtual ~ExceptionRecord() {}
+  virtual ~ExceptionRecord() = default;
 
   DWORD
   GetExceptionCode() const { return m_code; }

--- a/lldb/source/Plugins/Process/Windows/Common/IDebugDelegate.h
+++ b/lldb/source/Plugins/Process/Windows/Common/IDebugDelegate.h
@@ -24,7 +24,7 @@ class HostThread;
 // notification of events that happen in a debugged process.
 class IDebugDelegate {
 public:
-  virtual ~IDebugDelegate() {}
+  virtual ~IDebugDelegate() = default;
 
   virtual void OnExitProcess(uint32_t exit_code) = 0;
   virtual void OnDebuggerConnected(lldb::addr_t image_base) = 0;

--- a/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.h
+++ b/lldb/source/Plugins/Process/Windows/Common/NativeThreadWindows.h
@@ -23,7 +23,7 @@ class NativeThreadWindows : public NativeThreadProtocol {
 public:
   NativeThreadWindows(NativeProcessWindows &process, const HostThread &thread);
 
-  ~NativeThreadWindows() {}
+  ~NativeThreadWindows() override = default;
 
   Status DoStop();
   Status DoResume(lldb::StateType resume_state);

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessDebugger.cpp
@@ -63,7 +63,7 @@ static bool IsPageExecutable(uint32_t protect) {
 
 namespace lldb_private {
 
-ProcessDebugger::~ProcessDebugger() {}
+ProcessDebugger::~ProcessDebugger() = default;
 
 lldb::pid_t ProcessDebugger::GetDebuggedProcessId() const {
   if (m_session_data)

--- a/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/ProcessWindows.cpp
@@ -126,7 +126,7 @@ ProcessWindows::ProcessWindows(lldb::TargetSP target_sp,
           RegisterContextWindows::GetNumHardwareBreakpointSlots(),
           LLDB_INVALID_BREAK_ID) {}
 
-ProcessWindows::~ProcessWindows() {}
+ProcessWindows::~ProcessWindows() = default;
 
 Status ProcessWindows::EnableBreakpointSite(BreakpointSite *bp_site) {
   if (bp_site->HardwareRequired())

--- a/lldb/source/Plugins/Process/Windows/Common/RegisterContextWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/RegisterContextWindows.cpp
@@ -30,7 +30,7 @@ RegisterContextWindows::RegisterContextWindows(Thread &thread,
     : RegisterContext(thread, concrete_frame_idx), m_context(),
       m_context_stale(true) {}
 
-RegisterContextWindows::~RegisterContextWindows() {}
+RegisterContextWindows::~RegisterContextWindows() = default;
 
 void RegisterContextWindows::InvalidateAllRegisters() {
   m_context_stale = true;

--- a/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/arm/RegisterContextWindows_arm.cpp
@@ -80,7 +80,7 @@ RegisterContextWindows_arm::RegisterContextWindows_arm(
     Thread &thread, uint32_t concrete_frame_idx)
     : RegisterContextWindows(thread, concrete_frame_idx) {}
 
-RegisterContextWindows_arm::~RegisterContextWindows_arm() {}
+RegisterContextWindows_arm::~RegisterContextWindows_arm() = default;
 
 size_t RegisterContextWindows_arm::GetRegisterCount() {
   return std::size(g_register_infos_arm);


### PR DESCRIPTION
Replace empty user-defined destructors with `= default`.