### PR TITLE
[lldb][test] Link test binaries with -random_uuid

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -209,6 +209,10 @@ ifeq "$(OS)" "Darwin"
 	DSFLAGS := $(DSFLAGS_EXTRAS)
 	DSYM = $(EXE).dSYM
 	ARFLAGS := -static -o
+	# The default UUID is a hash based on filename and __text section content.
+	# Use a random UUID so that LLDB and Spotlight never confuse two test
+	# binaries, where repeated test code can result in identical binaries.
+	LDFLAGS += -Wl,-random_uuid
 else
 	ifeq "$(SPLIT_DEBUG_SYMBOLS)" "YES"
 		DSYM = $(EXE).debug


### PR DESCRIPTION
While reviewing https://github.com/llvm/llvm-project/pull/197237, it occurred to me that `-random_uuid` could be an alternative solution to problem that was solved by adding a ".noindex" suffix to the lldb-test-build directory name.