### PR TITLE
[AArch64][GlobalISel] Skip RegBankSelect pass at -O0

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/InstructionSelect.h
@@ -41,10 +41,11 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
   MachineFunctionProperties getRequiredProperties() const override {
-    return MachineFunctionProperties()
-        .setIsSSA()
-        .setLegalized()
-        .setRegBankSelected();
+    MachineFunctionProperties Properties;
+    Properties.setIsSSA().setLegalized();
+    if (RequireRegBankSelected)
+      Properties.setRegBankSelected();
+    return Properties;
   }
 
   MachineFunctionProperties getSetProperties() const override {
@@ -52,7 +53,7 @@ public:
   }
 
   InstructionSelect(CodeGenOptLevel OL = CodeGenOptLevel::Default,
-                    char &PassID = ID);
+                    bool RequireRegBankSelected = true, char &PassID = ID);
 
   bool runOnMachineFunction(MachineFunction &MF) override;
   bool selectMachineFunction(MachineFunction &MF);
@@ -67,6 +68,7 @@ protected:
   ProfileSummaryInfo *PSI = nullptr;
 
   CodeGenOptLevel OptLevel = CodeGenOptLevel::None;
+  bool RequireRegBankSelected = true;
 
   bool selectInstr(MachineInstr &MI);
 };

--- a/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/InstructionSelect.cpp
@@ -63,8 +63,10 @@ INITIALIZE_PASS_END(InstructionSelect, DEBUG_TYPE,
                     "Select target instructions out of generic instructions",
                     false, false)
 
-InstructionSelect::InstructionSelect(CodeGenOptLevel OL, char &PassID)
-    : MachineFunctionPass(PassID), OptLevel(OL) {}
+InstructionSelect::InstructionSelect(CodeGenOptLevel OL,
+                                     bool RequireRegBankSelected, char &PassID)
+    : MachineFunctionPass(PassID), OptLevel(OL),
+      RequireRegBankSelected(RequireRegBankSelected) {}
 
 /// This class observes instruction insertions/removals.
 /// InstructionSelect stores an iterator of the instruction prior to the one

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -118,6 +118,12 @@ static cl::opt<bool> EnableAtomicTidy(
              " to make use of cmpxchg flow-based information"),
     cl::init(true));
 
+static cl::opt<int> SkipRegBankSelectAtO(
+    "aarch64-skip-regbankselect-at-O", cl::Hidden,
+    cl::desc("Skip RegBankSelect at or below an opt level (-1 to disable) "
+             "and assign register banks during instruction selection"),
+    cl::init(0));
+
 static cl::opt<bool>
 EnableEarlyIfConversion("aarch64-enable-early-ifcvt", cl::Hidden,
                         cl::desc("Run early if-conversion"),
@@ -567,6 +573,8 @@ public:
     if (TM.getOptLevel() != CodeGenOptLevel::None)
       substitutePass(&PostRASchedulerID, &PostMachineSchedulerID);
     setEnableSinkAndFold(EnableSinkFold);
+    SkipRegBankSelect =
+        static_cast<int>(TM.getOptLevel()) <= SkipRegBankSelectAtO;
   }
 
   AArch64TargetMachine &getAArch64TargetMachine() const {
@@ -595,6 +603,9 @@ public:
   bool addRegAssignAndRewriteOptimized() override;
 
   std::unique_ptr<CSEConfigBase> getCSEConfig() const override;
+
+private:
+  bool SkipRegBankSelect = false;
 };
 
 } // end anonymous namespace
@@ -784,12 +795,14 @@ void AArch64PassConfig::addPreRegBankSelect() {
 }
 
 bool AArch64PassConfig::addRegBankSelect() {
-  addPass(new RegBankSelect());
+  if (!SkipRegBankSelect)
+    addPass(new RegBankSelect());
   return false;
 }
 
 bool AArch64PassConfig::addGlobalInstructionSelect() {
-  addPass(new InstructionSelect(getOptLevel()));
+  addPass(new InstructionSelect(getOptLevel(),
+                                /*RequireRegBankSelected=*/!SkipRegBankSelect));
   if (!getAArch64TargetMachine().isGlobalISelOptNone())
     addPass(createAArch64PostSelectOptimize());
   return false;

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -88,6 +88,7 @@ public:
         !MF.getFunction().hasFnAttribute(Attribute::SpeculativeLoadHardening);
     MFReturnAddr = Register();
 
+    assignFallbackRegBanks(MF);
     processPHIs(MF);
   }
 
@@ -119,6 +120,7 @@ private:
 
   bool convertPtrAddToAdd(MachineInstr &I, MachineRegisterInfo &MRI);
 
+  void assignFallbackRegBanks(MachineFunction &MF) const;
   bool selectVaStartAAPCS(MachineInstr &I, MachineFunction &MF,
                           MachineRegisterInfo &MRI) const;
   bool selectVaStartDarwin(MachineInstr &I, MachineFunction &MF,
@@ -705,6 +707,42 @@ static unsigned getMinSizeForRegBank(const RegisterBank &RB) {
   }
 }
 
+static const RegisterBank *
+getCheapRegBankForDef(Register Reg, MachineInstr &MI, MachineRegisterInfo &MRI,
+                      const AArch64RegisterBankInfo &RBI) {
+  if (!Reg.isVirtual())
+    return nullptr;
+
+  const RegisterBank *GPR = &RBI.getRegBank(AArch64::GPRRegBankID);
+  const RegisterBank *FPR = &RBI.getRegBank(AArch64::FPRRegBankID);
+
+  switch (MI.getOpcode()) {
+  case TargetOpcode::G_CONSTANT: {
+    LLT DstTy = MRI.getType(Reg);
+    if (!DstTy.isVector() && DstTy.getSizeInBits() <= 64 &&
+        (!DstTy.isScalar() || DstTy.getSizeInBits() >= 32))
+      return GPR;
+    return nullptr;
+  }
+  case TargetOpcode::G_FRAME_INDEX:
+    return GPR;
+  case TargetOpcode::G_FCONSTANT:
+    return FPR;
+  case TargetOpcode::G_LOAD: {
+    LLT DstTy = MRI.getType(MI.getOperand(0).getReg());
+    if (DstTy.isPointer())
+      return GPR;
+
+    LLT MemTy = cast<GLoad>(MI).getMMO().getMemoryType();
+    if (DstTy.isInteger() && MemTy.getSizeInBits() == DstTy.getSizeInBits())
+      return GPR;
+    return nullptr;
+  }
+  default:
+    return nullptr;
+  }
+}
+
 /// Create a REG_SEQUENCE instruction using the registers in \p Regs.
 /// Helper function for functions like createDTuple and createQTuple.
 ///
@@ -737,6 +775,57 @@ static Register createTuple(ArrayRef<Register> Regs,
     RegSequence.addImm(SubRegs[I]);
   }
   return RegSequence.getReg(0);
+}
+
+// Preassign banks for unbanked virtual defs when standalone RegBankSelect is
+// skipped.
+void AArch64InstructionSelector::assignFallbackRegBanks(
+    MachineFunction &MF) const {
+  if (MF.getProperties().hasRegBankSelected())
+    return;
+
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  MachineIRBuilder Builder(MF);
+  for (MachineBasicBlock &MBB : MF) {
+    for (MachineInstr &MI : make_early_inc_range(MBB)) {
+      for (unsigned OpIdx = 0, End = MI.getNumOperands(); OpIdx != End;
+           ++OpIdx) {
+        MachineOperand &MO = MI.getOperand(OpIdx);
+        if (!MO.isReg() || !MO.isDef())
+          continue;
+        Register Reg = MO.getReg();
+        if (!Reg || Reg.isPhysical())
+          continue;
+        if (RBI.getRegBank(Reg, MRI, TRI))
+          continue;
+
+        if (const RegisterBank *RB = getCheapRegBankForDef(Reg, MI, MRI, RBI)) {
+          MRI.setRegBank(Reg, *RB);
+          continue;
+        }
+
+        const RegisterBankInfo::InstructionMapping &Mapping =
+            RBI.getInstrMapping(MI);
+        if (!Mapping.isValid() || OpIdx >= Mapping.getNumOperands())
+          continue;
+
+        const RegisterBankInfo::ValueMapping &OpMapping =
+            Mapping.getOperandMapping(OpIdx);
+        if (OpMapping.isValid() && OpMapping.NumBreakDowns == 1 &&
+            OpMapping.BreakDown[0].RegBank)
+          MRI.setRegBank(Reg, *OpMapping.BreakDown[0].RegBank);
+      }
+
+      if (MI.getOpcode() == TargetOpcode::G_CONSTANT) {
+        Register Dst = MI.getOperand(0).getReg();
+        LLT DstTy = MRI.getType(Dst);
+        const RegisterBank *RB = MRI.getRegBankOrNull(Dst);
+        if (RB == &RBI.getRegBank(AArch64::GPRRegBankID) && DstTy.isScalar() &&
+            DstTy.getSizeInBits() < 32)
+          AArch64RegisterBankInfo::widenNarrowGPRConstant(Builder, MI, MRI);
+      }
+    }
+  }
 }
 
 /// Create a tuple of D-registers using the registers in \p Regs.
