### PR TITLE
[NFC][LLVM] Fix Intrinsics.td to adhere to 80 col limit

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -161,7 +161,8 @@ class Range<AttrIndex idx, int lower, int upper> : IntrinsicProperty {
   int Upper = upper;
 }
 
-// ArgProperty - Base class for argument properties that can be specified in ArgInfo.
+// ArgProperty - Base class for argument properties that can be specified in
+// ArgInfo.
 class ArgProperty;
 
 // ArgName - Specifies the name of an argument for pretty-printing.
@@ -174,10 +175,11 @@ class ImmArgPrinter<string funcname> : ArgProperty {
   string FuncName = funcname;
 }
 
-// ArgInfo - The specified argument has properties defined by a list of ArgProperty objects.
-class ArgInfo<ArgIndex idx, list<ArgProperty> arg_properties> : IntrinsicProperty {
+// ArgInfo - The specified argument has properties defined by a list of
+// ArgProperty objects.
+class ArgInfo<ArgIndex idx, list<ArgProperty> properties> : IntrinsicProperty {
   int ArgNo = idx.Value;
-  list<ArgProperty> Properties = arg_properties;
+  list<ArgProperty> Properties = properties;
 }
 
 def IntrNoReturn : IntrinsicProperty;
@@ -760,8 +762,8 @@ class DefaultAttrsIntrinsic<list<LLVMType> ret_types,
                             intr_properties, name,
                             sd_properties, /*disable_default_attributes*/ 0> {}
 
-/// ClangBuiltin - If this intrinsic exactly corresponds to a Clang builtin, this
-/// specifies the name of the builtin.  This provides automatic CBE and CFE
+/// ClangBuiltin - If this intrinsic exactly corresponds to a Clang builtin,
+/// this specifies the name of the builtin. This provides automatic CBE and CFE
 /// support.
 class ClangBuiltin<string name> {
   string ClangBuiltinName = name;
@@ -776,13 +778,14 @@ class MSBuiltin<string name> {
 /// 2. Can be freely speculated, and
 /// 3. Will not create undef or poison on defined inputs.
 class PureIntrinsic<list<LLVMType> ret_types,
-                list<LLVMType> param_types = [],
-                list<IntrinsicProperty> intr_properties = [],
-                string name = "",
-                list<SDNodeProperty> sd_properties = []>
-                : DefaultAttrsIntrinsic<ret_types, param_types,
-                            intr_properties # [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison],
-                            name, sd_properties>;
+                    list<LLVMType> param_types = [],
+                    list<IntrinsicProperty> intr_properties = [],
+                    string name = "",
+                    list<SDNodeProperty> sd_properties = []>
+  : DefaultAttrsIntrinsic<ret_types, param_types,
+      intr_properties 
+        # [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison],
+      name, sd_properties>;
 
 #ifndef TEST_INTRINSICS_SUPPRESS_DEFS
 
@@ -814,79 +817,79 @@ def int_gcwrite : Intrinsic<[],
 // Note these are to support the Objective-C ARC optimizer which wants to
 // eliminate retain and releases where possible.
 
-def int_objc_autorelease                    : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty],
-                                                        [Returned<ArgIndex<0>>]>;
-def int_objc_autoreleasePoolPop             : Intrinsic<[], [llvm_ptr_ty]>;
-def int_objc_autoreleasePoolPush            : Intrinsic<[llvm_ptr_ty], []>;
-def int_objc_autoreleaseReturnValue         : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty],
-                                                        [Returned<ArgIndex<0>>]>;
-def int_objc_copyWeak                       : Intrinsic<[],
-                                                        [llvm_ptr_ty,
-                                                         llvm_ptr_ty]>;
-def int_objc_destroyWeak                    : Intrinsic<[], [llvm_ptr_ty]>;
-def int_objc_initWeak                       : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty,
-                                                         llvm_ptr_ty]>;
-def int_objc_loadWeak                       : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_loadWeakRetained               : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_moveWeak                       : Intrinsic<[],
-                                                        [llvm_ptr_ty,
-                                                         llvm_ptr_ty]>;
+def int_objc_autorelease                  : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty],
+                                                      [Returned<ArgIndex<0>>]>;
+def int_objc_autoreleasePoolPop           : Intrinsic<[], [llvm_ptr_ty]>;
+def int_objc_autoreleasePoolPush          : Intrinsic<[llvm_ptr_ty], []>;
+def int_objc_autoreleaseReturnValue       : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty],
+                                                      [Returned<ArgIndex<0>>]>;
+def int_objc_copyWeak                     : Intrinsic<[],
+                                                      [llvm_ptr_ty,
+                                                       llvm_ptr_ty]>;
+def int_objc_destroyWeak                  : Intrinsic<[], [llvm_ptr_ty]>;
+def int_objc_initWeak                     : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty,
+                                                       llvm_ptr_ty]>;
+def int_objc_loadWeak                     : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_loadWeakRetained             : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_moveWeak                     : Intrinsic<[],
+                                                      [llvm_ptr_ty,
+                                                       llvm_ptr_ty]>;
 
-def int_objc_release                        : Intrinsic<[], [llvm_ptr_ty]>;
-def int_objc_retain                         : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty],
-                                                        [Returned<ArgIndex<0>>]>;
+def int_objc_release                      : Intrinsic<[], [llvm_ptr_ty]>;
+def int_objc_retain                       : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty],
+                                                      [Returned<ArgIndex<0>>]>;
 
-def int_objc_retainAutorelease              : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty],
-                                                        [Returned<ArgIndex<0>>]>;
-def int_objc_retainAutoreleaseReturnValue   : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty],
-                                                        [Returned<ArgIndex<0>>]>;
+def int_objc_retainAutorelease            : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty],
+                                                      [Returned<ArgIndex<0>>]>;
+def int_objc_retainAutoreleaseReturnValue : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty],
+                                                      [Returned<ArgIndex<0>>]>;
 def int_objc_retainAutoreleasedReturnValue  : Intrinsic<[llvm_ptr_ty],
                                                         [llvm_ptr_ty]>;
 def int_objc_unsafeClaimAutoreleasedReturnValue : Intrinsic<[llvm_ptr_ty],
                                                             [llvm_ptr_ty]>;
-def int_objc_claimAutoreleasedReturnValue   : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
+def int_objc_claimAutoreleasedReturnValue : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
 
