### PR TITLE
[clang][lit] Add option to skip clang-repl checks

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -231,6 +231,7 @@ def have_host_clang_repl_cuda():
 
     return False
 
+
 skip_clang_repl_checks = lit.util.pythonize_bool(
     lit_config.params.get(
         "clang_skip_clang_repl_checks",
@@ -238,8 +239,8 @@ skip_clang_repl_checks = lit.util.pythonize_bool(
     )
 )
 
-if not skip_clang_repl_checks and have_host_jit_feature_support('jit'):
-    config.available_features.add('host-supports-jit')
+if not skip_clang_repl_checks and have_host_jit_feature_support("jit"):
+    config.available_features.add("host-supports-jit")
 
     if have_host_clang_repl_cuda():
         config.available_features.add('host-supports-cuda')

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -231,7 +231,14 @@ def have_host_clang_repl_cuda():
 
     return False
 
-if have_host_jit_feature_support('jit'):
+skip_clang_repl_checks = lit.util.pythonize_bool(
+    lit_config.params.get(
+        "clang_skip_clang_repl_checks",
+        os.environ.get("CLANG_LIT_SKIP_CLANG_REPL_CHECKS", "0"),
+    )
+)
+
+if not skip_clang_repl_checks and have_host_jit_feature_support('jit'):
     config.available_features.add('host-supports-jit')
 
     if have_host_clang_repl_cuda():


### PR DESCRIPTION
Whenever lit or llvm-lit is invoked to run clang tests, clang-repl is run at least once to check for host jit capabilities, and possibly several more times to probe related capabilities. This adds a noticeable delay before testing starts, especially for debug builds.

This change adds a lit parameter (clang_skip_clang_repl_checks) and an environment variable check (CLANG_LIT_SKIP_CLANG_REPL_CHECKS) to allow the clang-repl probes to be skipped. When this option is used, any tests that rely on jit execution will be reported as unsupported.

This option is intended only to allow quicker targeted testing during development. It should not be used for comprehensive verification before submitting a patch.

On my local test system, executing `ninja check-clang-cir-codegen` with a previously completed debug build took 18 seconds to run 354 tests with this option and 53 seconds without it. This is the sort of use case I am targeting -- lit test runs when the clang-repl overhead will constitute a significant portion of the total time to execute the tests.