### PR TITLE
[mlir][spirv] Fix `fp8` and `bf16` leaking into unsupported ops

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVArithmeticOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVArithmeticOps.td
@@ -464,12 +464,12 @@ def SPIRV_DotOp : SPIRV_Op<"Dot",
   }];
 
   let arguments = (ins
-    SPIRV_VectorOf<SPIRV_AnyFloat>:$vector1,
-    SPIRV_VectorOf<SPIRV_AnyFloat>:$vector2
+    AnyTypeOf<[SPIRV_FloatVector, SPIRV_VectorOf<SPIRV_BFloat16KHR>]>:$vector1,
+    AnyTypeOf<[SPIRV_FloatVector, SPIRV_VectorOf<SPIRV_BFloat16KHR>]>:$vector2
   );
 
   let results = (outs
-    SPIRV_AnyFloat:$result
+    AnyTypeOf<[SPIRV_Float, SPIRV_BFloat16KHR]>:$result
   );
 
   let assemblyFormat = "operands attr-dict `:` type($vector1) `->` type($result)";

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVBase.td
@@ -4301,7 +4301,13 @@ def SPIRV_Float : FloatOfWidths<[16, 32, 64]>;
 def SPIRV_Float16or32 : FloatOfWidths<[16, 32]>;
 def SPIRV_AnyFloat : AnyTypeOf<[SPIRV_Float, SPIRV_BFloat16KHR, SPIRV_Float8E4M3EXT, SPIRV_Float8E5M2EXT]>;
 def SPIRV_Vector : VectorOfRankAndLengthAndType<[1], [2, 3, 4, 8, 16],
-                                       [SPIRV_Bool, SPIRV_Integer, SPIRV_AnyFloat]>;
+                                       [SPIRV_Bool, SPIRV_Integer, SPIRV_Float]>;
+def SPIRV_FloatVector : VectorOfRankAndLengthAndType<[1], [2, 3, 4, 8, 16],
+                                       [SPIRV_Float]>;
+def SPIRV_ExtendedFloatVector : VectorOfRankAndLengthAndType<[1], [2, 3, 4, 8, 16],
+                                       [SPIRV_BFloat16KHR, SPIRV_Float8E4M3EXT,
+                                        SPIRV_Float8E5M2EXT]>;
+def SPIRV_AnyFloatVector : AnyTypeOf<[SPIRV_FloatVector, SPIRV_ExtendedFloatVector]>;
 // Component type check is done in the type parser for the following SPIR-V
 // dialect-specific types so we use "Any" here.
 def SPIRV_AnyPtr : DialectType<SPIRV_Dialect, SPIRV_IsPtrType,
@@ -4330,17 +4336,19 @@ def SPIRV_AnyNamedBarrier : DialectType<SPIRV_Dialect, SPIRV_IsNamedBarrierType,
 def SPIRV_AnyTensorArm : DialectType<SPIRV_Dialect, SPIRV_IsTensorArmType,
                                  "any SPIR-V tensorArm type">;
 
-def SPIRV_Numerical : AnyTypeOf<[SPIRV_Integer, SPIRV_AnyFloat]>;
+def SPIRV_Numerical : AnyTypeOf<[SPIRV_Integer, SPIRV_Float]>;
 def SPIRV_Scalar : AnyTypeOf<[SPIRV_Numerical, SPIRV_Bool]>;
 def SPIRV_Aggregate : AnyTypeOf<[SPIRV_AnyArray, SPIRV_AnyRTArray, SPIRV_AnyStruct]>;
 def SPIRV_Composite :