-def int_objc_retainBlock                    : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_storeStrong                    : Intrinsic<[],
-                                                        [llvm_ptr_ty,
-                                                         llvm_ptr_ty]>;
-def int_objc_storeWeak                      : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty,
-                                                         llvm_ptr_ty]>;
-def int_objc_clang_arc_use                  : Intrinsic<[],
-                                                        [llvm_vararg_ty]>;
-def int_objc_clang_arc_noop_use : DefaultAttrsIntrinsic<[],
-                                                        [llvm_vararg_ty],
-                                                        [IntrInaccessibleMemOnly]>;
-def int_objc_retainedObject                 : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_unretainedObject               : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_unretainedPointer              : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_retain_autorelease             : Intrinsic<[llvm_ptr_ty],
-                                                        [llvm_ptr_ty],
-                                                        [Returned<ArgIndex<0>>]>;
-def int_objc_sync_enter                     : Intrinsic<[llvm_i32_ty],
-                                                        [llvm_ptr_ty]>;
-def int_objc_sync_exit                      : Intrinsic<[llvm_i32_ty],
-                                                        [llvm_ptr_ty]>;
+def int_objc_retainBlock                  : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_storeStrong                  : Intrinsic<[],
+                                                      [llvm_ptr_ty,
+                                                       llvm_ptr_ty]>;
+def int_objc_storeWeak                    : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty,
+                                                       llvm_ptr_ty]>;
+def int_objc_clang_arc_use                : Intrinsic<[],
+                                                      [llvm_vararg_ty]>;
+def int_objc_clang_arc_noop_use           : DefaultAttrsIntrinsic<[],
+                                                     [llvm_vararg_ty],
+                                                     [IntrInaccessibleMemOnly]>;
+def int_objc_retainedObject               : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_unretainedObject             : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_unretainedPointer            : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_retain_autorelease           : Intrinsic<[llvm_ptr_ty],
+                                                      [llvm_ptr_ty],
+                                                      [Returned<ArgIndex<0>>]>;
+def int_objc_sync_enter                   : Intrinsic<[llvm_i32_ty],
+                                                      [llvm_ptr_ty]>;
+def int_objc_sync_exit                    : Intrinsic<[llvm_i32_ty],
+                                                      [llvm_ptr_ty]>;
 def int_objc_arc_annotation_topdown_bbstart : Intrinsic<[],
                                                         [llvm_ptr_ty,
                                                          llvm_ptr_ty]>;
-def int_objc_arc_annotation_topdown_bbend   : Intrinsic<[],
-                                                        [llvm_ptr_ty,
-                                                         llvm_ptr_ty]>;
+def int_objc_arc_annotation_topdown_bbend : Intrinsic<[],
+                                                      [llvm_ptr_ty,
+                                                       llvm_ptr_ty]>;
 def int_objc_arc_annotation_bottomup_bbstart  : Intrinsic<[],
                                                           [llvm_ptr_ty,
                                                            llvm_ptr_ty]>;
@@ -904,16 +907,19 @@ def int_swift_async_context_addr : Intrinsic<[llvm_ptr_ty], [], []>;
 //
 def int_returnaddress : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_i32_ty],
                                   [IntrNoMem, ImmArg<ArgIndex<0>>]>;
-def int_addressofreturnaddress : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], [IntrNoMem]>;
+def int_addressofreturnaddress : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], 
+                                                       [IntrNoMem]>;
 def int_frameaddress : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [llvm_i32_ty],
                                  [IntrNoMem, ImmArg<ArgIndex<0>>]>;
 def int_sponentry  : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], [IntrNoMem]>;
 def int_stackaddress : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], []>;
-def int_read_register  : DefaultAttrsIntrinsic<[llvm_anyint_ty], [llvm_metadata_ty],
-                                   [IntrReadMem], "llvm.read_register">;
+def int_read_register  : DefaultAttrsIntrinsic<[llvm_anyint_ty], 
+                             [llvm_metadata_ty], [IntrReadMem], 
+                             "llvm.read_register">;
 def int_write_register : Intrinsic<[], [llvm_metadata_ty, llvm_anyint_ty],
                                    [IntrNoCallback], "llvm.write_register">;
-def int_write_volatile_register : Intrinsic<[], [llvm_metadata_ty, llvm_anyint_ty],
+def int_write_volatile_register : Intrinsic<[],
+                                            [llvm_metadata_ty, llvm_anyint_ty],
                                             [], "llvm.write_volatile_register">;
 def int_read_volatile_register  : Intrinsic<[llvm_anyint_ty], [llvm_metadata_ty],
                                             [IntrHasSideEffects],
@@ -957,7 +963,8 @@ def int_stackrestore  : DefaultAttrsIntrinsic<[], [llvm_anyptr_ty]>,
 
 def int_get_dynamic_area_offset : DefaultAttrsIntrinsic<[llvm_anyint_ty]>;
 
-def int_thread_pointer : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], [IntrNoMem]>,
+def int_thread_pointer : DefaultAttrsIntrinsic<
+                             [llvm_anyptr_ty], [], [IntrNoMem]>,
                          ClangBuiltin<"__builtin_thread_pointer">;
 
 // IntrInaccessibleMemOrArgMemOnly is a little more pessimistic than strictly
@@ -965,10 +972,12 @@ def int_thread_pointer : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], [IntrNoMem]
 // from being reordered overly much with respect to nearby access to the same
 // memory while not impeding optimization.
 def int_prefetch
