### PR TITLE
[PowerPC] Change arguments of PPCEmitTimePseudo

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -73,7 +73,7 @@ let isTerminator = 1, isBarrier = 1, PPC970_Unit = 7, hasSideEffects = 0 in {
 }
 
 let Defs = [LR8] in
-  def MovePCtoLR8 : PPCEmitTimePseudo<(outs), (ins), "#MovePCtoLR8", []>,
+  def MovePCtoLR8 : PPCEmitTimePseudo<(outs), (ins)>,
                     PPC970_Unit_BRU;
 
 let isBranch = 1, isTerminator = 1, hasCtrlDep = 1, PPC970_Unit = 7, hasSideEffects = 0 in {
@@ -433,18 +433,16 @@ let Interpretation64Bit = 1, isCodeGenOnly = 1 in {
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNdi8 :PPCEmitTimePseudo< (outs),
                         (ins calltarget:$dst, i32imm:$offset),
-                 "#TC_RETURNd8 $dst $offset",
-                 []>;
+                 [], "#TC_RETURNd8 $dst $offset">;
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNai8 :PPCEmitTimePseudo<(outs), (ins abscalltarget:$func, i32imm:$offset),
-                 "#TC_RETURNa8 $func $offset",
-                 [(PPCtc_return (i64 imm:$func), imm:$offset)]>;
+                 [(PPCtc_return (i64 imm:$func), imm:$offset)],
+                 "#TC_RETURNa8 $func $offset">;
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNri8 : PPCEmitTimePseudo<(outs), (ins CTRRC8:$dst, i32imm:$offset),
-                 "#TC_RETURNr8 $dst $offset",
-                 []>;
+                 [], "#TC_RETURNr8 $dst $offset">;
 
 let hasSideEffects = 0 in {
 let isTerminator = 1, isBarrier = 1, PPC970_Unit = 7, isBranch = 1,
@@ -559,7 +557,7 @@ def MTCTR8loop : XFXForm_1_ext<31, 467, 9, (outs), (ins g8rc:$RST),
 
 let hasSideEffects = 1, hasNoSchedulingInfo = 1, isNotDuplicable = 1, Uses = [CTR8], Defs = [CTR8] in
 def DecreaseCTR8loop : PPCEmitTimePseudo<(outs crbitrc:$rT), (ins i64imm:$stride),
-                                        "#DecreaseCTR8loop", [(set i1:$rT, (int_loop_decrement (i64 imm:$stride)))]>;
+                                         [(set i1:$rT, (int_loop_decrement (i64 imm:$stride)))]>;
 
 let Pattern = [(set i64:$RST, readcyclecounter)] in
 def MFTB8 : XFXForm_1_ext<31, 339, 268, (outs g8rc:$RST), (ins),
@@ -571,10 +569,10 @@ def MFTB8 : XFXForm_1_ext<31, 339, 268, (outs g8rc:$RST), (ins),
 // the POWER3.
 
 let Defs = [X1], Uses = [X1] in
-def DYNALLOC8 : PPCEmitTimePseudo<(outs g8rc:$result), (ins g8rc:$negsize, memri:$fpsi),"#DYNALLOC8",
+def DYNALLOC8 : PPCEmitTimePseudo<(outs g8rc:$result), (ins g8rc:$negsize, memri:$fpsi),
                        [(set i64:$result,
                              (PPCdynalloc i64:$negsize, iaddr:$fpsi))]>;
-def DYNAREAOFFSET8 : PPCEmitTimePseudo<(outs i64imm:$result), (ins memri:$fpsi), "#DYNAREAOFFSET8",
+def DYNAREAOFFSET8 : PPCEmitTimePseudo<(outs i64imm:$result), (ins memri:$fpsi),
                        [(set i64:$result, (PPCdynareaoffset iaddr:$fpsi))]>;
 // Probed alloca to support stack clash protection.
 let Defs = [X1], Uses = [X1], hasNoSchedulingInfo = 1 in {
@@ -584,15 +582,13 @@ def PROBED_ALLOCA_64 : PPCCustomInserterPseudo<(outs g8rc:$result),
                              (PPCprobedalloca i64:$negsize, iaddr:$fpsi))]>;
 def PREPARE_PROBED_ALLOCA_64 : PPCEmitTimePseudo<(outs
     g8rc:$fp, g8rc:$actual_negsize),
-    (ins g8rc:$negsize, memri:$fpsi), "#PREPARE_PROBED_ALLOCA_64", []>;
+    (ins g8rc:$negsize, memri:$fpsi)>;
 def PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_64 : PPCEmitTimePseudo<(outs
     g8rc:$fp, g8rc:$actual_negsize),
-    (ins g8rc:$negsize, memri:$fpsi),
-    "#PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_64", []>,
+    (ins g8rc:$negsize, memri:$fpsi)>,
     RegConstraint<"$actual_negsize = $negsize">;
 def PROBED_STACKALLOC_64 : PPCEmitTimePseudo<(outs g8rc:$scratch, g8rc:$temp),
-    (ins i64imm:$stacksize),
-    "#PROBED_STACKALLOC_64", []>;
+    (ins i64imm:$stacksize)>;
 }
 
 let hasSideEffects = 0 in {
@@ -1400,19 +1396,15 @@ def LD   : DSForm_1<58, 0, (outs g8rc:$RST), (ins (memrix $D, $RA):$addr),
 // Otherwise, we need to create two instructions to form a 32-bit offset,
 // so we have a custom matcher for TOC_ENTRY in PPCDAGToDAGIsel::Select().
 def LDtoc: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtoc",
                   [(set i64:$rD,
                      (PPCtoc_entry tglobaladdr:$disp, i64:$reg))]>, isPPC64;
 def LDtocJTI: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtocJTI",
                   [(set i64:$rD,
                      (PPCtoc_entry tjumptable:$disp, i64:$reg))]>, isPPC64;
 def LDtocCPT: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtocCPT",
                   [(set i64:$rD,
                      (PPCtoc_entry tconstpool:$disp, i64:$reg))]>, isPPC64;
 def LDtocBA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtocCPT",
                   [(set i64:$rD,
                      (PPCtoc_entry tblockaddress:$disp, i64:$reg))]>, isPPC64;
 
@@ -1462,8 +1454,7 @@ def LQ   : DQForm_RTp5_RA17_MEM<56, 0,
 // RA and RB.
 def LQX_PSEUDO : PPCCustomInserterPseudo<(outs g8prc:$RTp), (ins memrr:$src)>;
 
-def RESTORE_QUADWORD : PPCEmitTimePseudo<(outs g8prc:$RTp), (ins memrix:$src),
-                                         "#RESTORE_QUADWORD", []>;
+def RESTORE_QUADWORD : PPCEmitTimePseudo<(outs g8prc:$RTp), (ins memrix:$src)>;
 }
 
 }
@@ -1477,30 +1468,27 @@ def : Pat<(int_ppc_atomic_load_i128 ForceXForm:$src),
 // Support for medium and large code model.
 let hasSideEffects = 0 in {
 let isReMaterializable = 1 in {
-def ADDIStocHA8: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, tocentry:$disp),
-                       "#ADDIStocHA8", []>, isPPC64;
-def ADDItocL8: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, tocentry:$disp),
-                     "#ADDItocL8", []>, isPPC64;
+def ADDIStocHA8: PPCEmitTimePseudo<(outs g8rc:$rD),
+                                   (ins g8rc_nox0:$reg, tocentry:$disp)>, isPPC64;
+def ADDItocL8: PPCEmitTimePseudo<(outs g8rc:$rD),
+                                 (ins g8rc_nox0:$reg, tocentry:$disp)>, isPPC64;
 }
 
 // Local Data Transform
-def ADDItoc8 : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, tocentry:$disp),
-                   "#ADDItoc8",
-                   []>, isPPC64;
+def ADDItoc8 : PPCEmitTimePseudo<(outs g8rc:$rD),
+                                 (ins g8rc_nox0:$reg, tocentry:$disp)>, isPPC64;
 let mayLoad = 1 in
-def LDtocL: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc_nox0:$reg),
-                   "#LDtocL", []>, isPPC64;
+def LDtocL: PPCEmitTimePseudo<(outs g8rc:$rD),
+                              (ins tocentry:$disp, g8rc_nox0:$reg)>, isPPC64;
 }
 
 // Support for thread-local storage.
 def ADDISgotTprelHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDISgotTprelHA",
                          [(set i64:$rD,
                            (PPCaddisGotTprelHA i64:$reg,
                                                tglobaltlsaddr:$disp))]>,
                   isPPC64;
 def LDgotTprelL: PPCEmitTimePseudo<(outs g8rc_nox0:$rD), (ins s16imm64:$disp, g8rc_nox0:$reg),
-                        "#LDgotTprelL",
                         [(set i64:$rD,
                           (PPCldGotTprelL tglobaltlsaddr:$disp, i64:$reg))]>,
                  isPPC64;
@@ -1511,25 +1499,23 @@ def CFENCE8 : PPCPostRAExpPseudo<(outs), (ins g8rc:$cr)>;
 def : Pat<(PPCaddTls i64:$in, tglobaltlsaddr:$g),
           (ADD8TLS $in, tglobaltlsaddr:$g)>;
 def ADDIStlsgdHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDIStlsgdHA",
                          [(set i64:$rD,
                            (PPCaddisTlsgdHA i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
 def ADDItlsgdL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                       "#ADDItlsgdL",
                        [(set i64:$rD,
                          (PPCaddiTlsgdL i64:$reg, tglobaltlsaddr:$disp))]>,
                  isPPC64;
 
 class GETtlsADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$reg, tlsgd:$sym),
-                                             asmstr,
                                              [(set i64:$rD,
-                                               (PPCgetTlsAddr i64:$reg, tglobaltlsaddr:$sym))]>,
+                                               (PPCgetTlsAddr i64:$reg, tglobaltlsaddr:$sym))],
+                                             asmstr>,
                                       isPPC64;
 class GETtlsldADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$reg, tlsgd:$sym),