-    AnyTypeOf<[SPIRV_Vector, SPIRV_AnyArray, SPIRV_AnyRTArray, SPIRV_AnyStruct,
-               SPIRV_AnyCooperativeMatrix, SPIRV_AnyMatrix, SPIRV_AnyTensorArm]>;
+    AnyTypeOf<[SPIRV_Vector, SPIRV_ExtendedFloatVector, SPIRV_AnyArray,
+               SPIRV_AnyRTArray, SPIRV_AnyStruct, SPIRV_AnyCooperativeMatrix,
+               SPIRV_AnyMatrix, SPIRV_AnyTensorArm]>;
 def SPIRV_Type : AnyTypeOf<[
     SPIRV_Void, SPIRV_Bool, SPIRV_Integer, SPIRV_AnyFloat, SPIRV_Vector,
     SPIRV_AnyPtr, SPIRV_AnyArray, SPIRV_AnyRTArray, SPIRV_AnyStruct,
     SPIRV_AnyCooperativeMatrix, SPIRV_AnyMatrix, SPIRV_AnySampledImage,
-    SPIRV_AnySampler, SPIRV_AnyImage, SPIRV_AnyTensorArm
+    SPIRV_AnySampler, SPIRV_AnyImage, SPIRV_AnyTensorArm,
+    SPIRV_AnyFloatVector
   ]>;
 
 def SPIRV_SignedInt : SignedIntOfWidths<[8, 16, 32, 64]>;
