### PR TITLE
[AMDGPU] Use separate tables for VOPDX and VOPDY in `getCanBeVOPD` (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -3543,7 +3543,7 @@ def FP4FP8DstByteSelTable : GenericTable {
 def VOPDComponentTable : GenericTable {
   let FilterClass = "VOPD_Component";
   let CppTypeName = "VOPDComponentInfo";
-  let Fields = ["BaseVOP", "VOPDOp", "CanBeVOPDX", "CanBeVOPD3X"];
+  let Fields = ["BaseVOP", "VOPDOp", "CanBeVOPDX"];
   let PrimaryKey = ["BaseVOP"];
   let PrimaryKeyName = "getVOPDComponentHelper";
 }
@@ -3573,7 +3573,8 @@ def hi16_to_vgpr32 : OutPatFrag<(ops node:$op),
   (REG_SEQUENCE VGPR_32, (i16 (IMPLICIT_DEF)), lo16, $op, hi16)>;
 
 // Instructions eligible to be the first (X) instruction in Dual Issue VALU
-// (VOPD) encoding.
+// (VOPD) encoding. This only includes VOPD3 opcodes that are subtarget dependent.
+// Non-VOPD3 opcodes should be checked with CanBeVOPDX from VOPDComponentTable.
 def VOPDXTable : GenericTable {
   let FilterClass = "VOPDX";
   let CppTypeName = "VOPDXYInfo";

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -3572,6 +3572,8 @@ def lo16_to_vgpr32 : OutPatFrag<(ops node:$op),
 def hi16_to_vgpr32 : OutPatFrag<(ops node:$op),
   (REG_SEQUENCE VGPR_32, (i16 (IMPLICIT_DEF)), lo16, $op, hi16)>;
 
+// Instructions eligible to be the first (X) instruction in Dual Issue VALU
+// (VOPD) encoding.
 def VOPDXTable : GenericTable {
   let FilterClass = "VOPDX";
   let CppTypeName = "VOPDXYInfo";
@@ -3580,6 +3582,8 @@ def VOPDXTable : GenericTable {
   let PrimaryKeyName = "canBeVOPDX";
 }
 
+// Instructions eligible to be the second (Y) instruction in Dual Issue VALU
+// (VOPD) encoding.
 def VOPDYTable : GenericTable {
   let FilterClass = "VOPDY";
   let CppTypeName = "VOPDXYInfo";

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.td
@@ -3572,6 +3572,22 @@ def lo16_to_vgpr32 : OutPatFrag<(ops node:$op),
 def hi16_to_vgpr32 : OutPatFrag<(ops node:$op),
   (REG_SEQUENCE VGPR_32, (i16 (IMPLICIT_DEF)), lo16, $op, hi16)>;
 
+def VOPDXTable : GenericTable {
+  let FilterClass = "VOPDX";
+  let CppTypeName = "VOPDXYInfo";
+  let Fields = ["VOPDOp", "Subtarget", "VOPD3"];
+  let PrimaryKey = ["VOPDOp", "Subtarget", "VOPD3"];
+  let PrimaryKeyName = "canBeVOPDX";
+}
+
+def VOPDYTable : GenericTable {
+  let FilterClass = "VOPDY";
+  let CppTypeName = "VOPDXYInfo";
+  let Fields = ["VOPDOp", "Subtarget", "VOPD3"];
+  let PrimaryKey = ["VOPDOp", "Subtarget", "VOPD3"];
+  let PrimaryKeyName = "canBeVOPDY";
+}
+
 include "SIInstructions.td"
 
 include "DSInstructions.td"

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -675,7 +675,8 @@ CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
     return {canBeVOPDX(Info->VOPDOp, EncodingFamily, true) != nullptr,
             canBeVOPDY(Info->VOPDOp, EncodingFamily, true) != nullptr};
   }
-  // VOPDX eligibility is encoding-family-independent for non-VOPD3, so re-use information in Info.
+  // VOPDX eligibility is encoding-family-independent for non-VOPD3, so re-use
+  // information in Info.
   return {Info->CanBeVOPDX,
           canBeVOPDY(Info->VOPDOp, EncodingFamily, false) != nullptr};
 }

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -405,7 +405,6 @@ struct VOPDComponentInfo {
   uint16_t BaseVOP;
   uint16_t VOPDOp;
   bool CanBeVOPDX;
-  bool CanBeVOPD3X;
 };
 
 struct VOPDInfo {
@@ -676,7 +675,7 @@ CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
     return {canBeVOPDX(Info->VOPDOp, EncodingFamily, true) != nullptr,
             canBeVOPDY(Info->VOPDOp, EncodingFamily, true) != nullptr};
   }
-  // VOPDX eligibility is encoding-family-independent for non-VOPD3.
+  // VOPDX eligibility is encoding-family-independent for non-VOPD3, so re-use information in Info.
   return {Info->CanBeVOPDX,
           canBeVOPDY(Info->VOPDOp, EncodingFamily, false) != nullptr};
 }

--- a/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp
@@ -421,6 +421,12 @@ struct VOPTrue16Info {
   bool IsTrue16;
 };
 
+struct VOPDXYInfo {
+  uint16_t VOPDOp;
+  uint16_t Subtarget;
+  bool VOPD3;
+};
+
 #define GET_FP4FP8DstByteSelTable_DECL
 #define GET_FP4FP8DstByteSelTable_IMPL
 
@@ -461,6 +467,10 @@ struct FP4FP8DstByteSelInfo {
 #define GET_VOPDComponentTable_IMPL
 #define GET_VOPDPairs_DECL
 #define GET_VOPDPairs_IMPL
+#define GET_VOPDXTable_DECL
+#define GET_VOPDXTable_IMPL
+#define GET_VOPDYTable_DECL
+#define GET_VOPDYTable_IMPL
 #define GET_VOPTrue16Table_DECL
 #define GET_VOPTrue16Table_IMPL
 #define GET_True16D16Table_IMPL
@@ -657,28 +667,18 @@ unsigned getVOPDEncodingFamily(const MCSubtargetInfo &ST) {
 CanBeVOPD getCanBeVOPD(unsigned Opc, unsigned EncodingFamily, bool VOPD3) {
   bool IsConvertibleToBitOp = VOPD3 ? getBitOp2(Opc) : 0;
   Opc = IsConvertibleToBitOp ? (unsigned)AMDGPU::V_BITOP3_B32_e64 : Opc;
+  // Normalize through VOPDComponentTable so that e32, e64 and e64_dpp variants
+  // of the same logical opcode all share a single entry.
   const VOPDComponentInfo *Info = getVOPDComponentHelper(Opc);
-  if (Info) {
-    // Check that Opc can be used as VOPDY for this encoding. V_MOV_B32 as a
-    // VOPDX is just a placeholder here, it is supported on all encodings.
-    // TODO: This can be optimized by creating tables of supported VOPDY
-    // opcodes per encoding.
-    unsigned VOPDMov = AMDGPU::getVOPDOpcode(AMDGPU::V_MOV_B32_e32, VOPD3);
-    bool CanBeVOPDX;
-    if (VOPD3) {
-      CanBeVOPDX = getVOPDFull(AMDGPU::getVOPDOpcode(Opc, VOPD3), VOPDMov,
-                               EncodingFamily, VOPD3) != -1;
-    } else {
-      // The list of VOPDX opcodes is currently the same in all encoding
-      // families, so we do not need a family-specific check.
-      CanBeVOPDX = Info->CanBeVOPDX;
-    }
-    bool CanBeVOPDY = getVOPDFull(VOPDMov, AMDGPU::getVOPDOpcode(Opc, VOPD3),
-                                  EncodingFamily, VOPD3) != -1;
-    return {CanBeVOPDX, CanBeVOPDY};
+  if (!Info)
+    return {false, false};
+  if (VOPD3) {
+    return {canBeVOPDX(Info->VOPDOp, EncodingFamily, true) != nullptr,
+            canBeVOPDY(Info->VOPDOp, EncodingFamily, true) != nullptr};
   }
-
-  return {false, false};
+  // VOPDX eligibility is encoding-family-independent for non-VOPD3.
+  return {Info->CanBeVOPDX,
+          canBeVOPDY(Info->VOPDOp, EncodingFamily, false) != nullptr};
 }
 
 unsigned getVOPDOpcode(unsigned Opc, bool VOPD3) {

--- a/llvm/lib/Target/AMDGPU/VOPDInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPDInstructions.td
@@ -289,3 +289,27 @@ foreach Gen = [GFX1250GenD3, GFX13GenD3] in {
     }
   }
 }
+
+class VOPDXY<bits<6> Op, int Sub, bit IsVOPD3> {
+  bits<6> VOPDOp = Op;
+  bits<4> Subtarget = Sub;
+  bit VOPD3 = IsVOPD3;
+}
+
+class VOPDX<bits<6> Op, int Sub, bit IsVOPD3> : VOPDXY<Op, Sub, IsVOPD3>;
+class VOPDY<bits<6> Op, int Sub, bit IsVOPD3> : VOPDXY<Op, Sub, IsVOPD3>;
+
+foreach Gen = [GFX11GenD, GFX1170GenD, GFX12GenD, GFX1250GenD, GFX13GenD] in {
+  foreach p = Gen.VOPDYPseudos in
+    def "VOPDY_" # p # Gen.Suffix :
+        VOPDY<!cast<VOPD_Component>(p).VOPDOp, Gen.Subtarget, 0>;
+}
+
+foreach Gen = [GFX1250GenD3, GFX13GenD3] in {
+  foreach p = Gen.VOPDXPseudos in
+    def "VOPDX_VOPD3_" # p # Gen.Suffix :
+        VOPDX<!cast<VOPD_Component>(p).VOPDOp, Gen.Subtarget, 1>;
+  foreach p = Gen.VOPDYPseudos in
+    def "VOPDY_VOPD3_" # p # Gen.Suffix :
+        VOPDY<!cast<VOPD_Component>(p).VOPDOp, Gen.Subtarget, 1>;
+}


### PR DESCRIPTION
With this change a table for valid VOPDX (only for VOPD3X instructions) and VOPDY operations is generated through TableGen. This simplifies the look-up leading to a 2-3% compile-time speed-up for tested shaders where `getCanBeVOPD` is on a hot path.

Assisted-by: Claude Code