-    : DefaultAttrsIntrinsic<[], [ llvm_anyptr_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty ],
+    : DefaultAttrsIntrinsic<[], 
+                [llvm_anyptr_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
                 [IntrInaccessibleMemOrArgMemOnly,
                  ReadOnly<ArgIndex<0>>, NoCapture<ArgIndex<0>>,
-                 ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
+                 ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>,
+                 ImmArg<ArgIndex<3>>]>;
 def int_pcmarker      : DefaultAttrsIntrinsic<[], [llvm_i32_ty]>;
 
 def int_readcyclecounter : DefaultAttrsIntrinsic<[llvm_i64_ty]>;
@@ -977,8 +986,9 @@ def int_readsteadycounter : DefaultAttrsIntrinsic<[llvm_i64_ty]>;
 
 // The assume intrinsic is marked InaccessibleMemOnly so that proper control
 // dependencies will be maintained.
-def int_assume : DefaultAttrsIntrinsic<
-    [], [llvm_i1_ty], [IntrWriteMem, IntrInaccessibleMemOnly, NoUndef<ArgIndex<0>>]>;
+def int_assume : DefaultAttrsIntrinsic<[], [llvm_i1_ty],
+                   [IntrWriteMem, IntrInaccessibleMemOnly,
+                    NoUndef<ArgIndex<0>>]>;
 
 // 'llvm.experimental.noalias.scope.decl' intrinsic: Inserted at the location of
 // noalias scope declaration. Makes it possible to identify that a noalias scope
@@ -992,8 +1002,8 @@ def int_experimental_noalias_scope_decl
 
 // Stack Protector Intrinsic - The stackprotector intrinsic writes the stack
 // guard to the correct place on the stack frame.
-def int_stackprotector : DefaultAttrsIntrinsic<[], [llvm_ptr_ty, llvm_ptr_ty], []>;
-def int_stackguard : DefaultAttrsIntrinsic<[llvm_ptr_ty], [], []>;
+def int_stackprotector : DefaultAttrsIntrinsic<[], [llvm_ptr_ty, llvm_ptr_ty]>;
+def int_stackguard     : DefaultAttrsIntrinsic<[llvm_ptr_ty], []>;
 
 // A cover for instrumentation based profiling.
 def int_instrprof_cover : Intrinsic<[], [llvm_ptr_ty, llvm_i64_ty,
@@ -1006,13 +1016,13 @@ def int_instrprof_increment : Intrinsic<[],
 
 // A counter increment with step for instrumentation based profiling.
 def int_instrprof_increment_step : Intrinsic<[],
-                                        [llvm_ptr_ty, llvm_i64_ty,
-                                         llvm_i32_ty, llvm_i32_ty, llvm_i64_ty]>;
+                                     [llvm_ptr_ty, llvm_i64_ty,
+                                      llvm_i32_ty, llvm_i32_ty, llvm_i64_ty]>;
 
 // Callsite instrumentation for contextual profiling
 def int_instrprof_callsite : Intrinsic<[],
-                                        [llvm_ptr_ty, llvm_i64_ty,
-                                         llvm_i32_ty, llvm_i32_ty, llvm_ptr_ty]>;
+                               [llvm_ptr_ty, llvm_i64_ty,
+                                llvm_i32_ty, llvm_i32_ty, llvm_ptr_ty]>;
 
 // A timestamp for instrumentation based profiling.
 def int_instrprof_timestamp : Intrinsic<[], [llvm_ptr_ty, llvm_i64_ty,
@@ -1053,7 +1063,8 @@ def int_structured_gep
                             [LLVMMatchType<0>, llvm_vararg_ty],
                             [IntrNoMem, IntrSpeculatable]>;
 
-def int_structured_alloca : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [], [IntrInaccessibleMemOnly]>;
+def int_structured_alloca : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [],
+                                                  [IntrInaccessibleMemOnly]>;
 
 //===------------------- Standard C Library Intrinsics --------------------===//
 //
@@ -1121,7 +1132,8 @@ def int_experimental_memset_pattern
 // FIXME: Add version of these floating point intrinsics which allow non-default
 // rounding modes and FP exception handling.
 
-let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in {
+let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
+  in {
   def int_fma  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty],
                            [LLVMMatchType<0>, LLVMMatchType<0>,
                             LLVMMatchType<0>]>;
@@ -1133,7 +1145,8 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in
   // rounding mode. LLVM purposely does not model changes to the FP
   // environment so they can be treated as readnone.
   def int_sqrt : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
-  def int_powi : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>, llvm_anyint_ty]>;
+  def int_powi : DefaultAttrsIntrinsic<
+                   [llvm_anyfloat_ty], [LLVMMatchType<0>, llvm_anyint_ty]>;
   def int_sin  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_cos  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_pow  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty],
@@ -1151,13 +1164,15 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in
   def int_ceil  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_trunc : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_rint  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
-  def int_nearbyint : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_nearbyint : DefaultAttrsIntrinsic<
+                        [llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_round : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
-  def int_roundeven    : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
+  def int_roundeven    : DefaultAttrsIntrinsic<
+                          [llvm_anyfloat_ty], [LLVMMatchType<0>]>;
 
   // Truncate a floating point number with a specific rounding mode
   def int_fptrunc_round : DefaultAttrsIntrinsic<[ llvm_anyfloat_ty ],
-                                                [ llvm_anyfloat_ty, llvm_metadata_ty ]>;
+                            [ llvm_anyfloat_ty, llvm_metadata_ty ]>;
 
   // Convert from native LLVM floating-point to arbitrary FP format
   // Returns an integer containing the arbitrary FP bits
@@ -1175,11 +1190,13 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in
             [ llvm_anyint_ty, llvm_metadata_ty ],
             [ IntrNoMem, IntrSpeculatable ]>;
 
-  def int_canonicalize : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>],
-                                   [IntrNoMem]>;
+  def int_canonicalize : DefaultAttrsIntrinsic<
+                           [llvm_anyfloat_ty], [LLVMMatchType<0>],
+                           [IntrNoMem]>;
   // Arithmetic fence intrinsic.
-  def int_arithmetic_fence : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>],
-                                                   [IntrNoMem]>;
+  def int_arithmetic_fence : DefaultAttrsIntrinsic<
+                               [llvm_anyfloat_ty], [LLVMMatchType<0>],
+                               [IntrNoMem]>;
 
   // If the value doesn't fit an unspecified value is returned, but this
   // is not poison so we can still mark these as IntrNoCreateUndefOrPoison.
@@ -1188,12 +1205,14 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in
   def int_lrint : DefaultAttrsIntrinsic<[llvm_anyint_ty], [llvm_anyfloat_ty]>;
   def int_llrint : DefaultAttrsIntrinsic<[llvm_anyint_ty], [llvm_anyfloat_ty]>;
 
-  // TODO: int operand should be constrained to same number of elements as the result.
+  // TODO: int operand should be constrained to same number of elements as the
+  // result.
   def int_ldexp : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>,
                                                              llvm_anyint_ty]>;
 
-  // TODO: Should constrain all element counts to match
-  def int_frexp : DefaultAttrsIntrinsic<[llvm_anyfloat_ty, llvm_anyint_ty], [LLVMMatchType<0>]>;
+  // TODO: Should constrain all element counts to match.
+  def int_frexp : DefaultAttrsIntrinsic<[llvm_anyfloat_ty, llvm_anyint_ty],
+                    [LLVMMatchType<0>]>;
 }
 
 // TODO: Move all of these into the IntrNoCreateUndefOrPoison case above.
@@ -1204,7 +1223,8 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable] in {
   def int_asin : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_acos : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_atan : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
-  def int_atan2 : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_atan2 : DefaultAttrsIntrinsic<
+                    [llvm_anyfloat_ty], [LLVMMatchType<0>, LLVMMatchType<0>]>;
   def int_tan  : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_sinh : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
   def int_cosh : DefaultAttrsIntrinsic<[llvm_anyfloat_ty], [LLVMMatchType<0>]>;
@@ -1271,7 +1291,8 @@ let IntrProperties = [IntrInaccessibleMemOnly] in {
 def int_is_fpclass
     : DefaultAttrsIntrinsic<[LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
                             [llvm_anyfloat_ty, llvm_i32_ty],
-                            [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison, ImmArg<ArgIndex<1>>]>;
+                            [IntrNoMem, IntrSpeculatable,
+                             IntrNoCreateUndefOrPoison, ImmArg<ArgIndex<1>>]>;
 
 //===--------------- Constrained Floating Point Intrinsics ----------------===//
 //
@@ -1513,7 +1534,8 @@ def int_expect_with_probability : DefaultAttrsIntrinsic<[llvm_anyint_ty],
 //
 
 // None of these intrinsics accesses memory at all.
-let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in {
+let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
+  in {
   def int_bswap: DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>]>;
   def int_ctpop: DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>]>;
   def int_bitreverse : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>]>;
@@ -1525,10 +1547,11 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in
       [LLVMMatchType<0>, LLVMMatchType<0>]>;
 }
 
-let IntrProperties = [IntrNoMem, IntrSpeculatable,
-                      ImmArg<ArgIndex<1>>] in {
-  def int_ctlz : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>, llvm_i1_ty]>;
-  def int_cttz : DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>, llvm_i1_ty]>;
+let IntrProperties = [IntrNoMem, IntrSpeculatable, ImmArg<ArgIndex<1>>] in {
+  def int_ctlz : DefaultAttrsIntrinsic<[llvm_anyint_ty],
+                                       [LLVMMatchType<0>, llvm_i1_ty]>;
+  def int_cttz : DefaultAttrsIntrinsic<[llvm_anyint_ty],
+                                       [LLVMMatchType<0>, llvm_i1_ty]>;
 }
 
 //===------------------------ Debugger Intrinsics -------------------------===//
