### PR TITLE
[Driver][MSVC] Correctly handle the -fuse-ld=(empty) case

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -332,7 +332,7 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     AddRunTimeLibs(TC, TC.getDriver(), CmdArgs, Args);
   }
 
-  const Arg* A = Args.getLastArg(options::OPT_fuse_ld_EQ);
+  const Arg *A = Args.getLastArg(options::OPT_fuse_ld_EQ);
   StringRef Linker = A ? A->getValue() : TC.getDriver().getPreferredLinker();
 
   if (Linker.empty()) {

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -332,8 +332,10 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     AddRunTimeLibs(TC, TC.getDriver(), CmdArgs, Args);
   }
 
-  StringRef PreferredLinker = TC.getDriver().getPreferredLinker();
-  if (PreferredLinker.empty()) {
+  const Arg* A = Args.getLastArg(options::OPT_fuse_ld_EQ);
+  StringRef Linker = A ? A->getValue() : TC.getDriver().getPreferredLinker();
+
+  if (Linker.empty()) {
     // If DWARF is requested, use LLD, because MSVC's link.exe will silently
     // truncate the .debug_* sections to eight characters. PE/COFF doesn't allow
     // section names longer than eight bytes in executables - LLD uses the same
@@ -341,15 +343,11 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     if (Args.hasArg(options::OPT_gdwarf, options::OPT_gdwarf_2,
                     options::OPT_gdwarf_3, options::OPT_gdwarf_4,
                     options::OPT_gdwarf_5, options::OPT_gdwarf_6))
-      PreferredLinker = "lld-link";
+      Linker = "lld-link";
     else
-      PreferredLinker = "link";
+      Linker = "link";
   }
 
-  StringRef Linker =
-      Args.getLastArgValue(options::OPT_fuse_ld_EQ, PreferredLinker);
-  if (Linker.empty())
-    Linker = PreferredLinker;
   // We need to translate 'lld' into 'lld-link'.
   if (Linker.equals_insensitive("lld"))
     Linker = "lld-link";

--- a/clang/test/Driver/msvc-link.c
+++ b/clang/test/Driver/msvc-link.c
@@ -52,9 +52,11 @@
 // RUN:        FileCheck --check-prefix=HYBRID-WARN %s
 // HYBRID-WARN: warning: argument unused during compilation: '-marm64x' [-Wunused-command-line-argument]
 
+// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
 // DEBUG-LINK: link.exe"
 // DEBUG-LINK-SAME: "-debug"
+// DEBUG-LINK-NOT: lld
 
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld-link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s

--- a/clang/test/Driver/msvc-link.c
+++ b/clang/test/Driver/msvc-link.c
@@ -52,11 +52,9 @@
 // RUN:        FileCheck --check-prefix=HYBRID-WARN %s
 // HYBRID-WARN: warning: argument unused during compilation: '-marm64x' [-Wunused-command-line-argument]
 
-// RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld= -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LINK %s
 // DEBUG-LINK: link.exe"
 // DEBUG-LINK-SAME: "-debug"
-// DEBUG-LINK-NOT: lld
 
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s
 // RUN: %clang --target=i686-pc-windows-msvc -g -fuse-ld=lld-link -### %s 2>&1 | FileCheck --check-prefix=DEBUG-LLD %s


### PR DESCRIPTION
We need to distinguish the case where `-fuse-ld` is unspecified and when `-fuse-ld=(empty)` as is already done in the generic `ToolChain` implementation but wasn't done in the MSVC driver to correctly handle the `CLANG_DEFAULT_LINKER` CMake option.