### PR TITLE
Use symbol matching for types in llvm-mode.el

### DIFF
--- a/llvm/utils/emacs/llvm-mode.el
+++ b/llvm/utils/emacs/llvm-mode.el
@@ -25,7 +25,8 @@
    "\\(i[0-9]+\\|"
    (regexp-opt
     '("void" "half" "bfloat" "float" "double" "fp128" "x86_fp80" "ppc_fp128"
-      "x86_mmx" "x86_amx" "ptr" "type" "label" "opaque" "token") t)
+      "x86_mmx" "x86_amx" "ptr" "type" "label" "opaque" "token")
+    'symbols)
    "\\)"))
 
 (defvar llvm-font-lock-keywords


### PR DESCRIPTION
llvm-mode.el does this:

    (defconst llvm-mode-primitive-type-regexp
      (concat
       "\\(i[0-9]+\\|"
       (regexp-opt '(...strings...) t)

Here the "t" means to wrap the regexp in "\(..\)".  However, this means that in assembly like:

    !10 = distinct !DICompositeType(tag: DW_TAG_structure_type, ...

.. the "type" in "DW_TAG_structure_type" will be highlighted differently.

The fix is to tell regexp-opt to only match complete symbols.