### PR TITLE
[llvm-reduce] Fix !inline_history verifier issues

### DIFF
--- a/llvm/test/tools/llvm-reduce/remove-funcs-inline-history.ll
+++ b/llvm/test/tools/llvm-reduce/remove-funcs-inline-history.ll
@@ -1,0 +1,27 @@
+; Test that llvm-reduce doesn't cause verifier errors with !inline_history
+; metadata when removing functions. The metadata references to removed functions
+; should become null (not ptr null) because we use replaceNonMetadataUsesWith.
+;
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=functions --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefix=CHECK-FINAL %s < %t
+
+; CHECK-INTERESTINGNESS: define void @interesting()
+define void @interesting() {
+  ; CHECK-INTERESTINGNESS: call void @interesting()
+  call void @interesting(), !inline_history !{ptr @uninteresting}
+  call void @interesting(), !inline_history !{ptr @interesting, ptr @uninteresting}
+  ret void
+}
+
+; CHECK-FINAL: define void @interesting()
+; The metadata operand for @uninteresting becomes null.
+; CHECK-FINAL: call void @interesting(), !inline_history ![[MD1:[0-9]+]]
+; CHECK-FINAL: call void @interesting(), !inline_history ![[MD2:[0-9]+]]
+; CHECK-FINAL: ret void
+
+; CHECK-FINAL: ![[MD1]] = distinct !{null}
+; CHECK-FINAL: ![[MD2]] = distinct !{ptr @interesting, null}
+
+define void @uninteresting() {
+  ret void
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceFunctions.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceFunctions.cpp
@@ -46,8 +46,10 @@ void llvm::reduceFunctionsDeltaPass(Oracle &O, ReducerWorkItem &WorkItem) {
 
   // And finally, we can actually delete them.
   for (Constant *F : FuncsToRemove) {
-    // Replace all *still* remaining uses with the default value.
-    F->replaceAllUsesWith(getDefaultValue(F->getType()));
+    // Replace all *still* remaining non-metadata uses with the default value.
+    // Metadata uses (e.g. in !inline_history) are left for eraseFromParent()
+    // to handle, which sets them to null rather than ptr null.
+    F->replaceNonMetadataUsesWith(getDefaultValue(F->getType()));
     // And finally, fully drop it.
     cast<Function>(F)->eraseFromParent();
   }


### PR DESCRIPTION
We'd RAUW a function which would cause !inline_history metadata nodes to be `ptr null` which doesn't pass the verifier.

Instead we can keep around metadata usages of the function with replaceNonMetadataUsesWith().