### PR TITLE
[clang] Fix comma location tracking inside ParenListExpr.

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -6083,31 +6083,44 @@ public:
 
 class ParenListExpr final
     : public Expr,
-      private llvm::TrailingObjects<ParenListExpr, Stmt *> {
+      private llvm::TrailingObjects<ParenListExpr, Stmt *, SourceLocation> {
   friend class ASTStmtReader;
   friend TrailingObjects;
 
   /// The location of the left and right parentheses.
   SourceLocation LParenLoc, RParenLoc;
 
+  /// The number of comma locations stored after the expression list.
+  unsigned NumCommas;
+
+  size_t numTrailingObjects(OverloadToken<Stmt *>) const {
+    return getNumExprs();
+  }
+
+  size_t numTrailingObjects(OverloadToken<SourceLocation>) const {
+    return NumCommas;
+  }
+
   /// Build a paren list.
   ParenListExpr(SourceLocation LParenLoc, ArrayRef<Expr *> Exprs,
-                SourceLocation RParenLoc);
+                SourceLocation RParenLoc, ArrayRef<SourceLocation> CommaLocs);
 
   /// Build an empty paren list.
-  ParenListExpr(EmptyShell Empty, unsigned NumExprs);
+  ParenListExpr(EmptyShell Empty, unsigned NumExprs, unsigned NumCommas);
 
 public:
   /// Create a paren list.
   static ParenListExpr *Create(const ASTContext &Ctx, SourceLocation LParenLoc,
-                               ArrayRef<Expr *> Exprs,
-                               SourceLocation RParenLoc);
+                               ArrayRef<Expr *> Exprs, SourceLocation RParenLoc,
+                               ArrayRef<SourceLocation> CommaLocs = {});
 
   /// Create an empty paren list.
-  static ParenListExpr *CreateEmpty(const ASTContext &Ctx, unsigned NumExprs);
+  static ParenListExpr *CreateEmpty(const ASTContext &Ctx, unsigned NumExprs,
+                                    unsigned NumCommas = 0);
 
   /// Return the number of expressions in this paren list.
   unsigned getNumExprs() const { return ParenListExprBits.NumExprs; }
+  unsigned getNumCommas() const { return NumCommas; }
 
   Expr *getExpr(unsigned Init) {
     assert(Init < getNumExprs() && "Initializer access out of range!");
@@ -6118,13 +6131,19 @@ public:
     return const_cast<ParenListExpr *>(this)->getExpr(Init);
   }
 
-  Expr **getExprs() { return reinterpret_cast<Expr **>(getTrailingObjects()); }
+  Expr **getExprs() {
+    return reinterpret_cast<Expr **>(getTrailingObjects<Stmt *>());
+  }
 
   Expr *const *getExprs() const {
-    return reinterpret_cast<Expr *const *>(getTrailingObjects());
+    return reinterpret_cast<Expr *const *>(getTrailingObjects<Stmt *>());
   }
 
   ArrayRef<Expr *> exprs() const { return {getExprs(), getNumExprs()}; }
+
+  ArrayRef<SourceLocation> getCommaLocs() const {
+    return {getTrailingObjects<SourceLocation>(), getNumCommas()};
+  }
 
   SourceLocation getLParenLoc() const { return LParenLoc; }
   SourceLocation getRParenLoc() const { return RParenLoc; }
@@ -6137,10 +6156,12 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(getTrailingObjects(getNumExprs()));
+    return child_range(getTrailingObjects<Stmt *>(),
+                       getTrailingObjects<Stmt *>() + getNumExprs());
   }
   const_child_range children() const {
-    return const_child_range(getTrailingObjects(getNumExprs()));
+    return const_child_range(getTrailingObjects<Stmt *>(),
+                             getTrailingObjects<Stmt *>() + getNumExprs());
   }
 };
 

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -6093,15 +6093,12 @@ class ParenListExpr final
   /// The location of the left and right parentheses.
   SourceLocation LParenLoc, RParenLoc;
 
-  /// The number of comma locations stored after the expression list.
-  unsigned NumCommas;
-
   size_t numTrailingObjects(OverloadToken<Stmt *>) const {
     return getNumExprs();
   }
 
   size_t numTrailingObjects(OverloadToken<SourceLocation>) const {
-    return NumCommas;
+    return getNumCommas();
   }
 
   /// Build a paren list.
@@ -6109,21 +6106,20 @@ class ParenListExpr final
                 SourceLocation RParenLoc, ArrayRef<SourceLocation> CommaLocs);
 
   /// Build an empty paren list.
-  ParenListExpr(EmptyShell Empty, unsigned NumExprs, unsigned NumCommas);
+  ParenListExpr(EmptyShell Empty, unsigned NumExprs);
 
 public:
   /// Create a paren list.
   static ParenListExpr *Create(const ASTContext &Ctx, SourceLocation LParenLoc,
                                ArrayRef<Expr *> Exprs, SourceLocation RParenLoc,
-                               ArrayRef<SourceLocation> CommaLocs = {});
+                               ArrayRef<SourceLocation> CommaLocs);
 
   /// Create an empty paren list.
-  static ParenListExpr *CreateEmpty(const ASTContext &Ctx, unsigned NumExprs,
-                                    unsigned NumCommas = 0);
+  static ParenListExpr *CreateEmpty(const ASTContext &Ctx, unsigned NumExprs);
 
   /// Return the number of expressions in this paren list.
   unsigned getNumExprs() const { return ParenListExprBits.NumExprs; }
