### PR TITLE
[OpenCL] Fix image2d_t qualifier for intel_sub_group_block_write_ui

### DIFF
--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -17934,15 +17934,15 @@ void    __ovld __conv intel_sub_group_block_write2( __local uint* p, uint2 data 
 void    __ovld __conv intel_sub_group_block_write4( __local uint* p, uint4 data );
 void    __ovld __conv intel_sub_group_block_write8( __local uint* p, uint8 data );
 
-uint       __ovld __conv intel_sub_group_block_read_ui( const __local uint* p );
-uint2      __ovld __conv intel_sub_group_block_read_ui2( const __local uint* p );
-uint4      __ovld __conv intel_sub_group_block_read_ui4( const __local uint* p );
-uint8      __ovld __conv intel_sub_group_block_read_ui8( const __local uint* p );
+uint __ovld __conv intel_sub_group_block_read_ui( const __local uint* p );
+uint2 __ovld __conv intel_sub_group_block_read_ui2( const __local uint* p );
+uint4 __ovld __conv intel_sub_group_block_read_ui4( const __local uint* p );
+uint8 __ovld __conv intel_sub_group_block_read_ui8( const __local uint* p );
 
-void       __ovld __conv intel_sub_group_block_write_ui( __local uint* p, uint data );
-void       __ovld __conv intel_sub_group_block_write_ui2( __local uint* p, uint2 data );
-void       __ovld __conv intel_sub_group_block_write_ui4( __local uint* p, uint4 data );
-void       __ovld __conv intel_sub_group_block_write_ui8( __local uint* p, uint8 data );
+void __ovld __conv intel_sub_group_block_write_ui( __local uint* p, uint data );
+void __ovld __conv intel_sub_group_block_write_ui2( __local uint* p, uint2 data );
+void __ovld __conv intel_sub_group_block_write_ui4( __local uint* p, uint4 data );
+void __ovld __conv intel_sub_group_block_write_ui8(__local uint *p, uint8 data);
 
 #if defined(cl_intel_subgroups_char)
 uchar      __ovld __conv intel_sub_group_block_read_uc(   const __local uchar* p );

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -17930,8 +17930,6 @@ void    __ovld __conv intel_sub_group_block_write2( __local uint* p, uint2 data 
 void    __ovld __conv intel_sub_group_block_write4( __local uint* p, uint4 data );
 void    __ovld __conv intel_sub_group_block_write8( __local uint* p, uint8 data );
 
-#if defined(cl_intel_subgroups_char) || defined(cl_intel_subgroups_short) ||   \
-    defined(cl_intel_subgroups_long)
 uint       __ovld __conv intel_sub_group_block_read_ui( const __local uint* p );
 uint2      __ovld __conv intel_sub_group_block_read_ui2( const __local uint* p );
 uint4      __ovld __conv intel_sub_group_block_read_ui4( const __local uint* p );
@@ -17941,8 +17939,6 @@ void       __ovld __conv intel_sub_group_block_write_ui( __local uint* p, uint d
 void       __ovld __conv intel_sub_group_block_write_ui2( __local uint* p, uint2 data );
 void       __ovld __conv intel_sub_group_block_write_ui4( __local uint* p, uint4 data );
 void       __ovld __conv intel_sub_group_block_write_ui8( __local uint* p, uint8 data );
-#endif // defined(cl_intel_subgroups_char) || defined(cl_intel_subgroups_short) ||
-       // defined(cl_intel_subgroups_long)
 
 #if defined(cl_intel_subgroups_char)
 uchar      __ovld __conv intel_sub_group_block_read_uc(   const __local uchar* p );

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -17553,10 +17553,10 @@ uint4      __ovld __conv intel_sub_group_block_read_ui4( const __global uint* p 
 uint8      __ovld __conv intel_sub_group_block_read_ui8( const __global uint* p );
 
 #if defined(__opencl_c_images)
-void       __ovld __conv intel_sub_group_block_write_ui(read_only image2d_t, int2, uint);
-void       __ovld __conv intel_sub_group_block_write_ui2(read_only image2d_t, int2, uint2);
-void       __ovld __conv intel_sub_group_block_write_ui4(read_only image2d_t, int2, uint4);
-void       __ovld __conv intel_sub_group_block_write_ui8(read_only image2d_t, int2, uint8);
+void       __ovld __conv intel_sub_group_block_write_ui(write_only image2d_t, int2, uint);
+void       __ovld __conv intel_sub_group_block_write_ui2(write_only image2d_t, int2, uint2);
+void       __ovld __conv intel_sub_group_block_write_ui4(write_only image2d_t, int2, uint4);
+void       __ovld __conv intel_sub_group_block_write_ui8(write_only image2d_t, int2, uint8);
 #endif // defined(__opencl_c_images)
 
 #if defined(__opencl_c_read_write_images)

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -17934,14 +17934,14 @@ void    __ovld __conv intel_sub_group_block_write2( __local uint* p, uint2 data 
 void    __ovld __conv intel_sub_group_block_write4( __local uint* p, uint4 data );
 void    __ovld __conv intel_sub_group_block_write8( __local uint* p, uint8 data );
 
-uint __ovld __conv intel_sub_group_block_read_ui( const __local uint* p );
-uint2 __ovld __conv intel_sub_group_block_read_ui2( const __local uint* p );
-uint4 __ovld __conv intel_sub_group_block_read_ui4( const __local uint* p );
-uint8 __ovld __conv intel_sub_group_block_read_ui8( const __local uint* p );
+uint __ovld __conv intel_sub_group_block_read_ui(const __local uint *p);
+uint2 __ovld __conv intel_sub_group_block_read_ui2(const __local uint *p);
+uint4 __ovld __conv intel_sub_group_block_read_ui4(const __local uint *p);
+uint8 __ovld __conv intel_sub_group_block_read_ui8(const __local uint *p);
 
-void __ovld __conv intel_sub_group_block_write_ui( __local uint* p, uint data );
-void __ovld __conv intel_sub_group_block_write_ui2( __local uint* p, uint2 data );
-void __ovld __conv intel_sub_group_block_write_ui4( __local uint* p, uint4 data );
+void __ovld __conv intel_sub_group_block_write_ui(__local uint *p, uint data);
+void __ovld __conv intel_sub_group_block_write_ui2(__local uint *p, uint2 data);
+void __ovld __conv intel_sub_group_block_write_ui4(__local uint *p, uint4 data);
 void __ovld __conv intel_sub_group_block_write_ui8(__local uint *p, uint8 data);
 
 #if defined(cl_intel_subgroups_char)

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -17553,10 +17553,14 @@ uint4      __ovld __conv intel_sub_group_block_read_ui4( const __global uint* p 
 uint8      __ovld __conv intel_sub_group_block_read_ui8( const __global uint* p );
 
 #if defined(__opencl_c_images)
-void       __ovld __conv intel_sub_group_block_write_ui(write_only image2d_t, int2, uint);
-void       __ovld __conv intel_sub_group_block_write_ui2(write_only image2d_t, int2, uint2);
-void       __ovld __conv intel_sub_group_block_write_ui4(write_only image2d_t, int2, uint4);
-void       __ovld __conv intel_sub_group_block_write_ui8(write_only image2d_t, int2, uint8);
+void __ovld __conv intel_sub_group_block_write_ui(write_only image2d_t, int2,
+                                                  uint);
+void __ovld __conv intel_sub_group_block_write_ui2(write_only image2d_t, int2,
+                                                   uint2);
+void __ovld __conv intel_sub_group_block_write_ui4(write_only image2d_t, int2,
+                                                   uint4);
+void __ovld __conv intel_sub_group_block_write_ui8(write_only image2d_t, int2,
+                                                   uint8);
 #endif // defined(__opencl_c_images)
 
 #if defined(__opencl_c_read_write_images)

--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -1964,10 +1964,10 @@ let Extension = FuncExtIntelSubgroups in {
   def : Builtin<"intel_sub_group_block_read_ui4", [VectorType<UInt, 4>, PointerType<ConstType<UInt>, GlobalAS>], Attr.Convergent>;
   def : Builtin<"intel_sub_group_block_read_ui8", [VectorType<UInt, 8>, PointerType<ConstType<UInt>, GlobalAS>], Attr.Convergent>;
 
-  def : Builtin<"intel_sub_group_block_write_ui", [Void, ImageType<Image2d, "RO">, VectorType<Int, 2>, UInt], Attr.Convergent>;
-  def : Builtin<"intel_sub_group_block_write_ui2", [Void, ImageType<Image2d, "RO">, VectorType<Int, 2>, VectorType<UInt, 2>], Attr.Convergent>;
-  def : Builtin<"intel_sub_group_block_write_ui4", [Void, ImageType<Image2d, "RO">, VectorType<Int, 2>, VectorType<UInt, 4>], Attr.Convergent>;
-  def : Builtin<"intel_sub_group_block_write_ui8", [Void, ImageType<Image2d, "RO">, VectorType<Int, 2>, VectorType<UInt, 8>], Attr.Convergent>;
+  def : Builtin<"intel_sub_group_block_write_ui", [Void, ImageType<Image2d, "WO">, VectorType<Int, 2>, UInt], Attr.Convergent>;
+  def : Builtin<"intel_sub_group_block_write_ui2", [Void, ImageType<Image2d, "WO">, VectorType<Int, 2>, VectorType<UInt, 2>], Attr.Convergent>;
+  def : Builtin<"intel_sub_group_block_write_ui4", [Void, ImageType<Image2d, "WO">, VectorType<Int, 2>, VectorType<UInt, 4>], Attr.Convergent>;
+  def : Builtin<"intel_sub_group_block_write_ui8", [Void, ImageType<Image2d, "WO">, VectorType<Int, 2>, VectorType<UInt, 8>], Attr.Convergent>;
 
   def : Builtin<"intel_sub_group_block_write_ui", [Void, PointerType<UInt, GlobalAS>, UInt], Attr.Convergent>;
   def : Builtin<"intel_sub_group_block_write_ui2", [Void, PointerType<UInt, GlobalAS>, VectorType<UInt, 2>], Attr.Convergent>;

--- a/clang/test/SemaOpenCL/intel-subgroups-builtins.cl
+++ b/clang/test/SemaOpenCL/intel-subgroups-builtins.cl
@@ -123,7 +123,7 @@ void test_block_write_ui_global(__global uint *out, uint value, uint2 value2,
   intel_sub_group_block_write_ui8(out, value8);
 }
 
-void test_block_write_ui_image(read_only image2d_t image,
+void test_block_write_ui_image(write_only image2d_t image,
                                read_write image2d_t rw, int2 coord,
                                uint value, uint2 value2, uint4 value4,
                                uint8 value8) {


### PR DESCRIPTION
The intel_sub_group_block_write_ui[2,4,8] overloads for image2d_t were
declared with a read_only qualifier, both in opencl-c.h and in
OpenCLBuiltins.td.  A write operation cannot target a read_only image, and
the base intel_sub_group_block_write together with the analogous _us, _uc
and _ul aliases all correctly use write_only image2d_t.

Per the cl_intel_subgroups_short [1], cl_intel_subgroups_char [2] and
cl_intel_subgroups_long [3] specifications, the _ui aliases are added "for
naming consistency [...] There is no change to the description or behavior
of these functions" relative to the cl_intel_subgroups base, which uses
write_only image2d_t for writes.

The typo was introduced in b833bf6ae14f and preserved across all
later edits to this area.

Switch the qualifier from read_only to write_only in both opencl-c.h and
OpenCLBuiltins.td, and update intel-subgroups-builtins.cl to match the
corrected signature (the existing test was exercising the buggy overload).

[1] https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_short.html
[2] https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_char.html
[3] https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_long.html

Co-Authored-By: Claude Opus