### PR TITLE
[SCEV] Avoid redundant stack push/pop in createSCEVIter

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -7729,14 +7729,15 @@ const SCEV *ScalarEvolution::createSCEVIter(Value *V) {
   using PointerTy = PointerIntPair<Value *, 1, bool>;
   SmallVector<PointerTy> Stack;
 
-  Stack.emplace_back(V, true);
   Stack.emplace_back(V, false);
   while (!Stack.empty()) {
-    auto E = Stack.pop_back_val();
+    auto E = Stack.back();
     Value *CurV = E.getPointer();
 
-    if (getExistingSCEV(CurV))
+    if (getExistingSCEV(CurV)) {
+      Stack.pop_back();
       continue;
+    }
 
     SmallVector<Value *> Ops;
     const SCEV *CreatedSCEV = nullptr;
@@ -7752,10 +7753,10 @@ const SCEV *ScalarEvolution::createSCEVIter(Value *V) {
 
     if (CreatedSCEV) {
       insertValueToMap(CurV, CreatedSCEV);
+      Stack.pop_back();
     } else {
-      // Queue CurV for SCEV creation, followed by its's operands which need to
-      // be constructed first.
-      Stack.emplace_back(CurV, true);
+      Stack.back().setInt(true);
+      // Queue its operands which need to be constructed.
       for (Value *Op : Ops)
         Stack.emplace_back(Op, false);
     }


### PR DESCRIPTION
This patch simplifies the iterative worklist handling in createSCEVIter.

In the previous implementation, a `Value` that could not be materialized immediately would typically be pushed onto the stack twice and popped twice: first in the initial unvisited state, and then again after being re-queued in the visited state once its operands had to be processed first.

This change avoids that redundant re-queue step by updating the existing stack entry in place before pushing unresolved operands. Use `setInt(true)` to update the existing `Stack` entry in place instead of pushing a separate `(V, true)` entry. This saves one `emplace_back`/`pop_back` pair for each `Value`, and reduces memory consumption of the `Stack` worklist.