### PR TITLE
[llvm][tools] Add debug map support llvm-dwarfdump

### DIFF
--- a/llvm/test/tools/llvm-dwarfdump/AArch64/Inputs/macho-oso-exe.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/Inputs/macho-oso-exe.yaml
@@ -1,0 +1,65 @@
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000002
+  ncmds:           3
+  sizeofcmds:      248
+  flags:           0x00200085
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          4294967296
+    vmsize:          4096
+    fileoff:         0
+    filesize:        4096
+    maxprot:         5
+    initprot:        5
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0000000100000000
+        size:            4
+        offset:          0x00000118
+        align:           2
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         72
+    segname:         __LINKEDIT
+    vmaddr:          4294971392
+    vmsize:          4096
+    fileoff:         4096
+    filesize:        64
+    maxprot:         1
+    initprot:        1
+    nsects:          0
+    flags:           0
+  - cmd:             LC_SYMTAB
+    cmdsize:         24
+    symoff:          4096
+    nsyms:           1
+    stroff:          4112
+    strsize:         16
+LinkEditData:
+  NameList:
+    - n_strx:          1
+      n_type:          0x66
+      n_sect:          0
+      n_desc:          1
+      n_value:         0
+  StringTable:
+    - ''
+    - 'test.o'
+    - ''
+    - ''
+...

--- a/llvm/test/tools/llvm-dwarfdump/AArch64/Inputs/macho-oso-obj.yaml
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/Inputs/macho-oso-obj.yaml
@@ -1,0 +1,106 @@
+--- !mach-o
+FileHeader:
+  magic:           0xFEEDFACF
+  cputype:         0x0100000C
+  cpusubtype:      0x00000000
+  filetype:        0x00000001
+  ncmds:           2
+  sizeofcmds:      472
+  flags:           0x00002000
+  reserved:        0x00000000
+LoadCommands:
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         152
+    segname:         __TEXT
+    vmaddr:          0
+    vmsize:          4096
+    fileoff:         0
+    filesize:        4096
+    maxprot:         7
+    initprot:        5
+    nsects:          1
+    flags:           0
+    Sections:
+      - sectname:        __text
+        segname:         __TEXT
+        addr:            0x0000000000000000
+        size:            4
+        offset:          0x000001F8
+        align:           2
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x80000400
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+  - cmd:             LC_SEGMENT_64
+    cmdsize:         312
+    segname:         __DWARF
+    vmaddr:          4096
+    vmsize:          4096
+    fileoff:         4096
+    filesize:        40
+    maxprot:         7
+    initprot:        3
+    nsects:          3
+    flags:           0
+    Sections:
+      - sectname:        __debug_abbrev
+        segname:         __DWARF
+        addr:            0x0000000000001000
+        size:            10
+        offset:          0x00001000
+        align:           0
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x00000000
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+      - sectname:        __debug_info
+        segname:         __DWARF
+        addr:            0x000000000000100A
+        size:            19
+        offset:          0x0000100A
+        align:           0
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x00000000
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+      - sectname:        __debug_str
+        segname:         __DWARF
+        addr:            0x000000000000101D
+        size:            11
+        offset:          0x0000101D
+        align:           0
+        reloff:          0x00000000
+        nreloc:          0
+        flags:           0x00000000
+        reserved1:       0x00000000
+        reserved2:       0x00000000
+        reserved3:       0x00000000
+DWARF:
+  debug_str:
+    - 'oso-test.c'
+  debug_abbrev:
+    - Table:
+        - Code:            0x00000001
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_language
+              Form:            DW_FORM_data2
+  debug_info:
+    - Version:         4
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x00000001
+          Values:
+            - Value:           0x0000000000000000
+            - Value:           0x000000000000000C
+        - AbbrCode:        0x00000000
+...

--- a/llvm/test/tools/llvm-dwarfdump/AArch64/macho-oso.test
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/macho-oso.test
@@ -21,7 +21,16 @@
 # NO-OSO-NOT: test.o
 # NO-OSO-NOT: DW_TAG_compile_unit
 
