### PR TITLE
[Old DRAFT] [Analysis][AIX] Add !implicit.ref globals as ThinLTO summary ref edges to support pragma comment(copyright) LTO interaction

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6819,6 +6819,29 @@ The ``#pragma comment(lib, ...)`` directive is supported on all ELF targets.
 The second parameter is the library name (without the traditional Unix prefix of
 ``lib``).  This allows you to provide an implicit link of dependent libraries.
 
+Embedding Copyright Information on AIX
+======================================
+Clang supports the ``#pragma comment(copyright, "string")`` directive on AIX
+targets. This directive embeds a copyright or identifying string into the
+compiled object file. The string is included in the final executable or shared
+library and loaded into memory at program runtime. The directive is ignored on
+non-AIX targets.
+
+.. code-block:: c
+
+   #pragma comment(copyright, "string-literal")
+
+The second argument is an ordinary string literal. Concatenated ordinary string 
+literals are also accepted. The directive is intended to appear at file scope;
+Clang treats it as being at file scope when it appears within other scopes.
+
+Interaction with C++20 Modules
+-------------------------------
+
+When ``#pragma comment(copyright, ...)`` appears in a C++20 module interface
+unit, the copyright string is embedded only in the object file compiled from
+that interface unit. Importing TUs do not re-emit the string.
+
 Evaluating Object Size
 ======================
 

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6821,7 +6821,7 @@ The second parameter is the library name (without the traditional Unix prefix of
 
 Embedding Copyright Information on AIX
 ======================================
-Clang supports the ``#pragma comment(copyright, "string")`` directive on AIX
+Clang supports the ``#pragma comment(copyright, "string")`` directive for AIX
 targets. This directive embeds a copyright or identifying string into the
 compiled object file. The string is included in the final executable or shared
 library and loaded into memory at program runtime. The directive is ignored on
@@ -6831,7 +6831,7 @@ non-AIX targets.
 
    #pragma comment(copyright, "string-literal")
 
-The second argument is an ordinary string literal. Concatenated ordinary string 
+The second argument is an ordinary string literal. Concatenated ordinary string
 literals are also accepted. The directive is intended to appear at file scope;
 Clang treats it as being at file scope when it appears within other scopes.
 

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -6842,6 +6842,38 @@ When ``#pragma comment(copyright, ...)`` appears in a C++20 module interface
 unit, the copyright string is embedded only in the object file compiled from
 that interface unit. Importing TUs do not re-emit the string.
 
+LTO Interaction
+-------------------------------
+
+**Full LTO**
+
+During Full LTO all translation units are merged into a single module
+before optimization. ``LowerCommentStringPass`` runs at prelink per
+translation unit, creating ``@__loadtime_comment_str`` and attaching
+``!implicit.ref`` to all defined functions. After merging, both string
+globals survive as ``@__loadtime_comment_str`` and
+``@__loadtime_comment_str.2``. The linker sees ``.ref`` directives from
+all live function csects and retains both copyright strings. Functions
+are inlined normally.
+
+**ThinLTO**
+
+During ThinLTO each module is compiled independently. Because
+``@__loadtime_comment_str`` is an ``internal`` global referenced via
+``!implicit.ref`` metadata, ThinLTO marks functions carrying
+``!implicit.ref`` as ``notEligibleToImport``. This means such functions
+are not inlined across module boundaries by ThinLTO. Both copyright
+strings still appear in the final binary -- each translation unit's
+string is anchored by the ``.ref`` directive emitted from its own
+function csects, and the cross-module call from the importing module
+forces the linker to include the exporting object, which carries the
+``.ref`` and the copyright string.
+
+This is an expected behavior. A function that depends on a translation-unit
+local ``internal`` global cannot be imported into another module without
+bringing that global along, which ThinLTO cannot do for ``internal``
+globals.
+
 Evaluating Object Size
 ======================
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1360,6 +1360,10 @@ def err_pragma_comment_unknown_kind : Error<"unknown kind of pragma comment">;
 // PS4 recognizes only #pragma comment(lib)
 def warn_pragma_comment_ignored : Warning<"'#pragma comment %0' ignored">,
   InGroup<IgnoredPragmas>;
+def warn_pragma_comment_once
+    : Warning<"'#pragma comment %0' "
+              "ignored: it can be specified only once per translation unit">,
+      InGroup<IgnoredPragmas>;
 // - #pragma detect_mismatch
 def err_pragma_detect_mismatch_malformed : Error<
   "pragma detect_mismatch is malformed; it requires two comma-separated "

--- a/clang/include/clang/Basic/PragmaKinds.h
+++ b/clang/include/clang/Basic/PragmaKinds.h
@@ -17,7 +17,8 @@ enum PragmaMSCommentKind {
   PCK_Lib,      // #pragma comment(lib, ...)
   PCK_Compiler, // #pragma comment(compiler, ...)
   PCK_ExeStr,   // #pragma comment(exestr, ...)
-  PCK_User      // #pragma comment(user, ...)
+  PCK_User,     // #pragma comment(user, ...)
+  PCK_Copyright // #pragma comment(copyright, ...)
 };
 
 enum PragmaMSStructKind {

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -2605,6 +2605,9 @@ void TextNodeDumper::VisitPragmaCommentDecl(const PragmaCommentDecl *D) {
   case PCK_User:
     OS << "user";
     break;
+  case PCK_Copyright:
+    OS << "copyright";
+    break;
   }
   StringRef Arg = D->getArg();
   if (!Arg.empty())

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1736,6 +1736,8 @@ void CodeGenModule::Release() {
 
   EmitBackendOptionsMetadata(getCodeGenOpts());
 
+  EmitLoadTimeComment();
+
   // If there is device offloading code embed it in the host now.
   EmbedObject(&getModule(), CodeGenOpts, *getFileSystem(), getDiags());
 
@@ -3679,6 +3681,41 @@ void CodeGenModule::AddDependentLib(StringRef Lib) {
   LinkerOptionsMetadata.push_back(llvm::MDNode::get(C, MDOpts));
 }
 
+/// Process copyright pragma and create LLVM metadata.
+/// #pragma comment(copyright, "string") embeds copyright information into the
+/// .text section of the object file as read-only data. The string is
+/// loaded into memory when the program runs and survives into the final
+/// executable or shared library.
+///
+/// Example: #pragma comment(copyright, "Copyright string")
+///
+/// Only one copyright pragma is allowed per translation unit. Subsequent
+/// pragmas in the same TU are ignored with a warning at the parse level.
+void CodeGenModule::ProcessPragmaCommentCopyright(StringRef Comment,
+                                                  bool isFromASTFile) {
+  assert(getTriple().isOSAIX() &&
+         "pragma comment copyright is supported only when targeting AIX");
+
+  // Interaction with C++20 Modules and PCH:
+  // When a module interface unit containing a copyright pragma is imported,
+  // Clang deserializes the PragmaCommentDecl from the precompiled module file
+  // (.pcm) into the importing TU's AST. isFromASTFile() returns true for such
+  // deserialized declarations. We skip those to ensure only the module
+  // interface TU that originally parsed the pragma emits the copyright metadata
+  // -- not every TU that imports it. This prevents duplicate copyright strings
+  // in the final binary.
+  if (isFromASTFile)
+    return;
+
+  assert(!LoadTimeComment &&
+         "Only one copyright pragma allowed per translation unit.");
+
+  // Create LLVM metadata with the comment string.
+  auto &C = getLLVMContext();
+  llvm::Metadata *Ops[] = {llvm::MDString::get(C, Comment)};
+  LoadTimeComment = llvm::MDNode::get(C, Ops);
+}
+
 /// Add link options implied by the given module, including modules
 /// it depends on, using a postorder walk.
 static void addLinkOptionsPostorder(CodeGenModule &CGM, Module *Mod,
@@ -4197,6 +4234,18 @@ bool CodeGenModule::MustBeEmitted(const ValueDecl *Global) {
     return true;
 
   return getContext().DeclMustBeEmitted(Global);
+}
+
+void CodeGenModule::EmitLoadTimeComment() {
+  // Emit copyright metadata for #pragma comment(copyright, ...).
+  // The LoadTimeComment is set during pragma processing and contains the
+  // copyright string that will be embedded in the .text section of the
+  // XCOFF object file and loaded into memory when the program runs.
+
+  if (LoadTimeComment) {
+    auto *NMD = getModule().getOrInsertNamedMetadata("comment_string.loadtime");
+    NMD->addOperand(LoadTimeComment);
+  }
 }
 
 bool CodeGenModule::MayBeEmittedEagerly(const ValueDecl *Global) {
@@ -7952,6 +8001,9 @@ void CodeGenModule::EmitTopLevelDecl(Decl *D) {
       break;
     case PCK_Lib:
         AddDependentLib(PCD->getArg());
+      break;
+    case PCK_Copyright:
+      ProcessPragmaCommentCopyright(PCD->getArg(), PCD->isFromASTFile());
       break;
     case PCK_Compiler:
     case PCK_ExeStr:

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3682,12 +3682,6 @@ void CodeGenModule::AddDependentLib(StringRef Lib) {
 }
 
 /// Process copyright pragma and create LLVM metadata.
-/// #pragma comment(copyright, "string") embeds copyright information into the
-/// .text section of the object file as read-only data. The string is
-/// loaded into memory when the program runs and survives into the final
-/// executable or shared library.
-///
-/// Example: #pragma comment(copyright, "Copyright string")
 ///
 /// Only one copyright pragma is allowed per translation unit. Subsequent
 /// pragmas in the same TU are ignored with a warning at the parse level.
@@ -4237,11 +4231,6 @@ bool CodeGenModule::MustBeEmitted(const ValueDecl *Global) {
 }
 
 void CodeGenModule::EmitLoadTimeComment() {
-  // Emit copyright metadata for #pragma comment(copyright, ...).
-  // The LoadTimeComment is set during pragma processing and contains the
-  // copyright string that will be embedded in the .text section of the
-  // XCOFF object file and loaded into memory when the program runs.
-
   if (LoadTimeComment) {
     auto *NMD = getModule().getOrInsertNamedMetadata("comment_string.loadtime");
     NMD->addOperand(LoadTimeComment);

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1544,7 +1544,7 @@ public:
   /// Appends a dependent lib to the appropriate metadata value.
   void AddDependentLib(StringRef Lib);
 
-  /// Process Pragma Comment Copyright.
+  /// Process #pragma comment(copyright, ...).
   void ProcessPragmaCommentCopyright(StringRef Comment, bool isFromASTFile);
 
   llvm::GlobalVariable::LinkageTypes getFunctionLinkage(GlobalDecl GD);
@@ -2139,11 +2139,8 @@ private:
   /// false, the definition can be emitted lazily if it's used.
   bool MustBeEmitted(const ValueDecl *D);
 
-  /// Emit load-time comment metadata for #pragma comment(copyright, ...).
-  /// This adds the copyright string to the module's named metadata, which will
-  /// be processed by the IR passes to embed it in the .text section
-  /// of the generated object file, where it will be loaded into memory at
-  /// program runtime.
+  /// Emit the load-time comment metadata (e.g., from
+  /// #pragma comment(copyright, ...)) for the translation unit.
   void EmitLoadTimeComment();
 
   /// Determine whether the definition can be emitted eagerly, or should be

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -1544,9 +1544,6 @@ public:
   /// Appends a dependent lib to the appropriate metadata value.
   void AddDependentLib(StringRef Lib);
 
-  /// Process #pragma comment(copyright, ...).
-  void ProcessPragmaCommentCopyright(StringRef Comment, bool isFromASTFile);
-
   llvm::GlobalVariable::LinkageTypes getFunctionLinkage(GlobalDecl GD);
 
   void setFunctionLinkage(GlobalDecl GD, llvm::Function *F) {
@@ -1955,6 +1952,9 @@ private:
   ABIArgInfo convertABIArgInfo(const llvm::abi::ArgInfo &AbiInfo,
                                QualType Type);
 
+  /// Process #pragma comment(copyright, ...).
+  void ProcessPragmaCommentCopyright(StringRef Comment, bool isFromASTFile);
+
   bool shouldDropDLLAttribute(const Decl *D, const llvm::GlobalValue *GV) const;
 
   llvm::Constant *GetOrCreateLLVMFunction(
@@ -2139,10 +2139,6 @@ private:
   /// false, the definition can be emitted lazily if it's used.
   bool MustBeEmitted(const ValueDecl *D);
 
-  /// Emit the load-time comment metadata (e.g., from
-  /// #pragma comment(copyright, ...)) for the translation unit.
-  void EmitLoadTimeComment();
-
   /// Determine whether the definition can be emitted eagerly, or should be
   /// delayed until the end of the translation unit. This is relevant for
   /// definitions whose linkage can change, e.g. implicit function instantions
@@ -2172,6 +2168,10 @@ private:
   /// Emit deactivation symbols for any PFP fields whose offset is taken with
   /// offsetof.
   void emitPFPFieldsWithEvaluatedOffset();
+
+  /// Emit the load-time comment metadata (e.g., from
+  /// #pragma comment(copyright, ...)) for the translation unit.
+  void EmitLoadTimeComment();
 };
 
 }  // end namespace CodeGen

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -619,6 +619,9 @@ private:
   /// A vector of metadata strings for dependent libraries for ELF.
   SmallVector<llvm::MDNode *, 16> ELFDependentLibraries;
 
+  /// Metadata for copyright pragma comment (if present).
+  llvm::MDNode *LoadTimeComment = nullptr;
+
   /// @name Cache for Objective-C runtime types
   /// @{
 
@@ -1541,6 +1544,8 @@ public:
   /// Appends a dependent lib to the appropriate metadata value.
   void AddDependentLib(StringRef Lib);
 
+  /// Process Pragma Comment Copyright.
+  void ProcessPragmaCommentCopyright(StringRef Comment, bool isFromASTFile);
 
   llvm::GlobalVariable::LinkageTypes getFunctionLinkage(GlobalDecl GD);
 
@@ -2133,6 +2138,13 @@ private:
   /// Determine whether the definition must be emitted; if this returns \c
   /// false, the definition can be emitted lazily if it's used.
   bool MustBeEmitted(const ValueDecl *D);
+
+  /// Emit load-time comment metadata for #pragma comment(copyright, ...).
+  /// This adds the copyright string to the module's named metadata, which will
+  /// be processed by the IR passes to embed it in the .text section
+  /// of the generated object file, where it will be loaded into memory at
+  /// program runtime.
+  void EmitLoadTimeComment();
 
   /// Determine whether the definition can be emitted eagerly, or should be
   /// delayed until the end of the translation unit. This is relevant for

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -3311,10 +3311,9 @@ void PragmaCommentHandler::HandlePragma(Preprocessor &PP,
     return;
   }
 
-  // Handle AIX Target restrictions (i.e., warn on all non-copyright kinds).
   if (PP.getTargetInfo().getTriple().isOSAIX() && Kind != PCK_Copyright) {
-    // pragma comment kinds linker, lib, compiler, exestr and user are
-    // ignored when targeting AIX.
+    // Currently, pragma comment kinds aside from "copyright" are not fully
+    // implemented by Clang for AIX targets.
     PP.Diag(Tok.getLocation(), diag::warn_pragma_comment_ignored)
         << II->getName();
     return;

--- a/clang/lib/Parse/ParsePragma.cpp
+++ b/clang/lib/Parse/ParsePragma.cpp
@@ -237,6 +237,7 @@ struct PragmaCommentHandler : public PragmaHandler {
 
 private:
   Sema &Actions;
+  bool SeenCopyrightInTU = false; // TU-scoped
 };
 
 struct PragmaDetectMismatchHandler : public PragmaHandler {
@@ -480,7 +481,8 @@ void Parser::initializePragmaHandlers() {
   PP.AddPragmaHandler(OpenACCHandler.get());
 
   if (getLangOpts().MicrosoftExt ||
-      getTargetInfo().getTriple().isOSBinFormatELF()) {
+      getTargetInfo().getTriple().isOSBinFormatELF() ||
+      getTargetInfo().getTriple().isOSAIX()) {
     MSCommentHandler = std::make_unique<PragmaCommentHandler>(Actions);
     PP.AddPragmaHandler(MSCommentHandler.get());
   }
@@ -607,7 +609,8 @@ void Parser::resetPragmaHandlers() {
   OpenACCHandler.reset();
 
   if (getLangOpts().MicrosoftExt ||
-      getTargetInfo().getTriple().isOSBinFormatELF()) {
+      getTargetInfo().getTriple().isOSBinFormatELF() ||
+      getTargetInfo().getTriple().isOSAIX()) {
     PP.RemovePragmaHandler(MSCommentHandler.get());
     MSCommentHandler.reset();
   }
@@ -3269,7 +3272,9 @@ void PragmaDetectMismatchHandler::HandlePragma(Preprocessor &PP,
 /// \code
 ///   #pragma comment(linker, "foo")
 /// \endcode
-/// 'linker' is one of five identifiers: compiler, exestr, lib, linker, user.
+/// 'linker' is one of six identifiers: compiler, copyright, exestr, lib,
+/// linker, user.
+///
 /// "foo" is a string, which is fully macro expanded, and permits string
 /// concatenation, embedded escape characters etc.  See MSDN for more details.
 void PragmaCommentHandler::HandlePragma(Preprocessor &PP,
@@ -3289,18 +3294,29 @@ void PragmaCommentHandler::HandlePragma(Preprocessor &PP,
     return;
   }
 
-  // Verify that this is one of the 5 explicitly listed options.
+  // Verify that this is one of the 6 explicitly listed options.
   IdentifierInfo *II = Tok.getIdentifierInfo();
   PragmaMSCommentKind Kind =
-    llvm::StringSwitch<PragmaMSCommentKind>(II->getName())
-    .Case("linker",   PCK_Linker)
-    .Case("lib",      PCK_Lib)
-    .Case("compiler", PCK_Compiler)
-    .Case("exestr",   PCK_ExeStr)
-    .Case("user",     PCK_User)
-    .Default(PCK_Unknown);
+      llvm::StringSwitch<PragmaMSCommentKind>(II->getName())
+          .Case("linker", PCK_Linker)
+          .Case("lib", PCK_Lib)
+          .Case("compiler", PCK_Compiler)
+          .Case("exestr", PCK_ExeStr)
+          .Case("user", PCK_User)
+          .Case("copyright", PCK_Copyright)
+          .Default(PCK_Unknown);
+
   if (Kind == PCK_Unknown) {
     PP.Diag(Tok.getLocation(), diag::err_pragma_comment_unknown_kind);
+    return;
+  }
+
+  // Handle AIX Target restrictions (i.e., warn on all non-copyright kinds).
+  if (PP.getTargetInfo().getTriple().isOSAIX() && Kind != PCK_Copyright) {
+    // pragma comment kinds linker, lib, compiler, exestr and user are
+    // ignored when targeting AIX.
+    PP.Diag(Tok.getLocation(), diag::warn_pragma_comment_ignored)
+        << II->getName();
     return;
   }
 
@@ -3308,6 +3324,17 @@ void PragmaCommentHandler::HandlePragma(Preprocessor &PP,
     PP.Diag(Tok.getLocation(), diag::warn_pragma_comment_ignored)
         << II->getName();
     return;
+  }
+
+  // Handle pragma comment copyright kind.
+  if (Kind == PCK_Copyright) {
+    if (SeenCopyrightInTU) {
+      // pragma comment copyright can each appear only once in a TU.
+      PP.Diag(Tok.getLocation(), diag::warn_pragma_comment_once)
+          << II->getName();
+      return;
+    }
+    SeenCopyrightInTU = true;
   }
 
   // Read the optional string if present.
@@ -3335,6 +3362,10 @@ void PragmaCommentHandler::HandlePragma(Preprocessor &PP,
     PP.Diag(Tok.getLocation(), diag::err_pragma_comment_malformed);
     return;
   }
+
+  // Skip further processing for well-formed copyright with an empty string.
+  if (Kind == PCK_Copyright && ArgumentString.empty())
+    return;
 
   // If the pragma is lexically sound, notify any interested PPCallbacks.
   if (PP.getPPCallbacks())

--- a/clang/test/CodeGen/PowerPC/pragma-comment-copyright-modules.cpp
+++ b/clang/test/CodeGen/PowerPC/pragma-comment-copyright-modules.cpp
@@ -1,0 +1,30 @@
+// RUN: split-file %s %t
+
+// Build the module interface to a PCM
+// RUN: %clang_cc1 -std=c++20 -triple powerpc-ibm-aix \
+// RUN:   -emit-module-interface %t/copymod.cppm -o %t/copymod.pcm
+
+// Verify that module interface emits copyright global when compiled to IR
+
+// RUN: %clang_cc1 -std=c++20 -triple powerpc-ibm-aix -emit-llvm %t/copymod.cppm -o - \
+// RUN:   | FileCheck %s --check-prefix=CHECK-MOD
+// CHECK-MOD: @__loadtime_comment_str = internal unnamed_addr constant [10 x i8] c"module me\00", section "__loadtime_comment"
+// CHECK-MOD: @llvm.compiler.used = appending global {{.*}} @__loadtime_comment_str
+
+// Compile an importing TU that uses the prebuilt module and verify that it
+// does NOT re-emit the module's copyright global.
+
+// RUN: %clang_cc1 -std=c++20 -triple powerpc-ibm-aix \
+// RUN:   -fprebuilt-module-path=%t -emit-llvm %t/importmod.cc -o - \
+// RUN:   | FileCheck %s --check-prefix=CHECK-IMPORT
+// CHECK-IMPORT-NOT: @__loadtime_comment_str
+// CHECK-IMPORT-NOT: c"module me\00"
+
+//--- copymod.cppm
+export module copymod;
+#pragma comment(copyright, "module me")
+export inline void f [[gnu::always_inline]]() {}
+
+//--- importmod.cc
+import copymod;
+void g() { f(); }

--- a/clang/test/CodeGen/PowerPC/pragma-comment.c
+++ b/clang/test/CodeGen/PowerPC/pragma-comment.c
@@ -1,0 +1,22 @@
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 %t/pragma-copyright.c -triple powerpc-ibm-aix   -emit-llvm -disable-llvm-passes -o - | FileCheck %s  --check-prefix=CHECK-COPYRIGHT
+// RUN: %clang_cc1 %t/pragma-copyright.c -triple powerpc64-ibm-aix -emit-llvm -disable-llvm-passes -o - | FileCheck %s  --check-prefix=CHECK-COPYRIGHT
+
+// RUN: %clang_cc1 %t/operator-pragma-copyright.c -triple powerpc-ibm-aix   -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefix=CHECK-OPERATOR
+// RUN: %clang_cc1 %t/operator-pragma-copyright.c -triple powerpc64-ibm-aix -emit-llvm -disable-llvm-passes -o - | FileCheck %s --check-prefix=CHECK-OPERATOR
+
+//--- pragma-copyright.c
+#pragma comment(copyright, "@(#) Hello, " " world\n\t\"quoted\"")
+
+int main() { return 0; }
+
+// CHECK-COPYRIGHT: !comment_string.loadtime = !{![[COPYRIGHT:[0-9]+]]}
+// CHECK-COPYRIGHT: ![[COPYRIGHT]] = !{!"@(#) Hello, world\0A\09\22quoted\22"}
+
+//--- operator-pragma-copyright.c
+_Pragma("comment(copyright, \"IBM Copyright Pragma Operator\")")
+void foo() {}
+
+// CHECK-OPERATOR: !comment_string.loadtime = !{![[COPYRIGHT:[0-9]+]]}
+// CHECK-OPERATOR: ![[COPYRIGHT]] = !{!"IBM Copyright Pragma Operator"}

--- a/clang/test/CodeGen/lto-newpm-pipeline.c
+++ b/clang/test/CodeGen/lto-newpm-pipeline.c
@@ -36,6 +36,7 @@
 // CHECK-FULL-O0-NEXT: Running pass: NameAnonGlobalPass
 // CHECK-FULL-O0-NEXT: Running pass: AnnotationRemarksPass
 // CHECK-FULL-O0-NEXT: Running analysis: TargetLibraryAnalysis
+// CHECK-FULL-O0-NEXT: Running pass: LowerCommentStringPass
 // CHECK-FULL-O0-NEXT: Running pass: VerifierPass
 // CHECK-FULL-O0-NEXT: Running pass: BitcodeWriterPass
 
@@ -50,6 +51,7 @@
 // CHECK-THIN-O0-NEXT: Running pass: NameAnonGlobalPass
 // CHECK-THIN-O0-NEXT: Running pass: AnnotationRemarksPass
 // CHECK-THIN-O0-NEXT: Running analysis: TargetLibraryAnalysis
+// CHECK-THIN-O0-NEXT: Running pass: LowerCommentStringPass
 // CHECK-THIN-O0-NEXT: Running pass: VerifierPass
 // CHECK-THIN-O0-NEXT: Running pass: ThinLTOBitcodeWriterPass
 

--- a/clang/test/Preprocessor/pragma-comment.c
+++ b/clang/test/Preprocessor/pragma-comment.c
@@ -1,0 +1,92 @@
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -fsyntax-only -verify %t/unsupported.c
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fsyntax-only -verify %t/unsupported.c
+// RUN: %clang_cc1 -triple systemz -fsyntax-only -verify %t/unsupported.c
+// RUN: %clang_cc1 -triple powerpc64-linux-gnu -fsyntax-only -verify %t/unsupported.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/copyright.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/copyright.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/empty-copyright.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/empty-copyright.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/other-kinds.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/other-kinds.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/duplicate.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/duplicate.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/raw-string-literal.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/raw-string-literal.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/concat-escape.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/concat-escape.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/u8-literal.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/u8-literal.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/wide-literal.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/wide-literal.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/utf16-literal.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/utf16-literal.c
+
+// RUN: %clang_cc1 -triple powerpc-ibm-aix   -fsyntax-only -verify %t/utf32-literal.c
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix -fsyntax-only -verify %t/utf32-literal.c
+
+//--- unsupported.c
+// pragma comment kinds not supported on this target.
+#pragma comment(copyright, "copyright")            // expected-warning {{'#pragma comment copyright' ignored}}
+#pragma comment(compiler)                          // expected-warning {{'#pragma comment compiler' ignored}}
+#pragma comment(exestr, "foo")                     // expected-warning {{'#pragma comment exestr' ignored}}
+#pragma comment(user, "foo\abar\nbaz\tsomething")  // expected-warning {{'#pragma comment user' ignored}}
+#pragma comment(timestamp)                         // expected-error {{unknown kind of pragma comment}}
+#pragma comment(date)                              // expected-error {{unknown kind of pragma comment}}
+
+//--- copyright.c
+// Copyright pragma is accepted without diagnostics.
+#pragma comment(copyright, "copyright") // expected-no-diagnostics
+
+//--- empty-copyright.c
+// An empty copyright string is accepted without diagnostics.
+#pragma comment(copyright, "") // expected-no-diagnostics
+
+//--- other-kinds.c
+// Non-copyright comment kinds produce warnings/errors.
+#pragma comment(lib, "m")                          // expected-warning {{'#pragma comment lib' ignored}}
+#pragma comment(linker, "foo")                     // expected-warning {{'#pragma comment linker' ignored}}
+#pragma comment(compiler)                          // expected-warning {{'#pragma comment compiler' ignored}}
+#pragma comment(exestr, "foo")                     // expected-warning {{'#pragma comment exestr' ignored}}
+#pragma comment(user, "foo\abar\nbaz\tsomething")  // expected-warning {{'#pragma comment user' ignored}}
+#pragma comment(timestamp)                         // expected-error {{unknown kind of pragma comment}}
+#pragma comment(date)                              // expected-error {{unknown kind of pragma comment}}
+
+//--- duplicate.c
+// A second copyright pragma in the same translation unit warns.
+#pragma comment(copyright, "@(#) Copyright")
+#pragma comment(copyright, "Duplicate Copyright") // expected-warning {{'#pragma comment copyright' ignored: it can be specified only once per translation unit}}
+
+//--- raw-string-literal.c
+// Raw string literals are accepted
+#pragma comment(copyright, R"foo(printf("Hello (world)");)foo")  // expected-no-diagnostics
+
+//--- concat-escape.c
+// Concatenated ordinary string literals and escapes are accepted
+#pragma comment(copyright, "@(#) Hello, " "world\n\t\"@(#) quoted\"") // expected-no-diagnostics
+
+//--- u8-literal.c
+// UTF-8-prefixed string literals are rejected.
+#pragma comment(copyright, u8"@(#) Hello unicode") // expected-error {{expected string literal in pragma comment}}
+
+//--- wide-literal.c
+// Wide string literals are rejected.
+#pragma comment(copyright, L"@(#) Hello wide") // expected-error {{expected string literal in pragma comment}}
+
+//--- utf16-literal.c
+// UTF-16-prefixed string literals are rejected.
+#pragma comment(copyright, u"@(#) Hello utf16") // expected-error {{expected string literal in pragma comment}}
+
+//--- utf32-literal.c
+// UTF-32-prefixed string literals are rejected.
+#pragma comment(copyright, U"@(#) Hello utf32") // expected-error {{expected string literal in pragma comment}}

--- a/clang/test/Preprocessor/pragma-comment.c
+++ b/clang/test/Preprocessor/pragma-comment.c
@@ -68,11 +68,11 @@
 #pragma comment(copyright, "Duplicate Copyright") // expected-warning {{'#pragma comment copyright' ignored: it can be specified only once per translation unit}}
 
 //--- raw-string-literal.c
-// Raw string literals are accepted
+// Raw string literals are accepted.
 #pragma comment(copyright, R"foo(printf("Hello (world)");)foo")  // expected-no-diagnostics
 
 //--- concat-escape.c
-// Concatenated ordinary string literals and escapes are accepted
+// Concatenated ordinary string literals and escapes are accepted.
 #pragma comment(copyright, "@(#) Hello, " "world\n\t\"@(#) quoted\"") // expected-no-diagnostics
 
 //--- u8-literal.c

--- a/llvm/include/llvm/Transforms/Utils/LowerCommentStringPass.h
+++ b/llvm/include/llvm/Transforms/Utils/LowerCommentStringPass.h
@@ -1,0 +1,24 @@
+//===-- LowerCommentStringPass.h - Lower Comment string metadata        --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_UTILS_LOWERCOMMENTSTRINGPASS_H
+#define LLVM_TRANSFORMS_UTILS_LOWERCOMMENTSTRINGPASS_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+class LowerCommentStringPass : public PassInfoMixin<LowerCommentStringPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+
+  static bool isRequired() { return true; }
+};
+
+} // namespace llvm
+
+#endif // LLVM_TRANSFORMS_UTILS_LOWERCOMMENTSTRINGPASS_H

--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -40,6 +40,7 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
@@ -175,6 +176,27 @@ findRefEdges(ModuleSummaryIndex &Index, const User *CurUser,
                                                  V.Value));
   }
   return HasBlockAddress;
+}
+
+/// Collect globals referenced via !implicit.ref metadata on a function
+/// and add them as reference edges in the module summary. This ensures
+/// ThinLTO liveness analysis treats them as live when the function is
+/// live, and imports them alongside the function during cross-module
+/// importing.
+static void findImplicitRefEdges(
+    ModuleSummaryIndex &Index, const Function &F,
+    SetVector<ValueInfo, SmallVector<ValueInfo, 0>> &RefEdges) {
+  if (!F.hasMetadata(LLVMContext::MD_implicit_ref))
+    return;
+  SmallVector<MDNode *, 4> MDs;
+  F.getMetadata(LLVMContext::MD_implicit_ref, MDs);
+  for (MDNode *MD : MDs) {
+    for (const MDOperand &Op : MD->operands()) {
+      if (auto *VAM = dyn_cast_or_null<ValueAsMetadata>(Op.get()))
+        if (auto *GV = dyn_cast<GlobalValue>(VAM->getValue()))
+          RefEdges.insert(Index.getOrInsertValueInfo(GV));
+    }
+  }
 }
 
 static CalleeInfo::HotnessType getHotness(uint64_t ProfileCount,
@@ -346,6 +368,8 @@ static void computeFunctionSummary(
   // list.
   bool HasLocalIFuncCallOrRef = false;
   findRefEdges(Index, &F, RefEdges, Visited, HasLocalIFuncCallOrRef);
+  findImplicitRefEdges(Index, F, RefEdges);
+
   std::vector<const Instruction *> NonVolatileLoads;
   std::vector<const Instruction *> NonVolatileStores;
 

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -369,6 +369,7 @@
 #include "llvm/Transforms/Utils/LibCallsShrinkWrap.h"
 #include "llvm/Transforms/Utils/LoopSimplify.h"
 #include "llvm/Transforms/Utils/LoopVersioning.h"
+#include "llvm/Transforms/Utils/LowerCommentStringPass.h"
 #include "llvm/Transforms/Utils/LowerGlobalDtors.h"
 #include "llvm/Transforms/Utils/LowerIFunc.h"
 #include "llvm/Transforms/Utils/LowerInvoke.h"

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -145,6 +145,7 @@
 #include "llvm/Transforms/Utils/ExtraPassManager.h"
 #include "llvm/Transforms/Utils/InjectTLIMappings.h"
 #include "llvm/Transforms/Utils/LibCallsShrinkWrap.h"
+#include "llvm/Transforms/Utils/LowerCommentStringPass.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 #include "llvm/Transforms/Utils/MoveAutoInit.h"
 #include "llvm/Transforms/Utils/NameAnonGlobals.h"
@@ -1729,6 +1730,13 @@ PassBuilder::buildModuleOptimizationPipeline(OptimizationLevel Level,
           InlineContext{ThinOrFullLTOPhase::None, InlinePass::CGSCCInliner}));
     }
   }
+
+  // Lower !comment_string.loadtime metadata to a concrete TU-local string
+  // global and attach !implicit.ref to all defined functions. Running late
+  // ensures compiler-generated functions (e.g. from inlining, coroutines)
+  // are also anchored to the copyright string via .ref directives.
+  MPM.addPass(LowerCommentStringPass());
+
   return MPM;
 }
 
@@ -1896,6 +1904,12 @@ PassBuilder::buildThinLTOPreLinkDefaultPipeline(OptimizationLevel Level) {
   addAnnotationRemarksPass(MPM);
 
   addRequiredLTOPreLinkPasses(MPM);
+
+  // Lower !comment_string.loadtime metadata. Must run at the end of prelink
+  // so all compiler-generated functions are present before !implicit.ref
+  // is attached. !implicit.ref metadata will travel with any function
+  // imported by ThinLTO postlink.
+  MPM.addPass(LowerCommentStringPass());
 
   instructionCountersPass(MPM, /* IsPreOptimization */ false);
 
@@ -2480,6 +2494,11 @@ PassBuilder::buildO0DefaultPipeline(OptimizationLevel Level,
 
   // Emit annotation remarks.
   addAnnotationRemarksPass(MPM);
+
+  // Lower !comment_string.loadtime metadata to a concrete TU-local string
+  // global. Running at the end of the O0 pipeline ensures all functions
+  // including AlwaysInliner-generated ones are captured.
+  MPM.addPass(LowerCommentStringPass());
 
   instructionCountersPass(MPM, /* IsPreOptimization */ false);
 

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -62,6 +62,7 @@ MODULE_PASS("check-debugify", NewPMCheckDebugifyPass())
 MODULE_PASS("constmerge", ConstantMergePass())
 MODULE_PASS("coro-cleanup", CoroCleanupPass())
 MODULE_PASS("coro-early", CoroEarlyPass())
+MODULE_PASS("lower-comment-string", LowerCommentStringPass())
 MODULE_PASS("cross-dso-cfi", CrossDSOCFIPass())
 MODULE_PASS("ctx-instr-gen",
             PGOInstrumentationGen(PGOInstrumentationType::CTXPROF))

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -54,6 +54,7 @@ add_llvm_component_library(LLVMTransformUtils
   LoopUtils.cpp
   LoopVersioning.cpp
   LowerAtomic.cpp
+  LowerCommentStringPass.cpp
   LowerGlobalDtors.cpp
   LowerIFunc.cpp
   LowerInvoke.cpp

--- a/llvm/lib/Transforms/Utils/LowerCommentStringPass.cpp
+++ b/llvm/lib/Transforms/Utils/LowerCommentStringPass.cpp
@@ -106,7 +106,7 @@ PreservedAnalyses LowerCommentStringPass::run(Module &M,
   // 1. Create a single null-terminated string global.
   Constant *StrInit = ConstantDataArray::getString(Ctx, Text, /*AddNull=*/true);
 
-  // Global variable should be Internal, constant, TU-local.
+  // The global variable should be internal, constant, and TU-local.
   // This avoids duplicate symbol issues across TUs.
   auto *StrGV = new GlobalVariable(M, StrInit->getType(),
                                    /*isConstant=*/true,

--- a/llvm/lib/Transforms/Utils/LowerCommentStringPass.cpp
+++ b/llvm/lib/Transforms/Utils/LowerCommentStringPass.cpp
@@ -1,0 +1,150 @@
+//===-- LowerCommentStringPass.cpp - Lower Comment string metadata -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// This pass lowers the module-level comment string metadata emitted by Clang:
+//
+//     !comment_string.loadtime = !{!"Copyright ..."}
+//
+// into concrete, translation-unit-local globals.
+// This Pass is enabled only for AIX.
+// For each module (translation unit), the pass performs the following:
+//
+//   1. Creates a null-terminated, internal constant string global
+//      (`__loadtime_comment_str`) containing the copyright text with
+//      section attribute "__loadtime_comment". The backend places this
+//      in the .text section of the object file.
+//
+//   2. Marks the string in `llvm.compiler.used` so it cannot be dropped by
+//      optimization or LTO.
+//
+//   3. Attaches `!implicit.ref` metadata referencing the string to every
+//      defined function in the module. The PowerPC AIX backend recognizes
+//      this metadata and emits a `.ref` directive from the function to the
+//      string, creating a concrete relocation that prevents the linker from
+//      discarding the string (as long as the referencing symbol is kept).
+//
+//  Input IR:
+//     !comment_string.loadtime = !{!"Copyright"}
+//  Output IR:
+//     @__loadtime_comment_str = internal constant [N x i8] c"Copyright\00",
+//                          section "__loadtime_comment"
+//     @llvm.compiler.used = appending global [1 x ptr] [ptr
+//     @__loadtime_comment_str]
+//
+//     define i32 @func() !implicit.ref !5 { ... }
+//     !5 = !{ptr @__loadtime_comment_str}
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Utils/LowerCommentStringPass.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/MDBuilder.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/TargetParser/Triple.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+
+#define DEBUG_TYPE "lower-comment-string"
+
+using namespace llvm;
+
+static cl::opt<bool>
+    DisableCopyrightMetadata("disable-lower-comment-string", cl::ReallyHidden,
+                             cl::desc("Disable LowerCommentString pass."),
+                             cl::init(false));
+
+static bool isSupportedTarget(const Module &M) {
+  Triple T{M.getTargetTriple()};
+  return T.isOSAIX();
+}
+
+PreservedAnalyses LowerCommentStringPass::run(Module &M,
+                                              ModuleAnalysisManager &AM) {
+  if (DisableCopyrightMetadata || !isSupportedTarget(M))
+    return PreservedAnalyses::all();
+
+  LLVMContext &Ctx = M.getContext();
+
+  // Single-metadata: !comment_string.loadtime = !{!0}
+  // Each operand node is expected to have one MDString operand.
+  NamedMDNode *MD = M.getNamedMetadata("comment_string.loadtime");
+  if (!MD || MD->getNumOperands() == 0)
+    return PreservedAnalyses::all();
+
+  // At this point we are guaranteed that one TU contains a single copyright
+  // metadata entry. Create TU-local string global for that metadata entry.
+  MDNode *MdNode = MD->getOperand(0);
+  if (!MdNode || MdNode->getNumOperands() == 0)
+    return PreservedAnalyses::all();
+
+  auto *MdString = dyn_cast_or_null<MDString>(MdNode->getOperand(0));
+  if (!MdString)
+    return PreservedAnalyses::all();
+
+  StringRef Text = MdString->getString();
+  if (Text.empty())
+    return PreservedAnalyses::all();
+
+  // 1. Create a single null-terminated string global.
+  Constant *StrInit = ConstantDataArray::getString(Ctx, Text, /*AddNull=*/true);
+
+  // Global variable should be Internal, constant, TU-local.
+  // This avoids duplicate symbol issues across TUs.
+  auto *StrGV = new GlobalVariable(M, StrInit->getType(),
+                                   /*isConstant=*/true,
+                                   GlobalValue::InternalLinkage, StrInit,
+                                   /*Name=*/"__loadtime_comment_str");
+  // Set unnamed_addr to allow the linker to merge identical strings.
+  StrGV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+  StrGV->setAlignment(Align(1));
+  // Place in the "__loadtime_comment" section.
+  // The GV is constant, so we expect a read-only section.
+  StrGV->setSection("__loadtime_comment");
+
+  // 2. Add the string to llvm.compiler.used to prevent LLVM optimization/LTO
+  // passes from removing it.
+  appendToCompilerUsed(M, {StrGV});
+
+  // 3. Attach !implicit.ref metadata to every defined function.
+  // Create a metadata node pointing to the copyright string:
+  //   !N = !{ptr @__loadtime_comment_str}
+  Metadata *Ops[] = {ConstantAsMetadata::get(StrGV)};
+  MDNode *ImplicitRefMD = MDNode::get(Ctx, Ops);
+
+  auto AddImplicitRef = [&](Function &F) {
+    if (F.isDeclaration())
+      return;
+    // Attach the !implicit.ref metadata to the function.
+    F.setMetadata(LLVMContext::MD_implicit_ref, ImplicitRefMD);
+    LLVM_DEBUG(dbgs() << "[copyright] attached implicit.ref to function:  "
+                      << F.getName() << "\n");
+  };
+
+  // Process all functions in the module and add !implicit.ref to the function.
+  for (Function &F : M)
+    AddImplicitRef(F);
+
+  // Cleanup the processed metadata.
+  MD->eraseFromParent();
+  LLVM_DEBUG(dbgs() << "[copyright] created string and anchor for module\n");
+
+  return PreservedAnalyses::all();
+}

--- a/llvm/test/Analysis/ModuleSummaryAnalysis/implicit-ref-edges.ll
+++ b/llvm/test/Analysis/ModuleSummaryAnalysis/implicit-ref-edges.ll
@@ -1,0 +1,39 @@
+;; Tests that globals referenced via !implicit.ref metadata on a function
+;; are added as explicit reference edges in the module summary.
+;; This ensures ThinLTO liveness analysis marks them live when the function
+;; is live, preventing GlobalDCE from eliminating them.
+
+; RUN: opt -module-summary %s -o %t.bc
+; RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
+target triple = "powerpc-ibm-aix7.3.0.0"
+
+@counter = global i32 0, align 4
+@__loadtime_comment_str = internal unnamed_addr constant [14 x i8] c"Copyright TU1\00",
+                          section "__loadtime_comment", align 1
+@llvm.compiler.used = appending global [1 x ptr] [ptr @__loadtime_comment_str], 
+                     section "llvm.metadata"
+
+define void @f_tu1() !implicit.ref !0 {
+entry:
+  %0 = load i32, ptr @counter, align 4
+  %inc = add nsw i32 %0, 1
+  store i32 %inc, ptr @counter, align 4
+  ret void
+}
+
+!llvm.module.flags = !{!1, !2}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"EnableSplitLTOUnit", i32 0}
+!0 = !{ptr @__loadtime_comment_str}
+
+;; Verify key globals appear in the summary (order is platform-dependent
+;; since internal globals have GUIDs that include the module path).
+; CHECK-DAG: gv: (name: "__loadtime_comment_str"{{.*}}linkage: internal{{.*}}notEligibleToImport: 1
+; CHECK-DAG: gv: (name: "counter"
+
+;; f_tu1 must have exactly two ref edges -- counter (existing IR use) and
+;; __loadtime_comment_str (added by findImplicitRefEdges fix). It must also
+;; be notEligibleToImport because it references an internal global.
+; CHECK-DAG: gv: (name: "f_tu1"{{.*}}notEligibleToImport: 1{{.*}}refs: (^{{[0-9]+}}, ^{{[0-9]+}})

--- a/llvm/test/CodeGen/AArch64/print-pipeline-passes.ll
+++ b/llvm/test/CodeGen/AArch64/print-pipeline-passes.ll
@@ -2,7 +2,7 @@
 ; RUN: opt -mtriple=aarch64 -S -passes='default<O2>' -print-pipeline-passes < %s | FileCheck %s
 
 ; CHECK: loop-idiom-vectorize
-; O0: {{^}}function(ee-instrument<>),always-inline,coro-cond(coro-early,cgscc(coro-split),coro-cleanup,globaldce),alloc-token,function(annotation-remarks),verify,print{{$}}
+; O0: {{^}}function(ee-instrument<>),always-inline,coro-cond(coro-early,cgscc(coro-split),coro-cleanup,globaldce),alloc-token,function(annotation-remarks),lower-comment-string,verify,print{{$}}
 
 define void @foo() {
 entry:

--- a/llvm/test/CodeGen/Hexagon/print-pipeline-passes.ll
+++ b/llvm/test/CodeGen/Hexagon/print-pipeline-passes.ll
@@ -3,7 +3,7 @@
 
 ; CHECK: hexagon-loop-idiom
 ; CHECK: hexagon-vlcr
-; O0: {{^}}function(ee-instrument<>),always-inline,coro-cond(coro-early,cgscc(coro-split),coro-cleanup,globaldce),alloc-token,function(annotation-remarks),verify,print{{$}}
+; O0: {{^}}function(ee-instrument<>),always-inline,coro-cond(coro-early,cgscc(coro-split),coro-cleanup,globaldce),alloc-token,function(annotation-remarks),lower-comment-string,verify,print{{$}}
 
 define void @test_hexagon_passes() {
 entry:

--- a/llvm/test/LTO/PowerPC/pragma-comment-copyright-lto.ll
+++ b/llvm/test/LTO/PowerPC/pragma-comment-copyright-lto.ll
@@ -1,0 +1,67 @@
+; RUN: rm -rf %t && mkdir %t
+; RUN: split-file %s %t
+; RUN: llvm-as %t/tu1.ll -o %t/tu1.bc
+; RUN: llvm-as %t/tu2.ll -o %t/tu2.bc
+; RUN: llvm-lto -filetype=asm \
+; RUN:   -exported-symbol=main \
+; RUN:   -exported-symbol=f_tu1 \
+; RUN:   %t/tu1.bc %t/tu2.bc \
+; RUN:   -o %t/out.s 
+; RUN: FileCheck %s < %t/out.s
+
+
+;--- tu1.ll
+;; TU1: already lowered by LowerCommentStringPass at prelink
+target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
+target triple = "powerpc-ibm-aix7.3.0.0"
+
+@__loadtime_comment_str = internal unnamed_addr constant
+    [14 x i8] c"Copyright TU1\00",
+    section "__loadtime_comment", align 1
+@llvm.compiler.used = appending global [1 x ptr]
+    [ptr @__loadtime_comment_str], section "llvm.metadata"
+
+define void @f_tu1() !implicit.ref !0 {
+entry:
+  ret void
+}
+
+!0 = !{ptr @__loadtime_comment_str}
+
+;--- tu2.ll
+;; TU2: already lowered by LowerCommentStringPass at prelink
+target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
+target triple = "powerpc-ibm-aix7.3.0.0"
+
+@__loadtime_comment_str = internal unnamed_addr constant
+    [14 x i8] c"Copyright TU2\00",
+    section "__loadtime_comment", align 1
+@llvm.compiler.used = appending global [1 x ptr]
+    [ptr @__loadtime_comment_str], section "llvm.metadata"
+
+declare void @f_tu1()
+
+define i32 @main() !implicit.ref !0 {
+entry:
+  call void @f_tu1()
+  ret i32 0
+}
+
+!0 = !{ptr @__loadtime_comment_str}
+
+;; .ref directive emitted from f_tu1's csect anchoring TU1's string
+; CHECK-LABEL: .f_tu1:
+; CHECK-NEXT:  .ref __loadtime_comment_str
+
+;; .ref directive emitted from main's csect anchoring TU2's string
+; CHECK-LABEL: .main:
+; CHECK-NEXT:  .ref __loadtime_comment_str.2
+
+;; Both copyright strings in the read-only __loadtime_comment csect
+; CHECK:      .csect __loadtime_comment[RO],2
+; CHECK-DAG:   .lglobl __loadtime_comment_str
+; CHECK-LABEL: __loadtime_comment_str:
+; CHECK-DAG:  .string "Copyright TU1"
+; CHECK-DAG:   .lglobl __loadtime_comment_str.2
+; CHECK-LABEL: __loadtime_comment_str.2:
+; CHECK-DAG:  .string "Copyright TU2"

--- a/llvm/test/LTO/PowerPC/pragma-comment-copyright-lto.ll
+++ b/llvm/test/LTO/PowerPC/pragma-comment-copyright-lto.ll
@@ -1,67 +1,85 @@
+;;
+;; Full LTO test for #pragma comment(copyright, ...) on AIX.
+;; Two TUs each with a copyright string are linked via Full LTO.
+;;
+;; Verifies:
+;;   - LowerCommentStringPass runs at lto-pre-link<O2> per TU
+;;   - f_unused is DCE'd -- not exported and never called
+;;   - f_add is inlined into main and f_add(1,2) constant-folded to li 3,3
+;;   - Both copyright strings appear in the merged __loadtime_comment[RO] csect
+;;   - .ref directives anchor each string to its function csect
+
+; REQUIRES: powerpc-registered-target
+
 ; RUN: rm -rf %t && mkdir %t
 ; RUN: split-file %s %t
-; RUN: llvm-as %t/tu1.ll -o %t/tu1.bc
-; RUN: llvm-as %t/tu2.ll -o %t/tu2.bc
+; RUN: opt -passes='lto-pre-link<O2>' %t/tu1.ll -S -o %t/tu1_lowered.ll
+; RUN: opt -passes='lto-pre-link<O2>' %t/tu2.ll -S -o %t/tu2_lowered.ll
+; RUN: llvm-as %t/tu1_lowered.ll -o %t/tu1.bc
+; RUN: llvm-as %t/tu2_lowered.ll -o %t/tu2.bc
 ; RUN: llvm-lto -filetype=asm \
 ; RUN:   -exported-symbol=main \
-; RUN:   -exported-symbol=f_tu1 \
+; RUN:   -exported-symbol=f_add \
 ; RUN:   %t/tu1.bc %t/tu2.bc \
-; RUN:   -o %t/out.s 
+; RUN:   -o %t/out.s
 ; RUN: FileCheck %s < %t/out.s
 
-
 ;--- tu1.ll
-;; TU1: already lowered by LowerCommentStringPass at prelink
 target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
 target triple = "powerpc-ibm-aix7.3.0.0"
 
-@__loadtime_comment_str = internal unnamed_addr constant
-    [14 x i8] c"Copyright TU1\00",
-    section "__loadtime_comment", align 1
-@llvm.compiler.used = appending global [1 x ptr]
-    [ptr @__loadtime_comment_str], section "llvm.metadata"
+define i32 @f_add(i32 noundef %a, i32 noundef %b) {
+entry:
+  %add = add nsw i32 %a, %b
+  ret i32 %add
+}
 
-define void @f_tu1() !implicit.ref !0 {
+;; f_unused is not exported and never called -- Full LTO must DCE it
+define void @f_unused() {
 entry:
   ret void
 }
 
-!0 = !{ptr @__loadtime_comment_str}
+!comment_string.loadtime = !{!0}
+!llvm.module.flags = !{!1, !2}
+!0 = !{!"Copyright TU1"}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"EnableSplitLTOUnit", i32 1}
 
 ;--- tu2.ll
-;; TU2: already lowered by LowerCommentStringPass at prelink
 target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
 target triple = "powerpc-ibm-aix7.3.0.0"
 
-@__loadtime_comment_str = internal unnamed_addr constant
-    [14 x i8] c"Copyright TU2\00",
-    section "__loadtime_comment", align 1
-@llvm.compiler.used = appending global [1 x ptr]
-    [ptr @__loadtime_comment_str], section "llvm.metadata"
+declare i32 @f_add(i32 noundef, i32 noundef)
 
-declare void @f_tu1()
-
-define i32 @main() !implicit.ref !0 {
+define i32 @main() {
 entry:
-  call void @f_tu1()
-  ret i32 0
+  %call = call i32 @f_add(i32 1, i32 2)
+  ret i32 %call
 }
 
-!0 = !{ptr @__loadtime_comment_str}
+!comment_string.loadtime = !{!0}
+!llvm.module.flags = !{!1, !2}
+!0 = !{!"Copyright TU2"}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"EnableSplitLTOUnit", i32 1}
 
-;; .ref directive emitted from f_tu1's csect anchoring TU1's string
-; CHECK-LABEL: .f_tu1:
+;; f_add csect anchors TU1 copyright string
+; CHECK-LABEL: .f_add:
 ; CHECK-NEXT:  .ref __loadtime_comment_str
 
-;; .ref directive emitted from main's csect anchoring TU2's string
+;; f_unused is DCE'd -- must not appear in assembly
+; CHECK-NOT: .f_unused:
+
+;; main anchors both strings: TU2's own and TU1's via inlined f_add
 ; CHECK-LABEL: .main:
-; CHECK-NEXT:  .ref __loadtime_comment_str.2
+; CHECK:       .ref __loadtime_comment_str.2
+; CHECK:       .ref __loadtime_comment_str
+
+;; f_add(1,2) constant-folded -- no optimization regression with pragma
+; CHECK:       li 3, 3
 
 ;; Both copyright strings in the read-only __loadtime_comment csect
-; CHECK:      .csect __loadtime_comment[RO],2
-; CHECK-DAG:   .lglobl __loadtime_comment_str
-; CHECK-LABEL: __loadtime_comment_str:
+; CHECK:      .csect __loadtime_comment[RO]
 ; CHECK-DAG:  .string "Copyright TU1"
-; CHECK-DAG:   .lglobl __loadtime_comment_str.2
-; CHECK-LABEL: __loadtime_comment_str.2:
 ; CHECK-DAG:  .string "Copyright TU2"

--- a/llvm/test/LTO/PowerPC/pragma-comment-copyright-thinlto.ll
+++ b/llvm/test/LTO/PowerPC/pragma-comment-copyright-thinlto.ll
@@ -1,0 +1,89 @@
+; llvm/test/LTO/PowerPC/pragma-comment-copyright-thinlto.ll
+;;
+;; ThinLTO test for #pragma comment(copyright, ...) on AIX.
+;;
+;; Tests that copyright strings survive ThinLTO with the
+;; ModuleSummaryAnalysis fix (findImplicitRefEdges) that adds
+;; !implicit.ref-referenced globals as explicit reference edges
+;; in the ThinLTO summary, keeping them live.
+;;
+;; f_add is notEligibleToImport because it references an internal
+;; global (@__loadtime_comment_str) via !implicit.ref. Both copyright
+;; strings still appear in the final binary via the external call path.
+
+; REQUIRES: powerpc-registered-target
+
+; RUN: rm -rf %t && mkdir %t
+; RUN: split-file %s %t
+; RUN: opt -passes='thinlto-pre-link<O2>' %t/tu1.ll -o - | \
+; RUN:   opt -module-summary -o %t/tu1.bc
+; RUN: opt -passes='thinlto-pre-link<O2>' %t/tu2.ll -o - | \
+; RUN:   opt -module-summary -o %t/tu2.bc
+; RUN: llvm-lto2 run -filetype=asm \
+; RUN:   -r %t/tu1.bc,f_add,px \
+; RUN:   -r %t/tu1.bc,f_unused,p \
+; RUN:   -r %t/tu2.bc,main,px \
+; RUN:   -r %t/tu2.bc,f_add,l \
+; RUN:   %t/tu1.bc %t/tu2.bc -o %t/out
+; RUN: FileCheck %s --check-prefix=CHECK-TU1 < %t/out.1
+; RUN: FileCheck %s --check-prefix=CHECK-TU2 < %t/out.2
+
+;--- tu1.ll
+target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
+target triple = "powerpc-ibm-aix7.3.0.0"
+
+define i32 @f_add(i32 noundef %a, i32 noundef %b) {
+entry:
+  %add = add nsw i32 %a, %b
+  ret i32 %add
+}
+
+;; f_unused is not exported and never called -- ThinLTO must DCE it
+define void @f_unused() {
+entry:
+  ret void
+}
+
+!comment_string.loadtime = !{!0}
+!llvm.module.flags = !{!1, !2}
+!0 = !{!"Copyright TU1"}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"EnableSplitLTOUnit", i32 0}
+
+;--- tu2.ll
+target datalayout = "E-m:a-p:32:32-Fi32-i64:64-n32-f64:32:64"
+target triple = "powerpc-ibm-aix7.3.0.0"
+
+declare i32 @f_add(i32 noundef, i32 noundef)
+
+define i32 @main() {
+entry:
+  %call = call i32 @f_add(i32 1, i32 2)
+  ret i32 %call
+}
+
+!comment_string.loadtime = !{!0}
+!llvm.module.flags = !{!1, !2}
+!0 = !{!"Copyright TU2"}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 1, !"EnableSplitLTOUnit", i32 0}
+
+;; TU1: f_add anchors copyright string, f_unused is DCE'd
+; CHECK-TU1-LABEL: .f_add:
+; CHECK-TU1-NEXT:  .ref __loadtime_comment_str
+; CHECK-TU1-NOT:   .f_unused:
+; CHECK-TU1:       .csect __loadtime_comment[RO]
+; CHECK-TU1:       __loadtime_comment_str:
+; CHECK-TU1-NEXT:  .string "Copyright TU1"
+
+;; TU2: main anchors TU2 copyright string
+;; f_add is NOT inlined -- notEligibleToImport because it references
+;; an internal global via !implicit.ref. Cross-boundary call via
+;; .extern .f_add keeps tu1 linked, preserving Copyright TU1.
+; CHECK-TU2:      .ref __loadtime_comment_str
+; CHECK-TU2:      bl .f_add
+; CHECK-TU2:      .csect __loadtime_comment[RO]
+; CHECK-TU2:      __loadtime_comment_str:
+; CHECK-TU2-NEXT: .string "Copyright TU2"
+; CHECK-TU2:      .extern .f_add
+; CHECK-TU2-NOT:  .string "Copyright TU1"

--- a/llvm/test/Other/new-pm-O0-defaults.ll
+++ b/llvm/test/Other/new-pm-O0-defaults.ll
@@ -61,6 +61,7 @@
 ; CHECK-CORO-NEXT: Running analysis: TargetLibraryAnalysis
 ; CHECK-LTO-NEXT: Running pass: AnnotationRemarksPass
 ; CHECK-LTO-NEXT: Running analysis: TargetLibraryAnalysis
+; CHECK-CORO-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-NEXT: Running pass: PrintModulePass
 
 ; Make sure we get the IR back out without changes when we print the module.

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -282,6 +282,7 @@
 ; CHECK-DEFAULT-NEXT: Running pass: CGProfilePass
 ; CHECK-DEFAULT-NEXT: Running pass: RelLookupTableConverterPass
 ; CHECK-LTO-NOT: Running pass: RelLookupTableConverterPass
+; CHECK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT: Running pass: AnnotationRemarksPass on foo
 ; CHECK-LTO-NEXT: Running pass: CanonicalizeAliasesPass
 ; CHECK-LTO-NEXT: Running pass: NameAnonGlobalPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
@@ -205,6 +205,7 @@
 ; CHECK-POSTLINK-O-NEXT: Running pass: RelLookupTableConverterPass
 ; CHECK-EP-OPT-EARLY-NEXT: Running pass: NoOpModulePass
 ; CHECK-EP-OPT-LAST-NEXT: Running pass: NoOpModulePass
+; CHECK-POSTLINK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT:          Running pass: AnnotationRemarksPass on foo
 ; CHECK-O-NEXT: Running pass: PrintModulePass
 

--- a/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
@@ -187,6 +187,7 @@
 ; CHECK-O-NEXT: Running pass: ConstantMergePass
 ; CHECK-O-NEXT: Running pass: CGProfilePass
 ; CHECK-O-NEXT: Running pass: RelLookupTableConverterPass
+; CHECK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT: Running pass: AnnotationRemarksPass on foo
 ; CHECK-O-NEXT: Running pass: PrintModulePass
 

--- a/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
@@ -194,6 +194,7 @@
 ; CHECK-O-NEXT: Running pass: ConstantMergePass
 ; CHECK-O-NEXT: Running pass: CGProfilePass
 ; CHECK-O-NEXT: Running pass: RelLookupTableConverterPass
+; CHECK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT: Running pass: AnnotationRemarksPass on foo
 ; CHECK-O-NEXT: Running pass: PrintModulePass
 

--- a/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
@@ -184,6 +184,7 @@
 ; CHECK-O-NEXT:          Running pass: AnnotationRemarksPass on foo
 ; CHECK-O-NEXT: Running pass: CanonicalizeAliasesPass
 ; CHECK-O-NEXT: Running pass: NameAnonGlobalPass
+; CHECK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT: Running pass: PrintModulePass
 
 ; Make sure we get the IR back out without changes when we print the module.

--- a/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
@@ -187,6 +187,7 @@
 ; CHECK-O-NEXT: Running pass: AnnotationRemarksPass on foo
 ; CHECK-O-NEXT: Running pass: CanonicalizeAliasesPass
 ; CHECK-O-NEXT: Running pass: NameAnonGlobalPass
+; CHECK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT: Running pass: PrintModulePass
 
 ; Make sure we get the IR back out without changes when we print the module.

--- a/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
@@ -150,6 +150,7 @@
 ; CHECK-O-NEXT: Running pass: AnnotationRemarksPass on foo
 ; CHECK-O-NEXT: Running pass: CanonicalizeAliasesPass
 ; CHECK-O-NEXT: Running pass: NameAnonGlobalPass
+; CHECK-O-NEXT: Running pass: LowerCommentStringPass
 ; CHECK-O-NEXT: Running pass: PrintModulePass
 
 ; Make sure we get the IR back out without changes when we print the module.

--- a/llvm/test/Transforms/LowerCommentString/lower-comment-string.ll
+++ b/llvm/test/Transforms/LowerCommentString/lower-comment-string.ll
@@ -1,0 +1,41 @@
+; RUN: opt -passes=lower-comment-string -S %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-O0
+
+; Verify that lower-comment-string is enabled by default on all opt pipelines.
+; RUN: opt --O0 -S %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-O0
+; RUN: opt --O1 -S %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-ON
+; RUN: opt --O2 -S %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-ON
+; RUN: opt --O3 -S %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-ON
+
+target triple = "powerpc-ibm-aix"
+
+define void @f0() {
+entry:
+  ret void    
+}
+define i32 @main() {
+entry:
+  ret i32 0
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"wchar_size", i32 2}
+
+!comment_string.loadtime = !{!1}
+!1 = !{!"@(#) Copyright IBM 2025"}
+
+
+; ---- Globals--------------------------------------------
+; CHECK: @__loadtime_comment_str = internal unnamed_addr constant [24 x i8] c"@(#) Copyright IBM 2025\00", section "__loadtime_comment", align 1
+; Preservation in llvm.compiler.used sets
+; CHECK-NEXT: @llvm.compiler.used = appending global [1 x ptr] [ptr @__loadtime_comment_str], section "llvm.metadata"
+; CHECK-NOT: ![[copyright:[0-9]+]] = !{!"@(#) Copyright IBM 2025"}
+
+; Function has an implicit ref MD pointing at the string:
+; CHECK-O0: define void @f0() !implicit.ref ![[MD:[0-9]+]]
+; CHECK-ON: define void @f0() local_unnamed_addr #0 !implicit.ref ![[MD:[0-9]+]]
+; CHECK-O0: define i32 @main() !implicit.ref ![[MD]]
+; CHECK-ON: define noundef i32 @main() local_unnamed_addr #0 !implicit.ref ![[MD]]
+
+; Verify metadata content
+; CHECK-O0: ![[MD]] = !{ptr @__loadtime_comment_str}
+; CHECK-ON: ![[MD]] = !{ptr @__loadtime_comment_str}


### PR DESCRIPTION
New PR: https://github.com/llvm/llvm-project/pull/199398

**Note**: This PR adds LTO support for the pragma comment copyright feature implemented in #178184. Should be reviewed/merged after #178184.

`LowerCommentStringPass` implements `#pragma comment(copyright, ...)` on AIX by creating a TU-local  `@__loadtime_comment_str` global in the `__loadtime_comment` section and attaching `!implicit.ref` metadata to all
defined functions. The PowerPC backend reads `!implicit.ref` and emits `.ref` directives from each function csect to the copyright string csect, so the AIX XCOFF linker keeps the copyright string alive whenever any function from the TU is live.

This change teaches `ModuleSummaryAnalysis` to include globals referenced via `!implicit.ref` metadata as explicit reference edges in the ThinLTO module summary via a new helper `findImplicitRefEdges`.

