### PR TITLE
Revert "DebugInfo: Shrink-to-fit some containers to reduce peak memory usage"

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugAbbrev.cpp
@@ -50,7 +50,6 @@ Error DWARFAbbreviationDeclarationSet::extract(DataExtractor Data,
     PrevAbbrCode = AbbrDecl.getCode();
     Decls.push_back(std::move(AbbrDecl));
   }
-  Decls.shrink_to_fit();
   return Error::success();
 }
 

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1269,9 +1269,6 @@ Error DWARFDebugLine::LineTable::parse(
         " is not terminated",
         DebugLineOffset));
 
-  Rows.shrink_to_fit();
-  Sequences.shrink_to_fit();
-
   // Sort all sequences so that address lookup will work faster.
   if (!Sequences.empty()) {
     llvm::stable_sort(Sequences, Sequence::orderByHighPC);

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -496,7 +496,6 @@ void DWARFUnit::extractDIEsToVector(
 
     // Stop when compile unit die is removed from the parents stack.
   } while (Parents.size() > 1);
-  Dies.shrink_to_fit();
 }
 
 void DWARFUnit::extractDIEsIfNeeded(bool CUDieOnly) {


### PR DESCRIPTION
Reverts llvm/llvm-project#198935

I think this broke llvm/test/tools/llvm-gsymutil/X86/elf-dwo.yaml .