### PR TITLE
[lit] Add --check to run only selected RUN lines from a test

### DIFF
--- a/llvm/utils/lit/lit/LitConfig.py
+++ b/llvm/utils/lit/lit/LitConfig.py
@@ -42,6 +42,7 @@ class LitConfig(object):
         per_test_coverage=False,
         gtest_sharding=True,
         update_tests=False,
+        checkFilter=None,
     ):
         # The name of the test runner.
         self.progname = progname
@@ -96,6 +97,7 @@ class LitConfig(object):
         self.gtest_sharding = bool(gtest_sharding)
         self.update_tests = update_tests
         self.test_updaters = [diff_test_updater]
+        self.checkFilter = checkFilter
 
     @property
     def maxIndividualTestTime(self):

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1921,6 +1921,23 @@ def _expandLateSubstitutionsExternal(commandLine):
         commandLine = "%s && test -e %s" % (commandLine, filePath)
     return commandLine
 
+def _applyCheckFilter(test, check_filter):
+    """Keep only CommandDirective entries whose 0-indexed integer(s)
+    is/are in check_filter.
+    """
+    if check_filter is None:
+        return test
+    out = []
+    n = -1
+    for d in test:
+        if isinstance(d, CommandDirective):
+            n += 1
+            if n not in check_filter:
+                continue
+        out.append(d)
+    return out
+
+
 def executeShTest(
     test, litConfig, useExternalSh, extra_substitutions=[], preamble_commands=[]
 ):
@@ -1933,6 +1950,7 @@ def executeShTest(
     parsed = parseIntegratedTestScript(test, require_script=not script)
     if isinstance(parsed, lit.Test.Result):
         return parsed
+    parsed = _applyCheckFilter(parsed, litConfig.checkFilter)
     script += parsed
 
     if litConfig.noExecute:

--- a/llvm/utils/lit/lit/cl_arguments.py
+++ b/llvm/utils/lit/lit/cl_arguments.py
@@ -428,6 +428,15 @@ def parse_args():
         default=os.environ.get("LIT_FILTER", ".*"),
     )
     selection_group.add_argument(
+        "--check",
+        dest="checkFilter",
+        metavar="LIST",
+        type=_check_filter,
+        default=None,
+        help="Within each test file, keep only the listed RUN lines. "
+        "LIST is comma-separated 0-indexed integers or ranges: '1,3-5'.",
+    )
+    selection_group.add_argument(
         "--filter-out",
         metavar="REGEX",
         type=_case_insensitive_regex,
@@ -585,6 +594,33 @@ def _case_insensitive_regex(arg):
 
 def _semicolon_list(arg):
     return arg.split(";")
+
+
+def _check_filter(arg):
+    out = []
+    for tok in arg.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if "-" in tok and tok[0] != "-":
+            a, sep, b = tok.partition("-")
+            if a.isdigit() and b.isdigit():
+                lo, hi = int(a), int(b)
+                if hi < lo:
+                    raise _error(
+                        "range '{}' is empty (high < low)", tok
+                    )
+                out.extend(range(lo, hi + 1))
+                continue
+        if tok.isdigit():
+            out.append(int(tok))
+        else:
+            raise _error(
+                "expected integer or integer range, got '{}'", tok
+            )
+    if not out:
+        raise _error("empty selector list")
+    return out
 
 
 def _error(desc, *args):

--- a/llvm/utils/lit/lit/main.py
+++ b/llvm/utils/lit/lit/main.py
@@ -44,6 +44,7 @@ def main(builtin_params={}):
         gtest_sharding=opts.gtest_sharding,
         maxRetriesPerTest=opts.maxRetriesPerTest,
         update_tests=opts.update_tests,
+        checkFilter=opts.checkFilter,
     )
 
     discovered_tests = lit.discovery.find_tests_for_inputs(

--- a/llvm/utils/lit/tests/Inputs/check-filter/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/check-filter/lit.cfg
@@ -1,0 +1,7 @@
+import lit.formats
+
+config.name = "check-filter"
+config.suffixes = [".ll", ".mir", ".s"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None

--- a/llvm/utils/lit/tests/Inputs/check-filter/sample.ll
+++ b/llvm/utils/lit/tests/Inputs/check-filter/sample.ll
@@ -1,0 +1,4 @@
+; RUN: echo FIRST-RUN
+; RUN: echo SECOND-RUN
+define i32 @foo(i32 %a) { ret i32 0 }
+define i32 @bar() { ret i32 1 }

--- a/llvm/utils/lit/tests/check-filter.py
+++ b/llvm/utils/lit/tests/check-filter.py
@@ -1,0 +1,23 @@
+# Verify lit's --check filter. --check=N drops every CommandDirective except
+# the Nth (0-indexed).
+
+# --- --check=0: keep only the first RUN ---
+# RUN: %{lit} -a --check=0 %{inputs}/check-filter/sample.ll \
+# RUN:   | FileCheck --check-prefix=CHECK-0 \
+# RUN:       --implicit-check-not="executed command: echo SECOND-RUN" %s
+#
+# CHECK-0:     executed command: echo FIRST-RUN
+
+# --- --check=1: skip the first, keep the second ---
+# RUN: %{lit} -a --check=1 %{inputs}/check-filter/sample.ll \
+# RUN:   | FileCheck --check-prefix=CHECK-1 \
+# RUN:       --implicit-check-not="executed command: echo FIRST-RUN" %s
+#
+# CHECK-1:     executed command: echo SECOND-RUN
+
+# --- No filter: both RUNs execute ---
+# RUN: %{lit} -a %{inputs}/check-filter/sample.ll \
+# RUN:   | FileCheck --check-prefix=NO-FILTER %s
+#
+# NO-FILTER:   executed command: echo FIRST-RUN
+# NO-FILTER:   executed command: echo SECOND-RUN


### PR DESCRIPTION
Adds `llvm-lit --check=LIST <test>` which keeps only the listed RUN
directives in the test and discards the rest. `LIST` is a
comma-separated mix of 0-indexed integers and ranges (e.g.
`--check=0,2,4-6`). The selection is applied to the
`parseIntegratedTestScript` output.

Stacked above https://github.com/llvm/llvm-project/pull/199390; and below https://github.com/llvm/llvm-project/pull/200618.