### PR TITLE
[lldb] Remove XFAIL from TestCxxFrameFormatPartialFailure

### DIFF
--- a/lldb/test/Shell/Settings/TestCxxFrameFormatPartialFailure.test
+++ b/lldb/test/Shell/Settings/TestCxxFrameFormatPartialFailure.test
@@ -1,5 +1,3 @@
-# XFAIL: target-windows
-
 # Test that the plugin.cplusplus.display.function-name-format setting
 # doesn't print into the frame-format setting unless all its format variables
 # were successful.


### PR DESCRIPTION
This is fixed on Windows after #198600 as it now uses LLD.