### PR TITLE
[libc++] Remove locale::facet::__on_zero_shared from the ABI

### DIFF
--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -145,7 +145,7 @@ protected:
   //    void operator=(const facet&) = delete;
 
 private:
-  void __on_zero_shared() _NOEXCEPT override;
+  _LIBCPP_HIDE_FROM_ABI_VIRTUAL void __on_zero_shared() _NOEXCEPT override;
 };
 
 class _LIBCPP_EXPORTED_FROM_ABI locale::id {

--- a/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1491,7 +1491,6 @@
 {'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state10__sub_waitERNS_11unique_lockINS_5mutexEEE', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state12__make_readyEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state13set_exceptionESt13exception_ptr', 'type': 'FUNC'}
-{'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state24set_value_at_thread_exitEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state28set_exception_at_thread_exitESt13exception_ptr', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__117__assoc_sub_state4copyEv', 'type': 'FUNC'}
@@ -1733,7 +1732,6 @@
 {'is_defined': True, 'name': '__ZNSt3__16locale4noneE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__16locale4timeE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5ctypeE', 'size': 0, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '__ZNSt3__16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/lib/abi/i686-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/i686-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1371,7 +1371,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale4noneE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale4timeE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5ctypeE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt6__ndk16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -702,7 +702,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale4noneE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale4timeE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5ctypeE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facet16__on_zero_sharedEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facetD0Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facetD1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facetD2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}

--- a/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -702,7 +702,6 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale4noneE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale4timeE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5ctypeE', 'storage_mapping_class': 'RO', 'type': 'OBJECT'}
-{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facet16__on_zero_sharedEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facetD0Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facetD1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__16locale5facetD2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1723,7 +1723,6 @@
 {'is_defined': True, 'name': '__ZNSt3__16locale4noneE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__16locale4timeE', 'size': 0, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5ctypeE', 'size': 0, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '__ZNSt3__16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-linux-android23.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1371,7 +1371,6 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale4noneE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale4timeE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5ctypeE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt6__ndk16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1383,7 +1383,6 @@
 {'is_defined': True, 'name': '_ZNSt3__16locale4noneE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__16locale4timeE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5ctypeE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt3__16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1382,7 +1382,6 @@
 {'is_defined': True, 'name': '_ZNSt3__16locale4noneE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__16locale4timeE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5ctypeE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt3__16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
@@ -1353,7 +1353,6 @@
 {'is_defined': True, 'name': '_ZNSt3__16locale4noneE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__16locale4timeE', 'size': 4, 'type': 'OBJECT'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5ctypeE', 'size': 4, 'type': 'OBJECT'}
-{'is_defined': True, 'name': '_ZNSt3__16locale5facet16__on_zero_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD0Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__16locale5facetD2Ev', 'type': 'FUNC'}

--- a/libcxx/src/ios.cpp
+++ b/libcxx/src/ios.cpp
@@ -9,6 +9,7 @@
 #include <__config>
 #include <__locale>
 #include <algorithm>
+#include <atomic>
 #include <ios>
 #include <limits>
 #include <memory>


### PR DESCRIPTION
`locale::facet::__on_zero_shared` is only ever directly called by `locale::facet::~facet()`, which is already in the dylib, so we can avoid exporting `__on_zero_shared`. It's still accessible through the vtable though.
