### PR TITLE
[CI] Unify handling of scripted PR workflows

### DIFF
--- a/.github/actions/checkout-baseline-tooling/action.yml
+++ b/.github/actions/checkout-baseline-tooling/action.yml
@@ -6,7 +6,7 @@ description: >-
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: llvm/llvm-project/.github/actions/checkout-baseline-tooling@main
       with:
         persist-credentials: false
         sparse-checkout: |

--- a/.github/actions/checkout-baseline-tooling/action.yml
+++ b/.github/actions/checkout-baseline-tooling/action.yml
@@ -1,0 +1,17 @@
+name: Checkout Baseline Tooling
+description: >-
+  Checkout the baseline tooling scripts prior to running any pre-commit hooks
+  or other GH action or workflow scripts.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+        sparse-checkout: |
+          llvm/utils/git/
+          .ci/
+          .github/
+        ref: main
+        path: baseline-scripts

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -26,6 +26,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
 
+      - name: Checkout Baseline Tooling
+        uses: llvm/llvm-project/.github/actions/checkout-baseline-tooling@main
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
@@ -49,10 +52,10 @@ jobs:
         # Create an empty comments file so the pr-write job doesn't fail.
         run: |
           echo "[]" > comments &&
-          python ./llvm/utils/git/code-format-helper.py \
+          python ./baseline-scripts/llvm/utils/git/code-format-helper.py \
             --write-comment-to-file \
             --token ${{ secrets.GITHUB_TOKEN }} \
-            --issue-number $GITHUB_PR_NUMBER \
+            --issue-number "$GITHUB_PR_NUMBER" \
             --start-rev HEAD~1 \
             --end-rev HEAD \
             --changed-files "$CHANGED_FILES"

--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -33,6 +33,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
       
+      - name: Checkout Baseline Tooling
+        uses: llvm/llvm-project/.github/actions/checkout-baseline-tooling@main
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
@@ -55,7 +58,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
 
-          . <(git diff --name-only HEAD~1...HEAD | python3 .ci/compute_projects.py)
+          . <(git diff --name-only HEAD~1...HEAD | python3 ./baseline-scripts/.ci/compute_projects.py)
 
           if [[ "${projects_to_build}" == "" ]]; then
             echo "No projects to analyze"
@@ -91,7 +94,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "[]" > comments &&
-          python3 llvm/utils/git/code-lint-helper.py \
+          python3 ./baseline-scripts/llvm/utils/git/code-lint-helper.py \
             --token ${{ secrets.GITHUB_TOKEN }} \
             --issue-number $GITHUB_PR_NUMBER \
             --start-rev HEAD~1 \


### PR DESCRIPTION
A few workflows already force the use of baseline scripting when testing PRs. This PR pulls that out into a separate action that we can just reuse in other workflows as well.