### PR TITLE
[CodeGen][GC] Initialize roots with `Constant::getNullValue()` instead of `ConstantPointerNull::get()`

### DIFF
--- a/llvm/lib/CodeGen/GCRootLowering.cpp
+++ b/llvm/lib/CodeGen/GCRootLowering.cpp
@@ -179,9 +179,8 @@ static bool InsertRootInitializers(Function &F, ArrayRef<AllocaInst *> Roots) {
 
   for (AllocaInst *Root : Roots)
     if (!InitedRoots.count(Root)) {
-      new StoreInst(
-          ConstantPointerNull::get(cast<PointerType>(Root->getAllocatedType())),
-          Root, std::next(Root->getIterator()));
+      new StoreInst(Constant::getNullValue(Root->getAllocatedType()), Root,
+                    std::next(Root->getIterator()));
       MadeChange = true;
     }
 

--- a/llvm/test/CodeGen/Generic/gc-lowering.ll
+++ b/llvm/test/CodeGen/Generic/gc-lowering.ll
@@ -60,3 +60,29 @@ define void @no_gc() {
 ;
   ret void
 }
+
+@metadata = constant i32 0
+
+define void @non_ptr_alloca_root() gc "shadow-stack" {
+; CHECK-LABEL: define void @non_ptr_alloca_root() gc "shadow-stack" {
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    %A = alloca double, align 8
+; CHECK-NEXT:    store double 0.000000e+00, ptr %A, align 8
+; CHECK-NEXT:    %B = alloca { double, double }, align 8
+; CHECK-NEXT:    store { double, double } zeroinitializer, ptr %B, align 8
+; CHECK-NEXT:    call void @llvm.gcroot(ptr %A, ptr @metadata)
+; CHECK-NEXT:    call void @llvm.gcroot(ptr %B, ptr @metadata)
+; CHECK-NEXT:    ret void
+; CHECK-NEXT:  }
+entry:
+  %A = alloca double
+  %B = alloca { double, double }
+
+  ;; ptr A;
+  call void @llvm.gcroot(ptr %A, ptr @metadata)
+
+  ;; ptr B;
+  call void @llvm.gcroot(ptr %B, ptr @metadata)
+
+  ret void
+}


### PR DESCRIPTION
Fixes #199219