### PR TITLE
[lldb] Remove ValueObjectRecognizerSynthesizedValue::IsSynthetic override

### DIFF
--- a/lldb/include/lldb/Target/StackFrameRecognizer.h
+++ b/lldb/include/lldb/Target/StackFrameRecognizer.h
@@ -196,7 +196,6 @@ class ValueObjectRecognizerSynthesizedValue : public ValueObject {
   CompilerType GetCompilerTypeImpl() override {
     return m_parent->GetCompilerType();
   }
-  bool IsSynthetic() override { return true; }
 
  private:
   lldb::ValueType m_type;


### PR DESCRIPTION
Removes the `IsSynthetic` override on `ValueObjectRecognizerSynthesizedValue`. This class does not also override `GetNonSyntheticValue`.

There was a bug in which code assumed that when `IsSynthetic()` returned true, that `GetNonSyntheticValue` would produce a different value object. However the default behavior of `GetNonSyntheticValue` is to return itself.

It seems to me that either:
1. `ValueObjectSynthetic` should be the only class to override `IsSynthetic` to true
2. or, that classes which override `IsSynthetic` should also override `GetNonSyntheticValue`

In either case, I think it's best to remove this `IsSynthetic` on `ValueObjectRecognizerSynthesizedValue`.