### PR TITLE
[VPlan] Simplify VPSCEVExpander, clarify naming/comments (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationPlanner.h
@@ -74,19 +74,18 @@ class VPBuilder {
 
   /// Lightweight SCEV-to-VPlan expander. Converts SCEVConstant, SCEVUnknown,
   /// SCEVVScale and SCEVMulExpr into VPInstructions. Other SCEV expressions are
-  /// unsupported.
+  /// not yet supported.
   class VPSCEVExpander {
     VPBuilder &Builder;
-    VPlan &Plan;
     DebugLoc DL;
 
   public:
-    VPSCEVExpander(VPBuilder &Builder, VPlan &Plan, DebugLoc DL)
-        : Builder(Builder), Plan(Plan), DL(DL) {}
+    VPSCEVExpander(VPBuilder &Builder, DebugLoc DL)
+        : Builder(Builder), DL(DL) {}
 
-    /// Expand \p S into recipes and live-ins using the builder. Returns nullptr
-    /// if \p S cannot be expanded yet.
-    VPValue *expand(const SCEV *S);
+    /// Try to expand \p S into recipes and live-ins using the builder. Returns
+    /// nullptr if \p S cannot be expanded yet.
+    VPValue *tryToExpand(const SCEV *S);
   };
 
   /// Insert \p VPI in BB at InsertPt if BB is set.
@@ -452,10 +451,10 @@ public:
         FPBinOp ? FPBinOp->getFastMathFlags() : FastMathFlags(), DL));
   }
 
-  /// Expand \p Expr using VPSCEVExpander. Returns nullptr if \p S cannot be
-  /// expanded yet.
+  /// Try to expand \p Expr using VPSCEVExpander. Returns nullptr if \p Expr
+  /// cannot be expanded yet.
   VPValue *expandSCEV(const SCEV *Expr, DebugLoc DL) {
-    return VPSCEVExpander(*this, getPlan(), DL).expand(Expr);
+    return VPSCEVExpander(*this, DL).tryToExpand(Expr);
   }
 
   VPExpandSCEVRecipe *createExpandSCEV(const SCEV *Expr) {

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -1482,8 +1482,8 @@ void VPlanTransforms::addMinimumIterationCheck(
                                     TripCount, Step)) {
       // Generate the minimum iteration check only if we cannot prove the
       // check is known to be true, or known to be false.
-      // // Try to expand SCEVs to VPInstructions in CheckBlock, or to
-      // VPExpandSCEV in Entry failing that.
+      // Try to expand Step into VPInstructions in CheckBlock; otherwise fall
+      // back to a VPExpandSCEV recipe in the plan's entry block.
       VPValue *MinTripCountVPV = Builder.expandSCEV(Step, DL);
       if (!MinTripCountVPV)
         MinTripCountVPV = VPBuilder(Plan.getEntry()).createExpandSCEV(Step);

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -168,7 +168,7 @@ struct VPlanTransforms {
   LLVM_ABI_FOR_TEST static void addMiddleCheck(VPlan &Plan, bool TailFolded);
 
   // Create a check in \p CheckBlock to see if the vector loop should be
-  // executed.
+  // executed. May create VPExpandSCEV recipes in the plan's entry block.
   static void addMinimumIterationCheck(
       VPlan &Plan, ElementCount VF, unsigned UF,
       ElementCount MinProfitableTripCount, bool RequiresScalarEpilogue,

--- a/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUtils.cpp
@@ -860,27 +860,25 @@ bool vputils::isUsedByLoadStoreAddress(const VPValue *V) {
   return false;
 }
 
-VPValue *VPBuilder::VPSCEVExpander::expand(const SCEV *S) {
+VPValue *VPBuilder::VPSCEVExpander::tryToExpand(const SCEV *S) {
   switch (S->getSCEVType()) {
   case scConstant:
-    return Plan.getOrAddLiveIn(cast<SCEVConstant>(S)->getValue());
+    return Builder.getPlan().getOrAddLiveIn(cast<SCEVConstant>(S)->getValue());
   case scUnknown:
-    return Plan.getOrAddLiveIn(cast<SCEVUnknown>(S)->getValue());
+    return Builder.getPlan().getOrAddLiveIn(cast<SCEVUnknown>(S)->getValue());
   case scVScale:
     return Builder.createNaryOp(VPInstruction::VScale, {}, S->getType());
   case scMulExpr: {
     auto *Mul = cast<SCEVMulExpr>(S);
     SmallVector<VPValue *, 2> Ops;
     for (const SCEVUse &Op : Mul->operands()) {
-      VPValue *OpV = expand(Op);
+      VPValue *OpV = tryToExpand(Op);
       if (!OpV)
         return nullptr;
       Ops.push_back(OpV);
     }
     VPIRFlags::WrapFlagsTy WrapFlags(Mul->hasNoUnsignedWrap(),
                                      Mul->hasNoSignedWrap());
-    // Chain the operands with Mul, matching SCEVExpander behavior of applying
-    // wrap flags to all chained multiplies.
     VPValue *Result = Ops.front();
     for (VPValue *Op : drop_begin(Ops))
       Result = Builder.createOverflowingOp(Instruction::Mul, {Result, Op},


### PR DESCRIPTION
Address post-commit comments from https://github.com/llvm/llvm-project/pull/189455,
removing unneeded member, and clarify naming/comments to stress the current logic 
tries to expand a SCEV to VPInstructions, with only a small sub-set of SCEV expression supported.

