### PR TITLE
[flang][FIRToMemRef] Get strides from descriptor for some array_coor cases.

### DIFF
--- a/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
+++ b/flang/lib/Optimizer/Transforms/FIRToMemRef.cpp
@@ -710,27 +710,35 @@ FIRToMemRef::convertArrayCoorOp(Operation *memOp, fir::ArrayCoorOp arrayCoorOp,
   strides.reserve(rank);
 
   SmallVector<Value> &shapeVec = sliceInfo.shapeVec;
+  const bool firMemrefIsBox = mlir::isa<fir::BaseBoxType>(firMemref.getType());
+  const bool firMemrefIsEmbox =
+      firMemref.getDefiningOp<fir::EmboxOp>() != nullptr;
   // Pick how to derive sizes/strides for the reinterpret_cast view:
   //
-  //   shapeVec path: use the collected fir.shape extents and synthesize
-  //     row-major strides. Valid when those extents describe the underlying
-  //     memref's layout -- shape from a defining embox, a shape_shift that
-  //     carries lower bounds, or no slicing at all.
+  //   shapeVec path: synthesize row-major strides from fir.shape extents.
+  //     Valid when the converted MemRef describes a contiguous storage block:
+  //     either the array_coor base is a raw ref/heap/ptr (no descriptor at
+  //     all), or it is a fir.box produced by fir.embox -- getFIRConvert
+  //     rewinds to embox.getMemref()/box_addr(embox) in that case, so the
+  //     reinterpret_cast operates on the underlying contiguous ref. This
+  //     matches CodeGen XArrayCoorOp's non-boxed branch.
   //
   //   box_dims path: query the descriptor at runtime. Required when:
   //     (a) the slice is projected (physical layout is owned by the box);
   //     (b) we have no shape information at all; or
-  //     (c) the array_coor itself carries fir.shape + fir.slice on a
-  //         descriptor-backed memref with no shift -- those extents describe
-  //         the post-slice view, not the source, so they cannot be used to
-  //         compute strides (e.g. rebox sourced array_coor).
-  const bool descriptorOwnsLayout =
-      sliceInfo.hasProjectedSlice || shapeVec.empty() ||
-      (isDescriptor && sliceInfo.shiftVec.empty() && arrayCoorOp.getShape() &&
-       arrayCoorOp.getSlice());
+  //     (c) the array_coor base is a fir.box that is NOT a fir.embox result.
+  //         getFIRConvert materializes fir.box_addr(box) -- an opaque pointer
+  //         with no layout in its type -- so strides must come from the
+  //         descriptor. This matches CodeGen XArrayCoorOp's boxed branch
+  //         (getStrideFromBox); shape/shape_shift on array_coor is
+  //         informational only (lower bounds for index translation).
+  const bool descriptorOwnsLayout = sliceInfo.hasProjectedSlice ||
+                                    shapeVec.empty() ||
+                                    (firMemrefIsBox && !firMemrefIsEmbox);
   if (descriptorOwnsLayout) {
-    // Projected slices carry their physical layout in the descriptor. Rebuild
-    // the MemRef view from box metadata instead of from slice triplets.
+    // Rebuild the MemRef view from descriptor metadata instead of from slice
+    // triplets. Reached only when firMemref is a fir.box value (case b/c), or
+    // for projected slices (case a) where the source remains the box.
     auto boxElementSize =
         fir::BoxEleSizeOp::create(rewriter, loc, indexTy, firMemref);
 
@@ -739,6 +747,12 @@ FIRToMemRef::convertArrayCoorOp(Operation *memOp, fir::ArrayCoorOp arrayCoorOp,
       auto boxDims = fir::BoxDimsOp::create(rewriter, loc, indexTy, indexTy,
                                             indexTy, firMemref, dim);
 
+      // TODO: when an explicit fir.shape/fir.shape_shift is available
+      // (shapeVec non-empty), prefer its extents over the descriptor's
+      // box_dims extent result. For boxed array_coor the shape extents must
+      // agree with the descriptor's runtime extents, so either source is
+      // correct; using the shape would let constant extents reach the
+      // reinterpret_cast and improve downstream analysis.
       Value extent = boxDims->getResult(1);
       sizes.push_back(castTypeToIndexType(extent, rewriter));
 

--- a/flang/test/Transforms/FIRToMemRef/array-coor-rebox-slice-shape.mlir
+++ b/flang/test/Transforms/FIRToMemRef/array-coor-rebox-slice-shape.mlir
@@ -35,6 +35,36 @@ func.func @array_coor_box_slice_shape_no_shift(%arg0: !fir.box<!fir.array<?x?xi3
   return
 }
 
+// array_coor on a rebox with explicit fir.shape but NO slice on the
+// array_coor itself. The rebox may be non-contiguous, so the descriptor
+// owns the layout: extents and strides must come from fir.box_dims, not
+// from the synthesized contiguous strides of the explicit shape.
+// CHECK-LABEL: func.func @array_coor_rebox_shape_no_slice
+// CHECK:       %[[REBOX:.+]] = fir.rebox
+// CHECK:       fir.box_addr %[[REBOX]]
+// CHECK:       fir.box_elesize %[[REBOX]]
+// CHECK:       fir.box_dims %[[REBOX]]
+// CHECK:       arith.divsi
+// CHECK:       fir.box_dims %[[REBOX]]
+// CHECK:       arith.divsi
+// CHECK:       memref.reinterpret_cast %{{.+}} to offset:
+// CHECK-SAME:  sizes: [{{%.+}}, {{%.+}}], strides: [{{%.+}}, {{%.+}}]
+// CHECK:       memref.load %{{.+}}[{{%.+}}, {{%.+}}]
+// CHECK-NOT:   fir.array_coor
+func.func @array_coor_rebox_shape_no_slice(%arg0: !fir.box<!fir.array<?x?xi32>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %rebox = fir.rebox %arg0 : (!fir.box<!fir.array<?x?xi32>>) -> !fir.box<!fir.array<?x?xi32>>
+  %dim0:3 = fir.box_dims %rebox, %c0 : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+  %dim1:3 = fir.box_dims %rebox, %c1 : (!fir.box<!fir.array<?x?xi32>>, index) -> (index, index, index)
+  %shape = fir.shape %dim0#1, %dim1#1 : (index, index) -> !fir.shape<2>
+  %addr = fir.array_coor %rebox(%shape) %c1, %c2 :
+      (!fir.box<!fir.array<?x?xi32>>, !fir.shape<2>, index, index) -> !fir.ref<i32>
+  %val = fir.load %addr : !fir.ref<i32>
+  return
+}
+
 // Row loop: load VP(I,2) for I=1..2 using the same slice+shape pattern.
 // CHECK-LABEL: func.func @array_coor_box_slice_shape_row_loop
 // CHECK:       scf.for

--- a/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
+++ b/flang/test/Transforms/FIRToMemRef/array-coor-slice-shift.mlir
@@ -75,17 +75,20 @@ func.func @array_coor_slice_shift_section() {
   return
 }
 
-// Descriptor-backed array_coor with shape_shift + slice.
-// TODO: the strides must still be taken from the descriptor.
+// Descriptor-backed array_coor with shape_shift + slice. The descriptor owns
+// the layout: extents and strides must come from fir.box_dims, not from the
+// shape_shift extents. This matches the CodeGen XArrayCoorOp lowering, which
+// reads stride from the box (getStrideFromBox) regardless of any explicit
+// shape; the shape_shift only contributes lower bounds for index translation.
 // CHECK-LABEL: func.func @array_coor_box_shape_shift_slice
-// CHECK:       %[[C1:.*]] = arith.constant 1 : index
-// CHECK:       %[[C5:.*]] = arith.constant 5 : index
-// CHECK:       %[[C10:.*]] = arith.constant 10 : index
 // CHECK:       fir.box_addr %arg0
-// CHECK:       memref.reinterpret_cast %{{.+}} to offset: [%{{.+}}], sizes: [%[[C5]], %[[C10]]], strides: [%[[C10]], %{{.+}}]
+// CHECK:       fir.box_elesize %arg0
+// CHECK:       fir.box_dims %arg0
+// CHECK:       arith.divsi
+// CHECK:       fir.box_dims %arg0
+// CHECK:       arith.divsi
+// CHECK:       memref.reinterpret_cast %{{.+}} to offset: [%{{.+}}], sizes: [{{%.+}}, {{%.+}}], strides: [{{%.+}}, {{%.+}}]
 // CHECK:       memref.load
-// CHECK-NOT:   fir.box_dims
-// CHECK-NOT:   fir.box_elesize
 // CHECK-NOT:   fir.array_coor
 func.func @array_coor_box_shape_shift_slice(%arg0: !fir.box<!fir.array<?x?xi32>>) {
   %c1 = arith.constant 1 : index


### PR DESCRIPTION
This is a follow-up on Jean's comment https://github.com/llvm/llvm-project/pull/198933#discussion_r3279535746

This patch makes use of the descriptor strides when `fir.array_coor`'s
memref is a `fir.box` that is not a fir.embox result.
