### PR TITLE
[Clang]fix dependent qualified base member lookup crash

### DIFF
--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -352,29 +352,30 @@ private:
     DefinitionData(CXXRecordDecl *D);
 
     /// Retrieve the set of direct base classes.
-    CXXBaseSpecifier *getBases() const {
+    CXXBaseSpecifier *getBases(const ASTContext &Context) const {
       if (!Bases.isOffset())
         return Bases.get(nullptr);
-      return getBasesSlowCase();
+      return getBasesSlowCase(Context);
     }
 
     /// Retrieve the set of virtual base classes.
-    CXXBaseSpecifier *getVBases() const {
+    CXXBaseSpecifier *getVBases(const ASTContext &Context) const {
       if (!VBases.isOffset())
         return VBases.get(nullptr);
-      return getVBasesSlowCase();
+      return getVBasesSlowCase(Context);
+    }    
+    ArrayRef<CXXBaseSpecifier> bases(const ASTContext &Context) const {
+      return {getBases(Context), NumBases};
     }
 
-    ArrayRef<CXXBaseSpecifier> bases() const { return {getBases(), NumBases}; }
-
-    ArrayRef<CXXBaseSpecifier> vbases() const {
-      return {getVBases(), NumVBases};
+    ArrayRef<CXXBaseSpecifier> vbases(const ASTContext &Context) const {
+      return {getVBases(Context), NumVBases};
     }
 
-  private:
-    CXXBaseSpecifier *getBasesSlowCase() const;
-    CXXBaseSpecifier *getVBasesSlowCase() const;
-  };
+ private:
+    CXXBaseSpecifier *getBasesSlowCase(const ASTContext &Context) const;
+    CXXBaseSpecifier *getVBasesSlowCase(const ASTContext &Context) const;
+};
 
   struct DefinitionData *DefinitionData;
 
@@ -612,8 +613,10 @@ public:
     return base_class_const_range(bases_begin(), bases_end());
   }
 
-  base_class_iterator bases_begin() { return data().getBases(); }
-  base_class_const_iterator bases_begin() const { return data().getBases(); }
+  base_class_iterator bases_begin() { return data().getBases(getASTContext()); }
+  base_class_const_iterator bases_begin() const {
+    return data().getBases(getASTContext());
+  }
   base_class_iterator bases_end() { return bases_begin() + data().NumBases; }
   base_class_const_iterator bases_end() const {
     return bases_begin() + data().NumBases;
@@ -629,8 +632,12 @@ public:
     return base_class_const_range(vbases_begin(), vbases_end());
   }
 
-  base_class_iterator vbases_begin() { return data().getVBases(); }
-  base_class_const_iterator vbases_begin() const { return data().getVBases(); }
+  base_class_iterator vbases_begin() {
+    return data().getVBases(getASTContext());
+  }
+  base_class_const_iterator vbases_begin() const {
+    return data().getVBases(getASTContext());
+  }
   base_class_iterator vbases_end() { return vbases_begin() + data().NumVBases; }
   base_class_const_iterator vbases_end() const {
     return vbases_begin() + data().NumVBases;

--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -363,7 +363,7 @@ private:
       if (!VBases.isOffset())
         return VBases.get(nullptr);
       return getVBasesSlowCase(Context);
-    }    
+    }
     ArrayRef<CXXBaseSpecifier> bases(const ASTContext &Context) const {
       return {getBases(Context), NumBases};
     }
@@ -372,10 +372,10 @@ private:
       return {getVBases(Context), NumVBases};
     }
 
- private:
+  private:
     CXXBaseSpecifier *getBasesSlowCase(const ASTContext &Context) const;
     CXXBaseSpecifier *getVBasesSlowCase(const ASTContext &Context) const;
