### PR TITLE
[libc][math] Added missing gamma, error, and fma entries to math.yaml

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -359,6 +359,23 @@ functions:
     arguments:
       - type: long double
       - type: long double
+  - name: dfmaf128
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: float128
+      - type: float128
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: dfmal
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: long double
+      - type: long double
+      - type: long double
   - name: dmulf128
     standards:
       - llvm_libc_ext


### PR DESCRIPTION
Part of #199266

Added the following missing math function entries to `libc/include/math.yaml`:
- erf, tgamma, tgammaf
- dfmaf128, dfmal
@Sukumarsawant 