### PR TITLE
[LLDB] Refactor SDK-related functions in Platform

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.cpp
@@ -15,7 +15,6 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Core/Progress.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/PseudoTerminal.h"
 #include "lldb/Target/Process.h"
@@ -282,24 +281,21 @@ std::vector<ArchSpec> PlatformAppleSimulator::GetSupportedArchitectures(
   return result;
 }
 
-static llvm::StringRef GetXcodeSDKDir(std::string preferred,
-                                      std::string secondary) {
-  llvm::StringRef sdk;
-  auto get_sdk = [&](std::string sdk) -> llvm::StringRef {
-    Progress progress("Looking for Xcode SDK", sdk);
+static std::string GetXcodeSDKDir(std::string preferred,
+                                  std::string secondary) {
+  auto get_sdk = [&](std::string sdk) -> std::string {
     auto sdk_path_or_err =
-        HostInfo::GetSDKRoot(HostInfo::SDKOptions{XcodeSDK(std::move(sdk))});
+        PlatformDarwin::ResolveXcodeSDK(XcodeSDK(std::move(sdk)));
     if (!sdk_path_or_err) {
-      Debugger::ReportError("Error while searching for Xcode SDK: " +
-                            toString(sdk_path_or_err.takeError()));
+      Debugger::ReportError(toString(sdk_path_or_err.takeError()));
       return {};
     }
-    return *sdk_path_or_err;
+    return sdk_path_or_err->GetPath();
   };
 
-  sdk = get_sdk(preferred);
+  std::string sdk = get_sdk(std::move(preferred));
   if (sdk.empty())
-    sdk = get_sdk(secondary);
+    sdk = get_sdk(std::move(secondary));
   return sdk;
 }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleSimulator.h
@@ -120,7 +120,7 @@ protected:
   std::string m_sdk_name_primary;
   std::string m_sdk_name_secondary;
   bool m_have_searched_for_sdk = false;
-  llvm::StringRef m_sdk;
+  std::string m_sdk;
   XcodeSDK::Type m_sdk_type;
 
   void LoadCoreSimulator();

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1110,39 +1110,25 @@ ResolveSDKPathFromDebugInfo(lldb_private::Target *target) {
 
   ModuleSP exe_module_sp = target->GetExecutableModule();
   if (!exe_module_sp)
-    return llvm::createStringError("failed to get module from target");
+    return llvm::createStringError("could not get module from target");
 
   SymbolFile *sym_file = exe_module_sp->GetSymbolFile();
   if (!sym_file)
-    return llvm::createStringError("failed to get symbol file from executable");
+    return llvm::createStringError("could not get symbol file from executable");
 
   if (sym_file->GetNumCompileUnits() == 0)
     return llvm::createStringError(
-        "Failed to resolve SDK for target: executable's symbol file has no "
+        "could not resolve SDK for target: executable's symbol file has no "
         "compile units");
 
   XcodeSDK merged_sdk;
-  for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
-    if (auto cu_sp = sym_file->GetCompileUnitAtIndex(i)) {
-      auto cu_sdk = sym_file->ParseXcodeSDK(*cu_sp);
-      merged_sdk.Merge(cu_sdk);
-    }
-  }
+  for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i)
+    if (auto cu_sp = sym_file->GetCompileUnitAtIndex(i))
+      merged_sdk.Merge(sym_file->ParseXcodeSDK(*cu_sp));
 
   // TODO: The result of this loop is almost equivalent to deriving the SDK
   // from the target triple, which would be a lot cheaper.
-  FileSpec sdk_path = merged_sdk.GetSysroot();
-  if (FileSystem::Instance().Exists(sdk_path)) {
-    return sdk_path;
-  }
-  Progress progress("Looking for Xcode SDK", merged_sdk.GetString().str());
-  auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{merged_sdk});
-  if (!path_or_err)
-    return llvm::createStringError(
-        llvm::formatv("Failed to resolve SDK path: {0}",
-                      llvm::toString(path_or_err.takeError())));
-
-  return FileSpec(*path_or_err);
+  return PlatformDarwin::ResolveXcodeSDK(std::move(merged_sdk));
 }
 
 void PlatformDarwin::AddClangModuleCompilationOptionsForSDKType(
@@ -1506,30 +1492,32 @@ PlatformDarwin::GetSDKPathFromDebugInfo(Module &module) {
   return std::pair{std::move(merged_sdk), found_mismatch};
 }
 
-llvm::Expected<std::string>
-PlatformDarwin::ResolveSDKPathFromDebugInfo(Module &module) {
-  auto sdk_or_err = GetSDKPathFromDebugInfo(module);
-  if (!sdk_or_err)
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        llvm::formatv("Failed to parse SDK path from debug-info: {0}",
-                      llvm::toString(sdk_or_err.takeError())));
-
-  auto [sdk, _] = std::move(*sdk_or_err);
-
-  if (FileSystem::Instance().Exists(sdk.GetSysroot()))
-    return sdk.GetSysroot().GetPath();
+llvm::Expected<FileSpec> PlatformDarwin::ResolveXcodeSDK(XcodeSDK sdk) {
+  if (FileSpec sysroot = sdk.GetSysroot();
+      FileSystem::Instance().Exists(sysroot))
+    return sysroot;
 
   Progress progress("Looking for Xcode SDK", sdk.GetString().str());
   auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!path_or_err)
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        llvm::formatv("Error while searching for SDK (XcodeSDK '{0}'): {1}",
-                      sdk.GetString(),
-                      llvm::toString(path_or_err.takeError())));
+    return llvm::joinErrors(llvm::createStringError(llvm::formatv(
+                                "could not find SDK '{0}'", sdk.GetString())),
+                            path_or_err.takeError());
+  return FileSpec(*path_or_err);
+}
 