-};
+  };
 
   struct DefinitionData *DefinitionData;
 

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -130,7 +130,7 @@ bool CXXRecordDecl::forallBases(ForallBasesCallback BaseMatches) const {
   if (const CXXRecordDecl *Def = getDefinition())
     Record = Def;
   else if (!dataPtr())
-  return false;
+    return false;
   while (true) {
     for (const auto &I : Record->bases()) {
       const auto *Base = I.getType()->getAsCXXRecordDecl();

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -127,9 +127,6 @@ bool CXXRecordDecl::forallBases(ForallBasesCallback BaseMatches) const {
 
   const CXXRecordDecl *Record = this;
   while (true) {
-    if (!Record->hasDefinition())
-      return false;
-
     for (const auto &I : Record->bases()) {
       const auto *Base = I.getType()->getAsCXXRecordDecl();
       if (!Base || !(Base->isBeingDefined() || Base->isCompleteDefinition()))

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -126,11 +126,6 @@ bool CXXRecordDecl::forallBases(ForallBasesCallback BaseMatches) const {
   SmallVector<const CXXRecordDecl*, 8> Queue;
 
   const CXXRecordDecl *Record = this;
-
-  if (const CXXRecordDecl *Def = getDefinition())
-    Record = Def;
-  else if (!dataPtr())
-    return false;
   while (true) {
     for (const auto &I : Record->bases()) {
       const auto *Base = I.getType()->getAsCXXRecordDecl();

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -127,6 +127,9 @@ bool CXXRecordDecl::forallBases(ForallBasesCallback BaseMatches) const {
 
   const CXXRecordDecl *Record = this;
   while (true) {
+    if (!Record->hasDefinition())
+      return false;
+
     for (const auto &I : Record->bases()) {
       const auto *Base = I.getType()->getAsCXXRecordDecl();
       if (!Base || !(Base->isBeingDefined() || Base->isCompleteDefinition()))

--- a/clang/lib/AST/CXXInheritance.cpp
+++ b/clang/lib/AST/CXXInheritance.cpp
@@ -126,6 +126,11 @@ bool CXXRecordDecl::forallBases(ForallBasesCallback BaseMatches) const {
   SmallVector<const CXXRecordDecl*, 8> Queue;
 
   const CXXRecordDecl *Record = this;
+
+  if (const CXXRecordDecl *Def = getDefinition())
+    Record = Def;
+  else if (!dataPtr())
+  return false;
   while (true) {
     for (const auto &I : Record->bases()) {
       const auto *Base = I.getType()->getAsCXXRecordDecl();

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -113,12 +113,16 @@ CXXRecordDecl::DefinitionData::DefinitionData(CXXRecordDecl *D)
       IsLambda(false), IsParsingBaseSpecifiers(false),
       ComputedVisibleConversions(false), HasODRHash(false), Definition(D) {}
 
-CXXBaseSpecifier *CXXRecordDecl::DefinitionData::getBasesSlowCase() const {
-  return Bases.get(Definition->getASTContext().getExternalSource());
+CXXBaseSpecifier *
+CXXRecordDecl::DefinitionData::getBasesSlowCase(
+    const ASTContext &Context) const {
+  return Bases.get(Context.getExternalSource());
 }
 
-CXXBaseSpecifier *CXXRecordDecl::DefinitionData::getVBasesSlowCase() const {
-  return VBases.get(Definition->getASTContext().getExternalSource());
+CXXBaseSpecifier *
+CXXRecordDecl::DefinitionData::getVBasesSlowCase(
+    const ASTContext &Context) const {
+  return VBases.get(Context.getExternalSource());
 }
 
 CXXRecordDecl::CXXRecordDecl(Kind K, TagKind TK, const ASTContext &C,
@@ -186,7 +190,7 @@ CXXRecordDecl::setBases(CXXBaseSpecifier const * const *Bases,
   ASTContext &C = getASTContext();
 
   if (!data().Bases.isOffset() && data().NumBases > 0)
-    C.Deallocate(data().getBases());
+    C.Deallocate(data().getBases(C));
 
   if (NumBases) {
     if (!C.getLangOpts().CPlusPlus17) {
@@ -209,7 +213,7 @@ CXXRecordDecl::setBases(CXXBaseSpecifier const * const *Bases,
   data().Bases = new(C) CXXBaseSpecifier [NumBases];
   data().NumBases = NumBases;
   for (unsigned i = 0; i < NumBases; ++i) {
-    data().getBases()[i] = *Bases[i];
+    data().getBases(C)[i] = *Bases[i];
     // Keep track of inherited vbases for this base class.
     const CXXBaseSpecifier *Base = Bases[i];
     QualType BaseType = Base->getType();
@@ -484,7 +488,7 @@ CXXRecordDecl::setBases(CXXBaseSpecifier const * const *Bases,
     QualType Type = VBases[I]->getType();
     if (!Type->isDependentType())
       addedClassSubobject(Type->getAsCXXRecordDecl());
-    data().getVBases()[I] = *VBases[I];
+    data().getVBases(C)[I] = *VBases[I];
   }
 
   data().IsParsingBaseSpecifiers = false;

--- a/clang/lib/AST/DeclCXX.cpp
+++ b/clang/lib/AST/DeclCXX.cpp
@@ -113,14 +113,12 @@ CXXRecordDecl::DefinitionData::DefinitionData(CXXRecordDecl *D)
       IsLambda(false), IsParsingBaseSpecifiers(false),
       ComputedVisibleConversions(false), HasODRHash(false), Definition(D) {}
 
-CXXBaseSpecifier *
-CXXRecordDecl::DefinitionData::getBasesSlowCase(
+CXXBaseSpecifier *CXXRecordDecl::DefinitionData::getBasesSlowCase(
     const ASTContext &Context) const {
   return Bases.get(Context.getExternalSource());
 }
 
-CXXBaseSpecifier *
-CXXRecordDecl::DefinitionData::getVBasesSlowCase(
+CXXBaseSpecifier *CXXRecordDecl::DefinitionData::getVBasesSlowCase(
     const ASTContext &Context) const {
   return VBases.get(Context.getExternalSource());
 }

--- a/clang/lib/AST/ODRDiagsEmitter.cpp
+++ b/clang/lib/AST/ODRDiagsEmitter.cpp
@@ -739,11 +739,12 @@ bool ODRDiagsEmitter::diagnoseMismatch(
       return Diag(Loc, diag::note_module_odr_violation_definition_data)
              << SecondModule << Range << DiffType;
     };
-    auto GetSourceRange = [](const struct CXXRecordDecl::DefinitionData *DD) {
+    auto GetSourceRange = [](const CXXRecordDecl *Record,
+                             const struct CXXRecordDecl::DefinitionData *DD) {
       unsigned NumBases = DD->NumBases;
       if (NumBases == 0)
         return SourceRange();
-      ArrayRef<CXXBaseSpecifier> bases = DD->bases();
+      ArrayRef<CXXBaseSpecifier> bases = DD->bases(Record->getASTContext());
       return SourceRange(bases[0].getBeginLoc(),
                          bases[NumBases - 1].getEndLoc());
     };
@@ -753,27 +754,33 @@ bool ODRDiagsEmitter::diagnoseMismatch(
     unsigned SecondNumBases = SecondDD->NumBases;
     unsigned SecondNumVBases = SecondDD->NumVBases;
     if (FirstNumBases != SecondNumBases) {
-      DiagBaseError(FirstRecord->getLocation(), GetSourceRange(FirstDD),
+      DiagBaseError(FirstRecord->getLocation(),
+                    GetSourceRange(FirstRecord, FirstDD),
                     NumBases)
           << FirstNumBases;
-      DiagBaseNote(SecondRecord->getLocation(), GetSourceRange(SecondDD),
+      DiagBaseNote(SecondRecord->getLocation(),
+                   GetSourceRange(SecondRecord, SecondDD),
                    NumBases)
           << SecondNumBases;
       return true;
     }
 
     if (FirstNumVBases != SecondNumVBases) {
-      DiagBaseError(FirstRecord->getLocation(), GetSourceRange(FirstDD),
+      DiagBaseError(FirstRecord->getLocation(),
+                    GetSourceRange(FirstRecord, FirstDD),
                     NumVBases)
           << FirstNumVBases;
-      DiagBaseNote(SecondRecord->getLocation(), GetSourceRange(SecondDD),
+      DiagBaseNote(SecondRecord->getLocation(),
+                   GetSourceRange(SecondRecord, SecondDD),
                    NumVBases)
           << SecondNumVBases;
       return true;
     }
 
-    ArrayRef<CXXBaseSpecifier> FirstBases = FirstDD->bases();
-    ArrayRef<CXXBaseSpecifier> SecondBases = SecondDD->bases();
+    ArrayRef<CXXBaseSpecifier> FirstBases =
+        FirstDD->bases(FirstRecord->getASTContext());
+    ArrayRef<CXXBaseSpecifier> SecondBases =
+        SecondDD->bases(SecondRecord->getASTContext());
     for (unsigned I = 0; I < FirstNumBases; ++I) {
       const CXXBaseSpecifier FirstBase = FirstBases[I];
       const CXXBaseSpecifier SecondBase = SecondBases[I];

--- a/clang/lib/AST/ODRDiagsEmitter.cpp
+++ b/clang/lib/AST/ODRDiagsEmitter.cpp
@@ -755,24 +755,20 @@ bool ODRDiagsEmitter::diagnoseMismatch(
     unsigned SecondNumVBases = SecondDD->NumVBases;
     if (FirstNumBases != SecondNumBases) {
       DiagBaseError(FirstRecord->getLocation(),
-                    GetSourceRange(FirstRecord, FirstDD),
-                    NumBases)
+                    GetSourceRange(FirstRecord, FirstDD), NumBases)
           << FirstNumBases;
       DiagBaseNote(SecondRecord->getLocation(),
-                   GetSourceRange(SecondRecord, SecondDD),
-                   NumBases)
+                   GetSourceRange(SecondRecord, SecondDD), NumBases)
           << SecondNumBases;
       return true;
     }
 
     if (FirstNumVBases != SecondNumVBases) {
       DiagBaseError(FirstRecord->getLocation(),
-                    GetSourceRange(FirstRecord, FirstDD),
-                    NumVBases)
+                    GetSourceRange(FirstRecord, FirstDD), NumVBases)
           << FirstNumVBases;
       DiagBaseNote(SecondRecord->getLocation(),
-                   GetSourceRange(SecondRecord, SecondDD),
-                   NumVBases)
+                   GetSourceRange(SecondRecord, SecondDD), NumVBases)
           << SecondNumVBases;
       return true;
     }

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -630,7 +630,6 @@ bool Sema::CheckQualifiedMemberReference(Expr *BaseExpr,
     assert(BaseType->isDependentType());
     return false;
   }
-
   for (LookupResult::iterator I = R.begin(), E = R.end(); I != E; ++I) {
     // If this is an implicit member reference and we find a
     // non-instance member, it's not an error.
@@ -643,6 +642,8 @@ bool Sema::CheckQualifiedMemberReference(Expr *BaseExpr,
       continue;
 
     CXXRecordDecl *MemberRecord = cast<CXXRecordDecl>(DC)->getCanonicalDecl();
+    if (!BaseRecord->hasDefinition() || !MemberRecord->hasDefinition())
+      return false;
     if (BaseRecord->getCanonicalDecl() == MemberRecord ||
         !BaseRecord->isProvablyNotDerivedFrom(MemberRecord))
       return false;

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -642,8 +642,6 @@ bool Sema::CheckQualifiedMemberReference(Expr *BaseExpr,
       continue;
 
     CXXRecordDecl *MemberRecord = cast<CXXRecordDecl>(DC)->getCanonicalDecl();
-    if (!BaseRecord->hasDefinition() || !MemberRecord->hasDefinition())
-      return false;
     if (BaseRecord->getCanonicalDecl() == MemberRecord ||
         !BaseRecord->isProvablyNotDerivedFrom(MemberRecord))
       return false;

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -7481,12 +7481,12 @@ void ASTRecordWriter::AddCXXDefinitionData(const CXXRecordDecl *D) {
   if (!Data.IsLambda) {
     Record->push_back(Data.NumBases);
     if (Data.NumBases > 0)
-      AddCXXBaseSpecifiers(Data.bases());
+      AddCXXBaseSpecifiers(Data.bases(D->getASTContext()));
 
     // FIXME: Make VBases lazily computed when needed to avoid storing them.
     Record->push_back(Data.NumVBases);
     if (Data.NumVBases > 0)
-      AddCXXBaseSpecifiers(Data.vbases());
+      AddCXXBaseSpecifiers(Data.vbases(D->getASTContext()));
 
     AddDeclRef(D->getFirstFriend());
   } else {

--- a/clang/test/SemaTemplate/current-instantiation.cpp
+++ b/clang/test/SemaTemplate/current-instantiation.cpp
@@ -247,3 +247,18 @@ namespace RebuildDependentScopeDeclRefExpr {
   // FIXME: We should issue a typo-correction here.
   template<typename T> N<X<T>::think> X<T>::foo() {} // expected-error {{no member named 'think' in 'RebuildDependentScopeDeclRefExpr::X<T>'}}
 }
+
+namespace GH195133 {
+  template <typename T> struct A {
+    void f();
+  };
+
+  template <typename T> struct X {
+    struct S : A<int> {};
+    static void f(S *p) {
+      p->template A<int>::f();
+    }
+  };
+
+  void g() { X<int>::f(nullptr); }
+}


### PR DESCRIPTION
`CXXRecordDecl::forallBases()` can be called during template instantiation for a record that has no definition so in  that case calling `bases()` asserts because the record's `DefinitionData` is null , so fix this  by checking `hasDefinition()` before iterating over the record's bases. If the record has no definition, return `false`, matching the existing behavior for cases where the base classes cannot be computed

Fixes #195133