### PR TITLE
[InstSimplify] Fix interaction between FMF and constrained FP ops

### DIFF
--- a/llvm/include/llvm/Analysis/ConstantFolding.h
+++ b/llvm/include/llvm/Analysis/ConstantFolding.h
@@ -40,6 +40,7 @@ class GlobalVariable;
 class Instruction;
 class TargetLibraryInfo;
 class Type;
+class Value;
 
 /// If this constant is a constant offset from a global, return the global and
 /// the constant. Because of constantexprs, this function is recursive.
@@ -168,6 +169,13 @@ LLVM_ABI Constant *ConstantFoldCall(const CallBase *Call, Function *F,
                                     ArrayRef<Constant *> Operands,
                                     const TargetLibraryInfo *TLI = nullptr,
                                     bool AllowNonDeterministic = true);
+
+/// Try to constant fold a call to the specified function.  Fails if the call is
+/// not foldable, or if the arguments are not all constants / metadata values.
+LLVM_ABI Constant *TryConstantFoldCall(const CallBase *Call, Function *Callee,
+                                       ArrayRef<Value *> Args,
+                                       const TargetLibraryInfo *TLI,
+                                       bool AllowNonDeterministic = true);
 
 LLVM_ABI Constant *ConstantFoldBinaryIntrinsic(Intrinsic::ID ID, Constant *LHS,
                                                Constant *RHS, Type *Ty);

