### PR TITLE
[lldb][NativePDB] Use CV qualifiers from `this` type for methods

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.cpp
@@ -809,14 +809,22 @@ clang::QualType PdbAstBuilderClang::CreateType(PdbTypeSymId type) {
   if (cvt.kind() == LF_PROCEDURE) {
     ProcedureRecord pr;
     llvm::cantFail(TypeDeserializer::deserializeAs<ProcedureRecord>(cvt, pr));
-    return CreateFunctionType(pr.ArgumentList, pr.ReturnType, pr.CallConv);
+    return CreateFunctionType(pr.ArgumentList, pr.ReturnType, pr.CallConv,
+                              /*type_quals=*/0);
   }
 
   if (cvt.kind() == LF_MFUNCTION) {
     MemberFunctionRecord mfr;
     llvm::cantFail(
         TypeDeserializer::deserializeAs<MemberFunctionRecord>(cvt, mfr));
-    return CreateFunctionType(mfr.ArgumentList, mfr.ReturnType, mfr.CallConv);
+    unsigned int type_quals = 0;
+    if (!mfr.ThisType.isNoneType()) {
+      clang::QualType this_type = GetOrCreateClangType(mfr.getThisType());
+      if (!this_type.isNull())
+        type_quals = this_type->getPointeeType().getLocalFastQualifiers();
+    }
+    return CreateFunctionType(mfr.ArgumentList, mfr.ReturnType, mfr.CallConv,
+                              type_quals);
   }
 
   return {};
@@ -1243,7 +1251,8 @@ clang::QualType PdbAstBuilderClang::CreateArrayType(const ArrayRecord &ar) {
 
 clang::QualType PdbAstBuilderClang::CreateFunctionType(
     TypeIndex args_type_idx, TypeIndex return_type_idx,
-    llvm::codeview::CallingConvention calling_convention) {
+    llvm::codeview::CallingConvention calling_convention,
+    unsigned int type_quals) {
   SymbolFileNativePDB *pdb = static_cast<SymbolFileNativePDB *>(
       m_clang.GetSymbolFile()->GetBackingSymbolFile());
   PdbIndex &index = pdb->GetIndex();
@@ -1278,8 +1287,8 @@ clang::QualType PdbAstBuilderClang::CreateFunctionType(
     return {};
 
   CompilerType return_ct = ToCompilerType(return_type);
-  CompilerType func_sig_ast_type =
-      m_clang.CreateFunctionType(return_ct, arg_types, is_variadic, 0, *cc);
+  CompilerType func_sig_ast_type = m_clang.CreateFunctionType(
+      return_ct, arg_types, is_variadic, type_quals, *cc);
 
   return clang::QualType::getFromOpaquePtr(
       func_sig_ast_type.GetOpaqueQualType());

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderClang.h
@@ -120,7 +120,8 @@ private:
                                  const llvm::codeview::EnumRecord &record);
   clang::QualType
   CreateFunctionType(TypeIndex args_type_idx, TypeIndex return_type_idx,
-                     llvm::codeview::CallingConvention calling_convention);
+                     llvm::codeview::CallingConvention calling_convention,
+                     unsigned int type_quals);
   clang::QualType CreateType(PdbTypeSymId type);
 
   void CreateFunctionParameters(PdbCompilandSymId func_id,

--- a/lldb/test/Shell/SymbolFile/NativePDB/ast-methods.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/ast-methods.cpp
@@ -18,6 +18,12 @@ struct Struct {
   int overloaded_method() {}
   int overloaded_method(char c) {}
   int overloaded_method(char c, int i, ...) {}
+
+  void const_method() const {}
+  void volatile_method() volatile {}
+  void const_volatile_method() const volatile {}
+
+  virtual void virtual_const_method() const {}
 };
 
 Struct s;
@@ -29,6 +35,10 @@ int main(int argc, char **argv) {
   s.overloaded_method();
   s.overloaded_method('a');
   s.overloaded_method('a', 1);
+  s.const_method();
+  s.volatile_method();
+  s.const_volatile_method();
+  s.virtual_const_method();
   return 0;
 }
 
@@ -40,9 +50,13 @@ int main(int argc, char **argv) {
 // AST: | |-CXXMethodDecl {{.*}} overloaded_method 'int (){{.*}}'
 // AST: | |-CXXMethodDecl {{.*}} overloaded_method 'int (char){{.*}}'
 // AST: | | `-ParmVarDecl {{.*}} 'char'
-// AST: | `-CXXMethodDecl {{.*}} overloaded_method 'int (char, int, ...)'
-// AST: |   |-ParmVarDecl {{.*}} 'char'
-// AST: |   `-ParmVarDecl {{.*}} 'int'
+// AST: | |-CXXMethodDecl {{.*}} overloaded_method 'int (char, int, ...)'
+// AST: | | |-ParmVarDecl {{.*}} 'char'
+// AST: | | `-ParmVarDecl {{.*}} 'int'
+// AST: | |-CXXMethodDecl {{.*}} const_method 'void () const'
+// AST: | |-CXXMethodDecl {{.*}} volatile_method 'void () volatile'
+// AST: | |-CXXMethodDecl {{.*}} const_volatile_method 'void () const volatile'
+// AST: | `-CXXMethodDecl {{.*}} virtual_const_method 'void () const' virtual
 
 // SYMBOL:      struct Struct {
 // SYMBOL-NEXT:     void simple_method();
@@ -51,6 +65,10 @@ int main(int argc, char **argv) {
 // SYMBOL-NEXT:     int overloaded_method();
 // SYMBOL-NEXT:     int overloaded_method(char);
 // SYMBOL-NEXT:     int overloaded_method(char, int, ...);
+// SYMBOL-NEXT:     void const_method() const; 
+// SYMBOL-NEXT:     void volatile_method() volatile; 
+// SYMBOL-NEXT:     void const_volatile_method() const volatile; 
+// SYMBOL-NEXT:     virtual void virtual_const_method() const; 
 // SYMBOL-NEXT: };
 // SYMBOL-NEXT: Struct s;
 // SYMBOL-NEXT: int main(int argc, char **argv);

--- a/lldb/test/Shell/SymbolFile/PDB/ast-restore.test
+++ b/lldb/test/Shell/SymbolFile/PDB/ast-restore.test
@@ -58,7 +58,7 @@ CLASS-DAG:             static const N0::N1::(anonymous namespace)::ScopedEnum Cl
 CLASS-DAG:             N0::N1::Class::Inner m_inner;
 CLASS-DAG:             {{(inline )?}}Class(N0::N1::(anonymous namespace)::Enum);
 CLASS-DAG:             {{(static )?}}{{(inline )?}}int StaticFunc(const N0::N1::Class &);
-CLASS-DAG:             {{(inline )?}}int PrivateFunc(const N0::N1::Class::Inner &);
+CLASS-DAG:             {{(inline )?}}int PrivateFunc(const N0::N1::Class::Inner &){{( const)?}};
 CLASS:         };
 CLASS:     }
 CLASS: }


### PR DESCRIPTION
When we create the Clang types for methods, we ignored the qualifiers. So `const` methods would become non-const.

With this PR, we use the qualifiers from `*this` for the function type.