-  unsigned getNumCommas() const { return NumCommas; }
+  unsigned getNumCommas() const { return getNumExprs() ? getNumExprs() - 1 : 0; }
 
   Expr *getExpr(unsigned Init) {
     assert(Init < getNumExprs() && "Initializer access out of range!");

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -6086,31 +6086,44 @@ public:
 
 class ParenListExpr final
     : public Expr,
-      private llvm::TrailingObjects<ParenListExpr, Stmt *> {
+      private llvm::TrailingObjects<ParenListExpr, Stmt *, SourceLocation> {
   friend class ASTStmtReader;
   friend TrailingObjects;
 
   /// The location of the left and right parentheses.
   SourceLocation LParenLoc, RParenLoc;
 
+  /// The number of comma locations stored after the expression list.
+  unsigned NumCommas;
+
+  size_t numTrailingObjects(OverloadToken<Stmt *>) const {
+    return getNumExprs();
+  }
+
+  size_t numTrailingObjects(OverloadToken<SourceLocation>) const {
+    return NumCommas;
+  }
+
   /// Build a paren list.
   ParenListExpr(SourceLocation LParenLoc, ArrayRef<Expr *> Exprs,
-                SourceLocation RParenLoc);
+                SourceLocation RParenLoc, ArrayRef<SourceLocation> CommaLocs);
 
   /// Build an empty paren list.
-  ParenListExpr(EmptyShell Empty, unsigned NumExprs);
+  ParenListExpr(EmptyShell Empty, unsigned NumExprs, unsigned NumCommas);
 
 public:
   /// Create a paren list.
   static ParenListExpr *Create(const ASTContext &Ctx, SourceLocation LParenLoc,
-                               ArrayRef<Expr *> Exprs,
-                               SourceLocation RParenLoc);
+                               ArrayRef<Expr *> Exprs, SourceLocation RParenLoc,
+                               ArrayRef<SourceLocation> CommaLocs = {});
 
   /// Create an empty paren list.
-  static ParenListExpr *CreateEmpty(const ASTContext &Ctx, unsigned NumExprs);
+  static ParenListExpr *CreateEmpty(const ASTContext &Ctx, unsigned NumExprs,
+                                    unsigned NumCommas = 0);
 
   /// Return the number of expressions in this paren list.
   unsigned getNumExprs() const { return ParenListExprBits.NumExprs; }
+  unsigned getNumCommas() const { return NumCommas; }
 
   Expr *getExpr(unsigned Init) {
     assert(Init < getNumExprs() && "Initializer access out of range!");
@@ -6121,13 +6134,19 @@ public:
     return const_cast<ParenListExpr *>(this)->getExpr(Init);
   }
 
-  Expr **getExprs() { return reinterpret_cast<Expr **>(getTrailingObjects()); }
+  Expr **getExprs() {
+    return reinterpret_cast<Expr **>(getTrailingObjects<Stmt *>());
+  }
 
   Expr *const *getExprs() const {
-    return reinterpret_cast<Expr *const *>(getTrailingObjects());
+    return reinterpret_cast<Expr *const *>(getTrailingObjects<Stmt *>());
   }
 
   ArrayRef<Expr *> exprs() const { return {getExprs(), getNumExprs()}; }
+
+  ArrayRef<SourceLocation> getCommaLocs() const {
+    return {getTrailingObjects<SourceLocation>(), getNumCommas()};
+  }
 
   SourceLocation getLParenLoc() const { return LParenLoc; }
   SourceLocation getRParenLoc() const { return RParenLoc; }
@@ -6140,10 +6159,12 @@ public:
 
   // Iterators
   child_range children() {
-    return child_range(getTrailingObjects(getNumExprs()));
+    return child_range(getTrailingObjects<Stmt *>(),
+                       getTrailingObjects<Stmt *>() + getNumExprs());
   }
   const_child_range children() const {
-    return const_child_range(getTrailingObjects(getNumExprs()));
+    return const_child_range(getTrailingObjects<Stmt *>(),
+                             getTrailingObjects<Stmt *>() + getNumExprs());
   }
 };
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4250,7 +4250,9 @@ private:
   ///         assignment-expression
   ///         simple-expression-list , assignment-expression
   /// \endverbatim
-  bool ParseSimpleExpressionList(SmallVectorImpl<Expr *> &Exprs);
+  bool ParseSimpleExpressionList(
+      SmallVectorImpl<Expr *> &Exprs,
+      SmallVectorImpl<SourceLocation> *CommaLocs = nullptr);
 
   /// This parses the unit that starts with a '(' token, based on what is
   /// allowed by ExprType. The actual thing parsed is returned in ExprType. If

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4229,6 +4229,10 @@ private:
   /// [C++0x]   braced-init-list
   /// \endverbatim
   bool ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
+                           llvm::function_ref<void()> ExpressionStarts,
+                           bool FailImmediatelyOnInvalidExpr,
+                           SmallVectorImpl<SourceLocation> &CommaLocs);
+  bool ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
                            llvm::function_ref<void()> ExpressionStarts =
                                llvm::function_ref<void()>(),
                            bool FailImmediatelyOnInvalidExpr = false);
@@ -4243,7 +4247,7 @@ private:
   /// \endverbatim
   bool ParseSimpleExpressionList(
       SmallVectorImpl<Expr *> &Exprs,
-      SmallVectorImpl<SourceLocation> *CommaLocs = nullptr);
+      SmallVectorImpl<SourceLocation> &CommaLocs);
 
   /// This parses the unit that starts with a '(' token, based on what is
   /// allowed by ExprType. The actual thing parsed is returned in ExprType. If

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -4241,7 +4241,9 @@ private:
   ///         assignment-expression
   ///         simple-expression-list , assignment-expression
   /// \endverbatim
