### PR TITLE
Emit newline after IR-dump banner in PrintCallGraphPass

### DIFF
--- a/llvm/lib/Analysis/CallGraphSCCPass.cpp
+++ b/llvm/lib/Analysis/CallGraphSCCPass.cpp
@@ -678,7 +678,7 @@ namespace {
       auto PrintBannerOnce = [&]() {
         if (BannerPrinted)
           return;
-        OS << Banner;
+        OS << Banner << "\n";
         BannerPrinted = true;
       };
 

--- a/llvm/test/Other/legacy-callgraph-scc-pass-printer.ll
+++ b/llvm/test/Other/legacy-callgraph-scc-pass-printer.ll
@@ -1,0 +1,11 @@
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -enable-ipra \
+; RUN:     -print-after=DummyCGSCCPass -o - %s 2>&1 | FileCheck %s
+; REQUIRES: x86-registered-target
+
+; The legacy CallGraphSCCPass printer should emit the banner as its own line.
+; CHECK-LABEL: *** IR Dump After DummyCGSCCPass (DummyCGSCCPass) ***
+; CHECK-NEXT: define void @bar() {
+
+define void @bar() {
+  ret void
+}


### PR DESCRIPTION
Required for Compiler Explorer's opt-pipeline viewer: the tool parses pass output by splitting on the IR-dump banner line, so the banner must end with a newline. Without it, targets that exercise this pass cannot be inspected through the opt-pipeline feature.

Assisted by Claude.