### PR TITLE
[ConstantFolding] Handle large exponents in ldexp

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -3716,13 +3716,10 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
         // APFloat::scalbn takes the exponent as `int`. Clamp wider integer
         // exponents into [INT_MIN, INT_MAX] so values still saturate the
         // result to +/-inf or +/-0.
-        int64_t Exp = Op2C->getSExtValue();
-        int ClampedExp = static_cast<int>(
-            std::clamp<int64_t>(Exp, std::numeric_limits<int>::min(),
-                                std::numeric_limits<int>::max()));
+        APInt Exp = Op2C->getValue().truncSSat(32);
         return ConstantFP::get(
             Ty->getContext(),
-            scalbn(Op1V, ClampedExp, APFloat::rmNearestTiesToEven));
+            scalbn(Op1V, Exp.getSExtValue(), APFloat::rmNearestTiesToEven));
       }
       case Intrinsic::is_fpclass: {
         FPClassTest Mask = static_cast<FPClassTest>(Op2C->getZExtValue());

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -3713,9 +3713,16 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
     } else if (auto *Op2C = dyn_cast<ConstantInt>(Operands[1])) {
       switch (IntrinsicID) {
       case Intrinsic::ldexp: {
+        // APFloat::scalbn takes the exponent as `int`. Clamp wider integer
+        // exponents into [INT_MIN, INT_MAX] so values still saturate the
+        // result to +/-inf or +/-0.
+        int64_t Exp = Op2C->getSExtValue();
+        int ClampedExp = static_cast<int>(
+            std::clamp<int64_t>(Exp, std::numeric_limits<int>::min(),
+                                std::numeric_limits<int>::max()));
         return ConstantFP::get(
             Ty->getContext(),
-            scalbn(Op1V, Op2C->getSExtValue(), APFloat::rmNearestTiesToEven));
+            scalbn(Op1V, ClampedExp, APFloat::rmNearestTiesToEven));
       }
       case Intrinsic::is_fpclass: {
         FPClassTest Mask = static_cast<FPClassTest>(Op2C->getZExtValue());

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -3716,7 +3716,8 @@ static Constant *ConstantFoldIntrinsicCall2(Intrinsic::ID IntrinsicID, Type *Ty,
         // APFloat::scalbn takes the exponent as `int`. Clamp wider integer
         // exponents into [INT_MIN, INT_MAX] so values still saturate the
         // result to +/-inf or +/-0.
-        APInt Exp = Op2C->getValue().truncSSat(32);
+        APInt Exp = Op2C->getValue();
+        Exp = Exp.getBitWidth() < 32 ? Exp.sext(32) : Exp.truncSSat(32);
         return ConstantFP::get(
             Ty->getContext(),
             scalbn(Op1V, Exp.getSExtValue(), APFloat::rmNearestTiesToEven));

--- a/llvm/test/Transforms/InstCombine/ldexp.ll
+++ b/llvm/test/Transforms/InstCombine/ldexp.ll
@@ -4,6 +4,7 @@
 declare float @llvm.ldexp.f32.i32(float, i32)
 declare <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float>, <2 x i32>)
 declare float @llvm.ldexp.f32.i64(float, i64)
+declare double @llvm.ldexp.f64.i64(double, i64)
 
 ; select c, (ldexp val, e0), (ldexp val, e1) -> ldexp val, (select c, e0, e1)
 define float @select_ldexp_f32_sameval_differentexp(i1 %cond, float %val, i32 %exp0, i32 %exp1) {
@@ -1091,6 +1092,32 @@ define <2 x float> @ldexp_v2f32_mask_select_0_swap(<2 x i1> %cond, <2 x float> %
   %select = select <2 x i1> %cond, <2 x i32> zeroinitializer, <2 x i32> %y
   %ldexp = call nsz nnan <2 x float> @llvm.ldexp.f32.v2i32(<2 x float> %x, <2 x i32> %select)
   ret <2 x float> %ldexp
+}
+
+; Exponent constants that exceed `int` saturate to +/-inf / +/-0 rather than
+; silently narrowing.
+define double @ldexp_i64_exp_above_int_max() {
+; CHECK-LABEL: define double @ldexp_i64_exp_above_int_max() {
+; CHECK-NEXT:    ret double +inf
+;
+  %r = call double @llvm.ldexp.f64.i64(double 1.0, i64 4294967330)
+  ret double %r
+}
+
+define double @ldexp_i64_exp_below_int_min() {
+; CHECK-LABEL: define double @ldexp_i64_exp_below_int_min() {
+; CHECK-NEXT:    ret double 0.000000e+00
+;
+  %r = call double @llvm.ldexp.f64.i64(double 1.0, i64 -4294967330)
+  ret double %r
+}
+
+define double @ldexp_i64_neg_input_exp_above_int_max() {
+; CHECK-LABEL: define double @ldexp_i64_neg_input_exp_above_int_max() {
+; CHECK-NEXT:    ret double -inf
+;
+  %r = call double @llvm.ldexp.f64.i64(double -1.0, i64 4294967330)
+  ret double %r
 }
 
 attributes #0 = { strictfp }

--- a/llvm/test/Transforms/InstCombine/ldexp.ll
+++ b/llvm/test/Transforms/InstCombine/ldexp.ll
@@ -3,6 +3,7 @@
 
 declare float @llvm.ldexp.f32.i32(float, i32)
 declare <2 x float> @llvm.ldexp.v2f32.v2i32(<2 x float>, <2 x i32>)
+declare double @llvm.ldexp.f64.i16(double, i16)
 declare float @llvm.ldexp.f32.i64(float, i64)
 declare double @llvm.ldexp.f64.i64(double, i64)
 
@@ -1126,6 +1127,22 @@ define double @ldexp_i64_neg_input_exp_above_int64_max() {
 ;
   ; This constant is 2^65, i.e. it exceeds the range of i64.
   %r = call double @llvm.ldexp.f64.i128(double -1.0, i128 36893488147419103232)
+  ret double %r
+}
+
+define double @ldexp_i16_exp_narrow_int() {
+; CHECK-LABEL: define double @ldexp_i16_exp_narrow_int() {
+; CHECK-NEXT:    ret double 4.096000e+03
+;
+  %r = call double @llvm.ldexp.f64.i16(double 1.0, i16 12)
+  ret double %r
+}
+
+define double @ldexp_i16_exp_narrow_int_negative() {
+; CHECK-LABEL: define double @ldexp_i16_exp_narrow_int_negative() {
+; CHECK-NEXT:    ret double 4.000000e+00
+;
+  %r = call double @llvm.ldexp.f64.i16(double 8.0, i16 -1)
   ret double %r
 }
 

--- a/llvm/test/Transforms/InstCombine/ldexp.ll
+++ b/llvm/test/Transforms/InstCombine/ldexp.ll
@@ -1120,6 +1120,15 @@ define double @ldexp_i64_neg_input_exp_above_int_max() {
   ret double %r
 }
 
+define double @ldexp_i64_neg_input_exp_above_int64_max() {
+; CHECK-LABEL: define double @ldexp_i64_neg_input_exp_above_int64_max() {
+; CHECK-NEXT:    ret double -inf
+;
+  ; This constant is 2^65, i.e. it exceeds the range of i64.
+  %r = call double @llvm.ldexp.f64.i128(double -1.0, i128 36893488147419103232)
+  ret double %r
+}
+
 attributes #0 = { strictfp }
 
 !0 = !{i32 -127, i32 0}


### PR DESCRIPTION
Previously if you passed a constant exponent to llvm.ldexp greater than
the width of `int`, we would silently truncate it to `int` before
using it in scalbn.  We'd thus generate the incorrect result.

We now clamp it to fit within int.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