-  bool ParseSimpleExpressionList(SmallVectorImpl<Expr *> &Exprs);
+  bool ParseSimpleExpressionList(
+      SmallVectorImpl<Expr *> &Exprs,
+      SmallVectorImpl<SourceLocation> *CommaLocs = nullptr);
 
   /// This parses the unit that starts with a '(' token, based on what is
   /// allowed by ExprType. The actual thing parsed is returned in ExprType. If

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -7361,7 +7361,8 @@ public:
                                     Scope *UDLScope = nullptr);
   ExprResult ActOnParenExpr(SourceLocation L, SourceLocation R, Expr *E);
   ExprResult ActOnParenListExpr(SourceLocation L, SourceLocation R,
-                                MultiExprArg Val);
+                                MultiExprArg Val,
+                                ArrayRef<SourceLocation> CommaLocs = {});
   ExprResult ActOnCXXParenListInitExpr(ArrayRef<Expr *> Args, QualType T,
                                        unsigned NumUserSpecifiedExprs,
                                        SourceLocation InitLoc,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -7362,7 +7362,7 @@ public:
   ExprResult ActOnParenExpr(SourceLocation L, SourceLocation R, Expr *E);
   ExprResult ActOnParenListExpr(SourceLocation L, SourceLocation R,
                                 MultiExprArg Val,
-                                ArrayRef<SourceLocation> CommaLocs = {});
+                                ArrayRef<SourceLocation> CommaLocs);
   ExprResult ActOnCXXParenListInitExpr(ArrayRef<Expr *> Args, QualType T,
                                        unsigned NumUserSpecifiedExprs,
                                        SourceLocation InitLoc,

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -8045,8 +8045,16 @@ ExpectedStmt ASTNodeImporter::VisitParenListExpr(ParenListExpr *E) {
   if (!ToRParenLocOrErr)
     return ToRParenLocOrErr.takeError();
 
+  SmallVector<SourceLocation, 4> ToCommaLocs;
+  for (SourceLocation CommaLoc : E->getCommaLocs()) {
+    ExpectedSLoc ToCommaLocOrErr = import(CommaLoc);
+    if (!ToCommaLocOrErr)
+      return ToCommaLocOrErr.takeError();
+    ToCommaLocs.push_back(*ToCommaLocOrErr);
+  }
+
   return ParenListExpr::Create(Importer.getToContext(), *ToLParenLocOrErr,
-                               ToExprs, *ToRParenLocOrErr);
+                               ToExprs, *ToRParenLocOrErr, ToCommaLocs);
 }
 
 ExpectedStmt ASTNodeImporter::VisitStmtExpr(StmtExpr *E) {

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -4960,33 +4960,42 @@ SourceLocation DesignatedInitUpdateExpr::getEndLoc() const {
 }
 
 ParenListExpr::ParenListExpr(SourceLocation LParenLoc, ArrayRef<Expr *> Exprs,
-                             SourceLocation RParenLoc)
+                             SourceLocation RParenLoc,
+                             ArrayRef<SourceLocation> CommaLocs)
     : Expr(ParenListExprClass, QualType(), VK_PRValue, OK_Ordinary),
