### PR TITLE
[Clang] Fix ConstExpr comparing qualified atomic vec types 

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -643,6 +643,7 @@ Bug Fixes in This Version
   an array via an element-at-a-time copy loop (#GH192026)
 - Fixed an issue where certain designated initializers would be rejected for constexpr variables. (#GH193373)
 - Fixed a crash when ``#embed`` is used with C++ modules (#GH195350)
+- Fixed an assertion failure when assigning atomic vector to vector type in C (#GH54822).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -1619,14 +1619,18 @@ template <class Emitter>
 bool Compiler<Emitter>::VisitVectorBinOp(const BinaryOperator *E) {
   const Expr *LHS = E->getLHS();
   const Expr *RHS = E->getRHS();
+
+  QualType LHSTy = LHS->getType().getAtomicUnqualifiedType();
+  QualType RHSTy = RHS->getType().getAtomicUnqualifiedType();
+
   assert(!E->isCommaOp() &&
          "Comma op should be handled in VisitBinaryOperator");
   assert(E->getType()->isVectorType());
-  assert(LHS->getType()->isVectorType());
-  assert(RHS->getType()->isVectorType());
+  assert(LHSTy->isVectorType());
+  assert(RHSTy->isVectorType());
 
   // We can only handle vectors with primitive element types.
-  if (!canClassify(LHS->getType()->castAs<VectorType>()->getElementType()))
+  if (!canClassify(LHSTy->castAs<VectorType>()->getElementType()))
     return false;
 
   // Prepare storage for result.
@@ -1643,14 +1647,14 @@ bool Compiler<Emitter>::VisitVectorBinOp(const BinaryOperator *E) {
                 ? BinaryOperator::getOpForCompoundAssignment(E->getOpcode())
                 : E->getOpcode();
 
-  PrimType ElemT = this->classifyVectorElementType(LHS->getType());
-  PrimType RHSElemT = this->classifyVectorElementType(RHS->getType());
+  PrimType ElemT = this->classifyVectorElementType(LHSTy);
+  PrimType RHSElemT = this->classifyVectorElementType(RHSTy);
   PrimType ResultElemT = this->classifyVectorElementType(E->getType());
 
   if (E->getOpcode() == BO_Assign) {
     assert(Ctx.getASTContext().hasSameUnqualifiedType(
-        LHS->getType()->castAs<VectorType>()->getElementType(),
-        RHS->getType()->castAs<VectorType>()->getElementType()));
+        LHSTy->castAs<VectorType>()->getElementType(),
+        RHSTy->castAs<VectorType>()->getElementType()));
     if (!this->visit(LHS))
       return false;
     if (!this->visit(RHS))

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -11879,13 +11879,15 @@ bool VectorExprEvaluator::VisitBinaryOperator(const BinaryOperator *E) {
   Expr *LHS = E->getLHS();
   Expr *RHS = E->getRHS();
 
-  assert(LHS->getType()->isVectorType() && RHS->getType()->isVectorType() &&
+  QualType LHSTy = LHS->getType().getAtomicUnqualifiedType();
+  QualType RHSTy = RHS->getType().getAtomicUnqualifiedType();
+  assert(LHSTy->isVectorType() && RHSTy->isVectorType() &&
          "Must both be vector types");
   // Checking JUST the types are the same would be fine, except shifts don't
   // need to have their types be the same (since you always shift by an int).
-  assert(LHS->getType()->castAs<VectorType>()->getNumElements() ==
+  assert(LHSTy->castAs<VectorType>()->getNumElements() ==
              E->getType()->castAs<VectorType>()->getNumElements() &&
-         RHS->getType()->castAs<VectorType>()->getNumElements() ==
+         RHSTy->castAs<VectorType>()->getNumElements() ==
              E->getType()->castAs<VectorType>()->getNumElements() &&
          "All operands must be the same size.");
 

--- a/clang/test/AST/ByteCode/atomic-vector.c
+++ b/clang/test/AST/ByteCode/atomic-vector.c
@@ -1,0 +1,17 @@
+// RUN: %clang_cc1 -triple x86_64 -emit-llvm %s -o -                                         | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64 -emit-llvm %s -o - -fexperimental-new-constant-interpreter | FileCheck %s
+
+typedef int A __attribute__((__vector_size__(16)));
+
+void vector_to_atomic_vector() {
+  _Atomic(A) atomic_vec;
+  A vec;
+  atomic_vec = vec;
+}
+
+// CHECK: %[[ATOMIC_VEC_ADDR:.*]] = alloca <4 x i32>, align 16
+// CHECK: %[[VEC_ADDR:.*]] = alloca <4 x i32>, align 16
+// CHECK: %[[ATOMIC_TMP:.*]] = alloca <4 x i32>, align 16
+// CHECK: %[[TMP_VEC:.*]] = load <4 x i32>, ptr %[[VEC_ADDR]], align 16
+// CHECK: store <4 x i32> %[[TMP_VEC]], ptr %[[ATOMIC_TMP]], align 16
+// CHECK: call void @__atomic_store(i64 noundef 16, ptr noundef %[[ATOMIC_VEC_ADDR]], ptr noundef %[[ATOMIC_TMP]], i32 noundef 5)


### PR DESCRIPTION
Fix ConstExpr comparing vec types with atomic qualified

Issue #54822