### PR TITLE
[libc++][mdspan] LWG4314: Missing move in `mdspan` layout `mapping::operator()`

### DIFF
--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -146,20 +146,22 @@ public:
   template <class... _Indices>
     requires((sizeof...(_Indices) == extents_type::rank()) && (is_convertible_v<_Indices, index_type> && ...) &&
              (is_nothrow_constructible_v<index_type, _Indices> && ...))
-  _LIBCPP_HIDE_FROM_ABI constexpr index_type operator()(_Indices... __idx) const noexcept {
-    // Mappings are generally meant to be used for accessing allocations and are meant to guarantee to never
-    // return a value exceeding required_span_size(), which is used to know how large an allocation one needs
-    // Thus, this is a canonical point in multi-dimensional data structures to make invalid element access checks
-    // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
-    _LIBCPP_ASSERT_UNCATEGORIZED(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idx...),
-                                 "layout_left::mapping: out of bounds indexing");
-    array<index_type, extents_type::rank()> __idx_a{static_cast<index_type>(__idx)...};
-    return [&]<size_t... _Pos>(index_sequence<_Pos...>) {
-      index_type __res = 0;
-      ((__res = __idx_a[extents_type::rank() - 1 - _Pos] + __extents_.extent(extents_type::rank() - 1 - _Pos) * __res),
-       ...);
-      return __res;
-    }(make_index_sequence<sizeof...(_Indices)>());
+  _LIBCPP_HIDE_FROM_ABI constexpr index_type operator()(_Indices... __i) const noexcept {
+    return [&]<class... _IndexTypes>(_IndexTypes... __idxs) {
+      // Mappings are generally meant to be used for accessing allocations and are meant to guarantee to never
+      // return a value exceeding required_span_size(), which is used to know how large an allocation one needs
+      // Thus, this is a canonical point in multi-dimensional data structures to make invalid element access checks
+      // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
+      _LIBCPP_ASSERT_UNCATEGORIZED(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idxs...),
+                                   "mdspan: operator[] out of bounds access");
+      return [&]<size_t... _Pos>(index_sequence<_Pos...>) {
+        index_type __res = 0;
+        ((__res = static_cast<index_type>(std::move(__idxs...[extents_type::rank() - 1 - _Pos])) +
+                  __extents_.extent(extents_type::rank() - 1 - _Pos) * __res),
+         ...);
+        return __res;
+      }(make_index_sequence<sizeof...(_Indices)>());
+    }(extents_type::__index_cast(std::move(__i))...);
   }
 
   _LIBCPP_HIDE_FROM_ABI static constexpr bool is_always_unique() noexcept { return true; }

--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -27,6 +27,7 @@
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__utility/integer_sequence.h>
+#include <__utility/move.h>
 #include <array>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -28,6 +28,7 @@
 #include <__type_traits/is_convertible.h>
 #include <__type_traits/is_nothrow_constructible.h>
 #include <__utility/integer_sequence.h>
+#include <__utility/move.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header

--- a/libcxx/include/__mdspan/layout_right.h
+++ b/libcxx/include/__mdspan/layout_right.h
@@ -146,18 +146,20 @@ public:
   template <class... _Indices>
     requires((sizeof...(_Indices) == extents_type::rank()) && (is_convertible_v<_Indices, index_type> && ...) &&
              (is_nothrow_constructible_v<index_type, _Indices> && ...))
-  _LIBCPP_HIDE_FROM_ABI constexpr index_type operator()(_Indices... __idx) const noexcept {
-    // Mappings are generally meant to be used for accessing allocations and are meant to guarantee to never
-    // return a value exceeding required_span_size(), which is used to know how large an allocation one needs
-    // Thus, this is a canonical point in multi-dimensional data structures to make invalid element access checks
-    // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
-    _LIBCPP_ASSERT_UNCATEGORIZED(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idx...),
-                                 "layout_right::mapping: out of bounds indexing");
-    return [&]<size_t... _Pos>(index_sequence<_Pos...>) {
-      index_type __res = 0;
-      ((__res = static_cast<index_type>(__idx) + __extents_.extent(_Pos) * __res), ...);
-      return __res;
-    }(make_index_sequence<sizeof...(_Indices)>());
+  _LIBCPP_HIDE_FROM_ABI constexpr index_type operator()(_Indices... __i) const noexcept {
+    return [&]<class... _IndexTypes>(_IndexTypes... __idxs) {
+      // Mappings are generally meant to be used for accessing allocations and are meant to guarantee to never
+      // return a value exceeding required_span_size(), which is used to know how large an allocation one needs
+      // Thus, this is a canonical point in multi-dimensional data structures to make invalid element access checks
+      // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
+      _LIBCPP_ASSERT_UNCATEGORIZED(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idxs...),
+                                   "layout_right::mapping: out of bounds indexing");
+      return [&]<size_t... _Pos>(index_sequence<_Pos...>) {
+        index_type __res = 0;
+        ((__res = static_cast<index_type>(__idxs) + __extents_.extent(_Pos) * __res), ...);
+        return __res;
+      }(make_index_sequence<sizeof...(_Indices)>());
+    }(extents_type::__index_cast(std::move(__i))...);
   }
 
   _LIBCPP_HIDE_FROM_ABI static constexpr bool is_always_unique() noexcept { return true; }

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -31,6 +31,7 @@
 #include <__type_traits/is_same.h>
 #include <__utility/as_const.h>
 #include <__utility/integer_sequence.h>
+#include <__utility/move.h>
 #include <__utility/swap.h>
 #include <array>
 #include <limits>

