### PR TITLE
[mlir][gpu][Pipeline] Fix a link issue introduced in PR#197779.

### DIFF
--- a/mlir/lib/Dialect/GPU/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/GPU/Pipelines/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_dialect_library(MLIRGPUPipelines
   MLIRAffineToStandard
   MLIRAMDGPUToROCDL
   MLIRArithToLLVM
+  MLIRArithTransforms
   MLIRFuncToLLVM
   MLIRGPUToLLVMSPV
   MLIRGPUToNVVMTransforms
@@ -22,6 +23,7 @@ add_mlir_dialect_library(MLIRGPUPipelines
   MLIRIndexToLLVM
   MLIRMathToLLVM
   MLIRMathToXeVM
+  MLIRMathTransforms
   MLIRNVGPUToNVVM
   MLIRNVVMToLLVM
   MLIRReconcileUnrealizedCasts


### PR DESCRIPTION
Link MLIRArithTransforms and MLIRMathTransforms in GPU pipelines.