@@ -1585,7 +1608,8 @@ def int_eh_unwind_init: Intrinsic<[]>,
 def int_eh_dwarf_cfa  : Intrinsic<[llvm_ptr_ty], [llvm_i32_ty]>;
 
 def int_eh_sjlj_lsda             : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
-def int_eh_sjlj_callsite         : Intrinsic<[], [llvm_i32_ty], [IntrNoMem, ImmArg<ArgIndex<0>>]>;
+def int_eh_sjlj_callsite         : Intrinsic<[], [llvm_i32_ty],
+                                             [IntrNoMem, ImmArg<ArgIndex<0>>]>;
 
 def int_eh_sjlj_functioncontext : Intrinsic<[], [llvm_ptr_ty]>;
 def int_eh_sjlj_setjmp          : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty]>;
@@ -1595,12 +1619,15 @@ def int_eh_sjlj_setup_dispatch  : Intrinsic<[], []>;
 //===---------------- Generic Variable Attribute Intrinsics----------------===//
 //
 def int_var_annotation : DefaultAttrsIntrinsic<
-    [], [llvm_anyptr_ty, llvm_anyptr_ty, LLVMMatchType<1>, llvm_i32_ty, LLVMMatchType<1>],
+    [],
+    [llvm_anyptr_ty, llvm_anyptr_ty, LLVMMatchType<1>, llvm_i32_ty,
+     LLVMMatchType<1>],
     [IntrInaccessibleMemOnly]>;
 
 def int_ptr_annotation : DefaultAttrsIntrinsic<
     [llvm_anyptr_ty],
-    [LLVMMatchType<0>, llvm_anyptr_ty, LLVMMatchType<1>, llvm_i32_ty, LLVMMatchType<1>],
+    [LLVMMatchType<0>, llvm_anyptr_ty, LLVMMatchType<1>, llvm_i32_ty,
+     LLVMMatchType<1>],
     [IntrInaccessibleMemOnly]>;
 
 def int_annotation : DefaultAttrsIntrinsic<
@@ -1612,7 +1639,7 @@ def int_annotation : DefaultAttrsIntrinsic<
 // as CodeView debug info records. This is expensive, as it disables inlining
 // and is modelled as having side effects.
 def int_codeview_annotation : DefaultAttrsIntrinsic<[], [llvm_metadata_ty],
-                                        [IntrInaccessibleMemOnly, IntrNoDuplicate]>;
+                                [IntrInaccessibleMemOnly, IntrNoDuplicate]>;
 
 //===------------------------ Trampoline Intrinsics -----------------------===//
 //
@@ -1630,42 +1657,53 @@ def int_adjust_trampoline : DefaultAttrsIntrinsic<
 //
 
 // Expose the carry flag from add operations on two integrals.
