### PR TITLE
[VPlan] Add option to not check old type in VPUser::setOperand(), to avoid use-after-free in VPlan destructor

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -916,7 +916,10 @@ VPlan::~VPlan() {
           Def->replaceAllUsesWith(&DummyValue);
 
         for (unsigned I = 0, E = R.getNumOperands(); I != E; I++)
-          R.setOperand(I, &DummyValue);
+          // Some operands may have already been deleted prior to the VPlan
+          // destructor being called. Don't attempt to check the operand's type
+          // as that may be use-after-free.
+          R.setOperand(I, &DummyValue, /*CheckOpType=*/false);
       }
     } else if (auto *CanIV = cast<VPRegionBlock>(VPB)->getCanonicalIV()) {
       CanIV->replaceAllUsesWith(&DummyValue);

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -425,10 +425,11 @@ public:
     return Operands[N];
   }
 
-  void setOperand(unsigned I, VPValue *New) {
-    assert((!Operands[I]->getScalarType() || !New->getScalarType() ||
-            Operands[I]->getScalarType() == New->getScalarType()) &&
-           "scalar type of new operand must match the old operand");
+  void setOperand(unsigned I, VPValue *New, bool CheckOpType = true) {
+    if (CheckOpType)
+      assert((!Operands[I]->getScalarType() || !New->getScalarType() ||
+              Operands[I]->getScalarType() == New->getScalarType()) &&
+             "scalar type of new operand must match the old operand");
     Operands[I]->removeUser(*this);
     Operands[I] = New;
     New->addUser(*this);

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -426,10 +426,10 @@ public:
   }
 
   void setOperand(unsigned I, VPValue *New, bool CheckOpType = true) {
-    if (CheckOpType)
-      assert((!Operands[I]->getScalarType() || !New->getScalarType() ||
-              Operands[I]->getScalarType() == New->getScalarType()) &&
-             "scalar type of new operand must match the old operand");
+    assert(!CheckOpType ||
+           (!Operands[I]->getScalarType() || !New->getScalarType() ||
+            Operands[I]->getScalarType() == New->getScalarType()) &&
+               "scalar type of new operand must match the old operand");
     Operands[I]->removeUser(*this);
     Operands[I] = New;
     New->addUser(*this);


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/195891 changed VPUser::setOperand() to check that the old and new types match, but this can lead to heap use-after-free when the VPlan destructor uses setOperand() to replace all the old operands with dummy values [*], if some of the old operands are already deleted (see
https://github.com/llvm/llvm-project/pull/195891#issuecomment-4521506395 for an ASan report).

This patch fixes the issue by not checking the old operands' types when the VPlan destructor is replacing the old operands with dummy values.

[*]
```
VPlan::~VPlan() {
  VPSymbolicValue DummyValue(nullptr);
...
        for (unsigned I = 0, E = R.getNumOperands(); I != E; I++)
          R.setOperand(I, &DummyValue); // Use-after-free if the operand was deleted
```
