### PR TITLE
[clang-doc][nfc] Avoid combining constexpr with std::initializer_list as this seems to give MSVC trouble.

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeWriter.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeWriter.cpp
@@ -252,7 +252,7 @@ struct BlockToIdList {
   std::initializer_list<RecordId> RIDs;
 };
 
-static constexpr BlockToIdList RecordsByBlock[] = {
+static const BlockToIdList RecordsByBlock[] = {
     // Version Block
     {BI_VERSION_BLOCK_ID, {VERSION}},
     // Comment Block


### PR DESCRIPTION
Some Windows bots using MSVC 2019 and 2022 get assertion errors in the clang-doc lit tests (see [here](https://github.com/llvm/llvm-project/pull/198066). This seems to be due to MSVC having trouble with a correctly initializing structures using std::initializer_list when embedded in a struct declared with constexpr.

This workaround changes constexpr to const in a struct definition to avoid this issue.