### PR TITLE
[lld][LoongArch] Handle DTPREL relocations in debug sections

### DIFF
--- a/lld/ELF/Arch/LoongArch.cpp
+++ b/lld/ELF/Arch/LoongArch.cpp
@@ -454,6 +454,9 @@ RelExpr LoongArch::getRelExpr(const RelType type, const Symbol &s,
   case R_LARCH_PCREL20_S2:
   case R_LARCH_PCADD_HI20:
     return R_PC;
+  case R_LARCH_TLS_DTPREL32:
+  case R_LARCH_TLS_DTPREL64:
+    return R_DTPREL;
   default:
     Err(ctx) << getErrorLoc(ctx, loc) << "unknown relocation (" << type.v
              << ") against symbol " << &s;

--- a/lld/test/ELF/loongarch-tls-dtprel.s
+++ b/lld/test/ELF/loongarch-tls-dtprel.s
@@ -1,0 +1,26 @@
+# REQUIRES: loongarch
+# RUN: llvm-mc -filetype=obj -triple=loongarch32 %s -o %32.o
+# RUN: llvm-mc -filetype=obj -triple=loongarch64 %s -o %64.o
+# RUN: llvm-readobj -r %32.o | FileCheck %s
+# RUN: llvm-readobj -r %64.o | FileCheck %s
+# RUN: ld.lld %32.o -o %32
+# RUN: ld.lld %64.o -o %64
+
+# CHECK:      .rela.debug_info {
+# CHECK-NEXT:   0x0 R_LARCH_TLS_DTPREL32 var 0x0
+# CHECK-NEXT:   0x4 R_LARCH_TLS_DTPREL32 .tdata 0x1
+# CHECK-NEXT:   0x8 R_LARCH_TLS_DTPREL64 var 0x0
+# CHECK-NEXT:   0x10 R_LARCH_TLS_DTPREL64 .tdata 0x1
+# CHECK-NEXT: }
+
+.section .tdata,"awT",@progbits
+.skip 8
+.globl var
+var:
+  .word 0
+
+.section        .debug_info,"",@progbits
+  .dtprelword var
+  .dtprelword .tdata+1
+  .dtpreldword var
+  .dtpreldword .tdata+1

--- a/lld/test/ELF/loongarch-tls-dtprel.s
+++ b/lld/test/ELF/loongarch-tls-dtprel.s
@@ -1,0 +1,34 @@
+# REQUIRES: loongarch
+# RUN: llvm-mc -filetype=obj -triple=loongarch32 %s -o %32.o
+# RUN: llvm-mc -filetype=obj -triple=loongarch64 %s -o %64.o
+# RUN: llvm-readobj -r %32.o | FileCheck %s
+# RUN: llvm-readobj -r %64.o | FileCheck %s
+# RUN: ld.lld %32.o -o %32
+# RUN: ld.lld %64.o -o %64
+
+# CHECK:      .rela.debug_info {
+# CHECK-NEXT:   0x0 R_LARCH_TLS_DTPREL32 var 0x0
+# CHECK-NEXT:   0x4 R_LARCH_TLS_DTPREL32 var 0x1
+# CHECK-NEXT:   0x8 R_LARCH_TLS_DTPREL32 .tdata 0x0
+# CHECK-NEXT:   0xC R_LARCH_TLS_DTPREL32 .tdata 0x1
+# CHECK-NEXT:   0x10 R_LARCH_TLS_DTPREL64 var 0x0
+# CHECK-NEXT:   0x18 R_LARCH_TLS_DTPREL64 var 0x1
+# CHECK-NEXT:   0x20 R_LARCH_TLS_DTPREL64 .tdata 0x0
+# CHECK-NEXT:   0x28 R_LARCH_TLS_DTPREL64 .tdata 0x1
+# CHECK-NEXT: }
+
+.section .tdata,"awT",@progbits
+.skip 8
+.globl var
+var:
+  .word 0
+
+.section        .debug_info,"",@progbits
+  .dtprelword var
+  .dtprelword var+1
+  .dtprelword .tdata
+  .dtprelword .tdata+1
+  .dtpreldword var
+  .dtpreldword var+1
+  .dtpreldword .tdata
+  .dtpreldword .tdata+1


### PR DESCRIPTION
Teach the LoongArch lld backend to classify R_LARCH_TLS_DTPREL32 and R_LARCH_TLS_DTPREL64 as R_DTPREL.

This allows linker processing of TLS debug info references emitted into .debug_info via .dtprelword/.dtpreldword. Add 32-bit and 64-bit tests that assemble objects with DTPREL relocations in debug sections.