### PR TITLE
[lldb] Skip libc++ category tests on Darwin when no in-tree libc++ is built

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 include(GNUInstallDirs)
 
 option(LLDB_INCLUDE_TESTS "Generate build targets for the LLDB unit tests." ${LLVM_INCLUDE_TESTS})
+option(LLDB_ENABLE_LIBCXX_TESTS "Set to OFF to acknowledge that libc++ is intentionally not built in-tree and silence the missing-libc++ warning." ON)
 
 if(LLDB_BUILT_STANDALONE)
   set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -802,8 +802,13 @@ def canRunLibcxxTests():
 
     platform = lldbplatformutil.getPlatform()
 
-    if lldbplatformutil.target_is_android() or lldbplatformutil.platformIsDarwin():
+    if lldbplatformutil.target_is_android():
         return True, "libc++ always present"
+
+    if lldbplatformutil.platformIsDarwin():
+        if not configuration.libcxx_include_dir or not configuration.libcxx_library_dir:
+            return False, "libc++ tests require a locally built libc++"
+        return True, "libc++ present"
 
     if platform == "linux":
         if not configuration.libcxx_include_dir or not configuration.libcxx_library_dir:

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -205,13 +205,15 @@ if(TARGET clang)
             "LLDB_TEST_LIBCXX_ROOT_DIR to it.")
       endif()
     else()
-      # We require libcxx for the test suite, so if we aren't building it,
-      # provide a helpful error about how to resolve the situation.
-      if(NOT LLDB_HAS_LIBCXX)
-        message(SEND_ERROR
-          "LLDB test suite requires libc++, but it is currently disabled. "
-          "Please add `libcxx` to `LLVM_ENABLE_RUNTIMES` or disable tests via "
-          "`LLDB_INCLUDE_TESTS=OFF`.")
+      # The LLDB test suite uses libc++ for many tests. If it isn't being
+      # built in-tree, tests in the "libc++" category will be skipped
+      # (same behavior as Linux).
+      if(NOT LLDB_HAS_LIBCXX AND LLDB_ENABLE_LIBCXX_TESTS)
+        message(WARNING
+          "LLDB's libc++ specific tests will be skipped. Add `libcxx` to "
+          "`LLVM_ENABLE_RUNTIMES` to get full coverage, set "
+          "`LLDB_ENABLE_LIBCXX_TESTS=OFF` to silence this warning, or disable "
+          "all tests with `LLDB_INCLUDE_TESTS=OFF`.")
       endif()
     endif()
   endif()


### PR DESCRIPTION
`canRunLibcxxTests()` previously short-circuited with "libc++ always present" for all Darwin targets, meaning the "libc++" test category was never skipped on macOS — even when `LLDB_HAS_LIBCXX` is `OFF` and no `--libcxx-include-dir` / `--libcxx-library-dir` are passed to dotest. The tests would silently run against the system libc++ instead of an in-tree build, producing results inconsistent with what the suite is designed to validate.

This fixes `canRunLibcxxTests()` to apply the same `libcxx_include_dir` / `libcxx_library_dir` guard on `Darwin` that `Linux` already uses. When those dirs are absent (i.e. no in-tree libc++ was built), the function returns `False` and `checkLibcxxSupport()` appends `libc++` to `skip_categories` — skipping those tests exactly as Linux does.

On the CMake side, the `SEND_ERROR` for `LLDB_HAS_LIBCXX=OFF` is downgraded to a `WARNING` so downstreams that intentionally skip the runtimes build can keep `LLDB_INCLUDE_TESTS=ON` for the tests they actually want to run. The warning is also gated on the new `LLDB_ENABLE_LIBCXX_TESTS` option (default `ON`): setting it to OFF acknowledges the deliberate choice and silences the warning without requiring either an in-tree libc++ build or disabling all tests.