### PR TITLE
[SimplifyLibCalls] Fix optimizeFdim for Inf-Inf cases

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -3194,12 +3194,12 @@ Value *LibCallSimplifier::optimizeFdim(CallInst *CI, IRBuilderBase &B) {
       !match(CI->getArgOperand(1), m_APFloat(Y)))
     return nullptr;
 
+  // C99 fdim(x, y) = (x > y) ? x - y : +0.
+  if (X->compare(*Y) != APFloat::cmpGreaterThan && !X->isNaN() && !Y->isNaN())
+    return ConstantFP::getZero(CI->getType());
   APFloat Difference = *X;
   Difference.subtract(*Y, RoundingMode::NearestTiesToEven);
-
-  APFloat MaxVal =
-      maximum(Difference, APFloat::getZero(CI->getType()->getFltSemantics()));
-  return ConstantFP::get(CI->getType(), MaxVal);
+  return ConstantFP::get(CI->getType(), Difference);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/test/Transforms/InstCombine/fdim.ll
+++ b/llvm/test/Transforms/InstCombine/fdim.ll
@@ -77,9 +77,17 @@ define double @fdim_inf_ninf() {
 
 define double @fdim_inf() {
 ; CHECK-LABEL: define double @fdim_inf() {
-; CHECK-NEXT:    ret double +qnan
+; CHECK-NEXT:    ret double 0.000000e+00
 ;
   %dim = call double @fdim(double 0x7FF0000000000000, double 0x7FF0000000000000)
+  ret double %dim
+}
+
+define double @fdim_ninf() {
+; CHECK-LABEL: define double @fdim_ninf() {
+; CHECK-NEXT:    ret double 0.000000e+00
+;
+  %dim = call double @fdim(double 0xFFF0000000000000, double 0xFFF0000000000000)
   ret double %dim
 }
 


### PR DESCRIPTION
fdim(x,y) is defined as

    NaN if x or y is NaN, otherwise
    (x > y) ? x - y : +0

optimizeFdim computed fdim(x,y) as max(x-y, +0).  This is not correct
when x == y == +/-Inf; the result should be 0, but this optimization
returns NaN.

I was surprised by this bug because there's even a testcase checking the
incorrect behavior.  But returning 0 matches the description in C99 and
POSIX, where, just to be extra clear, the spelling of the piecewise function is

    NaN if either input is NaN
    x - y if x > y
    +0    if x <= y

Returning +0 also matches the behavior of libc on my machine
gcc.godbolt.org.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
