### PR TITLE
[clang][CodeGen] Forward PseudoProbeForProfiling in IRInstr PGOOptions

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -837,17 +837,17 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
                         CodeGenOpts.MemoryProfileUsePath, PGOOptions::IRInstr,
                         PGOOptions::NoCSAction, ClPGOColdFuncAttr,
                         CodeGenOpts.DebugInfoForProfiling,
-                        /*PseudoProbeForProfiling=*/false,
+                        CodeGenOpts.PseudoProbeForProfiling,
                         CodeGenOpts.AtomicProfileUpdate);
   else if (CodeGenOpts.hasProfileIRUse()) {
     // -fprofile-use.
     auto CSAction = CodeGenOpts.hasProfileCSIRUse() ? PGOOptions::CSIRUse
                                                     : PGOOptions::NoCSAction;
-    PGOOpt = PGOOptions(CodeGenOpts.ProfileInstrumentUsePath, "",
-                        CodeGenOpts.ProfileRemappingFile,
-                        CodeGenOpts.MemoryProfileUsePath, PGOOptions::IRUse,
-                        CSAction, ClPGOColdFuncAttr,
-                        CodeGenOpts.DebugInfoForProfiling);
+    PGOOpt = PGOOptions(
+        CodeGenOpts.ProfileInstrumentUsePath, "",
+        CodeGenOpts.ProfileRemappingFile, CodeGenOpts.MemoryProfileUsePath,
+        PGOOptions::IRUse, CSAction, ClPGOColdFuncAttr,
+        CodeGenOpts.DebugInfoForProfiling, CodeGenOpts.PseudoProbeForProfiling);
   } else if (!CodeGenOpts.SampleProfileFile.empty())
     // -fprofile-sample-use
     PGOOpt = PGOOptions(


### PR DESCRIPTION
We build Clang with PGO at the moment but I want to transition us to CSSPGO.
In order to do so, I need add the pseudo probe instrumentation. Unfortunately, I can't seem to generate a profile and apply pseudo probes at the same time -- it looked to have been explicitly disabled.

The IRInstr branch in BackendUtil.cpp hardcodes PseudoProbeForProfiling to false, silently suppressing pseudo probe emission when -fprofile-generate and -fpseudo-probe-for-profiling are both passed. This change forwards the CodeGenOpts value instead so pseudo probes can coexist with instrumentation PGO.

I added it also to the `-fprofile-use` case as well, so that the code layout for PGO itself should match and there would be no profile statleness.