### PR TITLE
[clang-format][Objective-C] Fix assertion crash on stray '-'/'+' in @interfa…

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -4262,7 +4262,11 @@ void UnwrappedLineParser::parseObjCUntilAtEnd() {
       addUnwrappedLine();
     } else if (FormatTok->isOneOf(tok::minus, tok::plus)) {
       nextToken();
-      parseObjCMethod();
+      // Guard against malformed input where '-'/'+' is not followed by a
+      // method declaration. parseObjCMethod() asserts the next token is '('
+      // or an identifier; silently skip the stray sign token otherwise.
+      if (FormatTok->isOneOf(tok::l_paren, tok::identifier))
+        parseObjCMethod();
     } else {
       parseStructuralElement();
     }

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -4262,9 +4262,6 @@ void UnwrappedLineParser::parseObjCUntilAtEnd() {
       addUnwrappedLine();
     } else if (FormatTok->isOneOf(tok::minus, tok::plus)) {
       nextToken();
-      // Guard against malformed input where '-'/'+' is not followed by a
-      // method declaration. parseObjCMethod() asserts the next token is '('
-      // or an identifier; silently skip the stray sign token otherwise.
       if (FormatTok->isOneOf(tok::l_paren, tok::identifier))
         parseObjCMethod();
     } else {

--- a/clang/unittests/Format/FormatTestObjC.cpp
+++ b/clang/unittests/Format/FormatTestObjC.cpp
@@ -1803,6 +1803,18 @@ TEST_F(FormatTestObjC, AttributesOnObjCProperty) {
       "@property(weak) id delegate ATTRIBUTE_MACRO(X) __attribute__((X));");
 }
 
+TEST_F(FormatTestObjC, NoCrashOnStrayMethodSign) {
+  // Issue #199075: clang-format used to assert in parseObjCMethod() when an
+  // ObjC interface/implementation contained a '-' or '+' that was not
+  // followed by '(' or an identifier.
+  verifyNoCrash("@interface;\n-");
+  verifyNoCrash("@interface Foo\n-");
+  verifyNoCrash("@interface Foo\n+");
+  verifyNoCrash("@implementation Foo\n-");
+  verifyNoCrash("@interface Foo\n-\n@end");
+  verifyNoCrash("@interface Foo\n- ;");
+}
+
 } // end namespace
 } // namespace test
 } // end namespace format

--- a/clang/unittests/Format/FormatTestObjC.cpp
+++ b/clang/unittests/Format/FormatTestObjC.cpp
@@ -1804,15 +1804,19 @@ TEST_F(FormatTestObjC, AttributesOnObjCProperty) {
 }
 
 TEST_F(FormatTestObjC, NoCrashOnStrayMethodSign) {
-  // Issue #199075: clang-format used to assert in parseObjCMethod() when an
-  // ObjC interface/implementation contained a '-' or '+' that was not
-  // followed by '(' or an identifier.
-  verifyNoCrash("@interface;\n-");
-  verifyNoCrash("@interface Foo\n-");
-  verifyNoCrash("@interface Foo\n+");
-  verifyNoCrash("@implementation Foo\n-");
-  verifyNoCrash("@interface Foo\n-\n@end");
-  verifyNoCrash("@interface Foo\n- ;");
+  verifyNoCrash("@interface;\n"
+                "-");
+  verifyNoCrash("@interface Foo\n"
+                "-");
+  verifyNoCrash("@interface Foo\n"
+                "+");
+  verifyNoCrash("@implementation Foo\n"
+                "-");
+  verifyNoCrash("@interface Foo\n"
+                "-\n"
+                "@end");
+  verifyNoCrash("@interface Foo\n"
+                "- ;");
 }
 
 } // end namespace


### PR DESCRIPTION
Before calling `parseObjCMethod()`, it now checks whether the next token is a `(` or an identifier; if not, it simply skips ahead, thereby preventing the assertion failure and subsequent crash.
Fixes #199075