### PR TITLE
[gsymutil] Disable readahead in `GsymReader::openFile()`

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
+++ b/llvm/lib/DebugInfo/GSYM/GsymReader.cpp
@@ -71,7 +71,9 @@ GsymReader::openFile(StringRef Filename) {
   auto Err = BuffOrErr.getError();
   if (Err)
     return llvm::errorCodeToError(Err);
-  return create(BuffOrErr.get());
+  auto &Buf = BuffOrErr.get();
+  Buf->randomAccessIfMmap();
+  return create(Buf);
 }
 
 llvm::Expected<std::unique_ptr<GsymReader>>

--- a/llvm/tools/llvm-gsymutil/Opts.td
+++ b/llvm/tools/llvm-gsymutil/Opts.td
@@ -60,6 +60,10 @@ defm output_version :
   Eq<"output-version",
      "Set the GSYM output version (1 or 2). Default: 1.">;
 def benchmark_reader :
-  FF<"benchmark-reader",
-     "Open a GSYM file and perform a lookup for every function start address to benchmark the reader performance">,
+  Joined<["--"], "benchmark-reader=">,
+  HelpText<"Benchmark reader with start,stride (default: 0,1 = every address)">,
+  Flags<[HelpHidden]>;
+def benchmark_reader_all :
+  Flag<["--"], "benchmark-reader">,
+  HelpText<"Benchmark reader by looking up every address">,
   Flags<[HelpHidden]>;

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -98,6 +98,8 @@ static std::string OutputFilename;
 static std::string JsonSummaryFile;
 static bool Verify;
 static bool BenchmarkReader;
+static uint32_t BenchmarkStart;
+static uint32_t BenchmarkStride;
 static unsigned NumThreads;
 static uint64_t SegmentSize;
 static bool Quiet;
@@ -161,7 +163,37 @@ static void parseArgs(int argc, char **argv) {
     JsonSummaryFile = A->getValue();
 
   Verify = Args.hasArg(OPT_verify);
-  BenchmarkReader = Args.hasArg(OPT_benchmark_reader);
+  BenchmarkStart = 0;
+  BenchmarkStride = 1;
+  if (Args.hasArg(OPT_benchmark_reader_all)) {
+    BenchmarkReader = true;
+  } else if (const llvm::opt::Arg *A =
+                 Args.getLastArg(OPT_benchmark_reader)) {
+    BenchmarkReader = true;
+    StringRef S{A->getValue()};
+    if (!S.empty()) {
+      auto [StartStr, StrideStr] = S.split(',');
+      if (!llvm::to_integer(StartStr, BenchmarkStart, 0)) {
+        llvm::errs() << ToolName
+                     << ": for the --benchmark-reader option: invalid start '"
+                     << StartStr << "'\n";
+        std::exit(1);
+      }
+      if (!StrideStr.empty() &&
+          !llvm::to_integer(StrideStr, BenchmarkStride, 0)) {
+        llvm::errs() << ToolName
+                     << ": for the --benchmark-reader option: invalid stride '"
+                     << StrideStr << "'\n";
+        std::exit(1);
+      }
+      if (BenchmarkStride == 0) {
+        llvm::errs() << ToolName
+                     << ": for the --benchmark-reader option: stride must be "
+                        "positive\n";
+        std::exit(1);
+      }
+    }
+  }
 
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_num_threads_EQ)) {
     StringRef S{A->getValue()};
@@ -732,12 +764,14 @@ static void doLookup(GsymReader &Gsym, uint64_t Addr, raw_ostream &OS) {
   }
 }
 
