### PR TITLE
[clang] Add CLANG_USE_EXPERIMENTAL_CONST_INTERP cmake option

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -489,6 +489,9 @@ option(CLANG_ENABLE_STATIC_ANALYZER
 
 option(CLANG_ENABLE_PROTO_FUZZER "Build Clang protobuf fuzzer." OFF)
 
+option(CLANG_USE_EXPERIMENTAL_CONST_INTERP
+  "Enable the experimental new constant interpreter by default." OFF)
+
 if (DEFINED CLANG_ENABLE_ARCMT)
   set(CLANG_ENABLE_OBJC_REWRITER ${CLANG_ENABLE_ARCMT})
   message(DEPRECATION "'CLANG_ENABLE_ARCMT' is deprecated as ARCMigrate has been removed from Clang. Please use 'CLANG_ENABLE_OBJC_REWRITER' instead to enable or disable the Objective-C rewriter.")

--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -490,7 +490,7 @@ option(CLANG_ENABLE_STATIC_ANALYZER
 option(CLANG_ENABLE_PROTO_FUZZER "Build Clang protobuf fuzzer." OFF)
 
 option(CLANG_USE_EXPERIMENTAL_CONST_INTERP
-  "Enable the experimental new constant interpreter by default." OFF)
+  "Use the new experimental constant interpreter for compile-time evaluation." OFF)
 
 if (DEFINED CLANG_ENABLE_ARCMT)
   set(CLANG_ENABLE_OBJC_REWRITER ${CLANG_ENABLE_ARCMT})

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -385,7 +385,7 @@ LANGOPT(ConstexprCallDepth, 32, 512, Benign,
         "maximum constexpr call depth")
 LANGOPT(ConstexprStepLimit, 32, 1048576, Benign,
         "maximum constexpr evaluation steps")
-LANGOPT(EnableNewConstInterp, 1, 0, Benign,
+LANGOPT(EnableNewConstInterp, 1, CLANG_USE_EXPERIMENTAL_CONST_INTERP, Benign,
         "enable the experimental new constant interpreter")
 LANGOPT(BracketDepth, 32, 256, Benign,
         "maximum bracket nesting depth")

--- a/clang/include/clang/Config/config.h.cmake
+++ b/clang/include/clang/Config/config.h.cmake
@@ -91,4 +91,8 @@
 /* Policy to use for xcselect */
 #cmakedefine CLANG_XCSELECT_HOST_SDK_POLICY ${CLANG_XCSELECT_HOST_SDK_POLICY}
 
+
+/* Enable the experimental new constant interpreter by default */
+#cmakedefine01 CLANG_USE_EXPERIMENTAL_CONST_INTERP
+
 #endif

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -12,6 +12,7 @@
 
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/LangStandard.h"
+#include "clang/Config/config.h"
 #include "llvm/Support/Path.h"
 
 using namespace clang;


### PR DESCRIPTION
To enable the new constant interpreter by default at configure time.

I don't expect any distributions to set this for now but it's useful for testing and I think we need it eventually.