### PR TITLE
[OpenCL] Add cl_intel_split_work_group_barrier builtins

### DIFF
--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -1895,7 +1895,7 @@ let Extension = FunctionExtension<"cl_khr_kernel_clock __opencl_c_kernel_clock_s
 }
 
 //--------------------------------------------------------------------
-// Intel different sub-group extensions.
+// Intel extensions.
 def FuncExtIntelBfloat16Conversions : FunctionExtension<"cl_intel_bfloat16_conversions">;
 def FuncExtIntelSplitWorkGroupBarrier : FunctionExtension<"cl_intel_split_work_group_barrier">;
 def FuncExtIntelSubgroupBufferPrefetch : FunctionExtension<"cl_intel_subgroup_buffer_prefetch">;

--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -1903,6 +1903,7 @@ def FuncExtIntelSubgroupsLong  : FunctionExtension<"cl_intel_subgroups_long">;
 def FuncExtIntelSubgroupBufferPrefetch : FunctionExtension<"cl_intel_subgroup_buffer_prefetch">;
 def FuncExtIntelSubgroupLocalBlockIO : FunctionExtension<"cl_intel_subgroup_local_block_io">;
 def FuncExtIntelBfloat16Conversions : FunctionExtension<"cl_intel_bfloat16_conversions">;
+def FuncExtIntelSplitWorkGroupBarrier : FunctionExtension<"cl_intel_split_work_group_barrier">;
 def FuncExtIntelSubgroupsRWImages : FunctionExtension<"cl_intel_subgroups __opencl_c_read_write_images">;
 def FuncExtIntelSubgroupsShortRWImages : FunctionExtension<"cl_intel_subgroups_short __opencl_c_read_write_images">;
 def FuncExtIntelSubgroupsCharRWImages : FunctionExtension<"cl_intel_subgroups_char __opencl_c_read_write_images">;
@@ -2283,6 +2284,18 @@ let Extension = FuncExtIntelBfloat16Conversions in {
   def : Builtin<"intel_convert_as_bfloat164_float4", [VectorType<Float, 4>, VectorType<UShort, 4>], Attr.Const>;
   def : Builtin<"intel_convert_as_bfloat168_float8", [VectorType<Float, 8>, VectorType<UShort, 8>], Attr.Const>;
   def : Builtin<"intel_convert_as_bfloat1616_float16", [VectorType<Float, 16>, VectorType<UShort, 16>], Attr.Const>;
+}
+
+let Extension = FuncExtIntelSplitWorkGroupBarrier in {
+  def : Builtin<"intel_work_group_barrier_arrive", [Void, MemFenceFlags], Attr.Convergent>;
+  let MinVersion = CL20 in {
+    def : Builtin<"intel_work_group_barrier_arrive", [Void, MemFenceFlags, MemoryScope], Attr.Convergent>;
+  }
+
+  def : Builtin<"intel_work_group_barrier_wait", [Void, MemFenceFlags], Attr.Convergent>;
+  let MinVersion = CL20 in {
+    def : Builtin<"intel_work_group_barrier_wait", [Void, MemFenceFlags, MemoryScope], Attr.Convergent>;
+  }
 }
 
 //--------------------------------------------------------------------

--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -1896,25 +1896,25 @@ let Extension = FunctionExtension<"cl_khr_kernel_clock __opencl_c_kernel_clock_s
 
 //--------------------------------------------------------------------
 // Intel different sub-group extensions.
-def FuncExtIntelSubgroups      : FunctionExtension<"cl_intel_subgroups">;
-def FuncExtIntelSubgroupsShort : FunctionExtension<"cl_intel_subgroups_short">;
-def FuncExtIntelSubgroupsChar  : FunctionExtension<"cl_intel_subgroups_char">;
-def FuncExtIntelSubgroupsLong  : FunctionExtension<"cl_intel_subgroups_long">;
-def FuncExtIntelSubgroupBufferPrefetch : FunctionExtension<"cl_intel_subgroup_buffer_prefetch">;
-def FuncExtIntelSubgroupLocalBlockIO : FunctionExtension<"cl_intel_subgroup_local_block_io">;
 def FuncExtIntelBfloat16Conversions : FunctionExtension<"cl_intel_bfloat16_conversions">;
 def FuncExtIntelSplitWorkGroupBarrier : FunctionExtension<"cl_intel_split_work_group_barrier">;
