### PR TITLE
[LLVM] Precise error message for intrinsic signature verification (2/n)

### DIFF
--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -1039,8 +1039,8 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
 
       if (Ty == OverloadTys[OIdx])
         return false;
-      OS << Position << " type (MatchType<" << OIdx << ">) expected "
-         << *OverloadTys[OIdx] << ", but got " << *Ty;
+      OS << Position << " type (matching overload type " << OIdx
+         << ") expected " << *OverloadTys[OIdx] << ", but got " << *Ty;
       return true;
     }
 

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -1032,8 +1032,8 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
   case IITDescriptor::Overloaded: {
     unsigned OIdx = D.getOverloadIndex();
     if (D.getOverloadKind() == IITDescriptor::AK_MatchType) {
-      // This is a dependent type instance, check it similar to other dependent
-      // types.
+      // This is a dependent type instance, check it similarly to other
+      // dependent types.
       if (OIdx >= OverloadTys.size())
         return IsDeferredCheck || DeferCheck(Ty);
 

--- a/llvm/lib/IR/Intrinsics.cpp
+++ b/llvm/lib/IR/Intrinsics.cpp
@@ -940,11 +940,15 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
 
   IITDescriptor D = Infos.consume_front();
 
-  auto PrintMsg = [&OS, &Position, Ty](bool IsValid,
-                                       const Twine &Expected) -> bool {
+  auto PrintMsg = [&OS, &Position,
+                   Ty](bool IsValid, const Twine &Expected,
+                       std::optional<unsigned> OIdx = std::nullopt) -> bool {
     if (IsValid)
       return false;
-    OS << Position << " type expected " << Expected << ", but got " << *Ty;
+    OS << Position << " type";
+    if (OIdx)
+      OS << " (overload type " << *OIdx << ")";
+    OS << " expected " << Expected << ", but got " << *Ty;
     return true;
   };
 
@@ -1025,17 +1029,22 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     return false;
   }
 
-  case IITDescriptor::Overloaded:
-    // If this is the second occurrence of an argument,
-    // verify that the later instance matches the previous instance.
-    if (D.getOverloadIndex() < OverloadTys.size())
-      return Ty != OverloadTys[D.getOverloadIndex()];
+  case IITDescriptor::Overloaded: {
+    unsigned OIdx = D.getOverloadIndex();
+    if (D.getOverloadKind() == IITDescriptor::AK_MatchType) {
+      // This is a dependent type instance, check it similar to other dependent
+      // types.
+      if (OIdx >= OverloadTys.size())
+        return IsDeferredCheck || DeferCheck(Ty);
 
-    if (D.getOverloadIndex() > OverloadTys.size() ||
-        D.getOverloadKind() == IITDescriptor::AK_MatchType)
-      return IsDeferredCheck || DeferCheck(Ty);
+      if (Ty == OverloadTys[OIdx])
+        return false;
+      OS << Position << " type (MatchType<" << OIdx << ">) expected "
+         << *OverloadTys[OIdx] << ", but got " << *Ty;
+      return true;
+    }
 
-    assert(D.getOverloadIndex() == OverloadTys.size() && !IsDeferredCheck &&
+    assert(OIdx == OverloadTys.size() && !IsDeferredCheck &&
            "Table consistency error");
     OverloadTys.push_back(Ty);
 
@@ -1043,17 +1052,19 @@ matchIntrinsicType(Type *Ty, ArrayRef<Intrinsic::IITDescriptor> &Infos,
     case IITDescriptor::AK_Any:
       return false; // Success
     case IITDescriptor::AK_AnyInteger:
-      return !Ty->isIntOrIntVectorTy();
+      return PrintMsg(Ty->isIntOrIntVectorTy(), "any integer or integer vector",
+                      OIdx);
     case IITDescriptor::AK_AnyFloat:
-      return !Ty->isFPOrFPVectorTy();
+      return PrintMsg(Ty->isFPOrFPVectorTy(), "any fp or fp vector", OIdx);
     case IITDescriptor::AK_AnyVector:
-      return !isa<VectorType>(Ty);
+      return PrintMsg(isa<VectorType>(Ty), "any vector type", OIdx);
     case IITDescriptor::AK_AnyPointer:
-      return !isa<PointerType>(Ty);
+      return PrintMsg(isa<PointerType>(Ty), "any pointer type", OIdx);
     default:
       break;
     }
     llvm_unreachable("all argument kinds not covered");
+  }
 
   case IITDescriptor::Extend: {
     // If this is a forward reference, defer the check for later.

--- a/llvm/test/Assembler/implicit-intrinsic-declaration-invalid.ll
+++ b/llvm/test/Assembler/implicit-intrinsic-declaration-invalid.ll
@@ -3,7 +3,7 @@
 ; Use of intrinsic without mangling suffix and invalid signature should
 ; be rejected.
 
-; CHECK: error: intrinsic argument 1 type (MatchType<0>) expected i8, but got i16
+; CHECK: error: intrinsic argument 1 type (matching overload type 0) expected i8, but got i16
 define void @test() {
   call i8 @llvm.umax(i8 0, i16 1)
   ret void

--- a/llvm/test/Assembler/implicit-intrinsic-declaration-invalid.ll
+++ b/llvm/test/Assembler/implicit-intrinsic-declaration-invalid.ll
@@ -3,7 +3,7 @@
 ; Use of intrinsic without mangling suffix and invalid signature should
 ; be rejected.
 
-; CHECK: error: intrinsic has incorrect argument type!
+; CHECK: error: intrinsic argument 1 type (MatchType<0>) expected i8, but got i16
 define void @test() {
   call i8 @llvm.umax(i8 0, i16 1)
   ret void

--- a/llvm/test/Verifier/arbitrary-fp-convert.ll
+++ b/llvm/test/Verifier/arbitrary-fp-convert.ll
@@ -47,7 +47,7 @@ define i8 @bad_rounding(half %v) {
 }
 
 ;--- ptr-to-arbitrary-fp.ll
-; PTR-TO-FP: intrinsic has incorrect argument type!
+; PTR-TO-FP: intrinsic argument 0 type (overload type 1) expected any fp or fp vector, but got ptr
 
 declare i8 @llvm.convert.to.arbitrary.fp.i8.ptr(ptr, metadata, metadata, i1)
 
@@ -58,7 +58,7 @@ define i8 @bad_ptr_to_fp(ptr %p) {
 }
 
 ;--- arbitrary-fp-to-ptr.ll
-; FP-TO-PTR: intrinsic has incorrect return type!
+; FP-TO-PTR: intrinsic return type (overload type 0) expected any fp or fp vector, but got ptr
 
 declare ptr @llvm.convert.from.arbitrary.fp.ptr.i8(i8, metadata)
 
@@ -69,7 +69,7 @@ define ptr @bad_fp_to_ptr(i8 %v) {
 }
 
 ;--- int-to-arbitrary-fp.ll
-; INT-TO-FP: intrinsic has incorrect argument type!
+; INT-TO-FP: intrinsic argument 0 type (overload type 1) expected any fp or fp vector, but got i32
 
 declare i8 @llvm.convert.to.arbitrary.fp.i8.i32(i32, metadata, metadata, i1)
 
@@ -80,7 +80,7 @@ define i8 @bad_int_to_fp(i32 %v) {
 }
 
 ;--- arbitrary-fp-to-int.ll
-; FP-TO-INT: intrinsic has incorrect return type!
+; FP-TO-INT: intrinsic return type (overload type 0) expected any fp or fp vector, but got i32
 
 declare i32 @llvm.convert.from.arbitrary.fp.i32.i8(i8, metadata)
 
@@ -91,7 +91,7 @@ define i32 @bad_fp_to_int(i8 %v) {
 }
 
 ;--- vec-ptr-to-arbitrary-fp.ll
-; VEC-PTR-TO-FP: intrinsic has incorrect argument type!
+; VEC-PTR-TO-FP: intrinsic argument 0 type (overload type 1) expected any fp or fp vector, but got <4 x ptr>
 
 declare <4 x i8> @llvm.convert.to.arbitrary.fp.v4i8.v4ptr(<4 x ptr>, metadata, metadata, i1)
 

--- a/llvm/test/Verifier/callbr.ll
+++ b/llvm/test/Verifier/callbr.ll
@@ -73,7 +73,7 @@ abnormal:
 declare i32 @llvm.callbr.landingpad.i64(i64)
 define void @callbrpad_bad_type() {
 entry:
-; CHECK: intrinsic argument 0 type (MatchType<0>) expected i32, but got i64
+; CHECK: intrinsic argument 0 type (matching overload type 0) expected i32, but got i64
 ; CHECK-NEXT: ptr @llvm.callbr.landingpad.i64
   %foo = call i32 @llvm.callbr.landingpad.i64(i64 42)
   ret void

--- a/llvm/test/Verifier/callbr.ll
+++ b/llvm/test/Verifier/callbr.ll
@@ -73,7 +73,7 @@ abnormal:
 declare i32 @llvm.callbr.landingpad.i64(i64)
 define void @callbrpad_bad_type() {
 entry:
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (MatchType<0>) expected i32, but got i64
 ; CHECK-NEXT: ptr @llvm.callbr.landingpad.i64
   %foo = call i32 @llvm.callbr.landingpad.i64(i64 42)
   ret void

--- a/llvm/test/Verifier/get-active-lane-mask.ll
+++ b/llvm/test/Verifier/get-active-lane-mask.ll
@@ -13,7 +13,7 @@ define <4 x i32> @t1(i32 %IV, i32 %TC) {
 declare i32 @llvm.get.active.lane.mask.i32.i32(i32, i32)
 
 define i32 @t2(i32 %IV, i32 %TC) {
-; CHECK:      intrinsic has incorrect return type!
+; CHECK:      intrinsic return type (overload type 0) expected any vector type, but got i32
 ; CHECK-NEXT: ptr @llvm.get.active.lane.mask.i32.i32
 
   %res = call i32 @llvm.get.active.lane.mask.i32.i32(i32 %IV, i32 %TC)

--- a/llvm/test/Verifier/intrinsic-arg-overloading-struct-ret.ll
+++ b/llvm/test/Verifier/intrinsic-arg-overloading-struct-ret.ll
@@ -2,7 +2,7 @@
 
 ; LD2 and LD2LANE
 
-; CHECK: intrinsic return struct element 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
+; CHECK: intrinsic return struct element 0 type (matching overload type 0) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld2.v4i32
 define { <4 x i64>, <4 x i32> } @test_ld2_ret(ptr %ptr) {
   %res = call { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32(ptr %ptr)
@@ -10,7 +10,7 @@ define { <4 x i64>, <4 x i32> } @test_ld2_ret(ptr %ptr) {
 }
 declare { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32(ptr %ptr)
 
-; CHECK: intrinsic return struct element 1 type (MatchType<0>) expected <4 x i64>, but got <4 x i32>
+; CHECK: intrinsic return struct element 1 type (matching overload type 0) expected <4 x i64>, but got <4 x i32>
 ; CHECK-NEXT: llvm.aarch64.neon.ld2lane.v4i64
 define { <4 x i64>, <4 x i32> } @test_ld2lane_ret(ptr %ptr, <4 x i64> %a, <4 x i64> %b) {
   %res = call { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i64(<4 x i64> %a, <4 x i64> %b, i64 0, ptr %ptr)
@@ -18,7 +18,7 @@ define { <4 x i64>, <4 x i32> } @test_ld2lane_ret(ptr %ptr, <4 x i64> %a, <4 x i
 }
 declare { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i64(<4 x i64>, <4 x i64>, i64, ptr)
 
-; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
+; CHECK: intrinsic argument 0 type (matching overload type 0) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld2lane.v4i32
 define { <4 x i32>, <4 x i32> } @test_ld2lane_arg(ptr %ptr, <4 x i64> %a, <4 x i32> %b) {
   %res = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i32(<4 x i64> %a, <4 x i32> %b, i64 0, ptr %ptr)
@@ -28,7 +28,7 @@ declare { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i32(<4 x i64>, <4 
 
 ; LD3 and LD3LANE
 
-; CHECK: intrinsic return struct element 1 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
+; CHECK: intrinsic return struct element 1 type (matching overload type 0) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld3.v4i32
 define { <4 x i32>, <4 x i64>, <4 x i32> } @test_ld3_ret(ptr %ptr) {
   %res = call { <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld3.v4i32(ptr %ptr)
@@ -36,7 +36,7 @@ define { <4 x i32>, <4 x i64>, <4 x i32> } @test_ld3_ret(ptr %ptr) {
 }
 declare { <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld3.v4i32(ptr %ptr)
 
-; CHECK: intrinsic return struct element 1 type (MatchType<0>) expected <4 x i64>, but got <4 x i32>
+; CHECK: intrinsic return struct element 1 type (matching overload type 0) expected <4 x i64>, but got <4 x i32>
 ; CHECK-NEXT: llvm.aarch64.neon.ld3lane.v4i64
 define { <4 x i64>, <4 x i32>, <4 x i64> } @test_ld3lane_ret(ptr %ptr, <4 x i64> %a, <4 x i64> %b, <4 x i64> %c) {
   %res = call { <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld3lane.v4i64(<4 x i64> %a, <4 x i64> %b, <4 x i64> %c, i64 0, ptr %ptr)
@@ -44,7 +44,7 @@ define { <4 x i64>, <4 x i32>, <4 x i64> } @test_ld3lane_ret(ptr %ptr, <4 x i64>
 }
 declare { <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld3lane.v4i64(<4 x i64>, <4 x i64>, <4 x i64>, i64, ptr)
 
-; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
+; CHECK: intrinsic argument 0 type (matching overload type 0) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld3lane.v4i32
 define { <4 x i32>, <4 x i32>, <4 x i32> } @test_ld3lane_arg(ptr %ptr, <4 x i64> %a, <4 x i32> %b, <4 x i32> %c) {
   %res = call { <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld3lane.v4i32(<4 x i64> %a, <4 x i32> %b, <4 x i32> %c, i64 0, ptr %ptr)
@@ -54,7 +54,7 @@ declare { <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld3lane.v4i32(<4 
 
 ; LD4 and LD4LANE
 
-; CHECK: intrinsic return struct element 2 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
+; CHECK: intrinsic return struct element 2 type (matching overload type 0) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld4.v4i32
 define { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @test_ld4_ret(ptr %ptr) {
   %res = call { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld4.v4i32(ptr %ptr)
@@ -62,7 +62,7 @@ define { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @test_ld4_ret(ptr %ptr) {
 }
 declare { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld4.v4i32(ptr %ptr)
 
-; CHECK: intrinsic return struct element 2 type (MatchType<0>) expected <4 x i64>, but got <4 x i32>
+; CHECK: intrinsic return struct element 2 type (matching overload type 0) expected <4 x i64>, but got <4 x i32>
 ; CHECK-NEXT: llvm.aarch64.neon.ld4lane.v4i64
 define { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @test_ld4lane_ret(ptr %ptr, <4 x i64> %a, <4 x i64> %b, <4 x i64> %c, <4 x i64> %d) {
   %res = call { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld4lane.v4i64(<4 x i64> %a, <4 x i64> %b, <4 x i64> %c, <4 x i64> %d, i64 0, ptr %ptr)
@@ -70,7 +70,7 @@ define { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @test_ld4lane_ret(ptr %ptr
 }
 declare { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld4lane.v4i64(<4 x i64>, <4 x i64>, <4 x i64>, <4 x i64>, i64, ptr)
 
-; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
+; CHECK: intrinsic argument 0 type (matching overload type 0) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld4lane.v4i32
 define { <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32> } @test_ld4lane_arg(ptr %ptr, <4 x i64> %a, <4 x i32> %b, <4 x i32> %c, <4 x i32> %d) {
   %res = call { <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld4lane.v4i32(<4 x i64> %a, <4 x i32> %b, <4 x i32> %c, <4 x i32> %d, i64 0, ptr %ptr)

--- a/llvm/test/Verifier/intrinsic-arg-overloading-struct-ret.ll
+++ b/llvm/test/Verifier/intrinsic-arg-overloading-struct-ret.ll
@@ -2,7 +2,7 @@
 
 ; LD2 and LD2LANE
 
-; CHECK: intrinsic has incorrect return type
+; CHECK: intrinsic return struct element 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld2.v4i32
 define { <4 x i64>, <4 x i32> } @test_ld2_ret(ptr %ptr) {
   %res = call { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32(ptr %ptr)
@@ -10,7 +10,7 @@ define { <4 x i64>, <4 x i32> } @test_ld2_ret(ptr %ptr) {
 }
 declare { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2.v4i32(ptr %ptr)
 
-; CHECK: intrinsic has incorrect return type
+; CHECK: intrinsic return struct element 1 type (MatchType<0>) expected <4 x i64>, but got <4 x i32>
 ; CHECK-NEXT: llvm.aarch64.neon.ld2lane.v4i64
 define { <4 x i64>, <4 x i32> } @test_ld2lane_ret(ptr %ptr, <4 x i64> %a, <4 x i64> %b) {
   %res = call { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i64(<4 x i64> %a, <4 x i64> %b, i64 0, ptr %ptr)
@@ -18,7 +18,7 @@ define { <4 x i64>, <4 x i32> } @test_ld2lane_ret(ptr %ptr, <4 x i64> %a, <4 x i
 }
 declare { <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i64(<4 x i64>, <4 x i64>, i64, ptr)
 
-; CHECK: intrinsic has incorrect argument type
+; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld2lane.v4i32
 define { <4 x i32>, <4 x i32> } @test_ld2lane_arg(ptr %ptr, <4 x i64> %a, <4 x i32> %b) {
   %res = call { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i32(<4 x i64> %a, <4 x i32> %b, i64 0, ptr %ptr)
@@ -28,7 +28,7 @@ declare { <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld2lane.v4i32(<4 x i64>, <4 
 
 ; LD3 and LD3LANE
 
-; CHECK: intrinsic has incorrect return type
+; CHECK: intrinsic return struct element 1 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld3.v4i32
 define { <4 x i32>, <4 x i64>, <4 x i32> } @test_ld3_ret(ptr %ptr) {
   %res = call { <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld3.v4i32(ptr %ptr)
@@ -36,7 +36,7 @@ define { <4 x i32>, <4 x i64>, <4 x i32> } @test_ld3_ret(ptr %ptr) {
 }
 declare { <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld3.v4i32(ptr %ptr)
 
-; CHECK: intrinsic has incorrect return type
+; CHECK: intrinsic return struct element 1 type (MatchType<0>) expected <4 x i64>, but got <4 x i32>
 ; CHECK-NEXT: llvm.aarch64.neon.ld3lane.v4i64
 define { <4 x i64>, <4 x i32>, <4 x i64> } @test_ld3lane_ret(ptr %ptr, <4 x i64> %a, <4 x i64> %b, <4 x i64> %c) {
   %res = call { <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld3lane.v4i64(<4 x i64> %a, <4 x i64> %b, <4 x i64> %c, i64 0, ptr %ptr)
@@ -44,7 +44,7 @@ define { <4 x i64>, <4 x i32>, <4 x i64> } @test_ld3lane_ret(ptr %ptr, <4 x i64>
 }
 declare { <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld3lane.v4i64(<4 x i64>, <4 x i64>, <4 x i64>, i64, ptr)
 
-; CHECK: intrinsic has incorrect argument type
+; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld3lane.v4i32
 define { <4 x i32>, <4 x i32>, <4 x i32> } @test_ld3lane_arg(ptr %ptr, <4 x i64> %a, <4 x i32> %b, <4 x i32> %c) {
   %res = call { <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld3lane.v4i32(<4 x i64> %a, <4 x i32> %b, <4 x i32> %c, i64 0, ptr %ptr)
@@ -54,7 +54,7 @@ declare { <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld3lane.v4i32(<4 
 
 ; LD4 and LD4LANE
 
-; CHECK: intrinsic has incorrect return type
+; CHECK: intrinsic return struct element 2 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld4.v4i32
 define { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @test_ld4_ret(ptr %ptr) {
   %res = call { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld4.v4i32(ptr %ptr)
@@ -62,7 +62,7 @@ define { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @test_ld4_ret(ptr %ptr) {
 }
 declare { <4 x i32>, <4 x i32>, <4 x i64>, <4 x i32> } @llvm.aarch64.neon.ld4.v4i32(ptr %ptr)
 
-; CHECK: intrinsic has incorrect return type
+; CHECK: intrinsic return struct element 2 type (MatchType<0>) expected <4 x i64>, but got <4 x i32>
 ; CHECK-NEXT: llvm.aarch64.neon.ld4lane.v4i64
 define { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @test_ld4lane_ret(ptr %ptr, <4 x i64> %a, <4 x i64> %b, <4 x i64> %c, <4 x i64> %d) {
   %res = call { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld4lane.v4i64(<4 x i64> %a, <4 x i64> %b, <4 x i64> %c, <4 x i64> %d, i64 0, ptr %ptr)
@@ -70,7 +70,7 @@ define { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @test_ld4lane_ret(ptr %ptr
 }
 declare { <4 x i64>, <4 x i64>, <4 x i32>, <4 x i64> } @llvm.aarch64.neon.ld4lane.v4i64(<4 x i64>, <4 x i64>, <4 x i64>, <4 x i64>, i64, ptr)
 
-; CHECK: intrinsic has incorrect argument type
+; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x i64>
 ; CHECK-NEXT: llvm.aarch64.neon.ld4lane.v4i32
 define { <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32> } @test_ld4lane_arg(ptr %ptr, <4 x i64> %a, <4 x i32> %b, <4 x i32> %c, <4 x i32> %d) {
   %res = call { <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32> } @llvm.aarch64.neon.ld4lane.v4i32(<4 x i64> %a, <4 x i32> %b, <4 x i32> %c, <4 x i32> %d, i64 0, ptr %ptr)

--- a/llvm/test/Verifier/matrix-intrinsics.ll
+++ b/llvm/test/Verifier/matrix-intrinsics.ll
@@ -62,9 +62,9 @@ define void @column.major_store(ptr %m, ptr %n, i64 %arg) {
 
 define <4 x float> @transpose_mixed_types(<4 x float> %fvec, <4 x i32> %ivec, i32 %arg) {
 ;
-; CHECK-NEXT: intrinsic argument 0 type (MatchType<0>) expected <4 x float>, but got <4 x i32>
+; CHECK-NEXT: intrinsic argument 0 type (matching overload type 0) expected <4 x float>, but got <4 x i32>
 ; CHECK-NEXT: ptr @llvm.matrix.transpose.v4f32.v4i32
-; CHECK-NEXT: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x float>
+; CHECK-NEXT: intrinsic argument 0 type (matching overload type 0) expected <4 x i32>, but got <4 x float>
 ; CHECK-NEXT: ptr @llvm.matrix.transpose.v4i32.v4f32
 ;
   %result.0 = call <4 x float> @llvm.matrix.transpose.v4f32.v4i32(<4 x i32> %ivec, i32 0, i32 0)

--- a/llvm/test/Verifier/matrix-intrinsics.ll
+++ b/llvm/test/Verifier/matrix-intrinsics.ll
@@ -62,9 +62,9 @@ define void @column.major_store(ptr %m, ptr %n, i64 %arg) {
 
 define <4 x float> @transpose_mixed_types(<4 x float> %fvec, <4 x i32> %ivec, i32 %arg) {
 ;
-; CHECK-NEXT: intrinsic has incorrect argument type!
+; CHECK-NEXT: intrinsic argument 0 type (MatchType<0>) expected <4 x float>, but got <4 x i32>
 ; CHECK-NEXT: ptr @llvm.matrix.transpose.v4f32.v4i32
-; CHECK-NEXT: intrinsic has incorrect argument type!
+; CHECK-NEXT: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <4 x float>
 ; CHECK-NEXT: ptr @llvm.matrix.transpose.v4i32.v4f32
 ;
   %result.0 = call <4 x float> @llvm.matrix.transpose.v4f32.v4i32(<4 x i32> %ivec, i32 0, i32 0)

--- a/llvm/test/Verifier/reduction-intrinsics.ll
+++ b/llvm/test/Verifier/reduction-intrinsics.ll
@@ -3,13 +3,13 @@
 ; Reject a vector reduction with a non-vector argument.
 
 define float @reduce_vector_not_vec_arg(float %x) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (overload type 0) expected any vector type, but got float
   %r0 = call float @llvm.vector.reduce.fmax.f32(float %x)
   ret float %r0
 }
 
 define i32 @reduce_vector_not_vec_arg2(i32 %x) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (overload type 0) expected any vector type, but got i32
   %r0 = call i32 @llvm.vector.reduce.smax.i32(i32 %x)
   ret i32 %r0
 }

--- a/llvm/test/Verifier/sat-intrinsics.ll
+++ b/llvm/test/Verifier/sat-intrinsics.ll
@@ -1,25 +1,25 @@
 ; RUN: not opt -S -passes=verify < %s 2>&1 | FileCheck %s
 
 define i32 @sadd_arg_int(float %x, i32 %y) {
-; CHECK: intrinsic argument 0 type (MatchType<0>) expected i32, but got float
+; CHECK: intrinsic argument 0 type (matching overload type 0) expected i32, but got float
   %r = call i32 @llvm.sadd.sat.i32(float %x, i32 %y)
   ret i32 %r
 }
 
 define i37 @uadd_arg_int(half %x, i37 %y) {
-; CHECK: intrinsic argument 1 type (MatchType<0>) expected i37, but got half
+; CHECK: intrinsic argument 1 type (matching overload type 0) expected i37, but got half
   %r = call i37 @llvm.uadd.sat.i37(i37 %y, half %x)
   ret i37 %r
 }
 
 define <4 x i32> @ssub_arg_int(<5 x i32> %x, <4 x i32> %y) {
-; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <5 x i32>
+; CHECK: intrinsic argument 0 type (matching overload type 0) expected <4 x i32>, but got <5 x i32>
   %r = call <4 x i32> @llvm.ssub.sat.v4i32(<5 x i32> %x, <4 x i32> %y)
   ret <4 x i32> %r
 }
 
 define <3 x i37> @usub_arg_int(<3 x i37> %x, <3 x i32> %y) {
-; CHECK: intrinsic argument 1 type (MatchType<0>) expected <3 x i37>, but got <3 x i32>
+; CHECK: intrinsic argument 1 type (matching overload type 0) expected <3 x i37>, but got <3 x i32>
   %r = call <3 x i37> @llvm.usub.sat.v3i37(<3 x i37> %x, <3 x i32> %y)
   ret <3 x i37> %r
 }

--- a/llvm/test/Verifier/sat-intrinsics.ll
+++ b/llvm/test/Verifier/sat-intrinsics.ll
@@ -1,37 +1,37 @@
 ; RUN: not opt -S -passes=verify < %s 2>&1 | FileCheck %s
 
 define i32 @sadd_arg_int(float %x, i32 %y) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (MatchType<0>) expected i32, but got float
   %r = call i32 @llvm.sadd.sat.i32(float %x, i32 %y)
   ret i32 %r
 }
 
 define i37 @uadd_arg_int(half %x, i37 %y) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 1 type (MatchType<0>) expected i37, but got half
   %r = call i37 @llvm.uadd.sat.i37(i37 %y, half %x)
   ret i37 %r
 }
 
 define <4 x i32> @ssub_arg_int(<5 x i32> %x, <4 x i32> %y) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (MatchType<0>) expected <4 x i32>, but got <5 x i32>
   %r = call <4 x i32> @llvm.ssub.sat.v4i32(<5 x i32> %x, <4 x i32> %y)
   ret <4 x i32> %r
 }
 
 define <3 x i37> @usub_arg_int(<3 x i37> %x, <3 x i32> %y) {
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 1 type (MatchType<0>) expected <3 x i37>, but got <3 x i32>
   %r = call <3 x i37> @llvm.usub.sat.v3i37(<3 x i37> %x, <3 x i32> %y)
   ret <3 x i37> %r
 }
 
 define float @ushl_return_int(i32 %x, i32 %y) {
-; CHECK: intrinsic has incorrect return type!
+; CHECK: intrinsic return type (overload type 0) expected any integer or integer vector, but got float
   %r = call float @llvm.ushl.sat.i32(i32 %x, i32 %y)
   ret float %r
 }
 
 define <4 x float> @sshl_return_int_vec(<4 x i32> %x, <4 x i32> %y) {
-; CHECK: intrinsic has incorrect return type!
+; CHECK: intrinsic return type (overload type 0) expected any integer or integer vector, but got <4 x float>
   %r = call <4 x float> @llvm.sshl.sat.v4i32(<4 x i32> %x, <4 x i32> %y)
   ret <4 x float> %r
 }

--- a/llvm/test/Verifier/scatter_gather.ll
+++ b/llvm/test/Verifier/scatter_gather.ll
@@ -50,7 +50,7 @@ define <8 x float> @gather8(<16 x ptr> %ptrs, <8 x i1> %mask, <8 x float> %passt
 declare <8 x float> @llvm.masked.gather.v8f32.v16p0(<16 x ptr>, <8 x i1>, <8 x float>)
 
 ; Passthru type doesn't match return type
-; CHECK: intrinsic argument 2 type (MatchType<0>) expected <16 x i32>, but got <8 x i32>
+; CHECK: intrinsic argument 2 type (matching overload type 0) expected <16 x i32>, but got <8 x i32>
 ; CHECK-NEXT: ptr @llvm.masked.gather.v16i32.v16p0
 define <16 x i32> @gather9(<16 x ptr> %ptrs, <16 x i1> %mask, <8 x i32> %passthru) {
   %res = call <16 x i32> @llvm.masked.gather.v16i32.v16p0(<16 x ptr> %ptrs, <16 x i1> %mask, <8 x i32> %passthru)

--- a/llvm/test/Verifier/scatter_gather.ll
+++ b/llvm/test/Verifier/scatter_gather.ll
@@ -17,7 +17,7 @@ define <8 x float> @gather3(<8 x ptr> %ptrs, <16 x i1> %mask, <8 x float> %passt
 declare <8 x float> @llvm.masked.gather.v8f32.v8p0(<8 x ptr>, <16 x i1>, <8 x float>)
 
 ; Return type is not a vector
-; CHECK: intrinsic has incorrect return type!
+; CHECK: intrinsic return type (overload type 0) expected any vector type, but got ptr
 define ptr @gather4(<8 x ptr> %ptrs, <8 x i1> %mask, <8 x float> %passthru) {
   %res = call ptr @llvm.masked.gather.p0.v8p0(<8 x ptr> %ptrs, <8 x i1> %mask, <8 x float> %passthru)
   ret ptr %res
@@ -50,7 +50,7 @@ define <8 x float> @gather8(<16 x ptr> %ptrs, <8 x i1> %mask, <8 x float> %passt
 declare <8 x float> @llvm.masked.gather.v8f32.v16p0(<16 x ptr>, <8 x i1>, <8 x float>)
 
 ; Passthru type doesn't match return type
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 2 type (MatchType<0>) expected <16 x i32>, but got <8 x i32>
 ; CHECK-NEXT: ptr @llvm.masked.gather.v16i32.v16p0
 define <16 x i32> @gather9(<16 x ptr> %ptrs, <16 x i1> %mask, <8 x i32> %passthru) {
   %res = call <16 x i32> @llvm.masked.gather.v16i32.v16p0(<16 x ptr> %ptrs, <16 x i1> %mask, <8 x i32> %passthru)
@@ -77,7 +77,7 @@ define void @scatter3(<8 x float> %value, <8 x ptr> %ptrs, <16 x i1> %mask) {
 declare void @llvm.masked.scatter.v8f32.v8p0(<8 x float>, <8 x ptr>, <16 x i1>)
 
 ; Value type is not a vector
-; CHECK: intrinsic has incorrect argument type!
+; CHECK: intrinsic argument 0 type (overload type 0) expected any vector type, but got ptr
 ; CHECK-NEXT: ptr @llvm.masked.scatter.p0.v8p0
 define void @scatter4(ptr %value, <8 x ptr> %ptrs, <8 x i1> %mask) {
   call void @llvm.masked.scatter.p0.v8p0(ptr %value, <8 x ptr> %ptrs, <8 x i1> %mask)

--- a/llvm/test/Verifier/stepvector-intrinsic.ll
+++ b/llvm/test/Verifier/stepvector-intrinsic.ll
@@ -3,7 +3,7 @@
 ; Reject stepvector intrinsics that return a scalar
 
 define i32 @stepvector_i32() {
-; CHECK: intrinsic has incorrect return type!
+; CHECK: intrinsic return type (overload type 0) expected any vector type, but got i32
   %1 = call i32 @llvm.stepvector.i32()
   ret i32 %1
 }

--- a/mlir/test/Dialect/LLVMIR/call-intrin.mlir
+++ b/mlir/test/Dialect/LLVMIR/call-intrin.mlir
@@ -61,7 +61,7 @@ llvm.func @no_intrinsic() {
 
 llvm.func @bad_types() {
   %0 = llvm.mlir.constant(1 : i8) : i8
-  // expected-error@below {{call intrinsic signature i8 (i8) to overloaded intrinsic "llvm.round" does not match any of the overloads: intrinsic has incorrect return type}}
+  // expected-error@below {{call intrinsic signature i8 (i8) to overloaded intrinsic "llvm.round" does not match any of the overloads: intrinsic return type (overload type 0) expected any fp or fp vector, but got i8}}
   // expected-error@below {{LLVM Translation failed for operation: llvm.call_intrinsic}}
   llvm.call_intrinsic "llvm.round"(%0) {} : (i8) -> i8
   llvm.return


### PR DESCRIPTION
Print precise error message for overloaded types and `LLVMMatchType` when an intrinsic's type signature verfication fails.