### PR TITLE
[AIX][libc++] Fix sized_delete.pass.cpp for AIX by adding -fsized-deallocation flag

### DIFF
--- a/libcxx/test/configs/ibm-libc++-shared.cfg.in
+++ b/libcxx/test/configs/ibm-libc++-shared.cfg.in
@@ -28,6 +28,12 @@ config.substitutions.append(('%{exec}',
 # using this feature. (Also see llvm.org/PR52188)
 config.available_features.add('LIBCXX-AIX-FIXME')
 
+# Add AIX target triple without version (e.g. 7.2, 7.3) to make it easier to match in tests.
+if 'powerpc64' in config.target_triple:
+    config.available_features.add('target=powerpc64-ibm-aix')
+else:
+    config.available_features.add('target=powerpc-ibm-aix')
+
 import os, site
 site.addsitedir(os.path.join('@LIBCXX_SOURCE_DIR@', 'utils'))
 import libcxx.test.params, libcxx.test.config

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
@@ -17,11 +17,12 @@
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=armv7-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=arm64ec-w64-windows-gnu): -fsized-deallocation
-
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc-ibm-aix7.2.5.11): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc64-ibm-aix7.2.5.11): -fsized-deallocation
 // UNSUPPORTED: sanitizer-new-delete
 
 // AIX, and z/OS default to -fno-sized-deallocation.
-// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}
+// XFAIL: target={{.+}}-zos{{.*}}
 
 #if !defined(__cpp_sized_deallocation)
 # error __cpp_sized_deallocation should be defined

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
@@ -17,8 +17,7 @@
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=armv7-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=arm64ec-w64-windows-gnu): -fsized-deallocation
-// ADDITIONAL_COMPILE_FLAGS(target=powerpc-ibm-aix7.2.5.11): -fsized-deallocation
-// ADDITIONAL_COMPILE_FLAGS(target=powerpc64-ibm-aix7.2.5.11): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(buildhost=aix): -fsized-deallocation
 // UNSUPPORTED: sanitizer-new-delete
 
 // AIX, and z/OS default to -fno-sized-deallocation.

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array.pass.cpp
@@ -17,7 +17,8 @@
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=armv7-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=arm64ec-w64-windows-gnu): -fsized-deallocation
-// ADDITIONAL_COMPILE_FLAGS(buildhost=aix): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc-ibm-aix): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc64-ibm-aix): -fsized-deallocation
 // UNSUPPORTED: sanitizer-new-delete
 
 // AIX, and z/OS default to -fno-sized-deallocation.

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
@@ -17,11 +17,12 @@
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=armv7-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=arm64ec-w64-windows-gnu): -fsized-deallocation
-
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc-ibm-aix7.2.5.11): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc64-ibm-aix7.2.5.11): -fsized-deallocation
 // UNSUPPORTED: sanitizer-new-delete
 
 // AIX, and z/OS default to -fno-sized-deallocation.
-// XFAIL: target={{.+}}-aix{{.*}}, target={{.+}}-zos{{.*}}
+// XFAIL: target={{.+}}-zos{{.*}}
 
 #if !defined(__cpp_sized_deallocation)
 # error __cpp_sized_deallocation should be defined

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
@@ -17,8 +17,7 @@
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=armv7-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=arm64ec-w64-windows-gnu): -fsized-deallocation
-// ADDITIONAL_COMPILE_FLAGS(target=powerpc-ibm-aix7.2.5.11): -fsized-deallocation
-// ADDITIONAL_COMPILE_FLAGS(target=powerpc64-ibm-aix7.2.5.11): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(buildhost=aix): -fsized-deallocation
 // UNSUPPORTED: sanitizer-new-delete
 
 // AIX, and z/OS default to -fno-sized-deallocation.

--- a/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
+++ b/libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete.pass.cpp
@@ -17,7 +17,8 @@
 // ADDITIONAL_COMPILE_FLAGS(target=aarch64-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=armv7-w64-windows-gnu): -fsized-deallocation
 // ADDITIONAL_COMPILE_FLAGS(target=arm64ec-w64-windows-gnu): -fsized-deallocation
-// ADDITIONAL_COMPILE_FLAGS(buildhost=aix): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc-ibm-aix): -fsized-deallocation
+// ADDITIONAL_COMPILE_FLAGS(target=powerpc64-ibm-aix): -fsized-deallocation
 // UNSUPPORTED: sanitizer-new-delete
 
 // AIX, and z/OS default to -fno-sized-deallocation.


### PR DESCRIPTION
By default `-fno-sized-deallocation` is passed for libc++ in AIX.  https://github.com/llvm/llvm-project/blob/47e6290a34507ba1b3f4e0a49bad28982ff3e3ef/clang/lib/Driver/ToolChains/AIX.cpp#L578

As many other targets have passed the argument through `ADDITIONAL_COMPILE_FLAGS` using the same for PPC. 
`ADDITIONAL_COMPILE_FLAGS` does not take regex so added a new feature to recognize target triple as `PowerPC` or `PowerPC64`. 