### PR TITLE
Revert "[libc] Enable baremetal float printf using modular format"

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -13,6 +13,9 @@
     "LIBC_CONF_PRINTF_DISABLE_FIXED_POINT": {
       "value": true
     },
+    "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
+      "value": true
+    },
     "LIBC_CONF_PRINTF_DISABLE_INDEX_MODE": {
       "value": true
     },
@@ -29,9 +32,6 @@
       "value": true
     },
     "LIBC_COPT_PRINTF_DISABLE_BITINT": {
-      "value": true
-    },
-    "LIBC_CONF_PRINTF_MODULAR": {
       "value": true
     }
   },


### PR DESCRIPTION
Reverts llvm/llvm-project#198900

This can cause build failures due to an error in the handling of argument indices for `va_list` `printf` variants.