-                                             asmstr,
                                              [(set i64:$rD,
-                                               (PPCgetTlsldAddr i64:$reg, tglobaltlsaddr:$sym))]>,
+                                               (PPCgetTlsldAddr i64:$reg, tglobaltlsaddr:$sym))],
+                                             asmstr>,
                                       isPPC64;
 
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1 in {
@@ -1557,15 +1543,15 @@ def GETtlsldADDRPCREL : GETtlsldADDRPseudo <"#GETtlsldADDRPCREL">;
 let Defs = [X0,X4,X5,X11,LR8,CR0] in {
 def GETtlsADDR64AIX :
   PPCEmitTimePseudo<(outs g8rc:$rD),(ins g8rc:$offset, g8rc:$handle),
-                    "GETtlsADDR64AIX",
                     [(set i64:$rD,
-                      (PPCgetTlsAddr i64:$offset, i64:$handle))]>, isPPC64;
+                      (PPCgetTlsAddr i64:$offset, i64:$handle))],
+                    "GETtlsADDR64AIX">, isPPC64;
 // On AIX, the call to .__tls_get_mod needs one input in X3 for the module handle.
 def GETtlsMOD64AIX :
   PPCEmitTimePseudo<(outs g8rc:$rD),(ins g8rc:$handle),
-                    "GETtlsMOD64AIX",
                     [(set i64:$rD,
-                      (PPCgetTlsMod i64:$handle))]>, isPPC64;
+                      (PPCgetTlsMod i64:$handle))],
+                    "GETtlsMOD64AIX">, isPPC64;
 }
 }
 
@@ -1576,19 +1562,16 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     in
 def ADDItlsgdLADDR : PPCEmitTimePseudo<(outs g8rc:$rD),
                             (ins g8rc_nox0:$reg, s16imm64:$disp, tlsgd:$sym),
-                            "#ADDItlsgdLADDR",
                             [(set i64:$rD,
                               (PPCaddiTlsgdLAddr i64:$reg,
                                                  tglobaltlsaddr:$disp,
                                                  tglobaltlsaddr:$sym))]>,
                      isPPC64;
 def ADDIStlsldHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDIStlsldHA",
                          [(set i64:$rD,
                            (PPCaddisTlsldHA i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
 def ADDItlsldL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                       "#ADDItlsldL",
                        [(set i64:$rD,
                          (PPCaddiTlsldL i64:$reg, tglobaltlsaddr:$disp))]>,
                  isPPC64;
@@ -1596,12 +1579,11 @@ def ADDItlsldL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm6
 // the region handle in R3 and GETtlsADDR64AIX.
 def TLSGDAIX8 :
   PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$offset, g8rc:$handle),
-                     "#TLSGDAIX8",
                      [(set i64:$rD,
                        (PPCTlsgdAIX i64:$offset, i64:$handle))]>;
 // This pseudo is expanded to the call to GETtlsMOD64AIX.
 def TLSLDAIX8 : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$handle),
-                     "#TLSLDAIX8", [(set i64:$rD, (PPCTlsldAIX i64:$handle))]>;
+                     [(set i64:$rD, (PPCTlsldAIX i64:$handle))]>;
 // Combined op for ADDItlsldL and GETtlsADDR, late expanded.  X3 and LR8
 // are true defines, while the rest of the Defs are clobbers.
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
@@ -1609,26 +1591,22 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     in
 def ADDItlsldLADDR : PPCEmitTimePseudo<(outs g8rc:$rD),
                             (ins g8rc_nox0:$reg, s16imm64:$disp, tlsgd:$sym),
-                            "#ADDItlsldLADDR",
                             [(set i64:$rD,
                               (PPCaddiTlsldLAddr i64:$reg,
                                                  tglobaltlsaddr:$disp,
                                                  tglobaltlsaddr:$sym))]>,
                      isPPC64;
 def ADDISdtprelHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                          "#ADDISdtprelHA",
                           [(set i64:$rD,
                             (PPCaddisDtprelHA i64:$reg,
                                               tglobaltlsaddr:$disp))]>,
                    isPPC64;
 def ADDIdtprelL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDIdtprelL",
                          [(set i64:$rD,
                            (PPCaddiDtprelL i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
 let Size = 8 in
 def PADDIdtprel : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                          "#PADDIdtprel",
                           [(set i64:$rD,
                             (PPCpaddiDtprel i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
@@ -1684,8 +1662,7 @@ def STQ : DSForm_1<62, 2, (outs), (ins g8prc:$RST, (memrix $D, $RA):$addr),
 
 def STQX_PSEUDO : PPCCustomInserterPseudo<(outs), (ins g8prc:$RSp, memrr:$dst)>;
 
-def SPILL_QUADWORD : PPCEmitTimePseudo<(outs), (ins g8prc:$RSp, memrix:$dst),
-                                       "#SPILL_QUADWORD", []>;
+def SPILL_QUADWORD : PPCEmitTimePseudo<(outs), (ins g8prc:$RSp, memrix:$dst)>;
 }
 
 }

--- a/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
+++ b/llvm/lib/Target/PowerPC/PPCInstr64Bit.td
@@ -73,7 +73,7 @@ let isTerminator = 1, isBarrier = 1, PPC970_Unit = 7, hasSideEffects = 0 in {
 }
 
 let Defs = [LR8] in
-  def MovePCtoLR8 : PPCEmitTimePseudo<(outs), (ins), "#MovePCtoLR8", []>,
+  def MovePCtoLR8 : PPCEmitTimePseudo<(outs), (ins)>,
                     PPC970_Unit_BRU;
 
 let isBranch = 1, isTerminator = 1, hasCtrlDep = 1, PPC970_Unit = 7, hasSideEffects = 0 in {
@@ -432,18 +432,16 @@ let Interpretation64Bit = 1, isCodeGenOnly = 1 in {
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNdi8 :PPCEmitTimePseudo< (outs),
                         (ins calltarget:$dst, i32imm:$offset),
-                 "#TC_RETURNd8 $dst $offset",
-                 []>;
+                 [], "#TC_RETURNd8 $dst $offset">;
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNai8 :PPCEmitTimePseudo<(outs), (ins abscalltarget:$func, i32imm:$offset),
-                 "#TC_RETURNa8 $func $offset",
-                 [(PPCtc_return (i64 imm:$func), imm:$offset)]>;
+                 [(PPCtc_return (i64 imm:$func), imm:$offset)],
+                 "#TC_RETURNa8 $func $offset">;
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNri8 : PPCEmitTimePseudo<(outs), (ins CTRRC8:$dst, i32imm:$offset),
-                 "#TC_RETURNr8 $dst $offset",
-                 []>;
+                 [], "#TC_RETURNr8 $dst $offset">;
 
 let hasSideEffects = 0 in {
 let isTerminator = 1, isBarrier = 1, PPC970_Unit = 7, isBranch = 1,
@@ -556,7 +554,7 @@ def MTCTR8loop : XFXForm_1_ext<31, 467, 9, (outs), (ins g8rc:$RST),
 
 let hasSideEffects = 1, hasNoSchedulingInfo = 1, isNotDuplicable = 1, Uses = [CTR8], Defs = [CTR8] in
 def DecreaseCTR8loop : PPCEmitTimePseudo<(outs crbitrc:$rT), (ins i64imm:$stride),
-                                        "#DecreaseCTR8loop", [(set i1:$rT, (int_loop_decrement (i64 imm:$stride)))]>;
+                                         [(set i1:$rT, (int_loop_decrement (i64 imm:$stride)))]>;
 
 let Pattern = [(set i64:$RST, readcyclecounter)] in
 def MFTB8 : XFXForm_1_ext<31, 339, 268, (outs g8rc:$RST), (ins),
@@ -568,10 +566,10 @@ def MFTB8 : XFXForm_1_ext<31, 339, 268, (outs g8rc:$RST), (ins),
 // the POWER3.
 
 let Defs = [X1], Uses = [X1] in
-def DYNALLOC8 : PPCEmitTimePseudo<(outs g8rc:$result), (ins g8rc:$negsize, memri:$fpsi),"#DYNALLOC8",
+def DYNALLOC8 : PPCEmitTimePseudo<(outs g8rc:$result), (ins g8rc:$negsize, memri:$fpsi),
                        [(set i64:$result,
                              (PPCdynalloc i64:$negsize, iaddr:$fpsi))]>;
-def DYNAREAOFFSET8 : PPCEmitTimePseudo<(outs i64imm:$result), (ins memri:$fpsi), "#DYNAREAOFFSET8",
+def DYNAREAOFFSET8 : PPCEmitTimePseudo<(outs i64imm:$result), (ins memri:$fpsi),
                        [(set i64:$result, (PPCdynareaoffset iaddr:$fpsi))]>;
 // Probed alloca to support stack clash protection.
 let Defs = [X1], Uses = [X1], hasNoSchedulingInfo = 1 in {
@@ -581,15 +579,13 @@ def PROBED_ALLOCA_64 : PPCCustomInserterPseudo<(outs g8rc:$result),
                              (PPCprobedalloca i64:$negsize, iaddr:$fpsi))]>;
 def PREPARE_PROBED_ALLOCA_64 : PPCEmitTimePseudo<(outs
     g8rc:$fp, g8rc:$actual_negsize),
-    (ins g8rc:$negsize, memri:$fpsi), "#PREPARE_PROBED_ALLOCA_64", []>;
+    (ins g8rc:$negsize, memri:$fpsi)>;
 def PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_64 : PPCEmitTimePseudo<(outs
     g8rc:$fp, g8rc:$actual_negsize),
-    (ins g8rc:$negsize, memri:$fpsi),
-    "#PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_64", []>,
+    (ins g8rc:$negsize, memri:$fpsi)>,
     RegConstraint<"$actual_negsize = $negsize">;
 def PROBED_STACKALLOC_64 : PPCEmitTimePseudo<(outs g8rc:$scratch, g8rc:$temp),
-    (ins i64imm:$stacksize),
-    "#PROBED_STACKALLOC_64", []>;
+    (ins i64imm:$stacksize)>;
 }
 
 let hasSideEffects = 0 in {
@@ -1397,19 +1393,15 @@ def LD   : DSForm_1<58, 0, (outs g8rc:$RST), (ins (memrix $D, $RA):$addr),
 // Otherwise, we need to create two instructions to form a 32-bit offset,
 // so we have a custom matcher for TOC_ENTRY in PPCDAGToDAGIsel::Select().
 def LDtoc: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtoc",
                   [(set i64:$rD,
                      (PPCtoc_entry tglobaladdr:$disp, i64:$reg))]>, isPPC64;
 def LDtocJTI: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtocJTI",
                   [(set i64:$rD,
                      (PPCtoc_entry tjumptable:$disp, i64:$reg))]>, isPPC64;
 def LDtocCPT: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtocCPT",
                   [(set i64:$rD,
                      (PPCtoc_entry tconstpool:$disp, i64:$reg))]>, isPPC64;
 def LDtocBA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc:$reg),
-                  "#LDtocCPT",
                   [(set i64:$rD,
                      (PPCtoc_entry tblockaddress:$disp, i64:$reg))]>, isPPC64;
 
@@ -1459,8 +1451,7 @@ def LQ   : DQForm_RTp5_RA17_MEM<56, 0,
 // RA and RB.
 def LQX_PSEUDO : PPCCustomInserterPseudo<(outs g8prc:$RTp), (ins memrr:$src)>;
 
-def RESTORE_QUADWORD : PPCEmitTimePseudo<(outs g8prc:$RTp), (ins memrix:$src),
-                                         "#RESTORE_QUADWORD", []>;
+def RESTORE_QUADWORD : PPCEmitTimePseudo<(outs g8prc:$RTp), (ins memrix:$src)>;
 }
 
 }
@@ -1474,30 +1465,27 @@ def : Pat<(int_ppc_atomic_load_i128 ForceXForm:$src),
 // Support for medium and large code model.
 let hasSideEffects = 0 in {
 let isReMaterializable = 1 in {
-def ADDIStocHA8: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, tocentry:$disp),
-                       "#ADDIStocHA8", []>, isPPC64;
-def ADDItocL8: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, tocentry:$disp),
-                     "#ADDItocL8", []>, isPPC64;
+def ADDIStocHA8: PPCEmitTimePseudo<(outs g8rc:$rD),
+                                   (ins g8rc_nox0:$reg, tocentry:$disp)>, isPPC64;
+def ADDItocL8: PPCEmitTimePseudo<(outs g8rc:$rD),
+                                 (ins g8rc_nox0:$reg, tocentry:$disp)>, isPPC64;
 }
 
 // Local Data Transform
-def ADDItoc8 : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, tocentry:$disp),
-                   "#ADDItoc8",
-                   []>, isPPC64;
+def ADDItoc8 : PPCEmitTimePseudo<(outs g8rc:$rD),
+                                 (ins g8rc_nox0:$reg, tocentry:$disp)>, isPPC64;
 let mayLoad = 1 in
-def LDtocL: PPCEmitTimePseudo<(outs g8rc:$rD), (ins tocentry:$disp, g8rc_nox0:$reg),
-                   "#LDtocL", []>, isPPC64;
+def LDtocL: PPCEmitTimePseudo<(outs g8rc:$rD),
+                              (ins tocentry:$disp, g8rc_nox0:$reg)>, isPPC64;
 }
 
 // Support for thread-local storage.
 def ADDISgotTprelHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDISgotTprelHA",
                          [(set i64:$rD,
                            (PPCaddisGotTprelHA i64:$reg,
                                                tglobaltlsaddr:$disp))]>,
                   isPPC64;
 def LDgotTprelL: PPCEmitTimePseudo<(outs g8rc_nox0:$rD), (ins s16imm64:$disp, g8rc_nox0:$reg),
-                        "#LDgotTprelL",
                         [(set i64:$rD,
                           (PPCldGotTprelL tglobaltlsaddr:$disp, i64:$reg))]>,
                  isPPC64;
@@ -1508,25 +1496,23 @@ def CFENCE8 : PPCPostRAExpPseudo<(outs), (ins g8rc:$cr)>;
 def : Pat<(PPCaddTls i64:$in, tglobaltlsaddr:$g),
           (ADD8TLS $in, tglobaltlsaddr:$g)>;
 def ADDIStlsgdHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDIStlsgdHA",
                          [(set i64:$rD,
                            (PPCaddisTlsgdHA i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
 def ADDItlsgdL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                       "#ADDItlsgdL",
                        [(set i64:$rD,
                          (PPCaddiTlsgdL i64:$reg, tglobaltlsaddr:$disp))]>,
                  isPPC64;
 
 class GETtlsADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$reg, tlsgd:$sym),
-                                             asmstr,
                                              [(set i64:$rD,
-                                               (PPCgetTlsAddr i64:$reg, tglobaltlsaddr:$sym))]>,
+                                               (PPCgetTlsAddr i64:$reg, tglobaltlsaddr:$sym))],
+                                             asmstr>,
                                       isPPC64;
 class GETtlsldADDRPseudo <string asmstr> : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$reg, tlsgd:$sym),
