### PR TITLE
[lldb][test] Fix thread safety analysis warning in LockedTest

### DIFF
--- a/lldb/unittests/Utility/LockedTest.cpp
+++ b/lldb/unittests/Utility/LockedTest.cpp
@@ -99,8 +99,10 @@ TEST(LockedTest, ExclusiveReleasesOnDestruction) {
     LockedPtr<Widget, std::mutex> handle(mutex, &widget);
     EXPECT_FALSE(mutex.try_lock());
   }
-  EXPECT_TRUE(mutex.try_lock());
-  mutex.unlock();
+  if (mutex.try_lock())
+    mutex.unlock();
+  else
+    ADD_FAILURE() << "Mutex was not released";
 }
 
 TEST(LockedTest, MoveTransfersLock) {


### PR DESCRIPTION
Guard `mutex.unlock()` with `if (mutex.try_lock())` to satisfy thread safety analysis. Statically, the compiler cannot verify that `mutex.try_lock()` succeeded when it is only asserted by `EXPECT_TRUE`, leading to a "releasing mutex 'mutex' that was not held" compilation error.

This fixes a regression introduced in #198941.