### PR TITLE
[offload] Use device memory for the multithreaded kernel lanuch test

### DIFF
--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -79,24 +79,29 @@ TEST_P(olLaunchKernelFooTest, Success) {
 
 TEST_P(olLaunchKernelFooTest, SuccessThreaded) {
   threadify([&](size_t) {
-    void *Mem;
-    ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
-                              LaunchArgs.GroupSize.x * sizeof(uint32_t), &Mem));
+    void *DevAlloc, *HstAlloc;
+    size_t Size = LaunchArgs.GroupSize.x * sizeof(uint32_t);
+    ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, &DevAlloc));
+    ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_HOST, Size, &HstAlloc));
+
     struct {
       void *Mem;
-    } Args{Mem};
+    } Args{DevAlloc};
 
     ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                   &LaunchArgs, nullptr));
 
+    ASSERT_SUCCESS(olMemcpy(Queue, HstAlloc, Host, DevAlloc, Device, Size));
+
     ASSERT_SUCCESS(olSyncQueue(Queue));
 
-    uint32_t *Data = (uint32_t *)Mem;
-    for (uint32_t i = 0; i < 64; i++) {
+    uint32_t *Data = static_cast<uint32_t *>(HstAlloc);
+    for (uint32_t i = 0; i < LaunchArgs.GroupSize.x; i++) {
       ASSERT_EQ(Data[i], i);
     }
 
-    ASSERT_SUCCESS(olMemFree(Mem));
+    ASSERT_SUCCESS(olMemFree(DevAlloc));
+    ASSERT_SUCCESS(olMemFree(HstAlloc));
   });
 }
 


### PR DESCRIPTION
This commit modifies the multithreaded kernel launch test to use device memory instead of managed memory. The test is reported to be failing intermittently in systems where concurrent managed memory access is not supported. This is the case for NVIDIA devices that do not support CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.

The concept of concurrent and coherent managed memory access should be exposed to liboffload users somehow, e.g., adding it as device property, so it is clear what execution patterns are allowed with managed memory. However, this test is just testing concurrent kernel launches. This commit fixes it until we decide how to proceed with the guarantees on that type of allocations.