-                                             asmstr,
                                              [(set i64:$rD,
-                                               (PPCgetTlsldAddr i64:$reg, tglobaltlsaddr:$sym))]>,
+                                               (PPCgetTlsldAddr i64:$reg, tglobaltlsaddr:$sym))],
+                                             asmstr>,
                                       isPPC64;
 
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1 in {
@@ -1554,15 +1540,15 @@ def GETtlsldADDRPCREL : GETtlsldADDRPseudo <"#GETtlsldADDRPCREL">;
 let Defs = [X0,X4,X5,X11,LR8,CR0] in {
 def GETtlsADDR64AIX :
   PPCEmitTimePseudo<(outs g8rc:$rD),(ins g8rc:$offset, g8rc:$handle),
-                    "GETtlsADDR64AIX",
                     [(set i64:$rD,
-                      (PPCgetTlsAddr i64:$offset, i64:$handle))]>, isPPC64;
+                      (PPCgetTlsAddr i64:$offset, i64:$handle))],
+                    "GETtlsADDR64AIX">, isPPC64;
 // On AIX, the call to .__tls_get_mod needs one input in X3 for the module handle.
 def GETtlsMOD64AIX :
   PPCEmitTimePseudo<(outs g8rc:$rD),(ins g8rc:$handle),
-                    "GETtlsMOD64AIX",
                     [(set i64:$rD,
-                      (PPCgetTlsMod i64:$handle))]>, isPPC64;
+                      (PPCgetTlsMod i64:$handle))],
+                    "GETtlsMOD64AIX">, isPPC64;
 }
 }
 
@@ -1573,19 +1559,16 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     in
 def ADDItlsgdLADDR : PPCEmitTimePseudo<(outs g8rc:$rD),
                             (ins g8rc_nox0:$reg, s16imm64:$disp, tlsgd:$sym),
