### PR TITLE
[Support] Add MemoryBuffer::randomAccessIfMmap()

### DIFF
--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -1333,6 +1333,7 @@ private:
   LLVM_ABI void unmapImpl();
   LLVM_ABI void dontNeedImpl();
   LLVM_ABI void willNeedImpl();
+  LLVM_ABI void randomAccessImpl();
 
   LLVM_ABI std::error_code init(sys::fs::file_t FD, uint64_t Offset,
                                 mapmode Mode, const char *Name);
@@ -1366,6 +1367,7 @@ public:
   }
   void dontNeed() { dontNeedImpl(); }
   void willNeed() { willNeedImpl(); }
+  void randomAccess() { randomAccessImpl(); }
 
   LLVM_ABI size_t size() const;
   LLVM_ABI char *data() const;

--- a/llvm/include/llvm/Support/MemoryBuffer.h
+++ b/llvm/include/llvm/Support/MemoryBuffer.h
@@ -88,6 +88,11 @@ public:
   /// This should be use purely as an read optimization.
   virtual void willNeedIfMmap() {}
 
+  /// For read-only MemoryBuffer_MMap, advise the kernel that accesses will be
+  /// random, disabling readahead. This calls madvise(MADV_RANDOM) on *NIX.
+  /// This function should not be called on a writable buffer.
+  virtual void randomAccessIfMmap() {}
+
   /// Open the specified file as a MemoryBuffer, returning a new MemoryBuffer
   /// if successful, otherwise returning null.
   ///

--- a/llvm/lib/Support/MemoryBuffer.cpp
+++ b/llvm/lib/Support/MemoryBuffer.cpp
@@ -249,6 +249,7 @@ public:
 
   void dontNeedIfMmap() override { MFR.dontNeed(); }
   void willNeedIfMmap() override { MFR.willNeed(); }
+  void randomAccessIfMmap() override { MFR.randomAccess(); }
 };
 } // namespace
 

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -944,6 +944,19 @@ void mapped_file_region::willNeedImpl() {
 #endif
 }
 
+void mapped_file_region::randomAccessImpl() {
+  assert(Mode == mapped_file_region::readonly);
+  if (!Mapping)
+    return;
+#if defined(__MVS__) || defined(_AIX)
+  // If we don't have madvise, or it isn't beneficial, treat this as a no-op.
+#elif defined(POSIX_MADV_RANDOM)
+  ::posix_madvise(Mapping, Size, POSIX_MADV_RANDOM);
+#else
+  ::madvise(Mapping, Size, MADV_RANDOM);
+#endif
+}
+
 int mapped_file_region::alignment() { return Process::getPageSizeEstimate(); }
 
 std::error_code detail::directory_iterator_construct(detail::DirIterState &it,

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1183,6 +1183,8 @@ void mapped_file_region::unmapImpl() {
 
 void mapped_file_region::dontNeedImpl() {}
 
+void mapped_file_region::randomAccessImpl() {}
+
 void mapped_file_region::willNeedImpl() {
   struct MEMORY_RANGE_ENTRY {
     PVOID VirtualAddress;


### PR DESCRIPTION
For read-only MemoryBuffer_MMap, advise the kernel that access pattern will be random, disabling readahead. This calls `madvise(MADV_RANDOM)` on *NIX. This function should not be called on a writable buffer.

The implementation follows existing pattern in `mapped_file_region::dontNeedImpl()` and `mapped_file_region::willNeedImpl()`.

See intended usage: https://github.com/llvm/llvm-project/pull/199230