### PR TITLE
[Instrumentor][FIX] Ensure we indicate changes properly.

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Instrumentor.h
+++ b/llvm/include/llvm/Transforms/IPO/Instrumentor.h
@@ -507,16 +507,18 @@ struct InstrumentationOpportunity {
 
   /// Instrument the value \p V using the configuration \p IConf, and
   /// potentially, the caches \p ICaches.
-  virtual Value *instrument(Value *&V, InstrumentationConfig &IConf,
+  virtual Value *instrument(Value *&V, bool &Changed,
+                            InstrumentationConfig &IConf,
                             InstrumentorIRBuilderTy &IIRB,
                             InstrumentationCaches &ICaches) {
     if (CB && !CB(*V))
       return nullptr;
 
     // Check if the filter matches before instrumenting
-    if (!evaluateFilter(*V, *this, IConf, IIRB))
+    if (!evaluateFilter(*V, Changed, *this, IConf, IIRB))
       return nullptr;
 
+    Changed = true;
     const DataLayout &DL = IIRB.IRB.GetInsertBlock()->getDataLayout();
     IRTCallDescription IRTCallDesc(*this, getRetTy(V->getContext()));
     auto *CI = IRTCallDesc.createLLVMCall(V, IConf, IIRB, DL, ICaches);

--- a/llvm/include/llvm/Transforms/IPO/InstrumentorUtils.h
+++ b/llvm/include/llvm/Transforms/IPO/InstrumentorUtils.h
@@ -177,7 +177,7 @@ template <typename EnumTy> struct BaseConfigTy {
 /// opportunity. Returns true if the filter passes (or is empty), false
 /// otherwise. Dynamic values (non-constants) are assumed to pass.
 LLVM_ABI
-bool evaluateFilter(Value &V, InstrumentationOpportunity &IO,
+bool evaluateFilter(Value &V, bool &Changed, InstrumentationOpportunity &IO,
                     InstrumentationConfig &IConf,
                     InstrumentorIRBuilderTy &IIRB);
 

--- a/llvm/lib/Transforms/IPO/Instrumentor.cpp
+++ b/llvm/lib/Transforms/IPO/Instrumentor.cpp
@@ -250,13 +250,13 @@ bool InstrumentorImpl::instrumentInstruction(Instruction &I,
   if (auto *IO = InstChoicesPRE.lookup(I.getOpcode())) {
     IIRB.IRB.SetInsertPoint(&I);
     ensureDbgLoc(IIRB.IRB);
-    Changed |= bool(IO->instrument(IPtr, IConf, IIRB, ICaches));
+    IO->instrument(IPtr, Changed, IConf, IIRB, ICaches);
   }
 
   if (auto *IO = InstChoicesPOST.lookup(I.getOpcode())) {
     IIRB.IRB.SetInsertPoint(I.getNextNode());
     ensureDbgLoc(IIRB.IRB);
-    Changed |= bool(IO->instrument(IPtr, IConf, IIRB, ICaches));
+    IO->instrument(IPtr, Changed, IConf, IIRB, ICaches);
   }
   IIRB.returnAllocas();
 
@@ -291,7 +291,7 @@ bool InstrumentorImpl::instrumentFunction(Function &Fn) {
     IIRB.IRB.SetInsertPoint(
         cast<Function>(FPtr)->getEntryBlock().getFirstInsertionPt());
     ensureDbgLoc(IIRB.IRB);
-    Changed |= bool(IO->instrument(FPtr, IConf, IIRB, ICaches));
+    IO->instrument(FPtr, Changed, IConf, IIRB, ICaches);
     IIRB.returnAllocas();
   }
 
@@ -305,7 +305,7 @@ bool InstrumentorImpl::instrumentFunction(Function &Fn) {
     for (Instruction *FinalTI : FinalTIs) {
       IIRB.IRB.SetInsertPoint(FinalTI);
       ensureDbgLoc(IIRB.IRB);
-      Changed |= bool(IO->instrument(FPtr, IConf, IIRB, ICaches));
+      IO->instrument(FPtr, Changed, IConf, IIRB, ICaches);
       IIRB.returnAllocas();
     }
   }
@@ -353,8 +353,10 @@ bool InstrumentorImpl::instrumentModule() {
       auto *IO = ChoiceIt.second;
       if (!IO->Enabled)
         continue;
-      if (!YtorFn)
+      if (!YtorFn) {
         YtorFn = CreateYtor(IsPRE);
+        Changed = true;
+      }
       IIRB.IRB.SetInsertPointPastAllocas(YtorFn);
       ensureDbgLoc(IIRB.IRB);
       Value *YtorPtr = YtorFn;
@@ -362,7 +364,7 @@ bool InstrumentorImpl::instrumentModule() {
       // Count epochs eagerly.
       ++IIRB.Epoch;
 
-      Changed |= bool(IO->instrument(YtorPtr, IConf, IIRB, ICaches));
+      IO->instrument(YtorPtr, Changed, IConf, IIRB, ICaches);
       IIRB.returnAllocas();
     }
   }
@@ -375,8 +377,10 @@ bool InstrumentorImpl::instrumentModule() {
       auto *IO = ChoiceIt.second;
       if (!IO->Enabled)
         continue;
-      if (!YtorFn)
+      if (!YtorFn) {
         YtorFn = CreateYtor(IsPRE);
+        Changed = true;
+      }
       for (GlobalVariable *GV : Globals) {
         if (!shouldInstrumentGlobalVariable(*GV))
           continue;
@@ -390,7 +394,7 @@ bool InstrumentorImpl::instrumentModule() {
         // Count epochs eagerly.
         ++IIRB.Epoch;
 
-        Changed |= bool(IO->instrument(GVPtr, IConf, IIRB, ICaches));
+        IO->instrument(GVPtr, Changed, IConf, IIRB, ICaches);
         IIRB.returnAllocas();
       }
     }
@@ -415,6 +419,7 @@ bool InstrumentorImpl::instrument() {
        IConf.IChoices[InstrumentationLocation::INSTRUCTION_POST])
     if (IO->Enabled)
       InstChoicesPOST[IO->getOpcode()] = IO;
+
   Changed |= instrumentModule();
 
   for (Function &Fn : M)

--- a/llvm/lib/Transforms/IPO/InstrumentorUtils.cpp
+++ b/llvm/lib/Transforms/IPO/InstrumentorUtils.cpp
@@ -410,7 +410,7 @@ private:
 };
 } // anonymous namespace
 
-bool llvm::instrumentor::evaluateFilter(Value &V,
+bool llvm::instrumentor::evaluateFilter(Value &V, bool &Changed,
                                         InstrumentationOpportunity &IO,
                                         InstrumentationConfig &IConf,
                                         InstrumentorIRBuilderTy &IIRB) {
@@ -431,6 +431,10 @@ bool llvm::instrumentor::evaluateFilter(Value &V,
     Value *ArgValue = Arg.GetterCB(V, *Arg.Ty, IConf, IIRB);
     if (!ArgValue)
       continue;
+
+    // TODO: This is likely too broad and we might want GetterCB to indicate
+    // changes.
+    Changed = true;
 
     if (auto *CI = dyn_cast<ConstantInt>(ArgValue)) {
       // Check for constant integer values.


### PR DESCRIPTION
We now indicate changes whenever we might have changed things even if the filter will rule out instrumentation. The issue was that we need to get the argument to check the filter and that process might create new IR, e.g., a global variable containing the function name.