### PR TITLE
[clang-tidy] Change IgnoreExternC default to true in modernize-use-using

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseUsingCheck.cpp
@@ -235,7 +235,7 @@ static constexpr StringRef DeclStmtName = "decl-stmt";
 UseUsingCheck::UseUsingCheck(StringRef Name, ClangTidyContext *Context)
     : ClangTidyCheck(Name, Context),
       IgnoreMacros(Options.get("IgnoreMacros", true)),
-      IgnoreExternC(Options.get("IgnoreExternC", false)) {}
+      IgnoreExternC(Options.get("IgnoreExternC", true)) {}
 
 void UseUsingCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
   Options.store(Opts, "IgnoreMacros", IgnoreMacros);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -49,6 +49,10 @@ Major New Features
 Potentially Breaking Changes
 ----------------------------
 
+- The :doc:`modernize-use-using <clang-tidy/checks/modernize/use-using>` check
+  now sets the `IgnoreExternC` option to `true` by default. The check will
+  no longer transform ``typedef``\ s within ``extern "C"`` blocks.
+
 - Deprecated the :program:`clang-tidy` check :doc:`performance-faster-string-find
   <clang-tidy/checks/performance/faster-string-find>`. It has been renamed to
   :doc:`performance-prefer-single-char-overloads
@@ -579,6 +583,8 @@ Changes in existing checks
     parentheses.
 
   - Preserve inline comment blocks that appear between the ``typedef``'s parts.
+
+  - The `IgnoreExternC` option is now set to `true` by default.
 
 - Improved :doc:`performance-enum-size
   <clang-tidy/checks/performance/enum-size>` check:

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-using.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-using.rst
@@ -49,4 +49,4 @@ Options
 .. option:: IgnoreExternC
 
    If set to `true`, the check will not give warning inside ``extern "C"``
-   scope. Default is `false`
+   scope. Default is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using-ignore-extern-c.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using-ignore-extern-c.cpp
@@ -1,9 +1,11 @@
-// RUN: %check_clang_tidy %s modernize-use-using %t -- -config="{CheckOptions: {modernize-use-using.IgnoreExternC: true}}" -- -I %S/Input/use-using/
+// RUN: %check_clang_tidy %s modernize-use-using %t -- -config="{CheckOptions: {modernize-use-using.IgnoreExternC: false}}" -- -I %S/Input/use-using/
 
 // Some Header
 extern "C" {
 
 typedef int NewInt;
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef' [modernize-use-using]
+// CHECK-FIXES: using NewInt = int;
 }
 
 extern "C++" {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -330,8 +330,6 @@ typedef class ISSUE_67529_1 *ISSUE_67529;
 extern "C" {
 
 typedef int InExternC;
-// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef' [modernize-use-using]
-// CHECK-FIXES: using InExternC = int;
 
 }
 


### PR DESCRIPTION
This prevents generating invalid C code in mixed-language headers by leaving `typedef` declarations inside `extern "C"` blocks intact by default.

Fixes #141394

Cc @zeyi2 @vbvictor