@@ -1007,6 +1096,10 @@ static bool selectDebugInstr(MachineInstr &I, MachineRegisterInfo &MRI,
       continue;
     LLT Ty = MRI.getType(Reg);
     const RegClassOrRegBank &RegClassOrBank = MRI.getRegClassOrRegBank(Reg);
+    if (RegClassOrBank.isNull()) {
+      LLVM_DEBUG(dbgs() << "Warning: DBG_VALUE operand has no register bank\n");
+      break;
+    }
     const TargetRegisterClass *RC =
         dyn_cast<const TargetRegisterClass *>(RegClassOrBank);
     if (!RC) {

--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -441,6 +441,28 @@ static bool foldTruncOfI32Constant(MachineInstr &MI, unsigned OpIdx,
   return true;
 }
 
+Register AArch64RegisterBankInfo::widenNarrowGPRConstant(
+    MachineIRBuilder &Builder, MachineInstr &MI, MachineRegisterInfo &MRI) {
+  assert(MI.getOpcode() == TargetOpcode::G_CONSTANT && "Expected a G_CONSTANT");
+
+  Register Dst = MI.getOperand(0).getReg();
+  [[maybe_unused]] LLT DstTy = MRI.getType(Dst);
+  assert(MRI.getRegBank(Dst) == &AArch64::GPRRegBank && DstTy.isScalar() &&
+         DstTy.getSizeInBits() < 32 &&
+         "Expected a scalar smaller than 32 bits on a GPR.");
+  Builder.setInsertPt(*MI.getParent(), std::next(MI.getIterator()));
+  Register ExtReg = MRI.createGenericVirtualRegister(LLT::integer(32));
+  Builder.buildTrunc(Dst, ExtReg);
+
+  APInt Val = MI.getOperand(1).getCImm()->getValue().zext(32);
+  LLVMContext &Ctx = Builder.getMF().getFunction().getContext();
+  MI.getOperand(1).setCImm(ConstantInt::get(Ctx, Val));
+  MI.getOperand(0).setReg(ExtReg);
+  MRI.setRegBank(ExtReg, AArch64::GPRRegBank);
+
+  return ExtReg;
+}
+
 void AArch64RegisterBankInfo::applyMappingImpl(
     MachineIRBuilder &Builder, const OperandsMapper &OpdMapper) const {
   MachineInstr &MI = OpdMapper.getMI();
@@ -448,21 +470,7 @@ void AArch64RegisterBankInfo::applyMappingImpl(
 
   switch (MI.getOpcode()) {
   case TargetOpcode::G_CONSTANT: {
-    Register Dst = MI.getOperand(0).getReg();
-    [[maybe_unused]] LLT DstTy = MRI.getType(Dst);
-    assert(MRI.getRegBank(Dst) == &AArch64::GPRRegBank && DstTy.isScalar() &&
-           DstTy.getSizeInBits() < 32 &&
-           "Expected a scalar smaller than 32 bits on a GPR.");
-    Builder.setInsertPt(*MI.getParent(), std::next(MI.getIterator()));
-    Register ExtReg = MRI.createGenericVirtualRegister(LLT::integer(32));
-    Builder.buildTrunc(Dst, ExtReg);
-
-    APInt Val = MI.getOperand(1).getCImm()->getValue().zext(32);
-    LLVMContext &Ctx = Builder.getMF().getFunction().getContext();
-    MI.getOperand(1).setCImm(ConstantInt::get(Ctx, Val));
-    MI.getOperand(0).setReg(ExtReg);
-    MRI.setRegBank(ExtReg, AArch64::GPRRegBank);
-
+    widenNarrowGPRConstant(Builder, MI, MRI);
     return applyDefaultMapping(OpdMapper);
   }
   case TargetOpcode::G_FCONSTANT: {

--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
@@ -21,6 +21,9 @@
 
 namespace llvm {
 
+class MachineIRBuilder;
+class MachineInstr;
+class MachineRegisterInfo;
 class TargetRegisterInfo;
 class AArch64RegisterInfo;
 
@@ -151,6 +154,12 @@ class AArch64RegisterBankInfo final : public AArch64GenRegisterBankInfo {
 
 public:
   AArch64RegisterBankInfo(const TargetRegisterInfo &TRI);
+
+  /// Rewrite a scalar GPR G_CONSTANT smaller than 32 bits to an i32
+  /// G_CONSTANT plus G_TRUNC.
+  static Register widenNarrowGPRConstant(MachineIRBuilder &Builder,
+                                         MachineInstr &MI,
+                                         MachineRegisterInfo &MRI);
 
   unsigned copyCost(const RegisterBank &A, const RegisterBank &B,
                     TypeSize Size) const override;

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-rcpc_immo.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-load-rcpc_immo.ll
@@ -45,7 +45,8 @@ define i8 @load_atomic_i8_aligned_monotonic_const(ptr readonly %ptr) {
 
 define i8 @load_atomic_i8_aligned_acquire(ptr %ptr) {
 ; GISEL-LABEL: load_atomic_i8_aligned_acquire:
-; GISEL:    ldapurb w0, [x0, #4]
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire:
 ; SDAG-AVOIDLDAPUR:    add x8, x0, #4
@@ -60,7 +61,8 @@ define i8 @load_atomic_i8_aligned_acquire(ptr %ptr) {
 
 define i8 @load_atomic_i8_aligned_acquire_const(ptr readonly %ptr) {
 ; GISEL-LABEL: load_atomic_i8_aligned_acquire_const:
-; GISEL:    ldapurb w0, [x0, #4]
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_aligned_acquire_const:
 ; SDAG-AVOIDLDAPUR:    add x8, x0, #4
@@ -125,7 +127,8 @@ define i16 @load_atomic_i16_aligned_monotonic_const(ptr readonly %ptr) {
 
 define i16 @load_atomic_i16_aligned_acquire(ptr %ptr) {
 ; GISEL-LABEL: load_atomic_i16_aligned_acquire:
-; GISEL:    ldapurh w0, [x0, #8]
+; GISEL:    add x8, x0, #8
+; GISEL:    ldaprh w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire:
 ; SDAG-AVOIDLDAPUR:    add x8, x0, #8
@@ -140,7 +143,8 @@ define i16 @load_atomic_i16_aligned_acquire(ptr %ptr) {
 
 define i16 @load_atomic_i16_aligned_acquire_const(ptr readonly %ptr) {
 ; GISEL-LABEL: load_atomic_i16_aligned_acquire_const:
-; GISEL:    ldapurh w0, [x0, #8]
+; GISEL:    add x8, x0, #8
+; GISEL:    ldaprh w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_aligned_acquire_const:
 ; SDAG-AVOIDLDAPUR:    add x8, x0, #8
@@ -433,7 +437,8 @@ define i8 @load_atomic_i8_unaligned_monotonic_const(ptr readonly %ptr) {
 
 define i8 @load_atomic_i8_unaligned_acquire(ptr %ptr) {
 ; GISEL-LABEL: load_atomic_i8_unaligned_acquire:
-; GISEL:    ldapurb w0, [x0, #4]
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_unaligned_acquire:
 ; SDAG-AVOIDLDAPUR:    add x8, x0, #4
@@ -448,7 +453,8 @@ define i8 @load_atomic_i8_unaligned_acquire(ptr %ptr) {
 
 define i8 @load_atomic_i8_unaligned_acquire_const(ptr readonly %ptr) {
 ; GISEL-LABEL: load_atomic_i8_unaligned_acquire_const:
-; GISEL:    ldapurb w0, [x0, #4]
+; GISEL:    add x8, x0, #4
+; GISEL:    ldaprb w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_unaligned_acquire_const:
 ; SDAG-AVOIDLDAPUR:    add x8, x0, #4
@@ -792,104 +798,72 @@ define i64 @load_atomic_i64_unaligned_seq_cst_const(ptr readonly %ptr) {
 }
 
 define i128 @load_atomic_i128_unaligned_unordered(ptr %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_unordered:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_unordered:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_unordered:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep unordered, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_unordered_const(ptr readonly %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_unordered_const:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_unordered_const:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_unordered_const:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep unordered, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_monotonic(ptr %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_monotonic:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_monotonic:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_monotonic:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep monotonic, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_monotonic_const(ptr readonly %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_monotonic_const:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_monotonic_const:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_monotonic_const:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep monotonic, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_acquire(ptr %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_acquire:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_acquire:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_acquire:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep acquire, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_acquire_const(ptr readonly %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_acquire_const:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_acquire_const:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_acquire_const:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep acquire, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_seq_cst(ptr %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_seq_cst:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_seq_cst:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_seq_cst:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep seq_cst, align 1
     ret i128 %r
 }
 
 define i128 @load_atomic_i128_unaligned_seq_cst_const(ptr readonly %ptr) {
-; GISEL-LABEL: load_atomic_i128_unaligned_seq_cst_const:
-; GISEL:    add x1, x8, #64
-; GISEL:    bl __atomic_load
-;
-; SDAG-LABEL: load_atomic_i128_unaligned_seq_cst_const:
-; SDAG:    add x1, x0, #64
-; SDAG:    bl __atomic_load
+; CHECK-LABEL: load_atomic_i128_unaligned_seq_cst_const:
+; CHECK:    add x1, x0, #64
+; CHECK:    bl __atomic_load
     %gep = getelementptr inbounds i128, ptr %ptr, i32 4
     %r = load atomic i128, ptr %gep seq_cst, align 1
     ret i128 %r
@@ -898,7 +872,8 @@ define i128 @load_atomic_i128_unaligned_seq_cst_const(ptr readonly %ptr) {
 define i8 @load_atomic_i8_from_gep() {
 ; GISEL-LABEL: load_atomic_i8_from_gep:
 ; GISEL:    bl init
-; GISEL:    ldapurb w0, [x8, #1]
+; GISEL:    add x8, x8, #1
+; GISEL:    ldaprb w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i8_from_gep:
 ; SDAG-AVOIDLDAPUR:    bl init
@@ -918,7 +893,8 @@ define i8 @load_atomic_i8_from_gep() {
 define i16 @load_atomic_i16_from_gep() {
 ; GISEL-LABEL: load_atomic_i16_from_gep:
 ; GISEL:    bl init
-; GISEL:    ldapurh w0, [x8, #2]
+; GISEL:    add x8, x8, #2
+; GISEL:    ldaprh w0, [x8]
 ;
 ; SDAG-AVOIDLDAPUR-LABEL: load_atomic_i16_from_gep:
 ; SDAG-AVOIDLDAPUR:    bl init

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-outline_atomics.ll
@@ -118,9 +118,8 @@ define dso_local void @store_atomic_i64_aligned_seq_cst(i64 %value, ptr %ptr) {
 define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_unordered:
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -132,9 +131,8 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -146,9 +144,8 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_release:
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -160,9 +157,8 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-rcpc.ll
@@ -117,14 +117,13 @@ define dso_local void @store_atomic_i64_aligned_seq_cst(i64 %value, ptr %ptr) {
 
 define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_unordered:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -135,14 +134,13 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 
 define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_monotonic:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -153,14 +151,13 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 
 define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_release:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -171,14 +168,13 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8_1a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8_1a.ll
@@ -118,9 +118,8 @@ define dso_local void @store_atomic_i64_aligned_seq_cst(i64 %value, ptr %ptr) {
 define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_unordered:
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldp x4, x5, [x2]
@@ -134,9 +133,8 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x2]
@@ -150,9 +148,8 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_release:
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x2]
@@ -166,9 +163,8 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomic-store-v8a.ll
@@ -117,14 +117,13 @@ define dso_local void @store_atomic_i64_aligned_seq_cst(i64 %value, ptr %ptr) {
 
 define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_unordered:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_unordered:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -135,14 +134,13 @@ define dso_local void @store_atomic_i128_aligned_unordered(i128 %value, ptr %ptr
 
 define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_monotonic:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_monotonic:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -153,14 +151,13 @@ define dso_local void @store_atomic_i128_aligned_monotonic(i128 %value, ptr %ptr
 
 define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_release:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_release:
 ; -O1:    ldxp xzr, x8, [x2]
@@ -171,14 +168,13 @@ define dso_local void @store_atomic_i128_aligned_release(i128 %value, ptr %ptr) 
 
 define dso_local void @store_atomic_i128_aligned_seq_cst(i128 %value, ptr %ptr) {
 ; -O0-LABEL: store_atomic_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: store_atomic_i128_aligned_seq_cst:
 ; -O1:    ldaxp xzr, x8, [x2]

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2.ll
@@ -290,14 +290,13 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -308,14 +307,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -326,14 +324,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -344,14 +341,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -362,14 +358,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -920,16 +915,14 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -941,16 +934,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -962,16 +953,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -983,16 +972,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1004,16 +991,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1290,8 +1275,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -1304,8 +1288,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -1318,8 +1301,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -1332,8 +1314,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -1346,8 +1327,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1685,15 +1665,14 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1705,15 +1684,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1725,15 +1703,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1745,15 +1722,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1765,15 +1741,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2050,7 +2025,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -2063,7 +2038,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -2076,7 +2051,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -2089,7 +2064,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -2102,7 +2077,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -2440,16 +2415,15 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2462,16 +2436,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2484,16 +2457,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2506,16 +2478,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2528,16 +2499,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2815,8 +2785,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -2830,8 +2800,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -2845,8 +2815,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -2860,8 +2830,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -2875,8 +2845,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -3255,18 +3225,17 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3281,18 +3250,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3307,18 +3275,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3333,18 +3300,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3359,18 +3325,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3690,10 +3655,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -3709,10 +3674,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -3728,10 +3693,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -3747,10 +3712,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -3766,10 +3731,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -4110,16 +4075,15 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4132,16 +4096,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4154,16 +4117,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4176,16 +4138,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4198,16 +4159,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4485,8 +4445,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -4500,8 +4460,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -4515,8 +4475,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -4530,8 +4490,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -4545,8 +4505,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -4885,16 +4845,15 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4907,16 +4866,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4929,16 +4887,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4951,16 +4908,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4973,16 +4929,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5260,8 +5215,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -5275,8 +5230,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -5290,8 +5245,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -5305,8 +5260,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -5320,8 +5275,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -5720,22 +5675,16 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5749,22 +5698,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5778,22 +5721,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5807,22 +5744,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5836,22 +5767,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6190,14 +6115,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -6212,14 +6132,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -6234,14 +6149,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -6256,14 +6166,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -6278,14 +6183,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -6685,22 +6585,16 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6714,22 +6608,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6743,22 +6631,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6772,22 +6654,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,22 +6677,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7155,14 +7025,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -7177,14 +7042,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -7199,14 +7059,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -7221,14 +7076,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -7243,14 +7093,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -7645,22 +7490,16 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7674,22 +7513,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7703,22 +7536,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7732,22 +7559,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7761,22 +7582,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8110,14 +7925,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -8132,14 +7942,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -8154,14 +7959,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -8176,14 +7976,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -8198,14 +7993,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -8600,22 +8390,16 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8629,22 +8413,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8658,22 +8436,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8687,22 +8459,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8716,22 +8482,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -9065,14 +8825,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -9087,14 +8842,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -9109,14 +8859,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -9131,14 +8876,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -9153,14 +8893,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2_lse128.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lse2_lse128.ll
@@ -510,12 +510,10 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -529,12 +527,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -548,12 +544,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -567,12 +561,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -586,12 +578,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -820,8 +810,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -834,8 +823,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -848,8 +836,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -862,8 +849,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -876,8 +862,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1030,11 +1015,10 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -1048,11 +1032,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -1066,11 +1049,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -1084,11 +1066,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -1102,11 +1083,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1335,7 +1315,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -1348,7 +1328,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -1361,7 +1341,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -1374,7 +1354,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -1387,7 +1367,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -1850,8 +1830,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -1865,8 +1845,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -1880,8 +1860,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -1895,8 +1875,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -1910,8 +1890,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -2250,14 +2230,13 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -2274,14 +2253,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -2298,14 +2276,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -2322,14 +2299,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -2346,14 +2322,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -2665,10 +2640,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -2684,10 +2659,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -2703,10 +2678,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -2722,10 +2697,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -2741,10 +2716,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -3165,8 +3140,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -3180,8 +3155,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -3195,8 +3170,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -3210,8 +3185,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -3225,8 +3200,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -3380,12 +3355,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3400,12 +3374,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3420,12 +3393,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3440,12 +3412,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -3460,12 +3431,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -3695,8 +3665,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -3710,8 +3680,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -3725,8 +3695,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -3740,8 +3710,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -3755,8 +3725,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -3910,18 +3880,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3937,18 +3901,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3964,18 +3922,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3991,18 +3943,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4018,18 +3964,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -4300,14 +4240,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -4322,14 +4257,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -4344,14 +4274,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -4366,14 +4291,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -4388,14 +4308,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -4550,18 +4465,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -4577,18 +4486,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -4604,18 +4507,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4631,18 +4528,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4658,18 +4549,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -4940,14 +4825,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -4962,14 +4842,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -4984,14 +4859,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -5006,14 +4876,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -5028,14 +4893,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -5190,18 +5050,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5217,18 +5071,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5244,18 +5092,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -5271,18 +5113,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -5298,18 +5134,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5575,14 +5405,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -5597,14 +5422,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -5619,14 +5439,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -5641,14 +5456,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -5663,14 +5473,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -5825,18 +5630,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5852,18 +5651,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5879,18 +5672,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -5906,18 +5693,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -5933,18 +5714,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -6210,14 +5985,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -6232,14 +6002,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -6254,14 +6019,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -6276,14 +6036,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -6298,14 +6053,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
@@ -239,11 +239,8 @@ define dso_local half @atomicrmw_fadd_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_monotonic:
@@ -256,11 +253,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_acquire:
@@ -273,11 +267,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_release:
@@ -290,11 +281,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_acq_rel:
@@ -307,11 +295,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_seq_cst:
@@ -394,10 +379,10 @@ define dso_local double @atomicrmw_fadd_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -408,10 +393,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -422,10 +407,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -436,10 +421,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -450,10 +435,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -464,15 +449,12 @@ define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -485,15 +467,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -506,15 +485,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -527,15 +503,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -548,15 +521,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -569,10 +539,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -583,10 +553,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -597,10 +567,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -611,10 +581,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -625,10 +595,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -639,10 +609,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -653,10 +623,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -667,10 +637,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -681,10 +651,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -695,10 +665,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -744,11 +714,8 @@ define dso_local half @atomicrmw_fsub_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_monotonic:
@@ -761,11 +728,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_acquire:
@@ -778,11 +742,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_release:
@@ -795,11 +756,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_acq_rel:
@@ -812,11 +770,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_seq_cst:
@@ -1130,11 +1085,8 @@ define dso_local half @atomicrmw_fmax_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_monotonic:
@@ -1147,11 +1099,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_acquire:
@@ -1164,11 +1113,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_release:
@@ -1181,11 +1127,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_acq_rel:
@@ -1198,11 +1141,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_seq_cst:
@@ -1516,11 +1456,8 @@ define dso_local half @atomicrmw_fmin_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_monotonic:
@@ -1533,11 +1470,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_acquire:
@@ -1550,11 +1484,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_release:
@@ -1567,11 +1498,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_acq_rel:
@@ -1584,11 +1512,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_seq_cst:
@@ -1902,11 +1827,8 @@ define dso_local half @atomicrmw_fmaximum_half_unaligned_seq_cst(ptr %ptr, half 
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_monotonic:
@@ -1919,11 +1841,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_monotonic(ptr %ptr,
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acquire:
@@ -1936,11 +1855,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acquire(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_release:
@@ -1953,11 +1869,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_release(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acq_rel:
@@ -1970,11 +1883,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acq_rel(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_seq_cst:
@@ -2288,11 +2198,8 @@ define dso_local half @atomicrmw_fminimum_half_unaligned_seq_cst(ptr %ptr, half 
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_monotonic:
@@ -2305,11 +2212,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_monotonic(ptr %ptr,
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_acquire:
@@ -2322,11 +2226,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acquire(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_release:
@@ -2339,11 +2240,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_release(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_acq_rel:
@@ -2356,11 +2254,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acq_rel(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-outline_atomics.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-outline_atomics.ll
@@ -146,9 +146,8 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -160,9 +159,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -174,9 +172,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -188,9 +185,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -202,9 +198,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -530,12 +525,10 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x2, x8, x10
-; -O0:    subs w10, w10, #1
+; -O0:    adds x2, x0, x9
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -547,12 +540,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x2, x8, x10
-; -O0:    subs w10, w10, #1
+; -O0:    adds x2, x0, x9
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -564,12 +555,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x2, x8, x10
-; -O0:    subs w10, w10, #1
+; -O0:    adds x2, x0, x9
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -581,12 +570,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x2, x8, x10
-; -O0:    subs w10, w10, #1
+; -O0:    adds x2, x0, x9
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -598,12 +585,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x2, x8, x10
-; -O0:    subs w10, w10, #1
+; -O0:    adds x2, x0, x9
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -830,8 +815,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -844,8 +828,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -858,8 +841,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -872,8 +854,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -886,8 +867,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1120,11 +1100,10 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x2, x8, x10
+; -O0:    subs x2, x0, x9
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1136,11 +1115,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x2, x8, x10
+; -O0:    subs x2, x0, x9
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1152,11 +1130,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x2, x8, x10
+; -O0:    subs x2, x0, x9
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1168,11 +1145,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x2, x8, x10
+; -O0:    subs x2, x0, x9
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1184,11 +1160,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x2, x8, x10
+; -O0:    subs x2, x0, x9
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1435,7 +1410,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -1448,7 +1423,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -1461,7 +1436,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -1474,7 +1449,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -1487,7 +1462,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -1740,12 +1715,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O0:    and x2, x8, x10
-; -O0:    and x3, x8, x9
+; -O0:    and x2, x0, x9
+; -O0:    and x3, x1, x8
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1758,12 +1732,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O0:    and x2, x8, x10
-; -O0:    and x3, x8, x9
+; -O0:    and x2, x0, x9
+; -O0:    and x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1776,12 +1749,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
-; -O0:    and x2, x8, x10
-; -O0:    and x3, x8, x9
+; -O0:    and x2, x0, x9
+; -O0:    and x3, x1, x8
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1794,12 +1766,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O0:    and x2, x8, x10
-; -O0:    and x3, x8, x9
+; -O0:    and x2, x0, x9
+; -O0:    and x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1812,12 +1783,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O0:    and x2, x8, x10
-; -O0:    and x3, x8, x9
+; -O0:    and x2, x0, x9
+; -O0:    and x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2070,8 +2040,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -2085,8 +2055,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -2100,8 +2070,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -2115,8 +2085,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -2130,8 +2100,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -2470,14 +2440,13 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x1, x8
+; -O0:    and x9, x0, x9
 ; -O0:    mvn x2, x9
 ; -O0:    mvn x3, x8
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2492,14 +2461,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x1, x8
+; -O0:    and x9, x0, x9
 ; -O0:    mvn x2, x9
 ; -O0:    mvn x3, x8
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2514,14 +2482,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x1, x8
+; -O0:    and x9, x0, x9
 ; -O0:    mvn x2, x9
 ; -O0:    mvn x3, x8
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2536,14 +2503,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x1, x8
+; -O0:    and x9, x0, x9
 ; -O0:    mvn x2, x9
 ; -O0:    mvn x3, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2558,14 +2524,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x1, x8
+; -O0:    and x9, x0, x9
 ; -O0:    mvn x2, x9
 ; -O0:    mvn x3, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2875,10 +2840,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -2894,10 +2859,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -2913,10 +2878,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -2932,10 +2897,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -2951,10 +2916,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -3110,12 +3075,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O0:    orr x2, x8, x10
-; -O0:    orr x3, x8, x9
+; -O0:    orr x2, x0, x9
+; -O0:    orr x3, x1, x8
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3128,12 +3092,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O0:    orr x2, x8, x10
-; -O0:    orr x3, x8, x9
+; -O0:    orr x2, x0, x9
+; -O0:    orr x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3146,12 +3109,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
-; -O0:    orr x2, x8, x10
-; -O0:    orr x3, x8, x9
+; -O0:    orr x2, x0, x9
+; -O0:    orr x3, x1, x8
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3164,12 +3126,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O0:    orr x2, x8, x10
-; -O0:    orr x3, x8, x9
+; -O0:    orr x2, x0, x9
+; -O0:    orr x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3182,12 +3143,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O0:    orr x2, x8, x10
-; -O0:    orr x3, x8, x9
+; -O0:    orr x2, x0, x9
+; -O0:    orr x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3415,8 +3375,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -3430,8 +3390,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -3445,8 +3405,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -3460,8 +3420,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -3475,8 +3435,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -3630,12 +3590,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x2, x8, x10
-; -O0:    eor x3, x8, x9
+; -O0:    eor x2, x0, x9
+; -O0:    eor x3, x1, x8
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3648,12 +3607,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x2, x8, x10
-; -O0:    eor x3, x8, x9
+; -O0:    eor x2, x0, x9
+; -O0:    eor x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3666,12 +3624,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x2, x8, x10
-; -O0:    eor x3, x8, x9
+; -O0:    eor x2, x0, x9
+; -O0:    eor x3, x1, x8
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3684,12 +3641,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x2, x8, x10
-; -O0:    eor x3, x8, x9
+; -O0:    eor x2, x0, x9
+; -O0:    eor x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3702,12 +3658,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x2, x8, x10
-; -O0:    eor x3, x8, x9
+; -O0:    eor x2, x0, x9
+; -O0:    eor x3, x1, x8
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3935,8 +3890,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -3950,8 +3905,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -3965,8 +3920,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -3980,8 +3935,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -3995,8 +3950,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -4355,18 +4310,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lt
+; -O0:    csel x3, x1, x8, lt
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4380,18 +4329,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lt
+; -O0:    csel x3, x1, x8, lt
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4405,18 +4348,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lt
+; -O0:    csel x3, x1, x8, lt
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4430,18 +4367,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lt
+; -O0:    csel x3, x1, x8, lt
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4455,18 +4386,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lt
+; -O0:    csel x3, x1, x8, lt
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4795,14 +4720,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -4817,14 +4737,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -4839,14 +4754,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -4861,14 +4771,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -4883,14 +4788,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -5250,18 +5150,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, ge
+; -O0:    csel x3, x1, x8, ge
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5275,18 +5169,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, ge
+; -O0:    csel x3, x1, x8, ge
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5300,18 +5188,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, ge
+; -O0:    csel x3, x1, x8, ge
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5325,18 +5207,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, ge
+; -O0:    csel x3, x1, x8, ge
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5350,18 +5226,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, ge
+; -O0:    csel x3, x1, x8, ge
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5690,14 +5560,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -5712,14 +5577,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -5734,14 +5594,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -5756,14 +5611,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -5778,14 +5628,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -6140,18 +5985,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lo
+; -O0:    csel x3, x1, x8, lo
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6165,18 +6004,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lo
+; -O0:    csel x3, x1, x8, lo
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6190,18 +6023,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lo
+; -O0:    csel x3, x1, x8, lo
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6215,18 +6042,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lo
+; -O0:    csel x3, x1, x8, lo
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6240,18 +6061,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, lo
+; -O0:    csel x3, x1, x8, lo
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6575,14 +6390,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -6597,14 +6407,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -6619,14 +6424,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -6641,14 +6441,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -6663,14 +6458,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -7025,18 +6815,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, hs
+; -O0:    csel x3, x1, x8, hs
 ; -O0:    bl __aarch64_cas16_relax
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7050,18 +6834,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, hs
+; -O0:    csel x3, x1, x8, hs
 ; -O0:    bl __aarch64_cas16_acq
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7075,18 +6853,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, hs
+; -O0:    csel x3, x1, x8, hs
 ; -O0:    bl __aarch64_cas16_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7100,18 +6872,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, hs
+; -O0:    csel x3, x1, x8, hs
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7125,18 +6891,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x11
-; -O0:    subs x10, x10, x9
-; -O0:    subs x12, x12, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w12, w10, #0x1
-; -O0:    csel x2, x8, x11, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x3, x8, x9, ne
+; -O0:    subs x10, x9, x0
+; -O0:    csel x2, x0, x9, hs
+; -O0:    csel x3, x1, x8, hs
 ; -O0:    bl __aarch64_cas16_acq_rel
-; -O0:    eor x8, x0, x8
-; -O0:    eor x9, x1, x9
-; -O0:    orr x8, x8, x9
+; -O0:    subs x10, x10, x11
+; -O0:    ccmp x8, x9, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7460,14 +7220,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -7482,14 +7237,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -7504,14 +7254,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -7526,14 +7271,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -7548,14 +7288,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc.ll
@@ -290,14 +290,13 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -308,14 +307,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -326,14 +324,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -344,14 +341,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -362,14 +358,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -920,16 +915,14 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -941,16 +934,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -962,16 +953,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -983,16 +972,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1004,16 +991,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1290,8 +1275,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -1304,8 +1288,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -1318,8 +1301,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -1332,8 +1314,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -1346,8 +1327,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1685,15 +1665,14 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1705,15 +1684,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1725,15 +1703,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1745,15 +1722,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1765,15 +1741,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2050,7 +2025,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -2063,7 +2038,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -2076,7 +2051,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -2089,7 +2064,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -2102,7 +2077,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -2440,16 +2415,15 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2462,16 +2436,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2484,16 +2457,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2506,16 +2478,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2528,16 +2499,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2815,8 +2785,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -2830,8 +2800,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -2845,8 +2815,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -2860,8 +2830,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -2875,8 +2845,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -3255,18 +3225,17 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3281,18 +3250,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3307,18 +3275,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3333,18 +3300,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3359,18 +3325,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3690,10 +3655,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -3709,10 +3674,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -3728,10 +3693,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -3747,10 +3712,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -3766,10 +3731,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -4110,16 +4075,15 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4132,16 +4096,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4154,16 +4117,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4176,16 +4138,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4198,16 +4159,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4485,8 +4445,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -4500,8 +4460,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -4515,8 +4475,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -4530,8 +4490,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -4545,8 +4505,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -4885,16 +4845,15 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4907,16 +4866,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4929,16 +4887,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4951,16 +4908,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4973,16 +4929,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5260,8 +5215,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -5275,8 +5230,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -5290,8 +5245,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -5305,8 +5260,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -5320,8 +5275,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -5720,22 +5675,16 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5749,22 +5698,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5778,22 +5721,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5807,22 +5744,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5836,22 +5767,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6190,14 +6115,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -6212,14 +6132,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -6234,14 +6149,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -6256,14 +6166,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -6278,14 +6183,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -6685,22 +6585,16 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6714,22 +6608,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6743,22 +6631,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6772,22 +6654,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,22 +6677,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7155,14 +7025,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -7177,14 +7042,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -7199,14 +7059,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -7221,14 +7076,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -7243,14 +7093,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -7645,22 +7490,16 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7674,22 +7513,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7703,22 +7536,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7732,22 +7559,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7761,22 +7582,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8110,14 +7925,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -8132,14 +7942,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -8154,14 +7959,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -8176,14 +7976,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -8198,14 +7993,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -8600,22 +8390,16 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8629,22 +8413,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8658,22 +8436,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8687,22 +8459,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8716,22 +8482,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -9065,14 +8825,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -9087,14 +8842,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -9109,14 +8859,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -9131,14 +8876,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -9153,14 +8893,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc3.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-rcpc3.ll
@@ -290,14 +290,13 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -308,14 +307,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -326,14 +324,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -344,14 +341,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -362,14 +358,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -920,16 +915,14 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -941,16 +934,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -962,16 +953,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -983,16 +972,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1004,16 +991,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1290,8 +1275,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -1304,8 +1288,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -1318,8 +1301,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -1332,8 +1314,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -1346,8 +1327,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1685,15 +1665,14 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1705,15 +1684,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1725,15 +1703,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1745,15 +1722,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1765,15 +1741,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2050,7 +2025,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -2063,7 +2038,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -2076,7 +2051,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -2089,7 +2064,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -2102,7 +2077,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -2440,16 +2415,15 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2462,16 +2436,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2484,16 +2457,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2506,16 +2478,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2528,16 +2499,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2815,8 +2785,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -2830,8 +2800,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -2845,8 +2815,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -2860,8 +2830,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -2875,8 +2845,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -3255,18 +3225,17 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3281,18 +3250,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3307,18 +3275,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3333,18 +3300,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3359,18 +3325,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3690,10 +3655,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -3709,10 +3674,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -3728,10 +3693,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -3747,10 +3712,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -3766,10 +3731,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -4110,16 +4075,15 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4132,16 +4096,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4154,16 +4117,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4176,16 +4138,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4198,16 +4159,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4485,8 +4445,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -4500,8 +4460,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -4515,8 +4475,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -4530,8 +4490,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -4545,8 +4505,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -4885,16 +4845,15 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4907,16 +4866,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4929,16 +4887,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4951,16 +4908,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4973,16 +4929,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5260,8 +5215,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -5275,8 +5230,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -5290,8 +5245,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -5305,8 +5260,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -5320,8 +5275,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -5720,22 +5675,16 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5749,22 +5698,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5778,22 +5721,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5807,22 +5744,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5836,22 +5767,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6190,14 +6115,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -6212,14 +6132,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -6234,14 +6149,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -6256,14 +6166,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -6278,14 +6183,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -6685,22 +6585,16 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6714,22 +6608,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6743,22 +6631,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6772,22 +6654,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,22 +6677,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7155,14 +7025,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -7177,14 +7042,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -7199,14 +7059,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -7221,14 +7076,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -7243,14 +7093,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -7645,22 +7490,16 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7674,22 +7513,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7703,22 +7536,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7732,22 +7559,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7761,22 +7582,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8110,14 +7925,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -8132,14 +7942,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -8154,14 +7959,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -8176,14 +7976,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -8198,14 +7993,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -8600,22 +8390,16 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8629,22 +8413,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8658,22 +8436,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8687,22 +8459,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8716,22 +8482,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -9065,14 +8825,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -9087,14 +8842,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -9109,14 +8859,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -9131,14 +8876,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -9153,14 +8893,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8_1a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8_1a.ll
@@ -146,9 +146,8 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -162,9 +161,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -178,9 +176,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -194,9 +191,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -210,9 +206,8 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -540,12 +535,10 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -559,12 +552,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -578,12 +569,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -597,12 +586,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -616,12 +603,10 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x2, x9, x11
-; -O0:    subs w11, w11, #1
+; -O0:    adds x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -850,8 +835,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -864,8 +848,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -878,8 +861,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -892,8 +874,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -906,8 +887,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1060,11 +1040,10 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -1078,11 +1057,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -1096,11 +1074,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -1114,11 +1091,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -1132,11 +1108,10 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x2, x9, x11
+; -O0:    subs x2, x10, x12
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1365,7 +1340,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -1378,7 +1353,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -1391,7 +1366,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -1404,7 +1379,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -1417,7 +1392,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -1590,12 +1565,11 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O0:    and x2, x9, x11
-; -O0:    and x9, x9, x10
+; -O0:    and x2, x10, x12
+; -O0:    and x9, x11, x9
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -1610,12 +1584,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O0:    and x2, x9, x11
-; -O0:    and x9, x9, x10
+; -O0:    and x2, x10, x12
+; -O0:    and x9, x11, x9
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -1630,12 +1603,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
-; -O0:    and x2, x9, x11
-; -O0:    and x9, x9, x10
+; -O0:    and x2, x10, x12
+; -O0:    and x9, x11, x9
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -1650,12 +1622,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O0:    and x2, x9, x11
-; -O0:    and x9, x9, x10
+; -O0:    and x2, x10, x12
+; -O0:    and x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -1670,12 +1641,11 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O0:    and x2, x9, x11
-; -O0:    and x9, x9, x10
+; -O0:    and x2, x10, x12
+; -O0:    and x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -1910,8 +1880,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -1925,8 +1895,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -1940,8 +1910,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -1955,8 +1925,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -1970,8 +1940,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -2310,14 +2280,13 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -2334,14 +2303,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -2358,14 +2326,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -2382,14 +2349,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -2406,14 +2372,13 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x10, x9, x10
-; -O0:    and x9, x9, x11
-; -O0:    mvn x2, x10
+; -O0:    and x9, x11, x9
+; -O0:    and x12, x10, x12
+; -O0:    mvn x2, x12
 ; -O0:    mvn x9, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -2725,10 +2690,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -2744,10 +2709,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -2763,10 +2728,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -2782,10 +2747,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -2801,10 +2766,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -2960,12 +2925,11 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O0:    orr x2, x9, x11
-; -O0:    orr x9, x9, x10
+; -O0:    orr x2, x10, x12
+; -O0:    orr x9, x11, x9
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -2980,12 +2944,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O0:    orr x2, x9, x11
-; -O0:    orr x9, x9, x10
+; -O0:    orr x2, x10, x12
+; -O0:    orr x9, x11, x9
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3000,12 +2963,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
-; -O0:    orr x2, x9, x11
-; -O0:    orr x9, x9, x10
+; -O0:    orr x2, x10, x12
+; -O0:    orr x9, x11, x9
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3020,12 +2982,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O0:    orr x2, x9, x11
-; -O0:    orr x9, x9, x10
+; -O0:    orr x2, x10, x12
+; -O0:    orr x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -3040,12 +3001,11 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O0:    orr x2, x9, x11
-; -O0:    orr x9, x9, x10
+; -O0:    orr x2, x10, x12
+; -O0:    orr x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -3275,8 +3235,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -3290,8 +3250,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -3305,8 +3265,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -3320,8 +3280,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -3335,8 +3295,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -3490,12 +3450,11 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -3510,12 +3469,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -3530,12 +3488,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -3550,12 +3507,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -3570,12 +3526,11 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x2, x9, x11
-; -O0:    eor x9, x9, x10
+; -O0:    eor x2, x10, x12
+; -O0:    eor x9, x11, x9
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -3805,8 +3760,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -3820,8 +3775,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -3835,8 +3790,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -3850,8 +3805,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -3865,8 +3820,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -4020,18 +3975,12 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -4047,18 +3996,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -4074,18 +4017,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4101,18 +4038,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4128,18 +4059,12 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lt
+; -O0:    csel x2, x10, x12, lt
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -4410,14 +4335,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -4432,14 +4352,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -4454,14 +4369,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -4476,14 +4386,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -4498,14 +4403,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -4660,18 +4560,12 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -4687,18 +4581,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -4714,18 +4602,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -4741,18 +4623,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -4768,18 +4644,12 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, ge
+; -O0:    csel x2, x10, x12, ge
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5050,14 +4920,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -5072,14 +4937,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -5094,14 +4954,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -5116,14 +4971,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -5138,14 +4988,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -5300,18 +5145,12 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5327,18 +5166,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5354,18 +5187,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -5381,18 +5208,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -5408,18 +5229,12 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, lo
+; -O0:    csel x2, x10, x12, lo
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -5685,14 +5500,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -5707,14 +5517,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -5729,14 +5534,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -5751,14 +5551,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -5773,14 +5568,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -5935,18 +5725,12 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    casp x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldp x4, x5, [x0]
@@ -5962,18 +5746,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspa x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldp x4, x5, [x0]
@@ -5989,18 +5767,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspl x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldp x4, x5, [x0]
@@ -6016,18 +5788,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldp x4, x5, [x0]
@@ -6043,18 +5809,12 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x9, x9, x12
-; -O0:    subs x11, x11, x10
-; -O0:    subs x13, x13, x10
-; -O0:    csel w11, w9, w11, eq
-; -O0:    ands w13, w11, #0x1
-; -O0:    csel x2, x9, x12, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x9, x9, x10, ne
+; -O0:    subs x13, x12, x10
+; -O0:    csel x9, x11, x9, hs
+; -O0:    csel x2, x10, x12, hs
 ; -O0:    caspal x0, x1, x2, x3, [x8]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x11, x8, x11
+; -O0:    ccmp x9, x10, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldp x4, x5, [x0]
@@ -6320,14 +6080,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -6342,14 +6097,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -6364,14 +6114,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -6386,14 +6131,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -6408,14 +6148,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a.ll
@@ -290,14 +290,13 @@ define dso_local i64 @atomicrmw_xchg_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_monotonic:
 ; -O1:    ldxp x8, x1, [x0]
@@ -308,14 +307,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acquire:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acquire:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -326,14 +324,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_release:
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_release:
 ; -O1:    ldxp x8, x1, [x0]
@@ -344,14 +341,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_acq_rel:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -362,14 +358,13 @@ define dso_local i128 @atomicrmw_xchg_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_xchg_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xchg_i128_aligned_seq_cst:
 ; -O1:    ldaxp x8, x1, [x0]
@@ -920,16 +915,14 @@ define dso_local i64 @atomicrmw_add_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_monotonic:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -941,16 +934,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acquire:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -962,16 +953,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_release:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -983,16 +972,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_acq_rel:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1004,16 +991,14 @@ define dso_local i128 @atomicrmw_add_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_add_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_aligned_seq_cst:
-; -O0:    adds x14, x8, x10
-; -O0:    subs w10, w10, #1
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    adds x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_add_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1290,8 +1275,7 @@ define dso_local i64 @atomicrmw_add_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_monotonic:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_monotonic:
@@ -1304,8 +1288,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acquire:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acquire:
@@ -1318,8 +1301,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_release:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_release:
@@ -1332,8 +1314,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_acq_rel:
@@ -1346,8 +1327,7 @@ define dso_local i128 @atomicrmw_add_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_add_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
-; -O0:    adds x9, x8, x9
-; -O0:    subs w11, w11, #1
+; -O0:    adds x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_add_i128_unaligned_seq_cst:
@@ -1685,15 +1665,14 @@ define dso_local i64 @atomicrmw_sub_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_monotonic:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1705,15 +1684,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acquire:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1725,15 +1703,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_release:
-; -O0:    subs x14, x8, x10
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -1745,15 +1722,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -1765,15 +1741,14 @@ define dso_local i128 @atomicrmw_sub_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_sub_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
-; -O0:    subs x14, x8, x10
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x14, x11, x10
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2050,7 +2025,7 @@ define dso_local i64 @atomicrmw_sub_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_monotonic:
@@ -2063,7 +2038,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acquire:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acquire:
@@ -2076,7 +2051,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_release:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_release:
@@ -2089,7 +2064,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_acq_rel:
@@ -2102,7 +2077,7 @@ define dso_local i128 @atomicrmw_sub_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_sub_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
-; -O0:    subs x9, x8, x9
+; -O0:    subs x8, x11, x8
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_sub_i128_unaligned_seq_cst:
@@ -2440,16 +2415,15 @@ define dso_local i64 @atomicrmw_and_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_monotonic:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2462,16 +2436,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acquire:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2484,16 +2457,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_release:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -2506,16 +2478,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_acq_rel:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2528,16 +2499,15 @@ define dso_local i128 @atomicrmw_and_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_and_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_aligned_seq_cst:
-; -O0:    and x14, x8, x10
-; -O0:    and x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    and x14, x11, x10
+; -O0:    and x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_and_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -2815,8 +2785,8 @@ define dso_local i64 @atomicrmw_and_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_monotonic:
@@ -2830,8 +2800,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acquire:
@@ -2845,8 +2815,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_release:
@@ -2860,8 +2830,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_acq_rel:
@@ -2875,8 +2845,8 @@ define dso_local i128 @atomicrmw_and_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_and_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
+; -O0:    and x8, x11, x8
+; -O0:    and x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_and_i128_unaligned_seq_cst:
@@ -3255,18 +3225,17 @@ define dso_local i64 @atomicrmw_nand_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3281,18 +3250,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3307,18 +3275,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -3333,18 +3300,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3359,18 +3325,17 @@ define dso_local i128 @atomicrmw_nand_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_nand_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x14, x9
+; -O0:    and x8, x13, x8
+; -O0:    and x10, x11, x10
+; -O0:    mvn x14, x10
 ; -O0:    mvn x15, x8
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -3690,10 +3655,10 @@ define dso_local i64 @atomicrmw_nand_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_monotonic:
@@ -3709,10 +3674,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acquire:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acquire:
@@ -3728,10 +3693,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_release:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_release:
@@ -3747,10 +3712,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_acq_rel:
@@ -3766,10 +3731,10 @@ define dso_local i128 @atomicrmw_nand_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_nand_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
-; -O0:    and x9, x8, x9
-; -O0:    and x8, x8, x10
-; -O0:    mvn x9, x9
+; -O0:    and x9, x11, x9
+; -O0:    and x8, x10, x8
 ; -O0:    mvn x8, x8
+; -O0:    mvn x9, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_nand_i128_unaligned_seq_cst:
@@ -4110,16 +4075,15 @@ define dso_local i64 @atomicrmw_or_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_monotonic:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4132,16 +4096,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_monotonic(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acquire:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4154,16 +4117,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acquire(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_release:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4176,16 +4138,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_release(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_acq_rel:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4198,16 +4159,15 @@ define dso_local i128 @atomicrmw_or_i128_aligned_acq_rel(ptr %ptr, i128 %value) 
 
 define dso_local i128 @atomicrmw_or_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_aligned_seq_cst:
-; -O0:    orr x14, x8, x10
-; -O0:    orr x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    orr x14, x11, x10
+; -O0:    orr x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_or_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4485,8 +4445,8 @@ define dso_local i64 @atomicrmw_or_i64_unaligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_monotonic:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_monotonic:
@@ -4500,8 +4460,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acquire:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acquire:
@@ -4515,8 +4475,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_release:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_release:
@@ -4530,8 +4490,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_acq_rel:
@@ -4545,8 +4505,8 @@ define dso_local i128 @atomicrmw_or_i128_unaligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_or_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
-; -O0:    orr x9, x8, x9
-; -O0:    orr x8, x8, x10
+; -O0:    orr x8, x11, x8
+; -O0:    orr x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_or_i128_unaligned_seq_cst:
@@ -4885,16 +4845,15 @@ define dso_local i64 @atomicrmw_xor_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_monotonic:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4907,16 +4866,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acquire:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4929,16 +4887,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_release:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -4951,16 +4908,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -4973,16 +4929,15 @@ define dso_local i128 @atomicrmw_xor_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_xor_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
-; -O0:    eor x14, x8, x10
-; -O0:    eor x15, x8, x9
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    eor x14, x11, x10
+; -O0:    eor x15, x13, x8
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5260,8 +5215,8 @@ define dso_local i64 @atomicrmw_xor_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_monotonic:
@@ -5275,8 +5230,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acquire:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acquire:
@@ -5290,8 +5245,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_release:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_release:
@@ -5305,8 +5260,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_acq_rel:
@@ -5320,8 +5275,8 @@ define dso_local i128 @atomicrmw_xor_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_xor_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
-; -O0:    eor x9, x8, x9
-; -O0:    eor x8, x8, x10
+; -O0:    eor x8, x11, x8
+; -O0:    eor x9, x10, x9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_xor_i128_unaligned_seq_cst:
@@ -5720,22 +5675,16 @@ define dso_local i64 @atomicrmw_max_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5749,22 +5698,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5778,22 +5721,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -5807,22 +5744,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -5836,22 +5767,16 @@ define dso_local i128 @atomicrmw_max_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_max_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lt
+; -O0:    csel x14, x11, x8, lt
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_max_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6190,14 +6115,9 @@ define dso_local i64 @atomicrmw_max_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_monotonic:
@@ -6212,14 +6132,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acquire:
@@ -6234,14 +6149,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_release:
@@ -6256,14 +6166,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_acq_rel:
@@ -6278,14 +6183,9 @@ define dso_local i128 @atomicrmw_max_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_max_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lt
+; -O0:    csel x9, x10, x9, lt
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_max_i128_unaligned_seq_cst:
@@ -6685,22 +6585,16 @@ define dso_local i64 @atomicrmw_min_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6714,22 +6608,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_monotonic(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6743,22 +6631,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acquire(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -6772,22 +6654,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_release(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -6801,22 +6677,16 @@ define dso_local i128 @atomicrmw_min_i128_aligned_acq_rel(ptr %ptr, i128 %value)
 
 define dso_local i128 @atomicrmw_min_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, ge
+; -O0:    csel x14, x11, x8, ge
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_min_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7155,14 +7025,9 @@ define dso_local i64 @atomicrmw_min_i64_unaligned_seq_cst(ptr %ptr, i64 %value) 
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_monotonic:
@@ -7177,14 +7042,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_monotonic(ptr %ptr, i128 %va
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acquire:
@@ -7199,14 +7059,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acquire(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_release:
@@ -7221,14 +7076,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_release(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_acq_rel:
@@ -7243,14 +7093,9 @@ define dso_local i128 @atomicrmw_min_i128_unaligned_acq_rel(ptr %ptr, i128 %valu
 
 define dso_local i128 @atomicrmw_min_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, ge
+; -O0:    csel x9, x10, x9, ge
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_min_i128_unaligned_seq_cst:
@@ -7645,22 +7490,16 @@ define dso_local i64 @atomicrmw_umax_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7674,22 +7513,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7703,22 +7536,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -7732,22 +7559,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -7761,22 +7582,16 @@ define dso_local i128 @atomicrmw_umax_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umax_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, lo
+; -O0:    csel x14, x11, x8, lo
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8110,14 +7925,9 @@ define dso_local i64 @atomicrmw_umax_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_monotonic:
@@ -8132,14 +7942,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acquire:
@@ -8154,14 +7959,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_release:
@@ -8176,14 +7976,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_acq_rel:
@@ -8198,14 +7993,9 @@ define dso_local i128 @atomicrmw_umax_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umax_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, lo
+; -O0:    csel x9, x10, x9, lo
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umax_i128_unaligned_seq_cst:
@@ -8600,22 +8390,16 @@ define dso_local i64 @atomicrmw_umin_i64_aligned_seq_cst(ptr %ptr, i64 %value) {
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_monotonic:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_monotonic:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8629,22 +8413,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_monotonic(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acquire:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stxp w8, x14, x15, [x11]
-; -O0:    stxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stxp w8, x14, x15, [x9]
+; -O0:    stxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acquire:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8658,22 +8436,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acquire(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_release:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_release:
 ; -O1:    ldxp x0, x1, [x8]
@@ -8687,22 +8459,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_release(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_acq_rel:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -8716,22 +8482,16 @@ define dso_local i128 @atomicrmw_umin_i128_aligned_acq_rel(ptr %ptr, i128 %value
 
 define dso_local i128 @atomicrmw_umin_i128_aligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
-; -O0:    subs x8, x8, x12
-; -O0:    subs x10, x10, x9
-; -O0:    subs x13, x13, x9
-; -O0:    csel w10, w8, w10, eq
-; -O0:    ands w13, w10, #0x1
-; -O0:    csel x14, x8, x12, ne
-; -O0:    ands w10, w10, #0x1
-; -O0:    csel x15, x8, x9, ne
-; -O0:    ldaxp x10, x9, [x11]
-; -O0:    cmp x10, x12
-; -O0:    cmp x9, x13
-; -O0:    stlxp w8, x14, x15, [x11]
-; -O0:    stlxp w8, x10, x9, [x11]
-; -O0:    eor x8, x10, x8
-; -O0:    eor x11, x9, x11
-; -O0:    orr x8, x8, x11
+; -O0:    subs x12, x8, x11
+; -O0:    csel x15, x13, x10, hs
+; -O0:    csel x14, x11, x8, hs
+; -O0:    ldaxp x10, x12, [x9]
+; -O0:    cmp x10, x11
+; -O0:    cmp x12, x13
+; -O0:    stlxp w8, x14, x15, [x9]
+; -O0:    stlxp w8, x10, x12, [x9]
+; -O0:    subs x12, x12, x13
+; -O0:    ccmp x10, x11, #0, eq
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_aligned_seq_cst:
 ; -O1:    ldaxp x0, x1, [x8]
@@ -9065,14 +8825,9 @@ define dso_local i64 @atomicrmw_umin_i64_unaligned_seq_cst(ptr %ptr, i64 %value)
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_monotonic:
@@ -9087,14 +8842,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_monotonic(ptr %ptr, i128 %v
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acquire:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acquire:
@@ -9109,14 +8859,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acquire(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_release:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_release:
@@ -9131,14 +8876,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_release(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_acq_rel:
@@ -9153,14 +8893,9 @@ define dso_local i128 @atomicrmw_umin_i128_unaligned_acq_rel(ptr %ptr, i128 %val
 
 define dso_local i128 @atomicrmw_umin_i128_unaligned_seq_cst(ptr %ptr, i128 %value) {
 ; -O0-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:
-; -O0:    subs x8, x8, x9
-; -O0:    subs x11, x11, x10
-; -O0:    subs x12, x12, x10
-; -O0:    csel w11, w8, w11, eq
-; -O0:    ands w12, w11, #0x1
-; -O0:    csel x9, x8, x9, ne
-; -O0:    ands w11, w11, #0x1
-; -O0:    csel x8, x8, x10, ne
+; -O0:    subs x12, x8, x11
+; -O0:    csel x8, x11, x8, hs
+; -O0:    csel x9, x10, x9, hs
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_umin_i128_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a_fp.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-v8a_fp.ll
@@ -5,10 +5,10 @@
 
 define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -19,10 +19,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -33,10 +33,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -47,10 +47,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -61,10 +61,10 @@ define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fadd_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fadd_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -75,15 +75,12 @@ define dso_local half @atomicrmw_fadd_half_aligned_seq_cst(ptr %ptr, half %value
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -96,15 +93,12 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -117,15 +111,12 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acquire(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -138,15 +129,12 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -159,15 +147,12 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -180,10 +165,10 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -194,10 +179,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -208,10 +193,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -222,10 +207,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -236,10 +221,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fadd_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fadd_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fadd_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -250,10 +235,10 @@ define dso_local float @atomicrmw_fadd_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -264,10 +249,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -278,10 +263,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -292,10 +277,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -306,10 +291,10 @@ define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fadd_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fadd_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fadd_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -355,11 +340,8 @@ define dso_local half @atomicrmw_fadd_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_monotonic:
@@ -372,11 +354,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_acquire:
@@ -389,11 +368,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_release:
@@ -406,11 +382,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_acq_rel:
@@ -423,11 +396,8 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fadd_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fadd_bfloat_unaligned_seq_cst:
@@ -510,10 +480,10 @@ define dso_local double @atomicrmw_fadd_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -524,10 +494,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -538,10 +508,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -552,10 +522,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -566,10 +536,10 @@ define dso_local half @atomicrmw_fsub_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -580,15 +550,12 @@ define dso_local half @atomicrmw_fsub_half_aligned_seq_cst(ptr %ptr, half %value
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -601,15 +568,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -622,15 +586,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acquire(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -643,15 +604,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -664,15 +622,12 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -685,10 +640,10 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -699,10 +654,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -713,10 +668,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -727,10 +682,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -741,10 +696,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fsub_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -755,10 +710,10 @@ define dso_local float @atomicrmw_fsub_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -769,10 +724,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -783,10 +738,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -797,10 +752,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -811,10 +766,10 @@ define dso_local double @atomicrmw_fsub_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fsub_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fsub_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -860,11 +815,8 @@ define dso_local half @atomicrmw_fsub_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_monotonic:
@@ -877,11 +829,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_acquire:
@@ -894,11 +843,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_release:
@@ -911,11 +857,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_acq_rel:
@@ -928,11 +871,8 @@ define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fsub_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fsub_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fsub_bfloat_unaligned_seq_cst:
@@ -1015,10 +955,10 @@ define dso_local double @atomicrmw_fsub_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1029,10 +969,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1043,10 +983,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1057,10 +997,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1071,10 +1011,10 @@ define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmax_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmax_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1085,15 +1025,12 @@ define dso_local half @atomicrmw_fmax_half_aligned_seq_cst(ptr %ptr, half %value
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -1106,15 +1043,12 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -1127,15 +1061,12 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acquire(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -1148,15 +1079,12 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -1169,15 +1097,12 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1190,10 +1115,10 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1204,10 +1129,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1218,10 +1143,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1232,10 +1157,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1246,10 +1171,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmax_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmax_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmax_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1260,10 +1185,10 @@ define dso_local float @atomicrmw_fmax_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -1274,10 +1199,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -1288,10 +1213,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -1302,10 +1227,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -1316,10 +1241,10 @@ define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmax_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmax_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmax_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -1365,11 +1290,8 @@ define dso_local half @atomicrmw_fmax_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_monotonic:
@@ -1382,11 +1304,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_acquire:
@@ -1399,11 +1318,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_release:
@@ -1416,11 +1332,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_acq_rel:
@@ -1433,11 +1346,8 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmax_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmax_bfloat_unaligned_seq_cst:
@@ -1520,10 +1430,10 @@ define dso_local double @atomicrmw_fmax_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -1534,10 +1444,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -1548,10 +1458,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -1562,10 +1472,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -1576,10 +1486,10 @@ define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value
 
 define dso_local half @atomicrmw_fmin_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmin_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -1590,15 +1500,12 @@ define dso_local half @atomicrmw_fmin_half_aligned_seq_cst(ptr %ptr, half %value
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -1611,15 +1518,12 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -1632,15 +1536,12 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acquire(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -1653,15 +1554,12 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -1674,15 +1572,12 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acq_rel(ptr %ptr, bfloat 
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -1695,10 +1590,10 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_seq_cst(ptr %ptr, bfloat 
 
 define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -1709,10 +1604,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -1723,10 +1618,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -1737,10 +1632,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -1751,10 +1646,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %va
 
 define dso_local float @atomicrmw_fmin_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmin_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmin_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -1765,10 +1660,10 @@ define dso_local float @atomicrmw_fmin_float_aligned_seq_cst(ptr %ptr, float %va
 
 define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -1779,10 +1674,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -1793,10 +1688,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -1807,10 +1702,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -1821,10 +1716,10 @@ define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double 
 
 define dso_local double @atomicrmw_fmin_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmin_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmin_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -1870,11 +1765,8 @@ define dso_local half @atomicrmw_fmin_half_unaligned_seq_cst(ptr %ptr, half %val
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_monotonic:
@@ -1887,11 +1779,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_monotonic(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_acquire:
@@ -1904,11 +1793,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acquire(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_release:
@@ -1921,11 +1807,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_release(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_acq_rel:
@@ -1938,11 +1821,8 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_acq_rel(ptr %ptr, bfloa
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmin_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmin_bfloat_unaligned_seq_cst:
@@ -2025,10 +1905,10 @@ define dso_local double @atomicrmw_fmin_double_unaligned_seq_cst(ptr %ptr, doubl
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2039,10 +1919,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_monotonic(ptr %ptr, half 
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2053,10 +1933,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_acquire(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2067,10 +1947,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_release(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2081,10 +1961,10 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_acq_rel(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fmaximum_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2095,15 +1975,12 @@ define dso_local half @atomicrmw_fmaximum_half_aligned_seq_cst(ptr %ptr, half %v
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -2116,15 +1993,12 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_monotonic(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -2137,15 +2011,12 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acquire(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -2158,15 +2029,12 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_release(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -2179,15 +2047,12 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_acq_rel(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -2200,10 +2065,10 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2214,10 +2079,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_monotonic(ptr %ptr, flo
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2228,10 +2093,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_acquire(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2242,10 +2107,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_release(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2256,10 +2121,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_acq_rel(ptr %ptr, float
 
 define dso_local float @atomicrmw_fmaximum_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2270,10 +2135,10 @@ define dso_local float @atomicrmw_fmaximum_float_aligned_seq_cst(ptr %ptr, float
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -2284,10 +2149,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_monotonic(ptr %ptr, d
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -2298,10 +2163,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_acquire(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -2312,10 +2177,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_release(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -2326,10 +2191,10 @@ define dso_local double @atomicrmw_fmaximum_double_aligned_acq_rel(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fmaximum_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -2375,11 +2240,8 @@ define dso_local half @atomicrmw_fmaximum_half_unaligned_seq_cst(ptr %ptr, half 
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_monotonic:
@@ -2392,11 +2254,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_monotonic(ptr %ptr,
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acquire:
@@ -2409,11 +2268,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acquire(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_release:
@@ -2426,11 +2282,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_release(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_acq_rel:
@@ -2443,11 +2296,8 @@ define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_acq_rel(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fmaximum_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fmaximum_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fmaximum_bfloat_unaligned_seq_cst:
@@ -2530,10 +2380,10 @@ define dso_local double @atomicrmw_fmaximum_double_unaligned_seq_cst(ptr %ptr, d
 
 define dso_local half @atomicrmw_fminimum_half_aligned_monotonic(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_monotonic:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_monotonic:
 ; -O1:    ldxrh w8, [x0]
@@ -2544,10 +2394,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_monotonic(ptr %ptr, half 
 
 define dso_local half @atomicrmw_fminimum_half_aligned_acquire(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_acquire:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_acquire:
 ; -O1:    ldaxrh w8, [x0]
@@ -2558,10 +2408,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_acquire(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_release(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_release:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_release:
 ; -O1:    ldxrh w8, [x0]
@@ -2572,10 +2422,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_release(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_acq_rel(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_acq_rel:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_acq_rel:
 ; -O1:    ldaxrh w8, [x0]
@@ -2586,10 +2436,10 @@ define dso_local half @atomicrmw_fminimum_half_aligned_acq_rel(ptr %ptr, half %v
 
 define dso_local half @atomicrmw_fminimum_half_aligned_seq_cst(ptr %ptr, half %value) {
 ; -O0-LABEL: atomicrmw_fminimum_half_aligned_seq_cst:
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_half_aligned_seq_cst:
 ; -O1:    ldaxrh w8, [x0]
@@ -2600,15 +2450,12 @@ define dso_local half @atomicrmw_fminimum_half_aligned_seq_cst(ptr %ptr, half %v
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_monotonic:
 ; -O1:    ldxrh w9, [x0]
@@ -2621,15 +2468,12 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_monotonic(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_acquire:
 ; -O1:    ldaxrh w9, [x0]
@@ -2642,15 +2486,12 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acquire(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_release:
 ; -O1:    ldxrh w9, [x0]
@@ -2663,15 +2504,12 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_release(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_acq_rel:
 ; -O1:    ldaxrh w9, [x0]
@@ -2684,15 +2522,12 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_acq_rel(ptr %ptr, bfl
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_aligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w11, w9, w11
-; -O0:    add w9, w9, w11
-; -O0:    csel w8, w8, w9, vs
-; -O0:    ldaxrh w9, [x10]
-; -O0:    cmp w9, w11, uxth
-; -O0:    stlxrh w8, w12, [x10]
-; -O0:    subs w8, w8, w9, uxth
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
+; -O0:    ldaxrh w8, [x11]
+; -O0:    cmp w8, w9, uxth
+; -O0:    stlxrh w10, w12, [x11]
+; -O0:    subs w9, w8, w9, uxth
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_aligned_seq_cst:
 ; -O1:    ldaxrh w9, [x0]
@@ -2705,10 +2540,10 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_aligned_seq_cst(ptr %ptr, bfl
 
 define dso_local float @atomicrmw_fminimum_float_aligned_monotonic(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_monotonic:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_monotonic:
 ; -O1:    ldxr w8, [x0]
@@ -2719,10 +2554,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_monotonic(ptr %ptr, flo
 
 define dso_local float @atomicrmw_fminimum_float_aligned_acquire(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_acquire:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_acquire:
 ; -O1:    ldaxr w8, [x0]
@@ -2733,10 +2568,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_acquire(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_release(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_release:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_release:
 ; -O1:    ldxr w8, [x0]
@@ -2747,10 +2582,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_release(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_acq_rel(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_acq_rel:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_acq_rel:
 ; -O1:    ldaxr w8, [x0]
@@ -2761,10 +2596,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_acq_rel(ptr %ptr, float
 
 define dso_local float @atomicrmw_fminimum_float_aligned_seq_cst(ptr %ptr, float %value) {
 ; -O0-LABEL: atomicrmw_fminimum_float_aligned_seq_cst:
-; -O0:    ldaxr w8, [x10]
-; -O0:    cmp w8, w11
-; -O0:    stlxr w9, w12, [x10]
-; -O0:    subs w8, w8, w9
+; -O0:    ldaxr w8, [x11]
+; -O0:    cmp w8, w9
+; -O0:    stlxr w10, w12, [x11]
+; -O0:    subs w9, w8, w9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_float_aligned_seq_cst:
 ; -O1:    ldaxr w8, [x0]
@@ -2775,10 +2610,10 @@ define dso_local float @atomicrmw_fminimum_float_aligned_seq_cst(ptr %ptr, float
 
 define dso_local double @atomicrmw_fminimum_double_aligned_monotonic(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_monotonic:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_monotonic:
 ; -O1:    ldxr x8, [x0]
@@ -2789,10 +2624,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_monotonic(ptr %ptr, d
 
 define dso_local double @atomicrmw_fminimum_double_aligned_acquire(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_acquire:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_acquire:
 ; -O1:    ldaxr x8, [x0]
@@ -2803,10 +2638,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_acquire(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_release(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_release:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_release:
 ; -O1:    ldxr x8, [x0]
@@ -2817,10 +2652,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_release(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_acq_rel(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_acq_rel:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_acq_rel:
 ; -O1:    ldaxr x8, [x0]
@@ -2831,10 +2666,10 @@ define dso_local double @atomicrmw_fminimum_double_aligned_acq_rel(ptr %ptr, dou
 
 define dso_local double @atomicrmw_fminimum_double_aligned_seq_cst(ptr %ptr, double %value) {
 ; -O0-LABEL: atomicrmw_fminimum_double_aligned_seq_cst:
-; -O0:    ldaxr x8, [x10]
-; -O0:    cmp x8, x11
-; -O0:    stlxr w9, x12, [x10]
-; -O0:    subs x8, x8, x9
+; -O0:    ldaxr x8, [x11]
+; -O0:    cmp x8, x9
+; -O0:    stlxr w10, x12, [x11]
+; -O0:    subs x9, x8, x9
 ;
 ; -O1-LABEL: atomicrmw_fminimum_double_aligned_seq_cst:
 ; -O1:    ldaxr x8, [x0]
@@ -2880,11 +2715,8 @@ define dso_local half @atomicrmw_fminimum_half_unaligned_seq_cst(ptr %ptr, half 
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_monotonic(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_monotonic:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_monotonic:
@@ -2897,11 +2729,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_monotonic(ptr %ptr,
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acquire(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_acquire:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_acquire:
@@ -2914,11 +2743,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acquire(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_release(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_release:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_release:
@@ -2931,11 +2757,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_release(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acq_rel(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_acq_rel:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_acq_rel:
@@ -2948,11 +2771,8 @@ define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_acq_rel(ptr %ptr, b
 
 define dso_local bfloat @atomicrmw_fminimum_bfloat_unaligned_seq_cst(ptr %ptr, bfloat %value) {
 ; -O0-LABEL: atomicrmw_fminimum_bfloat_unaligned_seq_cst:
-; -O0:    orr w8, w8, #0x400000
-; -O0:    and w9, w9, #0x1
-; -O0:    add w10, w9, w10
-; -O0:    add w9, w9, w10
-; -O0:    csel w8, w8, w9, vs
+; -O0:    add w8, w8, w9
+; -O0:    add w8, w8, w9
 ; -O0:    bl __atomic_compare_exchange
 ;
 ; -O1-LABEL: atomicrmw_fminimum_bfloat_unaligned_seq_cst:

--- a/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/arm64-atomic.ll
@@ -1018,9 +1018,11 @@ define i8 @atomic_load_relaxed_8(ptr %p, i32 %off32) #0 {
 ; CHECK-NOLSE-O0-LABEL: atomic_load_relaxed_8:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    ldrb w9, [x0, #4095]
-; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x0, w1, sxtw]
+; CHECK-NOLSE-O0-NEXT:    add x8, x0, w1, sxtw
+; CHECK-NOLSE-O0-NEXT:    ldrb w8, [x8]
 ; CHECK-NOLSE-O0-NEXT:    add w8, w8, w9, uxtb
-; CHECK-NOLSE-O0-NEXT:    ldurb w9, [x0, #-256]
+; CHECK-NOLSE-O0-NEXT:    subs x9, x0, #256
+; CHECK-NOLSE-O0-NEXT:    ldrb w9, [x9]
 ; CHECK-NOLSE-O0-NEXT:    add w8, w8, w9, uxtb
 ; CHECK-NOLSE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
 ; CHECK-NOLSE-O0-NEXT:    ldrb w9, [x9]
@@ -1030,9 +1032,11 @@ define i8 @atomic_load_relaxed_8(ptr %p, i32 %off32) #0 {
 ; CHECK-OUTLINE-O0-LABEL: atomic_load_relaxed_8:
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    ldrb w9, [x0, #4095]
-; CHECK-OUTLINE-O0-NEXT:    ldrb w8, [x0, w1, sxtw]
+; CHECK-OUTLINE-O0-NEXT:    add x8, x0, w1, sxtw
+; CHECK-OUTLINE-O0-NEXT:    ldrb w8, [x8]
 ; CHECK-OUTLINE-O0-NEXT:    add w8, w8, w9, uxtb
-; CHECK-OUTLINE-O0-NEXT:    ldurb w9, [x0, #-256]
+; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, #256
+; CHECK-OUTLINE-O0-NEXT:    ldrb w9, [x9]
 ; CHECK-OUTLINE-O0-NEXT:    add w8, w8, w9, uxtb
 ; CHECK-OUTLINE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
 ; CHECK-OUTLINE-O0-NEXT:    ldrb w9, [x9]
@@ -1054,9 +1058,11 @@ define i8 @atomic_load_relaxed_8(ptr %p, i32 %off32) #0 {
 ; CHECK-LSE-O0-LABEL: atomic_load_relaxed_8:
 ; CHECK-LSE-O0:       ; %bb.0:
 ; CHECK-LSE-O0-NEXT:    ldrb w9, [x0, #4095]
-; CHECK-LSE-O0-NEXT:    ldrb w8, [x0, w1, sxtw]
+; CHECK-LSE-O0-NEXT:    add x8, x0, w1, sxtw
+; CHECK-LSE-O0-NEXT:    ldrb w8, [x8]
 ; CHECK-LSE-O0-NEXT:    add w8, w8, w9, uxtb
-; CHECK-LSE-O0-NEXT:    ldurb w9, [x0, #-256]
+; CHECK-LSE-O0-NEXT:    subs x9, x0, #256
+; CHECK-LSE-O0-NEXT:    ldrb w9, [x9]
 ; CHECK-LSE-O0-NEXT:    add w8, w8, w9, uxtb
 ; CHECK-LSE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
 ; CHECK-LSE-O0-NEXT:    ldrb w9, [x9]
@@ -1108,9 +1114,11 @@ define i16 @atomic_load_relaxed_16(ptr %p, i32 %off32) #0 {
 ; CHECK-NOLSE-O0-LABEL: atomic_load_relaxed_16:
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    ldrh w9, [x0, #8190]
-; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x0, w1, sxtw #1]
+; CHECK-NOLSE-O0-NEXT:    add x8, x0, w1, sxtw #1
+; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x8]
 ; CHECK-NOLSE-O0-NEXT:    add w8, w8, w9, uxth
-; CHECK-NOLSE-O0-NEXT:    ldurh w9, [x0, #-256]
+; CHECK-NOLSE-O0-NEXT:    subs x9, x0, #256
+; CHECK-NOLSE-O0-NEXT:    ldrh w9, [x9]
 ; CHECK-NOLSE-O0-NEXT:    add w8, w8, w9, uxth
 ; CHECK-NOLSE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
 ; CHECK-NOLSE-O0-NEXT:    ldrh w9, [x9]
@@ -1120,9 +1128,11 @@ define i16 @atomic_load_relaxed_16(ptr %p, i32 %off32) #0 {
 ; CHECK-OUTLINE-O0-LABEL: atomic_load_relaxed_16:
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    ldrh w9, [x0, #8190]
-; CHECK-OUTLINE-O0-NEXT:    ldrh w8, [x0, w1, sxtw #1]
+; CHECK-OUTLINE-O0-NEXT:    add x8, x0, w1, sxtw #1
+; CHECK-OUTLINE-O0-NEXT:    ldrh w8, [x8]
 ; CHECK-OUTLINE-O0-NEXT:    add w8, w8, w9, uxth
-; CHECK-OUTLINE-O0-NEXT:    ldurh w9, [x0, #-256]
+; CHECK-OUTLINE-O0-NEXT:    subs x9, x0, #256
+; CHECK-OUTLINE-O0-NEXT:    ldrh w9, [x9]
 ; CHECK-OUTLINE-O0-NEXT:    add w8, w8, w9, uxth
 ; CHECK-OUTLINE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
 ; CHECK-OUTLINE-O0-NEXT:    ldrh w9, [x9]
@@ -1144,9 +1154,11 @@ define i16 @atomic_load_relaxed_16(ptr %p, i32 %off32) #0 {
 ; CHECK-LSE-O0-LABEL: atomic_load_relaxed_16:
 ; CHECK-LSE-O0:       ; %bb.0:
 ; CHECK-LSE-O0-NEXT:    ldrh w9, [x0, #8190]
-; CHECK-LSE-O0-NEXT:    ldrh w8, [x0, w1, sxtw #1]
+; CHECK-LSE-O0-NEXT:    add x8, x0, w1, sxtw #1
+; CHECK-LSE-O0-NEXT:    ldrh w8, [x8]
 ; CHECK-LSE-O0-NEXT:    add w8, w8, w9, uxth
-; CHECK-LSE-O0-NEXT:    ldurh w9, [x0, #-256]
+; CHECK-LSE-O0-NEXT:    subs x9, x0, #256
+; CHECK-LSE-O0-NEXT:    ldrh w9, [x9]
 ; CHECK-LSE-O0-NEXT:    add w8, w8, w9, uxth
 ; CHECK-LSE-O0-NEXT:    add x9, x0, #291, lsl #12 ; =1191936
 ; CHECK-LSE-O0-NEXT:    ldrh w9, [x9]
@@ -1676,7 +1688,6 @@ define i32 @load_zext(ptr %p8, ptr %p16) {
 ; CHECK-NOLSE-O0:       ; %bb.0:
 ; CHECK-NOLSE-O0-NEXT:    ldarb w9, [x0]
 ; CHECK-NOLSE-O0-NEXT:    ldrh w8, [x1]
-; CHECK-NOLSE-O0-NEXT:    uxth w8, w8
 ; CHECK-NOLSE-O0-NEXT:    add w0, w8, w9, uxtb
 ; CHECK-NOLSE-O0-NEXT:    ret
 ;
@@ -1684,7 +1695,6 @@ define i32 @load_zext(ptr %p8, ptr %p16) {
 ; CHECK-OUTLINE-O0:       ; %bb.0:
 ; CHECK-OUTLINE-O0-NEXT:    ldarb w9, [x0]
 ; CHECK-OUTLINE-O0-NEXT:    ldrh w8, [x1]
-; CHECK-OUTLINE-O0-NEXT:    uxth w8, w8
 ; CHECK-OUTLINE-O0-NEXT:    add w0, w8, w9, uxtb
 ; CHECK-OUTLINE-O0-NEXT:    ret
 ;
@@ -1700,7 +1710,6 @@ define i32 @load_zext(ptr %p8, ptr %p16) {
 ; CHECK-LSE-O0:       ; %bb.0:
 ; CHECK-LSE-O0-NEXT:    ldaprb w9, [x0]
 ; CHECK-LSE-O0-NEXT:    ldrh w8, [x1]
-; CHECK-LSE-O0-NEXT:    uxth w8, w8
 ; CHECK-LSE-O0-NEXT:    add w0, w8, w9, uxtb
 ; CHECK-LSE-O0-NEXT:    ret
   %val1.8 = load atomic i8, ptr %p8 acquire, align 1

--- a/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/gisel-commandline-option.ll
@@ -10,6 +10,11 @@
 
 ; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
 ; RUN:   --debugify-and-strip-all-safe=0 \
+; RUN:   -verify-machineinstrs=0 -O0 -aarch64-skip-regbankselect-at-O=-1 \
+; RUN:   | FileCheck %s --check-prefixes=ENABLED,FALLBACK,FORCE-RBS
+
+; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
+; RUN:   --debugify-and-strip-all-safe=0 \
 ; RUN:   -verify-machineinstrs=0 -O0 -aarch64-enable-global-isel-at-O=0 -global-isel-abort=1 \
 ; RUN:   | FileCheck %s --check-prefixes=ENABLED,NOFALLBACK
 
@@ -22,6 +27,11 @@
 ; RUN:   --debugify-and-strip-all-safe=0 \
 ; RUN:   -verify-machineinstrs=0 -global-isel \
 ; RUN:   | FileCheck %s --check-prefix ENABLED --check-prefix NOFALLBACK --check-prefix ENABLED-O1
+
+; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
+; RUN:   --debugify-and-strip-all-safe=0 \
+; RUN:   -verify-machineinstrs=0 -global-isel -O1 -aarch64-skip-regbankselect-at-O=1 \
+; RUN:   | FileCheck %s --check-prefix NOFALLBACK --check-prefix SKIP-RBS-O1
 
 ; RUN: llc -mtriple=aarch64-- -debug-pass=Structure %s -o /dev/null 2>&1 \
 ; RUN:   --debugify-and-strip-all-safe=0 \
@@ -69,15 +79,23 @@
 ; ENABLED-O1-NEXT:  Analysis containing CSE Info
 ; ENABLED:  Legalizer
 ; VERIFY-NEXT:   Verify generated machine code
-; ENABLED:  RegBankSelect
+; VERIFY-O0-NEXT:  AArch64PostLegalizerLowering
 ; VERIFY-NEXT:   Verify generated machine code
-; ENABLED-NEXT: Analysis for ComputingKnownBits
+; ENABLED-O1:  RegBankSelect
+; ENABLED-O1-NEXT: Analysis for ComputingKnownBits
+; VERIFY-O0-NEXT: Analysis for ComputingKnownBits
+; FORCE-RBS: RegBankSelect
+; FORCE-RBS-NEXT: Analysis for ComputingKnownBits
+; SKIP-RBS-O1: IRTranslator
+; SKIP-RBS-O1-NOT: RegBankSelect
+; SKIP-RBS-O1: InstructionSelect
+; SKIP-RBS-O1-NEXT: AArch64 Post Select Optimizer
 ; ENABLED-O1-NEXT: Lazy Branch Probability Analysis
 ; ENABLED-O1-NEXT: Lazy Block Frequency Analysis
-; ENABLED-NEXT:  InstructionSelect
+; ENABLED:  InstructionSelect
 ; ENABLED-O1-NEXT:  AArch64 Post Select Optimizer
-; VERIFY-NEXT:   Verify generated machine code
-; ENABLED-NEXT:  ResetMachineFunction
+; VERIFY-O0-NEXT: Verify generated machine code
+; ENABLED-O1-NEXT: ResetMachineFunction
 
 ; FALLBACK:       AArch64 Instruction Selection
 ; NOFALLBACK-NOT: AArch64 Instruction Selection

--- a/llvm/test/CodeGen/AArch64/GlobalISel/inline-asm.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/inline-asm.ll
@@ -28,11 +28,15 @@ define i16 @test_16bit_reg(i16 %x) {
 ; O0-LABEL: test_16bit_reg:
 ; O0:       // %bb.0:
 ; O0-NEXT:    fmov s0, w0
-; O0-NEXT:    // kill: def $h0 killed $h0 killed $s0
+; O0-NEXT:    // kill: def $q0 killed $s0
+; O0-NEXT:    // kill: def $h0 killed $h0 killed $q0
 ; O0-NEXT:    //APP
 ; O0-NEXT:    nop
 ; O0-NEXT:    //NO_APP
-; O0-NEXT:    // kill: def $s0 killed $h0
+; O0-NEXT:    fmov s1, s0
+; O0-NEXT:    // implicit-def: $w0
+; O0-NEXT:    fmov s0, w0
+; O0-NEXT:    fmov s0, s1
 ; O0-NEXT:    fmov w0, s0
 ; O0-NEXT:    ret
 ;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-fp-anyext-crash.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-fp-anyext-crash.ll
@@ -39,4 +39,3 @@ entry:
   %2 = load float, ptr %0, align 4
   ret i32 0
 }
-

--- a/llvm/test/CodeGen/AArch64/O0-pipeline.ll
+++ b/llvm/test/CodeGen/AArch64/O0-pipeline.ll
@@ -40,7 +40,6 @@
 ; CHECK-NEXT:       Analysis for ComputingKnownBits
 ; CHECK-NEXT:       Legalizer
 ; CHECK-NEXT:       AArch64PostLegalizerLowering
-; CHECK-NEXT:       RegBankSelect
 ; CHECK-NEXT:       Analysis for ComputingKnownBits
 ; CHECK-NEXT:       InstructionSelect
 ; CHECK-NEXT:       ResetMachineFunction

--- a/llvm/test/CodeGen/AArch64/arm64-fast-isel-materialize.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-fast-isel-materialize.ll
@@ -40,6 +40,10 @@ define float @cp_float() {
 ; CHECK-LABEL: cp_float
 ; CHECK:       adrp [[REG:x[0-9]+]], {{lCPI[0-9]+_0}}@PAGE
 ; CHECK-NEXT:  ldr s0, [[[REG]], {{lCPI[0-9]+_0}}@PAGEOFF]
+; GISEL-LABEL: cp_float
+; GISEL:       mov w8, #4059 ; =0xfdb
+; GISEL-NEXT:  movk w8, #16457, lsl #16
+; GISEL-NEXT:  fmov s0, w8
   ret float 0x400921FB60000000
 }
 
@@ -47,5 +51,8 @@ define double @cp_double() {
 ; CHECK-LABEL: cp_double
 ; CHECK:       adrp [[REG:x[0-9]+]], {{lCPI[0-9]+_0}}@PAGE
 ; CHECK-NEXT:  ldr d0, [[[REG]], {{lCPI[0-9]+_0}}@PAGEOFF]
+; GISEL-LABEL: cp_double
+; GISEL:       adrp [[GREG:x[0-9]+]], {{lCPI[0-9]+_0}}@PAGE
+; GISEL-NEXT:  ldr d0, [[[GREG]], {{lCPI[0-9]+_0}}@PAGEOFF]
   ret double 0x400921FB54442D18
 }

--- a/llvm/test/CodeGen/AArch64/cpa-globalisel.ll
+++ b/llvm/test/CodeGen/AArch64/cpa-globalisel.ll
@@ -653,14 +653,17 @@ define hidden void @multidim() {
 ; CHECK-CPA-O0-NEXT:    mov w10, w9
 ; CHECK-CPA-O0-NEXT:    ldrh w8, [x8, :lo12:b]
 ; CHECK-CPA-O0-NEXT:    add w9, w8, #1
+; CHECK-CPA-O0-NEXT:    // implicit-def: $x8
+; CHECK-CPA-O0-NEXT:    mov w8, w9
+; CHECK-CPA-O0-NEXT:    sxtw x9, w8
 ; CHECK-CPA-O0-NEXT:    mov w8, #2 // =0x2
 ; CHECK-CPA-O0-NEXT:    mov w11, w8
 ; CHECK-CPA-O0-NEXT:    adrp x8, a
 ; CHECK-CPA-O0-NEXT:    add x8, x8, :lo12:a
 ; CHECK-CPA-O0-NEXT:    addpt x8, x8, x11
 ; CHECK-CPA-O0-NEXT:    addpt x8, x8, x10, lsl #1
-; CHECK-CPA-O0-NEXT:    ldrb w8, [x8, w9, sxtw]
-; CHECK-CPA-O0-NEXT:    uxtb w8, w8
+; CHECK-CPA-O0-NEXT:    addpt x8, x8, x9
+; CHECK-CPA-O0-NEXT:    ldrb w8, [x8]
 ; CHECK-CPA-O0-NEXT:    cbnz w8, .LBB14_1
 ; CHECK-CPA-O0-NEXT:    b .LBB14_2
 ; CHECK-CPA-O0-NEXT:  .LBB14_1:
@@ -708,8 +711,8 @@ define hidden void @multidim() {
 ; CHECK-NOCPA-O0-NEXT:    add x8, x8, :lo12:a
 ; CHECK-NOCPA-O0-NEXT:    add x8, x8, #2
 ; CHECK-NOCPA-O0-NEXT:    add x8, x8, x10, lsl #1
-; CHECK-NOCPA-O0-NEXT:    ldrb w8, [x8, w9, sxtw]
-; CHECK-NOCPA-O0-NEXT:    uxtb w8, w8
+; CHECK-NOCPA-O0-NEXT:    add x8, x8, w9, sxtw
+; CHECK-NOCPA-O0-NEXT:    ldrb w8, [x8]
 ; CHECK-NOCPA-O0-NEXT:    cbnz w8, .LBB14_1
 ; CHECK-NOCPA-O0-NEXT:    b .LBB14_2
 ; CHECK-NOCPA-O0-NEXT:  .LBB14_1:

--- a/llvm/test/CodeGen/AArch64/popcount.ll
+++ b/llvm/test/CodeGen/AArch64/popcount.ll
@@ -15,11 +15,16 @@
 define i8 @popcount128(ptr nocapture nonnull readonly %0) {
 ; CHECKO0-LABEL: popcount128:
 ; CHECKO0:       // %bb.0: // %Entry
-; CHECKO0-NEXT:    ldr q0, [x0]
+; CHECKO0-NEXT:    ldr x8, [x0, #8]
+; CHECKO0-NEXT:    ldr x9, [x0]
+; CHECKO0-NEXT:    fmov d1, x9
+; CHECKO0-NEXT:    // implicit-def: $q0
+; CHECKO0-NEXT:    fmov d0, d1
+; CHECKO0-NEXT:    mov v0.d[1], x8
 ; CHECKO0-NEXT:    cnt v0.16b, v0.16b
-; CHECKO0-NEXT:    uaddlv h0, v0.16b
-; CHECKO0-NEXT:    // kill: def $q0 killed $h0
-; CHECKO0-NEXT:    // kill: def $s0 killed $s0 killed $q0
+; CHECKO0-NEXT:    addv b1, v0.16b
+; CHECKO0-NEXT:    // implicit-def: $q0
+; CHECKO0-NEXT:    fmov s0, s1
 ; CHECKO0-NEXT:    fmov w0, s0
 ; CHECKO0-NEXT:    ret
 ;
@@ -76,11 +81,16 @@ define i8 @popcount128(ptr nocapture nonnull readonly %0) {
 ;
 ; GISELO0-LABEL: popcount128:
 ; GISELO0:       // %bb.0: // %Entry
-; GISELO0-NEXT:    ldr q0, [x0]
+; GISELO0-NEXT:    ldr x8, [x0, #8]
+; GISELO0-NEXT:    ldr x9, [x0]
+; GISELO0-NEXT:    fmov d1, x9
+; GISELO0-NEXT:    // implicit-def: $q0
+; GISELO0-NEXT:    fmov d0, d1
+; GISELO0-NEXT:    mov v0.d[1], x8
 ; GISELO0-NEXT:    cnt v0.16b, v0.16b
-; GISELO0-NEXT:    uaddlv h0, v0.16b
-; GISELO0-NEXT:    // kill: def $q0 killed $h0
-; GISELO0-NEXT:    // kill: def $s0 killed $s0 killed $q0
+; GISELO0-NEXT:    addv b1, v0.16b
+; GISELO0-NEXT:    // implicit-def: $q0
+; GISELO0-NEXT:    fmov s0, s1
 ; GISELO0-NEXT:    fmov w0, s0
 ; GISELO0-NEXT:    ret
 Entry:
@@ -768,23 +778,22 @@ Entry:
 define i32 @ctpop_into_extract(ptr %p) {
 ; CHECKO0-LABEL: ctpop_into_extract:
 ; CHECKO0:       // %bb.0:
-; CHECKO0-NEXT:    mov w8, #-1 // =0xffffffff
-; CHECKO0-NEXT:    // implicit-def: $d2
-; CHECKO0-NEXT:    fmov s2, w8
 ; CHECKO0-NEXT:    ldr d0, [x0]
 ; CHECKO0-NEXT:    // implicit-def: $q1
 ; CHECKO0-NEXT:    fmov d1, d0
-; CHECKO0-NEXT:    mov w8, v1.s[0]
-; CHECKO0-NEXT:    mov w1, w8
-; CHECKO0-NEXT:    fmov d1, x1
-; CHECKO0-NEXT:    cnt v1.8b, v1.8b
-; CHECKO0-NEXT:    uaddlv h1, v1.8b
-; CHECKO0-NEXT:    // kill: def $q1 killed $h1
-; CHECKO0-NEXT:    // kill: def $s1 killed $s1 killed $q1
 ; CHECKO0-NEXT:    fmov w8, s1
-; CHECKO0-NEXT:    // implicit-def: $q1
-; CHECKO0-NEXT:    fmov d1, d2
-; CHECKO0-NEXT:    mov v1.s[1], w8
+; CHECKO0-NEXT:    fmov s1, w8
+; CHECKO0-NEXT:    // kill: def $d1 killed $s1
+; CHECKO0-NEXT:    cnt v1.8b, v1.8b
+; CHECKO0-NEXT:    addv b2, v1.8b
+; CHECKO0-NEXT:    // implicit-def: $d1
+; CHECKO0-NEXT:    fmov s1, s2
+; CHECKO0-NEXT:    // implicit-def: $q2
+; CHECKO0-NEXT:    fmov d2, d1
+; CHECKO0-NEXT:    movi v1.2d, #0xffffffffffffffff
+; CHECKO0-NEXT:    // kill: def $d1 killed $d1 killed $q1
+; CHECKO0-NEXT:    // kill: def $q1 killed $d1
+; CHECKO0-NEXT:    mov v1.s[1], v2.s[0]
 ; CHECKO0-NEXT:    // kill: def $d1 killed $d1 killed $q1
 ; CHECKO0-NEXT:    sub v0.2s, v0.2s, v1.2s
 ; CHECKO0-NEXT:    str d0, [x0]
@@ -868,23 +877,22 @@ define i32 @ctpop_into_extract(ptr %p) {
 ;
 ; GISELO0-LABEL: ctpop_into_extract:
 ; GISELO0:       // %bb.0:
-; GISELO0-NEXT:    mov w8, #-1 // =0xffffffff
-; GISELO0-NEXT:    // implicit-def: $d2
-; GISELO0-NEXT:    fmov s2, w8
 ; GISELO0-NEXT:    ldr d0, [x0]
 ; GISELO0-NEXT:    // implicit-def: $q1
 ; GISELO0-NEXT:    fmov d1, d0
-; GISELO0-NEXT:    mov w8, v1.s[0]
-; GISELO0-NEXT:    mov w1, w8
-; GISELO0-NEXT:    fmov d1, x1
-; GISELO0-NEXT:    cnt v1.8b, v1.8b
-; GISELO0-NEXT:    uaddlv h1, v1.8b
-; GISELO0-NEXT:    // kill: def $q1 killed $h1
-; GISELO0-NEXT:    // kill: def $s1 killed $s1 killed $q1
 ; GISELO0-NEXT:    fmov w8, s1
-; GISELO0-NEXT:    // implicit-def: $q1
-; GISELO0-NEXT:    fmov d1, d2
-; GISELO0-NEXT:    mov v1.s[1], w8
+; GISELO0-NEXT:    fmov s1, w8
+; GISELO0-NEXT:    // kill: def $d1 killed $s1
+; GISELO0-NEXT:    cnt v1.8b, v1.8b
+; GISELO0-NEXT:    addv b2, v1.8b
+; GISELO0-NEXT:    // implicit-def: $d1
+; GISELO0-NEXT:    fmov s1, s2
+; GISELO0-NEXT:    // implicit-def: $q2
+; GISELO0-NEXT:    fmov d2, d1
+; GISELO0-NEXT:    movi v1.2d, #0xffffffffffffffff
+; GISELO0-NEXT:    // kill: def $d1 killed $d1 killed $q1
+; GISELO0-NEXT:    // kill: def $q1 killed $d1
+; GISELO0-NEXT:    mov v1.s[1], v2.s[0]
 ; GISELO0-NEXT:    // kill: def $d1 killed $d1 killed $q1
 ; GISELO0-NEXT:    sub v0.2s, v0.2s, v1.2s
 ; GISELO0-NEXT:    str d0, [x0]
@@ -903,9 +911,8 @@ define <8 x i8> @bitcast_upper_bits(i32 %b, <8 x i8> %v) {
 ; CHECKO0-LABEL: bitcast_upper_bits:
 ; CHECKO0:       // %bb.0:
 ; CHECKO0-NEXT:    fmov d1, d0
-; CHECKO0-NEXT:    mov w8, w0
-; CHECKO0-NEXT:    mov w0, w8
-; CHECKO0-NEXT:    fmov d0, x0
+; CHECKO0-NEXT:    fmov s0, w0
+; CHECKO0-NEXT:    // kill: def $d0 killed $s0
 ; CHECKO0-NEXT:    add v0.8b, v0.8b, v1.8b
 ; CHECKO0-NEXT:    ret
 ;
@@ -933,9 +940,8 @@ define <8 x i8> @bitcast_upper_bits(i32 %b, <8 x i8> %v) {
 ; GISELO0-LABEL: bitcast_upper_bits:
 ; GISELO0:       // %bb.0:
 ; GISELO0-NEXT:    fmov d1, d0
-; GISELO0-NEXT:    mov w8, w0
-; GISELO0-NEXT:    mov w0, w8
-; GISELO0-NEXT:    fmov d0, x0
+; GISELO0-NEXT:    fmov s0, w0
+; GISELO0-NEXT:    // kill: def $d0 killed $s0
 ; GISELO0-NEXT:    add v0.8b, v0.8b, v1.8b
 ; GISELO0-NEXT:    ret
   %a = zext i32 %b to i64

--- a/llvm/test/DebugInfo/AArch64/debug-reg-bank.ll
+++ b/llvm/test/DebugInfo/AArch64/debug-reg-bank.ll
@@ -6,7 +6,7 @@ define void @foo(i32 %n) !dbg !7 {
   ; CHECK: bb.1.entry:
   ; CHECK-NEXT:   liveins: $w0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   DBG_VALUE %2:gpr32, $noreg, !12, !DIExpression(), debug-location !19
+  ; CHECK-NEXT:   DBG_VALUE %2:_, $noreg, !12, !DIExpression(), debug-location !19
   ; CHECK-NEXT:   RET_ReallyLR debug-location !20
 entry:
   %m = mul i32 %n, 13


### PR DESCRIPTION
Profiling of sqlite on aarch64-O0-g shows ~2.60% of compile-time is spent in RegBankSelect. Optimizing cross-register bank copies isn't necessary at O0, skipping this pass and selecting register banks before instruction selection is -a 1.20% geomean improvement on CTMark. sqlite is -1.72%.

https://llvm-compile-time-tracker.com/compare.php?from=376870209db2e3ad33b082f839a7899c2972cc93&to=8fb8909b7071bd7fb959ddfd8a8863736e83dd80&stat=instructions%3Au

Assisted-by: codex