### PR TITLE
[dsymutil] Bump .dSYM bundle directory mtime after a rewrite

### DIFF
--- a/llvm/test/tools/dsymutil/X86/bundle-mtime.test
+++ b/llvm/test/tools/dsymutil/X86/bundle-mtime.test
@@ -1,0 +1,24 @@
+## Verify dsymutil bumps the .dSYM bundle directory's mtime when rewriting an
+## existing bundle in place. macOS Spotlight keys off this mtime to decide
+## whether to reimport the bundle's UUID; without the bump, Spotlight serves
+## the previous build's UUID and DebugSymbols falls through to slow
+## dsymForUUID lookups.
+
+RUN: rm -rf %t.dir
+RUN: mkdir -p %t.dir
+RUN: cat %p/../Inputs/basic.macho.x86_64 > %t.dir/basic
+RUN: dsymutil -oso-prepend-path=%p/.. %t.dir/basic
+
+## Backdate the bundle dir to a known epoch so any update is visible.
+RUN: env TZ=GMT touch -t 197001020000 %t.dir/basic.dSYM
+## Marker with a newer-than-backdated timestamp; the second dsymutil run
+## must move the bundle dir's mtime past this marker.
+RUN: env TZ=GMT touch -t 200001010000 %t.dir/marker
+
+RUN: dsymutil -oso-prepend-path=%p/.. %t.dir/basic
+
+## `find -maxdepth 0 -newer` prints the bundle path iff its mtime is newer
+## than the marker. Without the mtime bump, the directory keeps its 1970
+## stamp and find prints nothing.
+RUN: find %t.dir/basic.dSYM -maxdepth 0 -newer %t.dir/marker | FileCheck %s
+CHECK: basic.dSYM

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -1049,11 +1049,19 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
     // previous build's UUID, falling through to slow dsymForUUID lookups.
     {
       StringRef DWARFFile = OutputLocationOrErr->DWARFFile;
-      auto Pos = DWARFFile.find(".dSYM/");
-      if (Pos == StringRef::npos)
-        Pos = DWARFFile.find(".dSYM");
-      if (Pos != StringRef::npos) {
-        StringRef BundlePath = DWARFFile.substr(0, Pos + 5);
+      // Walk components from the right: the innermost match is the bundle
+      // itself, even when a parent directory is also named *.dSYM.
+      StringRef BundlePath;
+      for (auto I = sys::path::rbegin(DWARFFile),
+                E = sys::path::rend(DWARFFile);
+           I != E; ++I) {
+        StringRef Component = *I;
+        if (sys::path::extension(Component) == ".dSYM") {
+          BundlePath = DWARFFile.substr(0, Component.end() - DWARFFile.begin());
+          break;
+        }
+      }
+      if (!BundlePath.empty()) {
         auto Now = std::chrono::system_clock::now();
         if (auto EC =
                 sys::fs::setLastAccessAndModificationTime(BundlePath, Now))

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -1042,6 +1042,25 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
         }
       }
     }
+
+    // Bump the .dSYM bundle directory's mtime so macOS Spotlight reimports
+    // the (possibly new) UUID. Rewriting the inner DWARF file alone leaves
+    // the bundle directory mtime frozen, and Spotlight keeps serving the
+    // previous build's UUID, falling through to slow dsymForUUID lookups.
+    {
+      StringRef DWARFFile = OutputLocationOrErr->DWARFFile;
+      auto Pos = DWARFFile.find(".dSYM/");
+      if (Pos == StringRef::npos)
+        Pos = DWARFFile.find(".dSYM");
+      if (Pos != StringRef::npos) {
+        StringRef BundlePath = DWARFFile.substr(0, Pos + 5);
+        auto Now = std::chrono::system_clock::now();
+        if (auto EC =
+                sys::fs::setLastAccessAndModificationTime(BundlePath, Now))
+          WithColor::warning() << "could not update mtime of " << BundlePath
+                               << ": " << EC.message() << '\n';
+      }
+    }
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
When dsymutil rewrites an existing .dSYM bundle, only the inner DWARF file is replaced and the bundle directory's mtime stays frozen at the time of the original build.

macOS Spotlight's bundle re-import path keys off the bundle directory's mtime to decide whether the importer should re-run. With the mtime frozen, Spotlight keeps the previous build's UUID indexed forever, DebugSymbols.framework's Spotlight lookup misses on the new UUID.

Bump the bundle directory's mtime explicitly at the end of a successful run, reusing the .dSYM extraction already used by the codesign path.

rdar://177725866