-                            "#ADDItlsgdLADDR",
                             [(set i64:$rD,
                               (PPCaddiTlsgdLAddr i64:$reg,
                                                  tglobaltlsaddr:$disp,
                                                  tglobaltlsaddr:$sym))]>,
                      isPPC64;
 def ADDIStlsldHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDIStlsldHA",
                          [(set i64:$rD,
                            (PPCaddisTlsldHA i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
 def ADDItlsldL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                       "#ADDItlsldL",
                        [(set i64:$rD,
                          (PPCaddiTlsldL i64:$reg, tglobaltlsaddr:$disp))]>,
                  isPPC64;
@@ -1593,12 +1576,11 @@ def ADDItlsldL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm6
 // the region handle in R3 and GETtlsADDR64AIX.
 def TLSGDAIX8 :
   PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$offset, g8rc:$handle),
-                     "#TLSGDAIX8",
                      [(set i64:$rD,
                        (PPCTlsgdAIX i64:$offset, i64:$handle))]>;
 // This pseudo is expanded to the call to GETtlsMOD64AIX.
 def TLSLDAIX8 : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc:$handle),
-                     "#TLSLDAIX8", [(set i64:$rD, (PPCTlsldAIX i64:$handle))]>;
+                     [(set i64:$rD, (PPCTlsldAIX i64:$handle))]>;
 // Combined op for ADDItlsldL and GETtlsADDR, late expanded.  X3 and LR8
 // are true defines, while the rest of the Defs are clobbers.
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
@@ -1606,26 +1588,22 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     in
 def ADDItlsldLADDR : PPCEmitTimePseudo<(outs g8rc:$rD),
                             (ins g8rc_nox0:$reg, s16imm64:$disp, tlsgd:$sym),
-                            "#ADDItlsldLADDR",
                             [(set i64:$rD,
                               (PPCaddiTlsldLAddr i64:$reg,
                                                  tglobaltlsaddr:$disp,
                                                  tglobaltlsaddr:$sym))]>,
                      isPPC64;
 def ADDISdtprelHA: PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                          "#ADDISdtprelHA",
                           [(set i64:$rD,
                             (PPCaddisDtprelHA i64:$reg,
                                               tglobaltlsaddr:$disp))]>,
                    isPPC64;
 def ADDIdtprelL : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                         "#ADDIdtprelL",
                          [(set i64:$rD,
                            (PPCaddiDtprelL i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
 let Size = 8 in
 def PADDIdtprel : PPCEmitTimePseudo<(outs g8rc:$rD), (ins g8rc_nox0:$reg, s16imm64:$disp),
-                          "#PADDIdtprel",
                           [(set i64:$rD,
                             (PPCpaddiDtprel i64:$reg, tglobaltlsaddr:$disp))]>,
                   isPPC64;
@@ -1681,8 +1659,7 @@ def STQ : DSForm_1<62, 2, (outs), (ins g8prc:$RST, (memrix $D, $RA):$addr),
 
 def STQX_PSEUDO : PPCCustomInserterPseudo<(outs), (ins g8prc:$RSp, memrr:$dst)>;
 
-def SPILL_QUADWORD : PPCEmitTimePseudo<(outs), (ins g8prc:$RSp, memrix:$dst),
-                                       "#SPILL_QUADWORD", []>;
+def SPILL_QUADWORD : PPCEmitTimePseudo<(outs), (ins g8prc:$RSp, memrix:$dst)>;
 }
 
 }

--- a/llvm/lib/Target/PowerPC/PPCInstrFormats.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFormats.td
@@ -2387,7 +2387,8 @@ class Z23Form_FRTB5_R1_RMC2<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 //===----------------------------------------------------------------------===//
 // EmitTimePseudo won't have encoding information for the [MC]CodeEmitter
 // stuff
-class PPCEmitTimePseudo<dag OOL, dag IOL, string asmstr, list<dag> pattern>
+class PPCEmitTimePseudo<dag OOL, dag IOL, list<dag> pattern = [],
+                         string asmstr = "#" # NAME>
     : I<0, OOL, IOL, asmstr, NoItinerary> {
   let isCodeGenOnly = 1;
   let PPC64 = 0;
@@ -2400,7 +2401,7 @@ class PPCEmitTimePseudo<dag OOL, dag IOL, string asmstr, list<dag> pattern>
 // a.k.a. ISelPseudos, however, these won't have isPseudo set
 class PPCCustomInserterPseudo<dag OOL, dag IOL, list<dag> pattern = [],
                          string asmstr = "#" # NAME>
-    : PPCEmitTimePseudo<OOL, IOL, asmstr, pattern> {
+    : PPCEmitTimePseudo<OOL, IOL, pattern, asmstr> {
   let usesCustomInserter = 1;
 }
 
@@ -2408,7 +2409,7 @@ class PPCCustomInserterPseudo<dag OOL, dag IOL, list<dag> pattern = [],
 // files is set only for PostRAPseudo
 class PPCPostRAExpPseudo<dag OOL, dag IOL, list<dag> pattern = [],
                          string asmstr = "#" # NAME>
-    : PPCEmitTimePseudo<OOL, IOL, asmstr, pattern> {
+    : PPCEmitTimePseudo<OOL, IOL, pattern, asmstr> {
   let isPseudo = 1;
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrFormats.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFormats.td
@@ -2400,14 +2400,14 @@ class PPCEmitTimePseudo<dag OOL, dag IOL, list<dag> pattern = [],
 // Instruction that require custom insertion support
 // a.k.a. ISelPseudos, however, these won't have isPseudo set
 class PPCCustomInserterPseudo<dag OOL, dag IOL, list<dag> pattern = []>
-    : PPCEmitTimePseudo<OOL, IOL, "", pattern> {
+    : PPCEmitTimePseudo<OOL, IOL, pattern, ""> {
   let usesCustomInserter = 1;
 }
 
 // PostRAPseudo will be expanded in expandPostRAPseudo, isPseudo flag in td
 // files is set only for PostRAPseudo
 class PPCPostRAExpPseudo<dag OOL, dag IOL, list<dag> pattern = []>
-    : PPCEmitTimePseudo<OOL, IOL, "", pattern> {
+    : PPCEmitTimePseudo<OOL, IOL, pattern, ""> {
   let isPseudo = 1;
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrFormats.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFormats.td
@@ -2387,7 +2387,8 @@ class Z23Form_FRTB5_R1_RMC2<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 //===----------------------------------------------------------------------===//
 // EmitTimePseudo won't have encoding information for the [MC]CodeEmitter
 // stuff
-class PPCEmitTimePseudo<dag OOL, dag IOL, string asmstr, list<dag> pattern>
+class PPCEmitTimePseudo<dag OOL, dag IOL, list<dag> pattern = [],
+                         string asmstr = "#" # NAME>
     : I<0, OOL, IOL, asmstr, NoItinerary> {
   let isCodeGenOnly = 1;
   let PPC64 = 0;

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -1487,19 +1487,19 @@ multiclass Z22Form_FRTA5_SH6r<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 let hasCtrlDep = 1 in {
 let Defs = [R1], Uses = [R1] in {
 def ADJCALLSTACKDOWN : PPCEmitTimePseudo<(outs), (ins u32imm:$amt1, u32imm:$amt2),
-                              "#ADJCALLSTACKDOWN $amt1 $amt2",
-                              [(callseq_start u32imm_timm:$amt1, u32imm_timm:$amt2)]>;
+                              [(callseq_start u32imm_timm:$amt1, u32imm_timm:$amt2)],
+                              "#ADJCALLSTACKDOWN $amt1 $amt2">;
 def ADJCALLSTACKUP   : PPCEmitTimePseudo<(outs), (ins u32imm:$amt1, u32imm:$amt2),
-                              "#ADJCALLSTACKUP $amt1 $amt2",
-                              [(callseq_end u32imm_timm:$amt1, u32imm_timm:$amt2)]>;
+                              [(callseq_end u32imm_timm:$amt1, u32imm_timm:$amt2)],
+                              "#ADJCALLSTACKUP $amt1 $amt2">;
 }
 } // hasCtrlDep
 
 let Defs = [R1], Uses = [R1] in
-def DYNALLOC : PPCEmitTimePseudo<(outs gprc:$result), (ins gprc:$negsize, memri:$fpsi), "#DYNALLOC",
+def DYNALLOC : PPCEmitTimePseudo<(outs gprc:$result), (ins gprc:$negsize, memri:$fpsi),
                        [(set i32:$result,
                              (PPCdynalloc i32:$negsize, iaddr:$fpsi))]>;
-def DYNAREAOFFSET : PPCEmitTimePseudo<(outs i32imm:$result), (ins memri:$fpsi), "#DYNAREAOFFSET",
+def DYNAREAOFFSET : PPCEmitTimePseudo<(outs i32imm:$result), (ins memri:$fpsi),
                        [(set i32:$result, (PPCdynareaoffset iaddr:$fpsi))]>;
 // Probed alloca to support stack clash protection.
 let Defs = [R1], Uses = [R1], hasNoSchedulingInfo = 1 in {
@@ -1509,15 +1509,13 @@ def PROBED_ALLOCA_32 : PPCCustomInserterPseudo<(outs gprc:$result),
                              (PPCprobedalloca i32:$negsize, iaddr:$fpsi))]>;
 def PREPARE_PROBED_ALLOCA_32 : PPCEmitTimePseudo<(outs
     gprc:$fp, gprc:$actual_negsize),
-    (ins gprc:$negsize, memri:$fpsi), "#PREPARE_PROBED_ALLOCA_32", []>;
+    (ins gprc:$negsize, memri:$fpsi)>;
 def PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_32 : PPCEmitTimePseudo<(outs
     gprc:$fp, gprc:$actual_negsize),
-    (ins gprc:$negsize, memri:$fpsi),
-    "#PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_32", []>,
+    (ins gprc:$negsize, memri:$fpsi)>,
     RegConstraint<"$actual_negsize = $negsize">;
 def PROBED_STACKALLOC_32 : PPCEmitTimePseudo<(outs gprc:$scratch, gprc:$temp),
-    (ins i64imm:$stacksize),
-    "#PROBED_STACKALLOC_32", []>;
+    (ins i64imm:$stacksize)>;
 }
 
 // SELECT_CC_* - Used to implement the SELECT_CC DAG operation.  Expanded after
@@ -1569,19 +1567,15 @@ let Predicates = [HasFPU] in {
 // SPILL_CR - Indicate that we're dumping the CR register, so we'll need to
 // scavenge a register for it.
 let mayStore = 1 in {
-def SPILL_CR : PPCEmitTimePseudo<(outs), (ins crrc:$cond, memri:$F),
-                     "#SPILL_CR", []>;
-def SPILL_CRBIT : PPCEmitTimePseudo<(outs), (ins crbitrc:$cond, memri:$F),
-                         "#SPILL_CRBIT", []>;
+def SPILL_CR : PPCEmitTimePseudo<(outs), (ins crrc:$cond, memri:$F)>;
+def SPILL_CRBIT : PPCEmitTimePseudo<(outs), (ins crbitrc:$cond, memri:$F)>;
 }
 
 // RESTORE_CR - Indicate that we're restoring the CR register (previously
 // spilled), so we'll need to scavenge a register for it.
 let mayLoad = 1 in {
-def RESTORE_CR : PPCEmitTimePseudo<(outs crrc:$cond), (ins memri:$F),
-                     "#RESTORE_CR", []>;
-def RESTORE_CRBIT : PPCEmitTimePseudo<(outs crbitrc:$cond), (ins memri:$F),
-                           "#RESTORE_CRBIT", []>;
+def RESTORE_CR : PPCEmitTimePseudo<(outs crrc:$cond), (ins memri:$F)>;
+def RESTORE_CRBIT : PPCEmitTimePseudo<(outs crbitrc:$cond), (ins memri:$F)>;
 }
 
 let isTerminator = 1, isBarrier = 1, PPC970_Unit = 7, hasSideEffects = 0 in {
@@ -1619,13 +1613,13 @@ def SETFLM : PPCCustomInserterPseudo<(outs f8rc:$FRT), (ins f8rc:$FLM),
 }
 
 let isBarrier = 1, hasSideEffects = 1, Defs = [RM] in
-def FENCE : PPCEmitTimePseudo<(outs), (ins), "#FENCE", []>;
+def FENCE : PPCEmitTimePseudo<(outs), (ins)>;
 
 let Defs = [LR] in
-  def MovePCtoLR : PPCEmitTimePseudo<(outs), (ins), "#MovePCtoLR", []>,
+  def MovePCtoLR : PPCEmitTimePseudo<(outs), (ins)>,
                    PPC970_Unit_BRU;
 let Defs = [LR] in
-  def MoveGOTtoLR : PPCEmitTimePseudo<(outs), (ins), "#MoveGOTtoLR", []>,
+  def MoveGOTtoLR : PPCEmitTimePseudo<(outs), (ins)>,
                     PPC970_Unit_BRU;
 
 let isBranch = 1, isTerminator = 1, hasCtrlDep = 1, PPC970_Unit = 7,
@@ -1853,19 +1847,19 @@ let isCall = 1, PPC970_Unit = 7, Defs = [LR, RM], isCodeGenOnly = 1 in {
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNdi :PPCEmitTimePseudo< (outs),
                         (ins calltarget:$dst, i32imm:$offset),
-                 "#TC_RETURNd $dst $offset",
-                 []>;
+                 [],
+                 "#TC_RETURNd $dst $offset">;
 
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNai :PPCEmitTimePseudo<(outs), (ins abscalltarget:$func, i32imm:$offset),
-                 "#TC_RETURNa $func $offset",
-                 [(PPCtc_return (i32 imm:$func), imm:$offset)]>;
+                 [(PPCtc_return (i32 imm:$func), imm:$offset)],
+                 "#TC_RETURNa $func $offset">;
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNri : PPCEmitTimePseudo<(outs), (ins CTRRC:$dst, i32imm:$offset),
-                 "#TC_RETURNr $dst $offset",
-                 []>;
+                 [],
+                 "#TC_RETURNr $dst $offset">;
 
 let isCall = 1, PPC970_Unit = 7, isCodeGenOnly = 1,
     Defs = [LR, R2], Uses = [CTR, RM], RST = 2 in {
@@ -1948,7 +1942,7 @@ let hasSideEffects = 1, isBarrier = 1 in {
 // from emitting it.
 let isBranch = 1, isTerminator = 1, Size = 0 in {
   def EH_SjLj_Setup : PPCEmitTimePseudo<(outs), (ins directbrtarget:$dst),
-                        "#EH_SjLj_Setup\t$dst", []>;
+                        [], "#EH_SjLj_Setup\t$dst">;
 }
 
 // System call.
@@ -2496,8 +2490,8 @@ let isCodeGenOnly = 1 in {
 def EnforceIEIO : XForm_24_eieio<31, 854, (outs), (ins),
                                  "eieio", IIC_LdStLoad, []>;
 
-def PseudoEIEIO : PPCEmitTimePseudo<(outs), (ins), "#PPCEIEIO",
-                  [(int_ppc_eieio)]> {
+def PseudoEIEIO : PPCEmitTimePseudo<(outs), (ins), [(int_ppc_eieio)],
+                            "#PPCEIEIO"> {
   let Size = 12;
 }
 
@@ -2953,7 +2947,7 @@ def MTCTRloop : XFXForm_1_ext<31, 467, 9, (outs), (ins gprc:$RST),
 
 let hasSideEffects = 1, hasNoSchedulingInfo = 1, isNotDuplicable = 1, Uses = [CTR], Defs = [CTR] in
 def DecreaseCTRloop : PPCEmitTimePseudo<(outs crbitrc:$rT), (ins i32imm:$stride),
-                                       "#DecreaseCTRloop", [(set i1:$rT, (int_loop_decrement (i32 imm:$stride)))]>;
+                                       [(set i1:$rT, (int_loop_decrement (i32 imm:$stride)))]>;
 
 let hasSideEffects = 0 in {
 let Defs = [LR] in {
@@ -3472,7 +3466,7 @@ def : Pat<(add i32:$in, (PPChi tblockaddress:$g, 0)),
           (ADDIS $in, tblockaddress:$g)>;
 
 // Support for thread-local storage.
-def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins), "#PPC32GOT",
+def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins),
                 [(set i32:$rD, (PPCppc32GOT))]> {
   let Size = 8;
 }
@@ -3481,20 +3475,17 @@ def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins), "#PPC32GOT",
 // This uses two output registers, the first as the real output, the second as a
 // temporary register, used internally in code generation. A "bl" also clobbers LR.
 let Defs = [LR] in
-def PPC32PICGOT: PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins), "#PPC32PICGOT",
-                []> {
+def PPC32PICGOT: PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins)> {
   let Size = 20;
 }
 
 def LDgotTprelL32: PPCEmitTimePseudo<(outs gprc_nor0:$rD), (ins s16imm:$disp, gprc_nor0:$reg),
-                           "#LDgotTprelL32",
                            [(set i32:$rD,
                              (PPCldGotTprelL tglobaltlsaddr:$disp, i32:$reg))]>;
 def : Pat<(PPCaddTls i32:$in, tglobaltlsaddr:$g),
           (ADD4TLS $in, tglobaltlsaddr:$g)>;
 
 def ADDItlsgdL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                         "#ADDItlsgdL32",
                          [(set i32:$rD,
                            (PPCaddiTlsgdL i32:$reg, tglobaltlsaddr:$disp))]>;
 // LR is a true define, while the rest of the Defs are clobbers.  R3 is
@@ -3502,7 +3493,6 @@ def ADDItlsgdL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16im
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$sym),
-                          "GETtlsADDR32",
                           [(set i32:$rD,
                             (PPCgetTlsAddr i32:$reg, tglobaltlsaddr:$sym))]>;
 // R3 is explicitly defined when this op is created, so not mentioned here.
@@ -3511,11 +3501,9 @@ def GETtlsADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$s
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R11,LR,CR0] in {
 def GETtlsADDR32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$offset, gprc:$handle),
-                          "GETtlsADDR32AIX",
                           [(set i32:$rD,
                             (PPCgetTlsAddr i32:$offset, i32:$handle))]>;
 def GETtlsMOD32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
-                          "GETtlsMOD32AIX",
                           [(set i32:$rD,
                             (PPCgetTlsMod i32:$handle))]>;
 }
@@ -3526,7 +3514,6 @@ def GETtlsMOD32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R3,LR] in
 def GETtlsTpointer32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins),
-                          "GETtlsTpointer32AIX",
                           [(set i32:$rD, (PPCgetTpointer))]>;
 
 // The following pattern matches local- and initial-exec TLS accesses on 32-bit AIX.
@@ -3543,30 +3530,26 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R3,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def ADDItlsgdLADDR32 : PPCEmitTimePseudo<(outs gprc:$rD),
                               (ins gprc_nor0:$reg, s16imm:$disp, tlsgd32:$sym),
-                              "#ADDItlsgdLADDR32",
                               [(set i32:$rD,
                                 (PPCaddiTlsgdLAddr i32:$reg,
                                                    tglobaltlsaddr:$disp,
                                                    tglobaltlsaddr:$sym))]>;
 def ADDItlsldL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                          "#ADDItlsldL32",
                           [(set i32:$rD,
                             (PPCaddiTlsldL i32:$reg, tglobaltlsaddr:$disp))]>;
 // This pseudo is expanded to two copies to put the variable offset in R4 and
 // the region handle in R3 and GETtlsADDR32AIX.
 def TLSGDAIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$offset, gprc:$handle),
-                          "#TLSGDAIX",
                           [(set i32:$rD,
                             (PPCTlsgdAIX i32:$offset, i32:$handle))]>;
 // This pseudo is expanded to the call to GETtlsMOD32AIX.
 def TLSLDAIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
-                          "#TLSLDAIX", [(set i32:$rD, (PPCTlsldAIX i32:$handle))]>;
+                          [(set i32:$rD, (PPCTlsldAIX i32:$handle))]>;
 // LR is a true define, while the rest of the Defs are clobbers.  R3 is
 // explicitly defined when this op is created, so not mentioned here.
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsldADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$sym),
-                            "GETtlsldADDR32",
                             [(set i32:$rD,
                               (PPCgetTlsldAddr i32:$reg,
                                                tglobaltlsaddr:$sym))]>;
@@ -3576,41 +3559,33 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R3,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def ADDItlsldLADDR32 : PPCEmitTimePseudo<(outs gprc:$rD),
                               (ins gprc_nor0:$reg, s16imm:$disp, tlsgd32:$sym),
-                              "#ADDItlsldLADDR32",
                               [(set i32:$rD,
                                 (PPCaddiTlsldLAddr i32:$reg,
                                                    tglobaltlsaddr:$disp,
                                                    tglobaltlsaddr:$sym))]>;
 def ADDIdtprelL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                           "#ADDIdtprelL32",
                            [(set i32:$rD,
                              (PPCaddiDtprelL i32:$reg, tglobaltlsaddr:$disp))]>;
 def ADDISdtprelHA32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                            "#ADDISdtprelHA32",
                             [(set i32:$rD,
                               (PPCaddisDtprelHA i32:$reg,
                                                 tglobaltlsaddr:$disp))]>;
 
 // Support for Position-independent code
 def LWZtoc : PPCEmitTimePseudo<(outs gprc:$rD), (ins tocentry32:$disp, gprc:$reg),
-                   "#LWZtoc",
                    [(set i32:$rD,
                      (PPCtoc_entry tglobaladdr:$disp, i32:$reg))]>;
 def LWZtocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins tocentry32:$disp, gprc_nor0:$reg),
-                    "#LWZtocL",
                     [(set i32:$rD,
                       (PPCtoc_entry tglobaladdr:$disp, i32:$reg))]>;
-def ADDIStocHA : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp),
-                       "#ADDIStocHA", []>;
+def ADDIStocHA : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp)>;
 // TOC Data Transform on AIX
-def ADDItoc : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tocentry32:$disp),
-                   "#ADDItoc", []>;
-def ADDItocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp),
-                   "#ADDItocL", []>;
+def ADDItoc : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tocentry32:$disp)>;
+def ADDItocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp)>;
 
 // Get Global (GOT) Base Register offset, from the word immediately preceding
 // the function label.
