### PR TITLE
[CIR] Omit nsw/nuw on integer vector binops

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1056,9 +1056,8 @@ public:
     else
       result.fullType = e->getType();
     result.compType = result.fullType;
-    if (const auto *vecType = dyn_cast_or_null<VectorType>(result.fullType)) {
+    if (const auto *vecType = result.fullType->getAs<VectorType>())
       result.compType = vecType->getElementType();
-    }
     result.opcode = e->getOpcode();
     result.loc = e->getSourceRange();
     // TODO(cir): Result.FPFeatures
@@ -1553,7 +1552,7 @@ LValue ScalarExprEmitter::emitCompoundAssignLValue(
 
   opInfo.fullType = promotionTypeCR;
   opInfo.compType = opInfo.fullType;
-  if (const auto *vecType = dyn_cast_or_null<VectorType>(opInfo.fullType))
+  if (const auto *vecType = opInfo.fullType->getAs<VectorType>())
     opInfo.compType = vecType->getElementType();
   opInfo.opcode = e->getOpcode();
   opInfo.fpFeatures = e->getFPFeaturesInEffect(cgf.getLangOpts());
@@ -1914,9 +1913,15 @@ static mlir::Value emitPointerArithmetic(CIRGenFunction &cgf,
                                   pointer.getType(), pointer, index);
 }
 
+static bool isIntegerVectorBinOp(mlir::Type ty) {
+  auto vecTy = mlir::dyn_cast<cir::VectorType>(ty);
+  return vecTy && mlir::isa<cir::IntType>(vecTy.getElementType());
+}
+
 mlir::Value ScalarExprEmitter::emitMul(const BinOpInfo &ops) {
   const mlir::Location loc = cgf.getLoc(ops.loc);
-  if (ops.compType->isSignedIntegerOrEnumerationType()) {
+  if (!isIntegerVectorBinOp(ops.lhs.getType()) &&
+      ops.compType->isSignedIntegerOrEnumerationType()) {
     switch (cgf.getLangOpts().getSignedOverflowBehavior()) {
     case LangOptions::SOB_Defined:
       if (!cgf.sanOpts.has(SanitizerKind::SignedIntegerOverflow))
@@ -1971,7 +1976,8 @@ mlir::Value ScalarExprEmitter::emitAdd(const BinOpInfo &ops) {
     return emitPointerArithmetic(cgf, ops, /*isSubtraction=*/false);
 
   const mlir::Location loc = cgf.getLoc(ops.loc);
-  if (ops.compType->isSignedIntegerOrEnumerationType()) {
+  if (!isIntegerVectorBinOp(ops.lhs.getType()) &&
+      ops.compType->isSignedIntegerOrEnumerationType()) {
     switch (cgf.getLangOpts().getSignedOverflowBehavior()) {
     case LangOptions::SOB_Defined:
       if (!cgf.sanOpts.has(SanitizerKind::SignedIntegerOverflow))
@@ -2016,7 +2022,8 @@ mlir::Value ScalarExprEmitter::emitSub(const BinOpInfo &ops) {
   const mlir::Location loc = cgf.getLoc(ops.loc);
   // The LHS is always a pointer if either side is.
   if (!mlir::isa<cir::PointerType>(ops.lhs.getType())) {
-    if (ops.compType->isSignedIntegerOrEnumerationType()) {
+    if (!isIntegerVectorBinOp(ops.lhs.getType()) &&
+        ops.compType->isSignedIntegerOrEnumerationType()) {
       switch (cgf.getLangOpts().getSignedOverflowBehavior()) {
       case LangOptions::SOB_Defined: {
         if (!cgf.sanOpts.has(SanitizerKind::SignedIntegerOverflow))

--- a/clang/test/CIR/CodeGen/vector-binop-overflow.cpp
+++ b/clang/test/CIR/CodeGen/vector-binop-overflow.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --check-prefix=CIR --input-file=%t.cir %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t-cir.ll %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
+// RUN: FileCheck --check-prefix=LLVM --input-file=%t.ll %s
+
+typedef int vi4 __attribute__((vector_size(16)));
+
+struct SimdStorage {
+  int __data __attribute__((vector_size(16)));
+};
+
+int scalar_add(int a, int b) { return a + b; }
+
+void vector_binops(vi4 a, vi4 b, SimdStorage &s) {
+  vi4 c = a + b;
+  vi4 d = a - b;
+  vi4 e = a * b;
+  s.__data = s.__data + 1;
+  s.__data = s.__data - 1;
+}
+
+// Scalar signed add keeps nsw.
+// CIR: cir.add nsw
+// LLVM: add nsw i32
+
+// Vector integer binops must not use nsw/nuw (CIR verifier rejects them).
+// CIR: cir.add %{{.*}}, %{{.*}} : !cir.vector<4 x !s32i>
+// CIR-NOT: cir.add{{.*}}nsw{{.*}}!cir.vector
+// CIR: cir.sub %{{.*}}, %{{.*}} : !cir.vector<4 x !s32i>
+// CIR-NOT: cir.sub{{.*}}nsw{{.*}}!cir.vector
+// CIR: cir.mul %{{.*}}, %{{.*}} : !cir.vector<4 x !s32i>
+// CIR-NOT: cir.mul{{.*}}nsw{{.*}}!cir.vector
+
+// LLVM: add <4 x i32>
+// LLVM-NOT: add nsw <4 x i32>
+// LLVM: sub <4 x i32>
+// LLVM-NOT: sub nsw <4 x i32>
+// LLVM: mul <4 x i32>
+// LLVM-NOT: mul nsw <4 x i32>


### PR DESCRIPTION
CIRGen was attaching `nsw` to `cir.add` on `!cir.vector` integer types
because the signed-overflow path keys off `compType` (the element type,
still `!s32i`), while the verifier only allows `nsw`/`nuw` on scalar
`!cir.int` results.  That mismatch showed up 144 times in the libcxx
CIR sweep on `std::experimental::simd` — `experimental/__simd/vec_ext.h`
increment/decrement (`__data + 1` / `__data - 1`).

Classic CodeGen never enters the signed-overflow block for vector
computation types; CIR now skips the scalar `nsw`/`nuw` path when the
MLIR operand is an integer vector, and uses `getAs<VectorType>()` for
`compType` so typedef-wrapped GCC vectors resolve the element type
correctly.

Regression test `vector-binop-overflow.cpp` checks scalar add still gets
`nsw` and vector add/sub/mul do not (CIR + LLVM + OGCG).