-      LParenLoc(LParenLoc), RParenLoc(RParenLoc) {
+      LParenLoc(LParenLoc), RParenLoc(RParenLoc), NumCommas(CommaLocs.size()) {
+  assert((CommaLocs.empty() || CommaLocs.size() + 1 == Exprs.size()) &&
+         "wrong number of comma locations for paren list");
   ParenListExprBits.NumExprs = Exprs.size();
-  llvm::copy(Exprs, getTrailingObjects());
+  llvm::copy(Exprs, getTrailingObjects<Stmt *>());
+  llvm::copy(CommaLocs, getTrailingObjects<SourceLocation>());
   setDependence(computeDependence(this));
 }
 
-ParenListExpr::ParenListExpr(EmptyShell Empty, unsigned NumExprs)
-    : Expr(ParenListExprClass, Empty) {
+ParenListExpr::ParenListExpr(EmptyShell Empty, unsigned NumExprs,
+                             unsigned NumCommas)
+    : Expr(ParenListExprClass, Empty), NumCommas(NumCommas) {
   ParenListExprBits.NumExprs = NumExprs;
 }
 
 ParenListExpr *ParenListExpr::Create(const ASTContext &Ctx,
                                      SourceLocation LParenLoc,
                                      ArrayRef<Expr *> Exprs,
-                                     SourceLocation RParenLoc) {
-  void *Mem = Ctx.Allocate(totalSizeToAlloc<Stmt *>(Exprs.size()),
-                           alignof(ParenListExpr));
-  return new (Mem) ParenListExpr(LParenLoc, Exprs, RParenLoc);
+                                     SourceLocation RParenLoc,
+                                     ArrayRef<SourceLocation> CommaLocs) {
+  void *Mem = Ctx.Allocate(
+      totalSizeToAlloc<Stmt *, SourceLocation>(Exprs.size(), CommaLocs.size()),
+      alignof(ParenListExpr));
+  return new (Mem) ParenListExpr(LParenLoc, Exprs, RParenLoc, CommaLocs);
 }
 
 ParenListExpr *ParenListExpr::CreateEmpty(const ASTContext &Ctx,
-                                          unsigned NumExprs) {
-  void *Mem =
-      Ctx.Allocate(totalSizeToAlloc<Stmt *>(NumExprs), alignof(ParenListExpr));
-  return new (Mem) ParenListExpr(EmptyShell(), NumExprs);
+                                          unsigned NumExprs,
+                                          unsigned NumCommas) {
+  void *Mem = Ctx.Allocate(
+      totalSizeToAlloc<Stmt *, SourceLocation>(NumExprs, NumCommas),
+      alignof(ParenListExpr));
+  return new (Mem) ParenListExpr(EmptyShell(), NumExprs, NumCommas);
 }
 
 /// Certain overflow-dependent code patterns can have their integer overflow

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -4963,18 +4963,17 @@ ParenListExpr::ParenListExpr(SourceLocation LParenLoc, ArrayRef<Expr *> Exprs,
                              SourceLocation RParenLoc,
                              ArrayRef<SourceLocation> CommaLocs)
     : Expr(ParenListExprClass, QualType(), VK_PRValue, OK_Ordinary),
-      LParenLoc(LParenLoc), RParenLoc(RParenLoc), NumCommas(CommaLocs.size()) {
-  assert((CommaLocs.empty() || CommaLocs.size() + 1 == Exprs.size()) &&
-         "wrong number of comma locations for paren list");
+      LParenLoc(LParenLoc), RParenLoc(RParenLoc) {
   ParenListExprBits.NumExprs = Exprs.size();
+  assert(CommaLocs.size() == getNumCommas() &&
+         "wrong number of comma locations for paren list");
   llvm::copy(Exprs, getTrailingObjects<Stmt *>());
   llvm::copy(CommaLocs, getTrailingObjects<SourceLocation>());
   setDependence(computeDependence(this));
 }
 
-ParenListExpr::ParenListExpr(EmptyShell Empty, unsigned NumExprs,
-                             unsigned NumCommas)
-    : Expr(ParenListExprClass, Empty), NumCommas(NumCommas) {
+ParenListExpr::ParenListExpr(EmptyShell Empty, unsigned NumExprs)
+    : Expr(ParenListExprClass, Empty) {
   ParenListExprBits.NumExprs = NumExprs;
 }
 
@@ -4983,19 +4982,20 @@ ParenListExpr *ParenListExpr::Create(const ASTContext &Ctx,
                                      ArrayRef<Expr *> Exprs,
                                      SourceLocation RParenLoc,
                                      ArrayRef<SourceLocation> CommaLocs) {
+  unsigned NumCommas = Exprs.empty() ? 0 : Exprs.size() - 1;
   void *Mem = Ctx.Allocate(
-      totalSizeToAlloc<Stmt *, SourceLocation>(Exprs.size(), CommaLocs.size()),
+      totalSizeToAlloc<Stmt *, SourceLocation>(Exprs.size(), NumCommas),
       alignof(ParenListExpr));
   return new (Mem) ParenListExpr(LParenLoc, Exprs, RParenLoc, CommaLocs);
 }
 
 ParenListExpr *ParenListExpr::CreateEmpty(const ASTContext &Ctx,
-                                          unsigned NumExprs,
-                                          unsigned NumCommas) {
+                                          unsigned NumExprs) {
+  unsigned NumCommas = NumExprs ? NumExprs - 1 : 0;
   void *Mem = Ctx.Allocate(
       totalSizeToAlloc<Stmt *, SourceLocation>(NumExprs, NumCommas),
       alignof(ParenListExpr));
-  return new (Mem) ParenListExpr(EmptyShell(), NumExprs, NumCommas);
+  return new (Mem) ParenListExpr(EmptyShell(), NumExprs);
 }
 
 /// Certain overflow-dependent code patterns can have their integer overflow

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -4958,33 +4958,42 @@ SourceLocation DesignatedInitUpdateExpr::getEndLoc() const {
 }
 
 ParenListExpr::ParenListExpr(SourceLocation LParenLoc, ArrayRef<Expr *> Exprs,
-                             SourceLocation RParenLoc)
+                             SourceLocation RParenLoc,
+                             ArrayRef<SourceLocation> CommaLocs)
     : Expr(ParenListExprClass, QualType(), VK_PRValue, OK_Ordinary),
-      LParenLoc(LParenLoc), RParenLoc(RParenLoc) {
+      LParenLoc(LParenLoc), RParenLoc(RParenLoc), NumCommas(CommaLocs.size()) {
+  assert((CommaLocs.empty() || CommaLocs.size() + 1 == Exprs.size()) &&
+         "wrong number of comma locations for paren list");
   ParenListExprBits.NumExprs = Exprs.size();
-  llvm::copy(Exprs, getTrailingObjects());
+  llvm::copy(Exprs, getTrailingObjects<Stmt *>());
+  llvm::copy(CommaLocs, getTrailingObjects<SourceLocation>());
   setDependence(computeDependence(this));
 }
 
-ParenListExpr::ParenListExpr(EmptyShell Empty, unsigned NumExprs)
-    : Expr(ParenListExprClass, Empty) {
+ParenListExpr::ParenListExpr(EmptyShell Empty, unsigned NumExprs,
+                             unsigned NumCommas)
+    : Expr(ParenListExprClass, Empty), NumCommas(NumCommas) {
   ParenListExprBits.NumExprs = NumExprs;
 }
 
 ParenListExpr *ParenListExpr::Create(const ASTContext &Ctx,
                                      SourceLocation LParenLoc,
                                      ArrayRef<Expr *> Exprs,
-                                     SourceLocation RParenLoc) {
-  void *Mem = Ctx.Allocate(totalSizeToAlloc<Stmt *>(Exprs.size()),
-                           alignof(ParenListExpr));
-  return new (Mem) ParenListExpr(LParenLoc, Exprs, RParenLoc);
+                                     SourceLocation RParenLoc,
+                                     ArrayRef<SourceLocation> CommaLocs) {
+  void *Mem = Ctx.Allocate(
+      totalSizeToAlloc<Stmt *, SourceLocation>(Exprs.size(), CommaLocs.size()),
+      alignof(ParenListExpr));
+  return new (Mem) ParenListExpr(LParenLoc, Exprs, RParenLoc, CommaLocs);
 }
 
 ParenListExpr *ParenListExpr::CreateEmpty(const ASTContext &Ctx,
-                                          unsigned NumExprs) {
-  void *Mem =
-      Ctx.Allocate(totalSizeToAlloc<Stmt *>(NumExprs), alignof(ParenListExpr));
-  return new (Mem) ParenListExpr(EmptyShell(), NumExprs);
+                                          unsigned NumExprs,
+                                          unsigned NumCommas) {
+  void *Mem = Ctx.Allocate(
+      totalSizeToAlloc<Stmt *, SourceLocation>(NumExprs, NumCommas),
+      alignof(ParenListExpr));
+  return new (Mem) ParenListExpr(EmptyShell(), NumExprs, NumCommas);
 }
 
 /// Certain overflow-dependent code patterns can have their integer overflow

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2698,7 +2698,9 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
       ExpressionStarts = SetPreferredType;
     }
 
-    bool SawError = ParseExpressionList(Exprs, ExpressionStarts);
+    SmallVector<SourceLocation, 4> CommaLocs;
+    bool SawError = ParseExpressionList(Exprs, ExpressionStarts, false,
+                                        CommaLocs);
 
     if (SawError) {
       if (ThisVarDecl && PP.isCodeCompletionReached() && !CalledSignatureHelp) {
@@ -2716,7 +2718,7 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
 
       ExprResult Initializer = Actions.ActOnParenListExpr(T.getOpenLocation(),
                                                           T.getCloseLocation(),
-                                                          Exprs);
+                                                          Exprs, CommaLocs);
       Actions.AddInitializerToDecl(ThisDecl, Initializer.get(),
                                    /*DirectInit=*/true);
     }

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2942,8 +2942,9 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool StopIfCastExpr,
     // Parse the expression-list.
     InMessageExpressionRAIIObject InMessage(*this, false);
     ExprVector ArgExprs;
+    SmallVector<SourceLocation, 4> CommaLocs;
 
-    if (!ParseSimpleExpressionList(ArgExprs)) {
+    if (!ParseSimpleExpressionList(ArgExprs, &CommaLocs)) {
       // FIXME: If we ever support comma expressions as operands to
       // fold-expressions, we'll need to allow multiple ArgExprs here.
       if (ExprType >= ParenParseOption::FoldExpr && ArgExprs.size() == 1 &&
@@ -2953,8 +2954,8 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool StopIfCastExpr,
       }
 
       ExprType = ParenParseOption::SimpleExpr;
-      Result = Actions.ActOnParenListExpr(OpenLoc, Tok.getLocation(),
-                                          ArgExprs);
+      Result = Actions.ActOnParenListExpr(OpenLoc, Tok.getLocation(), ArgExprs,
+                                          CommaLocs);
     }
   } else if (getLangOpts().OpenMP >= 50 && OpenMPDirectiveParsing &&
              ExprType == ParenParseOption::CastExpr && Tok.is(tok::l_square) &&
@@ -3278,7 +3279,9 @@ bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
   return SawError;
 }
 
-bool Parser::ParseSimpleExpressionList(SmallVectorImpl<Expr *> &Exprs) {
+bool Parser::ParseSimpleExpressionList(
+    SmallVectorImpl<Expr *> &Exprs,
+    SmallVectorImpl<SourceLocation> *CommaLocs) {
   while (true) {
     ExprResult Expr = ParseAssignmentExpression();
     if (Expr.isInvalid())
@@ -3293,6 +3296,9 @@ bool Parser::ParseSimpleExpressionList(SmallVectorImpl<Expr *> &Exprs) {
 
     // Move to the next argument, remember where the comma was.
     Token Comma = Tok;
+    if (CommaLocs)
+      CommaLocs->push_back(Comma.getLocation());
+
     ConsumeToken();
     checkPotentialAngleBracketDelimiter(Comma);
   }

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -2941,8 +2941,9 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool StopIfCastExpr,
     // Parse the expression-list.
     InMessageExpressionRAIIObject InMessage(*this, false);
     ExprVector ArgExprs;
+    SmallVector<SourceLocation, 4> CommaLocs;
 
-    if (!ParseSimpleExpressionList(ArgExprs)) {
+    if (!ParseSimpleExpressionList(ArgExprs, &CommaLocs)) {
       // FIXME: If we ever support comma expressions as operands to
       // fold-expressions, we'll need to allow multiple ArgExprs here.
       if (ExprType >= ParenParseOption::FoldExpr && ArgExprs.size() == 1 &&
@@ -2952,8 +2953,8 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool StopIfCastExpr,
       }
 
       ExprType = ParenParseOption::SimpleExpr;
-      Result = Actions.ActOnParenListExpr(OpenLoc, Tok.getLocation(),
-                                          ArgExprs);
+      Result = Actions.ActOnParenListExpr(OpenLoc, Tok.getLocation(), ArgExprs,
+                                          CommaLocs);
     }
   } else if (getLangOpts().OpenMP >= 50 && OpenMPDirectiveParsing &&
              ExprType == ParenParseOption::CastExpr && Tok.is(tok::l_square) &&
@@ -3277,7 +3278,9 @@ bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
   return SawError;
 }
 
-bool Parser::ParseSimpleExpressionList(SmallVectorImpl<Expr *> &Exprs) {
+bool Parser::ParseSimpleExpressionList(
+    SmallVectorImpl<Expr *> &Exprs,
+    SmallVectorImpl<SourceLocation> *CommaLocs) {
   while (true) {
     ExprResult Expr = ParseAssignmentExpression();
     if (Expr.isInvalid())
@@ -3292,6 +3295,9 @@ bool Parser::ParseSimpleExpressionList(SmallVectorImpl<Expr *> &Exprs) {
 
     // Move to the next argument, remember where the comma was.
     Token Comma = Tok;
+    if (CommaLocs)
+      CommaLocs->push_back(Comma.getLocation());
+
     ConsumeToken();
     checkPotentialAngleBracketDelimiter(Comma);
   }

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -1832,9 +1832,10 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
 
       if (OpKind == tok::lesslessless) {
         ExprVector ExecConfigExprs;
+        SmallVector<SourceLocation, 4> CommaLocs;
         SourceLocation OpenLoc = ConsumeToken();
 
-        if (ParseSimpleExpressionList(ExecConfigExprs)) {
+        if (ParseSimpleExpressionList(ExecConfigExprs, CommaLocs)) {
           LHS = ExprError();
         }
 
@@ -2944,7 +2945,7 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool StopIfCastExpr,
     ExprVector ArgExprs;
     SmallVector<SourceLocation, 4> CommaLocs;
 
-    if (!ParseSimpleExpressionList(ArgExprs, &CommaLocs)) {
+    if (!ParseSimpleExpressionList(ArgExprs, CommaLocs)) {
       // FIXME: If we ever support comma expressions as operands to
       // fold-expressions, we'll need to allow multiple ArgExprs here.
       if (ExprType >= ParenParseOption::FoldExpr && ArgExprs.size() == 1 &&
@@ -3236,6 +3237,15 @@ void Parser::injectEmbedTokens() {
 bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
                                  llvm::function_ref<void()> ExpressionStarts,
                                  bool FailImmediatelyOnInvalidExpr) {
+  SmallVector<SourceLocation, 4> CommaLocs;
+  return ParseExpressionList(Exprs, ExpressionStarts,
+                             FailImmediatelyOnInvalidExpr, CommaLocs);
+}
+
+bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
+                                 llvm::function_ref<void()> ExpressionStarts,
+                                 bool FailImmediatelyOnInvalidExpr,
+                                 SmallVectorImpl<SourceLocation> &CommaLocs) {
   bool SawError = false;
   while (true) {
     if (ExpressionStarts)
@@ -3273,6 +3283,7 @@ bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
       break;
     // Move to the next argument, remember where the comma was.
     Token Comma = Tok;
+    CommaLocs.push_back(Comma.getLocation());
     ConsumeToken();
     checkPotentialAngleBracketDelimiter(Comma);
   }
@@ -3281,7 +3292,7 @@ bool Parser::ParseExpressionList(SmallVectorImpl<Expr *> &Exprs,
 
 bool Parser::ParseSimpleExpressionList(
     SmallVectorImpl<Expr *> &Exprs,
-    SmallVectorImpl<SourceLocation> *CommaLocs) {
+    SmallVectorImpl<SourceLocation> &CommaLocs) {
   while (true) {
     ExprResult Expr = ParseAssignmentExpression();
     if (Expr.isInvalid())
@@ -3296,8 +3307,7 @@ bool Parser::ParseSimpleExpressionList(
 
     // Move to the next argument, remember where the comma was.
     Token Comma = Tok;
-    if (CommaLocs)
-      CommaLocs->push_back(Comma.getLocation());
+    CommaLocs.push_back(Comma.getLocation());
 
     ConsumeToken();
     checkPotentialAngleBracketDelimiter(Comma);

--- a/clang/lib/Parse/ParseExprCXX.cpp
+++ b/clang/lib/Parse/ParseExprCXX.cpp
@@ -911,17 +911,18 @@ bool Parser::ParseLambdaIntroducer(LambdaIntroducer &Intro,
         InitKind = LambdaCaptureInitKind::DirectInit;
 
         ExprVector Exprs;
+        SmallVector<SourceLocation, 4> CommaLocs;
         if (Tentative) {
           Parens.skipToEnd();
           *Tentative = LambdaIntroducerTentativeParse::Incomplete;
-        } else if (ParseExpressionList(Exprs)) {
+        } else if (ParseExpressionList(Exprs, {}, false, CommaLocs)) {
           Parens.skipToEnd();
           Init = ExprError();
         } else {
           Parens.consumeClose();
           Init = Actions.ActOnParenListExpr(Parens.getOpenLocation(),
                                             Parens.getCloseLocation(),
-                                            Exprs);
+                                            Exprs, CommaLocs);
         }
       } else if (Tok.isOneOf(tok::l_brace, tok::equal)) {
         // Each lambda init-capture forms its own full expression, which clears
@@ -2917,6 +2918,7 @@ Parser::ParseCXXNewExpression(bool UseGlobal, SourceLocation Start) {
   if (Tok.is(tok::l_paren)) {
     SourceLocation ConstructorLParen, ConstructorRParen;
     ExprVector ConstructorArgs;
+    SmallVector<SourceLocation, 4> CommaLocs;
     BalancedDelimiterTracker T(*this, tok::l_paren);
     T.consumeOpen();
     ConstructorLParen = T.getOpenLocation();
@@ -2940,7 +2942,7 @@ Parser::ParseCXXNewExpression(bool UseGlobal, SourceLocation Start) {
       if (ParseExpressionList(ConstructorArgs, [&] {
             PreferredType.enterFunctionArgument(Tok.getLocation(),
                                                 RunSignatureHelp);
-          })) {
+          }, false, CommaLocs)) {
         if (PP.isCodeCompletionReached() && !CalledSignatureHelp)
           RunSignatureHelp();
         SkipUntil(tok::semi, StopAtSemi | StopBeforeMatch);
@@ -2955,7 +2957,7 @@ Parser::ParseCXXNewExpression(bool UseGlobal, SourceLocation Start) {
     }
     Initializer = Actions.ActOnParenListExpr(ConstructorLParen,
                                              ConstructorRParen,
-                                             ConstructorArgs);
+                                             ConstructorArgs, CommaLocs);
   } else if (Tok.is(tok::l_brace) && getLangOpts().CPlusPlus11) {
     Diag(Tok.getLocation(),
          diag::warn_cxx98_compat_generalized_initializer_lists);

--- a/clang/lib/Parse/ParseOpenMP.cpp
+++ b/clang/lib/Parse/ParseOpenMP.cpp
@@ -365,10 +365,11 @@ void Parser::ParseOpenMPReductionInitializerForDecl(VarDecl *OmpPrivParm) {
       CalledSignatureHelp = true;
       return PreferredType;
     };
+    SmallVector<SourceLocation, 4> CommaLocs;
     if (ParseExpressionList(Exprs, [&] {
           PreferredType.enterFunctionArgument(Tok.getLocation(),
                                               RunSignatureHelp);
-        })) {
+        }, false, CommaLocs)) {
       if (PP.isCodeCompletionReached() && !CalledSignatureHelp)
         RunSignatureHelp();
       Actions.ActOnInitializerError(OmpPrivParm);
@@ -380,7 +381,8 @@ void Parser::ParseOpenMPReductionInitializerForDecl(VarDecl *OmpPrivParm) {
         RLoc = T.getCloseLocation();
 
       ExprResult Initializer =
-          Actions.ActOnParenListExpr(T.getOpenLocation(), RLoc, Exprs);
+          Actions.ActOnParenListExpr(T.getOpenLocation(), RLoc, Exprs,
+                                     CommaLocs);
       Actions.AddInitializerToDecl(OmpPrivParm, Initializer.get(),
                                    /*DirectInit=*/true);
     }

--- a/clang/lib/Sema/SemaCoroutine.cpp
+++ b/clang/lib/Sema/SemaCoroutine.cpp
@@ -532,8 +532,11 @@ VarDecl *Sema::buildCoroutinePromise(SourceLocation Loc) {
   if (!CtorArgExprs.empty()) {
     // Create an initialization sequence for the promise type using the
     // constructor arguments, wrapped in a parenthesized list expression.
+    SmallVector<SourceLocation, 4> CommaLocs(CtorArgExprs.size() - 1,
+                                             SourceLocation());
     Expr *PLE = ParenListExpr::Create(Context, FD->getLocation(),
-                                      CtorArgExprs, FD->getLocation());
+                                      CtorArgExprs, FD->getLocation(),
+                                      CommaLocs);
     InitializedEntity Entity = InitializedEntity::InitializeVariable(VD);
     InitializationKind Kind = InitializationKind::CreateForInit(
         VD->getLocation(), /*DirectInit=*/true, PLE);

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4334,7 +4334,10 @@ Sema::ActOnMemInitializer(Decl *ConstructorD,
                           ArrayRef<Expr *> Args,
                           SourceLocation RParenLoc,
                           SourceLocation EllipsisLoc) {
-  Expr *List = ParenListExpr::Create(Context, LParenLoc, Args, RParenLoc);
+  SmallVector<SourceLocation, 4> CommaLocs(
+      Args.empty() ? 0 : Args.size() - 1, SourceLocation());
+  Expr *List =
+      ParenListExpr::Create(Context, LParenLoc, Args, RParenLoc, CommaLocs);
   return BuildMemInitializer(ConstructorD, S, SS, MemberOrBase, TemplateTypeTy,
                              DS, IdLoc, List, EllipsisLoc);
 }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8349,7 +8349,7 @@ Sema::MaybeConvertParenListExprToParenExpr(Scope *S, Expr *OrigExpr) {
   for (unsigned i = 1, e = E->getNumExprs(); i != e && !Result.isInvalid();
        ++i) {
     SourceLocation CommaLoc =
-        i - 1 < CommaLocs.size() ? CommaLocs[i - 1] : E->getLParenLoc();
+        CommaLocs[i - 1].isValid() ? CommaLocs[i - 1] : E->getLParenLoc();
     Result = ActOnBinOp(S, CommaLoc, tok::comma, Result.get(), E->getExpr(i));
   }
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8344,20 +8344,24 @@ Sema::MaybeConvertParenListExprToParenExpr(Scope *S, Expr *OrigExpr) {
     return OrigExpr;
 
   ExprResult Result(E->getExpr(0));
+  ArrayRef<SourceLocation> CommaLocs = E->getCommaLocs();
 
-  for (unsigned i = 1, e = E->getNumExprs(); i != e && !Result.isInvalid(); ++i)
-    Result = ActOnBinOp(S, E->getExprLoc(), tok::comma, Result.get(),
-                        E->getExpr(i));
+  for (unsigned i = 1, e = E->getNumExprs(); i != e && !Result.isInvalid();
+       ++i) {
+    SourceLocation CommaLoc =
+        i - 1 < CommaLocs.size() ? CommaLocs[i - 1] : E->getLParenLoc();
+    Result = ActOnBinOp(S, CommaLoc, tok::comma, Result.get(), E->getExpr(i));
+  }
 
   if (Result.isInvalid()) return ExprError();
 
   return ActOnParenExpr(E->getLParenLoc(), E->getRParenLoc(), Result.get());
 }
 
-ExprResult Sema::ActOnParenListExpr(SourceLocation L,
-                                    SourceLocation R,
-                                    MultiExprArg Val) {
-  return ParenListExpr::Create(Context, L, Val, R);
+ExprResult Sema::ActOnParenListExpr(SourceLocation L, SourceLocation R,
+                                    MultiExprArg Val,
+                                    ArrayRef<SourceLocation> CommaLocs) {
+  return ParenListExpr::Create(Context, L, Val, R, CommaLocs);
 }
 
 ExprResult Sema::ActOnCXXParenListInitExpr(ArrayRef<Expr *> Args, QualType T,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -8318,20 +8318,24 @@ Sema::MaybeConvertParenListExprToParenExpr(Scope *S, Expr *OrigExpr) {
     return OrigExpr;
 
   ExprResult Result(E->getExpr(0));
+  ArrayRef<SourceLocation> CommaLocs = E->getCommaLocs();
 
-  for (unsigned i = 1, e = E->getNumExprs(); i != e && !Result.isInvalid(); ++i)
-    Result = ActOnBinOp(S, E->getExprLoc(), tok::comma, Result.get(),
-                        E->getExpr(i));
+  for (unsigned i = 1, e = E->getNumExprs(); i != e && !Result.isInvalid();
+       ++i) {
+    SourceLocation CommaLoc =
+        i - 1 < CommaLocs.size() ? CommaLocs[i - 1] : E->getLParenLoc();
+    Result = ActOnBinOp(S, CommaLoc, tok::comma, Result.get(), E->getExpr(i));
+  }
 
   if (Result.isInvalid()) return ExprError();
 
   return ActOnParenExpr(E->getLParenLoc(), E->getRParenLoc(), Result.get());
 }
 
-ExprResult Sema::ActOnParenListExpr(SourceLocation L,
-                                    SourceLocation R,
-                                    MultiExprArg Val) {
-  return ParenListExpr::Create(Context, L, Val, R);
+ExprResult Sema::ActOnParenListExpr(SourceLocation L, SourceLocation R,
+                                    MultiExprArg Val,
+                                    ArrayRef<SourceLocation> CommaLocs) {
+  return ParenListExpr::Create(Context, L, Val, R, CommaLocs);
 }
 
 ExprResult Sema::ActOnCXXParenListInitExpr(ArrayRef<Expr *> Args, QualType T,

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -7970,8 +7970,10 @@ ExprResult InitializationSequence::Perform(Sema &S,
         !Kind.isExplicitCast()) {
       // Rebuild the ParenListExpr.
       SourceRange ParenRange = Kind.getParenOrBraceRange();
+      SmallVector<SourceLocation, 4> CommaLocs(
+          Args.empty() ? 0 : Args.size() - 1, SourceLocation());
       return S.ActOnParenListExpr(ParenRange.getBegin(), ParenRange.getEnd(),
-                                  Args);
+                                  Args, CommaLocs);
     }
     assert(Kind.getKind() == InitializationKind::IK_Copy ||
            Kind.isExplicitCast() ||

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -3180,8 +3180,10 @@ public:
   /// Subclasses may override this routine to provide different behavior.
   ExprResult RebuildParenListExpr(SourceLocation LParenLoc,
                                   MultiExprArg SubExprs,
-                                  SourceLocation RParenLoc) {
-    return getSema().ActOnParenListExpr(LParenLoc, RParenLoc, SubExprs);
+                                  SourceLocation RParenLoc,
+                                  ArrayRef<SourceLocation> CommaLocs) {
+    return getSema().ActOnParenListExpr(LParenLoc, RParenLoc, SubExprs,
+                                        CommaLocs);
   }
 
   ExprResult RebuildCXXParenListInitExpr(ArrayRef<Expr *> Args, QualType T,
@@ -4496,13 +4498,13 @@ ExprResult TreeTransform<Derived>::TransformInitializer(Expr *Init,
   if (CXXScalarValueInitExpr *VIE = dyn_cast<CXXScalarValueInitExpr>(Init)) {
     SourceRange Parens = VIE->getSourceRange();
     return getDerived().RebuildParenListExpr(Parens.getBegin(), {},
-                                             Parens.getEnd());
+                                             Parens.getEnd(), {});
   }
 
   // FIXME: We shouldn't build ImplicitValueInitExprs for direct-initialization.
   if (isa<ImplicitValueInitExpr>(Init))
     return getDerived().RebuildParenListExpr(SourceLocation(), {},
-                                             SourceLocation());
+                                             SourceLocation(), {});
 
   // Revert initialization by constructor back to a parenthesized or braced list
   // of expressions. Any other form of initializer can just be reused directly.
@@ -4544,8 +4546,10 @@ ExprResult TreeTransform<Derived>::TransformInitializer(Expr *Init,
            "no parens or braces but have direct init with arguments?");
     return ExprEmpty();
   }
+  SmallVector<SourceLocation, 4> CommaLocs(
+      NewArgs.empty() ? 0 : NewArgs.size() - 1, SourceLocation());
   return getDerived().RebuildParenListExpr(Parens.getBegin(), NewArgs,
-                                           Parens.getEnd());
+                                           Parens.getEnd(), CommaLocs);
 }
 
 template<typename Derived>
@@ -14312,7 +14316,8 @@ TreeTransform<Derived>::TransformParenListExpr(ParenListExpr *E) {
 
   return getDerived().RebuildParenListExpr(E->getLParenLoc(),
                                            Inits,
-                                           E->getRParenLoc());
+                                           E->getRParenLoc(),
+                                           E->getCommaLocs());
 }
 
 /// Transform an address-of-label expression.

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -748,9 +748,17 @@ void ASTStmtReader::VisitParenListExpr(ParenListExpr *E) {
   unsigned NumExprs = Record.readInt();
   assert((NumExprs == E->getNumExprs()) && "Wrong NumExprs!");
   for (unsigned I = 0; I != NumExprs; ++I)
-    E->getTrailingObjects()[I] = Record.readSubStmt();
+    E->getTrailingObjects<Stmt *>()[I] = Record.readSubStmt();
   E->LParenLoc = readSourceLocation();
   E->RParenLoc = readSourceLocation();
+  if (Record.getIdx() < Record.size()) {
+    unsigned NumCommas = Record.readInt();
+    assert((NumCommas == E->getNumCommas()) && "Wrong NumCommas!");
+    for (unsigned I = 0; I != NumCommas; ++I)
+      E->getTrailingObjects<SourceLocation>()[I] = readSourceLocation();
+  } else {
+    assert(E->getNumCommas() == 0 && "missing comma locations");
+  }
 }
 
 void ASTStmtReader::VisitUnaryOperator(UnaryOperator *E) {
@@ -3303,11 +3311,17 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       S = new (Context) ParenExpr(Empty);
       break;
 
-    case EXPR_PAREN_LIST:
-      S = ParenListExpr::CreateEmpty(
-          Context,
-          /* NumExprs=*/Record[ASTStmtReader::NumExprFields]);
+    case EXPR_PAREN_LIST: {
+      unsigned NumExprs = Record[ASTStmtReader::NumExprFields];
+      unsigned NumCommas = 0;
+      unsigned CommaCountIdx = ASTStmtReader::NumExprFields + 1 + NumExprs + 2;
+      if (Record.size() > CommaCountIdx)
+        NumCommas = Record[CommaCountIdx];
+      S = ParenListExpr::CreateEmpty(Context,
+                                     /* NumExprs=*/NumExprs,
+                                     /* NumCommas=*/NumCommas);
       break;
+    }
 
     case EXPR_UNARY_OPERATOR: {
       BitsUnpacker UnaryOperatorBits(Record[ASTStmtReader::NumStmtFields]);

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -751,14 +751,9 @@ void ASTStmtReader::VisitParenListExpr(ParenListExpr *E) {
     E->getTrailingObjects<Stmt *>()[I] = Record.readSubStmt();
   E->LParenLoc = readSourceLocation();
   E->RParenLoc = readSourceLocation();
-  if (Record.getIdx() < Record.size()) {
-    unsigned NumCommas = Record.readInt();
-    assert((NumCommas == E->getNumCommas()) && "Wrong NumCommas!");
-    for (unsigned I = 0; I != NumCommas; ++I)
-      E->getTrailingObjects<SourceLocation>()[I] = readSourceLocation();
-  } else {
-    assert(E->getNumCommas() == 0 && "missing comma locations");
-  }
+  unsigned NumCommas = E->getNumCommas();
+  for (unsigned I = 0; I != NumCommas; ++I)
+    E->getTrailingObjects<SourceLocation>()[I] = readSourceLocation();
 }
 
 void ASTStmtReader::VisitUnaryOperator(UnaryOperator *E) {
@@ -3313,13 +3308,8 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
 
     case EXPR_PAREN_LIST: {
       unsigned NumExprs = Record[ASTStmtReader::NumExprFields];
-      unsigned NumCommas = 0;
-      unsigned CommaCountIdx = ASTStmtReader::NumExprFields + 1 + NumExprs + 2;
-      if (Record.size() > CommaCountIdx)
-        NumCommas = Record[CommaCountIdx];
       S = ParenListExpr::CreateEmpty(Context,
-                                     /* NumExprs=*/NumExprs,
-                                     /* NumCommas=*/NumCommas);
+                                     /* NumExprs=*/NumExprs);
       break;
     }
 

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -847,6 +847,9 @@ void ASTStmtWriter::VisitParenListExpr(ParenListExpr *E) {
     Record.AddStmt(SubStmt);
   Record.AddSourceLocation(E->getLParenLoc());
   Record.AddSourceLocation(E->getRParenLoc());
+  Record.push_back(E->getNumCommas());
+  for (SourceLocation CommaLoc : E->getCommaLocs())
+    Record.AddSourceLocation(CommaLoc);
   Code = serialization::EXPR_PAREN_LIST;
 }
 

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -847,7 +847,6 @@ void ASTStmtWriter::VisitParenListExpr(ParenListExpr *E) {
     Record.AddStmt(SubStmt);
   Record.AddSourceLocation(E->getLParenLoc());
   Record.AddSourceLocation(E->getRParenLoc());
-  Record.push_back(E->getNumCommas());
   for (SourceLocation CommaLoc : E->getCommaLocs())
     Record.AddSourceLocation(CommaLoc);
   Code = serialization::EXPR_PAREN_LIST;

--- a/clang/test/Sema/warn-comma-operator-paren-list-cast.c
+++ b/clang/test/Sema/warn-comma-operator-paren-list-cast.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -fsyntax-only -Wcomma -fno-caret-diagnostics %s 2>&1 | FileCheck %s
+
+void comma_in_paren_list_cast(void) {
+  int x;
+  (void)(int)(x = 0, 1);
+  // CHECK: :[[@LINE-1]]:20: warning: possible misuse of comma operator here
+}


### PR DESCRIPTION
The location of commas inside a ParenListExpr were not saved when parsing, leading to an incorrect location of the indicated comma when using BinaryOperator::getOperatorLoc() on the comma operator. To avoid this, an additional parameter is added to ParenListExpr to store the location of commas.

Assisted by gpt-5.5