### PR TITLE
[Sema] Fix friend inline redeclarations treated as overloads

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -664,6 +664,7 @@ Bug Fixes to C++ Support
 - Fixed a use-after-free bug when parsing default arguments containing lambdas in declarations with template-id declarators. (#GH196725)
 - Fixed a crash in constant evaluation using placement new on an array which was later initialized. (#GH196450)
 - Fixed an issue where Clang incorrectly accepted invalid unqualified uses of local nested class names outside their declaring scope. (#GH184622)
+- Fixed incorrect ambiguity diagnostics involving friend inline function redeclarations. (#GH180851)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -689,11 +689,24 @@ bool Sema::MergeCXXFunctionDecl(FunctionDecl *New, FunctionDecl *Old,
              (New->isInlineSpecified() ||
               New->getFriendObjectKind() == Decl::FOK_None)) {
     // C++11 [dcl.fcn.spec]p4:
-    //   If the definition of a function appears in a translation unit before its
-    //   first declaration as inline, the program is ill-formed.
-    Diag(New->getLocation(), diag::err_inline_decl_follows_def) << New;
-    Diag(Def->getLocation(), diag::note_previous_definition);
-    Invalid = true;
+    //   If the definition of a function appears in a translation unit before
+    //   its first declaration as inline, the program is ill-formed.
+    //
+    // Exception: a friend inline redeclaration of a function that takes the
+    // enclosing class as a parameter is valid. The class was incomplete at the
+    // point of the original definition, so it could not have been declared
+    // inline there.
+    bool HasEnclosingClassParam = false;
+    if (auto *RD = dyn_cast<CXXRecordDecl>(New->getLexicalDeclContext()))
+      for (const ParmVarDecl *P : New->parameters())
+        if (P->getType().getNonReferenceType()->getAsCXXRecordDecl() == RD)
+          HasEnclosingClassParam = true;
+
+    if (!HasEnclosingClassParam) {
+      Diag(New->getLocation(), diag::err_inline_decl_follows_def) << New;
+      Diag(Def->getLocation(), diag::note_previous_definition);
+      Invalid = true;
+    }
   }
 
   // C++17 [temp.deduct.guide]p3:

--- a/clang/test/SemaCXX/friend-inline-redeclaration.cpp
+++ b/clang/test/SemaCXX/friend-inline-redeclaration.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify -std=c++23 %s
+
+// Friend inline re-declaration, where the parameter type is a SAME class
+struct A;
+
+int foo(A&) { return 1; }
+double compute(A&&) { return 3.14; }
+char process(A&, char) { return 'x'; }
+long action(long, A&) { return 42; }
+
+struct A {
+  friend inline int foo(A&);
+  friend inline double compute(A&&);
+  friend inline char process(A&, char);
+  friend inline long action(long, A&);
+};
+
+// Friend inline re-declaration, but the parameter type is a DIFFERENT class,
+// not the enclosing one. The exception should NOT apply.
+struct Other {};
+struct Owner;
+
+int bar(Other&) { return 0; } // expected-note {{previous definition is here}}
+
+struct Owner {
+  friend inline int bar(Other&); // expected-error {{inline declaration of 'bar' follows non-inline definition}}
+};
+
+// Friend inline re-declaration with no parameters at all.
+// The exception requires at least one parameter of the enclosing class type.
+int init() { return 0; } // expected-note {{previous definition is here}}
+
+struct Engine {
+  friend inline int init(); // expected-error {{inline declaration of 'init' follows non-inline definition}}
+};


### PR DESCRIPTION
Matching friend inline declarations were incorrectly treated as distinct overloads instead of redeclarations, leading to spurious
ambiguity diagnostics. This patch fixes the redeclaration handling and adds test coverage.

Fixes #180851.