-def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI), "#UpdateGBR", []> {
+def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI)> {
   let Size = 8;
 }
 
@@ -3618,7 +3593,7 @@ def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI), "#U
 // cause iterator invalidation in MIR transformation passes, this pseudo can be
 // used instead. It will be removed unconditionally at pre-emit time (prior to
 // branch selection).
-def UNENCODED_NOP: PPCEmitTimePseudo<(outs), (ins), "#UNENCODED_NOP", []>;
+def UNENCODED_NOP: PPCEmitTimePseudo<(outs), (ins)>;
 
 // Standard shifts.  These are represented separately from the real shifts above
 // so that we can distinguish between shifts that allow 5-bit and 6-bit shift

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -3494,7 +3494,8 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$sym),
                           [(set i32:$rD,
-                            (PPCgetTlsAddr i32:$reg, tglobaltlsaddr:$sym))]>;
+                            (PPCgetTlsAddr i32:$reg, tglobaltlsaddr:$sym))],
+                          "GETtlsADDR32">;
 // R3 is explicitly defined when this op is created, so not mentioned here.
 // The rest of the Defs are the exact set of registers that will be clobbered by
 // the call.
@@ -3502,10 +3503,12 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R11,LR,CR0] in {
 def GETtlsADDR32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$offset, gprc:$handle),
                           [(set i32:$rD,
-                            (PPCgetTlsAddr i32:$offset, i32:$handle))]>;
+                            (PPCgetTlsAddr i32:$offset, i32:$handle))],
+                          "GETtlsADDR32AIX">;
 def GETtlsMOD32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
                           [(set i32:$rD,
-                            (PPCgetTlsMod i32:$handle))]>;
+                            (PPCgetTlsMod i32:$handle))],
+                          "GETtlsMOD32AIX">;
 }
 
 // For local-exec accesses on 32-bit AIX, a call to .__get_tpointer is

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -1487,19 +1487,19 @@ multiclass Z22Form_FRTA5_SH6r<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 let hasCtrlDep = 1 in {
 let Defs = [R1], Uses = [R1] in {
 def ADJCALLSTACKDOWN : PPCEmitTimePseudo<(outs), (ins u32imm:$amt1, u32imm:$amt2),
-                              "#ADJCALLSTACKDOWN $amt1 $amt2",
-                              [(callseq_start u32imm_timm:$amt1, u32imm_timm:$amt2)]>;
+                              [(callseq_start u32imm_timm:$amt1, u32imm_timm:$amt2)],
+                              "#ADJCALLSTACKDOWN $amt1 $amt2">;
 def ADJCALLSTACKUP   : PPCEmitTimePseudo<(outs), (ins u32imm:$amt1, u32imm:$amt2),
-                              "#ADJCALLSTACKUP $amt1 $amt2",
-                              [(callseq_end u32imm_timm:$amt1, u32imm_timm:$amt2)]>;
+                              [(callseq_end u32imm_timm:$amt1, u32imm_timm:$amt2)],
+                              "#ADJCALLSTACKUP $amt1 $amt2">;
 }
 } // hasCtrlDep
 
 let Defs = [R1], Uses = [R1] in
