### PR TITLE
[SelectionDAG] Error on FLDEXP libcall with non-int-sized exponent

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -7051,12 +7051,23 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
                              getValue(I.getArgOperand(0)),
                              getValue(I.getArgOperand(1)), Flags));
     return;
-  case Intrinsic::ldexp:
+  case Intrinsic::ldexp: {
+    // The lowering goes through the C `ldexp` libcall, whose exponent is an
+    // `int`. An IR exponent wider than that would silently lose its high bits
+    // through the calling convention.
+    Type *ExpTy = I.getArgOperand(1)->getType();
+    if (ExpTy->getScalarSizeInBits() > DAG.getLibInfo().getIntSize()) {
+      DAG.getContext()->emitError(&I,
+                                  "ldexp exponent is wider than sizeof(int)");
+      setValue(&I, DAG.getPOISON(getValue(I.getArgOperand(0)).getValueType()));
+      return;
+    }
     setValue(&I, DAG.getNode(ISD::FLDEXP, sdl,
                              getValue(I.getArgOperand(0)).getValueType(),
                              getValue(I.getArgOperand(0)),
                              getValue(I.getArgOperand(1)), Flags));
     return;
+  }
   case Intrinsic::modf:
   case Intrinsic::sincos:
   case Intrinsic::sincospi:
@@ -8545,6 +8556,18 @@ void SelectionDAGBuilder::pushFPOpOutChain(SDValue Result,
 void SelectionDAGBuilder::visitConstrainedFPIntrinsic(
     const ConstrainedFPIntrinsic &FPI) {
   SDLoc sdl = getCurSDLoc();
+
+  if (FPI.getIntrinsicID() == Intrinsic::experimental_constrained_ldexp) {
+    // See the non-constrained ldexp case in visitIntrinsicCall.
+    Type *ExpTy = FPI.getArgOperand(1)->getType();
+    if (ExpTy->getScalarSizeInBits() > DAG.getLibInfo().getIntSize()) {
+      DAG.getContext()->emitError(&FPI,
+                                  "ldexp exponent is wider than sizeof(int)");
+      setValue(&FPI,
+               DAG.getPOISON(getValue(FPI.getArgOperand(0)).getValueType()));
+      return;
+    }
+  }
 
   // We do not need to serialize constrained FP intrinsics against
   // each other or against (nonvolatile) loads, so they can be

--- a/llvm/test/CodeGen/X86/ldexp-libcall-i64-exponent.ll
+++ b/llvm/test/CodeGen/X86/ldexp-libcall-i64-exponent.ll
@@ -1,0 +1,29 @@
+; RUN: not llc -mtriple=x86_64-unknown-linux-gnu -filetype=null %s 2>&1 | FileCheck %s
+
+; Check that llvm.ldexp with an exponent wider than the libcall's int
+; fails cleanly rather than silently truncating.
+
+; CHECK: error: ldexp exponent is wider than sizeof(int)
+declare double @llvm.ldexp.f64.i64(double, i64)
+define double @ldexp_f64_i64(double %x, i64 %e) {
+  %r = call double @llvm.ldexp.f64.i64(double %x, i64 %e)
+  ret double %r
+}
+
+; CHECK: error: ldexp exponent is wider than sizeof(int)
+declare float @llvm.ldexp.f32.i64(float, i64)
+define float @ldexp_f32_i64(float %x, i64 %e) {
+  %r = call float @llvm.ldexp.f32.i64(float %x, i64 %e)
+  ret float %r
+}
+
+; CHECK: error: ldexp exponent is wider than sizeof(int)
+declare double @llvm.experimental.constrained.ldexp.f64.i64(double, i64, metadata, metadata)
+define double @strict_ldexp_f64_i64(double %x, i64 %e) #0 {
+  %r = call double @llvm.experimental.constrained.ldexp.f64.i64(double %x, i64 %e,
+                                                                 metadata !"round.tonearest",
+                                                                 metadata !"fpexcept.strict") #0
+  ret double %r
+}
+
+attributes #0 = { strictfp }


### PR DESCRIPTION
The `ldexp` libcall takes an int exponent, but llvm.ldexp accepts any
integer width. LegalizeDAG should error if its argument isn't an int,
just like we do for other libcalls like FPOWI.

This (minor) bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
