### PR TITLE
Add Pre-Optimization FunctionPropertiesStatistics Pass - All Properties

### DIFF
--- a/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
+++ b/llvm/include/llvm/Analysis/FunctionPropertiesAnalysis.h
@@ -185,9 +185,12 @@ public:
 
 /// Statistics pass for the FunctionPropertiesAnalysis results.
 class FunctionPropertiesStatisticsPass
-    : public RequiredPassInfoMixin<FunctionPropertiesStatisticsPass> {
+    : public PassInfoMixin<FunctionPropertiesStatisticsPass> {
+  bool IsPreOptimization;
+
 public:
-  explicit FunctionPropertiesStatisticsPass() {}
+  explicit FunctionPropertiesStatisticsPass(bool IsPreOptimization = false)
+      : IsPreOptimization(IsPreOptimization) {}
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };

--- a/llvm/include/llvm/IR/FunctionProperties.def
+++ b/llvm/include/llvm/IR/FunctionProperties.def
@@ -43,64 +43,73 @@ FUNCTION_PROPERTY(StoreInstCount, "Store Instruction Count")
 FUNCTION_PROPERTY(MaxLoopDepth, "Maximum Loop Depth in the Function")
 FUNCTION_PROPERTY(TopLevelLoopCount,
                   "Number of Top Level Loops in the Function")
-FUNCTION_PROPERTY(TotalInstructionCount,
-                  "Number of instructions (of all types)")
+FUNCTION_PROPERTY(TotalInstructionCount, "Number of instructions of all types")
 DETAILED_FUNCTION_PROPERTY(BasicBlocksWithSingleSuccessor,
-                  "Basic blocks with one successors")
+                           "Basic blocks with one successors")
 DETAILED_FUNCTION_PROPERTY(BasicBlocksWithTwoSuccessors,
-                  "Basic blocks with two successors")
+                           "Basic blocks with two successors")
 DETAILED_FUNCTION_PROPERTY(BasicBlocksWithMoreThanTwoSuccessors,
-                  "Basic blocks with more than two successors")
+                           "Basic blocks with more than two successors")
 DETAILED_FUNCTION_PROPERTY(BasicBlocksWithSinglePredecessor,
-                  "Basic blocks with one predecessors")
+                           "Basic blocks with one predecessors")
 DETAILED_FUNCTION_PROPERTY(BasicBlocksWithTwoPredecessors,
-                  "Basic blocks with two predecessors")
+                           "Basic blocks with two predecessors")
 DETAILED_FUNCTION_PROPERTY(BasicBlocksWithMoreThanTwoPredecessors,
-                  "Basic blocks with more than two predecessors")
+                           "Basic blocks with more than two predecessors")
 DETAILED_FUNCTION_PROPERTY(BigBasicBlocks, "Number of big basic blocks")
 DETAILED_FUNCTION_PROPERTY(MediumBasicBlocks, "Number of medium basic blocks")
 DETAILED_FUNCTION_PROPERTY(SmallBasicBlocks, "Number of small basic blocks")
-DETAILED_FUNCTION_PROPERTY(CastInstructionCount,
-                  "The number of cast instructions inside the function")
+DETAILED_FUNCTION_PROPERTY(
+    CastInstructionCount, "The number of cast instructions inside the function")
 DETAILED_FUNCTION_PROPERTY(
     FloatingPointInstructionCount,
     "The number of floating point instructions inside the function")
-DETAILED_FUNCTION_PROPERTY(IntegerInstructionCount,
-                  "The number of integer instructions inside the function")
-DETAILED_FUNCTION_PROPERTY(ConstantIntOperandCount, "Constant Int Operand Count")
+DETAILED_FUNCTION_PROPERTY(
+    IntegerInstructionCount,
+    "The number of integer instructions inside the function")
+DETAILED_FUNCTION_PROPERTY(ConstantIntOperandCount,
+                           "Constant Int Operand Count")
 DETAILED_FUNCTION_PROPERTY(ConstantFPOperandCount, "Constant FP Operand Count")
 DETAILED_FUNCTION_PROPERTY(ConstantOperandCount, "Constant Operand Count")
 DETAILED_FUNCTION_PROPERTY(InstructionOperandCount, "Instruction Operand Count")
 DETAILED_FUNCTION_PROPERTY(BasicBlockOperandCount, "Basic Block Operand Count")
-DETAILED_FUNCTION_PROPERTY(GlobalValueOperandCount, "Global Value Operand Count")
+DETAILED_FUNCTION_PROPERTY(GlobalValueOperandCount,
+                           "Global Value Operand Count")
 DETAILED_FUNCTION_PROPERTY(InlineAsmOperandCount, "Inline Asm Operand Count")
 DETAILED_FUNCTION_PROPERTY(ArgumentOperandCount, "Argument Operand Count")
 DETAILED_FUNCTION_PROPERTY(UnknownOperandCount, "Unknown Operand Count")
 DETAILED_FUNCTION_PROPERTY(CriticalEdgeCount, "Critical Edge Count")
