### PR TITLE
[clang] ast-text-dump: fix printing of declref to decomposition with no bindings

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -676,6 +676,8 @@ Bug Fixes to AST Handling
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^
+- Fixed a crash whith the AST text dumper, when dumping a reference to a
+  decomposition with no bindinds. (#GH198842)
 - Fixed the arguments of the format attribute on ``__builtin_os_log_format``.  Previously, they were off by 1.
 
 Miscellaneous Clang Crashes Fixed

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -966,11 +966,13 @@ void TextNodeDumper::dumpBareDeclRef(const Decl *D) {
       OS << " '" << Name << '\'';
     else
       switch (ND->getKind()) {
-      case Decl::Decomposition: {
-        auto *DD = cast<DecompositionDecl>(ND);
-        OS << " first_binding '" << DD->bindings()[0]->getDeclName() << '\'';
+      case Decl::Decomposition:
+        if (auto Bindings = cast<DecompositionDecl>(ND)->bindings();
+            !Bindings.empty())
+          OS << " first_binding '" << Bindings[0]->getDeclName() << '\'';
+        else
+          OS << " no_bindings";
         break;
-      }
       case Decl::Field: {
         auto *FD = cast<FieldDecl>(ND);
         OS << " field_index " << FD->getFieldIndex();

--- a/clang/test/AST/ast-dump-decl.cpp
+++ b/clang/test/AST/ast-dump-decl.cpp
@@ -1005,3 +1005,11 @@ namespace TestGH155936 {
   // CHECK: CXXRecordDecl 0x{{.+}} <line:[[@LINE-8]]:7, col:19> col:14 struct Foo definition
   // CHECH: CXXRecordDecl 0x{{.+}} <col:9, col:16> col:16 implicit struct Foo
 } // namspace GH155936
+
+namespace TestGH198842 {
+  struct X {};
+  auto && [] = X{};
+  // CHECK-LABEL: Dumping TestGH198842:
+  // CHECK: DecompositionDecl 0x{{.+}} <line:{{.+}}:3, col:18> col:11 'X &&' cinit external-linkage
+  // CHECK: MaterializeTemporaryExpr 0x{{.+}} <col:16, col:18> 'X' xvalue extended by Decomposition 0x{{.+}} no_bindings 'X &&'
+} // namespace TestGH198842


### PR DESCRIPTION
Clang supports empty structured binding groups as an extension, and the text node dumper has some special handling for giving a name to anonymous declarations, which assumed a decomposition would have at least one binding.

Fixes #198842