-def FuncExtIntelSubgroupsRWImages : FunctionExtension<"cl_intel_subgroups __opencl_c_read_write_images">;
-def FuncExtIntelSubgroupsShortRWImages : FunctionExtension<"cl_intel_subgroups_short __opencl_c_read_write_images">;
+def FuncExtIntelSubgroupBufferPrefetch : FunctionExtension<"cl_intel_subgroup_buffer_prefetch">;
+def FuncExtIntelSubgroupLocalBlockIO : FunctionExtension<"cl_intel_subgroup_local_block_io">;
+def FuncExtIntelSubgroups : FunctionExtension<"cl_intel_subgroups">;
+def FuncExtIntelSubgroupsChar : FunctionExtension<"cl_intel_subgroups_char">;
+def FuncExtIntelSubgroupsCharLocalBlockIO : FunctionExtension<"cl_intel_subgroups_char cl_intel_subgroup_local_block_io">;
+def FuncExtIntelSubgroupsCharPrefetch : FunctionExtension<"cl_intel_subgroups_char cl_intel_subgroup_buffer_prefetch">;
 def FuncExtIntelSubgroupsCharRWImages : FunctionExtension<"cl_intel_subgroups_char __opencl_c_read_write_images">;
+def FuncExtIntelSubgroupsLong : FunctionExtension<"cl_intel_subgroups_long">;
+def FuncExtIntelSubgroupsLongLocalBlockIO : FunctionExtension<"cl_intel_subgroups_long cl_intel_subgroup_local_block_io">;
+def FuncExtIntelSubgroupsLongPrefetch : FunctionExtension<"cl_intel_subgroups_long cl_intel_subgroup_buffer_prefetch">;
 def FuncExtIntelSubgroupsLongRWImages : FunctionExtension<"cl_intel_subgroups_long __opencl_c_read_write_images">;
 def FuncExtIntelSubgroupsPrefetch : FunctionExtension<"cl_intel_subgroups cl_intel_subgroup_buffer_prefetch">;
-def FuncExtIntelSubgroupsShortPrefetch : FunctionExtension<"cl_intel_subgroups_short cl_intel_subgroup_buffer_prefetch">;
-def FuncExtIntelSubgroupsCharPrefetch : FunctionExtension<"cl_intel_subgroups_char cl_intel_subgroup_buffer_prefetch">;
-def FuncExtIntelSubgroupsLongPrefetch : FunctionExtension<"cl_intel_subgroups_long cl_intel_subgroup_buffer_prefetch">;
+def FuncExtIntelSubgroupsRWImages : FunctionExtension<"cl_intel_subgroups __opencl_c_read_write_images">;
+def FuncExtIntelSubgroupsShort : FunctionExtension<"cl_intel_subgroups_short">;
 def FuncExtIntelSubgroupsShortLocalBlockIO : FunctionExtension<"cl_intel_subgroups_short cl_intel_subgroup_local_block_io">;
-def FuncExtIntelSubgroupsCharLocalBlockIO : FunctionExtension<"cl_intel_subgroups_char cl_intel_subgroup_local_block_io">;
-def FuncExtIntelSubgroupsLongLocalBlockIO : FunctionExtension<"cl_intel_subgroups_long cl_intel_subgroup_local_block_io">;
+def FuncExtIntelSubgroupsShortPrefetch : FunctionExtension<"cl_intel_subgroups_short cl_intel_subgroup_buffer_prefetch">;
+def FuncExtIntelSubgroupsShortRWImages : FunctionExtension<"cl_intel_subgroups_short __opencl_c_read_write_images">;
 
 // cl_intel_subgroups - shuffle functions
 // intel_sub_group_shuffle(T, uint) for float/int/uint vectors, half/double

--- a/clang/test/SemaOpenCL/intel-split-work-group-barrier-builtins.cl
+++ b/clang/test/SemaOpenCL/intel-split-work-group-barrier-builtins.cl
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -cl-std=CL3.0 -fdeclare-opencl-builtins -verify -fsyntax-only %s
+// expected-no-diagnostics
+
+// Keep this test header-free so it exercises OpenCLBuiltins.td instead of
+// declarations from opencl-c.h.
+
+typedef unsigned int cl_mem_fence_flags;
+typedef enum memory_scope {
+  memory_scope_work_item = 0,
+  memory_scope_work_group = 1,
+  memory_scope_device = 2,
+  memory_scope_all_svm_devices = 3,
+  memory_scope_sub_group = 4
+} memory_scope;
+
+void test_split_work_group_barrier(cl_mem_fence_flags flags,
+                                   memory_scope scope) {
+  intel_work_group_barrier_arrive(flags);
+  intel_work_group_barrier_wait(flags);
+  intel_work_group_barrier_arrive(flags, scope);
+  intel_work_group_barrier_wait(flags, scope);
+}


### PR DESCRIPTION
Add cl_intel_split_work_group_barrier declarations to OpenCLBuiltins.td
and cover the extension with a dedicated header-free SPIR test.

Specification:
https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_split_work_group_barrier.html

Co-authored-by: Copilot