+## N_OSO references to archive members are followed.
+# RUN: llvm-ar rcs %t/test.a %t/test.o
+# RUN: yaml2obj %p/Inputs/macho-oso-archive-exe.yaml -o %t/test-ar
+# RUN: cd %t && llvm-dwarfdump test-ar 2>&1 | FileCheck %s --check-prefix=ARCHIVE
+# ARCHIVE: test-ar:{{.*}}file format Mach-O arm64
+# ARCHIVE: test.a(test.o):{{.*}}file format Mach-O arm64
+# ARCHIVE: DW_TAG_compile_unit
+# ARCHIVE: DW_AT_name	("oso-test.c")
+
 ## When the .o file is missing, a warning is emitted.
 # RUN: rm %t/test.o
 # RUN: cd %t && llvm-dwarfdump test 2>&1 | FileCheck %s --check-prefix=MISSING
-# MISSING: warning: unable to open N_OSO referenced file 'test.o'
+# MISSING: warning: test.o:

--- a/llvm/test/tools/llvm-dwarfdump/AArch64/macho-oso.test
+++ b/llvm/test/tools/llvm-dwarfdump/AArch64/macho-oso.test
@@ -1,0 +1,27 @@
+# REQUIRES: aarch64-registered-target
+
+## Test that llvm-dwarfdump follows N_OSO references in Mach-O binaries
+## to dump DWARF from referenced object files.
+
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: yaml2obj %p/Inputs/macho-oso-obj.yaml -o %t/test.o
+# RUN: yaml2obj %p/Inputs/macho-oso-exe.yaml -o %t/test
+
+## N_OSO following should dump DWARF from the referenced .o file.
+# RUN: cd %t && llvm-dwarfdump test 2>&1 | FileCheck %s --check-prefix=OSO
+# OSO: test:{{.*}}file format Mach-O arm64
+# OSO: test.o:{{.*}}file format Mach-O arm64
+# OSO: .debug_info contents:
+# OSO: DW_TAG_compile_unit
+# OSO: DW_AT_name	("oso-test.c")
+
+## --no-debug-map suppresses debug map following.
+# RUN: cd %t && llvm-dwarfdump --no-debug-map test 2>&1 | FileCheck %s --check-prefix=NO-OSO
+# NO-OSO:     test:{{.*}}file format Mach-O arm64
+# NO-OSO-NOT: test.o
+# NO-OSO-NOT: DW_TAG_compile_unit
+
+## When the .o file is missing, a warning is emitted.
+# RUN: rm %t/test.o
+# RUN: cd %t && llvm-dwarfdump test 2>&1 | FileCheck %s --check-prefix=MISSING
+# MISSING: warning: unable to open N_OSO referenced file 'test.o'

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -375,15 +375,19 @@ static void error(Error Err) {
   exit(1);
 }
 
