### PR TITLE
[MLIR] Fix mlir-doc build, add missing "-dialect nvgpu"

### DIFF
--- a/mlir/include/mlir/Dialect/NVGPU/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/NVGPU/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_dialect(NVGPU nvgpu)
-add_mlir_doc(NVGPUOps NVGPU Dialects/ -gen-dialect-doc)
+add_mlir_doc(NVGPUOps NVGPU Dialects/ -gen-dialect-doc -dialect nvgpu)
 
 set(LLVM_TARGET_DEFINITIONS NVGPUOps.td)
 mlir_tablegen(NVGPUOps.h.inc -gen-op-decls)


### PR DESCRIPTION
Was broken with

> when more than 1 dialect is present, one must be selected via '-dialect'