### PR TITLE
[Support] Add path-based setLastAccessAndModificationTime overload

### DIFF
--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -728,6 +728,24 @@ inline std::error_code setLastAccessAndModificationTime(int FD,
   return setLastAccessAndModificationTime(FD, Time, Time);
 }
 
+/// Set the file modification and access time, by path.
+///
+/// Works for both regular files and directories on all supported platforms.
+///
+/// @returns errc::success if the file times were successfully set, otherwise a
+///          platform-specific error_code or errc::function_not_supported on
+///          platforms where the functionality isn't available.
+LLVM_ABI std::error_code
+setLastAccessAndModificationTime(const Twine &Path, TimePoint<> AccessTime,
+                                 TimePoint<> ModificationTime);
+
+/// Simpler version that sets both file modification and access time to the same
+/// time.
+inline std::error_code setLastAccessAndModificationTime(const Twine &Path,
+                                                        TimePoint<> Time) {
+  return setLastAccessAndModificationTime(Path, Time, Time);
+}
+
 /// Is status available?
 ///
 /// @param s Input file status.
@@ -799,6 +817,12 @@ enum OpenFlags : unsigned {
   /// Force files Atime to be updated on access. Only makes a difference on
   /// Windows.
   OF_UpdateAtime = 32,
+
+  /// Open the file with sufficient access to update its metadata, and allow
+  /// directories to be opened. Only makes a difference on Windows, where it
+  /// adds FILE_WRITE_ATTRIBUTES to the access mask and
+  /// FILE_FLAG_BACKUP_SEMANTICS to the open flags.
+  OF_UpdateAttributes = 64,
 };
 
 /// Create a potentially unique file name but does not create it.

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -818,11 +818,15 @@ enum OpenFlags : unsigned {
   /// Windows.
   OF_UpdateAtime = 32,
 
-  /// Open the file with sufficient access to update its metadata, and allow
-  /// directories to be opened. Only makes a difference on Windows, where it
-  /// adds FILE_WRITE_ATTRIBUTES to the access mask and
-  /// FILE_FLAG_BACKUP_SEMANTICS to the open flags.
+  /// Open the file with sufficient access to update its metadata. Only makes
+  /// a difference on Windows, where it adds FILE_WRITE_ATTRIBUTES to the
+  /// access mask.
   OF_UpdateAttributes = 64,
+
+  /// Allow opening a directory. Only makes a difference on Windows, where it
+  /// adds FILE_FLAG_BACKUP_SEMANTICS to the open flags so a handle to a
+  /// directory can be obtained.
+  OF_OpenDirectory = 128,
 };
 
 /// Create a potentially unique file name but does not create it.

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -1186,6 +1186,19 @@ ErrorOr<perms> getPermissions(const Twine &Path) {
   return Status.permissions();
 }
 
