### PR TITLE
[libc++] Fix shared_ptr(Y*) constraint check on GCC

### DIFF
--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -333,7 +333,7 @@ public:
   // In C++03 we get errors when trying to do SFINAE with the
   // delete operator, so we always pretend that it's deletable.
   // The same happens on GCC.
-#if !defined(_LIBCPP_CXX03_LANG) && !defined(_LIBCPP_COMPILER_GCC)
+#if !defined(_LIBCPP_CXX03_LANG)
                                  ,
                                  _If<is_array<_Tp>::value, __is_array_deletable<_Yp*>, __is_deletable<_Yp*> >
 #endif

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_Y.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.const/shared_ptr_Y.pass.cpp
@@ -137,7 +137,7 @@ int main(int, char**)
 
     // This should work in C++03 but we get errors when trying to do SFINAE with the delete operator.
     // GCC also complains about this.
-#if TEST_STD_VER >= 11 && !defined(TEST_COMPILER_GCC)
+#if TEST_STD_VER >= 11
     {
         // LWG2874: Make sure that when T (for std::shared_ptr<T>) is an array type,
         //          this constructor only participates in overload resolution when


### PR DESCRIPTION
GCC has fixed SFINAEing on `delete` since at least GCC 11, so we can properly constrain the constructor.