--- a/libcxx/include/__mdspan/layout_stride.h
+++ b/libcxx/include/__mdspan/layout_stride.h
@@ -283,16 +283,18 @@ public:
   template <class... _Indices>
     requires((sizeof...(_Indices) == __rank_) && (is_convertible_v<_Indices, index_type> && ...) &&
              (is_nothrow_constructible_v<index_type, _Indices> && ...))
-  _LIBCPP_HIDE_FROM_ABI constexpr index_type operator()(_Indices... __idx) const noexcept {
-    // Mappings are generally meant to be used for accessing allocations and are meant to guarantee to never
-    // return a value exceeding required_span_size(), which is used to know how large an allocation one needs
-    // Thus, this is a canonical point in multi-dimensional data structures to make invalid element access checks
-    // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
-    _LIBCPP_ASSERT_UNCATEGORIZED(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idx...),
-                                 "layout_stride::mapping: out of bounds indexing");
-    return [&]<size_t... _Pos>(index_sequence<_Pos...>) {
-      return ((static_cast<index_type>(__idx) * __strides_[_Pos]) + ... + index_type(0));
-    }(make_index_sequence<sizeof...(_Indices)>());
+  _LIBCPP_HIDE_FROM_ABI constexpr index_type operator()(_Indices... __i) const noexcept {
+    return [&]<class... _IndexTypes>(_IndexTypes... __idxs) {
+      // Mappings are generally meant to be used for accessing allocations and are meant to guarantee to never
+      // return a value exceeding required_span_size(), which is used to know how large an allocation one needs
+      // Thus, this is a canonical point in multi-dimensional data structures to make invalid element access checks
+      // However, mdspan does check this on its own, so for now we avoid double checking in hardened mode
+      _LIBCPP_ASSERT_UNCATEGORIZED(__mdspan_detail::__is_multidimensional_index_in(__extents_, __idxs...),
+                                   "layout_stride::mapping: out of bounds indexing");
+      return [&]<size_t... _Pos>(index_sequence<_Pos...>) {
+        return ((static_cast<index_type>(__idxs) * __strides_[_Pos]) + ... + index_type(0));
+      }(make_index_sequence<sizeof...(_Indices)>());
+    }(extents_type::__index_cast(std::move(__i))...);
   }
 
   _LIBCPP_HIDE_FROM_ABI static constexpr bool is_always_unique() noexcept { return true; }

--- a/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
+++ b/libcxx/test/std/containers/views/mdspan/ConvertibleToIntegral.h
@@ -20,6 +20,12 @@ struct IntType {
   constexpr operator signed char() const noexcept { return static_cast<signed char>(val); }
 };
 
+struct RValueInt {
+  int val;
+  constexpr RValueInt(int v) : val(v) {}
+  constexpr operator int() && noexcept { return val; }
+};
+
 // only non-const convertible
 struct IntTypeNC {
   int val;

--- a/libcxx/test/std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/extents/ctor_from_integral.pass.cpp
@@ -38,12 +38,6 @@
 #include "CtorTestCombinations.h"
 #include "test_macros.h"
 
-struct RValueInt {
-  int val;
-  constexpr RValueInt(int v) : val(v) {}
-  constexpr operator int() && noexcept { return val; }
-};
-
 struct IntegralCtorTest {
   template <class E, class AllExtents, class Extents, size_t... Indices>
   static constexpr void test_construction(AllExtents all_ext, Extents ext, std::index_sequence<Indices...>) {

--- a/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
@@ -82,6 +82,9 @@ constexpr bool test() {
   test_iteration<std::extents<unsigned, 7, 8>>();
   test_iteration<std::extents<signed char, D, D, D, D>>(1, 1, 1, 1);
 
+  std::layout_left::mapping<std::extents<int, 2>> mapping;
+  assert(mapping(RValueInt{1}) == 1);
+
   // Check operator constraint for number of arguments
   static_assert(
       check_operator_constraints(std::layout_left::mapping<std::extents<int, D>>(std::extents<int, D>(1)), 0));

--- a/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
@@ -82,6 +82,9 @@ constexpr bool test() {
   test_iteration<std::extents<unsigned, 7, 8>>();
   test_iteration<std::extents<signed char, D, D, D, D>>(1, 1, 1, 1);
 
+  std::layout_right::mapping<std::extents<int, 2>> mapping;
+  assert(mapping(RValueInt{1}) == 1);
+
   // Check operator constraint for number of arguments
   static_assert(
       check_operator_constraints(std::layout_right::mapping<std::extents<int, D>>(std::extents<int, D>(1)), 0));

--- a/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
@@ -83,6 +83,9 @@ constexpr bool test() {
   test_iteration<std::extents<unsigned, 7, 8>>(std::array<int, 2>{25, 3});
   test_iteration<std::extents<signed char, D, D, D, D>>(std::array<int, 4>{1, 1, 1, 1}, 1, 1, 1, 1);
 
+  std::layout_stride::mapping<std::extents<int, 2>> mapping;
+  assert(mapping(RValueInt{1}) == 1);
+
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(
       std::layout_stride::mapping<std::extents<int, D>>(std::extents<int, D>(1), std::array{1}), 0));

--- a/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -220,10 +220,6 @@ constexpr void test_index_cast() {
   // assert(&m[index] == &data[3]);
 }
 
-struct RValueInt {
-  constexpr operator int() && noexcept { return 0; }
-};
-
 constexpr bool test() {
   test_layout<std::layout_left>();
   test_layout<std::layout_right>();
@@ -231,7 +227,7 @@ constexpr bool test() {
 
   int data[1]{};
   std::mdspan m(data, std::extents<int, 1>{1});
-  TEST_IGNORE_NODISCARD m[RValueInt{}];
+  TEST_IGNORE_NODISCARD m[RValueInt{0}];
 
   test_index_cast();
   return true;


### PR DESCRIPTION
Partial #189824. The padded-layout part will be implemented in #187873.