### PR TITLE
[LoongArch] Emit DTPREL relocations for TLS debug info

### DIFF
--- a/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
+++ b/llvm/lib/Target/LoongArch/AsmParser/LoongArchAsmParser.cpp
@@ -95,6 +95,8 @@ class LoongArchAsmParser : public MCTargetAsmParser {
   bool parseOperand(OperandVector &Operands, StringRef Mnemonic);
 
   bool parseDirectiveOption();
+  bool parseDirectiveDtpRelWord();
+  bool parseDirectiveDtpRelDWord();
 
   void setFeatureBits(uint64_t Feature, StringRef FeatureString) {
     if (!(getSTI().hasFeature(Feature))) {
@@ -2079,9 +2081,31 @@ bool LoongArchAsmParser::parseDirectiveOption() {
   return false;
 }
 
+bool LoongArchAsmParser::parseDirectiveDtpRelWord() {
+  const MCExpr *Value;
+  if (getParser().parseExpression(Value))
+    return true;
+  getTargetStreamer().emitDTPRel32Value(Value);
+  return parseEOL();
+}
+
+bool LoongArchAsmParser::parseDirectiveDtpRelDWord() {
+  const MCExpr *Value;
+  if (getParser().parseExpression(Value))
+    return true;
+  getTargetStreamer().emitDTPRel64Value(Value);
+  return parseEOL();
+}
+
 ParseStatus LoongArchAsmParser::parseDirective(AsmToken DirectiveID) {
   if (DirectiveID.getString() == ".option")
     return parseDirectiveOption();
+
+  if (DirectiveID.getString() == ".dtprelword")
+    return parseDirectiveDtpRelWord();
+
+  if (DirectiveID.getString() == ".dtpreldword")
+    return parseDirectiveDtpRelDWord();
 
   return ParseStatus::NoMatch;
 }

--- a/llvm/lib/Target/LoongArch/CMakeLists.txt
+++ b/llvm/lib/Target/LoongArch/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_target(LoongArchCodeGen
   LoongArchSelectionDAGInfo.cpp
   LoongArchSubtarget.cpp
   LoongArchTargetMachine.cpp
+  LoongArchTargetObjectFile.cpp
   LoongArchTargetTransformInfo.cpp
 
   LINK_COMPONENTS

--- a/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.cpp
@@ -15,6 +15,7 @@
 #include "LoongArch.h"
 #include "LoongArchMachineFunctionInfo.h"
 #include "MCTargetDesc/LoongArchInstPrinter.h"
+#include "MCTargetDesc/LoongArchMCAsmInfo.h"
 #include "MCTargetDesc/LoongArchMCTargetDesc.h"
 #include "TargetInfo/LoongArchTargetInfo.h"
 #include "llvm/CodeGen/AsmPrinter.h"
@@ -40,6 +41,11 @@ cl::opt<bool> LArchAnnotateTableJump(
 // Simple pseudo-instructions have their lowering (with expansion to real
 // instructions) auto-generated.
 #include "LoongArchGenMCPseudoLowering.inc"
+
+LoongArchTargetStreamer &LoongArchAsmPrinter::getTargetStreamer() const {
+  return static_cast<LoongArchTargetStreamer &>(
+      *OutStreamer->getTargetStreamer());
+}
 
 void LoongArchAsmPrinter::emitInstruction(const MachineInstr *MI) {
   LoongArch_MC::verifyInstructionPredicates(
@@ -291,6 +297,28 @@ void LoongArchAsmPrinter::emitJumpTableInfo() {
     OutStreamer->emitValue(
         MCSymbolRefExpr::create(GetJTISymbol(JTIIdx), OutContext), Size);
   }
+}
+
+// Emit .dtprelword or .dtpreldword directive
+// and value for debug thread local expression.
+void LoongArchAsmPrinter::emitDebugValue(const MCExpr *Value,
+                                         unsigned Size) const {
+  if (auto *Expr = dyn_cast<MCSpecifierExpr>(Value)) {
+    if (Expr->getSpecifier() == LoongArchMCExpr::VK_DTPREL) {
+      switch (Size) {
+      case 4:
+        getTargetStreamer().emitDTPRel32Value(Expr->getSubExpr());
+        break;
+      case 8:
+        getTargetStreamer().emitDTPRel64Value(Expr->getSubExpr());
+        break;
+      default:
+        llvm_unreachable("Unexpected size of expression value.");
+      }
+      return;
+    }
+  }
+  AsmPrinter::emitDebugValue(Value, Size);
 }
 
 bool LoongArchAsmPrinter::runOnMachineFunction(MachineFunction &MF) {

--- a/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.h
+++ b/llvm/lib/Target/LoongArch/LoongArchAsmPrinter.h
@@ -14,6 +14,7 @@
 #define LLVM_LIB_TARGET_LOONGARCH_LOONGARCHASMPRINTER_H
 
 #include "LoongArchSubtarget.h"
+#include "MCTargetDesc/LoongArchTargetStreamer.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/StackMaps.h"
 #include "llvm/MC/MCStreamer.h"
@@ -27,6 +28,8 @@ public:
 
 private:
   const MCSubtargetInfo *STI;
+
+  LoongArchTargetStreamer &getTargetStreamer() const;
 
 public:
   explicit LoongArchAsmPrinter(TargetMachine &TM,
@@ -61,6 +64,7 @@ public:
     return lowerLoongArchMachineOperandToMCOperand(MO, MCOp, *this);
   }
   void emitJumpTableInfo() override;
+  void emitDebugValue(const MCExpr *Value, unsigned Size) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
@@ -13,6 +13,7 @@
 #include "LoongArchTargetMachine.h"
 #include "LoongArch.h"
 #include "LoongArchMachineFunctionInfo.h"
+#include "LoongArchTargetObjectFile.h"
 #include "LoongArchTargetTransformInfo.h"
 #include "MCTargetDesc/LoongArchBaseInfo.h"
 #include "TargetInfo/LoongArchTargetInfo.h"
@@ -98,7 +99,7 @@ LoongArchTargetMachine::LoongArchTargetMachine(
     : CodeGenTargetMachineImpl(T, TT.computeDataLayout(), TT, CPU, FS, Options,
                                getEffectiveRelocModel(RM),
                                getEffectiveLoongArchCodeModel(TT, CM), OL),
-      TLOF(std::make_unique<TargetLoweringObjectFileELF>()) {
+      TLOF(std::make_unique<LoongArchELFTargetObjectFile>()) {
   initAsmInfo();
 }
 

--- a/llvm/lib/Target/LoongArch/LoongArchTargetObjectFile.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchTargetObjectFile.cpp
@@ -1,0 +1,18 @@
+//=-- LoongArchTargetObjectFile.cpp - LoongArch Object Info -------*- C++ -*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "LoongArchTargetObjectFile.h"
+#include "MCTargetDesc/LoongArchMCAsmInfo.h"
+
+using namespace llvm;
+
+const MCExpr *LoongArchELFTargetObjectFile::getDebugThreadLocalSymbol(
+    const MCSymbol *Sym) const {
+  return MCSpecifierExpr::create(MCSymbolRefExpr::create(Sym, getContext()),
+                                 LoongArchMCExpr::VK_DTPREL, getContext());
+}

--- a/llvm/lib/Target/LoongArch/LoongArchTargetObjectFile.h
+++ b/llvm/lib/Target/LoongArch/LoongArchTargetObjectFile.h
@@ -1,0 +1,25 @@
+//=-- LoongArchTargetObjectFile.h - LoongArch Object Info ---------*- C++ -*-=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_LOONGARCH_LOONGARCHTARGETOBJECTFILE_H
+#define LLVM_LIB_TARGET_LOONGARCH_LOONGARCHTARGETOBJECTFILE_H
+
+#include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
+
+namespace llvm {
+
+/// This implementation is used for LoongArch ELF targets.
+class LoongArchELFTargetObjectFile : public TargetLoweringObjectFileELF {
+public:
+  /// Describe a TLS variable address within debug info.
+  const MCExpr *getDebugThreadLocalSymbol(const MCSymbol *Sym) const override;
+};
+
+} // end namespace llvm
+
+#endif

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchAsmBackend.cpp
@@ -64,6 +64,8 @@ MCFixupKindInfo LoongArchAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
       {"fixup_loongarch_abs_lo12", 10, 12, 0},
       {"fixup_loongarch_abs64_lo20", 5, 20, 0},
       {"fixup_loongarch_abs64_hi12", 10, 12, 0},
+      {"fixup_loongarch_dtprel32", 0, 32, 0},
+      {"fixup_loongarch_dtprel64", 0, 64, 0},
   };
 
   static_assert((std::size(Infos)) == LoongArch::NumTargetFixupKinds,
@@ -98,6 +100,8 @@ static uint64_t adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
   case FK_Data_4:
   case FK_Data_8:
   case FK_Data_leb128:
+  case LoongArch::fixup_loongarch_dtprel32:
+  case LoongArch::fixup_loongarch_dtprel64:
     return Value;
   case LoongArch::fixup_loongarch_b16: {
     if (!isInt<18>(Value))

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchELFObjectWriter.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchELFObjectWriter.cpp
@@ -96,6 +96,10 @@ unsigned LoongArchELFObjectWriter::getRelocType(const MCFixup &Fixup,
     return ELF::R_LARCH_ABS64_LO20;
   case LoongArch::fixup_loongarch_abs64_hi12:
     return ELF::R_LARCH_ABS64_HI12;
+  case LoongArch::fixup_loongarch_dtprel32:
+    return ELF::R_LARCH_TLS_DTPREL32;
+  case LoongArch::fixup_loongarch_dtprel64:
+    return ELF::R_LARCH_TLS_DTPREL64;
   }
 }
 

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchELFStreamer.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchELFStreamer.cpp
@@ -40,6 +40,20 @@ void LoongArchTargetELFStreamer::emitDirectiveOptionPop() {}
 void LoongArchTargetELFStreamer::emitDirectiveOptionRelax() {}
 void LoongArchTargetELFStreamer::emitDirectiveOptionNoRelax() {}
 
+void LoongArchTargetELFStreamer::emitDTPRel32Value(const MCExpr *Value) {
+  auto &S = getStreamer();
+  S.ensureHeadroom(4);
+  S.addFixup(Value, LoongArch::fixup_loongarch_dtprel32);
+  S.appendContents(4, 0);
+}
+
+void LoongArchTargetELFStreamer::emitDTPRel64Value(const MCExpr *Value) {
+  auto &S = getStreamer();
+  S.ensureHeadroom(8);
+  S.addFixup(Value, LoongArch::fixup_loongarch_dtprel64);
+  S.appendContents(8, 0);
+}
+
 void LoongArchTargetELFStreamer::finish() {
   LoongArchTargetStreamer::finish();
   ELFObjectWriter &W = getStreamer().getWriter();

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchELFStreamer.h
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchELFStreamer.h
@@ -23,6 +23,8 @@ public:
   void emitDirectiveOptionPop() override;
   void emitDirectiveOptionRelax() override;
   void emitDirectiveOptionNoRelax() override;
+  void emitDTPRel32Value(const MCExpr *) override;
+  void emitDTPRel64Value(const MCExpr *) override;
 
   void finish() override;
 };

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchFixupKinds.h
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchFixupKinds.h
@@ -35,6 +35,11 @@ enum Fixups {
   // 12-bit fixup corresponding to %abs_hi12(foo) for instruction lu52i.d.
   fixup_loongarch_abs64_hi12,
 
+  // .dtprelword
+  fixup_loongarch_dtprel32,
+  // .dtpreldword
+  fixup_loongarch_dtprel64,
+
   // Used as a sentinel, must be the last of the fixup which can be handled by
   // LoongArchAsmBackend::applyFixup.
   fixup_loongarch_invalid,

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.h
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCAsmInfo.h
@@ -23,7 +23,7 @@ class StringRef;
 class LoongArchMCExpr : public MCSpecifierExpr {
 public:
   using Specifier = uint16_t;
-  enum { VK_None };
+  enum { VK_None, VK_DTPREL };
 
 private:
   const bool RelaxHint;

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchTargetStreamer.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchTargetStreamer.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "LoongArchTargetStreamer.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCContext.h"
 
 using namespace llvm;
 
@@ -27,6 +29,8 @@ void LoongArchTargetStreamer::emitDirectiveOptionPush() {}
 void LoongArchTargetStreamer::emitDirectiveOptionPop() {}
 void LoongArchTargetStreamer::emitDirectiveOptionRelax() {}
 void LoongArchTargetStreamer::emitDirectiveOptionNoRelax() {}
+void LoongArchTargetStreamer::emitDTPRel32Value(const MCExpr *) {}
+void LoongArchTargetStreamer::emitDTPRel64Value(const MCExpr *) {}
 
 // This part is for ascii assembly output.
 LoongArchTargetAsmStreamer::LoongArchTargetAsmStreamer(
@@ -47,4 +51,18 @@ void LoongArchTargetAsmStreamer::emitDirectiveOptionRelax() {
 
 void LoongArchTargetAsmStreamer::emitDirectiveOptionNoRelax() {
   OS << "\t.option\tnorelax\n";
+}
+
+void LoongArchTargetAsmStreamer::emitDTPRel32Value(const MCExpr *Value) {
+  auto &MAI = getStreamer().getContext().getAsmInfo();
+  OS << "\t.dtprelword\t";
+  MAI.printExpr(OS, *Value);
+  OS << '\n';
+}
+
+void LoongArchTargetAsmStreamer::emitDTPRel64Value(const MCExpr *Value) {
+  auto &MAI = getStreamer().getContext().getAsmInfo();
+  OS << "\t.dtpreldword\t";
+  MAI.printExpr(OS, *Value);
+  OS << '\n';
 }

--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchTargetStreamer.h
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchTargetStreamer.h
@@ -27,6 +27,8 @@ public:
   virtual void emitDirectiveOptionPop();
   virtual void emitDirectiveOptionRelax();
   virtual void emitDirectiveOptionNoRelax();
+  virtual void emitDTPRel32Value(const MCExpr *);
+  virtual void emitDTPRel64Value(const MCExpr *);
 };
 
 // This part is for ascii assembly output.
@@ -40,6 +42,8 @@ public:
   void emitDirectiveOptionPop() override;
   void emitDirectiveOptionRelax() override;
   void emitDirectiveOptionNoRelax() override;
+  void emitDTPRel32Value(const MCExpr *) override;
+  void emitDTPRel64Value(const MCExpr *) override;
 };
 
 } // end namespace llvm

--- a/llvm/test/DebugInfo/LoongArch/tls.ll
+++ b/llvm/test/DebugInfo/LoongArch/tls.ll
@@ -1,0 +1,29 @@
+; RUN: llc -O0 -mtriple=loongarch32 -filetype=asm < %s | FileCheck %s -check-prefix=ASM-DTPREL32
+; RUN: llc -O0 -mtriple=loongarch64 -filetype=asm < %s | FileCheck %s -check-prefix=ASM-DTPREL64
+; RUN: llc -O0 -mtriple=loongarch32 -filetype=obj -o %32.o %s
+; RUN: llvm-readobj -r %32.o | FileCheck --check-prefix=OBJ-DTPREL32 %s
+; RUN: llc -O0 -mtriple=loongarch64 -filetype=obj -o %64.o %s
+; RUN: llvm-readobj -r %64.o | FileCheck --check-prefix=OBJ-DTPREL64 %s
+
+@x = thread_local global i32 5, align 4, !dbg !0
+
+; ASM-DTPREL32: .dtprelword x
+; ASM-DTPREL64: .dtpreldword x
+
+; OBJ-DTPREL32: R_LARCH_TLS_DTPREL32 x
+; OBJ-DTPREL64: R_LARCH_TLS_DTPREL64 x
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!7, !8}
+!llvm.ident = !{!9}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "x", scope: !2, file: !3, line: 1, type: !6, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, producer: "clang version 4.0.0", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5)
+!3 = !DIFile(filename: "tls.c", directory: "/tmp")
+!4 = !{}
+!5 = !{!0}
+!6 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = !{i32 2, !"Dwarf Version", i32 4}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = !{!"clang version 4.0.0"}

--- a/llvm/test/MC/LoongArch/Directives/tls.s
+++ b/llvm/test/MC/LoongArch/Directives/tls.s
@@ -1,0 +1,7 @@
+# RUN: llvm-mc -filetype=obj --triple=loongarch64 %s | llvm-readobj -r - | FileCheck %s
+
+# CHECK: R_LARCH_TLS_DTPREL32
+.dtprelword x
+
+# CHECK: R_LARCH_TLS_DTPREL64
+.dtpreldword x

--- a/llvm/utils/gn/secondary/llvm/lib/Target/LoongArch/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Target/LoongArch/BUILD.gn
@@ -55,6 +55,7 @@ static_library("LLVMLoongArchCodeGen") {
     "LoongArchSelectionDAGInfo.cpp",
     "LoongArchSubtarget.cpp",
     "LoongArchTargetMachine.cpp",
+    "LoongArchTargetObjectFile.cpp",
     "LoongArchTargetTransformInfo.cpp",
   ]
 }


### PR DESCRIPTION
Teach the LoongArch backend to lower thread-local debug references using target-specific DTPREL relocations.

This adds .dtprelword and .dtpreldword directive parsing and streaming, introduces 32-bit and 64-bit DTPREL fixups and ELF relocation mappings, and uses a LoongArch target object file to represent debug TLS symbols as VK_DTPREL expressions. LoongArchAsmPrinter is updated to emit the new directives for debug TLS values in assembly output.

Add MC and debug info tests for assembly emission and object relocations.