### PR TITLE
[Analysis] Skipping same value StoreInst in canSkipClobberingStore

### DIFF
--- a/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
@@ -355,18 +355,48 @@ static bool canSkipClobberingStore(const StoreInst *SI,
       MemLoc.Size.getValue().getKnownMinValue())
     return false;
 
-  auto *LI = dyn_cast<LoadInst>(SI->getValueOperand());
-  if (!LI || LI->getParent() != SI->getParent())
-    return false;
-  if (BatchAA.alias(MemoryLocation::get(LI), MemLoc) != AliasResult::MustAlias)
-    return false;
-  unsigned NumVisitedInsts = 0;
-  for (const Instruction *I = LI; I != SI; I = I->getNextNode())
-    if (++NumVisitedInsts > ScanLimit ||
-        isModSet(BatchAA.getModRefInfo(I, MemLoc)))
-      return false;
+  if (auto *LI = dyn_cast<LoadInst>(SI->getValueOperand())) {
+    if (LI->getParent() == SI->getParent() &&
+        BatchAA.alias(MemoryLocation::get(LI), MemLoc) ==
+            AliasResult::MustAlias) {
+      unsigned NumVisitedInsts = 0;
+      bool Clean = true;
+      for (const Instruction *I = LI; I != SI; I = I->getNextNode()) {
+        if (++NumVisitedInsts > ScanLimit ||
+            isModSet(BatchAA.getModRefInfo(I, MemLoc))) {
+          Clean = false;
+          break;
+        }
+      }
+      if (Clean)
+        return true;
+    }
+  }
 
-  return true;
+  // Checking if the store is writing the same value that MemLoc contains now.
+  // Then we can skip this store as well, because it does not effect the value
+  // loaded from MemLoc.
+  auto *StoredVal = SI->getValueOperand();
+  unsigned NumVisitedInsts = 0;
+  for (auto It = std::next(SI->getReverseIterator()),
+            End = SI->getParent()->rend();
+       It != End; ++It) {
+    if (++NumVisitedInsts > ScanLimit)
+      break;
+    const Instruction *I = &*It;
+    if (!isModSet(BatchAA.getModRefInfo(I, MemLoc)))
+      continue;
+
+    if (const auto *PrevSI = dyn_cast<StoreInst>(I)) {
+      if (PrevSI->getValueOperand() == StoredVal &&
+          BatchAA.alias(MemoryLocation::get(PrevSI), MemLoc) ==
+              AliasResult::MustAlias)
+        return true;
+    }
+    break;
+  }
+
+  return false;
 }
 
 MemDepResult MemoryDependenceResults::getSimplePointerDependencyFrom(


### PR DESCRIPTION
Resolves: [#173905](https://github.com/llvm/llvm-project/issues/173905)

- **If the target store is storing the same value loaded by the load Inst from MemLoc, then it is safe to skip to this clobberingStore.**

```
define dso_local i32 @set(ptr noundef captures(none) initializes((0, 4)) %0, ptr noundef writeonly captures(none) initializes((0, 4)) %1, i32 noundef %2) local_unnamed_addr #0 {
  store i32 %2, ptr %0, align 4
  store i32 %2, ptr %1, align 4
  %4 = load i32, ptr %0, align 4
  %5 = add i32 %4, %2
  ret i32 %5
}
```
```
; Function Attrs: mustprogress nofree noinline norecurse nosync nounwind willreturn memory(argmem: write) uwtable
define dso_local noundef range(i32 0, -1) i32 @set(ptr noundef writeonly captures(none) initializes((0, 4)) %0, ptr noundef writeonly captures(none) initializes((0, 4)) %1, i32 noundef %2) local_unnamed_addr #0 {
  store i32 %2, ptr %0, align 4
  store i32 %2, ptr %1, align 4
  %4 = shl i32 %2, 1
  ret i32 %4
}
```

- The extra **load Inst** was retained by the GVNPass because during it's `processLoad()`, the memory dependency analysis(`canSkipClobberingStore()`) has decided that the load is dependent on the 2nd store.

- Current code of canSkipClobberingStore is only skipping the store, if its value operand is an output of a load instruction. That is it is specific.
- This pr is an attempt to generalize this condition and include if the operand is a constant or a function argument.