### PR TITLE
llvm: Fix most LLVM_ABI annotations in Transforms

### DIFF
--- a/llvm/include/llvm/Transforms/AggressiveInstCombine/AggressiveInstCombine.h
+++ b/llvm/include/llvm/Transforms/AggressiveInstCombine/AggressiveInstCombine.h
@@ -22,7 +22,7 @@ namespace llvm {
 class AggressiveInstCombinePass
     : public OptionalPassInfoMixin<AggressiveInstCombinePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroAnnotationElide.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroAnnotationElide.h
@@ -27,8 +27,9 @@ struct CoroAnnotationElidePass
     : OptionalPassInfoMixin<CoroAnnotationElidePass> {
   CoroAnnotationElidePass() = default;
 
-  PreservedAnalyses run(LazyCallGraph::SCC &C, CGSCCAnalysisManager &AM,
-                        LazyCallGraph &CG, CGSCCUpdateResult &UR);
+  LLVM_ABI PreservedAnalyses run(LazyCallGraph::SCC &C,
+                                 CGSCCAnalysisManager &AM, LazyCallGraph &CG,
+                                 CGSCCUpdateResult &UR);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroCleanup.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroCleanup.h
@@ -21,7 +21,7 @@ namespace llvm {
 class Module;
 
 struct CoroCleanupPass : RequiredPassInfoMixin<CoroCleanupPass> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroConditionalWrapper.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroConditionalWrapper.h
@@ -18,11 +18,12 @@ class Module;
 // Only runs passes in the contained pass manager if the module contains any
 // coroutine intrinsic declarations.
 struct CoroConditionalWrapper : RequiredPassInfoMixin<CoroConditionalWrapper> {
-  CoroConditionalWrapper(ModulePassManager &&);
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI CoroConditionalWrapper(ModulePassManager &&);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
 private:
   ModulePassManager PM;

--- a/llvm/include/llvm/Transforms/Coroutines/CoroEarly.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroEarly.h
@@ -24,7 +24,7 @@ namespace llvm {
 class Module;
 
 struct CoroEarlyPass : RequiredPassInfoMixin<CoroEarlyPass> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroElide.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroElide.h
@@ -23,7 +23,7 @@ namespace llvm {
 class Function;
 
 struct CoroElidePass : RequiredPassInfoMixin<CoroElidePass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Coroutines/SpillUtils.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SpillUtils.h
@@ -28,28 +28,28 @@ struct AllocaInfo {
         MayWriteBeforeCoroBegin(MayWriteBeforeCoroBegin) {}
 };
 
-void collectSpillsFromArgs(SpillInfo &Spills, Function &F,
-                           const SuspendCrossingInfo &Checker);
-void collectSpillsAndAllocasFromInsts(
+LLVM_ABI void collectSpillsFromArgs(SpillInfo &Spills, Function &F,
+                                    const SuspendCrossingInfo &Checker);
+LLVM_ABI void collectSpillsAndAllocasFromInsts(
     SpillInfo &Spills, SmallVector<AllocaInfo, 8> &Allocas,
     SmallVector<Instruction *, 4> &DeadInstructions,
     SmallVector<CoroAllocaAllocInst *, 4> &LocalAllocas, Function &F,
     const SuspendCrossingInfo &Checker, const DominatorTree &DT,
     const coro::Shape &Shape);
 
-void collectSpillsFromDbgInfo(SpillInfo &Spills, Function &F,
-                              const SuspendCrossingInfo &Checker);
+LLVM_ABI void collectSpillsFromDbgInfo(SpillInfo &Spills, Function &F,
+                                       const SuspendCrossingInfo &Checker);
 
 /// Async and Retcon{Once} conventions assume that all spill uses can be sunk
 /// after the coro.begin intrinsic.
-void sinkSpillUsesAfterCoroBegin(const DominatorTree &DT,
-                                 CoroBeginInst *CoroBegin,
-                                 coro::SpillInfo &Spills,
-                                 SmallVectorImpl<coro::AllocaInfo> &Allocas);
+LLVM_ABI void
+sinkSpillUsesAfterCoroBegin(const DominatorTree &DT, CoroBeginInst *CoroBegin,
+                            coro::SpillInfo &Spills,
+                            SmallVectorImpl<coro::AllocaInfo> &Allocas);
 
 // Get the insertion point for a spill after a Def.
-BasicBlock::iterator getSpillInsertionPt(const coro::Shape &, Value *Def,
-                                         const DominatorTree &DT);
+LLVM_ABI BasicBlock::iterator
+getSpillInsertionPt(const coro::Shape &, Value *Def, const DominatorTree &DT);
 
 } // namespace llvm::coro
 

--- a/llvm/include/llvm/Transforms/IPO/Annotation2Metadata.h
+++ b/llvm/include/llvm/Transforms/IPO/Annotation2Metadata.h
@@ -23,7 +23,7 @@ class Module;
 /// Pass to convert @llvm.global.annotations to !annotation metadata.
 struct Annotation2MetadataPass
     : public OptionalPassInfoMixin<Annotation2MetadataPass> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/ArgumentPromotion.h
+++ b/llvm/include/llvm/Transforms/IPO/ArgumentPromotion.h
@@ -27,8 +27,9 @@ class ArgumentPromotionPass
 public:
   ArgumentPromotionPass(unsigned MaxElements = 2u) : MaxElements(MaxElements) {}
 
-  PreservedAnalyses run(LazyCallGraph::SCC &C, CGSCCAnalysisManager &AM,
-                        LazyCallGraph &CG, CGSCCUpdateResult &UR);
+  LLVM_ABI PreservedAnalyses run(LazyCallGraph::SCC &C,
+                                 CGSCCAnalysisManager &AM, LazyCallGraph &CG,
+                                 CGSCCUpdateResult &UR);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/CalledValuePropagation.h
+++ b/llvm/include/llvm/Transforms/IPO/CalledValuePropagation.h
@@ -26,7 +26,7 @@ namespace llvm {
 class CalledValuePropagationPass
     : public OptionalPassInfoMixin<CalledValuePropagationPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/IPO/ConstantMerge.h
+++ b/llvm/include/llvm/Transforms/IPO/ConstantMerge.h
@@ -28,7 +28,7 @@ class Module;
 /// A pass that merges duplicate global constants into a single constant.
 class ConstantMergePass : public OptionalPassInfoMixin<ConstantMergePass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/CrossDSOCFI.h
+++ b/llvm/include/llvm/Transforms/IPO/CrossDSOCFI.h
@@ -19,7 +19,7 @@
 namespace llvm {
 class CrossDSOCFIPass : public OptionalPassInfoMixin<CrossDSOCFIPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 }
 #endif // LLVM_TRANSFORMS_IPO_CROSSDSOCFI_H

--- a/llvm/include/llvm/Transforms/IPO/DeadArgumentElimination.h
+++ b/llvm/include/llvm/Transforms/IPO/DeadArgumentElimination.h
@@ -75,7 +75,7 @@ public:
   DeadArgumentEliminationPass(bool ShouldHackArguments = false)
       : ShouldHackArguments(ShouldHackArguments) {}
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 
   /// Convenience wrapper
   RetOrArg createRet(const Function *F, unsigned Idx) {

--- a/llvm/include/llvm/Transforms/IPO/ElimAvailExtern.h
+++ b/llvm/include/llvm/Transforms/IPO/ElimAvailExtern.h
@@ -24,7 +24,7 @@ class Module;
 class EliminateAvailableExternallyPass
     : public OptionalPassInfoMixin<EliminateAvailableExternallyPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/ExpandVariadics.h
+++ b/llvm/include/llvm/Transforms/IPO/ExpandVariadics.h
@@ -28,12 +28,12 @@ class ExpandVariadicsPass : public OptionalPassInfoMixin<ExpandVariadicsPass> {
 
 public:
   // Operates under passed mode unless overridden on commandline
-  ExpandVariadicsPass(ExpandVariadicsMode Mode);
+  LLVM_ABI ExpandVariadicsPass(ExpandVariadicsMode Mode);
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
-ModulePass *createExpandVariadicsPass(ExpandVariadicsMode);
+LLVM_ABI ModulePass *createExpandVariadicsPass(ExpandVariadicsMode);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/IPO/FatLTOCleanup.h
+++ b/llvm/include/llvm/Transforms/IPO/FatLTOCleanup.h
@@ -27,7 +27,7 @@ class ModuleSummaryIndex;
 class FatLtoCleanup : public RequiredPassInfoMixin<FatLtoCleanup> {
 public:
   FatLtoCleanup() = default;
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/ForceFunctionAttrs.h
+++ b/llvm/include/llvm/Transforms/IPO/ForceFunctionAttrs.h
@@ -21,7 +21,7 @@ class Module;
 /// Pass which forces specific function attributes into the IR, primarily as
 /// a debugging tool.
 struct ForceFunctionAttrsPass : OptionalPassInfoMixin<ForceFunctionAttrsPass> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 }
 

--- a/llvm/include/llvm/Transforms/IPO/GlobalOpt.h
+++ b/llvm/include/llvm/Transforms/IPO/GlobalOpt.h
@@ -24,7 +24,7 @@ class Module;
 /// Optimize globals that never have their address taken.
 class GlobalOptPass : public OptionalPassInfoMixin<GlobalOptPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/GlobalSplit.h
+++ b/llvm/include/llvm/Transforms/IPO/GlobalSplit.h
@@ -25,7 +25,7 @@ class Module;
 /// Pass to perform split of global variables.
 class GlobalSplitPass : public OptionalPassInfoMixin<GlobalSplitPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/HotColdSplitting.h
+++ b/llvm/include/llvm/Transforms/IPO/HotColdSplitting.h
@@ -41,7 +41,7 @@ public:
                    std::function<OptimizationRemarkEmitter &(Function &)> *GORE,
                    function_ref<AssumptionCache *(Function &)> LAC)
       : PSI(ProfSI), GetBFI(GBFI), GetTTI(GTTI), GetORE(GORE), LookupAC(LAC) {}
-  bool run(Module &M);
+  LLVM_ABI bool run(Module &M);
 
 private:
   bool isFunctionCold(const Function &F) const;
@@ -67,7 +67,7 @@ private:
 class HotColdSplittingPass
     : public OptionalPassInfoMixin<HotColdSplittingPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/IROutliner.h
+++ b/llvm/include/llvm/Transforms/IPO/IROutliner.h
@@ -158,13 +158,13 @@ struct OutlinableRegion {
 
   /// For the contained region, split the parent BasicBlock at the starting and
   /// ending instructions of the contained IRSimilarityCandidate.
-  void splitCandidate();
+  LLVM_ABI void splitCandidate();
 
   /// For the contained region, reattach the BasicBlock at the starting and
   /// ending instructions of the contained IRSimilarityCandidate, or if the
   /// function has been extracted, the start and end of the BasicBlock
   /// containing the called function.
-  void reattachCandidate();
+  LLVM_ABI void reattachCandidate();
 
   /// Find a corresponding value for \p V in similar OutlinableRegion \p Other.
   ///
@@ -172,7 +172,8 @@ struct OutlinableRegion {
   /// in.
   /// \param V [in] - The Value to look for in the other region.
   /// \return The corresponding Value to \p V if it exists, otherwise nullptr.
-  Value *findCorrespondingValueIn(const OutlinableRegion &Other, Value *V);
+  LLVM_ABI Value *findCorrespondingValueIn(const OutlinableRegion &Other,
+                                           Value *V);
 
   /// Find a corresponding BasicBlock for \p BB in similar OutlinableRegion \p Other.
   ///
@@ -180,14 +181,14 @@ struct OutlinableRegion {
   /// BasicBlock in.
   /// \param BB [in] - The BasicBlock to look for in the other region.
   /// \return The corresponding Value to \p V if it exists, otherwise nullptr.
-  BasicBlock *findCorrespondingBlockIn(const OutlinableRegion &Other,
-                                       BasicBlock *BB);
+  LLVM_ABI BasicBlock *findCorrespondingBlockIn(const OutlinableRegion &Other,
+                                                BasicBlock *BB);
 
   /// Get the size of the code removed from the region.
   ///
   /// \param [in] TTI - The TargetTransformInfo for the parent function.
   /// \returns the code size of the region
-  InstructionCost getBenefit(TargetTransformInfo &TTI);
+  LLVM_ABI InstructionCost getBenefit(TargetTransformInfo &TTI);
 };
 
 /// This class is a pass that identifies similarity in a Module, extracts
@@ -209,7 +210,7 @@ public:
     static_assert(DenseMapInfo<unsigned>::getTombstoneKey() ==
                   static_cast<unsigned>(-2));
   }
-  bool run(Module &M);
+  LLVM_ABI bool run(Module &M);
 
 private:
   /// Find repeated similar code sequences in \p M and outline them into new
@@ -467,7 +468,7 @@ private:
 /// Pass to outline similar regions.
 class IROutlinerPass : public OptionalPassInfoMixin<IROutlinerPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/LoopExtractor.h
+++ b/llvm/include/llvm/Transforms/IPO/LoopExtractor.h
@@ -22,9 +22,10 @@ namespace llvm {
 
 struct LoopExtractorPass : public OptionalPassInfoMixin<LoopExtractorPass> {
   LoopExtractorPass(unsigned NumLoops = ~0) : NumLoops(NumLoops) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
 private:
   unsigned NumLoops;

--- a/llvm/include/llvm/Transforms/IPO/MemProfContextDisambiguation.h
+++ b/llvm/include/llvm/Transforms/IPO/MemProfContextDisambiguation.h
@@ -87,17 +87,19 @@ class MemProfContextDisambiguation
   std::unique_ptr<ICallPromotionAnalysis> ICallAnalysis;
 
 public:
+  LLVM_ABI
   MemProfContextDisambiguation(const ModuleSummaryIndex *Summary = nullptr,
                                bool isSamplePGO = false);
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
-  void run(ModuleSummaryIndex &Index,
-           function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
-               isPrevailing,
-           LLVMContext &Ctx,
-           function_ref<void(StringRef, StringRef, const Twine &)> EmitRemark =
-               nullptr);
+  LLVM_ABI void
+  run(ModuleSummaryIndex &Index,
+      function_ref<bool(GlobalValue::GUID, const GlobalValueSummary *)>
+          isPrevailing,
+      LLVMContext &Ctx,
+      function_ref<void(StringRef, StringRef, const Twine &)> EmitRemark =
+          nullptr);
 };
 
 /// Strips MemProf attributes and metadata. Can be invoked by the pass pipeline
@@ -106,7 +108,7 @@ public:
 /// transformations.
 class MemProfRemoveInfo : public OptionalPassInfoMixin<MemProfRemoveInfo> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/OpenMPOpt.h
+++ b/llvm/include/llvm/Transforms/IPO/OpenMPOpt.h
@@ -24,17 +24,17 @@ using Kernel = Function *;
 using KernelSet = SetVector<Kernel>;
 
 /// Helper to determine if \p M contains OpenMP.
-bool containsOpenMP(Module &M);
+LLVM_ABI bool containsOpenMP(Module &M);
 
 /// Helper to determine if \p M is a OpenMP target offloading device module.
-bool isOpenMPDevice(Module &M);
+LLVM_ABI bool isOpenMPDevice(Module &M);
 
 /// Return true iff \p Fn is an OpenMP GPU kernel; \p Fn has the "kernel"
 /// attribute.
-bool isOpenMPKernel(Function &Fn);
+LLVM_ABI bool isOpenMPKernel(Function &Fn);
 
 /// Get OpenMP device kernels in \p M.
-KernelSet getDeviceKernels(Module &M);
+LLVM_ABI KernelSet getDeviceKernels(Module &M);
 
 } // namespace omp
 
@@ -44,7 +44,7 @@ public:
   OpenMPOptPass() = default;
   OpenMPOptPass(ThinOrFullLTOPhase LTOPhase) : LTOPhase(LTOPhase) {}
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
 private:
   const ThinOrFullLTOPhase LTOPhase = ThinOrFullLTOPhase::None;
@@ -55,8 +55,9 @@ public:
   OpenMPOptCGSCCPass() = default;
   OpenMPOptCGSCCPass(ThinOrFullLTOPhase LTOPhase) : LTOPhase(LTOPhase) {}
 
-  PreservedAnalyses run(LazyCallGraph::SCC &C, CGSCCAnalysisManager &AM,
-                        LazyCallGraph &CG, CGSCCUpdateResult &UR);
+  LLVM_ABI PreservedAnalyses run(LazyCallGraph::SCC &C,
+                                 CGSCCAnalysisManager &AM, LazyCallGraph &CG,
+                                 CGSCCUpdateResult &UR);
 
 private:
   const ThinOrFullLTOPhase LTOPhase = ThinOrFullLTOPhase::None;

--- a/llvm/include/llvm/Transforms/IPO/PartialInlining.h
+++ b/llvm/include/llvm/Transforms/IPO/PartialInlining.h
@@ -23,7 +23,7 @@ class Module;
 /// Pass to remove unused function declarations.
 class PartialInlinerPass : public OptionalPassInfoMixin<PartialInlinerPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/IPO/SCCP.h
+++ b/llvm/include/llvm/Transforms/IPO/SCCP.h
@@ -53,7 +53,7 @@ public:
 
   IPSCCPPass(IPSCCPOptions Options) : Options(Options) {}
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
   bool isFuncSpecEnabled() const { return Options.AllowFuncSpec; }
 };

--- a/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleProfileMatcher.h
@@ -130,7 +130,7 @@ public:
       : M(M), Reader(Reader), CG(CG), ProbeManager(ProbeManager),
         LTOPhase(LTOPhase), FuncNameToProfNameMap(&FuncNameToProfNameMap),
         SymbolMap(&SymMap), PSL(PSL) {};
-  void runOnModule();
+  LLVM_ABI void runOnModule();
   void clearMatchingData() {
     // Do not clear FuncMappings, it stores IRLoc to ProfLoc remappings which
     // will be used for sample loader.

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -25,6 +25,7 @@
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PatternMatch.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/KnownBits.h"
 #include <cassert>
@@ -204,9 +205,9 @@ public:
   /// dereferenceable).
   /// If the inversion will consume instructions, `DoesConsume` will be set to
   /// true. Otherwise it will be false.
-  Value *getFreelyInvertedImpl(Value *V, bool WillInvertAllUses,
-                                      BuilderTy *Builder, bool &DoesConsume,
-                                      unsigned Depth);
+  LLVM_ABI Value *getFreelyInvertedImpl(Value *V, bool WillInvertAllUses,
+                                        BuilderTy *Builder, bool &DoesConsume,
+                                        unsigned Depth);
 
   Value *getFreelyInverted(Value *V, bool WillInvertAllUses,
                                   BuilderTy *Builder, bool &DoesConsume) {
@@ -356,18 +357,19 @@ public:
   ProfileSummaryInfo *getProfileSummaryInfo() const { return PSI; }
 
   // Call target specific combiners
-  std::optional<Instruction *> targetInstCombineIntrinsic(IntrinsicInst &II);
-  std::optional<Value *>
+  LLVM_ABI std::optional<Instruction *>
+  targetInstCombineIntrinsic(IntrinsicInst &II);
+  LLVM_ABI std::optional<Value *>
   targetSimplifyDemandedUseBitsIntrinsic(IntrinsicInst &II, APInt DemandedMask,
                                          KnownBits &Known,
                                          bool &KnownBitsComputed);
-  std::optional<Value *> targetSimplifyDemandedVectorEltsIntrinsic(
+  LLVM_ABI std::optional<Value *> targetSimplifyDemandedVectorEltsIntrinsic(
       IntrinsicInst &II, APInt DemandedElts, APInt &UndefElts,
       APInt &UndefElts2, APInt &UndefElts3,
       std::function<void(Instruction *, unsigned, APInt, APInt &)>
           SimplifyAndSetOp);
 
-  void computeBackEdges();
+  LLVM_ABI void computeBackEdges();
   bool isBackEdge(const BasicBlock *From, const BasicBlock *To) {
     if (!ComputedBackEdges)
       computeBackEdges();
@@ -480,9 +482,10 @@ public:
 
   /// Return true if the cast from integer to FP can be proven to be exact
   /// for all possible inputs (the conversion does not lose any precision).
-  bool isKnownExactCastIntToFP(CastInst &I) const;
-  bool canBeCastedExactlyIntToFP(Value *V, Type *FPTy, bool IsSigned,
-                                 const Instruction *CxtI = nullptr) const;
+  LLVM_ABI bool isKnownExactCastIntToFP(CastInst &I) const;
+  LLVM_ABI bool
+  canBeCastedExactlyIntToFP(Value *V, Type *FPTy, bool IsSigned,
+                            const Instruction *CxtI = nullptr) const;
 
   OverflowResult computeOverflowForUnsignedMul(const Value *LHS,
                                                const Value *RHS,
@@ -543,7 +546,7 @@ public:
                              unsigned Depth = 0,
                              bool AllowMultipleUsers = false) = 0;
 
-  bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const;
+  LLVM_ABI bool isValidAddrSpaceCast(unsigned FromAS, unsigned ToAS) const;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Instrumentation/AddressSanitizerCommon.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/AddressSanitizerCommon.h
@@ -20,18 +20,20 @@
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 // Get AddressSanitizer parameters.
-void getAddressSanitizerParams(const Triple &TargetTriple, int LongSize,
-                               bool IsKasan, uint64_t *ShadowBase,
-                               int *MappingScale, bool *OrShadowOffset);
+LLVM_ABI void getAddressSanitizerParams(const Triple &TargetTriple,
+                                        int LongSize, bool IsKasan,
+                                        uint64_t *ShadowBase, int *MappingScale,
+                                        bool *OrShadowOffset);
 
 /// Remove memory attributes that are incompatible with the instrumentation
 /// added by AddressSanitizer and HWAddressSanitizer.
 /// \p ReadsArgMem - indicates whether function arguments may be read by
 /// instrumentation and require removing `writeonly` attributes.
-void removeASanIncompatibleFnAttributes(Function &F, bool ReadsArgMem);
+LLVM_ABI void removeASanIncompatibleFnAttributes(Function &F, bool ReadsArgMem);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Instrumentation/BlockCoverageInference.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/BlockCoverageInference.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -32,27 +33,27 @@ class BlockCoverageInference {
 public:
   using BlockSet = SmallSetVector<const BasicBlock *, 4>;
 
-  BlockCoverageInference(const Function &F, bool ForceInstrumentEntry);
+  LLVM_ABI BlockCoverageInference(const Function &F, bool ForceInstrumentEntry);
 
   /// \return true if \p BB should be instrumented for coverage.
-  bool shouldInstrumentBlock(const BasicBlock &BB) const;
+  LLVM_ABI bool shouldInstrumentBlock(const BasicBlock &BB) const;
 
   /// \return the set of blocks \p Deps such that \p BB is covered iff any
   /// blocks in \p Deps are covered.
-  BlockSet getDependencies(const BasicBlock &BB) const;
+  LLVM_ABI BlockSet getDependencies(const BasicBlock &BB) const;
 
   /// \return a hash that depends on the set of instrumented blocks.
-  uint64_t getInstrumentedBlocksHash() const;
+  LLVM_ABI uint64_t getInstrumentedBlocksHash() const;
 
   /// Dump the inference graph.
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
   /// View the inferred block coverage as a dot file.
   /// Filled gray blocks are instrumented, red outlined blocks are found to be
   /// covered, red edges show that a block's coverage can be inferred from its
   /// successors, and blue edges show that a block's coverage can be inferred
   /// from its predecessors.
-  void viewBlockCoverageGraph(
+  LLVM_ABI void viewBlockCoverageGraph(
       const DenseMap<const BasicBlock *, bool> *Coverage = nullptr) const;
 
 private:
@@ -75,7 +76,7 @@ private:
   void getReachableAvoiding(const BasicBlock &Start, const BasicBlock &Avoid,
                             bool IsForward, BlockSet &Reachable) const;
 
-  static std::string getBlockNames(ArrayRef<const BasicBlock *> BBs);
+  LLVM_ABI static std::string getBlockNames(ArrayRef<const BasicBlock *> BBs);
   static std::string getBlockNames(BlockSet BBs) {
     return getBlockNames(ArrayRef<const BasicBlock *>(BBs.begin(), BBs.end()));
   }

--- a/llvm/include/llvm/Transforms/Instrumentation/CGProfile.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/CGProfile.h
@@ -19,7 +19,7 @@ class Module;
 class CGProfilePass : public OptionalPassInfoMixin<CGProfilePass> {
 public:
   CGProfilePass(bool InLTO) : InLTO(InLTO) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
 private:
   bool InLTO = false;

--- a/llvm/include/llvm/Transforms/Instrumentation/ControlHeightReduction.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/ControlHeightReduction.h
@@ -21,8 +21,8 @@ namespace llvm {
 class ControlHeightReductionPass
     : public OptionalPassInfoMixin<ControlHeightReductionPass> {
 public:
-  ControlHeightReductionPass();
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI ControlHeightReductionPass();
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Instrumentation/PGOCtxProfFlattening.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PGOCtxProfFlattening.h
@@ -22,7 +22,7 @@ class PGOCtxProfFlatteningPass
 public:
   explicit PGOCtxProfFlatteningPass(bool IsPreThinlink)
       : IsPreThinlink(IsPreThinlink) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/Transforms/Instrumentation/PGOCtxProfLowering.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PGOCtxProfLowering.h
@@ -21,9 +21,9 @@ class PGOCtxProfLoweringPass
 public:
   explicit PGOCtxProfLoweringPass() = default;
   // True if contextual instrumentation is enabled.
-  static bool isCtxIRPGOInstrEnabled();
+  LLVM_ABI static bool isCtxIRPGOInstrEnabled();
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
 
 // Utility pass blocking inlining for any function that may be overridden during
@@ -38,7 +38,7 @@ class NoinlineNonPrevailing
 public:
   explicit NoinlineNonPrevailing() = default;
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Instrumentation/PGOForceFunctionAttrs.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/PGOForceFunctionAttrs.h
@@ -18,7 +18,7 @@ struct PGOForceFunctionAttrsPass
     : public OptionalPassInfoMixin<PGOForceFunctionAttrsPass> {
   PGOForceFunctionAttrsPass(PGOOptions::ColdFuncOpt ColdType)
       : ColdType(ColdType) {}
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
 private:
   PGOOptions::ColdFuncOpt ColdType;

--- a/llvm/include/llvm/Transforms/Scalar/ADCE.h
+++ b/llvm/include/llvm/Transforms/Scalar/ADCE.h
@@ -29,7 +29,7 @@ class Function;
 /// dead computations that other DCE passes do not catch, particularly involving
 /// loop computations.
 struct ADCEPass : OptionalPassInfoMixin<ADCEPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/AlignmentFromAssumptions.h
+++ b/llvm/include/llvm/Transforms/Scalar/AlignmentFromAssumptions.h
@@ -29,19 +29,20 @@ class SCEV;
 class Value;
 
 struct AlignmentFromAssumptionsPass
-    : public OptionalPassInfoMixin<AlignmentFromAssumptionsPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+    : public PassInfoMixin<AlignmentFromAssumptionsPass> {
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   // Glue for old PM.
-  bool runImpl(Function &F, AssumptionCache &AC, ScalarEvolution *SE_,
-               DominatorTree *DT_);
+  LLVM_ABI bool runImpl(Function &F, AssumptionCache &AC, ScalarEvolution *SE_,
+                        DominatorTree *DT_);
 
   ScalarEvolution *SE = nullptr;
   DominatorTree *DT = nullptr;
 
-  bool extractAlignmentInfo(CallInst *I, unsigned Idx, Value *&AAPtr,
-                            const SCEV *&AlignSCEV, const SCEV *&OffSCEV);
-  bool processAssumption(CallInst *I, unsigned Idx);
+  LLVM_ABI bool extractAlignmentInfo(CallInst *I, unsigned Idx, Value *&AAPtr,
+                                     const SCEV *&AlignSCEV,
+                                     const SCEV *&OffSCEV);
+  LLVM_ABI bool processAssumption(CallInst *I, unsigned Idx);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/AnnotationRemarks.h
+++ b/llvm/include/llvm/Transforms/Scalar/AnnotationRemarks.h
@@ -22,7 +22,7 @@ class Function;
 
 struct AnnotationRemarksPass
     : public RequiredPassInfoMixin<AnnotationRemarksPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/BDCE.h
+++ b/llvm/include/llvm/Transforms/Scalar/BDCE.h
@@ -24,7 +24,7 @@ class Function;
 
 // The Bit-Tracking Dead Code Elimination pass.
 struct BDCEPass : OptionalPassInfoMixin<BDCEPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/CallSiteSplitting.h
+++ b/llvm/include/llvm/Transforms/Scalar/CallSiteSplitting.h
@@ -17,7 +17,7 @@ class Function;
 
 struct CallSiteSplittingPass : OptionalPassInfoMixin<CallSiteSplittingPass> {
   /// Run the pass over the function.
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/ConstantHoisting.h
+++ b/llvm/include/llvm/Transforms/Scalar/ConstantHoisting.h
@@ -126,12 +126,12 @@ struct ConstantInfo {
 class ConstantHoistingPass
     : public OptionalPassInfoMixin<ConstantHoistingPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   // Glue for old PM.
-  bool runImpl(Function &F, TargetTransformInfo &TTI, DominatorTree &DT,
-               BlockFrequencyInfo *BFI, BasicBlock &Entry,
-               ProfileSummaryInfo *PSI);
+  LLVM_ABI bool runImpl(Function &F, TargetTransformInfo &TTI,
+                        DominatorTree &DT, BlockFrequencyInfo *BFI,
+                        BasicBlock &Entry, ProfileSummaryInfo *PSI);
 
   void cleanup() {
     ClonedCastMap.clear();

--- a/llvm/include/llvm/Transforms/Scalar/ConstraintElimination.h
+++ b/llvm/include/llvm/Transforms/Scalar/ConstraintElimination.h
@@ -16,7 +16,7 @@ namespace llvm {
 class ConstraintEliminationPass
     : public OptionalPassInfoMixin<ConstraintEliminationPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/CorrelatedValuePropagation.h
+++ b/llvm/include/llvm/Transforms/Scalar/CorrelatedValuePropagation.h
@@ -17,7 +17,7 @@ class Function;
 
 struct CorrelatedValuePropagationPass
     : OptionalPassInfoMixin<CorrelatedValuePropagationPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/DCE.h
+++ b/llvm/include/llvm/Transforms/Scalar/DCE.h
@@ -22,13 +22,13 @@ class Function;
 /// Basic Dead Code Elimination pass.
 class DCEPass : public OptionalPassInfoMixin<DCEPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 class RedundantDbgInstEliminationPass
     : public OptionalPassInfoMixin<RedundantDbgInstEliminationPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/DFAJumpThreading.h
+++ b/llvm/include/llvm/Transforms/Scalar/DFAJumpThreading.h
@@ -20,7 +20,7 @@ namespace llvm {
 class Function;
 
 struct DFAJumpThreadingPass : OptionalPassInfoMixin<DFAJumpThreadingPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/DeadStoreElimination.h
+++ b/llvm/include/llvm/Transforms/Scalar/DeadStoreElimination.h
@@ -27,7 +27,7 @@ class Function;
 /// only the redundant stores that are local to a single Basic Block.
 class DSEPass : public OptionalPassInfoMixin<DSEPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/DivRemPairs.h
+++ b/llvm/include/llvm/Transforms/Scalar/DivRemPairs.h
@@ -22,7 +22,7 @@ namespace llvm {
 /// improvements and better codegen.
 struct DivRemPairsPass : public OptionalPassInfoMixin<DivRemPairsPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 }
 #endif // LLVM_TRANSFORMS_SCALAR_DIVREMPAIRS_H

--- a/llvm/include/llvm/Transforms/Scalar/DropUnnecessaryAssumes.h
+++ b/llvm/include/llvm/Transforms/Scalar/DropUnnecessaryAssumes.h
@@ -22,7 +22,7 @@ struct DropUnnecessaryAssumesPass
   DropUnnecessaryAssumesPass(bool DropDereferenceable = false)
       : DropDereferenceable(DropDereferenceable) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
 private:
   bool DropDereferenceable;

--- a/llvm/include/llvm/Transforms/Scalar/ExpandMemCmp.h
+++ b/llvm/include/llvm/Transforms/Scalar/ExpandMemCmp.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class ExpandMemCmpPass : public OptionalPassInfoMixin<ExpandMemCmpPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/FlattenCFG.h
+++ b/llvm/include/llvm/Transforms/Scalar/FlattenCFG.h
@@ -18,7 +18,7 @@
 
 namespace llvm {
 struct FlattenCFGPass : OptionalPassInfoMixin<FlattenCFGPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/Float2Int.h
+++ b/llvm/include/llvm/Transforms/Scalar/Float2Int.h
@@ -30,10 +30,10 @@ class Value;
 
 class Float2IntPass : public OptionalPassInfoMixin<Float2IntPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   // Glue for old PM.
-  bool runImpl(Function &F, const DominatorTree &DT);
+  LLVM_ABI bool runImpl(Function &F, const DominatorTree &DT);
 
 private:
   void findRoots(Function &F, const DominatorTree &DT);

--- a/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVNExpression.h
@@ -57,7 +57,7 @@ enum ExpressionType {
   ET_BasicEnd
 };
 
-class Expression {
+class LLVM_ABI Expression {
 private:
   ExpressionType EType;
   unsigned Opcode;
@@ -133,7 +133,7 @@ inline raw_ostream &operator<<(raw_ostream &OS, const Expression &E) {
   return OS;
 }
 
-class BasicExpression : public Expression {
+class LLVM_ABI BasicExpression : public Expression {
 private:
   using RecyclerType = ArrayRecycler<Value *>;
   using RecyclerCapacity = RecyclerType::Capacity;
@@ -298,7 +298,7 @@ public:
   void setMemoryLeader(const MemoryAccess *ML) { MemoryLeader = ML; }
 };
 
-class CallExpression final : public MemoryExpression {
+class LLVM_ABI CallExpression final : public MemoryExpression {
 private:
   CallInst *Call;
 
@@ -331,7 +331,7 @@ public:
   }
 };
 
-class LoadExpression final : public MemoryExpression {
+class LLVM_ABI LoadExpression final : public MemoryExpression {
 private:
   LoadInst *Load;
 
@@ -373,7 +373,7 @@ public:
   }
 };
 
-class StoreExpression final : public MemoryExpression {
+class LLVM_ABI StoreExpression final : public MemoryExpression {
 private:
   StoreInst *Store;
   Value *StoredValue;
@@ -414,7 +414,7 @@ public:
   }
 };
 
-class AggregateValueExpression final : public BasicExpression {
+class LLVM_ABI AggregateValueExpression final : public BasicExpression {
 private:
   unsigned MaxIntOperands;
   unsigned NumIntOperands = 0;
@@ -508,7 +508,7 @@ public:
   int_op_inserter &operator++(int) { return *this; }
 };
 
-class PHIExpression final : public BasicExpression {
+class LLVM_ABI PHIExpression final : public BasicExpression {
 private:
   BasicBlock *BB;
 

--- a/llvm/include/llvm/Transforms/Scalar/GuardWidening.h
+++ b/llvm/include/llvm/Transforms/Scalar/GuardWidening.h
@@ -25,9 +25,10 @@ class Loop;
 class Function;
 
 struct GuardWideningPass : public OptionalPassInfoMixin<GuardWideningPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/IVUsersPrinter.h
+++ b/llvm/include/llvm/Transforms/Scalar/IVUsersPrinter.h
@@ -23,8 +23,9 @@ class IVUsersPrinterPass : public RequiredPassInfoMixin<IVUsersPrinterPass> {
 
 public:
   explicit IVUsersPrinterPass(raw_ostream &OS) : OS(OS) {}
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/IndVarSimplify.h
+++ b/llvm/include/llvm/Transforms/Scalar/IndVarSimplify.h
@@ -28,8 +28,9 @@ class IndVarSimplifyPass : public OptionalPassInfoMixin<IndVarSimplifyPass> {
 
 public:
   IndVarSimplifyPass(bool WidenIndVars = true) : WidenIndVars(WidenIndVars) {}
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/InductiveRangeCheckElimination.h
+++ b/llvm/include/llvm/Transforms/Scalar/InductiveRangeCheckElimination.h
@@ -20,7 +20,7 @@ namespace llvm {
 
 class IRCEPass : public OptionalPassInfoMixin<IRCEPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/InferAddressSpaces.h
+++ b/llvm/include/llvm/Transforms/Scalar/InferAddressSpaces.h
@@ -14,9 +14,9 @@
 namespace llvm {
 
 struct InferAddressSpacesPass : OptionalPassInfoMixin<InferAddressSpacesPass> {
-  InferAddressSpacesPass();
-  InferAddressSpacesPass(unsigned AddressSpace);
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI InferAddressSpacesPass();
+  LLVM_ABI InferAddressSpacesPass(unsigned AddressSpace);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
 private:
   unsigned FlatAddrSpace = 0;

--- a/llvm/include/llvm/Transforms/Scalar/InferAlignment.h
+++ b/llvm/include/llvm/Transforms/Scalar/InferAlignment.h
@@ -19,7 +19,7 @@
 namespace llvm {
 
 struct InferAlignmentPass : public OptionalPassInfoMixin<InferAlignmentPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/InstSimplifyPass.h
+++ b/llvm/include/llvm/Transforms/Scalar/InstSimplifyPass.h
@@ -31,7 +31,7 @@ namespace llvm {
 /// `instcombine` pass instead.
 class InstSimplifyPass : public OptionalPassInfoMixin<InstSimplifyPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/JumpTableToSwitch.h
+++ b/llvm/include/llvm/Transforms/Scalar/JumpTableToSwitch.h
@@ -23,7 +23,7 @@ class JumpTableToSwitchPass
 public:
   explicit JumpTableToSwitchPass(bool InLTO = false) : InLTO(InLTO) {}
   /// Run the pass over the function.
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/LICM.h
+++ b/llvm/include/llvm/Transforms/Scalar/LICM.h
@@ -42,8 +42,8 @@ class LPMUpdater;
 class Loop;
 class LoopNest;
 
-extern cl::opt<unsigned> SetLicmMssaOptCap;
-extern cl::opt<unsigned> SetLicmMssaNoAccForPromotionCap;
+extern LLVM_ABI cl::opt<unsigned> SetLicmMssaOptCap;
+extern LLVM_ABI cl::opt<unsigned> SetLicmMssaNoAccForPromotionCap;
 
 struct LICMOptions {
   unsigned MssaOptCap;
@@ -73,11 +73,13 @@ public:
                              AllowSpeculation)) {}
   LICMPass(LICMOptions Opts) : Opts(Opts) {}
 
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 /// Performs LoopNest Invariant Code Motion Pass.
@@ -91,11 +93,13 @@ public:
                               AllowSpeculation)) {}
   LNICMPass(LICMOptions Opts) : Opts(Opts) {}
 
-  PreservedAnalyses run(LoopNest &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(LoopNest &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/LoopAccessAnalysisPrinter.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopAccessAnalysisPrinter.h
@@ -25,7 +25,7 @@ class LoopAccessInfoPrinterPass
 public:
   explicit LoopAccessInfoPrinterPass(raw_ostream &OS, bool AllowPartial)
       : OS(OS), AllowPartial(AllowPartial) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // End llvm namespace

--- a/llvm/include/llvm/Transforms/Scalar/LoopBoundSplit.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopBoundSplit.h
@@ -33,8 +33,9 @@ class Loop;
 ///                              }
 class LoopBoundSplitPass : public OptionalPassInfoMixin<LoopBoundSplitPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopDataPrefetch.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopDataPrefetch.h
@@ -26,7 +26,7 @@ public:
   LoopDataPrefetchPass() = default;
 
   /// Run the pass over the function.
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopDeletion.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopDeletion.h
@@ -25,8 +25,9 @@ class LoopDeletionPass : public OptionalPassInfoMixin<LoopDeletionPass> {
 public:
   LoopDeletionPass() = default;
 
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopDistribute.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopDistribute.h
@@ -24,7 +24,7 @@ class Function;
 
 class LoopDistributePass : public OptionalPassInfoMixin<LoopDistributePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopFlatten.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopFlatten.h
@@ -24,8 +24,9 @@ class LoopFlattenPass : public OptionalPassInfoMixin<LoopFlattenPass> {
 public:
   LoopFlattenPass() = default;
 
-  PreservedAnalyses run(LoopNest &LN, LoopAnalysisManager &LAM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(LoopNest &LN, LoopAnalysisManager &LAM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopFuse.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopFuse.h
@@ -22,7 +22,7 @@ class Function;
 
 class LoopFusePass : public OptionalPassInfoMixin<LoopFusePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopIdiomRecognize.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopIdiomRecognize.h
@@ -27,30 +27,31 @@ class LPMUpdater;
 /// passes.
 struct DisableLIRP {
   /// When true, the entire pass is disabled.
-  static bool All;
+  LLVM_ABI static bool All;
 
   /// When true, Memset is disabled.
-  static bool Memset;
+  LLVM_ABI static bool Memset;
 
   /// When true, Memcpy is disabled.
-  static bool Memcpy;
+  LLVM_ABI static bool Memcpy;
 
   /// When true, Strlen is disabled.
-  static bool Strlen;
+  LLVM_ABI static bool Strlen;
 
   /// When true, Wcslen is disabled.
-  static bool Wcslen;
+  LLVM_ABI static bool Wcslen;
 
   /// When true, HashRecognize is disabled.
-  static bool HashRecognize;
+  LLVM_ABI static bool HashRecognize;
 };
 
 /// Performs Loop Idiom Recognize Pass.
 class LoopIdiomRecognizePass
     : public OptionalPassInfoMixin<LoopIdiomRecognizePass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopInstSimplify.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopInstSimplify.h
@@ -25,8 +25,9 @@ class LPMUpdater;
 class LoopInstSimplifyPass
     : public OptionalPassInfoMixin<LoopInstSimplifyPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopInterchange.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopInterchange.h
@@ -18,8 +18,9 @@ class LPMUpdater;
 class LoopNest;
 
 struct LoopInterchangePass : public OptionalPassInfoMixin<LoopInterchangePass> {
-  PreservedAnalyses run(LoopNest &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(LoopNest &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopLoadElimination.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopLoadElimination.h
@@ -26,7 +26,7 @@ class Function;
 /// iterations.
 struct LoopLoadEliminationPass
     : public OptionalPassInfoMixin<LoopLoadEliminationPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopPredication.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopPredication.h
@@ -24,8 +24,9 @@ class Loop;
 /// Performs Loop Predication Pass.
 class LoopPredicationPass : public OptionalPassInfoMixin<LoopPredicationPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/LoopRotation.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopRotation.h
@@ -23,13 +23,16 @@ class Loop;
 /// A simple loop rotation transformation.
 class LoopRotatePass : public OptionalPassInfoMixin<LoopRotatePass> {
 public:
-  LoopRotatePass(bool EnableHeaderDuplication = true,
-                 bool PrepareForLTO = false, bool CheckExitCount = false);
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI LoopRotatePass(bool EnableHeaderDuplication = true,
+                          bool PrepareForLTO = false,
+                          bool CheckExitCount = false);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
 private:
   const bool EnableHeaderDuplication;

--- a/llvm/include/llvm/Transforms/Scalar/LoopSimplifyCFG.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopSimplifyCFG.h
@@ -27,8 +27,9 @@ class Loop;
 /// Performs basic CFG simplifications to assist other loop passes.
 class LoopSimplifyCFGPass : public OptionalPassInfoMixin<LoopSimplifyCFGPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/LoopSink.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopSink.h
@@ -32,7 +32,7 @@ class Function;
 /// fundamental analyses and transforms of the loop.
 class LoopSinkPass : public OptionalPassInfoMixin<LoopSinkPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/LoopStrengthReduce.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopStrengthReduce.h
@@ -33,8 +33,9 @@ class LPMUpdater;
 class LoopStrengthReducePass
     : public OptionalPassInfoMixin<LoopStrengthReducePass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopTermFold.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopTermFold.h
@@ -21,8 +21,9 @@ class LPMUpdater;
 
 class LoopTermFoldPass : public OptionalPassInfoMixin<LoopTermFoldPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopUnrollAndJamPass.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopUnrollAndJamPass.h
@@ -23,8 +23,9 @@ class LoopUnrollAndJamPass
 
 public:
   explicit LoopUnrollAndJamPass(int OptLevel = 2) : OptLevel(OptLevel) {}
-  PreservedAnalyses run(LoopNest &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(LoopNest &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopUnrollPass.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopUnrollPass.h
@@ -16,7 +16,7 @@
 
 namespace llvm {
 
-extern cl::opt<bool> ForgetSCEVInLoopUnroll;
+extern LLVM_ABI cl::opt<bool> ForgetSCEVInLoopUnroll;
 
 class Function;
 class Loop;
@@ -42,8 +42,9 @@ public:
       : OptLevel(OptLevel), OnlyWhenForced(OnlyWhenForced),
         ForgetSCEV(ForgetSCEV) {}
 
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 /// A set of parameters used to control various transforms performed by the
@@ -139,9 +140,10 @@ public:
   explicit LoopUnrollPass(LoopUnrollOptions UnrollOpts = {})
       : UnrollOpts(UnrollOpts) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LoopVersioningLICM.h
+++ b/llvm/include/llvm/Transforms/Scalar/LoopVersioningLICM.h
@@ -19,8 +19,9 @@ class Loop;
 class LoopVersioningLICMPass
     : public OptionalPassInfoMixin<LoopVersioningLICMPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &LAR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &LAR,
+                                 LPMUpdater &U);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/LowerAtomicPass.h
+++ b/llvm/include/llvm/Transforms/Scalar/LowerAtomicPass.h
@@ -21,7 +21,7 @@ namespace llvm {
 /// A pass that lowers atomic intrinsic into non-atomic intrinsics.
 class LowerAtomicPass : public RequiredPassInfoMixin<LowerAtomicPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/LowerConstantIntrinsics.h
+++ b/llvm/include/llvm/Transforms/Scalar/LowerConstantIntrinsics.h
@@ -23,8 +23,8 @@ class DominatorTree;
 class Function;
 class TargetLibraryInfo;
 
-bool lowerConstantIntrinsics(Function &F, const TargetLibraryInfo &TLI,
-                             DominatorTree *DT);
+LLVM_ABI bool lowerConstantIntrinsics(Function &F, const TargetLibraryInfo &TLI,
+                                      DominatorTree *DT);
 
 struct LowerConstantIntrinsicsPass
     : OptionalPassInfoMixin<LowerConstantIntrinsicsPass> {
@@ -39,7 +39,7 @@ public:
   /// propagated and conditional branches are resolved where possible.
   /// This complements the Instruction Simplification and
   /// Instruction Combination passes of the optimized pass chain.
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/LowerGuardIntrinsic.h
+++ b/llvm/include/llvm/Transforms/Scalar/LowerGuardIntrinsic.h
@@ -20,7 +20,7 @@ namespace llvm {
 
 struct LowerGuardIntrinsicPass
     : OptionalPassInfoMixin<LowerGuardIntrinsicPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/LowerMatrixIntrinsics.h
+++ b/llvm/include/llvm/Transforms/Scalar/LowerMatrixIntrinsics.h
@@ -22,9 +22,10 @@ class LowerMatrixIntrinsicsPass
 
 public:
   LowerMatrixIntrinsicsPass(bool Minimal = false) : Minimal(Minimal) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/LowerWidenableCondition.h
+++ b/llvm/include/llvm/Transforms/Scalar/LowerWidenableCondition.h
@@ -19,7 +19,7 @@ namespace llvm {
 
 struct LowerWidenableConditionPass
     : OptionalPassInfoMixin<LowerWidenableConditionPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/MakeGuardsExplicit.h
+++ b/llvm/include/llvm/Transforms/Scalar/MakeGuardsExplicit.h
@@ -39,7 +39,7 @@ namespace llvm {
 
 struct MakeGuardsExplicitPass
     : public OptionalPassInfoMixin<MakeGuardsExplicitPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/MergeICmps.h
+++ b/llvm/include/llvm/Transforms/Scalar/MergeICmps.h
@@ -16,7 +16,7 @@ namespace llvm {
 class Function;
 
 struct MergeICmpsPass : OptionalPassInfoMixin<MergeICmpsPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/MergedLoadStoreMotion.h
+++ b/llvm/include/llvm/Transforms/Scalar/MergedLoadStoreMotion.h
@@ -48,9 +48,10 @@ public:
       : MergedLoadStoreMotionPass(MergedLoadStoreMotionOptions()) {}
   MergedLoadStoreMotionPass(const MergedLoadStoreMotionOptions &PassOptions)
       : Options(PassOptions) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/NaryReassociate.h
+++ b/llvm/include/llvm/Transforms/Scalar/NaryReassociate.h
@@ -100,12 +100,12 @@ class Value;
 
 class NaryReassociatePass : public OptionalPassInfoMixin<NaryReassociatePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   // Glue for old PM.
-  bool runImpl(Function &F, AssumptionCache *AC_, DominatorTree *DT_,
-               ScalarEvolution *SE_, TargetLibraryInfo *TLI_,
-               TargetTransformInfo *TTI_);
+  LLVM_ABI bool runImpl(Function &F, AssumptionCache *AC_, DominatorTree *DT_,
+                        ScalarEvolution *SE_, TargetLibraryInfo *TLI_,
+                        TargetTransformInfo *TTI_);
 
 private:
   // Runs only one iteration of the dominator-based algorithm. See the header

--- a/llvm/include/llvm/Transforms/Scalar/NewGVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/NewGVN.h
@@ -23,7 +23,7 @@ class Function;
 class NewGVNPass : public OptionalPassInfoMixin<NewGVNPass> {
 public:
   /// Run the pass over the function.
-  PreservedAnalyses run(Function &F, AnalysisManager<Function> &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, AnalysisManager<Function> &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/PartiallyInlineLibCalls.h
+++ b/llvm/include/llvm/Transforms/Scalar/PartiallyInlineLibCalls.h
@@ -22,7 +22,7 @@ class Function;
 class PartiallyInlineLibCallsPass
     : public OptionalPassInfoMixin<PartiallyInlineLibCallsPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/PlaceSafepoints.h
+++ b/llvm/include/llvm/Transforms/Scalar/PlaceSafepoints.h
@@ -58,9 +58,9 @@ class TargetLibraryInfo;
 
 class PlaceSafepointsPass : public OptionalPassInfoMixin<PlaceSafepointsPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
-  bool runImpl(Function &F, const TargetLibraryInfo &TLI);
+  LLVM_ABI bool runImpl(Function &F, const TargetLibraryInfo &TLI);
 
   void cleanup() {}
 

--- a/llvm/include/llvm/Transforms/Scalar/Reg2Mem.h
+++ b/llvm/include/llvm/Transforms/Scalar/Reg2Mem.h
@@ -19,7 +19,7 @@ namespace llvm {
 
 class RegToMemPass : public OptionalPassInfoMixin<RegToMemPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/RewriteStatepointsForGC.h
+++ b/llvm/include/llvm/Transforms/Scalar/RewriteStatepointsForGC.h
@@ -28,10 +28,10 @@ class TargetLibraryInfo;
 
 struct RewriteStatepointsForGC
     : public OptionalPassInfoMixin<RewriteStatepointsForGC> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 
-  bool runOnFunction(Function &F, DominatorTree &, TargetTransformInfo &,
-                     const TargetLibraryInfo &);
+  LLVM_ABI bool runOnFunction(Function &F, DominatorTree &,
+                              TargetTransformInfo &, const TargetLibraryInfo &);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/SROA.h
+++ b/llvm/include/llvm/Transforms/Scalar/SROA.h
@@ -29,13 +29,14 @@ class SROAPass : public OptionalPassInfoMixin<SROAPass> {
 public:
   /// If \p PreserveCFG is set, then the pass is not allowed to modify CFG
   /// in any way, even if it would update CFG analyses.
-  SROAPass(SROAOptions PreserveCFG);
+  LLVM_ABI SROAPass(SROAOptions PreserveCFG);
 
   /// Run the pass over the function.
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/ScalarizeMaskedMemIntrin.h
+++ b/llvm/include/llvm/Transforms/Scalar/ScalarizeMaskedMemIntrin.h
@@ -22,7 +22,7 @@ namespace llvm {
 
 struct ScalarizeMaskedMemIntrinPass
     : public OptionalPassInfoMixin<ScalarizeMaskedMemIntrinPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/SeparateConstOffsetFromGEP.h
+++ b/llvm/include/llvm/Transforms/Scalar/SeparateConstOffsetFromGEP.h
@@ -19,9 +19,10 @@ class SeparateConstOffsetFromGEPPass
 
 public:
   SeparateConstOffsetFromGEPPass(bool LowerGEP = false) : LowerGEP(LowerGEP) {}
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/SimpleLoopUnswitch.h
+++ b/llvm/include/llvm/Transforms/Scalar/SimpleLoopUnswitch.h
@@ -74,11 +74,13 @@ public:
   SimpleLoopUnswitchPass(bool NonTrivial = false, bool Trivial = true)
       : NonTrivial(NonTrivial), Trivial(Trivial) {}
 
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 /// A marker analysis to determine if SimpleLoopUnswitch should run again on a
@@ -86,7 +88,7 @@ public:
 struct ShouldRunExtraSimpleLoopUnswitch
     : public ShouldRunExtraPasses<ShouldRunExtraSimpleLoopUnswitch>,
       public AnalysisInfoMixin<ShouldRunExtraSimpleLoopUnswitch> {
-  static AnalysisKey Key;
+  LLVM_ABI static AnalysisKey Key;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/Sink.h
+++ b/llvm/include/llvm/Transforms/Scalar/Sink.h
@@ -23,7 +23,7 @@ class Function;
 /// Move instructions into successor blocks when possible.
 class SinkingPass : public OptionalPassInfoMixin<SinkingPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/SpeculativeExecution.h
+++ b/llvm/include/llvm/Transforms/Scalar/SpeculativeExecution.h
@@ -71,15 +71,16 @@ class TargetTransformInfo;
 class SpeculativeExecutionPass
     : public OptionalPassInfoMixin<SpeculativeExecutionPass> {
 public:
-  SpeculativeExecutionPass(bool OnlyIfDivergentTarget = false);
+  LLVM_ABI SpeculativeExecutionPass(bool OnlyIfDivergentTarget = false);
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
   // Glue for old PM
-  bool runImpl(Function &F, TargetTransformInfo *TTI);
+  LLVM_ABI bool runImpl(Function &F, TargetTransformInfo *TTI);
 
 private:
   bool runOnBasicBlock(BasicBlock &B);

--- a/llvm/include/llvm/Transforms/Scalar/StraightLineStrengthReduce.h
+++ b/llvm/include/llvm/Transforms/Scalar/StraightLineStrengthReduce.h
@@ -16,7 +16,7 @@ namespace llvm {
 class StraightLineStrengthReducePass
     : public OptionalPassInfoMixin<StraightLineStrengthReducePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/StructurizeCFG.h
+++ b/llvm/include/llvm/Transforms/Scalar/StructurizeCFG.h
@@ -17,12 +17,13 @@ private:
   bool SkipUniformRegions;
 
 public:
-  StructurizeCFGPass(bool SkipUniformRegions = false);
+  LLVM_ABI StructurizeCFGPass(bool SkipUniformRegions = false);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Scalar/TailRecursionElimination.h
+++ b/llvm/include/llvm/Transforms/Scalar/TailRecursionElimination.h
@@ -64,7 +64,7 @@ class TailCallElimPass : public OptionalPassInfoMixin<TailCallElimPass> {
 public:
   TailCallElimPass(bool UpdateFunctionEntryCount = true)
       : UpdateFunctionEntryCount(UpdateFunctionEntryCount) {}
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Scalar/WarnMissedTransforms.h
+++ b/llvm/include/llvm/Transforms/Scalar/WarnMissedTransforms.h
@@ -22,7 +22,7 @@ class WarnMissedTransformationsPass
 public:
   explicit WarnMissedTransformationsPass() = default;
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/AddDiscriminators.h
+++ b/llvm/include/llvm/Transforms/Utils/AddDiscriminators.h
@@ -24,7 +24,7 @@ class Function;
 class AddDiscriminatorsPass
     : public RequiredPassInfoMixin<AddDiscriminatorsPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/BreakCriticalEdges.h
+++ b/llvm/include/llvm/Transforms/Utils/BreakCriticalEdges.h
@@ -24,7 +24,7 @@ namespace llvm {
 class Function;
 struct BreakCriticalEdgesPass
     : public OptionalPassInfoMixin<BreakCriticalEdgesPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 #endif // LLVM_TRANSFORMS_UTILS_BREAKCRITICALEDGES_H

--- a/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
+++ b/llvm/include/llvm/Transforms/Utils/BypassSlowDivision.h
@@ -68,9 +68,10 @@ template <> struct DenseMapInfo<DivRemMapKey> {
 ///
 /// This optimization may add basic blocks immediately after BB; for obvious
 /// reasons, you shouldn't pass those blocks to bypassSlowDivision.
-bool bypassSlowDivision(BasicBlock *BB,
-                        const DenseMap<unsigned int, unsigned int> &BypassWidth,
-                        DomTreeUpdater *DTU = nullptr, LoopInfo *LI = nullptr);
+LLVM_ABI bool
+bypassSlowDivision(BasicBlock *BB,
+                   const DenseMap<unsigned int, unsigned int> &BypassWidth,
+                   DomTreeUpdater *DTU = nullptr, LoopInfo *LI = nullptr);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/CanonicalizeAliases.h
+++ b/llvm/include/llvm/Transforms/Utils/CanonicalizeAliases.h
@@ -25,7 +25,7 @@ class CanonicalizeAliasesPass
 public:
   CanonicalizeAliasesPass() = default;
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/CanonicalizeFreezeInLoops.h
+++ b/llvm/include/llvm/Transforms/Utils/CanonicalizeFreezeInLoops.h
@@ -24,8 +24,9 @@ class LPMUpdater;
 class CanonicalizeFreezeInLoopsPass
     : public OptionalPassInfoMixin<CanonicalizeFreezeInLoopsPass> {
 public:
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/ControlFlowUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/ControlFlowUtils.h
@@ -115,7 +115,7 @@ struct ControlFlowHub {
 
   /// Return the unified loop exit block and a flag indicating if the CFG was
   /// changed at all.
-  std::pair<BasicBlock *, bool>
+  LLVM_ABI std::pair<BasicBlock *, bool>
   finalize(DomTreeUpdater *DTU, SmallVectorImpl<BasicBlock *> &GuardBlocks,
            const StringRef Prefix,
            std::optional<unsigned> MaxControlFlowBooleans = std::nullopt);

--- a/llvm/include/llvm/Transforms/Utils/CountVisits.h
+++ b/llvm/include/llvm/Transforms/Utils/CountVisits.h
@@ -17,7 +17,7 @@ namespace llvm {
 class Function;
 
 struct CountVisitsPass : OptionalPassInfoMixin<CountVisitsPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 
 private:
   StringMap<uint32_t> Counts;

--- a/llvm/include/llvm/Transforms/Utils/CtorUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/CtorUtils.h
@@ -22,8 +22,9 @@ class Module;
 
 /// Call "ShouldRemove" for every entry in M's global_ctor list and remove the
 /// entries for which it returns true.  Return true if anything changed.
-bool optimizeGlobalCtorsList(
-    Module &M, function_ref<bool(uint32_t, Function *)> ShouldRemove);
+LLVM_ABI bool
+optimizeGlobalCtorsList(Module &M,
+                        function_ref<bool(uint32_t, Function *)> ShouldRemove);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/DXILUpgrade.h
+++ b/llvm/include/llvm/Transforms/Utils/DXILUpgrade.h
@@ -16,7 +16,7 @@ namespace llvm {
 /// Upgrade DXIL-style metadata into their LLVM representations
 class DXILUpgradePass : public OptionalPassInfoMixin<DXILUpgradePass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
@@ -83,7 +83,7 @@ struct DbgValueDef {
   bool operator==(DbgValueDef Other) const { return agreesWith(Other); }
   bool operator!=(DbgValueDef Other) const { return !agreesWith(Other); }
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 };
 
 class DbgSSABlock;
@@ -109,7 +109,7 @@ public:
     IncomingValues.push_back({BB, DV});
   }
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 };
 
 inline raw_ostream &operator<<(raw_ostream &OS, const DbgValueDef &DV) {
@@ -139,7 +139,7 @@ public:
     return *this;
   }
 
-  DbgSSABlock *operator*();
+  LLVM_ABI DbgSSABlock *operator*();
 };
 
 /// Thin wrapper around a block successor iterator.
@@ -160,7 +160,7 @@ public:
     return *this;
   }
 
-  DbgSSABlock *operator*();
+  LLVM_ABI DbgSSABlock *operator*();
 };
 
 class DbgSSABlock {
@@ -231,7 +231,7 @@ private:
 public:
   /// If InsertedPHIs is specified, it will be filled
   /// in with all PHI Nodes created by rewriting.
-  explicit DebugSSAUpdater(
+  LLVM_ABI explicit DebugSSAUpdater(
       SmallVectorImpl<DbgSSAPhi *> *InsertedPHIs = nullptr);
   DebugSSAUpdater(const DebugSSAUpdater &) = delete;
   DebugSSAUpdater &operator=(const DebugSSAUpdater &) = delete;
@@ -250,7 +250,7 @@ public:
     BlockMap.clear();
   }
 
-  void initialize();
+  LLVM_ABI void initialize();
 
   /// For a given BB, create a wrapper block for it. Stores it in the
   /// DebugSSAUpdater block map.
@@ -265,19 +265,19 @@ public:
 
   /// Indicate that a rewritten value is available in the specified block
   /// with the specified value.
-  void addAvailableValue(DbgSSABlock *BB, DbgValueDef DV);
+  LLVM_ABI void addAvailableValue(DbgSSABlock *BB, DbgValueDef DV);
 
   /// Return true if the DebugSSAUpdater already has a value for the specified
   /// block.
-  bool hasValueForBlock(DbgSSABlock *BB) const;
+  LLVM_ABI bool hasValueForBlock(DbgSSABlock *BB) const;
 
   /// Return the value for the specified block if the DebugSSAUpdater has one,
   /// otherwise return nullptr.
-  DbgValueDef findValueForBlock(DbgSSABlock *BB) const;
+  LLVM_ABI DbgValueDef findValueForBlock(DbgSSABlock *BB) const;
 
   /// Construct SSA form, materializing a value that is live at the end
   /// of the specified block.
-  DbgValueDef getValueAtEndOfBlock(DbgSSABlock *BB);
+  LLVM_ABI DbgValueDef getValueAtEndOfBlock(DbgSSABlock *BB);
 
   /// Construct SSA form, materializing a value that is live in the
   /// middle of the specified block.
@@ -299,7 +299,7 @@ public:
   /// their respective blocks.  However, the use of X happens in the *middle* of
   /// a block.  Because of this, we need to insert a new PHI node in SomeBB to
   /// merge the appropriate values, and this value isn't live out of the block.
-  DbgValueDef getValueInMiddleOfBlock(DbgSSABlock *BB);
+  LLVM_ABI DbgValueDef getValueInMiddleOfBlock(DbgSSABlock *BB);
 
 private:
   DbgValueDef getValueAtEndOfBlockInternal(DbgSSABlock *BB);
@@ -324,7 +324,7 @@ class SSAValueNameMap {
 
 public:
   using ValueID = uint64_t;
-  ValueID addValue(Value *V);
+  LLVM_ABI ValueID addValue(Value *V);
   std::string getName(ValueID ID) { return ValueIDToNameMap[ID]; }
 
 private:
@@ -358,7 +358,7 @@ public:
     return OrigSingleLocVariableValueTable[DVA];
   }
 
-  void printValues(DebugVariableAggregate DVA, raw_ostream &OS);
+  LLVM_ABI void printValues(DebugVariableAggregate DVA, raw_ostream &OS);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/DeclareRuntimeLibcalls.h
+++ b/llvm/include/llvm/Transforms/Utils/DeclareRuntimeLibcalls.h
@@ -15,7 +15,7 @@ namespace llvm {
 class DeclareRuntimeLibcallsPass
     : public OptionalPassInfoMixin<DeclareRuntimeLibcallsPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/EntryExitInstrumenter.h
+++ b/llvm/include/llvm/Transforms/Utils/EntryExitInstrumenter.h
@@ -25,10 +25,11 @@ struct EntryExitInstrumenterPass
     : public RequiredPassInfoMixin<EntryExitInstrumenterPass> {
   EntryExitInstrumenterPass(bool PostInlining) : PostInlining(PostInlining) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
-  void printPipeline(raw_ostream &OS,
-                     function_ref<StringRef(StringRef)> MapClassName2PassName);
+  LLVM_ABI void
+  printPipeline(raw_ostream &OS,
+                function_ref<StringRef(StringRef)> MapClassName2PassName);
 
   bool PostInlining;
 };

--- a/llvm/include/llvm/Transforms/Utils/EscapeEnumerator.h
+++ b/llvm/include/llvm/Transforms/Utils/EscapeEnumerator.h
@@ -43,7 +43,7 @@ public:
       : F(F), CleanupBBName(N), StateBB(F.begin()), StateE(F.end()),
         Builder(F.getContext()), HandleExceptions(HandleExceptions), DTU(DTU) {}
 
-  IRBuilder<> *Next();
+  LLVM_ABI IRBuilder<> *Next();
 };
 
 }

--- a/llvm/include/llvm/Transforms/Utils/Evaluator.h
+++ b/llvm/include/llvm/Transforms/Utils/Evaluator.h
@@ -42,7 +42,7 @@ class Evaluator {
   /// without creating a new interned Constant.
   class MutableValue {
     PointerUnion<Constant *, MutableAggregate *> Val;
-    void clear();
+    LLVM_ABI void clear();
     bool makeMutable();
 
   public:
@@ -66,8 +66,8 @@ class Evaluator {
       return cast<MutableAggregate *>(Val)->toConstant();
     }
 
-    Constant *read(Type *Ty, APInt Offset, const DataLayout &DL) const;
-    bool write(Constant *V, APInt Offset, const DataLayout &DL);
+    LLVM_ABI Constant *read(Type *Ty, APInt Offset, const DataLayout &DL) const;
+    LLVM_ABI bool write(Constant *V, APInt Offset, const DataLayout &DL);
   };
 
   struct MutableAggregate {
@@ -75,7 +75,7 @@ class Evaluator {
     SmallVector<MutableValue> Elements;
 
     MutableAggregate(Type *Ty) : Ty(Ty) {}
-    Constant *toConstant() const;
+    LLVM_ABI Constant *toConstant() const;
   };
 
 public:
@@ -96,8 +96,8 @@ public:
   /// Evaluate a call to function F, returning true if successful, false if we
   /// can't evaluate it.  ActualArgs contains the formal arguments for the
   /// function.
-  bool EvaluateFunction(Function *F, Constant *&RetVal,
-                        const SmallVectorImpl<Constant*> &ActualArgs);
+  LLVM_ABI bool EvaluateFunction(Function *F, Constant *&RetVal,
+                                 const SmallVectorImpl<Constant *> &ActualArgs);
 
   DenseMap<GlobalVariable *, Constant *> getMutatedInitializers() const {
     DenseMap<GlobalVariable *, Constant *> Result;

--- a/llvm/include/llvm/Transforms/Utils/FixIrreducible.h
+++ b/llvm/include/llvm/Transforms/Utils/FixIrreducible.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 struct FixIrreduciblePass : OptionalPassInfoMixin<FixIrreduciblePass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/GlobalStatus.h
+++ b/llvm/include/llvm/Transforms/Utils/GlobalStatus.h
@@ -22,7 +22,7 @@ class Value;
 /// Note that constants cannot be cyclic, so this test is pretty easy to
 /// implement recursively.
 ///
-bool isSafeToDestroyConstant(const Constant *C);
+LLVM_ABI bool isSafeToDestroyConstant(const Constant *C);
 
 /// As we analyze each global or thread-local variable, keep track of some
 /// information about it.  If we find out that the address of the global is
@@ -79,12 +79,12 @@ struct GlobalStatus {
   /// Set to the strongest atomic ordering requirement.
   AtomicOrdering Ordering = AtomicOrdering::NotAtomic;
 
-  GlobalStatus();
+  LLVM_ABI GlobalStatus();
 
   /// Look at all uses of the global and fill in the GlobalStatus structure.  If
   /// the global has its address taken, return true to indicate we can't do
   /// anything with it.
-  static bool analyzeGlobal(const Value *V, GlobalStatus &GS);
+  LLVM_ABI static bool analyzeGlobal(const Value *V, GlobalStatus &GS);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/GuardUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/GuardUtils.h
@@ -12,6 +12,8 @@
 #ifndef LLVM_TRANSFORMS_UTILS_GUARDUTILS_H
 #define LLVM_TRANSFORMS_UTILS_GUARDUTILS_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class CondBrInst;
@@ -26,18 +28,18 @@ class Value;
 /// deoptimize function \p DeoptIntrinsic.  If 'UseWC' is set, preserve the
 /// widenable nature of the guard by lowering to equivelent form.  If not set,
 /// lower to a form without widenable semantics.
-void makeGuardControlFlowExplicit(Function *DeoptIntrinsic, CallInst *Guard,
-                                  bool UseWC);
+LLVM_ABI void makeGuardControlFlowExplicit(Function *DeoptIntrinsic,
+                                           CallInst *Guard, bool UseWC);
 
 /// Given a branch we know is widenable (defined per Analysis/GuardUtils.h),
 /// widen it such that condition 'NewCond' is also known to hold on the taken
 /// path.  Branch remains widenable after transform.
-void widenWidenableBranch(CondBrInst *WidenableBR, Value *NewCond);
+LLVM_ABI void widenWidenableBranch(CondBrInst *WidenableBR, Value *NewCond);
 
 /// Given a branch we know is widenable (defined per Analysis/GuardUtils.h),
 /// *set* it's condition such that (only) 'Cond' is known to hold on the taken
 /// path and that the branch remains widenable after transform.
-void setWidenableBranchCond(CondBrInst *WidenableBR, Value *Cond);
+LLVM_ABI void setWidenableBranchCond(CondBrInst *WidenableBR, Value *Cond);
 
 } // llvm
 

--- a/llvm/include/llvm/Transforms/Utils/HelloWorld.h
+++ b/llvm/include/llvm/Transforms/Utils/HelloWorld.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class HelloWorldPass : public OptionalPassInfoMixin<HelloWorldPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/IRNormalizer.h
+++ b/llvm/include/llvm/Transforms/Utils/IRNormalizer.h
@@ -28,7 +28,8 @@ public:
   IRNormalizerPass(IRNormalizerOptions Options = IRNormalizerOptions())
       : Options(Options) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) const;
+  LLVM_ABI PreservedAnalyses run(Function &F,
+                                 FunctionAnalysisManager &AM) const;
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/InjectTLIMappings.h
+++ b/llvm/include/llvm/Transforms/Utils/InjectTLIMappings.h
@@ -19,7 +19,7 @@ namespace llvm {
 class Function;
 class InjectTLIMappings : public OptionalPassInfoMixin<InjectTLIMappings> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // End namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/InstructionNamer.h
+++ b/llvm/include/llvm/Transforms/Utils/InstructionNamer.h
@@ -13,7 +13,7 @@
 
 namespace llvm {
 struct InstructionNamerPass : OptionalPassInfoMixin<InstructionNamerPass> {
-  PreservedAnalyses run(Function &, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &, FunctionAnalysisManager &);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/LibCallsShrinkWrap.h
+++ b/llvm/include/llvm/Transforms/Utils/LibCallsShrinkWrap.h
@@ -20,7 +20,7 @@ class LibCallsShrinkWrapPass
 public:
   static StringRef name() { return "LibCallsShrinkWrapPass"; }
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/LoopConstrainer.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopConstrainer.h
@@ -80,7 +80,7 @@ struct LoopStructure {
     return Result;
   }
 
-  static std::optional<LoopStructure>
+  LLVM_ABI static std::optional<LoopStructure>
   parseLoopStructure(ScalarEvolution &, Loop &, bool, const char *&);
 };
 
@@ -213,13 +213,13 @@ private:
   SubRanges SR;
 
 public:
-  LoopConstrainer(Loop &L, LoopInfo &LI,
-                  function_ref<void(Loop *, bool)> LPMAddNewLoop,
-                  const LoopStructure &LS, ScalarEvolution &SE,
-                  DominatorTree &DT, Type *T, SubRanges SR);
+  LLVM_ABI LoopConstrainer(Loop &L, LoopInfo &LI,
+                           function_ref<void(Loop *, bool)> LPMAddNewLoop,
+                           const LoopStructure &LS, ScalarEvolution &SE,
+                           DominatorTree &DT, Type *T, SubRanges SR);
 
   // Entry point for the algorithm.  Returns true on success.
-  bool run();
+  LLVM_ABI bool run();
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/LoopPeel.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopPeel.h
@@ -19,34 +19,36 @@
 
 namespace llvm {
 
-bool canPeel(const Loop *L);
+LLVM_ABI bool canPeel(const Loop *L);
 
 /// Returns true if the last iteration of \p L can be peeled off. It makes sure
 /// the loop exit condition can be adjusted when peeling and that the loop
 /// executes at least 2 iterations.
-bool canPeelLastIteration(const Loop &L, ScalarEvolution &SE);
+LLVM_ABI bool canPeelLastIteration(const Loop &L, ScalarEvolution &SE);
 
 /// VMap is the value-map that maps instructions from the original loop to
 /// instructions in the last peeled-off iteration. If \p PeelLast is true, peel
 /// off the last \p PeelCount iterations from \p L (canPeelLastIteration must be
 /// true for \p L), otherwise peel off the first \p PeelCount iterations.
-void peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
-              ScalarEvolution *SE, DominatorTree &DT, AssumptionCache *AC,
-              bool PreserveLCSSA, ValueToValueMapTy &VMap);
+LLVM_ABI void peelLoop(Loop *L, unsigned PeelCount, bool PeelLast, LoopInfo *LI,
+                       ScalarEvolution *SE, DominatorTree &DT,
+                       AssumptionCache *AC, bool PreserveLCSSA,
+                       ValueToValueMapTy &VMap);
 
-TargetTransformInfo::PeelingPreferences
+LLVM_ABI TargetTransformInfo::PeelingPreferences
 gatherPeelingPreferences(Loop *L, ScalarEvolution &SE,
                          const TargetTransformInfo &TTI,
                          std::optional<bool> UserAllowPeeling,
                          std::optional<bool> UserAllowProfileBasedPeeling,
                          bool UnrollingSpecficValues = false);
 
-void computePeelCount(Loop *L, unsigned LoopSize,
-                      TargetTransformInfo::PeelingPreferences &PP,
-                      unsigned TripCount, DominatorTree &DT,
-                      ScalarEvolution &SE, const TargetTransformInfo &TTI,
-                      AssumptionCache *AC = nullptr,
-                      unsigned Threshold = UINT_MAX);
+LLVM_ABI void computePeelCount(Loop *L, unsigned LoopSize,
+                               TargetTransformInfo::PeelingPreferences &PP,
+                               unsigned TripCount, DominatorTree &DT,
+                               ScalarEvolution &SE,
+                               const TargetTransformInfo &TTI,
+                               AssumptionCache *AC = nullptr,
+                               unsigned Threshold = UINT_MAX);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -394,14 +394,14 @@ LLVM_ABI bool setLoopEstimatedTripCount(
 /// - The probability \c P that, at the end of any iteration, the latch of \p L
 ///   will start another iteration such that `1 - P` is the probability of
 ///   exiting the loop.
-BranchProbability getLoopProbability(Loop *L);
+LLVM_ABI BranchProbability getLoopProbability(Loop *L);
 
 /// Set branch weight metadata for the latch of \p L to indicate that, at the
 /// end of any iteration, \p P and `1 - P` are the probabilities of starting
 /// another iteration and exiting the loop, respectively.  Return false if the
 /// implementation is unable to handle the loop form of \p L (e.g., \p L must
 /// have a latch block that controls the loop exit).  Otherwise, return true.
-bool setLoopProbability(Loop *L, BranchProbability P);
+LLVM_ABI bool setLoopProbability(Loop *L, BranchProbability P);
 
 /// Based on branch weight metadata, return either:
 /// - An unknown probability if the implementation cannot extract the
@@ -410,7 +410,8 @@ bool setLoopProbability(Loop *L, BranchProbability P);
 /// - The probability \c P that control flows from \p B to its first target
 ///   label such that `1 - P` is the probability of control flowing to its
 ///   second target label, or vice-versa if \p ForFirstTarget is false.
-BranchProbability getBranchProbability(CondBrInst *B, bool ForFirstTarget);
+LLVM_ABI BranchProbability getBranchProbability(CondBrInst *B,
+                                                bool ForFirstTarget);
 
 /// Calculates the edge probability from Src to Dst.
 /// Dst has to be a successor to Src.
@@ -419,13 +420,14 @@ BranchProbability getBranchProbability(CondBrInst *B, bool ForFirstTarget);
 /// This does not use BranchProbabilityInfo and the values computed by this
 /// will vary from BPI because BPI has its own more advanced heuristics to
 /// determine probabilities even without branch_weights metadata.
-BranchProbability getBranchProbability(BasicBlock *Src, BasicBlock *Dst);
+LLVM_ABI BranchProbability getBranchProbability(BasicBlock *Src,
+                                                BasicBlock *Dst);
 
 /// Set branch weight metadata for \p B to indicate that \p P and `1 - P` are
 /// the probabilities of control flowing to its first and second target labels,
 /// respectively, or vice-versa if \p ForFirstTarget is false.
-void setBranchProbability(CondBrInst *B, BranchProbability P,
-                          bool ForFirstTarget);
+LLVM_ABI void setBranchProbability(CondBrInst *B, BranchProbability P,
+                                   bool ForFirstTarget);
 
 /// Check inner loop (L) backedge count is known to be invariant on all
 /// iterations of its outer loop. If the loop has no parent, this is trivially

--- a/llvm/include/llvm/Transforms/Utils/LoopVersioning.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopVersioning.h
@@ -44,9 +44,9 @@ public:
   /// It uses runtime check provided by the user. If \p UseLAIChecks is true,
   /// we will retain the default checks made by LAI. Otherwise, construct an
   /// object having no checks and we expect the user to add them.
-  LoopVersioning(const LoopAccessInfo &LAI,
-                 ArrayRef<RuntimePointerCheck> Checks, Loop *L, LoopInfo *LI,
-                 DominatorTree *DT, ScalarEvolution *SE);
+  LLVM_ABI LoopVersioning(const LoopAccessInfo &LAI,
+                          ArrayRef<RuntimePointerCheck> Checks, Loop *L,
+                          LoopInfo *LI, DominatorTree *DT, ScalarEvolution *SE);
 
   /// Performs the CFG manipulation part of versioning the loop including
   /// the DominatorTree and LoopInfo updates.
@@ -65,7 +65,8 @@ public:
 
   /// Same but if the client has already precomputed the set of values
   /// used outside the loop, this API will allows passing that.
-  void versionLoop(const SmallVectorImpl<Instruction *> &DefsUsedOutside);
+  LLVM_ABI void
+  versionLoop(const SmallVectorImpl<Instruction *> &DefsUsedOutside);
 
   /// Returns the versioned loop.  Control flows here if pointers in the
   /// loop don't alias (i.e. all memchecks passed).  (This loop is actually the
@@ -81,24 +82,24 @@ public:
   ///
   /// This is just wrapper that calls prepareNoAliasMetadata and
   /// annotateInstWithNoAlias on the instructions of the versioned loop.
-  void annotateLoopWithNoAlias();
+  LLVM_ABI void annotateLoopWithNoAlias();
 
   /// Returns a pair containing the alias_scope and noalias metadata nodes for
   /// \p OrigInst, if they exists.
-  std::pair<MDNode *, MDNode *>
+  LLVM_ABI std::pair<MDNode *, MDNode *>
   getNoAliasMetadataFor(const Instruction *OrigInst) const;
 
   /// Set up the aliasing scopes based on the memchecks.  This needs to
   /// be called before the first call to annotateInstWithNoAlias.
-  void prepareNoAliasMetadata();
+  LLVM_ABI void prepareNoAliasMetadata();
 
   /// Add the noalias annotations to \p VersionedInst.
   ///
   /// \p OrigInst is the instruction corresponding to \p VersionedInst in the
   /// original loop.  Initialize the aliasing scopes with
   /// prepareNoAliasMetadata once before this can be called.
-  void annotateInstWithNoAlias(Instruction *VersionedInst,
-                               const Instruction *OrigInst);
+  LLVM_ABI void annotateInstWithNoAlias(Instruction *VersionedInst,
+                                        const Instruction *OrigInst);
 
 private:
   /// Adds the necessary PHI nodes for the versioned loops based on the
@@ -154,7 +155,7 @@ private:
 /// array accesses from the loop.
 class LoopVersioningPass : public OptionalPassInfoMixin<LoopVersioningPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Utils/LowerAtomic.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerAtomic.h
@@ -21,23 +21,25 @@ namespace llvm {
 class IRBuilderBase;
 
 /// Convert the given Cmpxchg into primitive load and compare.
-bool lowerAtomicCmpXchgInst(AtomicCmpXchgInst *CXI);
+LLVM_ABI bool lowerAtomicCmpXchgInst(AtomicCmpXchgInst *CXI);
 
 /// Emit IR to implement the given cmpxchg operation on values in registers,
 /// returning the new value.
-std::pair<Value *, Value *> buildCmpXchgValue(IRBuilderBase &Builder,
-                                              Value *Ptr, Value *Cmp,
-                                              Value *Val, Align Alignment);
+LLVM_ABI std::pair<Value *, Value *> buildCmpXchgValue(IRBuilderBase &Builder,
+                                                       Value *Ptr, Value *Cmp,
+                                                       Value *Val,
+                                                       Align Alignment);
 
 /// Convert the given RMWI into primitive load and stores,
 /// assuming that doing so is legal. Return true if the lowering
 /// succeeds.
-bool lowerAtomicRMWInst(AtomicRMWInst *RMWI);
+LLVM_ABI bool lowerAtomicRMWInst(AtomicRMWInst *RMWI);
 
 /// Emit IR to implement the given atomicrmw operation on values in registers,
 /// returning the new value.
-Value *buildAtomicRMWValue(AtomicRMWInst::BinOp Op, IRBuilderBase &Builder,
-                           Value *Loaded, Value *Val);
+LLVM_ABI Value *buildAtomicRMWValue(AtomicRMWInst::BinOp Op,
+                                    IRBuilderBase &Builder, Value *Loaded,
+                                    Value *Val);
 }
 
 #endif // LLVM_TRANSFORMS_UTILS_LOWERATOMIC_H

--- a/llvm/include/llvm/Transforms/Utils/LowerGlobalDtors.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerGlobalDtors.h
@@ -21,7 +21,7 @@ namespace llvm {
 class LowerGlobalDtorsPass
     : public OptionalPassInfoMixin<LowerGlobalDtorsPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/LowerIFunc.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerIFunc.h
@@ -20,7 +20,7 @@ class LowerIFuncPass : public OptionalPassInfoMixin<LowerIFuncPass> {
 public:
   LowerIFuncPass() = default;
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/LowerInvoke.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerInvoke.h
@@ -21,7 +21,7 @@ namespace llvm {
 
 class LowerInvokePass : public OptionalPassInfoMixin<LowerInvokePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 }
 

--- a/llvm/include/llvm/Transforms/Utils/LowerSwitch.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerSwitch.h
@@ -19,7 +19,7 @@
 
 namespace llvm {
 struct LowerSwitchPass : public OptionalPassInfoMixin<LowerSwitchPass> {
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/LowerVectorIntrinsics.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerVectorIntrinsics.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_TRANSFORMS_UTILS_LOWERVECTORINTRINSICS_H
 #define LLVM_TRANSFORMS_UTILS_LOWERVECTORINTRINSICS_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -22,7 +23,7 @@ class Module;
 
 /// Lower \p CI as a loop. \p CI is a unary intrinsic with a vector argument and
 /// is deleted and replaced with a loop.
-bool lowerUnaryVectorIntrinsicAsLoop(Module &M, CallInst *CI);
+LLVM_ABI bool lowerUnaryVectorIntrinsicAsLoop(Module &M, CallInst *CI);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/MatrixUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/MatrixUtils.h
@@ -71,9 +71,9 @@ struct TileInfo {
   /// for ColumnLoop.Index = 0..NumColumns
   ///   for RowLoop.Index = 0..NumRows
   ///     for InnerLoop.Index = 0..NumInner
-  BasicBlock *CreateTiledLoops(BasicBlock *Start, BasicBlock *End,
-                               IRBuilderBase &B, DomTreeUpdater &DTU,
-                               LoopInfo &LI);
+  LLVM_ABI BasicBlock *CreateTiledLoops(BasicBlock *Start, BasicBlock *End,
+                                        IRBuilderBase &B, DomTreeUpdater &DTU,
+                                        LoopInfo &LI);
 
 private:
   /// Creates a new loop with header, body and latch blocks that iterates from

--- a/llvm/include/llvm/Transforms/Utils/MemoryOpRemark.h
+++ b/llvm/include/llvm/Transforms/Utils/MemoryOpRemark.h
@@ -32,7 +32,7 @@ class StoreInst;
 
 // FIXME: Once we get to more remarks like this one, we need to re-evaluate how
 // much of this logic should actually go into the remark emitter.
-struct MemoryOpRemark {
+struct LLVM_ABI MemoryOpRemark {
   OptimizationRemarkEmitter &ORE;
   StringRef RemarkPass;
   const DataLayout &DL;
@@ -94,7 +94,7 @@ private:
 };
 
 /// Special case for -ftrivial-auto-var-init remarks.
-struct AutoInitRemark : public MemoryOpRemark {
+struct LLVM_ABI AutoInitRemark : public MemoryOpRemark {
   AutoInitRemark(OptimizationRemarkEmitter &ORE, StringRef RemarkPass,
                  const DataLayout &DL, const TargetLibraryInfo &TLI)
       : MemoryOpRemark(ORE, RemarkPass, DL, TLI) {}

--- a/llvm/include/llvm/Transforms/Utils/MemoryTaggingSupport.h
+++ b/llvm/include/llvm/Transforms/Utils/MemoryTaggingSupport.h
@@ -48,15 +48,16 @@ struct AllocaInfo {
 // Returns whether Ends covered all possible exits. If they did not,
 // the caller should remove Ends to ensure that work done at the other
 // exits does not happen outside of the lifetime.
-void forAllReachableExits(const DominatorTree &DT, const PostDominatorTree &PDT,
-                          const LoopInfo &LI, const AllocaInfo &AInfo,
-                          const SmallVectorImpl<Instruction *> &RetVec,
-                          llvm::function_ref<void(Instruction *)> Callback);
+LLVM_ABI void
+forAllReachableExits(const DominatorTree &DT, const PostDominatorTree &PDT,
+                     const LoopInfo &LI, const AllocaInfo &AInfo,
+                     const SmallVectorImpl<Instruction *> &RetVec,
+                     llvm::function_ref<void(Instruction *)> Callback);
 
-bool isSupportedLifetime(const AllocaInfo &AInfo, const DominatorTree *DT,
-                         const LoopInfo *LI);
+LLVM_ABI bool isSupportedLifetime(const AllocaInfo &AInfo,
+                                  const DominatorTree *DT, const LoopInfo *LI);
 
-Instruction *getUntagLocationIfFunctionExit(Instruction &Inst);
+LLVM_ABI Instruction *getUntagLocationIfFunctionExit(Instruction &Inst);
 
 struct StackInfo {
   MapVector<AllocaInst *, AllocaInfo> AllocasToInstrument;
@@ -78,8 +79,8 @@ public:
   StackInfoBuilder(const StackSafetyGlobalInfo *SSI, const char *DebugType)
       : SSI(SSI), DebugType(DebugType) {}
 
-  void visit(OptimizationRemarkEmitter &ORE, Instruction &Inst);
-  AllocaInterestingness getAllocaInterestingness(const AllocaInst &AI);
+  LLVM_ABI void visit(OptimizationRemarkEmitter &ORE, Instruction &Inst);
+  LLVM_ABI AllocaInterestingness getAllocaInterestingness(const AllocaInst &AI);
   StackInfo &get() { return Info; };
 
 private:
@@ -88,18 +89,19 @@ private:
   const char *DebugType;
 };
 
-uint64_t getAllocaSizeInBytes(const AllocaInst &AI);
-void alignAndPadAlloca(memtag::AllocaInfo &Info, llvm::Align Align);
+LLVM_ABI uint64_t getAllocaSizeInBytes(const AllocaInst &AI);
+LLVM_ABI void alignAndPadAlloca(memtag::AllocaInfo &Info, llvm::Align Align);
 
-Value *readRegister(IRBuilder<> &IRB, StringRef Name);
-Value *getFP(IRBuilder<> &IRB);
-Value *getPC(const Triple &TargetTriple, IRBuilder<> &IRB);
-Value *getAndroidSlotPtr(IRBuilder<> &IRB, int Slot);
-Value *getDarwinSlotPtr(IRBuilder<> &IRB, int Slot);
+LLVM_ABI Value *readRegister(IRBuilder<> &IRB, StringRef Name);
+LLVM_ABI Value *getFP(IRBuilder<> &IRB);
+LLVM_ABI Value *getPC(const Triple &TargetTriple, IRBuilder<> &IRB);
+LLVM_ABI Value *getAndroidSlotPtr(IRBuilder<> &IRB, int Slot);
+LLVM_ABI Value *getDarwinSlotPtr(IRBuilder<> &IRB, int Slot);
 
-void annotateDebugRecords(AllocaInfo &Info, unsigned int Tag);
-Value *incrementThreadLong(IRBuilder<> &IRB, Value *ThreadLong,
-                           unsigned int Inc, bool IsMemtagDarwin = false);
+LLVM_ABI void annotateDebugRecords(AllocaInfo &Info, unsigned int Tag);
+LLVM_ABI Value *incrementThreadLong(IRBuilder<> &IRB, Value *ThreadLong,
+                                    unsigned int Inc,
+                                    bool IsMemtagDarwin = false);
 
 } // namespace memtag
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/MetaRenamer.h
+++ b/llvm/include/llvm/Transforms/Utils/MetaRenamer.h
@@ -19,7 +19,7 @@
 
 namespace llvm {
 struct MetaRenamerPass : OptionalPassInfoMixin<MetaRenamerPass> {
-  PreservedAnalyses run(Module &, ModuleAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Module &, ModuleAnalysisManager &);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/MisExpect.h
+++ b/llvm/include/llvm/Transforms/Utils/MisExpect.h
@@ -33,8 +33,8 @@ namespace llvm::misexpect {
 ///
 /// \param I The Instruction being checked
 /// \param RealWeights A vector of profile weights for each target block
-void checkBackendInstrumentation(const Instruction &I,
-                                 ArrayRef<uint32_t> RealWeights);
+LLVM_ABI void checkBackendInstrumentation(const Instruction &I,
+                                          ArrayRef<uint32_t> RealWeights);
 
 /// checkFrontendInstrumentation - compares PGO counters to the thresholds used
 /// for llvm.expect and warns if the PGO counters are outside of the expected
@@ -47,8 +47,8 @@ void checkBackendInstrumentation(const Instruction &I,
 /// \param I The Instruction being checked
 /// \param ExpectedWeights A vector of the expected weights for each target
 /// block, this determines the threshold values used when emitting diagnostics
-void checkFrontendInstrumentation(const Instruction &I,
-                                  ArrayRef<uint32_t> ExpectedWeights);
+LLVM_ABI void checkFrontendInstrumentation(const Instruction &I,
+                                           ArrayRef<uint32_t> ExpectedWeights);
 
 /// veryifyMisExpect - compares RealWeights to the thresholds used
 /// for llvm.expect and warns if the PGO counters are outside of the expected
@@ -57,8 +57,9 @@ void checkFrontendInstrumentation(const Instruction &I,
 /// \param I The Instruction being checked
 /// \param RealWeights A vector of profile weights from the profile data
 /// \param ExpectedWeights A vector of the weights attatch by llvm.expect
-void verifyMisExpect(const Instruction &I, ArrayRef<uint32_t> RealWeights,
-                     ArrayRef<uint32_t> ExpectedWeights);
+LLVM_ABI void verifyMisExpect(const Instruction &I,
+                              ArrayRef<uint32_t> RealWeights,
+                              ArrayRef<uint32_t> ExpectedWeights);
 
 /// checkExpectAnnotations - compares PGO counters to the thresholds used
 /// for llvm.expect and warns if the PGO counters are outside of the expected
@@ -71,9 +72,9 @@ void verifyMisExpect(const Instruction &I, ArrayRef<uint32_t> RealWeights,
 /// \param I The Instruction being checked
 /// \param ExistingWeights A vector of profile weights for each target block
 /// \param IsFrontend A boolean describing if this is Frontend instrumentation
-void checkExpectAnnotations(const Instruction &I,
-                            ArrayRef<uint32_t> ExistingWeights,
-                            bool IsFrontend);
+LLVM_ABI void checkExpectAnnotations(const Instruction &I,
+                                     ArrayRef<uint32_t> ExistingWeights,
+                                     bool IsFrontend);
 
 } // namespace llvm::misexpect
 

--- a/llvm/include/llvm/Transforms/Utils/MoveAutoInit.h
+++ b/llvm/include/llvm/Transforms/Utils/MoveAutoInit.h
@@ -22,7 +22,7 @@ namespace llvm {
 
 class MoveAutoInitPass : public OptionalPassInfoMixin<MoveAutoInitPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/NameAnonGlobals.h
+++ b/llvm/include/llvm/Transforms/Utils/NameAnonGlobals.h
@@ -23,7 +23,7 @@ class NameAnonGlobalPass : public RequiredPassInfoMixin<NameAnonGlobalPass> {
 public:
   NameAnonGlobalPass() = default;
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/RelLookupTableConverter.h
+++ b/llvm/include/llvm/Transforms/Utils/RelLookupTableConverter.h
@@ -63,7 +63,7 @@ class RelLookupTableConverterPass
 public:
   RelLookupTableConverterPass() = default;
 
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/SSAUpdater.h
@@ -57,32 +57,33 @@ private:
 public:
   /// If InsertedPHIs is specified, it will be filled
   /// in with all PHI Nodes created by rewriting.
-  explicit SSAUpdater(SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr);
+  LLVM_ABI explicit SSAUpdater(
+      SmallVectorImpl<PHINode *> *InsertedPHIs = nullptr);
   SSAUpdater(const SSAUpdater &) = delete;
   SSAUpdater &operator=(const SSAUpdater &) = delete;
-  ~SSAUpdater();
+  LLVM_ABI ~SSAUpdater();
 
   /// Reset this object to get ready for a new set of SSA updates with
   /// type 'Ty'.
   ///
   /// PHI nodes get a name based on 'Name'.
-  void Initialize(Type *Ty, StringRef Name);
+  LLVM_ABI void Initialize(Type *Ty, StringRef Name);
 
   /// Indicate that a rewritten value is available in the specified block
   /// with the specified value.
-  void AddAvailableValue(BasicBlock *BB, Value *V);
+  LLVM_ABI void AddAvailableValue(BasicBlock *BB, Value *V);
 
   /// Return true if the SSAUpdater already has a value for the specified
   /// block.
-  bool HasValueForBlock(BasicBlock *BB) const;
+  LLVM_ABI bool HasValueForBlock(BasicBlock *BB) const;
 
   /// Return the value for the specified block if the SSAUpdater has one,
   /// otherwise return nullptr.
-  Value *FindValueForBlock(BasicBlock *BB) const;
+  LLVM_ABI Value *FindValueForBlock(BasicBlock *BB) const;
 
   /// Construct SSA form, materializing a value that is live at the end
   /// of the specified block.
-  Value *GetValueAtEndOfBlock(BasicBlock *BB);
+  LLVM_ABI Value *GetValueAtEndOfBlock(BasicBlock *BB);
 
   /// Construct SSA form, materializing a value that is live in the
   /// middle of the specified block.
@@ -104,7 +105,7 @@ public:
   /// their respective blocks.  However, the use of X happens in the *middle* of
   /// a block.  Because of this, we need to insert a new PHI node in SomeBB to
   /// merge the appropriate values, and this value isn't live out of the block.
-  Value *GetValueInMiddleOfBlock(BasicBlock *BB);
+  LLVM_ABI Value *GetValueInMiddleOfBlock(BasicBlock *BB);
 
   /// Rewrite a use of the symbolic value.
   ///
@@ -113,23 +114,24 @@ public:
   /// rewritten to a value defined in the same block as the use, but above it.
   /// Any 'AddAvailableValue's added for the use's block will be considered to
   /// be below it.
-  void RewriteUse(Use &U);
+  LLVM_ABI void RewriteUse(Use &U);
 
   /// Rewrite debug value intrinsics to conform to a new SSA form.
   ///
   /// This will scout out all the debug value intrinsics associated with
   /// the instruction. Anything outside of its block will have its
   /// value set to the new SSA value if available, and undef if not.
-  void UpdateDebugValues(Instruction *I);
-  void UpdateDebugValues(Instruction *I,
-                         SmallVectorImpl<DbgVariableRecord *> &DbgValues);
+  LLVM_ABI void UpdateDebugValues(Instruction *I);
+  LLVM_ABI void
+  UpdateDebugValues(Instruction *I,
+                    SmallVectorImpl<DbgVariableRecord *> &DbgValues);
 
   /// Rewrite a use like \c RewriteUse but handling in-block definitions.
   ///
   /// This version of the method can rewrite uses in the same block as
   /// a definition, because it assumes that all uses of a value are below any
   /// inserted values.
-  void RewriteUseAfterInsertions(Use &U);
+  LLVM_ABI void RewriteUseAfterInsertions(Use &U);
 
 private:
   Value *GetValueAtEndOfBlockInternal(BasicBlock *BB);
@@ -149,8 +151,8 @@ protected:
   SSAUpdater &SSA;
 
 public:
-  LoadAndStorePromoter(ArrayRef<const Instruction *> Insts,
-                       SSAUpdater &S, StringRef Name = StringRef());
+  LLVM_ABI LoadAndStorePromoter(ArrayRef<const Instruction *> Insts,
+                                SSAUpdater &S, StringRef Name = StringRef());
   virtual ~LoadAndStorePromoter() = default;
 
   /// This does the promotion.
@@ -158,7 +160,7 @@ public:
   /// Insts is a list of loads and stores to promote, and Name is the basename
   /// for the PHIs to insert. After this is complete, the loads and stores are
   /// removed from the code.
-  void run(const SmallVectorImpl<Instruction *> &Insts);
+  LLVM_ABI void run(const SmallVectorImpl<Instruction *> &Insts);
 
   /// This hook is invoked after all the stores are found and inserted as
   /// available values.

--- a/llvm/include/llvm/Transforms/Utils/SampleProfileInference.h
+++ b/llvm/include/llvm/Transforms/Utils/SampleProfileInference.h
@@ -112,8 +112,8 @@ struct ProfiParams {
   const int64_t CostUnlikely = ((int64_t)1) << 30;
 };
 
-void applyFlowInference(const ProfiParams &Params, FlowFunction &Func);
-void applyFlowInference(FlowFunction &Func);
+LLVM_ABI void applyFlowInference(const ProfiParams &Params, FlowFunction &Func);
+LLVM_ABI void applyFlowInference(FlowFunction &Func);
 
 /// Sample profile inference pass.
 template <typename FT> class SampleProfileInference {

--- a/llvm/include/llvm/Transforms/Utils/SampleProfileLoaderBaseImpl.h
+++ b/llvm/include/llvm/Transforms/Utils/SampleProfileLoaderBaseImpl.h
@@ -163,9 +163,7 @@ public:
   }
 };
 
-
-
-extern cl::opt<bool> SampleProfileUseProfi;
+extern LLVM_ABI cl::opt<bool> SampleProfileUseProfi;
 
 static inline bool skipProfileForFunction(const Function &F) {
   return F.isDeclaration() || !F.hasFnAttribute("use-sample-profile");

--- a/llvm/include/llvm/Transforms/Utils/SampleProfileLoaderBaseUtil.h
+++ b/llvm/include/llvm/Transforms/Utils/SampleProfileLoaderBaseUtil.h
@@ -25,25 +25,25 @@ using namespace sampleprof;
 class ProfileSummaryInfo;
 class Module;
 
-extern cl::opt<unsigned> SampleProfileMaxPropagateIterations;
-extern cl::opt<unsigned> SampleProfileRecordCoverage;
-extern cl::opt<unsigned> SampleProfileSampleCoverage;
-extern cl::opt<bool> NoWarnSampleUnused;
+extern LLVM_ABI cl::opt<unsigned> SampleProfileMaxPropagateIterations;
+extern LLVM_ABI cl::opt<unsigned> SampleProfileRecordCoverage;
+extern LLVM_ABI cl::opt<unsigned> SampleProfileSampleCoverage;
+extern LLVM_ABI cl::opt<bool> NoWarnSampleUnused;
 
 namespace sampleprofutil {
 
 class SampleCoverageTracker {
 public:
-  bool markSamplesUsed(const FunctionSamples *FS, uint32_t LineOffset,
-                       uint32_t Discriminator, uint64_t Samples);
-  unsigned computeCoverage(unsigned Used, unsigned Total) const;
-  unsigned countUsedRecords(const FunctionSamples *FS,
-                            ProfileSummaryInfo *PSI) const;
-  unsigned countBodyRecords(const FunctionSamples *FS,
-                            ProfileSummaryInfo *PSI) const;
+  LLVM_ABI bool markSamplesUsed(const FunctionSamples *FS, uint32_t LineOffset,
+                                uint32_t Discriminator, uint64_t Samples);
+  LLVM_ABI unsigned computeCoverage(unsigned Used, unsigned Total) const;
+  LLVM_ABI unsigned countUsedRecords(const FunctionSamples *FS,
+                                     ProfileSummaryInfo *PSI) const;
+  LLVM_ABI unsigned countBodyRecords(const FunctionSamples *FS,
+                                     ProfileSummaryInfo *PSI) const;
   uint64_t getTotalUsedSamples() const { return TotalUsedSamples; }
-  uint64_t countBodySamples(const FunctionSamples *FS,
-                            ProfileSummaryInfo *PSI) const;
+  LLVM_ABI uint64_t countBodySamples(const FunctionSamples *FS,
+                                     ProfileSummaryInfo *PSI) const;
 
   void clear() {
     SampleCoverage.clear();
@@ -86,11 +86,11 @@ private:
 };
 
 /// Return true if the given callsite is hot wrt to hot cutoff threshold.
-bool callsiteIsHot(const FunctionSamples *CallsiteFS, ProfileSummaryInfo *PSI,
-                   bool ProfAccForSymsInList);
+LLVM_ABI bool callsiteIsHot(const FunctionSamples *CallsiteFS,
+                            ProfileSummaryInfo *PSI, bool ProfAccForSymsInList);
 
 /// Create a global variable to flag FSDiscriminators are used.
-void createFSDiscriminatorVariable(Module *M);
+LLVM_ABI void createFSDiscriminatorVariable(Module *M);
 
 } // end of namespace sampleprofutil
 } // end of namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/ScalarEvolutionExpander.h
+++ b/llvm/include/llvm/Transforms/Utils/ScalarEvolutionExpander.h
@@ -434,7 +434,7 @@ public:
 
   /// Remove inserted instructions that are dead, e.g. due to InstSimplifyFolder
   /// simplifications. \p Root is assumed to be used and won't be removed.
-  void eraseDeadInstructions(Value *Root);
+  LLVM_ABI void eraseDeadInstructions(Value *Root);
 
 private:
   LLVMContext &getContext() const { return SE.getContext(); }

--- a/llvm/include/llvm/Transforms/Utils/SimplifyIndVar.h
+++ b/llvm/include/llvm/Transforms/Utils/SimplifyIndVar.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_TRANSFORMS_UTILS_SIMPLIFYINDVAR_H
 #define LLVM_TRANSFORMS_UTILS_SIMPLIFYINDVAR_H
 
+#include "llvm/Support/Compiler.h"
 #include <utility>
 
 namespace llvm {
@@ -33,7 +34,7 @@ class TargetTransformInfo;
 
 /// Interface for visiting interesting IV users that are recognized but not
 /// simplified by this utility.
-class IVVisitor {
+class LLVM_ABI IVVisitor {
 protected:
   const DominatorTree *DT = nullptr;
 
@@ -52,18 +53,17 @@ public:
 /// where the first entry indicates that the function makes changes and the
 /// second entry indicates that it introduced new opportunities for loop
 /// unswitching.
-std::pair<bool, bool> simplifyUsersOfIV(PHINode *CurrIV, ScalarEvolution *SE,
-                                        DominatorTree *DT, LoopInfo *LI,
-                                        const TargetTransformInfo *TTI,
-                                        SmallVectorImpl<WeakTrackingVH> &Dead,
-                                        SCEVExpander &Rewriter,
-                                        IVVisitor *V = nullptr);
+LLVM_ABI std::pair<bool, bool>
+simplifyUsersOfIV(PHINode *CurrIV, ScalarEvolution *SE, DominatorTree *DT,
+                  LoopInfo *LI, const TargetTransformInfo *TTI,
+                  SmallVectorImpl<WeakTrackingVH> &Dead, SCEVExpander &Rewriter,
+                  IVVisitor *V = nullptr);
 
 /// SimplifyLoopIVs - Simplify users of induction variables within this
 /// loop. This does not actually change or add IVs.
-bool simplifyLoopIVs(Loop *L, ScalarEvolution *SE, DominatorTree *DT,
-                     LoopInfo *LI, const TargetTransformInfo *TTI,
-                     SmallVectorImpl<WeakTrackingVH> &Dead);
+LLVM_ABI bool simplifyLoopIVs(Loop *L, ScalarEvolution *SE, DominatorTree *DT,
+                              LoopInfo *LI, const TargetTransformInfo *TTI,
+                              SmallVectorImpl<WeakTrackingVH> &Dead);
 
 /// Collect information about induction variables that are used by sign/zero
 /// extend operations. This information is recorded by CollectExtend and provides
@@ -80,11 +80,12 @@ struct WideIVInfo {
 
 /// Widen Induction Variables - Extend the width of an IV to cover its
 /// widest uses.
-PHINode *createWideIV(const WideIVInfo &WI,
-    LoopInfo *LI, ScalarEvolution *SE, SCEVExpander &Rewriter,
-    DominatorTree *DT, SmallVectorImpl<WeakTrackingVH> &DeadInsts,
-    unsigned &NumElimExt, unsigned &NumWidened,
-    bool HasGuards, bool UsePostIncrementRanges);
+LLVM_ABI PHINode *createWideIV(const WideIVInfo &WI, LoopInfo *LI,
+                               ScalarEvolution *SE, SCEVExpander &Rewriter,
+                               DominatorTree *DT,
+                               SmallVectorImpl<WeakTrackingVH> &DeadInsts,
+                               unsigned &NumElimExt, unsigned &NumWidened,
+                               bool HasGuards, bool UsePostIncrementRanges);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/SimplifyLibCalls.h
+++ b/llvm/include/llvm/Transforms/Utils/SimplifyLibCalls.h
@@ -44,14 +44,14 @@ private:
   bool OnlyLowerUnknownSize;
 
 public:
-  FortifiedLibCallSimplifier(const TargetLibraryInfo *TLI,
-                             bool OnlyLowerUnknownSize = false);
+  LLVM_ABI FortifiedLibCallSimplifier(const TargetLibraryInfo *TLI,
+                                      bool OnlyLowerUnknownSize = false);
 
   /// Take the given call instruction and return a more
   /// optimal value to replace the instruction with or 0 if a more
   /// optimal form can't be found.
   /// The call must not be an indirect call.
-  Value *optimizeCall(CallInst *CI, IRBuilderBase &B);
+  LLVM_ABI Value *optimizeCall(CallInst *CI, IRBuilderBase &B);
 
 private:
   Value *optimizeMemCpyChk(CallInst *CI, IRBuilderBase &B);
@@ -127,10 +127,10 @@ private:
   static void eraseFromParentDefault(Instruction *I) { I->eraseFromParent(); }
 
   /// Replace an instruction's uses with a value using our replacer.
-  void replaceAllUsesWith(Instruction *I, Value *With);
+  LLVM_ABI void replaceAllUsesWith(Instruction *I, Value *With);
 
   /// Erase an instruction from its parent with our eraser.
-  void eraseFromParent(Instruction *I);
+  LLVM_ABI void eraseFromParent(Instruction *I);
 
   /// Replace an instruction with a value and erase it from its parent.
   void substituteInParent(Instruction *I, Value *With) {
@@ -139,7 +139,7 @@ private:
   }
 
 public:
-  LibCallSimplifier(
+  LLVM_ABI LibCallSimplifier(
       const DataLayout &DL, const TargetLibraryInfo *TLI, DominatorTree *DT,
       DomConditionCache *DC, AssumptionCache *AC,
       OptimizationRemarkEmitter &ORE, BlockFrequencyInfo *BFI,
@@ -155,7 +155,7 @@ public:
   /// other instructions that use the given instruction were modified
   /// and the given instruction is dead.
   /// The call must not be an indirect call.
-  Value *optimizeCall(CallInst *CI, IRBuilderBase &B);
+  LLVM_ABI Value *optimizeCall(CallInst *CI, IRBuilderBase &B);
 
 private:
   // String and Memory Library Call Optimizations

--- a/llvm/include/llvm/Transforms/Utils/StripConvergenceIntrinsics.h
+++ b/llvm/include/llvm/Transforms/Utils/StripConvergenceIntrinsics.h
@@ -21,7 +21,7 @@ namespace llvm {
 class StripConvergenceIntrinsicsPass
     : public OptionalPassInfoMixin<StripConvergenceIntrinsicsPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/StripGCRelocates.h
+++ b/llvm/include/llvm/Transforms/Utils/StripGCRelocates.h
@@ -17,7 +17,7 @@ class Function;
 
 class StripGCRelocates : public OptionalPassInfoMixin<StripGCRelocates> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/StripNonLineTableDebugInfo.h
+++ b/llvm/include/llvm/Transforms/Utils/StripNonLineTableDebugInfo.h
@@ -18,7 +18,7 @@ class Module;
 class StripNonLineTableDebugInfoPass
     : public OptionalPassInfoMixin<StripNonLineTableDebugInfoPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/UnifyFunctionExitNodes.h
+++ b/llvm/include/llvm/Transforms/Utils/UnifyFunctionExitNodes.h
@@ -22,7 +22,7 @@ namespace llvm {
 class UnifyFunctionExitNodesPass
     : public OptionalPassInfoMixin<UnifyFunctionExitNodesPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/UnifyLoopExits.h
+++ b/llvm/include/llvm/Transforms/Utils/UnifyLoopExits.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class UnifyLoopExitsPass : public OptionalPassInfoMixin<UnifyLoopExitsPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
+++ b/llvm/include/llvm/Transforms/Utils/UnrollLoop.h
@@ -126,7 +126,7 @@ LLVM_ABI MDNode *GetUnrollMetadata(MDNode *LoopID, StringRef Name);
 LLVM_ABI MDNode *getUnrollMetadataForLoop(const Loop *L, StringRef Name);
 
 struct UnrollPragmaInfo {
-  UnrollPragmaInfo(const Loop *L);
+  LLVM_ABI UnrollPragmaInfo(const Loop *L);
   const bool UserUnrollCount;
   const bool PragmaFullUnroll;
   const unsigned PragmaCount;

--- a/llvm/include/llvm/Transforms/Utils/VNCoercion.h
+++ b/llvm/include/llvm/Transforms/Utils/VNCoercion.h
@@ -24,6 +24,8 @@
 #ifndef LLVM_TRANSFORMS_UTILS_VNCOERCION_H
 #define LLVM_TRANSFORMS_UTILS_VNCOERCION_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class Constant;
 class Function;
@@ -39,8 +41,8 @@ class DataLayout;
 namespace VNCoercion {
 /// Return true if CoerceAvailableValueToLoadType would succeed if it was
 /// called.
-bool canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
-                                     Function *F);
+LLVM_ABI bool canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
+                                              Function *F);
 
 /// If we saw a store of a value to memory, and then a load from a must-aliased
 /// pointer of a different type, try to coerce the stored value to the loaded
@@ -48,55 +50,59 @@ bool canCoerceMustAliasedValueToLoad(Value *StoredVal, Type *LoadTy,
 /// IRBuilder used to insert new instructions.
 ///
 /// If we can't do it, return null.
-Value *coerceAvailableValueToLoadType(Value *StoredVal, Type *LoadedTy,
-                                      IRBuilderBase &IRB, Function *F);
+LLVM_ABI Value *coerceAvailableValueToLoadType(Value *StoredVal, Type *LoadedTy,
+                                               IRBuilderBase &IRB, Function *F);
 
 /// This function determines whether a value for the pointer LoadPtr can be
 /// extracted from the store at DepSI.
 ///
 /// On success, it returns the offset into DepSI that extraction would start.
 /// On failure, it returns -1.
-int analyzeLoadFromClobberingStore(Type *LoadTy, Value *LoadPtr,
-                                   StoreInst *DepSI, const DataLayout &DL);
+LLVM_ABI int analyzeLoadFromClobberingStore(Type *LoadTy, Value *LoadPtr,
+                                            StoreInst *DepSI,
+                                            const DataLayout &DL);
 
 /// This function determines whether a value for the pointer LoadPtr can be
 /// extracted from the load at DepLI.
 ///
 /// On success, it returns the offset into DepLI that extraction would start.
 /// On failure, it returns -1.
-int analyzeLoadFromClobberingLoad(Type *LoadTy, Value *LoadPtr, LoadInst *DepLI,
-                                  const DataLayout &DL);
+LLVM_ABI int analyzeLoadFromClobberingLoad(Type *LoadTy, Value *LoadPtr,
+                                           LoadInst *DepLI,
+                                           const DataLayout &DL);
 
 /// This function determines whether a value for the pointer LoadPtr can be
 /// extracted from the memory intrinsic at DepMI.
 ///
 /// On success, it returns the offset into DepMI that extraction would start.
 /// On failure, it returns -1.
-int analyzeLoadFromClobberingMemInst(Type *LoadTy, Value *LoadPtr,
-                                     MemIntrinsic *DepMI, const DataLayout &DL);
+LLVM_ABI int analyzeLoadFromClobberingMemInst(Type *LoadTy, Value *LoadPtr,
+                                              MemIntrinsic *DepMI,
+                                              const DataLayout &DL);
 
 /// If analyzeLoadFromClobberingStore/Load returned an offset, this function
 /// can be used to actually perform the extraction of the bits from the store.
 /// It inserts instructions to do so at InsertPt, and returns the extracted
 /// value.
-Value *getValueForLoad(Value *SrcVal, unsigned Offset, Type *LoadTy,
-                       Instruction *InsertPt, Function *F);
+LLVM_ABI Value *getValueForLoad(Value *SrcVal, unsigned Offset, Type *LoadTy,
+                                Instruction *InsertPt, Function *F);
 // This is the same as getValueForLoad, except it performs no insertion.
 // It only allows constant inputs.
-Constant *getConstantValueForLoad(Constant *SrcVal, unsigned Offset,
-                                  Type *LoadTy, const DataLayout &DL);
+LLVM_ABI Constant *getConstantValueForLoad(Constant *SrcVal, unsigned Offset,
+                                           Type *LoadTy, const DataLayout &DL);
 
 /// If analyzeLoadFromClobberingMemInst returned an offset, this function can be
 /// used to actually perform the extraction of the bits from the memory
 /// intrinsic.  It inserts instructions to do so at InsertPt, and returns the
 /// extracted value.
-Value *getMemInstValueForLoad(MemIntrinsic *SrcInst, unsigned Offset,
-                              Type *LoadTy, Instruction *InsertPt,
-                              const DataLayout &DL);
+LLVM_ABI Value *getMemInstValueForLoad(MemIntrinsic *SrcInst, unsigned Offset,
+                                       Type *LoadTy, Instruction *InsertPt,
+                                       const DataLayout &DL);
 // This is the same as getStoreValueForLoad, except it performs no insertion.
 // It returns nullptr if it cannot produce a constant.
-Constant *getConstantMemInstValueForLoad(MemIntrinsic *SrcInst, unsigned Offset,
-                                         Type *LoadTy, const DataLayout &DL);
+LLVM_ABI Constant *getConstantMemInstValueForLoad(MemIntrinsic *SrcInst,
+                                                  unsigned Offset, Type *LoadTy,
+                                                  const DataLayout &DL);
 } // namespace VNCoercion
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Vectorize/LoopIdiomVectorize.h
+++ b/llvm/include/llvm/Transforms/Vectorize/LoopIdiomVectorize.h
@@ -30,8 +30,9 @@ public:
   LoopIdiomVectorizePass(LoopIdiomVectorizeStyle S, unsigned BCVF)
       : VectorizeStyle(S), ByteCompareVF(BCVF) {}
 
-  PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
-                        LoopStandardAnalysisResults &AR, LPMUpdater &U);
+  LLVM_ABI PreservedAnalyses run(Loop &L, LoopAnalysisManager &AM,
+                                 LoopStandardAnalysisResults &AR,
+                                 LPMUpdater &U);
 };
 } // namespace llvm
 #endif // LLVM_LIB_TRANSFORMS_VECTORIZE_LOOPIDIOMVECTORIZE_H

--- a/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
+++ b/llvm/include/llvm/Transforms/Vectorize/LoopVectorizationLegality.h
@@ -76,7 +76,7 @@ class LoopVectorizeHints {
     Hint(const char *Name, unsigned Value, HintKind Kind)
         : Name(Name), Value(Value), Kind(Kind) {}
 
-    bool validate(unsigned Val);
+    LLVM_ABI bool validate(unsigned Val);
   };
 
   /// Vectorization width.
@@ -125,18 +125,18 @@ public:
     SK_AlwaysScalable = 2
   };
 
-  LoopVectorizeHints(const Loop *L, bool InterleaveOnlyWhenForced,
-                     OptimizationRemarkEmitter &ORE,
-                     const TargetTransformInfo *TTI = nullptr);
+  LLVM_ABI LoopVectorizeHints(const Loop *L, bool InterleaveOnlyWhenForced,
+                              OptimizationRemarkEmitter &ORE,
+                              const TargetTransformInfo *TTI = nullptr);
 
   /// Mark the loop L as already vectorized by setting the width to 1.
-  void setAlreadyVectorized();
+  LLVM_ABI void setAlreadyVectorized();
 
-  bool allowVectorization(Function *F, Loop *L,
-                          bool VectorizeOnlyWhenForced) const;
+  LLVM_ABI bool allowVectorization(Function *F, Loop *L,
+                                   bool VectorizeOnlyWhenForced) const;
 
   /// Dumps all the hint information.
-  void emitRemarkWithHints() const;
+  LLVM_ABI void emitRemarkWithHints() const;
 
   ElementCount getWidth() const {
     return ElementCount::get(
@@ -179,7 +179,7 @@ public:
   /// enabled by default because can be unsafe or inefficient. For example,
   /// reordering floating-point operations will change the way round-off
   /// error accumulates in the loop.
-  bool allowReordering() const;
+  LLVM_ABI bool allowReordering() const;
 
   bool isPotentiallyUnsafe() const {
     // Avoid FP vectorization if the target is unsure about proper support.
@@ -304,20 +304,20 @@ public:
   /// the new code path being implemented for outer loop vectorization
   /// (should be functional for inner loop vectorization) based on VPlan.
   /// If false, good old LV code.
-  bool canVectorize(bool UseVPlanNativePath);
+  LLVM_ABI bool canVectorize(bool UseVPlanNativePath);
 
   /// Returns true if it is legal to vectorize the FP math operations in this
   /// loop. Vectorizing is legal if we allow reordering of FP operations, or if
   /// we can use in-order reductions.
-  bool canVectorizeFPMath(bool EnableStrictReductions);
+  LLVM_ABI bool canVectorizeFPMath(bool EnableStrictReductions);
 
   /// Return true if we can vectorize this loop while folding its tail by
   /// masking.
-  bool canFoldTailByMasking() const;
+  LLVM_ABI bool canFoldTailByMasking() const;
 
   /// Mark all respective loads/stores for masking. Must only be called when
   /// tail-folding is possible.
-  void prepareToFoldTailByMasking();
+  LLVM_ABI void prepareToFoldTailByMasking();
 
   /// Returns the primary induction variable.
   PHINode *getPrimaryInduction() { return PrimaryInduction; }
@@ -344,42 +344,44 @@ public:
 
   /// Returns True if given store is a final invariant store of one of the
   /// reductions found in the loop.
-  bool isInvariantStoreOfReduction(StoreInst *SI);
+  LLVM_ABI bool isInvariantStoreOfReduction(StoreInst *SI);
 
   /// Returns True if given address is invariant and is used to store recurrent
   /// expression
-  bool isInvariantAddressOfReduction(Value *V);
+  LLVM_ABI bool isInvariantAddressOfReduction(Value *V);
 
   /// Returns True if V is a Phi node of an induction variable in this loop.
-  bool isInductionPhi(const Value *V) const;
+  LLVM_ABI bool isInductionPhi(const Value *V) const;
 
   /// Returns a pointer to the induction descriptor, if \p Phi is an integer or
   /// floating point induction.
-  const InductionDescriptor *getIntOrFpInductionDescriptor(PHINode *Phi) const;
+  LLVM_ABI const InductionDescriptor *
+  getIntOrFpInductionDescriptor(PHINode *Phi) const;
 
   /// Returns a pointer to the induction descriptor, if \p Phi is pointer
   /// induction.
-  const InductionDescriptor *getPointerInductionDescriptor(PHINode *Phi) const;
+  LLVM_ABI const InductionDescriptor *
+  getPointerInductionDescriptor(PHINode *Phi) const;
 
   /// Returns True if V is a cast that is part of an induction def-use chain,
   /// and had been proven to be redundant under a runtime guard (in other
   /// words, the cast has the same SCEV expression as the induction phi).
-  bool isCastedInductionVariable(const Value *V) const;
+  LLVM_ABI bool isCastedInductionVariable(const Value *V) const;
 
   /// Returns True if V can be considered as an induction variable in this
   /// loop. V can be the induction phi, or some redundant cast in the def-use
   /// chain of the inducion phi.
-  bool isInductionVariable(const Value *V) const;
+  LLVM_ABI bool isInductionVariable(const Value *V) const;
 
   /// Returns True if PN is a reduction variable in this loop.
   bool isReductionVariable(PHINode *PN) const { return Reductions.count(PN); }
 
   /// Returns True if Phi is a fixed-order recurrence in this loop.
-  bool isFixedOrderRecurrence(const PHINode *Phi) const;
+  LLVM_ABI bool isFixedOrderRecurrence(const PHINode *Phi) const;
 
   /// Return true if the block BB needs to be predicated in order for the loop
   /// to be vectorized.
-  bool blockNeedsPredication(const BasicBlock *BB) const;
+  LLVM_ABI bool blockNeedsPredication(const BasicBlock *BB) const;
 
   /// Check if this pointer is consecutive when vectorizing. This happens
   /// when the last index of the GEP is the induction variable, or that the
@@ -391,20 +393,20 @@ public:
   /// -1 - Address is consecutive, and decreasing.
   /// NOTE: This method must only be used before modifying the original scalar
   /// loop. Do not use after invoking 'createVectorizedLoopSkeleton' (PR34965).
-  int isConsecutivePtr(Type *AccessTy, Value *Ptr) const;
+  LLVM_ABI int isConsecutivePtr(Type *AccessTy, Value *Ptr) const;
 
   /// Returns true if \p V is invariant across all loop iterations according to
   /// SCEV.
-  bool isInvariant(Value *V) const;
+  LLVM_ABI bool isInvariant(Value *V) const;
 
   /// Returns true if value V is uniform across \p VF lanes, when \p VF is
   /// provided, and otherwise if \p V is invariant across all loop iterations.
-  bool isUniform(Value *V, ElementCount VF) const;
+  LLVM_ABI bool isUniform(Value *V, ElementCount VF) const;
 
   /// A uniform memory op is a load or store which accesses the same memory
   /// location on all \p VF lanes, if \p VF is provided and otherwise if the
   /// memory location is invariant.
-  bool isUniformMemOp(Instruction &I, ElementCount VF) const;
+  LLVM_ABI bool isUniformMemOp(Instruction &I, ElementCount VF) const;
 
   /// Returns the information that we collected about runtime memory check.
   const RuntimePointerChecking *getRuntimePointerChecking() const {

--- a/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SLPVectorizer.h
@@ -73,13 +73,14 @@ struct SLPVectorizerPass : public OptionalPassInfoMixin<SLPVectorizerPass> {
   const DataLayout *DL = nullptr;
 
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 
   // Glue for old PM.
-  bool runImpl(Function &F, ScalarEvolution *SE_, TargetTransformInfo *TTI_,
-               TargetLibraryInfo *TLI_, AAResults *AA_, LoopInfo *LI_,
-               DominatorTree *DT_, AssumptionCache *AC_, DemandedBits *DB_,
-               OptimizationRemarkEmitter *ORE_);
+  LLVM_ABI bool runImpl(Function &F, ScalarEvolution *SE_,
+                        TargetTransformInfo *TTI_, TargetLibraryInfo *TLI_,
+                        AAResults *AA_, LoopInfo *LI_, DominatorTree *DT_,
+                        AssumptionCache *AC_, DemandedBits *DB_,
+                        OptimizationRemarkEmitter *ORE_);
 
 private:
   /// Collect store and getelementptr instructions and organize them

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h
@@ -32,7 +32,7 @@ namespace llvm::sandboxir {
 /// profitable or not. For now profitability is checked at the end of the region
 /// pass pipeline by a dedicated pass that accepts or rejects the IR
 /// transaction, depending on the cost.
-class BottomUpVec final : public RegionPass {
+class LLVM_ABI BottomUpVec final : public RegionPass {
   bool Change = false;
   /// The original instructions that are potentially dead after vectorization.
   DenseSet<Instruction *> DeadInstrCandidates;

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/LoadStoreVec.h
@@ -28,7 +28,7 @@ class Instruction;
 class Scheduler;
 class Type;
 
-class LoadStoreVec final : public RegionPass {
+class LLVM_ABI LoadStoreVec final : public RegionPass {
   const DataLayout *DL = nullptr;
   /// Checks legality of vectorization and \returns the vector type on success,
   /// nullopt otherwise.

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PackReuse.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PackReuse.h
@@ -23,7 +23,7 @@ namespace llvm::sandboxir {
 /// This is useful because even though the duplicates will most probably be
 /// optimized away by future passes, their added cost can make vectorization
 /// more conservative than it should be.
-class PackReuse final : public RegionPass {
+class LLVM_ABI PackReuse final : public RegionPass {
   bool Change = false;
 
 public:

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromBBs.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromBBs.h
@@ -20,7 +20,7 @@
 
 namespace llvm::sandboxir {
 
-class RegionsFromBBs final : public FunctionPass {
+class LLVM_ABI RegionsFromBBs final : public FunctionPass {
   // The PM containing the pipeline of region passes.
   RegionPassManager RPM;
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h
@@ -20,7 +20,7 @@
 
 namespace llvm::sandboxir {
 
-class RegionsFromMetadata final : public FunctionPass {
+class LLVM_ABI RegionsFromMetadata final : public FunctionPass {
   // The PM containing the pipeline of region passes.
   RegionPassManager RPM;
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/SeedCollection.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/SeedCollection.h
@@ -21,7 +21,7 @@ namespace llvm::sandboxir {
 /// like stores to consecutive memory addresses. It then goes over the collected
 /// seeds, slicing them into appropriately sized chunks, creating a Region with
 /// the seed slice as the Auxiliary vector and runs the region pass pipeline.
-class SeedCollection final : public FunctionPass {
+class LLVM_ABI SeedCollection final : public FunctionPass {
 
   /// The PM containing the pipeline of region passes.
   RegionPassManager RPM;

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.h
@@ -19,7 +19,7 @@
 
 namespace llvm::sandboxir {
 
-class TransactionAcceptOrRevert : public RegionPass {
+class LLVM_ABI TransactionAcceptOrRevert : public RegionPass {
 public:
   TransactionAcceptOrRevert() : RegionPass("tr-accept-or-revert") {}
   bool runOnRegion(Region &Rgn, const Analyses &A) final;

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.h
@@ -17,7 +17,7 @@
 
 namespace llvm::sandboxir {
 
-class TransactionSave : public RegionPass {
+class LLVM_ABI TransactionSave : public RegionPass {
 public:
   TransactionSave() : RegionPass("tr-save") {}
   bool runOnRegion(Region &Rgn, const Analyses &A) final;

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/RegionWithScore.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/RegionWithScore.h
@@ -85,7 +85,7 @@ public:
   /// \Returns the ScoreBoard data structure that keeps track of instr costs.
   const ScoreBoard &getScoreboard() const { return Scoreboard; }
 
-  static SmallVector<std::unique_ptr<RegionWithScore>>
+  LLVM_ABI static SmallVector<std::unique_ptr<RegionWithScore>>
   createRegionsFromMD(Function &F, const TargetTransformInfo &TTI);
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h
@@ -21,9 +21,9 @@ namespace llvm::sandboxir {
 
 class SandboxVectorizerPassBuilder {
 public:
-  static std::unique_ptr<FunctionPass>
+  LLVM_ABI static std::unique_ptr<FunctionPass>
   createFunctionPass(StringRef Name, StringRef Args, StringRef AuxArg);
-  static std::unique_ptr<RegionPass>
+  LLVM_ABI static std::unique_ptr<RegionPass>
   createRegionPass(StringRef Name, StringRef Args, StringRef AuxArg);
 };
 

--- a/llvm/include/llvm/Transforms/Vectorize/VectorCombine.h
+++ b/llvm/include/llvm/Transforms/Vectorize/VectorCombine.h
@@ -29,7 +29,7 @@ public:
   VectorCombinePass(bool TryEarlyFoldsOnly = false)
       : TryEarlyFoldsOnly(TryEarlyFoldsOnly) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
 }
 #endif // LLVM_TRANSFORMS_VECTORIZE_VECTORCOMBINE_H


### PR DESCRIPTION
This updates most LLVM_ABI annotations in the Transforms headers to match expected usage:
* All public APIs should be properly annotated.
* Inlined functions should not be annotated.

These changes were done by a script fixing annotations on LLVM public headers and manually checked.

This effort is tracked in #109483.