### PR TITLE
[CoroSplit] Rename Suspend/End to AlwaysKill/NeverKill (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SuspendCrossingInfo.h
@@ -60,8 +60,8 @@ public:
 //   Kills: a bit vector which contains a set of indices of blocks that can
 //          reach block 'i' but there is a path crossing a suspend point
 //          not repeating 'i' (path to 'i' without cycles containing 'i').
-//   Suspend: a boolean indicating whether block 'i' contains a suspend point.
-//   End: a boolean indicating whether block 'i' contains a coro.end intrinsic.
+//   AlwaysKill: a boolean indicating whether block 'i' always propagate kills.
+//   NeverKill: a boolean indicating whether block 'i' never propagate kills.
 //   KillLoop: There is a path from 'i' to 'i' not otherwise repeating 'i' that
 //             crosses a suspend point.
 //
@@ -71,8 +71,8 @@ class SuspendCrossingInfo {
   struct BlockData {
     BitVector Consumes;
     BitVector Kills;
-    bool Suspend = false;
-    bool End = false;
+    bool AlwaysKill = false;
+    bool NeverKill = false;
     bool KillLoop = false;
     bool Changed = false;
   };

--- a/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
+++ b/llvm/lib/Transforms/Coroutines/SuspendCrossingInfo.cpp
@@ -121,21 +121,13 @@ bool SuspendCrossingInfo::computeBlockData(
       B.Consumes |= P.Consumes;
       B.Kills |= P.Kills;
 
-      // If block P is a suspend block, it should propagate kills into block
-      // B for every block P consumes.
-      if (P.Suspend)
+      if (P.AlwaysKill)
         B.Kills |= P.Consumes;
     }
 
-    if (B.Suspend) {
-      // If block B is a suspend block, it should kill all of the blocks it
-      // consumes.
+    if (B.AlwaysKill) {
       B.Kills |= B.Consumes;
-    } else if (B.End) {
-      // If block B is an end block, it should not propagate kills as the
-      // blocks following coro.end() are reached during initial invocation
-      // of the coroutine while all the data are still available on the
-      // stack or in the registers.
+    } else if (B.NeverKill) {
       B.Kills.reset();
     } else {
       // This is reached when B block it not Suspend nor coro.end and it
@@ -177,7 +169,7 @@ SuspendCrossingInfo::SuspendCrossingInfo(
     assert(CE->getParent()->getFirstInsertionPt() == CE->getIterator() &&
            CE->getParent()->size() <= 2 && "CoroEnd must be in its own BB");
 
-    getBlockData(CE->getParent()).End = true;
+    getBlockData(CE->getParent()).NeverKill = true;
   }
 
   // Mark all suspend blocks and indicate that they kill everything they
@@ -187,7 +179,7 @@ SuspendCrossingInfo::SuspendCrossingInfo(
   auto markSuspendBlock = [&](IntrinsicInst *BarrierInst) {
     BasicBlock *SuspendBlock = BarrierInst->getParent();
     auto &B = getBlockData(SuspendBlock);
-    B.Suspend = true;
+    B.AlwaysKill = true;
     B.Kills |= B.Consumes;
   };
   for (auto *CSI : CoroSuspends) {


### PR DESCRIPTION
Rename them so that we can generalize to more intrinsics, for example, `llvm.coro.is_in_ramp` in #198226