### PR TITLE
[Hexagon] Fix up vector predicate before compressing it for "bitcast"

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelLoweringHVX.cpp
@@ -2111,6 +2111,27 @@ HexagonTargetLowering::LowerHvxBitcast(SDValue Op, SelectionDAG &DAG) const {
   if (isHvxBoolTy(ValTy) && ResTy.isScalarInteger()) {
     unsigned HwLen = Subtarget.getVectorLength();
     MVT WordTy = MVT::getVectorVT(MVT::i32, HwLen/4);
+
+    // When the predicate is shorter than the predicate register, each boolean
+    // is represented by multiple consecutive bits in the input register.
+    // Condense the bits so each boolean is represented by one bit. This only
+    // handles 2x and 4x compaction ratios.
+    unsigned PredLen = ValTy.getVectorNumElements();
+    if (PredLen < HwLen) {
+      MVT ByteTy = MVT::getVectorVT(MVT::i8, HwLen);
+      Val = DAG.getNode(HexagonISD::Q2V, dl, ByteTy, Val);
+      if (HwLen > PredLen * 2) {
+        assert(HwLen == PredLen * 4);
+        PredLen *= 2;
+        Val = getInstr(Hexagon::V6_vdealh, dl, ByteTy, Val, DAG);
+      }
+      if (HwLen > PredLen) {
+        assert(HwLen == PredLen * 2);
+        Val = getInstr(Hexagon::V6_vdealb, dl, ByteTy, Val, DAG);
+      }
+      Val = DAG.getNode(HexagonISD::V2Q, dl, ValTy, Val);
+    }
+
     SDValue VQ = compressHvxPred(Val, dl, WordTy, DAG);
     unsigned BitWidth = ResTy.getSizeInBits();
 

--- a/llvm/test/CodeGen/Hexagon/inst_masked_store_bug1.ll
+++ b/llvm/test/CodeGen/Hexagon/inst_masked_store_bug1.ll
@@ -90,5 +90,5 @@ for.end49:                                        ; preds = %for.end, %entry
 ;; CHECK: outer_product
 ;; CHECK: {{r[0-9]+}} = lsr({{r[0-9]+}},#3)
 ;; CHECK: {{q[0-9]+}} = vand({{v[0-9]+}},{{r[0-9]+}})
-;; CHECK: {{v[0-9]+}} = vmux(q0,{{v[0-9]+}},{{v[0-9]+}})
+;; CHECK: {{v[0-9]+}} = vmux({{q[0-9]+}},{{v[0-9]+}},{{v[0-9]+}})
 ;; CHECK: vmem{{.*}} = {{v[0-9]+}}

--- a/llvm/test/CodeGen/Hexagon/isel-hvx-pred-bitcast-order.ll
+++ b/llvm/test/CodeGen/Hexagon/isel-hvx-pred-bitcast-order.ll
@@ -1,5 +1,11 @@
 ; RUN: llc -mtriple=hexagon < %s | FileCheck %s
 ;
+; CHECK-LABEL: foo_128_2x
+
+; Check that bitcast is computed corrected by fixing up a predicate register
+; before compressing it.
+; CHECK: v[[V1:[0-9]+]].b = vdeal(v{{[0-9]+}}.b)
+
 ; Check that the resulting register pair has the registers in the right order.
 
 ; CHECK: vdeal
@@ -19,11 +25,50 @@
 ; CHECK-NEXT: r31:30 = dealloc_return(r30):raw
 ; CHECK-NEXT: }
 
-define i64 @foo(<64 x i16> %a0, <64 x i16> %a1) #0 {
+define i64 @foo_128_2x(<64 x i16> %a0, <64 x i16> %a1) #0 {
   %v0 = icmp ugt <64 x i16> %a0, %a1
   %v1 = bitcast <64 x i1> %v0 to i64
   ret i64 %v1
 }
 
-attributes #0 = { nounwind readnone "target-cpu"="hexagonv66" "target-features"="+hvx,+hvx-length128b,-packets" }
+;; The remaining test cases only check the bitvector compression stage, which is
+;; the only distinction.
+
+; CHECK-LABEL: foo_128_4x
+; CHECK: v[[V1:[0-9]+]].h = vdeal(v{{[0-9]+}}.h)
+; CHECK: v{{[0-9]+}}.b = vdeal(v[[V1]].b)
+; CHECK: vdeal
+; CHECK: vdeal
+; CHECK: vshuff
+define i32 @foo_128_4x(<32 x i16> %a0, <32 x i16> %a1) #0 {
+  %v0 = icmp ugt <32 x i16> %a0, %a1
+  %v1 = bitcast <32 x i1> %v0 to i32
+  ret i32 %v1
+}
+
+; CHECK-LABEL: foo_64_2x
+; CHECK: v{{[0-9]+}}.b = vdeal(v{{[0-9]+}}.b)
+; CHECK: vdeal
+; CHECK: vdeal
+; CHECK: vshuff
+define i32 @foo_64_2x(<32 x i16> %a0, <32 x i16> %a1) #1 {
+  %v0 = icmp ugt <32 x i16> %a0, %a1
+  %v1 = bitcast <32 x i1> %v0 to i32
+  ret i32 %v1
+}
+
+; CHECK-LABEL: foo_64_4x
+; CHECK: v[[V1:[0-9]+]].h = vdeal(v{{[0-9]+}}.h)
+; CHECK: v{{[0-9]+}}.b = vdeal(v[[V1]].b)
+; CHECK: vdeal
+; CHECK: vdeal
+; CHECK: vshuff
+define i16 @foo_64_4x(<16 x i16> %a0, <16 x i16> %a1) #1 {
+  %v0 = icmp ugt <16 x i16> %a0, %a1
+  %v1 = bitcast <16 x i1> %v0 to i16
+  ret i16 %v1
+}
+
+attributes #0 = { nounwind readnone "target-cpu"="hexagonv68" "target-features"="+hvx,+hvx-length128b,-packets" }
+attributes #1 = { nounwind readnone "target-cpu"="hexagonv68" "target-features"="+hvx,+hvx-length64b,-packets" }
 


### PR DESCRIPTION
In v64i1 vector Predicate, each i1 is represented by 2 bits of predicate register. A predicate
register needs to be fixed before we compress it.