### PR TITLE
[clang] Fix crash in getCursorRawComments.

### DIFF
--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -9327,6 +9327,8 @@ CXString clang_Cursor_getBinaryOpcodeStr(enum CX_BinaryOperatorKind Op) {
 }
 
 static const RawComment *getCursorRawComment(CXCursor C) {
+  if (!clang_isDeclaration(C.kind) && C.kind != CXCursor_MacroDefinition)
+    return nullptr;
   ASTContext &Context = getCursorContext(C);
   if (clang_isDeclaration(C.kind))
     return Context.getRawCommentForAnyRedecl(getCursorDecl(C));


### PR DESCRIPTION
Fix a regression introduced in PR #198452 where querying raw comments on invalid cursors caused a segmentation fault due to unconditional ASTContext lookup. Adding an early exit for unsupported cursor kinds at the top of getCursorRawComment safely avoids resolving the context on invalid cursors with null translation units.