### PR TITLE
Revert "[Driver][MSVC] Use LLD if DWARF is requested"

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -332,26 +332,12 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     AddRunTimeLibs(TC, TC.getDriver(), CmdArgs, Args);
   }
 
-  StringRef PreferredLinker = TC.getDriver().getPreferredLinker();
-  if (PreferredLinker.empty()) {
-    // If DWARF is requested, use LLD, because MSVC's link.exe will silently
-    // truncate the .debug_* sections to eight characters. PE/COFF doesn't allow
-    // section names longer than eight bytes in executables - LLD uses the same
-    // name length extension as in object files (where long names are allowed).
-    if (Args.hasArg(options::OPT_gdwarf, options::OPT_gdwarf_2,
-                    options::OPT_gdwarf_3, options::OPT_gdwarf_4,
-                    options::OPT_gdwarf_5, options::OPT_gdwarf_6))
-      PreferredLinker = "lld-link";
-    else
-      PreferredLinker = "link";
-  }
-
-  StringRef Linker =
-      Args.getLastArgValue(options::OPT_fuse_ld_EQ, PreferredLinker);
+  StringRef Linker = Args.getLastArgValue(options::OPT_fuse_ld_EQ,
+                                          TC.getDriver().getPreferredLinker());
   if (Linker.empty())
-    Linker = PreferredLinker;
+    Linker = "link";
   // We need to translate 'lld' into 'lld-link'.
-  if (Linker.equals_insensitive("lld"))
+  else if (Linker.equals_insensitive("lld"))
     Linker = "lld-link";
 
   if (Linker == "lld-link") {

--- a/clang/test/Driver/msvc-link.c
+++ b/clang/test/Driver/msvc-link.c
@@ -51,21 +51,3 @@
 // RUN: %clang -c -marm64x  --target=arm64ec-pc-windows-msvc -fuse-ld=link -### %s 2>&1 | \
 // RUN:        FileCheck --check-prefix=HYBRID-WARN %s
 // HYBRID-WARN: warning: argument unused during compilation: '-marm64x' [-Wunused-command-line-argument]
-
-// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
-// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
-// DEBUG-LINK: link.exe"
-// DEBUG-LINK-SAME: "-debug"
-// DEBUG-LINK-NOT: lld
-
-// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld-link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -gdwarf -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-2 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-3 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-4 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-5 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// RUN: %clang --target=i686-pc-windows-msvc -gdwarf-6 -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
-// DEBUG-LLD: lld-link"
-// DEBUG-LLD-SAME: "-debug"
-// DEBUG-LLD-NOT: link.exe


### PR DESCRIPTION
Reverts llvm/llvm-project#198600 because the test doesn't correctly handle the case when Clang is configured `CLANG_DEFAULT_LINKER=lld`.