### PR TITLE
[flang-rt] Remove fallback if RPC headers not found

### DIFF
--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -123,9 +123,7 @@ function (add_flangrt_library name)
   endif ()
 
   # Include the RPC utilities from the `libc` project.
-  if (TARGET llvm-libc-common-utilities)
-    set(extra_deps llvm-libc-common-utilities)
-  endif()
+  set(extra_deps llvm-libc-common-utilities)
 
   # Also add header files to IDEs to list as part of the library.
   set_source_files_properties(${ARG_ADDITIONAL_HEADERS} PROPERTIES HEADER_FILE_ONLY ON)

--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -108,12 +108,8 @@ set(host_sources
   time-intrinsic.cpp
   trampoline.cpp
   unit-map.cpp
+  io-api-server.cpp
 )
-if (TARGET llvm-libc-common-utilities)
-  list(APPEND host_sources io-api-server.cpp)
-  set_property(SOURCE main.cpp APPEND PROPERTY
-    COMPILE_DEFINITIONS FLANG_RT_HAS_RPC_SERVER)
-endif()
 
 # Sources that can be compiled directly for the GPU.
 set(gpu_sources

--- a/flang-rt/lib/runtime/main.cpp
+++ b/flang-rt/lib/runtime/main.cpp
@@ -33,10 +33,7 @@ void RTNAME(ProgramStart)(int argc, const char *argv[], const char *envp[],
   Fortran::runtime::executionEnvironment.Configure(
       argc, argv, envp, envDefaults);
   ConfigureFloatingPoint();
-  // Register the IO handlers with the offloading runtime only if present.
-#ifdef FLANG_RT_HAS_RPC_SERVER
   Fortran::runtime::io::RegisterRPCHandlers();
-#endif
   // I/O is initialized on demand so that it works for non-Fortran main().
 }
 


### PR DESCRIPTION
Summary:
These are stored in the libc/shared and have a unified CMake helper to
find them. Likely these will be a more core dependency as LLVM uses them
for constexpr math, libcxx uses it, and compiler-rt will probably use
bits of it.

The original intention was to allow building flang-rt with a partial
checkout, but i don't think this is a reasonable use-case and I do not
think this exists in practice.
