### PR TITLE
[flang][OpenMP] Warn that declare simd in an interface body has no effect

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1643,6 +1643,19 @@ void OmpStructureChecker::Enter(const parser::OmpDeclareSimdDirective &x) {
   const Scope &containingScope = context_.FindScope(dirName.source);
   const Scope &progUnitScope = GetProgramUnitContaining(containingScope);
 
+  // A DECLARE SIMD directive may legally appear in an interface body, but it
+  // applies to the external procedure being declared rather than to any
+  // definition in this compilation. Flang does not propagate the directive to
+  // callers, so it has no effect; warn the user instead of silently ignoring
+  // it. See https://github.com/llvm/llvm-project/issues/192581.
+  if (const Symbol *progUnitSym{progUnitScope.symbol()}) {
+    if (const auto *subpDetails{progUnitSym->detailsIf<SubprogramDetails>()};
+        subpDetails && subpDetails->isInterface()) {
+      context_.Warn(common::UsageWarning::OpenMPUsage, dirName.source,
+          "'DECLARE SIMD' directive in an interface body has no effect"_warn_en_US);
+    }
+  }
+
   for (const parser::OmpClause &clause : x.v.Clauses().v) {
     const auto *u = std::get_if<parser::OmpClause::Uniform>(&clause.u);
     if (!u) {

--- a/flang/test/Semantics/OpenMP/declare-simd-interface-body.f90
+++ b/flang/test/Semantics/OpenMP/declare-simd-interface-body.f90
@@ -1,0 +1,29 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenmp -Werror
+! A DECLARE SIMD directive in an interface body applies to the external
+! procedure being declared, not to any definition in this compilation, so
+! Flang ignores it. Warn that it has no effect.
+! See https://github.com/llvm/llvm-project/issues/192581.
+
+interface
+  subroutine add2(i)
+  !WARNING: 'DECLARE SIMD' directive in an interface body has no effect [-Wopenmp-usage]
+  !$omp declare simd(add2) linear(i:1)
+    integer :: i
+  end subroutine
+
+  subroutine add3(i)
+  !WARNING: 'DECLARE SIMD' directive in an interface body has no effect [-Wopenmp-usage]
+  !$omp declare simd
+    integer :: i
+  end subroutine
+end interface
+
+contains
+
+! A DECLARE SIMD in an actual definition is fine and must not warn.
+subroutine sub(i)
+!$omp declare simd(sub) linear(i:1)
+  integer :: i
+  i = i + 1
+end subroutine
+end

--- a/flang/test/Semantics/OpenMP/linear-clause03.f90
+++ b/flang/test/Semantics/OpenMP/linear-clause03.f90
@@ -6,6 +6,7 @@ interface
   subroutine f(x, y)
     integer, allocatable :: x
     integer :: y
+    !WARNING: 'DECLARE SIMD' directive in an interface body has no effect [-Wopenmp-usage]
     !$omp declare simd(f) linear(ref(x) : 1) linear(uval(y))
   end
 end interface


### PR DESCRIPTION
Follow-up to the crash fix for #192581. A DECLARE SIMD directive may legally appear in the specification part of an interface body, but it applies to the external procedure being declared rather than to any definition in this compilation. Flang does not propagate the directive to callers, so it has no effect and is silently dropped during lowering.

Detect this in semantics by checking whether the program unit containing the directive is an interface body (SubprogramDetails::isInterface()) and emit an -Wopenmp-usage warning so the user knows the directive is ignored.

Updates #192581