-  return path_or_err->str();
+llvm::Expected<std::string>
+PlatformDarwin::ResolveSDKPathFromDebugInfo(Module &module) {
+  auto sdk_or_err = GetSDKPathFromDebugInfo(module);
+  if (!sdk_or_err)
+    return llvm::joinErrors(
+        llvm::createStringError("could not parse SDK path from debug-info"),
+        sdk_or_err.takeError());
+
+  auto path_or_err = ResolveXcodeSDK(std::move(sdk_or_err->first));
+  if (!path_or_err)
+    return path_or_err.takeError();
+  return path_or_err->GetPath();
 }
 
 llvm::Expected<XcodeSDK>
@@ -1550,23 +1538,14 @@ llvm::Expected<std::string>
 PlatformDarwin::ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
   auto sdk_or_err = GetSDKPathFromDebugInfo(unit);
   if (!sdk_or_err)
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        llvm::formatv("Failed to parse SDK path from debug-info: {0}",
-                      llvm::toString(sdk_or_err.takeError())));
+    return llvm::joinErrors(
+        llvm::createStringError("could not parse SDK path from debug-info"),
+        sdk_or_err.takeError());
 
-  auto sdk = std::move(*sdk_or_err);
-
-  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
-  auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  auto path_or_err = ResolveXcodeSDK(std::move(*sdk_or_err));
   if (!path_or_err)
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        llvm::formatv("Error while searching for SDK (XcodeSDK '{0}'): {1}",
-                      sdk.GetString(),
-                      llvm::toString(path_or_err.takeError())));
-
-  return path_or_err->str();
+    return path_or_err.takeError();
+  return path_or_err->GetPath();
 }
 
 llvm::Expected<FileSpecList>
@@ -1579,8 +1558,7 @@ PlatformDarwin::GetSafeAutoLoadPaths(const Target &target) const {
   info.type = sdk_type;
   XcodeSDK sdk(info);
 
-  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
-  auto sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  auto sdk_root_or_err = ResolveXcodeSDK(sdk);
   if (!sdk_root_or_err) {
     LLDB_LOG_ERROR(log, sdk_root_or_err.takeError(),
                    "Failed to resolve SDK root for triple '{1}': {0}",
@@ -1589,15 +1567,14 @@ PlatformDarwin::GetSafeAutoLoadPaths(const Target &target) const {
     // Fall back to any macOS SDK.
     sdk = XcodeSDK::GetAnyMacOS();
     LLDB_LOG(log, "Falling back to SDK '{0}'", sdk.GetString());
-    progress.Increment(1, sdk.GetString().str());
-    sdk_root_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+    sdk_root_or_err = ResolveXcodeSDK(sdk);
   }
 
   if (!sdk_root_or_err)
     return sdk_root_or_err.takeError();
 
   // $SDKROOT/usr/share/lldb is an auto-loadable path.
-  llvm::SmallString<256> resolved(*sdk_root_or_err);
+  llvm::SmallString<256> resolved(sdk_root_or_err->GetPath());
   llvm::sys::path::append(resolved, "usr", "share", "lldb");
 
   FileSpecList fspecs;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -135,6 +135,9 @@ public:
   llvm::Expected<std::string>
   ResolveSDKPathFromDebugInfo(CompileUnit &unit) override;
 
+  /// Resolve an XcodeSDK to an on-disk path under a Progress event.
+  static llvm::Expected<FileSpec> ResolveXcodeSDK(XcodeSDK sdk);
+
   /// Helper function for \c LocateExecutableScriptingResources
   /// which gathers FileSpecs for executable scripts (currently
   /// just Python) from a .dSYM Python directory.

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformMacOSX.cpp
@@ -23,7 +23,6 @@
 #include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Core/Progress.h"
 #include "lldb/Host/Config.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Host/HostInfo.h"
@@ -128,20 +127,15 @@ ConstString PlatformMacOSX::GetSDKDirectory(lldb_private::Target &target) {
   }
 
   // Use the default SDK as a fallback.
-  XcodeSDK sdk = XcodeSDK::GetAnyMacOS();
-  Progress progress("Looking for Xcode SDK", sdk.GetString().str());
-  auto sdk_path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  auto sdk_path_or_err =
+      PlatformDarwin::ResolveXcodeSDK(XcodeSDK::GetAnyMacOS());
   if (!sdk_path_or_err) {
-    Debugger::ReportError("Error while searching for Xcode SDK: " +
-                          toString(sdk_path_or_err.takeError()));
+    Debugger::ReportError(toString(sdk_path_or_err.takeError()));
     return {};
   }
 
-  FileSpec fspec(*sdk_path_or_err);
-  if (fspec) {
-    if (FileSystem::Instance().Exists(fspec))
-      return ConstString(fspec.GetPath());
-  }
+  if (FileSystem::Instance().Exists(*sdk_path_or_err))
+    return ConstString(sdk_path_or_err->GetPath());
 
   return {};
 }


### PR DESCRIPTION
There are a lot of similar and repetetive variants of SDK lookups in the Apple platform plugins. This commit unifies the implementations, error handling and progress reporting.

Assisted-by: claude