### PR TITLE
[lldb] Adjust TestFunctionTypes.py for arm64e

### DIFF
--- a/lldb/test/API/lang/c/function_types/TestFunctionTypes.py
+++ b/lldb/test/API/lang/c/function_types/TestFunctionTypes.py
@@ -50,7 +50,7 @@ class FunctionTypesTestCase(TestBase):
 
         self.expect(
             "expr string_not_empty",
-            substrs=["(int (*)(const char *)) $0 = ", "(a.out`"],
+            substrs=["(int (*)(const char *)) $0 = ", "a.out`"],
         )
 
         if self.platformIsDarwin():


### PR DESCRIPTION
Normally the open parens happen right before a.out, but on arm64e the load address is placed there instead. So instead of:

$0 = 0x0000d00d (a.out...)

we instead have:

$0 = 0xcafed00d (actual=0x0000d00d a.out ...)