### PR TITLE
[AIX] Re-apply: Remove unsupported AIX native echo option -n by using printf

### DIFF
--- a/llvm/utils/lit/tests/unit/Util.py
+++ b/llvm/utils/lit/tests/unit/Util.py
@@ -29,12 +29,12 @@ class TestCommandCache(unittest.TestCase):
     def test_basic(self):
         lit_config = self._lit_config()
 
-        self.assertEqual(lit_config.run_command_cached(["echo", "-n", "hi"]), b"hi")
+        self.assertEqual(lit_config.run_command_cached(["printf", "hi"]), b"hi")
         self.assertNotEqual(lit_config.run_command_cached("ls"), None)
 
         # Test that arguments (e.g. text=True) get forwarded to subprocess.run
         self.assertEqual(
-            lit_config.run_command_cached(["echo", "-n", "hi"], text=True), "hi"
+            lit_config.run_command_cached(["printf", "hi"], text=True), "hi"
         )
 
         # shell=True is not implied


### PR DESCRIPTION
AIX native echo doesn't support the `-n` flag.
Use `printf` instead to ensure the test works across all systems and making it portable.

The current test fails as follows:
```
FAIL: lit :: unit/Util.py (1 of 1)
******************** TEST 'lit :: unit/Util.py' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
# RUN: at line 1
"/opt/freeware/bin/python3.12" /home/himadhit/llvm/community/build/utils/lit/tests/unit/Util.py
# executed command: /opt/freeware/bin/python3.12 /home/himadhit/llvm/community/build/utils/lit/tests/unit/Util.py
# .---command stderr------------
# | F..
# | ======================================================================
# | FAIL: test_basic (__main__.TestCommandCache.test_basic)
# | ----------------------------------------------------------------------
# | Traceback (most recent call last):
# |   File "/home/himadhit/llvm/community/build/utils/lit/tests/unit/Util.py", line 32, in test_basic
# |     self.assertEqual(lit_config.run_command_cached(["echo", "-n", "hi"]), b"hi")
# | AssertionError: b'-n hi\n' != b'hi'
# | 
# | ----------------------------------------------------------------------
# | Ran 3 tests in 2.092s
# | 
# | FAILED (failures=1)
# `-----------------------------
# error: command failed with exit status: 1
```