### PR TITLE
[lldb] Consolidate ScriptedThreadPlan state into ScriptedMetadata

### DIFF
--- a/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadPlanInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/ScriptedThreadPlanInterface.h
@@ -14,12 +14,11 @@
 #include "ScriptedInterface.h"
 
 namespace lldb_private {
-class ScriptedThreadPlanInterface : public ScriptedInterface {
+class ScriptedThreadPlanInterface : virtual public ScriptedInterface {
 public:
   virtual llvm::Expected<StructuredData::GenericSP>
   CreatePluginObject(const ScriptedMetadata &scripted_metadata,
-                     lldb::ThreadPlanSP thread_plan_sp,
-                     const StructuredDataImpl &args_sp) = 0;
+                     lldb::ThreadPlanSP thread_plan_sp) = 0;
 
   virtual llvm::Expected<bool> ExplainsStop(Event *event) { return true; }
 

--- a/lldb/include/lldb/Target/ScriptedThreadPlan.h
+++ b/lldb/include/lldb/Target/ScriptedThreadPlan.h
@@ -19,6 +19,7 @@
 #include "lldb/Target/Thread.h"
 #include "lldb/Target/ThreadPlan.h"
 #include "lldb/Target/ThreadPlanTracer.h"
+#include "lldb/Utility/ScriptedMetadata.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/UserID.h"
 #include "lldb/lldb-forward.h"
@@ -28,8 +29,7 @@ namespace lldb_private {
 
 class ScriptedThreadPlan : public ThreadPlan {
 public:
-  ScriptedThreadPlan(Thread &thread, const char *class_name,
-                     const StructuredDataImpl &args_data);
+  ScriptedThreadPlan(Thread &thread, const ScriptedMetadata &scripted_metadata);
 
   void GetDescription(Stream *s, lldb::DescriptionLevel level) override;
 
@@ -58,9 +58,10 @@ protected:
 
   ScriptInterpreter *GetScriptInterpreter();
 
+  llvm::StringRef GetScriptClassName() const;
+
 private:
-  std::string m_class_name;
-  StructuredDataImpl m_args_data;
+  ScriptedMetadata m_scripted_metadata;
   std::string m_error_str;
   StructuredData::ObjectSP m_implementation_sp;
   StreamString m_stop_description; // Cache the stop description here

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -24,6 +24,7 @@
 #include "lldb/Utility/Broadcaster.h"
 #include "lldb/Utility/CompletionRequest.h"
 #include "lldb/Utility/Event.h"
+#include "lldb/Utility/ScriptedMetadata.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/UnimplementedError.h"
 #include "lldb/Utility/UserID.h"
@@ -1009,8 +1010,8 @@ public:
       bool stop_others, uint32_t frame_idx, Status &status);
 
   virtual lldb::ThreadPlanSP
-  QueueThreadPlanForStepScripted(bool abort_other_plans, const char *class_name,
-                                 StructuredData::ObjectSP extra_args_sp,
+  QueueThreadPlanForStepScripted(bool abort_other_plans,
+                                 const ScriptedMetadata &scripted_metadata,
                                  bool stop_other_threads, Status &status);
 
   // Thread Plan accessors:

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -897,8 +897,13 @@ SBError SBThread::StepUsingScriptedThreadPlan(const char *script_class_name,
   Status new_plan_status;
   StructuredData::ObjectSP obj_sp = args_data.m_impl_up->GetObjectSP();
 
+  StructuredData::DictionarySP args_dict_sp;
+  if (obj_sp && obj_sp->GetType() == lldb::eStructuredDataTypeDictionary)
+    args_dict_sp = std::static_pointer_cast<StructuredData::Dictionary>(obj_sp);
+
+  ScriptedMetadata scripted_metadata(script_class_name, args_dict_sp);
   ThreadPlanSP new_plan_sp = thread->QueueThreadPlanForStepScripted(
-      false, script_class_name, obj_sp, false, new_plan_status);
+      false, scripted_metadata, false, new_plan_status);
 
   if (new_plan_status.Fail()) {
     error = Status::FromErrorString(new_plan_status.AsCString());

--- a/lldb/source/API/SBThreadPlan.cpp
+++ b/lldb/source/API/SBThreadPlan.cpp
@@ -65,9 +65,11 @@ SBThreadPlan::SBThreadPlan(lldb::SBThread &sb_thread, const char *class_name) {
   LLDB_INSTRUMENT_VA(this, sb_thread, class_name);
 
   Thread *thread = sb_thread.get();
-  if (thread)
-    m_opaque_wp = std::make_shared<ScriptedThreadPlan>(*thread, class_name,
-                                                       StructuredDataImpl());
+  if (thread) {
+    ScriptedMetadata scripted_metadata(class_name, {});
+    m_opaque_wp =
+        std::make_shared<ScriptedThreadPlan>(*thread, scripted_metadata);
+  }
 }
 
 SBThreadPlan::SBThreadPlan(lldb::SBThread &sb_thread, const char *class_name,
@@ -75,9 +77,16 @@ SBThreadPlan::SBThreadPlan(lldb::SBThread &sb_thread, const char *class_name,
   LLDB_INSTRUMENT_VA(this, sb_thread, class_name, args_data);
 
   Thread *thread = sb_thread.get();
-  if (thread)
-    m_opaque_wp = std::make_shared<ScriptedThreadPlan>(*thread, class_name,
-                                                       *args_data.m_impl_up);
+  if (thread) {
+    StructuredData::ObjectSP args_obj = args_data.m_impl_up->GetObjectSP();
+    StructuredData::DictionarySP args_dict_sp;
+    if (args_obj && args_obj->GetType() == lldb::eStructuredDataTypeDictionary)
+      args_dict_sp =
+          std::static_pointer_cast<StructuredData::Dictionary>(args_obj);
+    ScriptedMetadata scripted_metadata(class_name, args_dict_sp);
+    m_opaque_wp =
+        std::make_shared<ScriptedThreadPlan>(*thread, scripted_metadata);
+  }
 }
 
 // Assignment operator
@@ -397,10 +406,10 @@ SBThreadPlan::QueueThreadPlanForStepScripted(const char *script_class_name,
   ThreadPlanSP thread_plan_sp(GetSP());
   if (thread_plan_sp) {
     Status plan_status;
-    StructuredData::ObjectSP empty_args;
+    ScriptedMetadata scripted_metadata(script_class_name, {});
     SBThreadPlan plan =
         SBThreadPlan(thread_plan_sp->GetThread().QueueThreadPlanForStepScripted(
-            false, script_class_name, empty_args, false, plan_status));
+            false, scripted_metadata, false, plan_status));
 
     if (plan_status.Fail())
       error.SetErrorString(plan_status.AsCString());
@@ -422,9 +431,14 @@ SBThreadPlan::QueueThreadPlanForStepScripted(const char *script_class_name,
   if (thread_plan_sp) {
     Status plan_status;
     StructuredData::ObjectSP args_obj = args_data.m_impl_up->GetObjectSP();
+    StructuredData::DictionarySP args_dict_sp;
+    if (args_obj && args_obj->GetType() == lldb::eStructuredDataTypeDictionary)
+      args_dict_sp =
+          std::static_pointer_cast<StructuredData::Dictionary>(args_obj);
+    ScriptedMetadata scripted_metadata(script_class_name, args_dict_sp);
     SBThreadPlan plan =
         SBThreadPlan(thread_plan_sp->GetThread().QueueThreadPlanForStepScripted(
-            false, script_class_name, args_obj, false, plan_status));
+            false, scripted_metadata, false, plan_status));
 
     if (plan_status.Fail())
       error.SetErrorString(plan_status.AsCString());

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -745,9 +745,10 @@ protected:
           thread->GetSelectedFrameIndex(DoNoSelectMostRelevantFrame),
           new_plan_status, m_options.m_step_out_avoid_no_debug);
     } else if (m_step_type == eStepTypeScripted) {
+      ScriptedMetadata scripted_metadata(m_class_options.GetName(),
+                                         m_class_options.GetStructuredData());
       new_plan_sp = thread->QueueThreadPlanForStepScripted(
-          abort_other_plans, m_class_options.GetName().c_str(),
-          m_class_options.GetStructuredData(), bool_stop_other_threads,
+          abort_other_plans, scripted_metadata, bool_stop_other_threads,
           new_plan_status);
     } else {
       result.AppendError("step type is not supported");

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.cpp
@@ -28,7 +28,8 @@ ScriptedThreadPlanPythonInterface::ScriptedThreadPlanPythonInterface(
 llvm::Expected<StructuredData::GenericSP>
 ScriptedThreadPlanPythonInterface::CreatePluginObject(
     const ScriptedMetadata &scripted_metadata,
-    lldb::ThreadPlanSP thread_plan_sp, const StructuredDataImpl &args_sp) {
+    lldb::ThreadPlanSP thread_plan_sp) {
+  StructuredDataImpl args_sp(scripted_metadata.GetArgsSP());
   return ScriptedPythonInterface::CreatePluginObject(scripted_metadata, nullptr,
                                                      thread_plan_sp, args_sp);
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/ScriptedThreadPlanPythonInterface.h
@@ -24,8 +24,7 @@ public:
 
   llvm::Expected<StructuredData::GenericSP>
   CreatePluginObject(const ScriptedMetadata &scripted_metadata,
-                     lldb::ThreadPlanSP thread_plan_sp,
-                     const StructuredDataImpl &args_sp) override;
+                     lldb::ThreadPlanSP thread_plan_sp) override;
 
   llvm::SmallVector<AbstractMethodRequirement>
   GetAbstractMethodRequirements() const override {

--- a/lldb/source/Target/ScriptedThreadPlan.cpp
+++ b/lldb/source/Target/ScriptedThreadPlan.cpp
@@ -24,11 +24,11 @@
 using namespace lldb;
 using namespace lldb_private;
 
-ScriptedThreadPlan::ScriptedThreadPlan(Thread &thread, const char *class_name,
-                                       const StructuredDataImpl &args_data)
+ScriptedThreadPlan::ScriptedThreadPlan(
+    Thread &thread, const ScriptedMetadata &scripted_metadata)
     : ThreadPlan(ThreadPlan::eKindPython, "Script based Thread Plan", thread,
                  eVoteNoOpinion, eVoteNoOpinion),
-      m_class_name(class_name), m_args_data(args_data), m_did_push(false),
+      m_scripted_metadata(scripted_metadata), m_did_push(false),
       m_stop_others(false) {
   ScriptInterpreter *interpreter = GetScriptInterpreter();
   if (!interpreter) {
@@ -74,14 +74,19 @@ ScriptInterpreter *ScriptedThreadPlan::GetScriptInterpreter() {
   return m_process.GetTarget().GetDebugger().GetScriptInterpreter();
 }
 
+llvm::StringRef ScriptedThreadPlan::GetScriptClassName() const {
+  if (m_interface && m_interface->GetScriptedMetadata())
+    return m_interface->GetScriptedMetadata()->GetClassName();
+  return "<unknown>";
+}
+
 void ScriptedThreadPlan::DidPush() {
   // We set up the script side in DidPush, so that it can push other plans in
   // the constructor, and doesn't have to care about the details of DidPush.
   m_did_push = true;
   if (m_interface) {
-    ScriptedMetadata scripted_metadata(m_class_name, {});
-    auto obj_or_err = m_interface->CreatePluginObject(
-        scripted_metadata, this->shared_from_this(), m_args_data);
+    auto obj_or_err = m_interface->CreatePluginObject(m_scripted_metadata,
+                                                      this->shared_from_this());
     if (!obj_or_err) {
       m_error_str = llvm::toString(obj_or_err.takeError());
       SetPlanComplete(false);
@@ -92,8 +97,7 @@ void ScriptedThreadPlan::DidPush() {
 
 bool ScriptedThreadPlan::ShouldStop(Event *event_ptr) {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
 
   bool should_stop = true;
   if (m_implementation_sp) {
@@ -110,8 +114,7 @@ bool ScriptedThreadPlan::ShouldStop(Event *event_ptr) {
 
 bool ScriptedThreadPlan::IsPlanStale() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
 
   bool is_stale = true;
   if (m_implementation_sp) {
@@ -128,8 +131,7 @@ bool ScriptedThreadPlan::IsPlanStale() {
 
 bool ScriptedThreadPlan::DoPlanExplainsStop(Event *event_ptr) {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
 
   bool explains_stop = true;
   if (m_implementation_sp) {
@@ -147,8 +149,7 @@ bool ScriptedThreadPlan::DoPlanExplainsStop(Event *event_ptr) {
 
 bool ScriptedThreadPlan::MischiefManaged() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
   bool mischief_managed = true;
   if (m_implementation_sp) {
     // I don't really need mischief_managed, since it's simpler to just call
@@ -165,8 +166,7 @@ bool ScriptedThreadPlan::MischiefManaged() {
 
 lldb::StateType ScriptedThreadPlan::GetPlanRunState() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
   lldb::StateType run_state = eStateRunning;
   if (m_implementation_sp)
     run_state = m_interface->GetRunState();
@@ -176,8 +176,7 @@ lldb::StateType ScriptedThreadPlan::GetPlanRunState() {
 void ScriptedThreadPlan::GetDescription(Stream *s,
                                         lldb::DescriptionLevel level) {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
   if (m_implementation_sp) {
     ScriptInterpreter *script_interp = GetScriptInterpreter();
     if (script_interp) {
@@ -187,8 +186,8 @@ void ScriptedThreadPlan::GetDescription(Stream *s,
         LLDB_LOG_ERROR(
             GetLog(LLDBLog::Thread), std::move(err),
             "Can't call ScriptedThreadPlan::GetStopDescription: {0}");
-        s->Printf("Scripted thread plan implemented by class %s.",
-                  m_class_name.c_str());
+        s->Format("Scripted thread plan implemented by class {0}.",
+                  GetScriptClassName());
       } else
         s->PutCString(
             reinterpret_cast<StreamString *>(stream.get())->GetData());
@@ -198,16 +197,15 @@ void ScriptedThreadPlan::GetDescription(Stream *s,
   // It's an error not to have a description, so if we get here, we should
   // add something.
   if (m_stop_description.Empty())
-    s->Printf("Scripted thread plan implemented by class %s.",
-              m_class_name.c_str());
+    s->Format("Scripted thread plan implemented by class {0}.",
+              GetScriptClassName());
   s->PutCString(m_stop_description.GetData());
 }
 
 // The ones below are not currently exported to Python.
 bool ScriptedThreadPlan::WillStop() {
   Log *log = GetLog(LLDBLog::Thread);
-  LLDB_LOGF(log, "%s called on Scripted Thread Plan: %s )",
-            LLVM_PRETTY_FUNCTION, m_class_name.c_str());
+  LLDB_LOG(log, "called on Scripted Thread Plan: {0}", GetScriptClassName());
   return true;
 }
 

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1435,12 +1435,10 @@ ThreadPlanSP Thread::QueueThreadPlanForStepUntil(
 }
 
 lldb::ThreadPlanSP Thread::QueueThreadPlanForStepScripted(
-    bool abort_other_plans, const char *class_name,
-    StructuredData::ObjectSP extra_args_sp, bool stop_other_threads,
-    Status &status) {
+    bool abort_other_plans, const ScriptedMetadata &scripted_metadata,
+    bool stop_other_threads, Status &status) {
 
-  ThreadPlanSP thread_plan_sp(new ScriptedThreadPlan(
-      *this, class_name, StructuredDataImpl(extra_args_sp)));
+  ThreadPlanSP thread_plan_sp(new ScriptedThreadPlan(*this, scripted_metadata));
   thread_plan_sp->SetStopOthers(stop_other_threads);
   status = QueueThreadPlan(thread_plan_sp, abort_other_plans);
   return thread_plan_sp;


### PR DESCRIPTION
This is a follow-up to 1b4a578a9f77.

Replace ScriptedThreadPlan's separate `m_class_name` and `m_args_data` members with a single `m_scripted_metadata`, and update its constructor, Thread::QueueThreadPlanForStepScripted and the SB/CLI callers to take a `const ScriptedMetadata &` directly. Drop the now-redundant `args_sp` parameter from ScriptedThreadPlanInterface::CreatePluginObject; the Python override constructs a StructuredDataImpl from the metadata's args dict for the dispatched call.

ScriptedThreadPlan keeps its own `m_scripted_metadata` member because the interface's metadata is only set when `DidPush()` calls `CreatePluginObject`, so the plan needs to hold the metadata between construction and `DidPush()`.