### PR TITLE
[OpenCL] Add cl_intel_bfloat16_conversions builtins

### DIFF
--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -1902,6 +1902,7 @@ def FuncExtIntelSubgroupsChar  : FunctionExtension<"cl_intel_subgroups_char">;
 def FuncExtIntelSubgroupsLong  : FunctionExtension<"cl_intel_subgroups_long">;
 def FuncExtIntelSubgroupBufferPrefetch : FunctionExtension<"cl_intel_subgroup_buffer_prefetch">;
 def FuncExtIntelSubgroupLocalBlockIO : FunctionExtension<"cl_intel_subgroup_local_block_io">;
+def FuncExtIntelBfloat16Conversions : FunctionExtension<"cl_intel_bfloat16_conversions">;
 def FuncExtIntelSubgroupsRWImages : FunctionExtension<"cl_intel_subgroups __opencl_c_read_write_images">;
 def FuncExtIntelSubgroupsShortRWImages : FunctionExtension<"cl_intel_subgroups_short __opencl_c_read_write_images">;
 def FuncExtIntelSubgroupsCharRWImages : FunctionExtension<"cl_intel_subgroups_char __opencl_c_read_write_images">;
@@ -2266,6 +2267,22 @@ let Extension = FuncExtIntelSubgroupsLongLocalBlockIO in {
   def : Builtin<"intel_sub_group_block_write_ul2", [Void, PointerType<ULong, LocalAS>, VectorType<ULong, 2>], Attr.Convergent>;
   def : Builtin<"intel_sub_group_block_write_ul4", [Void, PointerType<ULong, LocalAS>, VectorType<ULong, 4>], Attr.Convergent>;
   def : Builtin<"intel_sub_group_block_write_ul8", [Void, PointerType<ULong, LocalAS>, VectorType<ULong, 8>], Attr.Convergent>;
+}
+
+let Extension = FuncExtIntelBfloat16Conversions in {
+  def : Builtin<"intel_convert_bfloat16_as_ushort", [UShort, Float], Attr.Const>;
+  def : Builtin<"intel_convert_bfloat162_as_ushort2", [VectorType<UShort, 2>, VectorType<Float, 2>], Attr.Const>;
+  def : Builtin<"intel_convert_bfloat163_as_ushort3", [VectorType<UShort, 3>, VectorType<Float, 3>], Attr.Const>;
+  def : Builtin<"intel_convert_bfloat164_as_ushort4", [VectorType<UShort, 4>, VectorType<Float, 4>], Attr.Const>;
+  def : Builtin<"intel_convert_bfloat168_as_ushort8", [VectorType<UShort, 8>, VectorType<Float, 8>], Attr.Const>;
+  def : Builtin<"intel_convert_bfloat1616_as_ushort16", [VectorType<UShort, 16>, VectorType<Float, 16>], Attr.Const>;
+
+  def : Builtin<"intel_convert_as_bfloat16_float", [Float, UShort], Attr.Const>;
+  def : Builtin<"intel_convert_as_bfloat162_float2", [VectorType<Float, 2>, VectorType<UShort, 2>], Attr.Const>;
+  def : Builtin<"intel_convert_as_bfloat163_float3", [VectorType<Float, 3>, VectorType<UShort, 3>], Attr.Const>;
+  def : Builtin<"intel_convert_as_bfloat164_float4", [VectorType<Float, 4>, VectorType<UShort, 4>], Attr.Const>;
+  def : Builtin<"intel_convert_as_bfloat168_float8", [VectorType<Float, 8>, VectorType<UShort, 8>], Attr.Const>;
+  def : Builtin<"intel_convert_as_bfloat1616_float16", [VectorType<Float, 16>, VectorType<UShort, 16>], Attr.Const>;
 }
 
 //--------------------------------------------------------------------

--- a/clang/test/SemaOpenCL/intel-bfloat16-conversions-builtins.cl
+++ b/clang/test/SemaOpenCL/intel-bfloat16-conversions-builtins.cl
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -cl-std=CL3.0 -fdeclare-opencl-builtins -verify -fsyntax-only %s
+// expected-no-diagnostics
+
+// Keep this test header-free so it exercises OpenCLBuiltins.td instead of
+// declarations from opencl-c.h.
+
+typedef unsigned short ushort;
+typedef float float2 __attribute__((ext_vector_type(2)));
+typedef float float3 __attribute__((ext_vector_type(3)));
+typedef float float4 __attribute__((ext_vector_type(4)));
+typedef float float8 __attribute__((ext_vector_type(8)));
+typedef float float16 __attribute__((ext_vector_type(16)));
+typedef ushort ushort2 __attribute__((ext_vector_type(2)));
+typedef ushort ushort3 __attribute__((ext_vector_type(3)));
+typedef ushort ushort4 __attribute__((ext_vector_type(4)));
+typedef ushort ushort8 __attribute__((ext_vector_type(8)));
+typedef ushort ushort16 __attribute__((ext_vector_type(16)));
+
+ushort test_convert_bfloat16_as_ushort(float source) {
+  return intel_convert_bfloat16_as_ushort(source);
+}
+
+ushort2 test_convert_bfloat162_as_ushort2(float2 source) {
+  return intel_convert_bfloat162_as_ushort2(source);
+}
+
+ushort3 test_convert_bfloat163_as_ushort3(float3 source) {
+  return intel_convert_bfloat163_as_ushort3(source);
+}
+
+ushort4 test_convert_bfloat164_as_ushort4(float4 source) {
+  return intel_convert_bfloat164_as_ushort4(source);
+}
+
+ushort8 test_convert_bfloat168_as_ushort8(float8 source) {
+  return intel_convert_bfloat168_as_ushort8(source);
+}
+
+ushort16 test_convert_bfloat1616_as_ushort16(float16 source) {
+  return intel_convert_bfloat1616_as_ushort16(source);
+}
+
+float test_convert_as_bfloat16_float(ushort source) {
+  return intel_convert_as_bfloat16_float(source);
+}
+
+float2 test_convert_as_bfloat162_float2(ushort2 source) {
+  return intel_convert_as_bfloat162_float2(source);
+}
+
+float3 test_convert_as_bfloat163_float3(ushort3 source) {
+  return intel_convert_as_bfloat163_float3(source);
+}
+
+float4 test_convert_as_bfloat164_float4(ushort4 source) {
+  return intel_convert_as_bfloat164_float4(source);
+}
+
+float8 test_convert_as_bfloat168_float8(ushort8 source) {
+  return intel_convert_as_bfloat168_float8(source);
+}
+
+float16 test_convert_as_bfloat1616_float16(ushort16 source) {
+  return intel_convert_as_bfloat1616_float16(source);
+}


### PR DESCRIPTION
Add cl_intel_bfloat16_conversions declarations to OpenCLBuiltins.td
and cover the extension with a dedicated header-free SPIR test.

Specification:
https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_bfloat16_conversions.html

Co-authored-by: Copilot