### PR TITLE
[bazel] Use `additional_compiler_inputs` to handle include scanning for TargetPassRegistry.inc

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -3907,6 +3907,20 @@ gentbl_cc_library(
             allow_empty = True,
         ),
         hdrs = ["lib/Target/" + target["name"] + "/" + target["short_name"] + ".h"],
+        # The TargetMachine files use this pattern:
+        #
+        # // In FooTargetMachine.cpp
+        # #define GET_PASS_REGISTRY "FooPassRegistry.def"
+        # #include "llvm/Passes/TargetPassRegistry.inc"
+        #
+        # // In TargetPassRegistry.inc
+        # #include GET_PASS_REGISTRY
+        #
+        # This breaks when using include scanning, so include them explicitly here.
+        additional_compiler_inputs = glob(
+            ["lib/Target/" + target["name"] + "/*.def"],
+            allow_empty = True,
+        ),
         copts = llvm_copts,
         features = [
             "-layering_check",


### PR DESCRIPTION
This use of using `#include` with a macro breaks include scanning, for example:

* `GET_PASS_REGISTRY` defined here: https://github.com/llvm/llvm-project/blob/5c853423f4f9e7296b7596b7f3ccade481686bfd/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp#L603
* `GET_PASS_REGISTRY` included here: https://github.com/llvm/llvm-project/blob/5c853423f4f9e7296b7596b7f3ccade481686bfd/llvm/include/llvm/Passes/TargetPassRegistry.inc#L60

When include scanning is enabled, the `PassRegistry.def` gets omitted because it the include scanner does not handle this case. Providing it via `additional_compiler_inputs` ensures it is included even in that case.