--- a/llvm/include/llvm/Analysis/InstructionSimplify.h
+++ b/llvm/include/llvm/Analysis/InstructionSimplify.h
@@ -235,16 +235,6 @@ LLVM_ABI Value *simplifyBinOp(unsigned Opcode, Value *LHS, Value *RHS,
 LLVM_ABI Value *simplifyCall(CallBase *Call, Value *Callee,
                              ArrayRef<Value *> Args, const SimplifyQuery &Q);
 
-/// Given a constrained FP intrinsic call, tries to compute its simplified
-/// version. Returns a simplified result or null.
-///
-/// This function provides an additional contract: it guarantees that if
-/// simplification succeeds that the intrinsic is side effect free. As a result,
-/// successful simplification can be used to delete the intrinsic not just
-/// replace its result.
-LLVM_ABI Value *simplifyConstrainedFPCall(CallBase *Call,
-                                          const SimplifyQuery &Q);
-
 /// Given an operand for a Freeze, see if we can fold the result.
 /// If not, this returns null.
 LLVM_ABI Value *simplifyFreezeInst(Value *Op, const SimplifyQuery &Q);

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4688,6 +4688,28 @@ Constant *llvm::ConstantFoldBinaryIntrinsic(Intrinsic::ID ID, Constant *LHS,
   return ConstantFoldIntrinsicCall2(ID, Ty, {LHS, RHS}, nullptr);
 }
 
+Constant *llvm::TryConstantFoldCall(const CallBase *Call, Function *F,
+                                    ArrayRef<Value *> Args,
+                                    const TargetLibraryInfo *TLI,
+                                    bool AllowNonDeterministic) {
+  if (!canConstantFoldCallTo(Call, F))
+    return nullptr;
+
+  SmallVector<Constant *, 4> ConstantArgs;
+  ConstantArgs.reserve(Args.size());
+  for (Value *Arg : Args) {
+    Constant *C = dyn_cast<Constant>(Arg);
+    if (!C) {
+      if (isa<MetadataAsValue>(Arg))
+        continue;
+      return nullptr;
+    }
+    ConstantArgs.push_back(C);
+  }
+
+  return ConstantFoldCall(Call, F, ConstantArgs, TLI, AllowNonDeterministic);
+}
+
 Constant *llvm::ConstantFoldCall(const CallBase *Call, Function *F,
                                  ArrayRef<Constant *> Operands,
                                  const TargetLibraryInfo *TLI,

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -7460,28 +7460,6 @@ static Value *simplifyIntrinsic(CallBase *Call, Value *Callee,
   }
 }
 
-static Value *tryConstantFoldCall(CallBase *Call, Value *Callee,
-                                  ArrayRef<Value *> Args,
-                                  const SimplifyQuery &Q) {
-  auto *F = dyn_cast<Function>(Callee);
-  if (!F || !canConstantFoldCallTo(Call, F))
-    return nullptr;
-
-  SmallVector<Constant *, 4> ConstantArgs;
-  ConstantArgs.reserve(Args.size());
-  for (Value *Arg : Args) {
-    Constant *C = dyn_cast<Constant>(Arg);
-    if (!C) {
-      if (isa<MetadataAsValue>(Arg))
-        continue;
-      return nullptr;
-    }
-    ConstantArgs.push_back(C);
-  }
-
-  return ConstantFoldCall(Call, F, ConstantArgs, Q.TLI);
-}
-
 Value *llvm::simplifyCall(CallBase *Call, Value *Callee, ArrayRef<Value *> Args,
                           const SimplifyQuery &Q) {
   // Args should not contain operand bundle operands.
@@ -7497,24 +7475,15 @@ Value *llvm::simplifyCall(CallBase *Call, Value *Callee, ArrayRef<Value *> Args,
   if (isa<UndefValue>(Callee) || isa<ConstantPointerNull>(Callee))
     return PoisonValue::get(Call->getType());
 
-  if (Value *V = tryConstantFoldCall(Call, Callee, Args, Q))
-    return V;
+  if (auto *F = dyn_cast<Function>(Callee)) {
+    if (Value *V = TryConstantFoldCall(Call, F, Args, Q.TLI))
+      return V;
 
-  auto *F = dyn_cast<Function>(Callee);
-  if (F && F->isIntrinsic())
-    if (Value *Ret = simplifyIntrinsic(Call, Callee, Args, Q))
-      return Ret;
+    if (F->isIntrinsic())
+      if (Value *Ret = simplifyIntrinsic(Call, Callee, Args, Q))
+        return Ret;
+  }
 
-  return nullptr;
-}
-
-Value *llvm::simplifyConstrainedFPCall(CallBase *Call, const SimplifyQuery &Q) {
-  assert(isa<ConstrainedFPIntrinsic>(Call));
-  SmallVector<Value *, 4> Args(Call->args());
-  if (Value *V = tryConstantFoldCall(Call, Call->getCalledOperand(), Args, Q))
-    return V;
-  if (Value *Ret = simplifyIntrinsic(Call, Call->getCalledOperand(), Args, Q))
-    return Ret;
   return nullptr;
 }
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/AssumeBundleQueries.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/Loads.h"
 #include "llvm/Analysis/MemoryBuiltins.h"
@@ -2007,14 +2008,18 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
       return NewCall;
   }
 
-  // Unused constrained FP intrinsic calls may have declared side effect, which
-  // prevents it from being removed. In some cases however the side effect is
-  // actually absent. To detect this case, call SimplifyConstrainedFPCall. If it
-  // returns a replacement, the call may be removed.
-  if (CI.use_empty() && isa<ConstrainedFPIntrinsic>(CI)) {
-    if (simplifyConstrainedFPCall(&CI, SQ.getWithInstruction(&CI)))
-      return eraseInstFromFunction(CI);
-  }
+  // An unused constrained FP intrinsic call can be erased only if either:
+  //  - its exception behavior is not `strict`, or
+  //  - we can prove that it doesn't raise an FP exception.
+  // For the latter case, it's sufficient to check that constant-folding
+  // succeeds, because constant folding is exception-aware.
+  if (auto *FPI = dyn_cast<ConstrainedFPIntrinsic>(&CI);
+      FPI && FPI->use_empty() &&
+      (*FPI->getExceptionBehavior() != fp::ebStrict ||
+       TryConstantFoldCall(FPI, FPI->getCalledFunction(),
+                           to_vector_of<Value *, 4>(FPI->args()),
+                           &TLI) != nullptr))
+    return eraseInstFromFunction(*FPI);
 
   Intrinsic::ID IID = II->getIntrinsicID();
   switch (IID) {

--- a/llvm/test/Transforms/InstCombine/constrained.ll
+++ b/llvm/test/Transforms/InstCombine/constrained.ll
@@ -59,6 +59,30 @@ entry:
   ret float 1.0
 }
 
+; A fpexcept.strict operation may still be needed for its exception side-effect
+; even if its result would be poison.
+define void @f_unused_strict_nnan_snan() #0 {
+; CHECK-LABEL: @f_unused_strict_nnan_snan(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan double @llvm.experimental.constrained.fadd.f64(double +snan(0x4000000000001), double 1.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret void
+;
+entry:
+  %result = call nnan double @llvm.experimental.constrained.fadd.f64(double 0x7FF4000000000001, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+define void @f_unused_strict_ninf_inf_zero() #0 {
+; CHECK-LABEL: @f_unused_strict_ninf_inf_zero(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RESULT:%.*]] = call ninf double @llvm.experimental.constrained.fmul.f64(double +inf, double 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret void
+;
+entry:
+  %result = call ninf double @llvm.experimental.constrained.fmul.f64(double 0x7FF0000000000000, double 0.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret void
+}
+
 ; Constant evaluation.
 
 ; If operation does not raise exceptions, it may be folded even in strict mode.
@@ -118,8 +142,21 @@ entry:
   ret float %result
 }
 
+define double @f_eval_strict_nnan_snan() #0 {
+; CHECK-LABEL: @f_eval_strict_nnan_snan(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[RESULT:%.*]] = call nnan double @llvm.experimental.constrained.fadd.f64(double +snan(0x4000000000001), double 1.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret double poison
+;
+entry:
+  %result = call nnan double @llvm.experimental.constrained.fadd.f64(double 0x7FF4000000000001, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret double %result
+}
+
 
 declare float @llvm.experimental.constrained.fadd.f32(float, float, metadata, metadata)
+declare double @llvm.experimental.constrained.fadd.f64(double, double, metadata, metadata)
 declare float @llvm.experimental.constrained.fdiv.f32(float, float, metadata, metadata)
+declare double @llvm.experimental.constrained.fmul.f64(double, double, metadata, metadata)
 
 attributes #0 = { strictfp }

--- a/llvm/test/Transforms/InstSimplify/fp-undef-poison-strictfp.ll
+++ b/llvm/test/Transforms/InstSimplify/fp-undef-poison-strictfp.ll
@@ -911,9 +911,52 @@ define float @fma_poison_op2_defaultfp(float %x, float %y) #0 {
   ret float %r
 }
 
+; nnan/ninf still make the result poison under fpexcept.strict, but the
+; constrained call must remain if it would observably raise FE_INVALID.
+
+define double @fadd_nnan_strict_snan() #0 {
+; CHECK-LABEL: @fadd_nnan_strict_snan(
+; CHECK-NEXT:    [[R:%.*]] = call nnan double @llvm.experimental.constrained.fadd.f64(double +snan(0x4000000000001), double 1.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0:[0-9]+]]
+; CHECK-NEXT:    ret double poison
+;
+  %r = call nnan double @llvm.experimental.constrained.fadd.f64(double 0x7FF4000000000001, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret double %r
+}
+
+define double @fmul_ninf_strict_inf() #0 {
+; CHECK-LABEL: @fmul_ninf_strict_inf(
+; CHECK-NEXT:    [[R:%.*]] = call ninf double @llvm.experimental.constrained.fmul.f64(double +inf, double 0.000000e+00, metadata !"round.dynamic", metadata !"fpexcept.strict") #[[ATTR0]]
+; CHECK-NEXT:    ret double poison
+;
+  %r = call ninf double @llvm.experimental.constrained.fmul.f64(double 0x7FF0000000000000, double 0.0, metadata !"round.dynamic", metadata !"fpexcept.strict") #0
+  ret double %r
+}
+
+; fpexcept.maytrap does not need to preserve the original exception, so nnan
+; can fold the call's result to poison and leave no side-effecting operation.
+define double @fadd_nnan_maytrap_snan() #0 {
+; CHECK-LABEL: @fadd_nnan_maytrap_snan(
+; CHECK-NEXT:    ret double poison
+;
+  %r = call nnan double @llvm.experimental.constrained.fadd.f64(double 0x7FF4000000000001, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.maytrap") #0
+  ret double %r
+}
+
+; fpexcept.ignore has no observable exception, so nnan can still fold the
+; call's result to poison.
+define double @fadd_nnan_ignore_snan() #0 {
+; CHECK-LABEL: @fadd_nnan_ignore_snan(
+; CHECK-NEXT:    ret double poison
+;
+  %r = call nnan double @llvm.experimental.constrained.fadd.f64(double 0x7FF4000000000001, double 1.0, metadata !"round.dynamic", metadata !"fpexcept.ignore") #0
+  ret double %r
+}
+
 declare float @llvm.experimental.constrained.fadd.f32(float, float, metadata, metadata)
+declare double @llvm.experimental.constrained.fadd.f64(double, double, metadata, metadata)
 declare float @llvm.experimental.constrained.fsub.f32(float, float, metadata, metadata)
 declare float @llvm.experimental.constrained.fmul.f32(float, float, metadata, metadata)
+declare double @llvm.experimental.constrained.fmul.f64(double, double, metadata, metadata)
 declare float @llvm.experimental.constrained.fdiv.f32(float, float, metadata, metadata)
 declare float @llvm.experimental.constrained.frem.f32(float, float, metadata, metadata)
 declare float @llvm.experimental.constrained.fma.f32(float, float, float, metadata, metadata)


### PR DESCRIPTION
Suppose we have a constrained FP op with strict exception semantics, but
which also has the nnan flag.  And suppose we pass sNaN as an argument to
that op.

Previously we would replace the op's uses with poison (correct), but
also remove it.  Removing it is incorrect, because of its strict
exception semantics.

To fix this I got rid of the simplifyConstrainedFPCall function.  It was
only ever used in one place, and in that callsite we didn't even look at
the returned value.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.
