### PR TITLE
[llvm-ar] fix contradictory comment in tests

### DIFF
--- a/llvm/test/tools/llvm-ar/non-windows-name-case.test
+++ b/llvm/test/tools/llvm-ar/non-windows-name-case.test
@@ -1,4 +1,4 @@
-## Test that on windows, members are case insensitive.
+## Test that on non-Windows, members are case-sensitive.
 # UNSUPPORTED: system-windows
 
 # RUN: mkdir -p %t


### PR DESCRIPTION
Original comment was probably copied from [windows-name-case.test](llvm/test/tools/llvm-ar/windows-name-case.test)