-DETAILED_FUNCTION_PROPERTY(ControlFlowEdgeCount, "Number of basic block successors")
+DETAILED_FUNCTION_PROPERTY(ControlFlowEdgeCount,
+                           "Number of basic block successors")
 DETAILED_FUNCTION_PROPERTY(UnconditionalBranchCount,
-                  "Number of unconditional branch instructions")
+                           "Number of unconditional branch instructions")
 DETAILED_FUNCTION_PROPERTY(ConditionalBranchCount,
-                  "Number of conditional branch instructions")
-DETAILED_FUNCTION_PROPERTY(BranchInstructionCount, "Number of branch instructions")
+                           "Number of conditional branch instructions")
+DETAILED_FUNCTION_PROPERTY(BranchInstructionCount,
+                           "Number of branch instructions")
 DETAILED_FUNCTION_PROPERTY(BranchSuccessorCount, "Number of branch successors")
-DETAILED_FUNCTION_PROPERTY(SwitchInstructionCount, "Number of switch instructions")
+DETAILED_FUNCTION_PROPERTY(SwitchInstructionCount,
+                           "Number of switch instructions")
 DETAILED_FUNCTION_PROPERTY(SwitchSuccessorCount, "Number of switch successors")
 DETAILED_FUNCTION_PROPERTY(IntrinsicCount, "Intrinsic Count")
 DETAILED_FUNCTION_PROPERTY(NoReturnCallCount, "No Return Call Count")
 DETAILED_FUNCTION_PROPERTY(DirectCallCount, "Direct Call Count")
 DETAILED_FUNCTION_PROPERTY(IndirectCallCount, "Indirect Call Count")
-DETAILED_FUNCTION_PROPERTY(CallReturnsIntegerCount, "Call Returns Integer Count")
+DETAILED_FUNCTION_PROPERTY(CallReturnsIntegerCount,
+                           "Call Returns Integer Count")
 DETAILED_FUNCTION_PROPERTY(CallReturnsFloatCount, "Call Returns Float Count")
-DETAILED_FUNCTION_PROPERTY(CallReturnsPointerCount, "Call Returns Pointer Count")
-DETAILED_FUNCTION_PROPERTY(CallReturnsVectorIntCount, "Call Returns Vector Int Count")
+DETAILED_FUNCTION_PROPERTY(CallReturnsPointerCount,
+                           "Call Returns Pointer Count")
+DETAILED_FUNCTION_PROPERTY(CallReturnsVectorIntCount,
+                           "Call Returns Vector Int Count")
 DETAILED_FUNCTION_PROPERTY(CallReturnsVectorFloatCount,
-                  "Call Returns Vector Float Count")
+                           "Call Returns Vector Float Count")
 DETAILED_FUNCTION_PROPERTY(CallReturnsVectorPointerCount,
-                  "Call Returns Vector Pointer Count")
-DETAILED_FUNCTION_PROPERTY(CallWithManyArgumentsCount, "Call With Many Arguments Count")
+                           "Call Returns Vector Pointer Count")
+DETAILED_FUNCTION_PROPERTY(CallWithManyArgumentsCount,
+                           "Call With Many Arguments Count")
 DETAILED_FUNCTION_PROPERTY(CallWithPointerArgumentCount,
-                  "Call With Pointer Argument Count")
+                           "Call With Pointer Argument Count")
 
 #undef FUNCTION_PROPERTY
 #undef DETAILED_FUNCTION_PROPERTY

--- a/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
+++ b/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
@@ -29,9 +29,14 @@ using namespace llvm;
 
 #define DEBUG_TYPE "func-properties-stats"
 
