### PR TITLE
[clang-format] Recognize Verilog class item qualifiers

### DIFF
--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -1950,6 +1950,7 @@ struct AdditionalKeywords {
     case tok::kw_for:
     case tok::kw_if:
     case tok::kw_import:
+    case tok::kw_protected:
     case tok::kw_restrict:
     case tok::kw_signed:
     case tok::kw_static:

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1456,6 +1456,7 @@ void UnwrappedLineParser::parseStructuralElement(
            Tokens->peekNextToken()->is(tok::star)) {
       parseParens();
     }
+    skipVerilogQualifiers();
     // Skip things that can exist before keywords like 'if' and 'case'.
     if (FormatTok->isOneOf(Keywords.kw_priority, Keywords.kw_unique,
                            Keywords.kw_unique0)) {
@@ -4603,14 +4604,22 @@ void UnwrappedLineParser::parseVerilogExtern() {
   // "DPI-C"
   if (FormatTok->is(tok::string_literal))
     nextToken();
-  if (FormatTok->isOneOf(Keywords.kw_context, Keywords.kw_pure))
-    nextToken();
+  skipVerilogQualifiers();
   if (Keywords.isVerilogIdentifier(*FormatTok))
     nextToken();
   if (FormatTok->is(tok::equal))
     nextToken();
   if (Keywords.isVerilogHierarchy(*FormatTok))
     parseVerilogHierarchyHeader();
+}
+
+void UnwrappedLineParser::skipVerilogQualifiers() {
+  while (FormatTok->isOneOf(tok::kw_protected, tok::kw_virtual, tok::kw_static,
+                            Keywords.kw_rand, Keywords.kw_context,
+                            Keywords.kw_pure, Keywords.kw_randc,
+                            Keywords.kw_local)) {
+    nextToken();
+  }
 }
 
 bool UnwrappedLineParser::containsExpansion(const UnwrappedLine &Line) const {

--- a/clang/lib/Format/UnwrappedLineParser.h
+++ b/clang/lib/Format/UnwrappedLineParser.h
@@ -208,6 +208,8 @@ private:
   void parseVerilogCaseLabel();
   // For import, export, and extern.
   void parseVerilogExtern();
+  // Skip things that can precede the keywords like module.
+  void skipVerilogQualifiers();
   std::optional<llvm::SmallVector<llvm::SmallVector<FormatToken *, 8>, 1>>
   parseMacroCall();
 

--- a/clang/unittests/Format/FormatTestVerilog.cpp
+++ b/clang/unittests/Format/FormatTestVerilog.cpp
@@ -686,6 +686,9 @@ TEST_F(FormatTestVerilog, Hierarchy) {
                "x = x;");
   verifyFormat("export \"DPI-C\" function exported_sv_func;\n"
                "x = x;");
+  verifyFormat("extern protected virtual function int send\n"
+               "    (int value);\n"
+               "x = x;");
   verifyFormat("import \"DPI-C\" function void f1\n"
                "    (input int i1,\n"
                "     pair i2,\n"
@@ -719,6 +722,9 @@ TEST_F(FormatTestVerilog, Hierarchy) {
                "  generate\n"
                "  endgenerate\n"
                "endfunction : x");
+  verifyFormat("protected virtual function int x\n"
+               "    (int value);\n"
+               "endfunction");
   // Type names with '::' should be recognized.
   verifyFormat("function automatic x::x x\n"
                "    (input x);\n"


### PR DESCRIPTION
old

```SystemVerilog
class Packet
  extern protected virtual function int send
      (int value);
  endclass : Packet
```

new

```SystemVerilog
class Packet
  extern protected virtual function int send
      (int value);
endclass : Packet
```

Previously the `extern` line failed to parse completely because the `protected virtual` part was not recognized.  It made the following lines get indented wrong.