### PR TITLE
[DirectX][ObjectYAML] Fix name conflict in DXContainerYAML.h

### DIFF
--- a/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
+++ b/llvm/include/llvm/ObjectYAML/DXContainerYAML.h
@@ -325,7 +325,7 @@ struct Part {
   std::optional<DXContainerYAML::Signature> Signature;
   std::optional<DXContainerYAML::RootSignatureYamlDesc> RootSignature;
   std::optional<DXContainerYAML::DebugName> DebugName;
-  std::optional<CompilerVersion> CompilerVersion;
+  std::optional<DXContainerYAML::CompilerVersion> CompilerVersion;
 };
 
 struct Object {


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/198222, GCC with `-fpermissive` reports an error:
```
llvm/include/llvm/ObjectYAML/DXContainerYAML.h:328:34: error: declaration of ‘std::optional<llvm::DXContainerYAML::CompilerVersion> llvm::DXContainerYAML::Part::CompilerVersion’ changes meaning of ‘CompilerVersion’ [-Wchanges-meaning]
  328 |   std::optional<CompilerVersion> CompilerVersion;
```

Fix that.