-let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in {
-  def int_sadd_with_overflow : DefaultAttrsIntrinsic<[llvm_anyint_ty,
-                                          LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
-                                         [LLVMMatchType<0>, LLVMMatchType<0>]>;
-  def int_uadd_with_overflow : DefaultAttrsIntrinsic<[llvm_anyint_ty,
-                                          LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
-                                         [LLVMMatchType<0>, LLVMMatchType<0>]>;
+let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
+  in {
+  def int_sadd_with_overflow : DefaultAttrsIntrinsic<
+                                 [llvm_anyint_ty,
+                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
+                                 [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_uadd_with_overflow : DefaultAttrsIntrinsic<
+                                 [llvm_anyint_ty,
+                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
+                                 [LLVMMatchType<0>, LLVMMatchType<0>]>;
 
-  def int_ssub_with_overflow : DefaultAttrsIntrinsic<[llvm_anyint_ty,
-                                          LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
-                                         [LLVMMatchType<0>, LLVMMatchType<0>]>;
-  def int_usub_with_overflow : DefaultAttrsIntrinsic<[llvm_anyint_ty,
-                                          LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
-                                         [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_ssub_with_overflow : DefaultAttrsIntrinsic<
+                                 [llvm_anyint_ty,
+                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
+                                 [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_usub_with_overflow : DefaultAttrsIntrinsic<
+                                 [llvm_anyint_ty,
+                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
+                                 [LLVMMatchType<0>, LLVMMatchType<0>]>;
 
-  def int_smul_with_overflow : DefaultAttrsIntrinsic<[llvm_anyint_ty,
-                                          LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
-                                         [LLVMMatchType<0>, LLVMMatchType<0>]>;
-  def int_umul_with_overflow : DefaultAttrsIntrinsic<[llvm_anyint_ty,
-                                          LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
-                                         [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_smul_with_overflow : DefaultAttrsIntrinsic<
+                                 [llvm_anyint_ty,
+                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
+                                 [LLVMMatchType<0>, LLVMMatchType<0>]>;
+  def int_umul_with_overflow : DefaultAttrsIntrinsic<
+                                 [llvm_anyint_ty,
+                                  LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>],
+                                 [LLVMMatchType<0>, LLVMMatchType<0>]>;
 }
-//===------------------------- Saturation Arithmetic Intrinsics ---------------------===//
+//===------------------ Saturation Arithmetic Intrinsics ------------------===//
 //
 def int_sadd_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>],
-                             [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison, Commutative]>;
+                             [IntrNoMem, IntrSpeculatable,
+                              IntrNoCreateUndefOrPoison, Commutative]>;
 def int_uadd_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>],
-                             [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison, Commutative]>;
+                             [IntrNoMem, IntrSpeculatable,
+                              IntrNoCreateUndefOrPoison, Commutative]>;
 def int_ssub_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>],
-                             [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]>;
+                             [IntrNoMem, IntrSpeculatable,
+                              IntrNoCreateUndefOrPoison]>;
 def int_usub_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>],
-                             [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]>;
+                             [IntrNoMem, IntrSpeculatable,
+                              IntrNoCreateUndefOrPoison]>;
 def int_sshl_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>],
                              [IntrNoMem, IntrSpeculatable]>;
@@ -1673,7 +1711,7 @@ def int_ushl_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>],
                              [IntrNoMem, IntrSpeculatable]>;
 
-//===------------------------- Fixed Point Arithmetic Intrinsics ---------------------===//
+//===------------------- Fixed Point Arithmetic Intrinsics ----------------===//
 //
 def int_smul_fix : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
@@ -1693,24 +1731,24 @@ def int_udiv_fix : DefaultAttrsIntrinsic<[llvm_anyint_ty],
                              [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
                              [IntrNoMem, ImmArg<ArgIndex<2>>]>;
 
-//===------------------- Fixed Point Saturation Arithmetic Intrinsics ----------------===//
+//===------------ Fixed Point Saturation Arithmetic Intrinsics ------------===//
 //
 def int_smul_fix_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
-                                 [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
-                                 [IntrNoMem, IntrSpeculatable,
-                                  Commutative, ImmArg<ArgIndex<2>>]>;
+                         [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
+                         [IntrNoMem, IntrSpeculatable,
+                          Commutative, ImmArg<ArgIndex<2>>]>;
 def int_umul_fix_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
-                                 [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
-                                 [IntrNoMem, IntrSpeculatable,
-                                  Commutative, ImmArg<ArgIndex<2>>]>;
+                         [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
+                         [IntrNoMem, IntrSpeculatable,
+                          Commutative, ImmArg<ArgIndex<2>>]>;
 
 def int_sdiv_fix_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
-                                 [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
-                                 [IntrNoMem, ImmArg<ArgIndex<2>>]>;
+                         [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
+                         [IntrNoMem, ImmArg<ArgIndex<2>>]>;
 
 def int_udiv_fix_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
-                                 [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
-                                 [IntrNoMem, ImmArg<ArgIndex<2>>]>;
+                         [LLVMMatchType<0>, LLVMMatchType<0>, llvm_i32_ty],
+                         [IntrNoMem, ImmArg<ArgIndex<2>>]>;
 
 //===------------------ Integer Min/Max/Abs Intrinsics --------------------===//
 //
@@ -1732,10 +1770,12 @@ def int_umin : DefaultAttrsIntrinsic<
     [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]>;
 def int_scmp : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [llvm_anyint_ty, LLVMMatchType<1>],
-    [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison, Range<RetIndex, -1, 2>]>;
+    [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison,
+     Range<RetIndex, -1, 2>]>;
 def int_ucmp : DefaultAttrsIntrinsic<
     [llvm_anyint_ty], [llvm_anyint_ty, LLVMMatchType<1>],
-    [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison, Range<RetIndex, -1, 2>]>;
+    [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison,
+     Range<RetIndex, -1, 2>]>;
 
 //===------------------------- Memory Use Markers -------------------------===//
 //
@@ -1770,8 +1810,9 @@ def int_invariant_end   : DefaultAttrsIntrinsic<[],
 // Note that it is still experimental, which means that its semantics
 // might change in the future.
 def int_launder_invariant_group : DefaultAttrsIntrinsic<[llvm_anyptr_ty],
-                                            [LLVMMatchType<0>],
-                                            [IntrInaccessibleMemOnly, IntrSpeculatable]>;
+                                    [LLVMMatchType<0>],
+                                    [IntrInaccessibleMemOnly,
+                                     IntrSpeculatable]>;
 
 
 def int_strip_invariant_group : DefaultAttrsIntrinsic<[llvm_anyptr_ty],
@@ -1782,7 +1823,8 @@ def int_strip_invariant_group : DefaultAttrsIntrinsic<[llvm_anyptr_ty],
 //
 def int_experimental_stackmap : DefaultAttrsIntrinsic<[],
                                   [llvm_i64_ty, llvm_i32_ty, llvm_vararg_ty],
-                                  [Throws, ImmArg<ArgIndex<0>>, ImmArg<ArgIndex<1>>]>;
+                                  [Throws, ImmArg<ArgIndex<0>>,
+                                   ImmArg<ArgIndex<1>>]>;
 def int_experimental_patchpoint_void : Intrinsic<[],
                                                  [llvm_i64_ty, llvm_i32_ty,
                                                   llvm_ptr_ty, llvm_i32_ty,
@@ -1864,8 +1906,9 @@ def int_coro_prepare_async : Intrinsic<[llvm_ptr_ty], [llvm_ptr_ty],
                                        [IntrNoMem]>;
 def int_coro_begin : Intrinsic<[llvm_ptr_ty], [llvm_token_ty, llvm_ptr_ty],
                                [WriteOnly<ArgIndex<1>>]>;
-def int_coro_begin_custom_abi : Intrinsic<[llvm_ptr_ty], [llvm_token_ty, llvm_ptr_ty, llvm_i32_ty],
-                               [WriteOnly<ArgIndex<1>>]>;
+def int_coro_begin_custom_abi : Intrinsic<[llvm_ptr_ty],
+                                  [llvm_token_ty, llvm_ptr_ty, llvm_i32_ty],
+                                  [WriteOnly<ArgIndex<1>>]>;
 def int_coro_free : Intrinsic<[llvm_ptr_ty], [llvm_token_ty, llvm_ptr_ty],
                               [IntrReadMem, IntrArgMemOnly,
                                ReadOnly<ArgIndex<1>>,
@@ -1877,7 +1920,8 @@ def int_coro_end_async
     : Intrinsic<[], [llvm_ptr_ty, llvm_i1_ty, llvm_vararg_ty], []>;
 
 def int_coro_frame : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
-def int_coro_is_in_ramp : Intrinsic<[llvm_i1_ty], [], [IntrNoMem], "llvm.coro.is_in_ramp">;
+def int_coro_is_in_ramp : Intrinsic<[llvm_i1_ty], [], [IntrNoMem],
+                                    "llvm.coro.is_in_ramp">;
 def int_coro_noop : Intrinsic<[llvm_ptr_ty], [], [IntrNoMem]>;
 def int_coro_size : Intrinsic<[llvm_anyint_ty], [], [IntrNoMem]>;
 def int_coro_align : Intrinsic<[llvm_anyint_ty], [], [IntrNoMem]>;
@@ -1908,12 +1952,12 @@ def int_coro_await_suspend_void : Intrinsic<[],
                                        [Throws]>;
 
 def int_coro_await_suspend_bool : Intrinsic<[llvm_i1_ty],
-                                            [llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
-                                            [Throws]>;
+                                    [llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
+                                    [Throws]>;
 
 def int_coro_await_suspend_handle : Intrinsic<[],
-                                              [llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
-                                              [Throws]>;
+                                      [llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
+                                      [Throws]>;
 
 // Coroutine Lowering Intrinsics. Used internally by coroutine passes.
 
@@ -1922,12 +1966,14 @@ def int_coro_subfn_addr : DefaultAttrsIntrinsic<
     [IntrReadMem, IntrArgMemOnly, ReadOnly<ArgIndex<0>>,
      NoCapture<ArgIndex<0>>]>;
 
-///===-------------------------- Other Intrinsics --------------------------===//
+///===------------------------- Other Intrinsics --------------------------===//
 //
 // TODO: We should introduce a new memory kind fo traps (and other side effects
 //       we only model to keep things alive).
-def int_trap : Intrinsic<[], [], [IntrNoReturn, IntrCold, IntrInaccessibleMemOnly,
-               IntrWriteMem]>, ClangBuiltin<"__builtin_trap">;
+def int_trap : Intrinsic<[], [], 
+                  [IntrNoReturn, IntrCold, IntrInaccessibleMemOnly,
+                   IntrWriteMem]>,
+               ClangBuiltin<"__builtin_trap">;
 def int_debugtrap : Intrinsic<[]>,
                     ClangBuiltin<"__builtin_debugtrap">;
 def int_ubsantrap : Intrinsic<[], [llvm_i8_ty],
@@ -1941,8 +1987,8 @@ def int_allow_ubsan_check : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_i8_ty],
     [IntrInaccessibleMemOnly, ImmArg<ArgIndex<0>>, NoUndef<RetIndex>]>;
 
 // Return true if runtime check is allowed.
-def int_allow_runtime_check : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_metadata_ty],
-    [IntrInaccessibleMemOnly, NoUndef<RetIndex>]>,
+def int_allow_runtime_check : DefaultAttrsIntrinsic<[llvm_i1_ty],
+    [llvm_metadata_ty], [IntrInaccessibleMemOnly, NoUndef<RetIndex>]>,
     ClangBuiltin<"__builtin_allow_runtime_check">;
 
 // Return true if the specific sanitizer is enabled for the function.
@@ -1968,8 +2014,8 @@ def int_experimental_guard : Intrinsic<[], [llvm_i1_ty, llvm_vararg_ty],
                                        [Throws]>;
 
 // Supports widenable conditions for guards represented as explicit branches.
-def int_experimental_widenable_condition : DefaultAttrsIntrinsic<[llvm_i1_ty], [],
-        [IntrInaccessibleMemOnly, IntrSpeculatable, NoUndef<RetIndex>]>;
+def int_experimental_widenable_condition : DefaultAttrsIntrinsic<[llvm_i1_ty],
+        [], [IntrInaccessibleMemOnly, IntrSpeculatable, NoUndef<RetIndex>]>;
 
 // NOP: calls/invokes to this intrinsic are removed by codegen
 def int_donothing : DefaultAttrsIntrinsic<[], [], [IntrNoMem]>;
@@ -1984,13 +2030,17 @@ def int_sideeffect : DefaultAttrsIntrinsic<[], [], [IntrInaccessibleMemOnly]>;
 // Like the sideeffect intrinsic defined above, this intrinsic is treated by the
 // optimizer as having opaque side effects so that it won't be get rid of or moved
 // out of the block it probes.
-def int_pseudoprobe : DefaultAttrsIntrinsic<[], [llvm_i64_ty, llvm_i64_ty, llvm_i32_ty, llvm_i64_ty],
-                                    [IntrInaccessibleMemOnly]>;
+def int_pseudoprobe : DefaultAttrsIntrinsic<[], 
+                        [llvm_i64_ty, llvm_i64_ty, llvm_i32_ty, llvm_i64_ty],
+                        [IntrInaccessibleMemOnly]>;
 
 // Saturating floating point to integer intrinsics
-let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in {
-def int_fptoui_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty], [llvm_anyfloat_ty]>;
-def int_fptosi_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty], [llvm_anyfloat_ty]>;
+let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
+  in {
+def int_fptoui_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
+                       [llvm_anyfloat_ty]>;
+def int_fptosi_sat : DefaultAttrsIntrinsic<[llvm_anyint_ty],
+                       [llvm_anyfloat_ty]>;
 }
 
 // Clear cache intrinsic, default to ignore (ie. emit nothing)
@@ -2012,9 +2062,10 @@ def int_fake_use : DefaultAttrsIntrinsic<[], [llvm_vararg_ty],
 def int_ptrmask: PureIntrinsic<[llvm_any_ty], [LLVMMatchType<0>, llvm_anyint_ty]>;
 
 // Intrinsic to wrap a thread local variable.
-def int_threadlocal_address : DefaultAttrsIntrinsic<[llvm_anyptr_ty], [LLVMMatchType<0>],
-                                                    [NonNull<RetIndex>, NonNull<ArgIndex<0>>,
-                                                     IntrNoMem, IntrSpeculatable]>;
+def int_threadlocal_address : DefaultAttrsIntrinsic<[llvm_anyptr_ty],
+                                [LLVMMatchType<0>],
+                                [NonNull<RetIndex>, NonNull<ArgIndex<0>>,
+                                 IntrNoMem, IntrSpeculatable]>;
 
 def int_stepvector : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
                                             [], [IntrNoMem]>;
@@ -2022,26 +2073,29 @@ def int_stepvector : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
 def int_reloc_none : DefaultAttrsIntrinsic<[], [llvm_metadata_ty],
   [IntrNoMem, IntrHasSideEffects]>;
 
-//===---------------- Vector Predication Intrinsics --------------===//
+//===--------------------- Vector Predication Intrinsics ------------------===//
 // Memory Intrinsics
 def int_vp_store : DefaultAttrsIntrinsic<[],
                              [ llvm_anyvector_ty,
                                llvm_anyptr_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
-                             [ NoCapture<ArgIndex<1>>, IntrWriteMem, IntrArgMemOnly ]>;
+                             [ NoCapture<ArgIndex<1>>, IntrWriteMem,
+                               IntrArgMemOnly ]>;
 
 def int_vp_load  : DefaultAttrsIntrinsic<[ llvm_anyvector_ty],
                              [ llvm_anyptr_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
-                             [ NoCapture<ArgIndex<0>>, IntrReadMem, IntrArgMemOnly ]>;
+                             [ NoCapture<ArgIndex<0>>, IntrReadMem,
+                               IntrArgMemOnly ]>;
 
 def int_vp_load_ff : DefaultAttrsIntrinsic<[ llvm_anyvector_ty, llvm_i32_ty ],
                              [ llvm_anyptr_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
-                             [ NoCapture<ArgIndex<0>>, IntrNoSync, IntrReadMem, IntrWillReturn, IntrArgMemOnly ]>;
+                             [ NoCapture<ArgIndex<0>>, IntrNoSync, IntrReadMem,
+                               IntrWillReturn, IntrArgMemOnly ]>;
 
 def int_vp_gather: DefaultAttrsIntrinsic<[ llvm_anyvector_ty],
                              [ LLVMVectorOfAnyPointersToElt<0>,
@@ -2054,7 +2108,8 @@ def int_vp_scatter: DefaultAttrsIntrinsic<[],
                                LLVMVectorOfAnyPointersToElt<0>,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
-                             []>; // TODO allow IntrNoCapture for vectors of pointers
+                             []>; // TODO allow IntrNoCapture for vectors of
+                                  // pointers.
 
 // Experimental strided memory accesses
 def int_experimental_vp_strided_store : DefaultAttrsIntrinsic<[],
@@ -2063,47 +2118,49 @@ def int_experimental_vp_strided_store : DefaultAttrsIntrinsic<[],
                                llvm_anyint_ty, // Stride in bytes
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
-                             [ NoCapture<ArgIndex<1>>, IntrWriteMem, IntrArgMemOnly ]>;
+                             [ NoCapture<ArgIndex<1>>, IntrWriteMem,
+                               IntrArgMemOnly ]>;
 
 def int_experimental_vp_strided_load  : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
                              [ llvm_anyptr_ty,
                                llvm_anyint_ty, // Stride in bytes
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
-                             [ NoCapture<ArgIndex<0>>, IntrReadMem, IntrArgMemOnly ]>;
+                             [ NoCapture<ArgIndex<0>>, IntrReadMem,
+                               IntrArgMemOnly ]>;
 
 // Experimental histogram
 def int_experimental_vector_histogram_add : DefaultAttrsIntrinsic<[],
-                             [ llvm_anyvector_ty, // Vector of pointers
-                               llvm_anyint_ty,    // Increment
-                               LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
-                             [ IntrArgMemOnly ]>;
+                       [ llvm_anyvector_ty, // Vector of pointers
+                         llvm_anyint_ty,    // Increment
+                         LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
+                       [ IntrArgMemOnly ]>;
 
 def int_experimental_vector_histogram_uadd_sat : DefaultAttrsIntrinsic<[],
-                             [ llvm_anyvector_ty, // Vector of pointers
-                               llvm_anyint_ty,    // Increment
-                               LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
-                             [ IntrArgMemOnly ]>;
+                       [ llvm_anyvector_ty, // Vector of pointers
+                         llvm_anyint_ty,    // Increment
+                         LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
+                       [ IntrArgMemOnly ]>;
 
 def int_experimental_vector_histogram_umin : DefaultAttrsIntrinsic<[],
-                             [ llvm_anyvector_ty, // Vector of pointers
-                               llvm_anyint_ty,    // Update value
-                               LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
-                             [ IntrArgMemOnly ]>;
+                       [ llvm_anyvector_ty, // Vector of pointers
+                         llvm_anyint_ty,    // Update value
+                         LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
+                       [ IntrArgMemOnly ]>;
 
 def int_experimental_vector_histogram_umax : DefaultAttrsIntrinsic<[],
-                             [ llvm_anyvector_ty, // Vector of pointers
-                               llvm_anyint_ty,    // Update value
-                               LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
-                             [ IntrArgMemOnly ]>;
+                       [ llvm_anyvector_ty, // Vector of pointers
+                         llvm_anyint_ty,    // Update value
+                         LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>], // Mask
+                       [ IntrArgMemOnly ]>;
 
 // Experimental match
 def int_experimental_vector_match : DefaultAttrsIntrinsic<
-                             [ LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],
-                             [ llvm_anyvector_ty,
-                               llvm_anyvector_ty,
-                               LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],  // Mask
-                             [ IntrNoMem, IntrSpeculatable ]>;
+                       [ LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],
+                       [ llvm_anyvector_ty,
+                         llvm_anyvector_ty,
+                         LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],  // Mask
+                       [ IntrNoMem, IntrSpeculatable ]>;
 
 // Extract based on mask bits
 def int_experimental_vector_extract_last_active:
@@ -2399,13 +2456,15 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable] in {
                                llvm_i32_ty]>;
 
   // Comparisons
-  def int_vp_fcmp : DefaultAttrsIntrinsic<[ LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],
+  def int_vp_fcmp : DefaultAttrsIntrinsic<
+                             [ LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],
                              [ llvm_anyvector_ty,
                                LLVMMatchType<0>,
                                llvm_metadata_ty,
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty]>;
-  def int_vp_icmp : DefaultAttrsIntrinsic<[ LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],
+  def int_vp_icmp : DefaultAttrsIntrinsic<
+                             [ LLVMScalarOrSameVectorWidth<0, llvm_i1_ty> ],
                              [ llvm_anyvector_ty,
                                LLVMMatchType<0>,
                                llvm_metadata_ty,
@@ -2579,7 +2638,8 @@ def int_vp_is_fpclass:
                                 llvm_i32_ty,
                                 LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                 llvm_i32_ty],
-                              [IntrNoMem, IntrSpeculatable, ImmArg<ArgIndex<1>>]>;
+                              [ IntrNoMem, IntrSpeculatable,
+                                ImmArg<ArgIndex<1>>]>;
 
 //===-------------------------- Masked Intrinsics -------------------------===//
 //
@@ -2622,7 +2682,8 @@ def int_masked_compressstore:
 
 def int_experimental_vector_compress:
     DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-              [LLVMMatchType<0>, LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, LLVMMatchType<0>],
+              [LLVMMatchType<0>, LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
+               LLVMMatchType<0>],
               [IntrNoMem]>;
 
 def int_masked_udiv:
@@ -2654,30 +2715,37 @@ def int_masked_srem:
             [IntrNoMem]>;
 
 // Test whether a pointer is associated with a type metadata identifier.
-def int_type_test : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_ptr_ty, llvm_metadata_ty],
-                              [IntrNoMem, IntrSpeculatable]>;
+def int_type_test : DefaultAttrsIntrinsic<[llvm_i1_ty],
+                      [llvm_ptr_ty, llvm_metadata_ty],
+                      [IntrNoMem, IntrSpeculatable]>;
 
-// Safely loads a function pointer from a virtual table pointer using type metadata.
+// Safely loads a function pointer from a virtual table pointer using type
+// metadata.
 def int_type_checked_load : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_i1_ty],
-                                      [llvm_ptr_ty, llvm_i32_ty, llvm_metadata_ty],
-                                      [IntrNoMem]>;
+                              [llvm_ptr_ty, llvm_i32_ty, llvm_metadata_ty],
+                              [IntrNoMem]>;
 
-// Safely loads a relative function pointer from a virtual table pointer using type metadata.
-def int_type_checked_load_relative : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_i1_ty],
-                                      [llvm_ptr_ty, llvm_i32_ty, llvm_metadata_ty],
-                                      [IntrNoMem]>;
+// Safely loads a relative function pointer from a virtual table pointer using
+// type metadata.
+def int_type_checked_load_relative : DefaultAttrsIntrinsic<
+                                       [llvm_ptr_ty, llvm_i1_ty],
+                                       [llvm_ptr_ty, llvm_i32_ty,
+                                        llvm_metadata_ty],
+                                       [IntrNoMem]>;
 
 // Test whether a pointer is associated with a type metadata identifier. Used
 // for public visibility classes that may later be refined to private
 // visibility.
-def int_public_type_test : DefaultAttrsIntrinsic<[llvm_i1_ty], [llvm_ptr_ty, llvm_metadata_ty],
+def int_public_type_test : DefaultAttrsIntrinsic<[llvm_i1_ty],
+                              [llvm_ptr_ty, llvm_metadata_ty],
                               [IntrNoMem, IntrSpeculatable]>;
 
 // Create a branch funnel that implements an indirect call to a limited set of
 // callees. This needs to be a musttail call.
 def int_icall_branch_funnel : DefaultAttrsIntrinsic<[], [llvm_vararg_ty], []>;
 
-def int_load_relative: DefaultAttrsIntrinsic<[llvm_ptr_ty], [llvm_ptr_ty, llvm_anyint_ty],
+def int_load_relative: DefaultAttrsIntrinsic<[llvm_ptr_ty],
+                                 [llvm_ptr_ty, llvm_anyint_ty],
                                  [IntrReadMem, IntrArgMemOnly]>;
 
 def int_asan_check_memaccess :
@@ -2685,7 +2753,8 @@ def int_asan_check_memaccess :
 
 // Spin in an infinite loop (using instructions specified by the target) iff the
 // argument is true. Used to implement efficient conditional traps.
-def int_cond_loop : Intrinsic<[], [llvm_i1_ty], [IntrNoMem, IntrHasSideEffects]>;
+def int_cond_loop : Intrinsic<[], [llvm_i1_ty], 
+                              [IntrNoMem, IntrHasSideEffects]>;
 
 // HWASan intrinsics to test whether a pointer is addressable.
 //===----------------------------------------------------------------------===//
@@ -2759,7 +2828,8 @@ def int_memset_element_unordered_atomic
 
 //===------------------------ Reduction Intrinsics ------------------------===//
 //
-let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in {
+let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison]
+  in {
 
   def int_vector_reduce_fadd : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
                                          [LLVMVectorElementType<0>,
@@ -2789,13 +2859,15 @@ let IntrProperties = [IntrNoMem, IntrSpeculatable, IntrNoCreateUndefOrPoison] in
                                          [llvm_anyvector_ty]>;
   def int_vector_reduce_fmin : DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
                                          [llvm_anyvector_ty]>;
-  def int_vector_reduce_fminimum: DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
+  def int_vector_reduce_fminimum: DefaultAttrsIntrinsic<
+                                         [LLVMVectorElementType<0>],
                                          [llvm_anyvector_ty]>;
-  def int_vector_reduce_fmaximum: DefaultAttrsIntrinsic<[LLVMVectorElementType<0>],
+  def int_vector_reduce_fmaximum: DefaultAttrsIntrinsic<
+                                         [LLVMVectorElementType<0>],
                                          [llvm_anyvector_ty]>;
 }
 
-//===----- Matrix intrinsics ---------------------------------------------===//
+//===------ Matrix intrinsics ---------------------------------------------===//
 
 def int_matrix_transpose
   : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
@@ -2835,8 +2907,10 @@ def int_set_loop_iterations :
 
 // Same as the above, but produces a value (the same as the input operand) to
 // be fed into the loop.
-def int_start_loop_iterations :
-  DefaultAttrsIntrinsic<[llvm_anyint_ty], [LLVMMatchType<0>], [IntrNoDuplicate]>;
+def int_start_loop_iterations : DefaultAttrsIntrinsic<
+                                  [llvm_anyint_ty],
+                                  [LLVMMatchType<0>],
+                                  [IntrNoDuplicate]>;
 
 // Specify that the value given is the number of iterations that the next loop
 // will execute. Also test that the given count is not zero, allowing it to
@@ -2890,9 +2964,9 @@ def int_preserve_struct_access_index : DefaultAttrsIntrinsic<[llvm_anyptr_ty],
                                                   ImmArg<ArgIndex<1>>,
                                                   ImmArg<ArgIndex<2>>]>;
 def int_preserve_static_offset : DefaultAttrsIntrinsic<[llvm_ptr_ty],
-                                                       [llvm_ptr_ty],
-                                                       [IntrNoMem, IntrSpeculatable,
-                                                        ReadNone <ArgIndex<0>>]>;
+                                   [llvm_ptr_ty],
+                                   [IntrNoMem, IntrSpeculatable,
+                                    ReadNone <ArgIndex<0>>]>;
 
 //===------------ Intrinsics to perform common vector shuffles ------------===//
 
@@ -2919,23 +2993,22 @@ def int_vscale : DefaultAttrsIntrinsic<[llvm_anyint_ty],
 
 //===---------- Intrinsics to perform subvector insertion/extraction ------===//
 def int_vector_insert : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-                                              [LLVMMatchType<0>, llvm_anyvector_ty, llvm_i64_ty],
-                                              [IntrNoMem, IntrSpeculatable, ImmArg<ArgIndex<2>>]>;
+                          [LLVMMatchType<0>, llvm_anyvector_ty, llvm_i64_ty],
+                          [IntrNoMem, IntrSpeculatable, ImmArg<ArgIndex<2>>]>;
 
 def int_vector_extract : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-                                               [llvm_anyvector_ty, llvm_i64_ty],
-                                               [IntrNoMem, IntrSpeculatable, ImmArg<ArgIndex<1>>]>;
+                           [llvm_anyvector_ty, llvm_i64_ty],
+                           [IntrNoMem, IntrSpeculatable, ImmArg<ArgIndex<1>>]>;
 
 foreach n = 2...8 in {
-  def int_vector_interleave#n   : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
-                                                       !listsplat(LLVMOneNthElementsVectorType<0, n>, n),
-                                                       [IntrNoMem,
-                                                        IntrSpeculatable]>;
+  def int_vector_interleave#n : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+                              !listsplat(LLVMOneNthElementsVectorType<0, n>, n),
+                              [IntrNoMem, IntrSpeculatable]>;
 
-  def int_vector_deinterleave#n : DefaultAttrsIntrinsic<!listsplat(LLVMOneNthElementsVectorType<0, n>, n),
-                                                       [llvm_anyvector_ty],
-                                                       [IntrNoMem,
-                                                        IntrSpeculatable]>;
+  def int_vector_deinterleave#n : DefaultAttrsIntrinsic<
+                              !listsplat(LLVMOneNthElementsVectorType<0, n>, n),
+                              [llvm_anyvector_ty],
+                              [IntrNoMem, IntrSpeculatable]>;
 }
 
 //===-------------- Intrinsics to perform partial reduction ---------------===//
@@ -2947,8 +3020,8 @@ def int_vector_partial_reduce_add : DefaultAttrsIntrinsic<[LLVMMatchType<0>],
                                                            IntrSpeculatable]>;
 
 def int_vector_partial_reduce_fadd : DefaultAttrsIntrinsic<[LLVMMatchType<0>],
-                                                           [llvm_anyfloat_ty, llvm_anyfloat_ty],
-                                                           [IntrNoMem]>;
+                                       [llvm_anyfloat_ty, llvm_anyfloat_ty],
+                                       [IntrNoMem]>;
 
 //===----------------- Pointer Authentication Intrinsics ------------------===//
 //


### PR DESCRIPTION
Verified that there is no difference in the tablegen generated files for intrinsics except line number changes in the comments in IntrinsicEnums.inc.