### PR TITLE
[clang-format] Add a dependent build target to check-clang-format

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -255,3 +255,5 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/debuginfo-tests)
 endif()
 
 add_subdirectory(Analysis/LifetimeSafety)
+
+add_dependencies(check-clang-format clang-format-check-format)


### PR DESCRIPTION
This makes check-clang-format automatically builds clang-format-check-format, which checks that the new clang-format doesn't break the existing format of the clang-format source.