-def DYNALLOC : PPCEmitTimePseudo<(outs gprc:$result), (ins gprc:$negsize, memri:$fpsi), "#DYNALLOC",
+def DYNALLOC : PPCEmitTimePseudo<(outs gprc:$result), (ins gprc:$negsize, memri:$fpsi),
                        [(set i32:$result,
                              (PPCdynalloc i32:$negsize, iaddr:$fpsi))]>;
-def DYNAREAOFFSET : PPCEmitTimePseudo<(outs i32imm:$result), (ins memri:$fpsi), "#DYNAREAOFFSET",
+def DYNAREAOFFSET : PPCEmitTimePseudo<(outs i32imm:$result), (ins memri:$fpsi),
                        [(set i32:$result, (PPCdynareaoffset iaddr:$fpsi))]>;
 // Probed alloca to support stack clash protection.
 let Defs = [R1], Uses = [R1], hasNoSchedulingInfo = 1 in {
@@ -1509,15 +1509,13 @@ def PROBED_ALLOCA_32 : PPCCustomInserterPseudo<(outs gprc:$result),
                              (PPCprobedalloca i32:$negsize, iaddr:$fpsi))]>;
 def PREPARE_PROBED_ALLOCA_32 : PPCEmitTimePseudo<(outs
     gprc:$fp, gprc:$actual_negsize),
-    (ins gprc:$negsize, memri:$fpsi), "#PREPARE_PROBED_ALLOCA_32", []>;
+    (ins gprc:$negsize, memri:$fpsi)>;
 def PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_32 : PPCEmitTimePseudo<(outs
     gprc:$fp, gprc:$actual_negsize),
-    (ins gprc:$negsize, memri:$fpsi),
-    "#PREPARE_PROBED_ALLOCA_NEGSIZE_SAME_REG_32", []>,
+    (ins gprc:$negsize, memri:$fpsi)>,
     RegConstraint<"$actual_negsize = $negsize">;
 def PROBED_STACKALLOC_32 : PPCEmitTimePseudo<(outs gprc:$scratch, gprc:$temp),
-    (ins i64imm:$stacksize),
-    "#PROBED_STACKALLOC_32", []>;
+    (ins i64imm:$stacksize)>;
 }
 
 // SELECT_CC_* - Used to implement the SELECT_CC DAG operation.  Expanded after