+std::error_code setLastAccessAndModificationTime(const Twine &Path,
+                                                 TimePoint<> AccessTime,
+                                                 TimePoint<> ModificationTime) {
+  int FD;
+  if (std::error_code EC =
+          openFile(Path, FD, CD_OpenExisting, FA_Read, OF_UpdateAttributes))
+    return EC;
+  std::error_code EC =
+      setLastAccessAndModificationTime(FD, AccessTime, ModificationTime);
+  Process::SafelyCloseFileDescriptor(FD);
+  return EC;
+}
+
 size_t mapped_file_region::size() const {
   assert(Mapping && "Mapping failed but used anyway!");
   return Size;

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -1190,8 +1190,8 @@ std::error_code setLastAccessAndModificationTime(const Twine &Path,
                                                  TimePoint<> AccessTime,
                                                  TimePoint<> ModificationTime) {
   int FD;
-  if (std::error_code EC =
-          openFile(Path, FD, CD_OpenExisting, FA_Read, OF_UpdateAttributes))
+  if (std::error_code EC = openFile(Path, FD, CD_OpenExisting, FA_Read,
+                                    OF_UpdateAttributes | OF_OpenDirectory))
     return EC;
   std::error_code EC =
       setLastAccessAndModificationTime(FD, AccessTime, ModificationTime);

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1443,7 +1443,7 @@ Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
   DWORD NativeDisp = nativeDisposition(Disp, Flags);
   DWORD NativeAccess = nativeAccess(Access, Flags);
   DWORD NativeFlags = FILE_ATTRIBUTE_NORMAL;
-  if (Flags & OF_UpdateAttributes)
+  if (Flags & OF_OpenDirectory)
     NativeFlags |= FILE_FLAG_BACKUP_SEMANTICS;
 
   bool Inherit = false;
@@ -1453,7 +1453,7 @@ Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
   file_t Result;
   std::error_code EC = openNativeFileInternal(
       Name, Result, NativeDisp, NativeAccess, NativeFlags, Inherit,
-      /*AllowDirectory=*/Flags & OF_UpdateAttributes);
+      /*AllowDirectory=*/Flags & OF_OpenDirectory);
   if (EC)
     return errorCodeToError(EC);
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1392,13 +1392,16 @@ static DWORD nativeAccess(FileAccess Access, OpenFlags Flags) {
     Result |= DELETE;
   if (Flags & OF_UpdateAtime)
     Result |= FILE_WRITE_ATTRIBUTES;
+  if (Flags & OF_UpdateAttributes)
+    Result |= FILE_WRITE_ATTRIBUTES;
   return Result;
 }
 
 static std::error_code openNativeFileInternal(const Twine &Name,
                                               file_t &ResultFile, DWORD Disp,
                                               DWORD Access, DWORD Flags,
-                                              bool Inherit = false) {
+                                              bool Inherit = false,
+                                              bool AllowDirectory = false) {
   SmallVector<wchar_t, 128> PathUTF16;
   if (std::error_code EC = widenPath(Name, PathUTF16))
     return EC;
@@ -1420,7 +1423,7 @@ static std::error_code openNativeFileInternal(const Twine &Name,
     // no performances issues.
     if (LastError != ERROR_ACCESS_DENIED)
       return EC;
-    if (is_directory(Name))
+    if (!AllowDirectory && is_directory(Name))
       return make_error_code(errc::is_a_directory);
     return EC;
   }
@@ -1439,6 +1442,9 @@ Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
 
   DWORD NativeDisp = nativeDisposition(Disp, Flags);
   DWORD NativeAccess = nativeAccess(Access, Flags);
+  DWORD NativeFlags = FILE_ATTRIBUTE_NORMAL;
+  if (Flags & OF_UpdateAttributes)
+    NativeFlags |= FILE_FLAG_BACKUP_SEMANTICS;
 
   bool Inherit = false;
   if (Flags & OF_ChildInherit)
@@ -1446,7 +1452,8 @@ Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
 
   file_t Result;
   std::error_code EC = openNativeFileInternal(
-      Name, Result, NativeDisp, NativeAccess, FILE_ATTRIBUTE_NORMAL, Inherit);
+      Name, Result, NativeDisp, NativeAccess, NativeFlags, Inherit,
+      /*AllowDirectory=*/Flags & OF_UpdateAttributes);
   if (EC)
     return errorCodeToError(EC);
 

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -2004,6 +2004,39 @@ TEST_F(FileSystemTest, OpenFileForRead) {
 #endif
 }
 
+TEST_F(FileSystemTest, SetLastAccessAndModificationTimeFile) {
+  int FD;
+  SmallString<64> Path;
+  ASSERT_NO_ERROR(fs::createTemporaryFile("set-mtime", "tmp", FD, Path));
+  FileRemover Cleanup(Path);
+  ::close(FD);
+
+  TimePoint<> When(std::chrono::seconds(1234567890));
+  ASSERT_NO_ERROR(fs::setLastAccessAndModificationTime(Path, When));
+
+  fs::file_status Status;
+  ASSERT_NO_ERROR(fs::status(Twine(Path), Status));
+  EXPECT_EQ(std::chrono::time_point_cast<std::chrono::seconds>(When),
+            std::chrono::time_point_cast<std::chrono::seconds>(
+                Status.getLastModificationTime()));
+}
+
+TEST_F(FileSystemTest, SetLastAccessAndModificationTimeDirectory) {
+  SmallString<64> Dir;
+  ASSERT_NO_ERROR(fs::createUniqueDirectory("set-mtime-dir", Dir));
+
+  TimePoint<> When(std::chrono::seconds(1234567890));
+  ASSERT_NO_ERROR(fs::setLastAccessAndModificationTime(Dir, When));
+
+  fs::file_status Status;
+  ASSERT_NO_ERROR(fs::status(Twine(Dir), Status));
+  EXPECT_EQ(std::chrono::time_point_cast<std::chrono::seconds>(When),
+            std::chrono::time_point_cast<std::chrono::seconds>(
+                Status.getLastModificationTime()));
+
+  ASSERT_NO_ERROR(fs::remove(Dir));
+}
+
 TEST_F(FileSystemTest, OpenDirectoryAsFileForRead) {
   std::string Buf(5, '?');
   Expected<fs::file_t> FD = fs::openNativeFileForRead(TestDirectory);


### PR DESCRIPTION
The existing setLastAccessAndModificationTime takes a file descriptor. Add a const Twine & overload that opens the path internally so callers no longer need to manage the fd themselves. The new overload accepts both files and directories: on POSIX, O_RDONLY opens directories and the existing fd-based implementation accepts a directory fd. On Windows, FILE_FLAG_BACKUP_SEMANTICS is required to obtain a handle for a directory.

The path overload pair mirrors the existing (Twine &) / (int FD) shape used by setPermissions and resize_file.