### PR TITLE
[libc][math] Add missing functions from issignaling family to math.yaml

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -1609,6 +1609,9 @@ functions:
   - name: isnanf16
     standards:
       - bsd
+    return_type: int
+    arguments:
+      - type: float16
   - name: issignaling
     standards:
       - stdc

--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -1609,10 +1609,38 @@ functions:
   - name: isnanf16
     standards:
       - bsd
+  - name: issignaling
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: double
+  - name: issignalingf
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float
+  - name: issignalingf16
+    standards:
+      - stdc
     return_type: int
     arguments:
       - type: _Float16
     guard: LIBC_TYPES_HAS_FLOAT16
+  - name: issignalingf128
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: issignalingl
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: long double
   - name: ldexp
     standards:
       - stdc
@@ -2895,42 +2923,3 @@ functions:
       - type: long double
       - type: int
       - type: unsigned int
-  - name: issignaling
-    standards:
-      - stdc
-    return_type: double
-    arguments:
-      - type: int
-  - name: issignalingbf16
-    standards:
-      - stdc
-    return_type: _Float16
-    arguments:
-      - type: int
-    guard: LIBC_TYPES_HAS_FLOAT16
-  - name: issignalingf
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: float
-  - name: issignalingf16
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: _Float
-    guard: LIBC_TYPES_HAS_FLOAT16
-  - name: issignalingf128
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: float128
-    guard: LIBC_TYPES_HAS_FLOAT128
-  - name: issignalingl
-    standards:
-      - stdc
-    return_type: int
-    arguments:
-      - type: long double

--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -2895,3 +2895,42 @@ functions:
       - type: long double
       - type: int
       - type: unsigned int
+  - name: issignaling
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: int
+  - name: issignalingbf16
+    standards:
+      - stdc
+    return_type: _Float16
+    arguments:
+      - type: int
+    guard: LIBC_TYPES_HAS_FLOAT16
+  - name: issignalingf
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float
+  - name: issignalingf16
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: _Float
+    guard: LIBC_TYPES_HAS_FLOAT16
+  - name: issignalingf128
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: issignalingl
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: long double


### PR DESCRIPTION
Successfully added the following functions into `math.yaml`:
- issignaling
- issignalingf
- issignalingf16
- issignalingf128
- issignalingl

Also verified the additions using `/hdrgen/`.

Edit: Fixes #199266