@@ -1569,19 +1567,15 @@ let Predicates = [HasFPU] in {
 // SPILL_CR - Indicate that we're dumping the CR register, so we'll need to
 // scavenge a register for it.
 let mayStore = 1 in {
-def SPILL_CR : PPCEmitTimePseudo<(outs), (ins crrc:$cond, memri:$F),
-                     "#SPILL_CR", []>;
-def SPILL_CRBIT : PPCEmitTimePseudo<(outs), (ins crbitrc:$cond, memri:$F),
-                         "#SPILL_CRBIT", []>;
+def SPILL_CR : PPCEmitTimePseudo<(outs), (ins crrc:$cond, memri:$F)>;
+def SPILL_CRBIT : PPCEmitTimePseudo<(outs), (ins crbitrc:$cond, memri:$F)>;
 }
 
 // RESTORE_CR - Indicate that we're restoring the CR register (previously
 // spilled), so we'll need to scavenge a register for it.
 let mayLoad = 1 in {
-def RESTORE_CR : PPCEmitTimePseudo<(outs crrc:$cond), (ins memri:$F),
-                     "#RESTORE_CR", []>;
-def RESTORE_CRBIT : PPCEmitTimePseudo<(outs crbitrc:$cond), (ins memri:$F),
-                           "#RESTORE_CRBIT", []>;
+def RESTORE_CR : PPCEmitTimePseudo<(outs crrc:$cond), (ins memri:$F)>;
+def RESTORE_CRBIT : PPCEmitTimePseudo<(outs crbitrc:$cond), (ins memri:$F)>;
 }
 
 let isTerminator = 1, isBarrier = 1, PPC970_Unit = 7, hasSideEffects = 0 in {
@@ -1619,13 +1613,13 @@ def SETFLM : PPCCustomInserterPseudo<(outs f8rc:$FRT), (ins f8rc:$FLM),
 }
 
 let isBarrier = 1, hasSideEffects = 1, Defs = [RM] in
-def FENCE : PPCEmitTimePseudo<(outs), (ins), "#FENCE", []>;
+def FENCE : PPCEmitTimePseudo<(outs), (ins)>;
 
 let Defs = [LR] in
-  def MovePCtoLR : PPCEmitTimePseudo<(outs), (ins), "#MovePCtoLR", []>,
+  def MovePCtoLR : PPCEmitTimePseudo<(outs), (ins)>,
                    PPC970_Unit_BRU;
 let Defs = [LR] in
-  def MoveGOTtoLR : PPCEmitTimePseudo<(outs), (ins), "#MoveGOTtoLR", []>,
+  def MoveGOTtoLR : PPCEmitTimePseudo<(outs), (ins)>,
                     PPC970_Unit_BRU;
 
 let isBranch = 1, isTerminator = 1, hasCtrlDep = 1, PPC970_Unit = 7,
@@ -1853,19 +1847,19 @@ let isCall = 1, PPC970_Unit = 7, Defs = [LR, RM], isCodeGenOnly = 1 in {
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNdi :PPCEmitTimePseudo< (outs),
                         (ins calltarget:$dst, i32imm:$offset),
-                 "#TC_RETURNd $dst $offset",
-                 []>;
+                 [],
+                 "#TC_RETURNd $dst $offset">;
 
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNai :PPCEmitTimePseudo<(outs), (ins abscalltarget:$func, i32imm:$offset),
-                 "#TC_RETURNa $func $offset",
-                 [(PPCtc_return (i32 imm:$func), imm:$offset)]>;
+                 [(PPCtc_return (i32 imm:$func), imm:$offset)],
+                 "#TC_RETURNa $func $offset">;
 
 let isCall = 1, isTerminator = 1, isReturn = 1, isBarrier = 1, Uses = [RM] in
 def TCRETURNri : PPCEmitTimePseudo<(outs), (ins CTRRC:$dst, i32imm:$offset),
-                 "#TC_RETURNr $dst $offset",
-                 []>;
+                 [],
+                 "#TC_RETURNr $dst $offset">;
 
 let isCall = 1, PPC970_Unit = 7, isCodeGenOnly = 1,
     Defs = [LR, R2], Uses = [CTR, RM], RST = 2 in {
@@ -1946,7 +1940,7 @@ let hasSideEffects = 1, isBarrier = 1 in {
 // from emitting it.
 let isBranch = 1, isTerminator = 1, Size = 0 in {
   def EH_SjLj_Setup : PPCEmitTimePseudo<(outs), (ins directbrtarget:$dst),
-                        "#EH_SjLj_Setup\t$dst", []>;
+                        [], "#EH_SjLj_Setup\t$dst">;
 }
 
 // System call.
@@ -2494,8 +2488,8 @@ let isCodeGenOnly = 1 in {
 def EnforceIEIO : XForm_24_eieio<31, 854, (outs), (ins),
                                  "eieio", IIC_LdStLoad, []>;
 
-def PseudoEIEIO : PPCEmitTimePseudo<(outs), (ins), "#PPCEIEIO",
-                  [(int_ppc_eieio)]> {
+def PseudoEIEIO : PPCEmitTimePseudo<(outs), (ins), [(int_ppc_eieio)],
+                            "#PPCEIEIO"> {
   let Size = 12;
 }
 
@@ -2951,7 +2945,7 @@ def MTCTRloop : XFXForm_1_ext<31, 467, 9, (outs), (ins gprc:$RST),
 
 let hasSideEffects = 1, hasNoSchedulingInfo = 1, isNotDuplicable = 1, Uses = [CTR], Defs = [CTR] in
 def DecreaseCTRloop : PPCEmitTimePseudo<(outs crbitrc:$rT), (ins i32imm:$stride),
-                                       "#DecreaseCTRloop", [(set i1:$rT, (int_loop_decrement (i32 imm:$stride)))]>;
+                                       [(set i1:$rT, (int_loop_decrement (i32 imm:$stride)))]>;
 
 let hasSideEffects = 0 in {
 let Defs = [LR] in {
@@ -3470,7 +3464,7 @@ def : Pat<(add i32:$in, (PPChi tblockaddress:$g, 0)),
           (ADDIS $in, tblockaddress:$g)>;
 
 // Support for thread-local storage.
-def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins), "#PPC32GOT",
+def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins),
                 [(set i32:$rD, (PPCppc32GOT))]> {
   let Size = 8;
 }
@@ -3479,20 +3473,17 @@ def PPC32GOT: PPCEmitTimePseudo<(outs gprc:$rD), (ins), "#PPC32GOT",
 // This uses two output registers, the first as the real output, the second as a
 // temporary register, used internally in code generation. A "bl" also clobbers LR.
 let Defs = [LR] in
-def PPC32PICGOT: PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins), "#PPC32PICGOT",
-                []> {
+def PPC32PICGOT: PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins)> {
   let Size = 20;
 }
 
 def LDgotTprelL32: PPCEmitTimePseudo<(outs gprc_nor0:$rD), (ins s16imm:$disp, gprc_nor0:$reg),
-                           "#LDgotTprelL32",
                            [(set i32:$rD,
                              (PPCldGotTprelL tglobaltlsaddr:$disp, i32:$reg))]>;
 def : Pat<(PPCaddTls i32:$in, tglobaltlsaddr:$g),
           (ADD4TLS $in, tglobaltlsaddr:$g)>;
 
 def ADDItlsgdL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                         "#ADDItlsgdL32",
                          [(set i32:$rD,
                            (PPCaddiTlsgdL i32:$reg, tglobaltlsaddr:$disp))]>;
 // LR is a true define, while the rest of the Defs are clobbers.  R3 is
@@ -3500,7 +3491,6 @@ def ADDItlsgdL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16im
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$sym),
-                          "GETtlsADDR32",
                           [(set i32:$rD,
                             (PPCgetTlsAddr i32:$reg, tglobaltlsaddr:$sym))]>;
 // R3 is explicitly defined when this op is created, so not mentioned here.
@@ -3509,11 +3499,9 @@ def GETtlsADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$s
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R11,LR,CR0] in {
 def GETtlsADDR32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$offset, gprc:$handle),
-                          "GETtlsADDR32AIX",
                           [(set i32:$rD,
                             (PPCgetTlsAddr i32:$offset, i32:$handle))]>;
 def GETtlsMOD32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
-                          "GETtlsMOD32AIX",
                           [(set i32:$rD,
                             (PPCgetTlsMod i32:$handle))]>;
 }
@@ -3524,7 +3512,6 @@ def GETtlsMOD32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R3,LR] in
 def GETtlsTpointer32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins),
-                          "GETtlsTpointer32AIX",
                           [(set i32:$rD, (PPCgetTpointer))]>;
 
 // The following pattern matches local- and initial-exec TLS accesses on 32-bit AIX.
@@ -3541,30 +3528,26 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R3,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def ADDItlsgdLADDR32 : PPCEmitTimePseudo<(outs gprc:$rD),
                               (ins gprc_nor0:$reg, s16imm:$disp, tlsgd32:$sym),
-                              "#ADDItlsgdLADDR32",
                               [(set i32:$rD,
                                 (PPCaddiTlsgdLAddr i32:$reg,
                                                    tglobaltlsaddr:$disp,
                                                    tglobaltlsaddr:$sym))]>;
 def ADDItlsldL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                          "#ADDItlsldL32",
                           [(set i32:$rD,
                             (PPCaddiTlsldL i32:$reg, tglobaltlsaddr:$disp))]>;
 // This pseudo is expanded to two copies to put the variable offset in R4 and
 // the region handle in R3 and GETtlsADDR32AIX.
 def TLSGDAIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$offset, gprc:$handle),
-                          "#TLSGDAIX",
                           [(set i32:$rD,
                             (PPCTlsgdAIX i32:$offset, i32:$handle))]>;
 // This pseudo is expanded to the call to GETtlsMOD32AIX.
 def TLSLDAIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
-                          "#TLSLDAIX", [(set i32:$rD, (PPCTlsldAIX i32:$handle))]>;
+                          [(set i32:$rD, (PPCTlsldAIX i32:$handle))]>;
 // LR is a true define, while the rest of the Defs are clobbers.  R3 is
 // explicitly defined when this op is created, so not mentioned here.
 let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsldADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$sym),
-                            "GETtlsldADDR32",
                             [(set i32:$rD,
                               (PPCgetTlsldAddr i32:$reg,
                                                tglobaltlsaddr:$sym))]>;
@@ -3574,41 +3557,33 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R3,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def ADDItlsldLADDR32 : PPCEmitTimePseudo<(outs gprc:$rD),
                               (ins gprc_nor0:$reg, s16imm:$disp, tlsgd32:$sym),
-                              "#ADDItlsldLADDR32",
                               [(set i32:$rD,
                                 (PPCaddiTlsldLAddr i32:$reg,
                                                    tglobaltlsaddr:$disp,
                                                    tglobaltlsaddr:$sym))]>;
 def ADDIdtprelL32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                           "#ADDIdtprelL32",
                            [(set i32:$rD,
                              (PPCaddiDtprelL i32:$reg, tglobaltlsaddr:$disp))]>;
 def ADDISdtprelHA32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, s16imm:$disp),
-                            "#ADDISdtprelHA32",
                             [(set i32:$rD,
                               (PPCaddisDtprelHA i32:$reg,
                                                 tglobaltlsaddr:$disp))]>;
 
 // Support for Position-independent code
 def LWZtoc : PPCEmitTimePseudo<(outs gprc:$rD), (ins tocentry32:$disp, gprc:$reg),
-                   "#LWZtoc",
                    [(set i32:$rD,
                      (PPCtoc_entry tglobaladdr:$disp, i32:$reg))]>;
 def LWZtocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins tocentry32:$disp, gprc_nor0:$reg),
-                    "#LWZtocL",
                     [(set i32:$rD,
                       (PPCtoc_entry tglobaladdr:$disp, i32:$reg))]>;
-def ADDIStocHA : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp),
-                       "#ADDIStocHA", []>;
+def ADDIStocHA : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp)>;
 // TOC Data Transform on AIX
-def ADDItoc : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tocentry32:$disp),
-                   "#ADDItoc", []>;
-def ADDItocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp),
-                   "#ADDItocL", []>;
+def ADDItoc : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tocentry32:$disp)>;
+def ADDItocL : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc_nor0:$reg, tocentry32:$disp)>;
 
 // Get Global (GOT) Base Register offset, from the word immediately preceding
 // the function label.
-def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI), "#UpdateGBR", []> {
+def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI)> {
   let Size = 8;
 }
 
@@ -3616,7 +3591,7 @@ def UpdateGBR : PPCEmitTimePseudo<(outs gprc:$rD, gprc:$rT), (ins gprc:$rI), "#U
 // cause iterator invalidation in MIR transformation passes, this pseudo can be
 // used instead. It will be removed unconditionally at pre-emit time (prior to
 // branch selection).
