### PR TITLE
[Verifier] Add missing null-check.

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -5432,6 +5432,7 @@ void Verifier::visitProfMetadata(Instruction &I, MDNode *MD) {
     for (unsigned I = 3; I < MD->getNumOperands(); I += 2) {
       ConstantInt *ProfileValue =
           mdconst::dyn_extract<ConstantInt>(MD->getOperand(I));
+      Check(ProfileValue, "VP !prof value operand is not a const int", MD);
       uint64_t ProfileValueInt = ProfileValue->getZExtValue();
       auto [ValueIt, Inserted] = ProfileValues.insert(ProfileValueInt);
       Check(Inserted, "VP !prof should not have duplicate profile values", MD);

--- a/llvm/test/Verifier/value-profile.ll
+++ b/llvm/test/Verifier/value-profile.ll
@@ -6,6 +6,7 @@
 ; RUN: not opt -passes=verify %t/invalid-count.ll --disable-output 2>&1 | FileCheck %s --check-prefix=INVALID-COUNT
 ; RUN: not opt -passes=verify %t/invalid-place.ll --disable-output 2>&1 | FileCheck %s --check-prefix=INVALID-PLACE
 ; RUN: not opt -passes=verify %t/invalid-duplicate-values.ll -disable-output 2>&1 | FileCheck %s --check-prefix=INVALID-DUPLICATE-VALUES
+; RUN: not opt -passes=verify %t/invalid-value-not-const-int.ll -disable-output 2>&1 | FileCheck %s --check-prefix=INVALID-VALUE-NOT-CONST-INT
 
 ;--- valid.ll
 define void @test(ptr %0) {
@@ -45,3 +46,11 @@ define void @test(ptr %0) {
 }
 !0 = !{!"VP", i32 0, i64 1234, i64 72657670687977694852, i64 1, i64 72657670687977694852, i64 2}
 ; INVALID-DUPLICATE-VALUES: VP !prof should not have duplicate profile values
+
+;--- invalid-value-not-const-int.ll
+define void @test(ptr %0) {
+  call void %0(), !prof !0
+  ret void
+}
+!0 = !{!"VP", i32 0, i64 100, !"oops", i64 50}
+; INVALID-VALUE-NOT-CONST-INT: VP !prof value operand is not a const int


### PR DESCRIPTION
[Verifier] Add missing null-check.

visitProfMetadata's was using the result of dyn_extract without first
checkout that it's non-null.  Thus one could crash the verifier by
providing invalid IR.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.