@@ -4384,7 +4392,8 @@ def SPIRV_IOrUIVec4 : SPIRV_Vec4<SPIRV_SignlessOrUnsignedInt>;
 def SPIRV_Int32Vec4 : SPIRV_Vec4<AnyI32>;
 
 def SPIRV_SelectType : AnyTypeOf<[SPIRV_Scalar, SPIRV_Vector, SPIRV_AnyPtr,
-                                  SPIRV_AnyMatrix, SPIRV_AnyArray, SPIRV_AnyStruct]>;
+                                  SPIRV_AnyMatrix, SPIRV_AnyArray, SPIRV_AnyStruct,
+                                  SPIRV_AnyFloat, SPIRV_AnyFloatVector]>;
 
 //===----------------------------------------------------------------------===//
 // SPIR-V OpTrait definitions

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGroupOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVGroupOps.td
@@ -123,12 +123,12 @@ def SPIRV_GroupBroadcastOp : SPIRV_Op<"GroupBroadcast",
 
   let arguments = (ins
     SPIRV_ScopeAttr:$execution_scope,
-    SPIRV_Type:$value,
+    SPIRV_ScalarOrVector:$value,
     SPIRV_ScalarOrVectorOf<SPIRV_Integer>:$localid
   );
 
   let results = (outs
-    SPIRV_Type:$result
+    SPIRV_ScalarOrVector:$result
   );
 
   let assemblyFormat = [{

--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVNonUniformOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVNonUniformOps.td
@@ -263,12 +263,12 @@ def SPIRV_GroupNonUniformBroadcastOp : SPIRV_Op<"GroupNonUniformBroadcast", [
 
   let arguments = (ins
     SPIRV_ScopeAttr:$execution_scope,
-    SPIRV_Type:$value,
+    SPIRV_ScalarOrVector:$value,
     SPIRV_Integer:$id
   );
 
   let results = (outs
-    SPIRV_Type:$result
+    SPIRV_ScalarOrVector:$result
   );
 
   let assemblyFormat = [{
@@ -318,11 +318,11 @@ def SPIRV_GroupNonUniformBroadcastFirstOp : SPIRV_Op<"GroupNonUniformBroadcastFi
 
   let arguments = (ins
     SPIRV_ScopeAttr:$execution_scope,
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$value
+    SPIRV_ScalarOrVector:$value
   );
 
   let results = (outs
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$result
+    SPIRV_ScalarOrVector:$result
   );
 
   let hasVerifier = 0;
@@ -1498,13 +1498,13 @@ def SPIRV_GroupNonUniformRotateKHROp : SPIRV_Op<"GroupNonUniformRotateKHR", [
 
   let arguments = (ins
     SPIRV_ScopeAttr:$execution_scope,
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$value,
+    SPIRV_ScalarOrVector:$value,
     SPIRV_SignlessOrUnsignedInt:$delta,
     Optional<SPIRV_SignlessOrUnsignedInt>:$cluster_size
   );
 
   let results = (outs
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$result
+    SPIRV_ScalarOrVector:$result
   );
 
   let assemblyFormat = [{
@@ -1670,7 +1670,7 @@ def SPIRV_GroupNonUniformAllEqualOp : SPIRV_Op<"GroupNonUniformAllEqual", [
 
   let arguments = (ins
     SPIRV_ScopeAttr:$execution_scope,
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$value
+    SPIRV_ScalarOrVector:$value
   );
 
   let results = (outs
@@ -1750,12 +1750,12 @@ def SPIRV_GroupNonUniformQuadSwapOp : SPIRV_Op<"GroupNonUniformQuadSwap", [
 
   let arguments = (ins
     SPIRV_ScopeAttr:$execution_scope,
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$value,
+    SPIRV_ScalarOrVector:$value,
     SPIRV_QuadSwapDirectionAttr:$direction
   );
 
   let results = (outs
-    AnyTypeOf<[SPIRV_ScalarOrVectorOf<SPIRV_Float>, SPIRV_ScalarOrVectorOf<SPIRV_Integer>, SPIRV_ScalarOrVectorOf<SPIRV_Bool>]>:$result
+    SPIRV_ScalarOrVector:$result
   );
 
   let hasVerifier = 0;

--- a/mlir/lib/Dialect/SPIRV/IR/ImageOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/ImageOps.cpp
@@ -18,6 +18,10 @@ using namespace mlir;
 // Common utility functions
 //===----------------------------------------------------------------------===//
 
+static bool isCoreFloat(Type type) {
+  return isa<Float16Type, Float32Type, Float64Type>(type);
+}
+
 // TODO: In the future we should model image operands better, so we can move
 // some verification into ODS.
 static LogicalResult verifyImageOperands(Operation *imageOp,
@@ -50,7 +54,7 @@ static LogicalResult verifyImageOperands(Operation *imageOp,
     if (index + 1 > operands.size())
       return imageOp->emitError("Bias operand requires 1 argument");
 
-    if (!isa<FloatType>(operands[index].getType()))
+    if (!isCoreFloat(operands[index].getType()))
       return imageOp->emitError("Bias must be a floating-point type scalar");
 
     auto samplingOp = cast<spirv::SamplingOpInterface>(imageOp);
@@ -84,7 +88,7 @@ static LogicalResult verifyImageOperands(Operation *imageOp,
     spirv::ImageType imageType;
 
     if (isa<spirv::SamplingOpInterface>(imageOp)) {
-      if (!isa<mlir::FloatType>(operands[index].getType()))
+      if (!isCoreFloat(operands[index].getType()))
         return imageOp->emitError("for sampling operations, Lod must be a "
                                   "floating-point type scalar");
 
@@ -157,12 +161,12 @@ static LogicalResult verifyImageOperands(Operation *imageOp,
             "of components in coordinate, minus the array layer component, if "
             "present");
 
-      if (!isa<mlir::FloatType>(dXVector.getElementType()) ||
-          !isa<mlir::FloatType>(dYVector.getElementType()))
+      if (!isCoreFloat(dXVector.getElementType()) ||
+          !isCoreFloat(dYVector.getElementType()))
         return imageOp->emitError(
             "Grad arguments must be a vector of floating-point type");
-    } else if (isa<mlir::FloatType>(operands[index].getType()) &&
-               isa<mlir::FloatType>(operands[index + 1].getType())) {
+    } else if (isCoreFloat(operands[index].getType()) &&
+               isCoreFloat(operands[index + 1].getType())) {
       if (numberOfComponents != 1)
         return imageOp->emitError(
             "number of components of each Grad argument must equal the number "

--- a/mlir/test/Dialect/SPIRV/IR/arithmetic-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/arithmetic-ops.mlir
@@ -348,9 +348,17 @@ func.func @dot(%arg0: vector<4xf32>, %arg1: vector<4xf32>) -> f16 {
 // -----
 
 func.func @dot(%arg0: vector<4xi32>, %arg1: vector<4xi32>) -> i32 {
-  // expected-error @+1 {{'spirv.Dot' op operand #0 must be fixed-length vector of 16/32/64-bit float or BFloat16 or Float8E4M3 or Float8E5M2 values of length 2/3/4/8/16}}
+  // expected-error @+1 {{op operand #0 must be vector of 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or fixed-length vector of BFloat16 values of length 2/3/4/8/16 of ranks 1, but got 'vector<4xi32>'}}
   %0 = spirv.Dot %arg0, %arg1 : vector<4xi32> -> i32
   return %0 : i32
+}
+
+// -----
+
+func.func @dot(%arg0: vector<4xf8E4M3FN>, %arg1: vector<4xf8E4M3FN>) -> f8E4M3FN {
+  // expected-error @+1 {{op operand #0 must be vector of 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or fixed-length vector of BFloat16 values of length 2/3/4/8/16 of ranks 1, but got 'vector<4xf8E4M3FN>'}}
+  %0 = spirv.Dot %arg0, %arg1 : vector<4xf8E4M3FN> -> f8E4M3FN
+  return %0 : f8E4M3FN
 }
 
 // -----

--- a/mlir/test/Dialect/SPIRV/IR/atomic-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/atomic-ops.mlir
@@ -121,6 +121,22 @@ func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i32) -> i32
 
 // -----
 
+func.func @atomic_exchange_bf16(%ptr: !spirv.ptr<bf16, Workgroup>, %value: bf16) -> bf16 {
+  // expected-error @+1 {{'spirv.AtomicExchange' op operand #1 must be 8/16/32/64-bit integer or 16/32/64-bit float, but got 'bf16'}}
+  %0 = spirv.AtomicExchange <Workgroup> <Release> %ptr, %value : !spirv.ptr<bf16, Workgroup>
+  return %0: bf16
+}
+
+// -----
+
+func.func @atomic_exchange_float8(%ptr: !spirv.ptr<f8E4M3FN, Workgroup>, %value: f8E4M3FN) -> f8E4M3FN {
+  // expected-error @+1 {{'spirv.AtomicExchange' op operand #1 must be 8/16/32/64-bit integer or 16/32/64-bit float, but got 'f8E4M3FN'}}
+  %0 = spirv.AtomicExchange <Workgroup> <Release> %ptr, %value : !spirv.ptr<f8E4M3FN, Workgroup>
+  return %0: f8E4M3FN
+}
+
+// -----
+
 func.func @atomic_exchange(%ptr: !spirv.ptr<i32, Workgroup>, %value: i64) -> i32 {
   // expected-error @+1 {{'spirv.AtomicExchange' op failed to verify that `value` type matches pointee type of `pointer`}}
   %0 = "spirv.AtomicExchange"(%ptr, %value) {memory_scope = #spirv.scope<Workgroup>, semantics = #spirv.memory_semantics<AcquireRelease>} : (!spirv.ptr<i32, Workgroup>, i64) -> (i32)

--- a/mlir/test/Dialect/SPIRV/IR/composite-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/composite-ops.mlir
@@ -100,7 +100,7 @@ func.func @composite_construct_vector_wrong_count(%arg0: f32, %arg1: f32, %arg2 
 // -----
 
 func.func @composite_construct_vector_rank_two(%arg0: vector<2x2xi1>, %arg1: vector<2x2xi1>) -> vector<4x2xi1> {
-  // expected-error @+1 {{ op operand #0 must be variadic of void or bool or 8/16/32/64-bit integer or 16/32/64-bit float or BFloat16 or Float8E4M3 or Float8E5M2 or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float or BFloat16 or Float8E4M3 or Float8E5M2 values of length 2/3/4/8/16 of ranks 1 or any SPIR-V pointer type or any SPIR-V array type or any SPIR-V runtime array type or any SPIR-V struct type or any SPIR-V cooperative matrix type or any SPIR-V matrix type or any SPIR-V sampled image type or any SPIR-V sampler type or any SPIR-V image type or any SPIR-V tensorArm type, but got 'vector<2x2xi1>'}}
+  // expected-error @+1 {{op operand #0 must be variadic of void or bool or 8/16/32/64-bit integer or 16/32/64-bit float or BFloat16 or Float8E4M3 or Float8E5M2 or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or any SPIR-V pointer type or any SPIR-V array type or any SPIR-V runtime array type or any SPIR-V struct type or any SPIR-V cooperative matrix type or any SPIR-V matrix type or any SPIR-V sampled image type or any SPIR-V sampler type or any SPIR-V image type or any SPIR-V tensorArm type or vector of 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or vector of BFloat16 or Float8E4M3 or Float8E5M2 values of length 2/3/4/8/16 of ranks 1, but got 'vector<2x2xi1>'}}
   %0 = spirv.CompositeConstruct %arg0, %arg1 : (vector<2x2xi1>, vector<2x2xi1>) -> vector<4x2xi1>
   return %0: vector<4x2xi1>
 }

--- a/mlir/test/Dialect/SPIRV/IR/group-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/group-ops.mlir
@@ -64,6 +64,22 @@ func.func @group_broadcast_negative_locid_vec4(%value: f32, %localid: vector<4xi
 
 // -----
 
+func.func @group_broadcast_bf16(%value: bf16, %localid: i32 ) -> bf16 {
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'bf16'}}
+  %0 = spirv.GroupBroadcast <Workgroup> %value, %localid : bf16, i32
+  return %0: bf16
+}
+
+// -----
+
+func.func @group_broadcast_float8(%value: f8E4M3FN, %localid: i32 ) -> f8E4M3FN {
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'f8E4M3FN'}}
+  %0 = spirv.GroupBroadcast <Workgroup> %value, %localid : f8E4M3FN, i32
+  return %0: f8E4M3FN
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // spirv.KHR.SubgroupBallot
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Dialect/SPIRV/IR/image-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/image-ops.mlir
@@ -365,6 +365,22 @@ func.func @bias_with_rect(%arg0 : !spirv.sampled_image<!spirv.image<f32, Rect, N
   spirv.Return
 }
 
+// -----
+
+func.func @bias_bfloat16(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim1D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : f32, %arg2 : bf16) -> () {
+  // expected-error @+1 {{Bias must be a floating-point type scalar}}
+  %0 = spirv.ImageSampleImplicitLod %arg0, %arg1 ["Bias"], %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim1D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, f32, bf16 -> vector<4xf32>
+  spirv.Return
+}
+
+// -----
+
+func.func @bias_float8(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim1D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : f32, %arg2 : f8E4M3FN) -> () {
+  // expected-error @+1 {{Bias must be a floating-point type scalar}}
+  %0 = spirv.ImageSampleImplicitLod %arg0, %arg1 ["Bias"], %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim1D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, f32, f8E4M3FN -> vector<4xf32>
+  spirv.Return
+}
+
 // TODO: We cannot currently test Bias with MS != 0 as all implemented implicit operations already check for that.
 
 // -----
@@ -400,6 +416,22 @@ func.func @lod_too_many_arguments(%arg0 : !spirv.sampled_image<!spirv.image<f32,
 func.func @lod_with_rect(%arg0 : !spirv.sampled_image<!spirv.image<f32, Rect, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : vector<2xf32>, %arg2 : f32) -> () {
   // expected-error @+1 {{Lod must only be used with an image type that has a dim operand of 1D, 2D, 3D, or Cube}}
   %0 = spirv.ImageSampleExplicitLod %arg0, %arg1 ["Lod"], %arg2 : !spirv.sampled_image<!spirv.image<f32, Rect, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, vector<2xf32>, f32 -> vector<4xf32>
+  spirv.Return
+}
+
+// -----
+
+func.func @lod_bfloat16(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : vector<2xf32>, %arg2 : bf16) -> () {
+  // expected-error @+1 {{for sampling operations, Lod must be a floating-point type scalar}}
+  %0 = spirv.ImageSampleExplicitLod %arg0, %arg1 ["Lod"], %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, vector<2xf32>, bf16 -> vector<4xf32>
+  spirv.Return
+}
+
+// -----
+
+func.func @lod_float8(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : vector<2xf32>, %arg2 : f8E4M3FN) -> () {
+  // expected-error @+1 {{for sampling operations, Lod must be a floating-point type scalar}}
+  %0 = spirv.ImageSampleExplicitLod %arg0, %arg1 ["Lod"], %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, vector<2xf32>, f8E4M3FN -> vector<4xf32>
   spirv.Return
 }
 
@@ -452,6 +484,22 @@ func.func @grad_arg_size_mismatch(%arg0 : !spirv.sampled_image<!spirv.image<f32,
 func.func @gard_arg_wrong_type(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : vector<2xf32>, %arg2 : vector<2xsi32>) -> () {
   // expected-error @+1 {{Grad arguments must be a vector of floating-point type}}
   %0 = spirv.ImageSampleExplicitLod %arg0, %arg1 ["Grad"], %arg2, %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, vector<2xf32>, vector<2xsi32>, vector<2xsi32> -> vector<4xf32>
+  spirv.Return
+}
+
+// -----
+
+func.func @gard_arg_bfloat16(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : vector<2xf32>, %arg2 : vector<2xbf16>) -> () {
+  // expected-error @+1 {{Grad arguments must be a vector of floating-point type}}
+  %0 = spirv.ImageSampleExplicitLod %arg0, %arg1 ["Grad"], %arg2, %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, vector<2xf32>, vector<2xbf16>, vector<2xbf16> -> vector<4xf32>
+  spirv.Return
+}
+
+// -----
+
+func.func @gard_arg_float8(%arg0 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, %arg1 : vector<2xf32>, %arg2 : vector<2xf8E4M3FN>) -> () {
+  // expected-error @+1 {{Grad arguments must be a vector of floating-point type}}
+  %0 = spirv.ImageSampleExplicitLod %arg0, %arg1 ["Grad"], %arg2, %arg2 : !spirv.sampled_image<!spirv.image<f32, Dim2D, NoDepth, NonArrayed, SingleSampled, NeedSampler, Rgba8>>, vector<2xf32>, vector<2xf8E4M3FN>, vector<2xf8E4M3FN> -> vector<4xf32>
   spirv.Return
 }
 

--- a/mlir/test/Dialect/SPIRV/IR/non-uniform-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/non-uniform-ops.mlir
@@ -123,6 +123,24 @@ func.func @group_non_uniform_broadcast_negative_non_const(%value: f32, %localid:
 
 // -----
 
+func.func @group_non_uniform_broadcast_bf16(%value: bf16) -> bf16 {
+  %one = spirv.Constant 1 : i32
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'bf16'}}
+  %0 = spirv.GroupNonUniformBroadcast <Workgroup> %value, %one : bf16, i32
+  return %0: bf16
+}
+
+// -----
+
+func.func @group_non_uniform_broadcast_float8(%value: f8E4M3FN) -> f8E4M3FN {
+  %one = spirv.Constant 1 : i32
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'f8E4M3FN'}}
+  %0 = spirv.GroupNonUniformBroadcast <Workgroup> %value, %one : f8E4M3FN, i32
+  return %0: f8E4M3FN
+}
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // spirv.GroupNonUniformBroadcastFirst
 //===----------------------------------------------------------------------===//
@@ -155,7 +173,7 @@ func.func @group_non_uniform_broadcast_first_negative_scope(%value: f32) -> f32 
 
 
 func.func @group_non_uniform_broadcast_first_negative_type(%value: !spirv.array<3 x i32>) -> !spirv.array<3 x i32> {
-  // expected-error @+1 {{op operand #0 must be 16/32/64-bit float or fixed-length vector of 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or 8/16/32/64-bit integer or fixed-length vector of 8/16/32/64-bit integer values of length 2/3/4/8/16 of ranks 1 or bool or fixed-length vector of bool values of length 2/3/4/8/16 of ranks 1, but got '!spirv.array<3 x i32>'}}
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got '!spirv.array<3 x i32>'}}
   %0 = spirv.GroupNonUniformBroadcastFirst <Subgroup> %value : !spirv.array<3 x i32>
   return %0 : !spirv.array<3 x i32>
 }
@@ -394,6 +412,22 @@ func.func @group_non_uniform_shuffle2(%val: vector<2xf32>, %id: i32) -> vector<2
 
 // -----
 
+func.func @group_non_uniform_shuffle_bf16(%val: bf16, %id: i32) -> bf16 {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffle' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'bf16'}}
+  %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : bf16, i32
+  return %0: bf16
+}
+
+// -----
+
+func.func @group_non_uniform_shuffle_float8(%val: f8E4M3FN, %id: i32) -> f8E4M3FN {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffle' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'f8E4M3FN'}}
+  %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f8E4M3FN, i32
+  return %0: f8E4M3FN
+}
+
+// -----
+
 func.func @group_non_uniform_shuffle(%val: vector<2xf32>, %id: i32) -> vector<2xf32> {
   // expected-error @+1 {{execution_scope must be 'Workgroup' or 'Subgroup'}}
   %0 = spirv.GroupNonUniformShuffle <Device> %val, %id : vector<2xf32>, i32
@@ -426,6 +460,22 @@ func.func @group_non_uniform_shuffle2(%val: vector<2xf32>, %id: i32) -> vector<2
   // CHECK: %{{.+}} = spirv.GroupNonUniformShuffleXor <Subgroup> %{{.+}}, %{{.+}} : vector<2xf32>, i32
   %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %id : vector<2xf32>, i32
   return %0: vector<2xf32>
+}
+
+// -----
+
+func.func @group_non_uniform_shuffle_xor_bf16(%val: bf16, %id: i32) -> bf16 {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffleXor' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'bf16'}}
+  %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %id : bf16, i32
+  return %0: bf16
+}
+
+// -----
+
+func.func @group_non_uniform_shuffle_xor_float8(%val: f8E4M3FN, %id: i32) -> f8E4M3FN {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffleXor' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'f8E4M3FN'}}
+  %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %id : f8E4M3FN, i32
+  return %0: f8E4M3FN
 }
 
 // -----
@@ -466,6 +516,22 @@ func.func @group_non_uniform_shuffle2(%val: vector<2xf32>, %id: i32) -> vector<2
 
 // -----
 
+func.func @group_non_uniform_shuffle_up_bf16(%val: bf16, %id: i32) -> bf16 {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffleUp' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'bf16'}}
+  %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %id : bf16, i32
+  return %0: bf16
+}
+
+// -----
+
+func.func @group_non_uniform_shuffle_up_float8(%val: f8E4M3FN, %id: i32) -> f8E4M3FN {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffleUp' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'f8E4M3FN'}}
+  %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %id : f8E4M3FN, i32
+  return %0: f8E4M3FN
+}
+
+// -----
+
 func.func @group_non_uniform_shuffle(%val: vector<2xf32>, %id: i32) -> vector<2xf32> {
   // expected-error @+1 {{execution_scope must be 'Workgroup' or 'Subgroup'}}
   %0 = spirv.GroupNonUniformShuffleUp <Device> %val, %id : vector<2xf32>, i32
@@ -498,6 +564,22 @@ func.func @group_non_uniform_shuffle2(%val: vector<2xf32>, %id: i32) -> vector<2
   // CHECK: %{{.+}} = spirv.GroupNonUniformShuffleDown <Subgroup> %{{.+}}, %{{.+}} : vector<2xf32>, i32
   %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %id : vector<2xf32>, i32
   return %0: vector<2xf32>
+}
+
+// -----
+
+func.func @group_non_uniform_shuffle_down_bf16(%val: bf16, %id: i32) -> bf16 {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffleDown' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'bf16'}}
+  %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %id : bf16, i32
+  return %0: bf16
+}
+
+// -----
+
+func.func @group_non_uniform_shuffle_down_float8(%val: f8E4M3FN, %id: i32) -> f8E4M3FN {
+  // expected-error @+1 {{'spirv.GroupNonUniformShuffleDown' op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got 'f8E4M3FN'}}
+  %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %id : f8E4M3FN, i32
+  return %0: f8E4M3FN
 }
 
 // -----
@@ -854,7 +936,7 @@ func.func @group_non_uniform_quad_swap(%value: vector<4xf32>) -> vector<4xf32> {
 // -----
 
 func.func @group_non_uniform_quad_swap(%value: !spirv.array<3 x i32>) -> !spirv.array<3 x i32> {
-  // expected-error @+1 {{op operand #0 must be 16/32/64-bit float or fixed-length vector of 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or 8/16/32/64-bit integer or fixed-length vector of 8/16/32/64-bit integer values of length 2/3/4/8/16 of ranks 1 or bool or fixed-length vector of bool values of length 2/3/4/8/16 of ranks 1, but got '!spirv.array<3 x i32>'}}
+  // expected-error @+1 {{op operand #0 must be 8/16/32/64-bit integer or 16/32/64-bit float or bool or vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1, but got '!spirv.array<3 x i32>'}}
   %0 = spirv.GroupNonUniformQuadSwap <Device> <Horizontal> %value : !spirv.array<3 x i32>
   return %0: !spirv.array<3 x i32>
 }

--- a/mlir/test/Dialect/SPIRV/IR/structure-ops.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/structure-ops.mlir
@@ -198,7 +198,7 @@ func.func @coop_matrix_const_wrong_type() -> () {
 //===----------------------------------------------------------------------===//
 
 func.func @ccr_result_not_composite() -> () {
-  // expected-error @+1 {{op result #0 must be vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float or BFloat16 or Float8E4M3 or Float8E5M2 values of length 2/3/4/8/16 of ranks 1 or any SPIR-V array type or any SPIR-V runtime array type or any SPIR-V struct type or any SPIR-V cooperative matrix type or any SPIR-V matrix type or any SPIR-V tensorArm type, but got 'i32'}}
+  // expected-error @+1 {{op result #0 must be vector of bool or 8/16/32/64-bit integer or 16/32/64-bit float values of length 2/3/4/8/16 of ranks 1 or vector of BFloat16 or Float8E4M3 or Float8E5M2 values of length 2/3/4/8/16 of ranks 1 or any SPIR-V array type or any SPIR-V runtime array type or any SPIR-V struct type or any SPIR-V cooperative matrix type or any SPIR-V matrix type or any SPIR-V tensorArm type, but got 'i32'}}
   %0 = spirv.EXT.ConstantCompositeReplicate [1 : i32] : i32
   return
 }


### PR DESCRIPTION
Including `SPIRV_AnyFloat` in the majority of types caused fp8 and bf16 to be allowed in ops that are not allowed by float8 and bfloat16 extensions. This patch tries to rectify to only allow fp8 and bf16 in ops allowed by the respective specs. Additional tests have been also added to increase the coverage with respect to those types.

Assisted-by: Codex + Claude Code