### PR TITLE
Open yaml, etc as text files

### DIFF
--- a/llvm/tools/dsymutil/DebugMap.cpp
+++ b/llvm/tools/dsymutil/DebugMap.cpp
@@ -147,7 +147,7 @@ DebugMap::DebugMap(const Triple &BinaryTriple, StringRef BinaryPath,
 ErrorOr<std::vector<std::unique_ptr<DebugMap>>>
 DebugMap::parseYAMLDebugMap(BinaryHolder &BinHolder, StringRef InputFile,
                             StringRef PrependPath, bool Verbose) {
-  auto ErrOrFile = MemoryBuffer::getFileOrSTDIN(InputFile);
+  auto ErrOrFile = MemoryBuffer::getFileOrSTDIN(InputFile, /*IsText=*/true);
   if (auto Err = ErrOrFile.getError())
     return Err;
 

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -784,7 +784,7 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
     auto ParseAllowDisallowFile =
         [&](const std::string &FilePath) -> Expected<StringSet<>> {
-      auto BufOrErr = MemoryBuffer::getFile(FilePath);
+      auto BufOrErr = MemoryBuffer::getFile(FilePath, /*IsText=*/true);
       if (!BufOrErr)
         return make_error<StringError>(
             Twine("cannot open allow/disallow file '") + FilePath +

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -610,14 +610,14 @@ static llvm::Error handleFileConversionToGSYM(StringRef Filename,
                                               const std::string &OutFile,
                                               OutputAggregator &Out) {
   ErrorOr<std::unique_ptr<MemoryBuffer>> BuffOrErr =
-      MemoryBuffer::getFileOrSTDIN(Filename);
+      MemoryBuffer::getFileOrSTDIN(Filename, /*IsText=*/true);
   error(Filename, BuffOrErr.getError());
   std::unique_ptr<MemoryBuffer> Buffer = std::move(BuffOrErr.get());
 
   std::unique_ptr<MemoryBuffer> SymtabBuffer;
   std::unique_ptr<Binary> SymtabBinary;
   if (!SymtabFilename.empty()) {
-    auto SymtabBufOrErr = MemoryBuffer::getFile(SymtabFilename);
+    auto SymtabBufOrErr = MemoryBuffer::getFile(SymtabFilename, /*IsText=*/true);
     if (!SymtabBufOrErr)
       return createStringError(SymtabBufOrErr.getError(),
                                "failed to open symbol table file '%s'",

--- a/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
+++ b/llvm/tools/llvm-gsymutil/llvm-gsymutil.cpp
@@ -617,7 +617,8 @@ static llvm::Error handleFileConversionToGSYM(StringRef Filename,
   std::unique_ptr<MemoryBuffer> SymtabBuffer;
   std::unique_ptr<Binary> SymtabBinary;
   if (!SymtabFilename.empty()) {
-    auto SymtabBufOrErr = MemoryBuffer::getFile(SymtabFilename, /*IsText=*/true);
+    auto SymtabBufOrErr =
+        MemoryBuffer::getFile(SymtabFilename, /*IsText=*/true);
     if (!SymtabBufOrErr)
       return createStringError(SymtabBufOrErr.getError(),
                                "failed to open symbol table file '%s'",


### PR DESCRIPTION
These tests were failing on z/OS because the text input files were being opened as binary.  

```
FAIL: LLVM :: tools/dsymutil/AArch64/typedef-different-types.test
FAIL: LLVM :: tools/dsymutil/X86/mismatch.m
FAIL: LLVM :: tools/dsymutil/embed-resource.test
FAIL: LLVM :: tools/llvm-gsymutil/X86/elf-symtab-file.yaml
```
Open the files as text to solve the problems.