### PR TITLE
[mlir][mem2reg] fix assert for indirect blocking uses inside regions

### DIFF
--- a/mlir/lib/Transforms/Mem2Reg.cpp
+++ b/mlir/lib/Transforms/Mem2Reg.cpp
@@ -421,8 +421,9 @@ LogicalResult MemorySlotPromotionAnalyzer::computeBlockingUses(
     for (OpOperand *blockingUse : newBlockingUses) {
       assert(llvm::is_contained(user->getResults(), blockingUse->get()));
 
+      Operation *useOwner = blockingUse->getOwner();
       SmallPtrSetImpl<OpOperand *> &newUserBlockingUseSet =
-          blockingUsesMap[blockingUse->getOwner()];
+          userToBlockingUses[useOwner->getParentRegion()][useOwner];
       newUserBlockingUseSet.insert(blockingUse);
     }
   }

--- a/mlir/test/Dialect/LLVMIR/mem2reg.mlir
+++ b/mlir/test/Dialect/LLVMIR/mem2reg.mlir
@@ -1180,3 +1180,17 @@ llvm.func @dead_direct_use(%arg0 : i1) {
   }
   llvm.return
 }
+
+// -----
+
+// CHECK-LABEL: @indirect_blocking_use_in_different_region
+llvm.func @indirect_blocking_use_in_different_region(%arg0 : i1) {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NOT: llvm.alloca
+  %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
+  %2 = llvm.addrspacecast %1 : !llvm.ptr to !llvm.ptr<5>
+  scf.if %arg0 {
+    %3 = llvm.addrspacecast %2 : !llvm.ptr<5> to !llvm.ptr
+  }
+  llvm.return
+}


### PR DESCRIPTION
When adding new blocking uses created by the interface of a previous blocking uses (typically forwarding  the blocking uses to the op result users), the mem2reg framework was assuming that the new blocking uses are in the same region as the original blocking use, which is not true in general and lead to the assert:

`Transforms/Mem2Reg.cpp:743: void {anonymous}::MemorySlotPromoter::removeBlockingUses(mlir::Region*): Assertion `op->getParentRegion() == region && "all operations must still be in the same region"' failed.`

This patch fixes this by adding the new uses into the userToBlockingUses for the region of the new blocking uses.

Note: this fix is extracted from https://github.com/llvm/llvm-project/pull/196924 for clarity as it is orthogonal.