### PR TITLE
[SeparateConstOffsetFromGEP] Set `inbounds` correctly.

### DIFF
--- a/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
+++ b/llvm/lib/Transforms/Scalar/SeparateConstOffsetFromGEP.cpp
@@ -1512,21 +1512,39 @@ void SeparateConstOffsetFromGEP::swapGEPOperand(GetElementPtrInst *First,
   First->setOperand(1, Offset2);
   Second->setOperand(1, Offset1);
 
-  // We changed p+o+c to p+c+o, p+c may not be inbound anymore.
+  // After changing (p+o)+c to (p+c)+o, the inner GEP may not be inbounds
+  // anymore.
   const DataLayout &DAL = First->getDataLayout();
-  APInt Offset(DAL.getIndexSizeInBits(
-                   cast<PointerType>(First->getType())->getAddressSpace()),
-               0);
-  Value *NewBase =
-      First->stripAndAccumulateInBoundsConstantOffsets(DAL, Offset);
-  uint64_t ObjectSize;
-  if (!getObjectSize(NewBase, ObjectSize, DAL, TLI) ||
-     Offset.ugt(ObjectSize)) {
+  unsigned IdxBits = DAL.getIndexSizeInBits(
+      cast<PointerType>(First->getType())->getAddressSpace());
+
+  auto ClearNoWrapFlags = [&] {
     // TODO(gep_nowrap): Make flag preservation more precise.
     First->setNoWrapFlags(GEPNoWrapFlags::none());
     Second->setNoWrapFlags(GEPNoWrapFlags::none());
-  } else
-    First->setIsInBounds(true);
+  };
+
+  APInt FirstOffset(IdxBits, 0);
+  if (!First->accumulateConstantOffset(DAL, FirstOffset)) {
+    ClearNoWrapFlags();
+    return;
+  }
+
+  APInt BaseOffset(IdxBits, 0);
+  Value *NewBase =
+      First->getOperand(0)->stripAndAccumulateInBoundsConstantOffsets(
+          DAL, BaseOffset);
+
+  bool Overflow = false;
+  APInt TotalOffset = BaseOffset.uadd_ov(FirstOffset, Overflow);
+  uint64_t ObjectSize;
+  if (Overflow || !getObjectSize(NewBase, ObjectSize, DAL, TLI) ||
+      TotalOffset.ugt(ObjectSize)) {
+    ClearNoWrapFlags();
+    return;
+  }
+
+  First->setIsInBounds(true);
 }
 
 void SeparateConstOffsetFromGEPPass::printPipeline(

--- a/llvm/test/Transforms/SeparateConstOffsetFromGEP/AMDGPU/lower-gep.ll
+++ b/llvm/test/Transforms/SeparateConstOffsetFromGEP/AMDGPU/lower-gep.ll
@@ -238,7 +238,7 @@ define void @test_A_sub_B_add_ConstantInt_null_basptr() {
 ; CHECK-NEXT:    [[TMP2:%.*]] = sext i32 [[REM]] to i64
 ; CHECK-NEXT:    [[SUB22:%.*]] = sub i64 [[TMP2]], [[TMP1]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = shl i64 [[SUB22]], 2
-; CHECK-NEXT:    [[UGLYGEP:%.*]] = getelementptr inbounds i8, ptr null, i64 2044
+; CHECK-NEXT:    [[UGLYGEP:%.*]] = getelementptr i8, ptr null, i64 2044
 ; CHECK-NEXT:    [[UGLYGEP3:%.*]] = getelementptr i8, ptr [[UGLYGEP]], i64 [[TMP3]]
 ; CHECK-NEXT:    store float 1.000000e+00, ptr [[UGLYGEP3]], align 4
 ; CHECK-NEXT:    br label [[COND_END]]

--- a/llvm/test/Transforms/SeparateConstOffsetFromGEP/split-gep-sub.ll
+++ b/llvm/test/Transforms/SeparateConstOffsetFromGEP/split-gep-sub.ll
@@ -72,4 +72,44 @@ for.end:
   ret void
 }
 
+; Check that the hoisted constant-offset GEP is not marked inbounds
+; when the offset clearly exceeds the underlying object: @g is 40
+; bytes, the hoisted offset is 800.
+
+@g = global [10 x i32] zeroinitializer
+
+define void @hoist_out_of_bounds_const(i64 %lim, i64 %step) {
+; CHECK-LABEL: @hoist_out_of_bounds_const(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[LOOP:%.*]]
+; CHECK:       loop:
+; CHECK-NEXT:    [[IV:%.*]] = phi i64 [ 0, [[ENTRY:%.*]] ], [ [[NEXT:%.*]], [[LOOP]] ]
+; CHECK-NEXT:    [[ADDEND:%.*]] = mul i64 [[IV]], [[STEP:%.*]]
+; CHECK-NEXT:    [[TMP0:%.*]] = shl i64 [[ADDEND]], 2
+; CHECK-NEXT:    [[UGLYGEP:%.*]] = getelementptr i8, ptr @g, i64 800
+; CHECK-NEXT:    [[UGLYGEP2:%.*]] = getelementptr i8, ptr [[UGLYGEP]], i64 [[TMP0]]
+; CHECK-NEXT:    store volatile i32 0, ptr [[UGLYGEP2]], align 4
+; CHECK-NEXT:    [[NEXT]] = add i64 [[IV]], 1
+; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i64 [[NEXT]], [[LIM:%.*]]
+; CHECK-NEXT:    br i1 [[CMP]], label [[LOOP]], label [[EXIT:%.*]]
+; CHECK:       exit:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv = phi i64 [ 0, %entry ], [ %next, %loop ]
+  %addend = mul i64 %iv, %step
+  %off = add i64 %addend, 200
+  %gep = getelementptr i32, ptr @g, i64 %off
+  store volatile i32 0, ptr %gep, align 4
+  %next = add i64 %iv, 1
+  %cmp = icmp slt i64 %next, %lim
+  br i1 %cmp, label %loop, label %exit
+
+exit:
+  ret void
+}
+
 declare i32 @foo()

--- a/llvm/test/Transforms/SeparateConstOffsetFromGEP/split-gep-sub.ll
+++ b/llvm/test/Transforms/SeparateConstOffsetFromGEP/split-gep-sub.ll
@@ -78,7 +78,7 @@ for.end:
 
 @g = global [10 x i32] zeroinitializer
 
-define void @hoist_out_of_bounds_const(i64 %lim, i64 %step) {
+define ptr @hoist_out_of_bounds_const(i64 %lim, i64 %step) {
 ; CHECK-LABEL: @hoist_out_of_bounds_const(
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    br label [[LOOP:%.*]]
@@ -88,12 +88,11 @@ define void @hoist_out_of_bounds_const(i64 %lim, i64 %step) {
 ; CHECK-NEXT:    [[TMP0:%.*]] = shl i64 [[ADDEND]], 2
 ; CHECK-NEXT:    [[UGLYGEP:%.*]] = getelementptr i8, ptr @g, i64 800
 ; CHECK-NEXT:    [[UGLYGEP2:%.*]] = getelementptr i8, ptr [[UGLYGEP]], i64 [[TMP0]]
-; CHECK-NEXT:    store volatile i32 0, ptr [[UGLYGEP2]], align 4
 ; CHECK-NEXT:    [[NEXT]] = add i64 [[IV]], 1
 ; CHECK-NEXT:    [[CMP:%.*]] = icmp slt i64 [[NEXT]], [[LIM:%.*]]
 ; CHECK-NEXT:    br i1 [[CMP]], label [[LOOP]], label [[EXIT:%.*]]
 ; CHECK:       exit:
-; CHECK-NEXT:    ret void
+; CHECK-NEXT:    ret ptr [[UGLYGEP2]]
 ;
 entry:
   br label %loop
@@ -103,13 +102,12 @@ loop:
   %addend = mul i64 %iv, %step
   %off = add i64 %addend, 200
   %gep = getelementptr i32, ptr @g, i64 %off
-  store volatile i32 0, ptr %gep, align 4
   %next = add i64 %iv, 1
   %cmp = icmp slt i64 %next, %lim
   br i1 %cmp, label %loop, label %exit
 
 exit:
-  ret void
+  ret ptr %gep
 }
 
 declare i32 @foo()


### PR DESCRIPTION
swapGEPOperand reorders the GEPs (ptr+off)+const into (ptr+const)+off.
When it does so, it needs to determine if the inner GEP is inbounds.

Previously the way it did this was to call
stripAndAccumulateInBoundsConstantOffsets on (ptr+const), and then check
if this offset was indeed in-bounds.

However, this GEP was not necessarily marked as `inbounds` itself. If it
was not, stripAndAccumulateInBoundsConstantOffsets would return 0 for
the offset (instead of `const`), in which case we'd check if
`0 < [obj width]`, which is trivially true, and then incorrectly mark
the GEP as inbounds.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