-#define FUNCTION_PROPERTY(Name, Description) STATISTIC(Num##Name, Description);
+#define FUNCTION_PROPERTY(Name, Description)                                   \
+  STATISTIC(Num##Name, Description);                                           \
+  STATISTIC(Num##Name##PreOptimization, Description " (before "                \
+                                                    "optimizations)");
 #define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
-  STATISTIC(Num##Name, Description);
+  STATISTIC(Num##Name, Description);                                           \
+  STATISTIC(Num##Name##PreOptimization, Description " (before "                \
+                                                    "optimizations)");
 #include "llvm/IR/FunctionProperties.def"
 
 namespace llvm {
@@ -381,12 +386,22 @@ FunctionPropertiesStatisticsPass::run(Function &F,
   LLVM_DEBUG(dbgs() << "STATSCOUNT: running on function " << F.getName()
                     << "\n");
   auto &AnalysisResults = FAM.getResult<FunctionPropertiesAnalysis>(F);
-
+  if (IsPreOptimization) {
+#define FUNCTION_PROPERTY(Name, Description)                                   \
+  Num##Name##PreOptimization += AnalysisResults.Name;
+#define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
+  Num##Name##PreOptimization += AnalysisResults.Name;
+#include "llvm/IR/FunctionProperties.def"
+#undef FUNCTION_PROPERTY
+#undef DETAILED_FUNCTION_PROPERTY
+  } else {
 #define FUNCTION_PROPERTY(Name, Description) Num##Name += AnalysisResults.Name;
 #define DETAILED_FUNCTION_PROPERTY(Name, Description)                          \
   Num##Name += AnalysisResults.Name;
 #include "llvm/IR/FunctionProperties.def"
-
+#undef FUNCTION_PROPERTY
+#undef DETAILED_FUNCTION_PROPERTY
+  }
   return PreservedAnalyses::all();
 }
 

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -831,6 +831,12 @@ Expected<bool> parseLintOptions(StringRef Params) {
                                             "LintPass");
 }
 
+/// Parser of parameters for FunctionPropertiesStatistics pass.
+Expected<bool> parseFunctionPropertiesStatisticsOptions(StringRef Params) {
+  return PassBuilder::parseSinglePassOption(Params, "pre-opt",
+                                            "FunctionPropertiesStatisticsPass");
+}
+
 /// Parser of parameters for InstCount pass.
 Expected<bool> parseInstCountOptions(StringRef Params) {
   return PassBuilder::parseSinglePassOption(Params, "pre-opt", "InstCountPass");

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -424,16 +424,14 @@ static void instructionCountersPass(ModulePassManager &MPM,
   if (AreStatisticsEnabled()) {
     MPM.addPass(
         createModuleToFunctionPassAdaptor(InstCountPass(IsPreOptimization)));
+    MPM.addPass(createModuleToFunctionPassAdaptor(
+        FunctionPropertiesStatisticsPass(IsPreOptimization)));
   }
 }
 
 // Helper to add AnnotationRemarksPass.
 static void addAnnotationRemarksPass(ModulePassManager &MPM) {
   MPM.addPass(createModuleToFunctionPassAdaptor(AnnotationRemarksPass()));
-  if (AreStatisticsEnabled()) {
-    MPM.addPass(
-        createModuleToFunctionPassAdaptor(FunctionPropertiesStatisticsPass()));
-  }
 }
 
 // Helper to check if the current compilation phase is preparing for LTO

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -450,7 +450,6 @@ FUNCTION_PASS("fix-irreducible", FixIrreduciblePass())
 FUNCTION_PASS("flatten-cfg", FlattenCFGPass())
 FUNCTION_PASS("float2int", Float2IntPass())
 FUNCTION_PASS("free-machine-function", FreeMachineFunctionPass())
-FUNCTION_PASS("func-properties-stats", FunctionPropertiesStatisticsPass())
 FUNCTION_PASS("gc-lowering", GCLoweringPass())
 FUNCTION_PASS("guard-widening", GuardWideningPass())
 FUNCTION_PASS("gvn-hoist", GVNHoistPass())
@@ -595,6 +594,12 @@ FUNCTION_PASS_WITH_PARAMS(
     [](bool PostInlining) { return EntryExitInstrumenterPass(PostInlining); },
     parseEntryExitInstrumenterPassOptions, "post-inline")
 FUNCTION_PASS_WITH_PARAMS(
+    "func-properties-stats", "FunctionPropertiesStatisticsPass",
+    [](bool IsPreOptimizations) {
+      return FunctionPropertiesStatisticsPass(IsPreOptimizations);
+    },
+    parseFunctionPropertiesStatisticsOptions, "pre-opt")
+FUNCTION_PASS_WITH_PARAMS(
     "function-simplification", "",
     [this](OptimizationLevel OL) {
       return buildFunctionSimplificationPipeline(OL, ThinOrFullLTOPhase::None);
@@ -619,9 +624,7 @@ FUNCTION_PASS_WITH_PARAMS(
     "no-verify-fixpoint;verify-fixpoint;max-iterations=N")
 FUNCTION_PASS_WITH_PARAMS(
     "instcount", "InstCountPass",
-    [](bool IsPreOptimizations) { 
-      return InstCountPass(IsPreOptimizations); 
-    },
+    [](bool IsPreOptimizations) { return InstCountPass(IsPreOptimizations); },
     parseInstCountOptions, "pre-opt")
 FUNCTION_PASS_WITH_PARAMS(
     "lint", "LintPass",

--- a/llvm/test/Analysis/FunctionPropertiesAnalysis/func-properties-analysis.ll
+++ b/llvm/test/Analysis/FunctionPropertiesAnalysis/func-properties-analysis.ll
@@ -1,18 +1,12 @@
-; Testing with all of the below run lines that the pass gets added to the appropriate pipelines
 ; REQUIRES: asserts
-; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes=func-properties-stats < %s 2>&1 | FileCheck %s
-; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='thinlto<O3>' < %s 2>&1 | FileCheck %s
-; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='thinlto-pre-link<O2>' < %s 2>&1 | FileCheck %s
-; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='lto<O1>' < %s 2>&1 | FileCheck %s
-; RUN: opt -stats -enable-detailed-function-properties -disable-output -O3 < %s 2>&1 | FileCheck %s
-; RUN: opt -stats -enable-detailed-function-properties -disable-output -O0 < %s 2>&1 | FileCheck %s
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='func-properties-stats' < %s 2>&1 | FileCheck %s
 
 ; CHECK-DAG: 10 func-properties-stats - Number of basic blocks
 ; CHECK-DAG: 8 func-properties-stats - Number of branch instructions
 ; CHECK-DAG: 10 func-properties-stats - Number of branch successors
 ; CHECK-DAG: 2 func-properties-stats - Number of conditional branch instructions
 ; CHECK-DAG: 6 func-properties-stats - Number of unconditional branch instructions
-; CHECK-DAG: 18 func-properties-stats - Number of instructions (of all types)
+; CHECK-DAG: 18 func-properties-stats - Number of instructions of all types
 ; CHECK-DAG: 14 func-properties-stats - Number of basic block successors
 ; CHECK-DAG: 1 func-properties-stats - Number of switch instructions
 ; CHECK-DAG: 4 func-properties-stats - Number of switch successors

--- a/llvm/test/Analysis/FunctionPropertiesAnalysis/pipeline.ll
+++ b/llvm/test/Analysis/FunctionPropertiesAnalysis/pipeline.ll
@@ -1,0 +1,41 @@
+; REQUIRES: asserts
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='func-properties-stats<pre-opt>' < %s 2>&1 | FileCheck %s --check-prefix=PRE
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='func-properties-stats' < %s 2>&1 | FileCheck %s --check-prefixes=POSTNOOPT
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -O0 < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POSTNOOPT
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -O3 < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POST
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='lto<O3>' < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POST
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='lto-pre-link<O2>' < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POST
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='lto-pre-link<O3>' < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POST
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='thinlto<O3>' < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POST
+; RUN: opt -stats -enable-detailed-function-properties -disable-output -passes='thinlto-pre-link<O2>' < %s 2>&1 | FileCheck %s --check-prefixes=PRE,POST
+
+; --- <pre-opt> ---
+; PRE-DAG: 4 func-properties-stats - Number of basic blocks (before optimizations)
+; PRE-DAG: 5 func-properties-stats - Number of instructions of all types (before optimizations)
+; PRE-DAG: 4 func-properties-stats - Number of basic block successors (before optimizations)
+
+; --- No <pre-opt> in pass but no optimization passes run ---
+; POSTNOOPT-DAG: 4 func-properties-stats - Number of basic blocks
+; POSTNOOPT-DAG: 5 func-properties-stats - Number of instructions of all types
+; POSTNOOPT-DAG: 4 func-properties-stats - Number of basic block successors
+
+; --- Post optimization values ---
+; POST-DAG: 1 func-properties-stats - Number of basic blocks
+; POST-DAG: 1 func-properties-stats - Number of instructions of all types
+; POST-NOT: func-properties-stats - Number of basic block successors
+
+define i32 @test_count() {
+entry:
+  ; This branch is trivially resolvable
+  br i1 true, label %then, label %else
+
+then:
+  br label %end
+
+else:
+  br label %end
+
+end:
+  %phi = phi i32 [ 1, %then ], [ 2, %else ]
+  ret i32 %phi
+}


### PR DESCRIPTION
Adding a PreOptimization pass for function properties that provides the statistics preoptimization without leading to timeouts (also thanks to https://github.com/llvm/llvm-project/pull/198940 and internal changes on the faulty target)

First iteration led to timeouts so it got reverted
https://github.com/llvm/llvm-project/pull/188837
(UPDATE) Through a flame graph proved that changes in https://github.com/llvm/llvm-project/pull/198940 , mainly the change inside the loop, was the one responsible. Flame graph spent a majority of the time on updateForBB, and it's the only part there could be a blocker

Previous iteration tried to get only some of the statistics, but managed to prove locally that it's not necessary to distinguish between them
https://github.com/llvm/llvm-project/pull/199073