### PR TITLE
[VPlan] Clear VPTypeAnalysis cache in convertToStridedAccesses

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -61,6 +61,9 @@ public:
 
   /// Return the LLVMContext used by the analysis.
   LLVMContext &getContext() { return Ctx; }
+
+  /// Clears the type cache. Use if a value may have been deleted.
+  void invalidateCache() { CachedTypes.clear(); }
 };
 
 // Collect a VPlan's ephemeral recipes (those used only by an assume).

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -6795,6 +6795,8 @@ void VPlanTransforms::convertToStridedAccesses(VPlan &Plan,
   if (Plan.hasScalarVFOnly())
     return;
 
+  Ctx.Types.invalidateCache();
+
   VPTypeAnalysis TypeInfo(Plan);
   VPRegionBlock *VectorLoop = Plan.getVectorLoopRegion();
   VPValue *I32VF = nullptr;


### PR DESCRIPTION
This is an attempt to fix the crashes reported in https://github.com/llvm/llvm-project/pull/147297#issuecomment-4516349199

The VPTypeAnalysis that's reused in VPCostContext is live across a lot of various passes, including some that I'm fairly sure delete values e.g. VPlanTransforms::removeBranchOnConst. So this will run into the same issue https://github.com/llvm/llvm-project/issues/184650.

This isn't the prettiest solution and I don't think we can write a test case for this. But this should be temporary since we plan to eventually remove VPTypeAnalysis: https://github.com/llvm/llvm-project/pull/195485. It's really only to fix the crashes for now.
