### PR TITLE
[CIR] Fix atomic-fetch conflict:

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenAtomic.cpp
@@ -570,26 +570,9 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
   cir::AtomicFetchKindAttr fetchAttr;
   bool fetchFirst = true;
 
-  bool fetchRequiredIntCast = false;
-  mlir::Type pointeeType = ptr.getElementType();
   auto handleFetchOp = [&](cir::AtomicFetchKind kind) {
     opName = cir::AtomicFetchOp::getOperationName();
     fetchAttr = cir::AtomicFetchKindAttr::get(builder.getContext(), kind);
-
-    // The fetch operation only takes int/float as its element type, so
-    // pointer-to-pointer needs to just be cast to a intptr type. Do the first
-    // part here, and we can cast the rest later. Classic codegen has to do a
-    // bit more to handle floating point types for exchange, but this isn't
-    // really necessary for CIR. This mirrors the logic in CIRGenBuiltin for
-    // binary atomic values. Clang type checking enforces that 'val' is a
-    // PtrDiffT, so we cast to that.
-    if (mlir::isa<cir::PointerType>(pointeeType)) {
-      fetchRequiredIntCast = true;
-      mlir::Type ptrSizeInt =
-          cgf.convertType(cgf.getContext().getPointerDiffType());
-
-      ptr = ptr.withElementType(builder, ptrSizeInt);
-    }
   };
 
   switch (expr->getOp()) {
@@ -825,9 +808,6 @@ static void emitAtomicOp(CIRGenFunction &cgf, AtomicExpr *expr, Address dest,
     rmwOp->setAttr("fetch_first", builder.getUnitAttr());
 
   mlir::Value result = rmwOp->getResult(0);
-
-  if (fetchRequiredIntCast)
-    result = builder.createIntToPtr(result, pointeeType);
 
   builder.createStore(loc, result, dest);
 }

--- a/clang/test/CIR/CodeGen/atomic.c
+++ b/clang/test/CIR/CodeGen/atomic.c
@@ -932,15 +932,13 @@ float *atomic_fetch_ptr_to_ptr(float **ptr, int value) {
   // CIR: %[[PTR_LOAD:.*]] = cir.load align(8) %[[PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.float>>>, !cir.ptr<!cir.ptr<!cir.float>>
   // CIR: %[[PTR_CAST:.*]] = cir.cast bitcast %[[PTR_LOAD]] : !cir.ptr<!cir.ptr<!cir.float>> -> !cir.ptr<!s64i>
   // CIR: %[[RESULT:.*]] = cir.atomic.fetch add seq_cst syncscope(system) fetch_first %[[PTR_CAST]], %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
-  // CIR: %[[RESULT_CAST:.*]] = cir.cast int_to_ptr %[[RESULT]] : !s64i -> !cir.ptr<!cir.float>
-  // CIR: cir.store align(8) %[[RESULT_CAST]], %[[ATOMIC_TEMP]] : !cir.ptr<!cir.float>, !cir.ptr<!cir.ptr<!cir.float>>
+  // CIR: %[[ATOMIC_TEMP_CAST:.*]] = cir.cast bitcast %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!cir.float>> -> !cir.ptr<!s64i>
+  // CIR: cir.store align(8) %[[RESULT]], %[[ATOMIC_TEMP_CAST]] : !s64i, !cir.ptr<!s64i>
 
   // LLVM: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %{{.*}} seq_cst, align 8
-  // LLVM: %[[RESULT_CAST:.*]] = inttoptr i64 %[[RESULT]] to ptr
-  // LLVM: store ptr %[[RESULT_CAST]], ptr %{{.*}}, align 8
+  // LLVM: store i64 %[[RESULT]], ptr %{{.*}}, align 8
 
   // OGCG: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %{{.*}} seq_cst, align 8
-  // OGCG Skips the cast and just stores it directly.
   // OGCG: store i64 %[[RESULT]], ptr %{{.*}}, align 8
 }
 
@@ -954,17 +952,15 @@ float *atomic_fetch_ptr_to_ptr2(float **ptr, int value) {
   // CIR: %[[PTR_LOAD:.*]] = cir.load align(8) %[[PTR]] : !cir.ptr<!cir.ptr<!cir.ptr<!cir.float>>>, !cir.ptr<!cir.ptr<!cir.float>>
   // CIR: %[[PTR_CAST:.*]] = cir.cast bitcast %[[PTR_LOAD]] : !cir.ptr<!cir.ptr<!cir.float>> -> !cir.ptr<!s64i>
   // CIR: %[[RESULT:.*]] = cir.atomic.fetch add seq_cst syncscope(system) %[[PTR_CAST]], %{{.*}} : (!cir.ptr<!s64i>, !s64i) -> !s64i
-  // CIR: %[[RESULT_CAST:.*]] = cir.cast int_to_ptr %[[RESULT]] : !s64i -> !cir.ptr<!cir.float>
-  // CIR: cir.store align(8) %[[RESULT_CAST]], %[[ATOMIC_TEMP]] : !cir.ptr<!cir.float>, !cir.ptr<!cir.ptr<!cir.float>>
+  // CIR: %[[ATOMIC_TEMP_CAST:.*]] = cir.cast bitcast %[[ATOMIC_TEMP]] : !cir.ptr<!cir.ptr<!cir.float>> -> !cir.ptr<!s64i>
+  // CIR: cir.store align(8) %[[RESULT]], %[[ATOMIC_TEMP_CAST]] : !s64i, !cir.ptr<!s64i>
 
   // LLVM: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %[[VAL:.*]] seq_cst, align 8
   // LLVM: %[[ADD_RES:.*]] = add i64 %[[RESULT]], %[[VAL]]
-  // LLVM: %[[RESULT_CAST:.*]] = inttoptr i64 %[[ADD_RES]] to ptr
-  // LLVM: store ptr %[[RESULT_CAST]], ptr %{{.*}}, align 8
+  // LLVM: store i64 %[[ADD_RES]], ptr %{{.*}}, align 8
 
   // OGCG: %[[RESULT:.*]] = atomicrmw add ptr %{{.*}}, i64 %[[VAL:.*]] seq_cst, align 8
   // OGCG: %[[ADD_RES:.*]] = add i64 %[[RESULT]], %[[VAL]]
-  // OGCG Skips the cast and just stores it directly.
   // OGCG: store i64 %[[ADD_RES]], ptr %{{.*}}, align 8
 }
 


### PR DESCRIPTION
We had #195537 and #198871 both attempt to fix the same problem, in mildly different ways.  My patch (the latter) did so in a way that was rendered 'moot' by the former patch.

After looking into it further, I believe that the former is the 'correct' patch.

THIS patch is a partial revert of my patch, leaving the lambda (as I
    think it is a good 'readability' improvement), plus leaving/updating
the test.