### PR TITLE
[offload] Fix --libomptarget-nvptx-bc-path in tests

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -213,7 +213,7 @@ else: # Unices
     if config.cuda_libdir:
         config.test_flags += " -Wl,-rpath," + config.cuda_libdir
     if config.libomptarget_current_target.startswith('nvptx'):
-        config.test_flags_clang += " --libomptarget-nvptx-bc-path=" + config.llvm_library_intdir + "/nvptx64-nvidia-cuda"
+        config.test_flags_clang += " --libomptarget-nvptx-bc-path=" + config.llvm_library_dir + "/nvptx64-nvidia-cuda"
     if config.libomptarget_current_target.endswith('-LTO'):
         config.test_flags += " -foffload-lto"
     if config.libomptarget_current_target.endswith('-JIT-LTO') and evaluate_bool_env(


### PR DESCRIPTION
PR #198622, which landed as 3383f0d6fe01, causes 272 `libomptarget :: nvptx64-nvidia-cuda` test fails on my system with:

```
clang: error: bitcode library '/home/jdenny/llvm/build/\./lib/x86_64-unknown-linux-gnu/nvptx64-nvidia-cuda' does not exist
```

This patch fixes that.