### PR TITLE
LangRef: Clarify that unnamed_addr constants can be duplicated.

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -838,6 +838,15 @@ and can also be duplicated. Note that a constant with significant address
 *can* be merged with a ``unnamed_addr`` constant, the result being a
 constant whose address is significant.
 
+.. warning::
+
+     Constant duplication currently makes it unsound to compare pointers
+     if either may be ``unnamed_addr``, because each reference to the
+     global in the IR may return a different pointer, and optimization
+     passes may create additional references. This means that the current
+     semantics make it technically incorrect to use ``unnamed_addr``
+     for C string literals, but Clang does it anyway.
+
 If the ``local_unnamed_addr`` attribute is given, the address is known to
 not be significant within the module.
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -840,12 +840,15 @@ constant whose address is significant.
 
 .. warning::
 
-     Constant duplication currently makes it unsound to compare pointers
-     if either may be ``unnamed_addr``, because each reference to the
-     global in the IR may return a different pointer, and optimization
-     passes may create additional references. This means that the current
-     semantics make it technically incorrect to use ``unnamed_addr``
-     for C string literals, but Clang does it anyway.
+    Constant duplication currently makes it unsound to compare pointers
+    if either may be ``unnamed_addr``, because each reference to the
+    global in the IR may return a different pointer, and optimization
+    passes may create additional references. Optimization passes can also
+    create pointer comparisons with the expectation that the comparison
+    will return true if the object is the same, which theoretically can
+    make any usage of ``unnamed_addr`` unsound, but in practice it is
+    unlikely that input IR that does not explicitly compare pointers
+    will be affected by this issue.
 
 If the ``local_unnamed_addr`` attribute is given, the address is known to
 not be significant within the module.

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -831,12 +831,12 @@ always define a pointer to their "content" type because they describe a
 region of memory, and all :ref:`allocated object<allocatedobjects>` in LLVM are
 accessed through pointers.
 
-Global variables can be marked with ``unnamed_addr`` which indicates
-that the address is not significant, only the content. Constants marked
-like this can be merged with other constants if they have the same
-initializer. Note that a constant with significant address *can* be
-merged with a ``unnamed_addr`` constant, the result being a constant
-whose address is significant.
+Global variables can be marked with ``unnamed_addr`` which indicates that
+the address is not significant, only the content. Constants marked like
+this can be merged with other constants if they have the same initializer,
+and can also be duplicated. Note that a constant with significant address
+*can* be merged with a ``unnamed_addr`` constant, the result being a
+constant whose address is significant.
 
 If the ``local_unnamed_addr`` attribute is given, the address is known to
 not be significant within the module.


### PR DESCRIPTION
It has always been the intent that it was possible to duplicate
unnamed_addr constants, and LTO takes advantage of it. The current LangRef
wording allows it, but it was not explicitly spelled out, which led Clang
developers to add an optimization that assumed that it wasn't possible.

We are considering changing the semantics of unnamed_addr, but for now,
just make the current state explicit.
