### PR TITLE
[RISCV] Reserve all sub-registers of user reserved GPRs

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -177,12 +177,16 @@ BitVector RISCVRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
 
   for (size_t Reg = 0; Reg < getNumRegs(); Reg++) {
     // Mark any GPRs requested to be reserved as such
-    if (Subtarget.isRegisterReservedByUser(Reg))
-      markSuperRegs(Reserved, Reg);
+    if (Subtarget.isRegisterReservedByUser(Reg)) {
+      for (MCPhysReg Sub : subregs_inclusive(Reg))
+        markSuperRegs(Reserved, Sub);
+    }
 
     // Mark all the registers defined as constant in TableGen as reserved.
-    if (isConstantPhysReg(Reg))
-      markSuperRegs(Reserved, Reg);
+    if (isConstantPhysReg(Reg)) {
+      for (MCPhysReg Sub : subregs_inclusive(Reg))
+        markSuperRegs(Reserved, Sub);
+    }
   }
 
   // Use markSuperRegs to ensure any register aliases are also reserved

--- a/llvm/test/CodeGen/RISCV/fixed-x27-crash.ll
+++ b/llvm/test/CodeGen/RISCV/fixed-x27-crash.ll
@@ -1,0 +1,16 @@
+; RUN: llc < %s -mtriple=riscv64-unknown-fuchsia -mattr=+reserve-x27 -verify-machineinstrs
+
+define i64 @foo() {
+entry:
+  %local = alloca i64
+  br label %end
+
+end:                                           ; preds = %entry
+  store i64 0, ptr %local, align 8
+  %0 = tail call i64 @llvm.read_register.i64(metadata !0)
+  ret i64 %0
+}
+
+declare i64 @llvm.read_register.i64(metadata)
+
+!0 = !{!"s11"}


### PR DESCRIPTION
When a GPR is reserved by the user (e.g., via  `-mattr=+reserve-x27`)
or marked as constant, only the top-level register was being marked
reserved in `RISCVRegisterInfo::getReservedRegs`. Its sub-registers
(`X27_W` and `X27_H`) remained unreserved.

This broke `LiveIntervals` when register pressure tracking was enabled
by #115445. Because the sub-registers were not reserved, the register
unit was considered non-reserved, causing `LiveIntervals` to track its
liveness and crash in the Machine Verifier due to the reserved
register missing from basic block live-in lists.

Instead, we should ensure that reserving a register also reserves all
of its sub-registers, so that the register unit is correctly
identified as reserved and ignored by `LiveIntervals`.

Fixes #176227