### PR TITLE
[lldb][windows] relax TestMissingDll.py assert

### DIFF
--- a/lldb/test/API/windows/launch/missing-dll/TestMissingDll.py
+++ b/lldb/test/API/windows/launch/missing-dll/TestMissingDll.py
@@ -25,4 +25,5 @@ class MissingDllTestCase(TestBase):
 
         error = lldb.SBError()
         target.Launch(launch_info, error)
-        self.assertFailure(error, "Process prematurely exited with 0xc0000135")
+        self.assertFalse(error.Success(), "expected launch to fail")
+        self.assertIn("Process prematurely exited with 0xc0000135", error.GetCString())


### PR DESCRIPTION
The lldb-server path wraps the underlying error with `Cannot launch '<path>': `, while the in-process ProcessWindows plugin returns the bare error string. Relax the assert so that the test passes with or without `LLDB_USE_LLDB_SERVER=1`.

rdar://177623653