-static llvm::Error benchmarkReader(StringRef GSYMPath) {
+static llvm::Error benchmarkReader(StringRef GSYMPath, uint32_t Start,
+                                   uint32_t Stride) {
   auto Gsym = GsymReader::openFile(GSYMPath);
   if (!Gsym)
     return Gsym.takeError();
-  auto NumAddrs = (*Gsym)->getNumAddresses();
-  for (uint32_t I = 0; I < NumAddrs; ++I) {
+  uint32_t N = (*Gsym)->getNumAddresses();
+  uint32_t NumLookups = 0;
+  for (uint32_t I = Start; I < N; I += Stride) {
     auto Addr = (*Gsym)->getAddress(I);
     if (!Addr)
       return createStringError(std::errc::invalid_argument,
@@ -745,9 +779,10 @@ static llvm::Error benchmarkReader(StringRef GSYMPath) {
     auto LR = (*Gsym)->lookup(*Addr);
     if (!LR)
       return LR.takeError();
+    ++NumLookups;
   }
-  outs() << "Benchmarked " << NumAddrs << " lookups in \"" << GSYMPath
-         << "\"\n";
+  outs() << "Benchmarked " << NumLookups << " lookups (out of " << N
+         << " addresses) in \"" << GSYMPath << "\"\n";
   return Error::success();
 }
 
@@ -765,7 +800,8 @@ int llvm_gsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
   if (BenchmarkReader) {
     for (const auto &GSYMPath : InputFilenames)
-      if (auto Err = benchmarkReader(GSYMPath))
+      if (auto Err =
+              benchmarkReader(GSYMPath, BenchmarkStart, BenchmarkStride))
         error("Benchmark failed: ", std::move(Err));
     return EXIT_SUCCESS;
   }

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -167,8 +167,7 @@ static void parseArgs(int argc, char **argv) {
   BenchmarkStride = 1;
   if (Args.hasArg(OPT_benchmark_reader_all)) {
     BenchmarkReader = true;
-  } else if (const llvm::opt::Arg *A =
-                 Args.getLastArg(OPT_benchmark_reader)) {
+  } else if (const llvm::opt::Arg *A = Args.getLastArg(OPT_benchmark_reader)) {
     BenchmarkReader = true;
     StringRef S{A->getValue()};
     if (!S.empty()) {
@@ -800,8 +799,7 @@ int llvm_gsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
   if (BenchmarkReader) {
     for (const auto &GSYMPath : InputFilenames)
-      if (auto Err =
-              benchmarkReader(GSYMPath, BenchmarkStart, BenchmarkStride))
+      if (auto Err = benchmarkReader(GSYMPath, BenchmarkStart, BenchmarkStride))
         error("Benchmark failed: ", std::move(Err));
     return EXIT_SUCCESS;
   }


### PR DESCRIPTION
`GsymReader::lookup()` has random access pattern (i.e. binary search an address, then spot-load/parse info from rest of the GSYM data). Readahead strategies in kernels (which was enabled by default) don't necessarily improve (and may degrade) performance. This patch disables readahead.

In a production system, similar change has seen 5% improvement on IOPS and data reads.   An offline performance test on a Linux machine shows similar results - it reduces 14.3% total data read, 3.5% CPU%, and 2.9% wall time (while adding 9.4% page faults). The reduction of total data read and CPU % may help the performance of a heavily-loaded production system.
```
  ┌────────────────┬─────────────┬─────────┬────────┐
  │     Metric     │ MADV_RANDOM │ Default │  Diff  │
  ├────────────────┼─────────────┼─────────┼────────┤
  │ Wall (s)       │ 0.286       │ 0.294   │ -2.9%  │
  ├────────────────┼─────────────┼─────────┼────────┤
  │ Major PF       │ 203.6       │ 186.0   │ +9.4%  │
  ├────────────────┼─────────────┼─────────┼────────┤
  │ Minor PF       │ 4433.1      │ 4450.3  │ -0.4%  │
  ├────────────────┼─────────────┼─────────┼────────┤
  │ FS inputs (MB) │ 118.8       │ 138.7   │ -14.3% │
  ├────────────────┼─────────────┼─────────┼────────┤
  │ CPU %          │ 48.8        │ 50.6    │ -3.5%  │
  └────────────────┴─────────────┴─────────┴────────┘
```
The test is performed by doing 100 cold runs, where each run first purges kernel page cache, then opens/mmaps a 3.8 GB GSYM file, and then looks up 3 addresses at the beginning/middle/end of the address list. See [test script](https://gist.github.com/royitaqi/c06c733cccfbf747d63750b06db77b4a).

The pre-existing hidden option `llvm-gsymutil --benchmark-reader` is extended to take optional `=<start>,<stride>` to make performance testing easier.