### PR TITLE
[InstrProf] Do not emit metadata for zero values with zero counts

### DIFF
--- a/llvm/lib/ProfileData/InstrProf.cpp
+++ b/llvm/lib/ProfileData/InstrProf.cpp
@@ -1393,7 +1393,11 @@ void annotateValueSite(Module &M, Instruction &Inst,
     Vals.push_back(MDHelper.createConstant(
         ConstantInt::get(Type::getInt64Ty(Ctx), ZeroCount)));
   }
-  Inst.setMetadata(LLVMContext::MD_prof, MDNode::get(Ctx, Vals));
+  // Only add metadata if we have at least one value. Otherwise we will end
+  // up adding invalid metadata in the case where the profile only has a
+  // zero value with a zero count.
+  if (Vals.size() >= 5)
+    Inst.setMetadata(LLVMContext::MD_prof, MDNode::get(Ctx, Vals));
 }
 
 MDNode *mayHaveValueProfileOfKind(const Instruction &Inst,

--- a/llvm/test/Transforms/PGOProfile/Inputs/indirect-call-vp-zeros.ll
+++ b/llvm/test/Transforms/PGOProfile/Inputs/indirect-call-vp-zeros.ll
@@ -1,0 +1,16 @@
+:ir
+test_call
+# Func Hash:
+170957022131388415
+# Num Counters:
+1
+# Counter Values:
+130
+# Num Value Kinds:
+1
+# ValueKind = IPVK_IndirectCallTarget:
+0
+# NumValueSites:
+1
+1
+** External Symbol **:0

--- a/llvm/test/Transforms/PGOProfile/indirect-call-vp-zeros.ll
+++ b/llvm/test/Transforms/PGOProfile/indirect-call-vp-zeros.ll
@@ -4,9 +4,6 @@
 ;; Check that if we have a profile with VP metadat that has only zero values
 ;; with zero counts, we do not emit invalid VP metadata.
 
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-unknown-linux-gnu"
-
 define void @test_call(ptr %fptr) {
 entry:
   call void %fptr()

--- a/llvm/test/Transforms/PGOProfile/indirect-call-vp-zeros.ll
+++ b/llvm/test/Transforms/PGOProfile/indirect-call-vp-zeros.ll
@@ -1,0 +1,14 @@
+; RUN: llvm-profdata merge %S/Inputs/indirect-call-vp-zeros.ll -o %t.profdata
+; RUN: opt < %s -passes=pgo-instr-use -pgo-test-profile-file=%t.profdata -S
+
+;; Check that if we have a profile with VP metadat that has only zero values
+;; with zero counts, we do not emit invalid VP metadata.
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @test_call(ptr %fptr) {
+entry:
+  call void %fptr()
+  ret void
+}


### PR DESCRIPTION
If we have a indirect call site with a profile that has VP information for said callsite that only contains zero values with zero counts, we would start to emit invalid profile information after 1d146967d51ba76b8379d9e12961aa23e5745701. VP metadata in this case is at best redundant with BFI. So we restrict metadata emission to only if we have a sufficient number of values for the VP metadata to be valid.