### PR TITLE
[CodeGenPrepare] Report an error if ProfileSummaryAnalysis is not available

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -570,6 +570,11 @@ bool CodeGenPrepare::run(Function &F, FunctionAnalysisManager &AM) {
   BFI = &AM.getResult<BlockFrequencyAnalysis>(F);
   auto &MAMProxy = AM.getResult<ModuleAnalysisManagerFunctionProxy>(F);
   PSI = MAMProxy.getCachedResult<ProfileSummaryAnalysis>(*F.getParent());
+  if (!PSI)
+    reportFatalUsageError("this pass requires the profile-summary module "
+                          "analysis to be available; when running opt, use "
+                          "-passes='require<profile-summary>,"
+                          "function(codegenprepare)'");
   BBSectionsProfileReader =
       AM.getCachedResult<BasicBlockSectionsProfileReaderAnalysis>(F);
   DomTreeUpdater DTUpdater(&AM.getResult<DominatorTreeAnalysis>(F),

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -572,9 +572,7 @@ bool CodeGenPrepare::run(Function &F, FunctionAnalysisManager &AM) {
   PSI = MAMProxy.getCachedResult<ProfileSummaryAnalysis>(*F.getParent());
   if (!PSI)
     reportFatalUsageError("this pass requires the profile-summary module "
-                          "analysis to be available; when running opt, use "
-                          "-passes='require<profile-summary>,"
-                          "function(codegenprepare)'");
+                          "analysis to be available");
   BBSectionsProfileReader =
       AM.getCachedResult<BasicBlockSectionsProfileReaderAnalysis>(F);
   DomTreeUpdater DTUpdater(&AM.getResult<DominatorTreeAnalysis>(F),

--- a/llvm/test/Transforms/CodeGenPrepare/X86/null-psi-no-crash.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/null-psi-no-crash.ll
@@ -1,0 +1,6 @@
+; RUN: not opt -passes=codegenprepare -mtriple=x86_64-linux-gnu -disable-output < %s 2>&1 | FileCheck %s
+
+; CHECK: LLVM ERROR: this pass requires the profile-summary module analysis to be available
+define void @f() {
+  ret void
+}

--- a/llvm/test/Transforms/CodeGenPrepare/X86/null-psi-no-crash.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/null-psi-no-crash.ll
@@ -1,5 +1,7 @@
 ; RUN: not opt -passes=codegenprepare -mtriple=x86_64-linux-gnu -disable-output < %s 2>&1 | FileCheck %s
 
+; Check that if we do not require PSI in the pipeline, we error out instead of crashing.
+
 ; CHECK: LLVM ERROR: this pass requires the profile-summary module analysis to be available
 define void @f() {
   ret void


### PR DESCRIPTION
CodeGenPreparePass can't declare ProfileSummaryAnalysis as required, because
PSA is a module-level analysis, but CFP is a function-level pass.  Therefore it accesses
PSA using getCachedResult, and PSA might be null.

In practice this doesn't happen, because the CGP pass pipeline preparation code ensures
that PSA is present.  But if you invoke CTP via opt -passes=codegenprepare, then it's not
there, and we segfault.

Fix for https://github.com/llvm/llvm-project/issues/173360.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
