### PR TITLE
[clang][bytecode] Fix non-defaulted union copy/move ctors

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6856,8 +6856,8 @@ bool Compiler<Emitter>::compileConstructor(const CXXConstructorDecl *Ctor) {
     return false;
   bool IsUnion = R->isUnion();
 
-  // Union copy and move ctors are special.
-  if (IsUnion && Ctor->isCopyOrMoveConstructor()) {
+  // Default union copy and move ctors are special.
+  if (IsUnion && Ctor->isCopyOrMoveConstructor() && Ctor->isDefaulted()) {
     LocOverrideScope<Emitter> LOS(this, SourceInfo{});
 
     // No special case for NumFields == 0 here, so the Memcpy op

--- a/clang/test/AST/ByteCode/unions.cpp
+++ b/clang/test/AST/ByteCode/unions.cpp
@@ -386,6 +386,18 @@ namespace CopyCtor {
   static_assert(y.a == 42, "");
   static_assert(y.b == 42, ""); // both-error {{constant expression}} \
                                 // both-note {{'b' of union with active member 'a'}}
+
+  /// Non-defaulted copy ctor.
+  union U2 {
+    int a;
+    constexpr U2() : a(100) {}
+    constexpr U2(const U2 &u) {
+      a = 20;
+    };
+  };
+  constexpr U2 u2;
+  constexpr U2 u22(u2);
+  static_assert(u22.a == 20, "");
 }
 
 namespace UnionInBase {


### PR DESCRIPTION
They are like regular record ctors.