### PR TITLE
[libc][math] Add iscanonical functions to math.yaml

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -1588,6 +1588,38 @@ functions:
     return_type: int
     arguments:
       - type: long double
+  - name: iscanonical
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: double
+  - name: iscanonicalf
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float
+  - name: iscanonicalf128
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: iscanonicalf16
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: _Float16
+    guard: LIBC_TYPES_HAS_FLOAT16
+  - name: iscanonicall
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: long double
   - name: isnan
     standards:
       - bsd


### PR DESCRIPTION
Surface the existing `iscanonical`, `iscanonicalf`, `iscanonicalf128`,
`iscanonicalf16`, and `iscanonicall` implementations through the
generated `math.h`.
    
To test:
`cmake -Bbuild -Sruntimes -GNinja -DLLVM_ENABLE_RUNTIMES=libc -DLLVM_LIBC_FULL_BUILD=ON`
`pip install pyyaml`
`ninja -C build libc.include.math.__generated_hdr__`
Then check `build/libc/include/math.h` for their signatures.
    
Add `-DLIBC_TYPES_HAS_FLOAT128=ON` to test for iscanonicalf128
in cmake invocation if host does not support it.
And `-DLIBC_TYPES_HAS_FLOAT16=ON` for iscanonicalf16.