-static void error(StringRef Prefix, Error Err) {
+static bool error(StringRef Prefix, Error Err, bool Fatal = true) {
   if (!Err)
-    return;
-  WithColor::error() << Prefix << ": " << toString(std::move(Err)) << "\n";
-  exit(1);
+    return false;
+  if (Fatal) {
+    WithColor::error() << Prefix << ": " << toString(std::move(Err)) << "\n";
+    exit(1);
+  }
+  WithColor::warning() << Prefix << ": " << toString(std::move(Err)) << "\n";
+  return true;
 }
 
-static void error(StringRef Prefix, std::error_code EC) {
-  error(Prefix, errorCodeToError(EC));
+static bool error(StringRef Prefix, std::error_code EC, bool Fatal = true) {
+  return error(Prefix, errorCodeToError(EC), Fatal);
 }
 
 static DIDumpOptions getDumpOpts(DWARFContext &C) {
@@ -796,6 +800,9 @@ static bool verifyObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
 
 static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
                          HandlerFn HandleObj, raw_ostream &OS);
+static bool handleArchive(StringRef Filename, Archive &Arch,
+                          HandlerFn HandleObj, raw_ostream &OS,
+                          StringRef MemberFilter = "", bool Fatal = true);
 
 /// Extract unique N_OSO object file paths from a Mach-O binary's symbol table.
 static SmallVector<std::string> collectOSOPaths(const MachOObjectFile &MachO) {
@@ -823,37 +830,38 @@ static SmallVector<std::string> collectOSOPaths(const MachOObjectFile &MachO) {
   return Paths;
 }
 
+static bool handleFile(StringRef Filename, HandlerFn HandleObj, raw_ostream &OS,
+                       bool Fatal = true);
+
 static bool handleDebugMap(const MachOObjectFile &MachO, HandlerFn HandleObj,
                            raw_ostream &OS) {
-  bool Result = true;
-  for (const std::string &OSOPath : collectOSOPaths(MachO)) {
-    ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
-        MemoryBuffer::getFile(OSOPath);
-    if (!BuffOrErr) {
-      WithColor::warning() << "unable to open N_OSO referenced file '"
-                           << OSOPath << "': " << BuffOrErr.getError().message()
-                           << "\n";
-      continue;
-    }
-
-    Result &= handleBuffer(OSOPath, **BuffOrErr, HandleObj, OS);
-  }
-  return Result;
+  for (const std::string &OSOPath : collectOSOPaths(MachO))
+    handleFile(OSOPath, HandleObj, OS, /*Fatal=*/false);
+  return true;
 }
 
 static bool handleArchive(StringRef Filename, Archive &Arch,
-                          HandlerFn HandleObj, raw_ostream &OS) {
+                          HandlerFn HandleObj, raw_ostream &OS,
+                          StringRef MemberName, bool Fatal) {
+  bool FilterByMember = !MemberName.empty();
   bool Result = true;
   Error Err = Error::success();
   for (const auto &Child : Arch.children(Err)) {
-    auto BuffOrErr = Child.getMemoryBufferRef();
-    error(Filename, BuffOrErr.takeError());
     auto NameOrErr = Child.getName();
-    error(Filename, NameOrErr.takeError());
-    std::string Name = (Filename + "(" + NameOrErr.get() + ")").str();
-    Result &= handleBuffer(Name, BuffOrErr.get(), HandleObj, OS);
+    if (error(Filename, NameOrErr.takeError(), Fatal))
+      continue;
+    if (FilterByMember && *NameOrErr != MemberName)
+      continue;
+    auto BuffOrErr = Child.getMemoryBufferRef();
+    if (error(Filename, BuffOrErr.takeError(), Fatal))
+      continue;
+    std::string Name = (Filename + "(" + *NameOrErr + ")").str();
+    Result &= handleBuffer(Name, *BuffOrErr, HandleObj, OS);
+    // Archive member names are generally unique, stop after the first match.
+    if (FilterByMember)
+      break;
   }
-  error(Filename, std::move(Err));
+  error(Filename, std::move(Err), Fatal);
 
   return Result;
 }
@@ -880,7 +888,7 @@ static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
 
       if (DICtx->getNumCompileUnits() == 0 && !NoDebugMap)
         if (auto *MachO = dyn_cast<MachOObjectFile>(Obj))
-          Result = handleDebugMap(*MachO, HandleObj, OS);
+          Result &= handleDebugMap(*MachO, HandleObj, OS);
     }
   } else if (auto *Fat = dyn_cast<MachOUniversalBinary>(BinOrErr->get()))
     for (auto &ObjForArch : Fat->objects()) {
@@ -911,13 +919,43 @@ static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
   return Result;
 }
 
-static bool handleFile(StringRef Filename, HandlerFn HandleObj,
-                       raw_ostream &OS) {
+static bool handleArchiveMember(StringRef Filename, HandlerFn HandleObj,
+                                raw_ostream &OS, bool Fatal) {
+  StringRef ArchivePath = Filename.substr(0, Filename.rfind('('));
+  StringRef MemberName = Filename.substr(ArchivePath.size() + 1).drop_back();
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
+      MemoryBuffer::getFile(ArchivePath);
+  if (error(ArchivePath, BuffOrErr.getError(), Fatal))
+    return false;
+
+  Expected<std::unique_ptr<Binary>> BinOrErr =
+      object::createBinary(BuffOrErr->get()->getMemBufferRef());
+  if (error(ArchivePath, BinOrErr.takeError(), Fatal))
+    return false;
+
+  auto *Arch = dyn_cast<Archive>(BinOrErr->get());
+  if (!Arch) {
+    WithColor::error() << ArchivePath << ": is not an archive\n";
+    if (Fatal)
+      exit(1);
+    return false;
+  }
+
+  return handleArchive(ArchivePath, *Arch, HandleObj, OS, MemberName, Fatal);
+}
+
+static bool handleFile(StringRef Filename, HandlerFn HandleObj, raw_ostream &OS,
+                       bool Fatal) {
+  if (Filename.ends_with(")"))
+    return handleArchiveMember(Filename, HandleObj, OS, Fatal);
+
   ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
       MemoryBuffer::getFileOrSTDIN(Filename);
-  error(Filename, BuffOrErr.getError());
-  std::unique_ptr<MemoryBuffer> Buffer = std::move(BuffOrErr.get());
-  return handleBuffer(Filename, *Buffer, HandleObj, OS);
+  if (error(Filename, BuffOrErr.getError(), Fatal))
+    return false;
+
+  return handleBuffer(Filename, **BuffOrErr, HandleObj, OS);
 }
 
 int main(int argc, char **argv) {

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -23,6 +23,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/Archive.h"
+#include "llvm/Object/MachO.h"
 #include "llvm/Object/MachOUniversal.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Support/CommandLine.h"
@@ -198,6 +199,11 @@ static opt<bool> DumpNonSkeleton(
          "skeleton DIE from the main executable. This allows dumping the .dwo "
          "files with resolved addresses."),
     value_desc("d"), cat(DwarfDumpCategory));
+static opt<bool> NoDebugMap(
+    "no-debug-map",
+    desc("Do not follow Mach-O debug map (N_OSO) references to dump DWARF "
+         "from referenced object files."),
+    cat(DwarfDumpCategory));
 
 static alias IgnoreCaseAlias("i", desc("Alias for --ignore-case."),
                              aliasopt(IgnoreCase), cl::NotHidden);
@@ -791,6 +797,50 @@ static bool verifyObjectFile(ObjectFile &Obj, DWARFContext &DICtx,
 static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
                          HandlerFn HandleObj, raw_ostream &OS);
 
+/// Extract unique N_OSO object file paths from a Mach-O binary's symbol table.
+static SmallVector<std::string> collectOSOPaths(const MachOObjectFile &MachO) {
+  StringSet<> Seen;
+  SmallVector<std::string> Paths;
+
+  for (const SymbolRef &Sym : MachO.symbols()) {
+    DataRefImpl DRI = Sym.getRawDataRefImpl();
+    uint8_t NType = MachO.is64Bit() ? MachO.getSymbol64TableEntry(DRI).n_type
+                                    : MachO.getSymbolTableEntry(DRI).n_type;
+    if (NType != MachO::N_OSO)
+      continue;
+
+    Expected<StringRef> NameOrErr = Sym.getName();
+    if (!NameOrErr) {
+      WithColor::warning() << "N_OSO symbol has no name: "
+                           << toString(NameOrErr.takeError()) << "\n";
+      continue;
+    }
+
+    if (!NameOrErr->empty() && Seen.insert(*NameOrErr).second)
+      Paths.push_back(NameOrErr->str());
+  }
+
+  return Paths;
+}
+
+static bool handleDebugMap(const MachOObjectFile &MachO, HandlerFn HandleObj,
+                           raw_ostream &OS) {
+  bool Result = true;
+  for (const std::string &OSOPath : collectOSOPaths(MachO)) {
+    ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
+        MemoryBuffer::getFile(OSOPath);
+    if (!BuffOrErr) {
+      WithColor::warning() << "unable to open N_OSO referenced file '"
+                           << OSOPath << "': " << BuffOrErr.getError().message()
+                           << "\n";
+      continue;
+    }
+
+    Result &= handleBuffer(OSOPath, **BuffOrErr, HandleObj, OS);
+  }
+  return Result;
+}
+
 static bool handleArchive(StringRef Filename, Archive &Arch,
                           HandlerFn HandleObj, raw_ostream &OS) {
   bool Result = true;
@@ -827,6 +877,10 @@ static bool handleBuffer(StringRef Filename, MemoryBufferRef Buffer,
       DICtx->setParseCUTUIndexManually(ManuallyGenerateUnitIndex);
       if (!HandleObj(*Obj, *DICtx, Filename, OS))
         Result = false;
+
+      if (DICtx->getNumCompileUnits() == 0 && !NoDebugMap)
+        if (auto *MachO = dyn_cast<MachOObjectFile>(Obj))
+          Result = handleDebugMap(*MachO, HandleObj, OS);
     }
   } else if (auto *Fat = dyn_cast<MachOUniversalBinary>(BinOrErr->get()))
     for (auto &ObjForArch : Fat->objects()) {


### PR DESCRIPTION
Add debug map support to llvm-dwarfdump. This allows dwarfdump to be called on binaries which reference the object files from which it was linked. Those object files will usually contain the debug info. The debug map is only used when the binary itself has no compile units.

Assisted-by: claude