### PR TITLE
[flang] Add utility to obtain presentable function name

### DIFF
--- a/flang/include/flang/Optimizer/Support/Utils.h
+++ b/flang/include/flang/Optimizer/Support/Utils.h
@@ -24,8 +24,10 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
+#include <string>
 
 #include "flang/Optimizer/CodeGen/TypeConverter.h"
 
@@ -244,6 +246,10 @@ mlir::Value integerCast(const fir::LLVMTypeConverter &converter,
 /// it return false iff it is not a new allocation,
 /// otherwise it returns std::nullopt.
 std::optional<bool> isNewAllocationResult(mlir::OpResult result);
+
+/// Used to obtain user-facing function name that can be used in
+/// diagnostics and remarks without mangling or underscores.
+std::string getPresentableFunctionName(mlir::FunctionOpInterface func);
 } // namespace fir
 
 #endif // FORTRAN_OPTIMIZER_SUPPORT_UTILS_H

--- a/flang/lib/Optimizer/Support/Utils.cpp
+++ b/flang/lib/Optimizer/Support/Utils.cpp
@@ -148,3 +148,28 @@ std::optional<bool> fir::isNewAllocationResult(mlir::OpResult result) {
   }
   return false;
 }
+
+std::string fir::getPresentableFunctionName(mlir::FunctionOpInterface func) {
+  if (func.getName() == fir::NameUniquer::doProgramEntry()) {
+    // Main program entry is all uppercase - to avoid name conflicts. But
+    // from a reporting perspective, keep it lowercase for consistency with
+    // every other symbol.
+    if (auto bindcName =
+            func->getAttrOfType<mlir::StringAttr>(fir::getSymbolAttrName())) {
+      llvm::StringRef name = bindcName.getValue();
+      if (!name.empty())
+        return name.lower();
+    }
+  }
+  std::string result;
+  // The internal name is the saved name after ExternalNameConversion prepares
+  // the names for external visibility. Without doing this, for many names we
+  // would get the underscore version instead of the name as user wrote it.
+  if (auto internalName = func->getAttrOfType<mlir::StringAttr>(
+          fir::getInternalFuncNameAttrName());
+      internalName && !internalName.getValue().empty())
+    result = internalName.getValue().str();
+  else
+    result = func.getName().str();
+  return fir::NameUniquer::deconstruct(result).second.name;
+}


### PR DESCRIPTION
This PR adds `getPresentableFunctionName` utility to enable obtaining the demangled and no underscore function name that can be used for presentation for a user and is consistent with the name used in source code.