### PR TITLE
[ARM] Move expand-pseudos before load-store opt

### DIFF
--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -478,6 +478,10 @@ void ARMPassConfig::addPreRegAlloc() {
 }
 
 void ARMPassConfig::addPreSched2() {
+  // Expand some pseudo instructions into multiple instructions to allow
+  // proper scheduling.
+  addPass(createARMExpandPseudoPass());
+
   if (getOptLevel() != CodeGenOptLevel::None) {
     if (EnableARMLoadStoreOpt)
       addPass(createARMLoadStoreOptLegacyPass());
@@ -485,10 +489,6 @@ void ARMPassConfig::addPreSched2() {
     addPass(new ARMExecutionDomainFix());
     addPass(createBreakFalseDepsLegacyPass());
   }
-
-  // Expand some pseudo instructions into multiple instructions to allow
-  // proper scheduling.
-  addPass(createARMExpandPseudoPass());
 
   // Emit KCFI checks for indirect calls.
   addPass(createKCFIPass());

--- a/llvm/test/CodeGen/ARM/O3-pipeline.ll
+++ b/llvm/test/CodeGen/ARM/O3-pipeline.ll
@@ -163,11 +163,11 @@
 ; CHECK-NEXT:      Tail Duplication
 ; CHECK-NEXT:      Machine Copy Propagation Pass
 ; CHECK-NEXT:      Post-RA pseudo instruction expansion pass
+; CHECK-NEXT:      ARM pseudo instruction expansion pass
 ; CHECK-NEXT:      ARM load / store optimization pass
 ; CHECK-NEXT:      Reaching Definitions Analysis
 ; CHECK-NEXT:      ARM Execution Domain Fix
 ; CHECK-NEXT:      BreakFalseDeps
-; CHECK-NEXT:      ARM pseudo instruction expansion pass
 ; CHECK-NEXT:      Insert KCFI indirect call checks
 ; CHECK-NEXT:      Thumb2 instruction size reduce pass
 ; CHECK-NEXT:      MachineDominator Tree Construction

--- a/llvm/test/CodeGen/ARM/vector-llrint.ll
+++ b/llvm/test/CodeGen/ARM/vector-llrint.ll
@@ -1547,7 +1547,7 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) {
 ; LE-NEXT:    sub sp, sp, #40
 ; LE-NEXT:    vorr q4, q0, q0
 ; LE-NEXT:    add lr, sp, #24
-; LE-NEXT:    vorr d0, d6, d6
+; LE-NEXT:    vmov.f64 d0, d6
 ; LE-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-NEXT:    vorr q7, q2, q2
 ; LE-NEXT:    vorr q6, q1, q1
@@ -1582,7 +1582,7 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) {
 ; LE-NEXT:    mov r6, r1
 ; LE-NEXT:    vmov.32 d12[0], r0
 ; LE-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d17, d17
+; LE-NEXT:    vmov.f64 d0, d17
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #8
 ; LE-NEXT:    vmov.32 d12[1], r6
@@ -1612,7 +1612,7 @@ define <8 x i64> @llrint_v8i64_v8f64(<8 x double> %x) {
 ; BE-NEXT:    sub sp, sp, #40
 ; BE-NEXT:    vorr q4, q0, q0
 ; BE-NEXT:    add lr, sp, #24
-; BE-NEXT:    vorr d0, d6, d6
+; BE-NEXT:    vmov.f64 d0, d6
 ; BE-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; BE-NEXT:    vorr q7, q2, q2
 ; BE-NEXT:    vorr q6, q1, q1
@@ -1732,7 +1732,7 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; LE-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
 ; LE-NEXT:    vorr d0, d15, d15
 ; LE-NEXT:    bl llrint
-; LE-NEXT:    vorr d0, d14, d14
+; LE-NEXT:    vmov.f64 d0, d14
 ; LE-NEXT:    mov r7, r1
 ; LE-NEXT:    vmov.32 d13[0], r0
 ; LE-NEXT:    bl llrint
@@ -1748,8 +1748,8 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #56
 ; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d10, d10
 ; LE-NEXT:    vmov.32 d12[1], r5
+; LE-NEXT:    vmov.f64 d0, d10
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    vorr d0, d11, d11
 ; LE-NEXT:    add lr, sp, #96
@@ -1776,7 +1776,7 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; LE-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #80
 ; LE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d8, d8
+; LE-NEXT:    vmov.f64 d0, d8
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #160
 ; LE-NEXT:    vmov.32 d14[0], r0
@@ -1794,7 +1794,7 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; LE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-NEXT:    add lr, sp, #120
 ; LE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-NEXT:    vorr d0, d10, d10
+; LE-NEXT:    vmov.f64 d0, d10
 ; LE-NEXT:    bl llrint
 ; LE-NEXT:    add lr, sp, #40
 ; LE-NEXT:    vmov.32 d12[0], r0
@@ -1906,7 +1906,7 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-NEXT:    vorr d0, d9, d9
 ; BE-NEXT:    bl llrint
-; BE-NEXT:    vorr d0, d8, d8
+; BE-NEXT:    vmov.f64 d0, d8
 ; BE-NEXT:    mov r7, r1
 ; BE-NEXT:    vmov.32 d13[0], r0
 ; BE-NEXT:    bl llrint
@@ -1922,8 +1922,8 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-NEXT:    add lr, sp, #40
 ; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d8, d8
 ; BE-NEXT:    vmov.32 d12[1], r5
+; BE-NEXT:    vmov.f64 d0, d8
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d9, d9
 ; BE-NEXT:    add lr, sp, #80
@@ -1938,8 +1938,8 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; BE-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-NEXT:    add lr, sp, #64
 ; BE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d12, d12
 ; BE-NEXT:    vmov.32 d14[1], r4
+; BE-NEXT:    vmov.f64 d0, d12
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d13, d13
 ; BE-NEXT:    add lr, sp, #40
@@ -1957,8 +1957,8 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #104
 ; BE-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d12, d12
 ; BE-NEXT:    vmov.32 d8[1], r0
+; BE-NEXT:    vmov.f64 d0, d12
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vmov.32 d14[0], r0
 ; BE-NEXT:    ldr r0, [sp, #100] @ 4-byte Reload
@@ -1975,8 +1975,8 @@ define <16 x i64> @llrint_v16f64(<16 x double> %x) {
 ; BE-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-NEXT:    add lr, sp, #128
 ; BE-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; BE-NEXT:    vorr d0, d10, d10
 ; BE-NEXT:    vmov.32 d8[1], r0
+; BE-NEXT:    vmov.f64 d0, d10
 ; BE-NEXT:    bl llrint
 ; BE-NEXT:    vorr d0, d11, d11
 ; BE-NEXT:    mov r7, r1

--- a/llvm/test/CodeGen/ARM/vector-lrint.ll
+++ b/llvm/test/CodeGen/ARM/vector-lrint.ll
@@ -2487,11 +2487,11 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; LE-I32-NEXT:    sub sp, sp, #32
 ; LE-I32-NEXT:    vorr q7, q0, q0
 ; LE-I32-NEXT:    add lr, sp, #16
-; LE-I32-NEXT:    vorr d0, d6, d6
-; LE-I32-NEXT:    vstmia sp, {d4, d5} @ 16-byte Spill
-; LE-I32-NEXT:    vorr q5, q2, q2
+; LE-I32-NEXT:    vmov.f64 d0, d6
 ; LE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
+; LE-I32-NEXT:    vorr q5, q2, q2
 ; LE-I32-NEXT:    vorr q6, q1, q1
+; LE-I32-NEXT:    vstmia sp, {d4, d5} @ 16-byte Spill
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vorr d0, d10, d10
 ; LE-I32-NEXT:    vmov.32 d9[0], r0
@@ -2509,13 +2509,13 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; LE-I32-NEXT:    vmov.32 d10[1], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vldmia sp, {d16, d17} @ 16-byte Reload
-; LE-I32-NEXT:    vorr d0, d17, d17
+; LE-I32-NEXT:    vmov.f64 d0, d17
 ; LE-I32-NEXT:    vmov.32 d11[1], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #16
 ; LE-I32-NEXT:    vmov.32 d8[1], r0
 ; LE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I32-NEXT:    vorr d0, d17, d17
+; LE-I32-NEXT:    vmov.f64 d0, d17
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    vmov.32 d9[1], r0
 ; LE-I32-NEXT:    vorr q0, q5, q5
@@ -2534,7 +2534,7 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; LE-I64-NEXT:    sub sp, sp, #40
 ; LE-I64-NEXT:    vorr q4, q0, q0
 ; LE-I64-NEXT:    add lr, sp, #24
-; LE-I64-NEXT:    vorr d0, d6, d6
+; LE-I64-NEXT:    vmov.f64 d0, d6
 ; LE-I64-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; LE-I64-NEXT:    vorr q7, q2, q2
 ; LE-I64-NEXT:    vorr q6, q1, q1
@@ -2569,7 +2569,7 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; LE-I64-NEXT:    mov r6, r1
 ; LE-I64-NEXT:    vmov.32 d12[0], r0
 ; LE-I64-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d17, d17
+; LE-I64-NEXT:    vmov.f64 d0, d17
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #8
 ; LE-I64-NEXT:    vmov.32 d12[1], r6
@@ -2599,11 +2599,11 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; BE-I32-NEXT:    sub sp, sp, #32
 ; BE-I32-NEXT:    vorr q6, q0, q0
 ; BE-I32-NEXT:    add lr, sp, #16
-; BE-I32-NEXT:    vorr d0, d6, d6
-; BE-I32-NEXT:    vstmia sp, {d2, d3} @ 16-byte Spill
-; BE-I32-NEXT:    vorr q7, q2, q2
+; BE-I32-NEXT:    vmov.f64 d0, d6
 ; BE-I32-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
+; BE-I32-NEXT:    vorr q7, q2, q2
 ; BE-I32-NEXT:    vorr q5, q1, q1
+; BE-I32-NEXT:    vstmia sp, {d2, d3} @ 16-byte Spill
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vorr d0, d10, d10
 ; BE-I32-NEXT:    vmov.32 d9[0], r0
@@ -2621,13 +2621,13 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; BE-I32-NEXT:    vmov.32 d8[1], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vldmia sp, {d16, d17} @ 16-byte Reload
-; BE-I32-NEXT:    vorr d0, d17, d17
+; BE-I32-NEXT:    vmov.f64 d0, d17
 ; BE-I32-NEXT:    vmov.32 d10[1], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #16
 ; BE-I32-NEXT:    vmov.32 d11[1], r0
 ; BE-I32-NEXT:    vldmia lr, {d16, d17} @ 16-byte Reload
-; BE-I32-NEXT:    vorr d0, d17, d17
+; BE-I32-NEXT:    vmov.f64 d0, d17
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    vmov.32 d9[1], r0
 ; BE-I32-NEXT:    vrev64.32 q0, q5
@@ -2646,7 +2646,7 @@ define <8 x iXLen> @lrint_v8f64(<8 x double> %x) {
 ; BE-I64-NEXT:    sub sp, sp, #40
 ; BE-I64-NEXT:    vorr q4, q0, q0
 ; BE-I64-NEXT:    add lr, sp, #24
-; BE-I64-NEXT:    vorr d0, d6, d6
+; BE-I64-NEXT:    vmov.f64 d0, d6
 ; BE-I64-NEXT:    vstmia lr, {d6, d7} @ 16-byte Spill
 ; BE-I64-NEXT:    vorr q7, q2, q2
 ; BE-I64-NEXT:    vorr q6, q1, q1
@@ -2735,7 +2735,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
 ; LE-I32-NEXT:    add r0, sp, #240
 ; LE-I32-NEXT:    vstmia sp, {d0, d1} @ 16-byte Spill
-; LE-I32-NEXT:    vorr d0, d6, d6
+; LE-I32-NEXT:    vmov.f64 d0, d6
 ; LE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; LE-I32-NEXT:    add lr, sp, #48
 ; LE-I32-NEXT:    vld1.64 {d14, d15}, [r0]
@@ -2747,7 +2747,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I32-NEXT:    vorr d0, d10, d10
 ; LE-I32-NEXT:    vmov.32 d13[0], r0
 ; LE-I32-NEXT:    bl lrint
-; LE-I32-NEXT:    vorr d0, d14, d14
+; LE-I32-NEXT:    vmov.f64 d0, d14
 ; LE-I32-NEXT:    vmov.32 d12[0], r0
 ; LE-I32-NEXT:    bl lrint
 ; LE-I32-NEXT:    add lr, sp, #64
@@ -2878,7 +2878,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I64-NEXT:    vldmia lr, {d14, d15} @ 16-byte Reload
 ; LE-I64-NEXT:    vorr d0, d15, d15
 ; LE-I64-NEXT:    bl lrint
-; LE-I64-NEXT:    vorr d0, d14, d14
+; LE-I64-NEXT:    vmov.f64 d0, d14
 ; LE-I64-NEXT:    mov r7, r1
 ; LE-I64-NEXT:    vmov.32 d13[0], r0
 ; LE-I64-NEXT:    bl lrint
@@ -2894,8 +2894,8 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #56
 ; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d10, d10
 ; LE-I64-NEXT:    vmov.32 d12[1], r5
+; LE-I64-NEXT:    vmov.f64 d0, d10
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    vorr d0, d11, d11
 ; LE-I64-NEXT:    add lr, sp, #96
@@ -2922,7 +2922,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I64-NEXT:    vstmia lr, {d8, d9} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #80
 ; LE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d8, d8
+; LE-I64-NEXT:    vmov.f64 d0, d8
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #160
 ; LE-I64-NEXT:    vmov.32 d14[0], r0
@@ -2940,7 +2940,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; LE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; LE-I64-NEXT:    add lr, sp, #120
 ; LE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; LE-I64-NEXT:    vorr d0, d10, d10
+; LE-I64-NEXT:    vmov.f64 d0, d10
 ; LE-I64-NEXT:    bl lrint
 ; LE-I64-NEXT:    add lr, sp, #40
 ; LE-I64-NEXT:    vmov.32 d12[0], r0
@@ -3013,7 +3013,6 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I32-NEXT:    add lr, sp, #16
 ; BE-I32-NEXT:    vstmia lr, {d0, d1} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #80
-; BE-I32-NEXT:    vorr d0, d2, d2
 ; BE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #112
 ; BE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
@@ -3022,6 +3021,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I32-NEXT:    add lr, sp, #96
 ; BE-I32-NEXT:    vld1.64 {d16, d17}, [r0]
 ; BE-I32-NEXT:    add r0, sp, #224
+; BE-I32-NEXT:    vmov.f64 d0, d2
 ; BE-I32-NEXT:    vstmia lr, {d16, d17} @ 16-byte Spill
 ; BE-I32-NEXT:    add lr, sp, #48
 ; BE-I32-NEXT:    vld1.64 {d14, d15}, [r0]
@@ -3034,7 +3034,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I32-NEXT:    vorr d0, d12, d12
 ; BE-I32-NEXT:    vmov.32 d8[0], r0
 ; BE-I32-NEXT:    bl lrint
-; BE-I32-NEXT:    vorr d0, d14, d14
+; BE-I32-NEXT:    vmov.f64 d0, d14
 ; BE-I32-NEXT:    vmov.32 d10[0], r0
 ; BE-I32-NEXT:    bl lrint
 ; BE-I32-NEXT:    add lr, sp, #80
@@ -3165,7 +3165,7 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-I64-NEXT:    vorr d0, d9, d9
 ; BE-I64-NEXT:    bl lrint
-; BE-I64-NEXT:    vorr d0, d8, d8
+; BE-I64-NEXT:    vmov.f64 d0, d8
 ; BE-I64-NEXT:    mov r7, r1
 ; BE-I64-NEXT:    vmov.32 d13[0], r0
 ; BE-I64-NEXT:    bl lrint
@@ -3181,8 +3181,8 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I64-NEXT:    add lr, sp, #40
 ; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d8, d8
 ; BE-I64-NEXT:    vmov.32 d12[1], r5
+; BE-I64-NEXT:    vmov.f64 d0, d8
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d9, d9
 ; BE-I64-NEXT:    add lr, sp, #80
@@ -3197,8 +3197,8 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I64-NEXT:    vstmia lr, {d10, d11} @ 16-byte Spill
 ; BE-I64-NEXT:    add lr, sp, #64
 ; BE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d12, d12
 ; BE-I64-NEXT:    vmov.32 d14[1], r4
+; BE-I64-NEXT:    vmov.f64 d0, d12
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d13, d13
 ; BE-I64-NEXT:    add lr, sp, #40
@@ -3216,8 +3216,8 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #104
 ; BE-I64-NEXT:    vldmia lr, {d12, d13} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d12, d12
 ; BE-I64-NEXT:    vmov.32 d8[1], r0
+; BE-I64-NEXT:    vmov.f64 d0, d12
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vmov.32 d14[0], r0
 ; BE-I64-NEXT:    ldr r0, [sp, #100] @ 4-byte Reload
@@ -3234,8 +3234,8 @@ define <16 x iXLen> @lrint_v16f64(<16 x double> %x) {
 ; BE-I64-NEXT:    vldmia lr, {d8, d9} @ 16-byte Reload
 ; BE-I64-NEXT:    add lr, sp, #128
 ; BE-I64-NEXT:    vldmia lr, {d10, d11} @ 16-byte Reload
-; BE-I64-NEXT:    vorr d0, d10, d10
 ; BE-I64-NEXT:    vmov.32 d8[1], r0
+; BE-I64-NEXT:    vmov.f64 d0, d10
 ; BE-I64-NEXT:    bl lrint
 ; BE-I64-NEXT:    vorr d0, d11, d11
 ; BE-I64-NEXT:    mov r7, r1


### PR DESCRIPTION
Otherwise expanded code doesn't get those optimizations.