-def UNENCODED_NOP: PPCEmitTimePseudo<(outs), (ins), "#UNENCODED_NOP", []>;
+def UNENCODED_NOP: PPCEmitTimePseudo<(outs), (ins)>;
 
 // Standard shifts.  These are represented separately from the real shifts above
 // so that we can distinguish between shifts that allow 5-bit and 6-bit shift

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -3492,7 +3492,8 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R6,R7,R8,R9,R10,R11,R12,LR,CTR,CR0,CR1,CR5,CR6,CR7] in
 def GETtlsADDR32 : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$reg, tlsgd32:$sym),
                           [(set i32:$rD,
-                            (PPCgetTlsAddr i32:$reg, tglobaltlsaddr:$sym))]>;
+                            (PPCgetTlsAddr i32:$reg, tglobaltlsaddr:$sym))],
+                          "GETtlsADDR32">;
 // R3 is explicitly defined when this op is created, so not mentioned here.
 // The rest of the Defs are the exact set of registers that will be clobbered by
 // the call.
@@ -3500,10 +3501,12 @@ let hasExtraSrcRegAllocReq = 1, hasExtraDefRegAllocReq = 1,
     Defs = [R0,R4,R5,R11,LR,CR0] in {
 def GETtlsADDR32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$offset, gprc:$handle),
                           [(set i32:$rD,
-                            (PPCgetTlsAddr i32:$offset, i32:$handle))]>;
+                            (PPCgetTlsAddr i32:$offset, i32:$handle))],
+                          "GETtlsADDR32AIX">;
 def GETtlsMOD32AIX : PPCEmitTimePseudo<(outs gprc:$rD), (ins gprc:$handle),
                           [(set i32:$rD,
-                            (PPCgetTlsMod i32:$handle))]>;
+                            (PPCgetTlsMod i32:$handle))],
+                          "GETtlsMOD32AIX">;
 }
 
 // For local-exec accesses on 32-bit AIX, a call to .__get_tpointer is

--- a/llvm/lib/Target/PowerPC/PPCInstrMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrMMA.td
@@ -520,16 +520,12 @@ let Predicates = [MMA, IsNotISAFuture] in {
                      "xvi8ger4spp $AT, $XA, $XB", IIC_VecGeneral, []>,
     RegConstraint<"$ATi = $AT">;
   let mayStore = 1 in {
-    def SPILL_ACC: PPCEmitTimePseudo<(outs), (ins acc:$AT, memrix16:$dst),
-                                     "#SPILL_ACC", []>;
-    def SPILL_UACC: PPCEmitTimePseudo<(outs), (ins uacc:$AT, memrix16:$dst),
-                                     "#SPILL_UACC", []>;
+    def SPILL_ACC: PPCEmitTimePseudo<(outs), (ins acc:$AT, memrix16:$dst)>;
+    def SPILL_UACC: PPCEmitTimePseudo<(outs), (ins uacc:$AT, memrix16:$dst)>;
   }
   let mayLoad = 1, hasSideEffects = 0 in {
-    def RESTORE_ACC: PPCEmitTimePseudo<(outs acc:$AT), (ins memrix16:$src),
-                                       "#RESTORE_ACC", []>;
-    def RESTORE_UACC: PPCEmitTimePseudo<(outs uacc:$AT), (ins memrix16:$src),
-                                       "#RESTORE_UACC", []>;
+    def RESTORE_ACC: PPCEmitTimePseudo<(outs acc:$AT), (ins memrix16:$src)>;
+    def RESTORE_UACC: PPCEmitTimePseudo<(outs uacc:$AT), (ins memrix16:$src)>;
   }
 }
 
@@ -562,20 +558,14 @@ let Predicates = [MMA, IsISAFuture], isCodeGenOnly = 1 in {
                      RegConstraint<"$ATi = $AT">;
 
   let mayStore = 1 in {
-    def SPILL_WACC: PPCEmitTimePseudo<(outs), (ins wacc:$AT, memrix16:$dst),
-                                      "#SPILL_WACC", []>;
-    def SPILL_DMRP: PPCEmitTimePseudo<(outs), (ins dmrp:$AT, memrix16:$dst),
-                                      "#SPILL_DMRP", []>;
-    def SPILL_DMR: PPCEmitTimePseudo<(outs), (ins dmr:$AT, memrix16:$dst),
-                                      "#SPILL_DMR", []>;
+    def SPILL_WACC: PPCEmitTimePseudo<(outs), (ins wacc:$AT, memrix16:$dst)>;
+    def SPILL_DMRP: PPCEmitTimePseudo<(outs), (ins dmrp:$AT, memrix16:$dst)>;
+    def SPILL_DMR: PPCEmitTimePseudo<(outs), (ins dmr:$AT, memrix16:$dst)>;
   }
   let mayLoad = 1, hasSideEffects = 0 in {
-    def RESTORE_WACC: PPCEmitTimePseudo<(outs wacc:$AT), (ins memrix16:$src),
-                                        "#RESTORE_WACC", []>;
-    def RESTORE_DMRP: PPCEmitTimePseudo<(outs dmrp:$AT), (ins memrix16:$src),
-                                        "#RESTORE_DMRP", []>;
-    def RESTORE_DMR: PPCEmitTimePseudo<(outs dmr:$AT), (ins memrix16:$src),
-                                        "#RESTORE_DMR", []>;
+    def RESTORE_WACC: PPCEmitTimePseudo<(outs wacc:$AT), (ins memrix16:$src)>;
+    def RESTORE_DMRP: PPCEmitTimePseudo<(outs dmrp:$AT), (ins memrix16:$src)>;
+    def RESTORE_DMR: PPCEmitTimePseudo<(outs dmr:$AT), (ins memrix16:$src)>;
   }
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrMMA.td
@@ -519,16 +519,12 @@ let Predicates = [MMA, IsNotISAFuture] in {
                      "xvi8ger4spp $AT, $XA, $XB", IIC_VecGeneral, []>,
     RegConstraint<"$ATi = $AT">;
   let mayStore = 1 in {
-    def SPILL_ACC: PPCEmitTimePseudo<(outs), (ins acc:$AT, memrix16:$dst),
-                                     "#SPILL_ACC", []>;
-    def SPILL_UACC: PPCEmitTimePseudo<(outs), (ins uacc:$AT, memrix16:$dst),
-                                     "#SPILL_UACC", []>;
+    def SPILL_ACC: PPCEmitTimePseudo<(outs), (ins acc:$AT, memrix16:$dst)>;
+    def SPILL_UACC: PPCEmitTimePseudo<(outs), (ins uacc:$AT, memrix16:$dst)>;
   }
   let mayLoad = 1, hasSideEffects = 0 in {
-    def RESTORE_ACC: PPCEmitTimePseudo<(outs acc:$AT), (ins memrix16:$src),
-                                       "#RESTORE_ACC", []>;
-    def RESTORE_UACC: PPCEmitTimePseudo<(outs uacc:$AT), (ins memrix16:$src),
-                                       "#RESTORE_UACC", []>;
+    def RESTORE_ACC: PPCEmitTimePseudo<(outs acc:$AT), (ins memrix16:$src)>;
+    def RESTORE_UACC: PPCEmitTimePseudo<(outs uacc:$AT), (ins memrix16:$src)>;
   }
 }
 
@@ -561,20 +557,14 @@ let Predicates = [MMA, IsISAFuture], isCodeGenOnly = 1 in {
                      RegConstraint<"$ATi = $AT">;
 
   let mayStore = 1 in {
-    def SPILL_WACC: PPCEmitTimePseudo<(outs), (ins wacc:$AT, memrix16:$dst),
-                                      "#SPILL_WACC", []>;
-    def SPILL_DMRP: PPCEmitTimePseudo<(outs), (ins dmrp:$AT, memrix16:$dst),
-                                      "#SPILL_DMRP", []>;
-    def SPILL_DMR: PPCEmitTimePseudo<(outs), (ins dmr:$AT, memrix16:$dst),
-                                      "#SPILL_DMR", []>;
+    def SPILL_WACC: PPCEmitTimePseudo<(outs), (ins wacc:$AT, memrix16:$dst)>;
+    def SPILL_DMRP: PPCEmitTimePseudo<(outs), (ins dmrp:$AT, memrix16:$dst)>;
+    def SPILL_DMR: PPCEmitTimePseudo<(outs), (ins dmr:$AT, memrix16:$dst)>;
   }
   let mayLoad = 1, hasSideEffects = 0 in {
-    def RESTORE_WACC: PPCEmitTimePseudo<(outs wacc:$AT), (ins memrix16:$src),
-                                        "#RESTORE_WACC", []>;
-    def RESTORE_DMRP: PPCEmitTimePseudo<(outs dmrp:$AT), (ins memrix16:$src),
-                                        "#RESTORE_DMRP", []>;
-    def RESTORE_DMR: PPCEmitTimePseudo<(outs dmr:$AT), (ins memrix16:$src),
-                                        "#RESTORE_DMR", []>;
+    def RESTORE_WACC: PPCEmitTimePseudo<(outs wacc:$AT), (ins memrix16:$src)>;
+    def RESTORE_DMRP: PPCEmitTimePseudo<(outs dmrp:$AT), (ins memrix16:$src)>;
+    def RESTORE_DMR: PPCEmitTimePseudo<(outs dmr:$AT), (ins memrix16:$src)>;
   }
 }
 


### PR DESCRIPTION
Like #198861 but for PPCEmitTimePseudo.

This is not NFC. The asm name of LDtocBA was set to #LDtocCPT, which is the name of the instruction before. This looks like a cut`n`paste error, and I changed the asm name.
Unlike the other changes I made to pseudo instructions, the asm name is emitted in a couple of times, thus the string cannot be removed.