### PR TITLE
[HLSL] Fix improper parsing of IN_LIST within if condition

### DIFF
--- a/clang/cmake/caches/HLSL.cmake
+++ b/clang/cmake/caches/HLSL.cmake
@@ -21,6 +21,10 @@ endif()
 # (docs/offload-distribution.md) for setup, prerequisites, and run
 # instructions.
 if (HLSL_ENABLE_OFFLOAD_DISTRIBUTION)
+  # Cache scripts run before the project's cmake_minimum_required takes
+  # effect, so CMP0057 still defaults to OLD here and IN_LIST would be
+  # parsed as a literal token. Opt in explicitly so the check below works.
+  cmake_policy(SET CMP0057 NEW)
   if (NOT "OffloadTest" IN_LIST LLVM_EXTERNAL_PROJECTS)
     message(FATAL_ERROR
       "HLSL_ENABLE_OFFLOAD_DISTRIBUTION requires OffloadTest to be enabled "


### PR DESCRIPTION
Cmake does not properly parse IN_LIST within the if condition, and treats it as a token.
This is not desired behavior.
The CMP0057 policy supports the new [if() IN_LIST ](https://cmake.org/cmake/help/latest/command/if.html#command:if) operator.
Enable this policy and resolve the build error.


Fixes https://github.com/llvm/llvm-project/issues/199282
Assisted by: Github Copilot