### PR TITLE
[NFC][X86] Add peekThroughDemandedElts helper for future use

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -29704,6 +29704,15 @@ static SDValue LowerCTTZ(SDValue Op, const X86Subtarget &Subtarget,
   return DAG.getNode(X86ISD::CMOV, dl, VT, Ops);
 }
 
+static SDValue peekThroughDemandedElts(SDValue V, const APInt &DemandedElts,
+                                       SelectionDAG &DAG) {
+  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
+  while (SDValue NewV =
+             TLI.SimplifyMultipleUseDemandedVectorElts(V, DemandedElts, DAG))
+    V = NewV;
+  return V;
+}
+
 // Generic x86 vector reduction expansion.
 static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
                               SelectionDAG &DAG, bool AllowScalarization) {
@@ -29747,11 +29756,7 @@ static SDValue LowerVECREDUCE(SDValue Op, const X86Subtarget &Subtarget,
     APInt HiElts = APInt::getBitsSet(NumSrcElts, NumElts / 2, NumElts);
     if (!DAG.isIdentityElement(BinOp, SDNodeFlags(), Src, HiElts, 1)) {
       APInt LoElts = APInt::getLowBitsSet(NumSrcElts, NumElts / 2);
-      SDValue Lo = Src;
-      while (SDValue NewLo =
-                 TLI.SimplifyMultipleUseDemandedVectorElts(Lo, LoElts, DAG))
-        Lo = NewLo;
-
+      SDValue Lo = peekThroughDemandedElts(Src, LoElts, DAG);
       SmallVector<int, 16> Mask(NumSrcElts, -1);
       std::iota(Mask.begin(), Mask.begin() + (NumElts / 2), NumElts / 2);
       SDValue Hi =


### PR DESCRIPTION
Make it easier to bypass unnecessary ops based of DemandedElts