### PR TITLE
[libc++] Remove AppleClang woraround for __builtin_verbose_trap

### DIFF
--- a/libcxx/include/__verbose_trap
+++ b/libcxx/include/__verbose_trap
@@ -19,14 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if __has_builtin(__builtin_verbose_trap)
-// AppleClang shipped a slightly different version of __builtin_verbose_trap from the upstream
-// version before upstream Clang actually got the builtin.
-// TODO: Remove once AppleClang supports the two-arguments version of the builtin.
-#  if defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER < 1700
-#    define _LIBCPP_VERBOSE_TRAP(message) __builtin_verbose_trap(message)
-#  else
-#    define _LIBCPP_VERBOSE_TRAP(message) __builtin_verbose_trap("libc++", message)
-#  endif
+#  define _LIBCPP_VERBOSE_TRAP(message) __builtin_verbose_trap("libc++", message)
 #else
 #  define _LIBCPP_VERBOSE_TRAP(message) ((void)message, __builtin_trap())
 #endif


### PR DESCRIPTION
We've dropped support for AppleClang versions with a different `__builtin_verbose_trap`, so we can remove the workaround.
