### PR TITLE
[clang-format] Remove the blank line in the function try block

### DIFF
--- a/clang/lib/Format/DefinitionBlockSeparator.cpp
+++ b/clang/lib/Format/DefinitionBlockSeparator.cpp
@@ -202,6 +202,9 @@ void DefinitionBlockSeparator::separateBlocks(
     } else if (CurrentLine->First->closesScope()) {
       if (OpeningLineIndex > Lines.size())
         continue;
+      // A function try block should be together.
+      if (CurrentLine->First->startsSequence(tok::r_brace, tok::kw_catch))
+        continue;
       // Handling the case that opening brace has its own line, with checking
       // whether the last line already had an opening brace to guard against
       // misrecognition.

--- a/clang/unittests/Format/DefinitionBlockSeparatorTest.cpp
+++ b/clang/unittests/Format/DefinitionBlockSeparatorTest.cpp
@@ -478,8 +478,24 @@ TEST_F(DefinitionBlockSeparatorTest, OpeningBracketOwnsLine) {
 
 TEST_F(DefinitionBlockSeparatorTest, TryBlocks) {
   FormatStyle Style = getLLVMStyle();
-  Style.BreakBeforeBraces = FormatStyle::BS_Allman;
   Style.SeparateDefinitionBlocks = FormatStyle::SDS_Always;
+  verifyFormat("void foo() try {\n"
+               "  // do something\n"
+               "} catch (const std::exception &) {\n"
+               "  // handle exception\n"
+               "}",
+               Style, "", /*Inverse=*/false);
+  Style.BreakBeforeBraces = FormatStyle::BS_Allman;
+  verifyFormat("void foo()\n"
+               "try\n"
+               "{\n"
+               "  // do something\n"
+               "}\n"
+               "catch (const std::exception &)\n"
+               "{\n"
+               "  // handle exception\n"
+               "}",
+               Style, "", /*Inverse=*/false);
   verifyFormat("void FunctionWithInternalTry()\n"
                "{\n"
                "  try\n"


### PR DESCRIPTION
old with config `{SeparateDefinitionBlocks: Always}`

```C++
void foo() try {
  // do something
} catch (const std::exception &e) {

  // handle exception
}
```

new

```C++
void foo() try {
  // do something
} catch (const std::exception &e) {
  // handle exception
}
```

Fixes #58183.

With the option `SeparateDefinitionBlocks` set, the program previously added a blank line in the catch block.  Now the problem is fixed.