### PR TITLE
[llubi] Print out inst location in stack trace

### DIFF
--- a/llvm/test/tools/llubi/alloca_large_count.ll
+++ b/llvm/test/tools/llubi/alloca_large_count.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i128 -1, align 4 at @main
+; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i128 -1, align 4 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Alloca with large array size that overflows uint64_t. Size: -1
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/alloca_large_size.ll
+++ b/llvm/test/tools/llubi/alloca_large_size.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i32 100, align 4 at @main
+; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i32 100, align 4 at @main <stdin>:5
 ; CHECK-NEXT: Error: Insufficient stack space.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/alloca_poison_count.ll
+++ b/llvm/test/tools/llubi/alloca_poison_count.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i32 poison, align 4 at @main
+; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i32 poison, align 4 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Alloca with poison array size.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/alloca_size_overflow.ll
+++ b/llvm/test/tools/llubi/alloca_size_overflow.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i64 -1, align 4 at @main
+; CHECK-NEXT: #0   %alloc_dyn = alloca i32, i64 -1, align 4 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Alloca with allocation size that overflows uint64_t. Size: -1
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_false.ll
+++ b/llvm/test/tools/llubi/assume_false.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 false) at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 false) at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Assume on false or poison condition.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_invalid_align.ll
+++ b/llvm/test/tools/llubi/assume_invalid_align.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT:   call void @llvm.assume(i1 true) [ "align"(ptr null, i128 18446744073709551617) ]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr %alloc, i128 18446744073709551616) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr %alloc, i128 18446744073709551616) ] at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: The pointer ptr 0x8 [alloc] violates align(18446744073709551616) assumption.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_misalign.ll
+++ b/llvm/test/tools/llubi/assume_misalign.ll
@@ -9,6 +9,6 @@ define void @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr %alloc, i32 2048) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr %alloc, i32 2048) ] at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: The pointer ptr 0x8 [alloc] violates align(2048) assumption.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_misalign_all_ones.ll
+++ b/llvm/test/tools/llubi/assume_misalign_all_ones.ll
@@ -9,6 +9,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr addrspace(1) null, i32 2048) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr addrspace(1) null, i32 2048) ] at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: The pointer ptr 0xFFFFFFFFFFFFFFFF [dangling] violates align(2048) assumption.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_nondereferenceable.ll
+++ b/llvm/test/tools/llubi/assume_nondereferenceable.ll
@@ -9,6 +9,6 @@ define void @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "dereferenceable{{(_or_null)?}}"(ptr %alloc, i32 2048) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "dereferenceable{{(_or_null)?}}"(ptr %alloc, i32 2048) ] at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: The pointer ptr 0x8 [alloc] violates dereferenceable{{(_or_null)?}}(2048) assumption.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_null.ll
+++ b/llvm/test/tools/llubi/assume_null.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "nonnull"(ptr null) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "nonnull"(ptr null) ] at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: The pointer ptr 0x0 [dangling] violates nonnull assumption.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_null_all_ones.ll
+++ b/llvm/test/tools/llubi/assume_null_all_ones.ll
@@ -15,6 +15,6 @@ define void @main() {
 ; CHECK-NEXT:   store i64 -1, ptr %storage, align 4
 ; CHECK-NEXT:   %res = load ptr addrspace(1), ptr %storage, align 8 => ptr 0xFFFFFFFFFFFFFFFF [dangling]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "nonnull"(ptr addrspace(1) %res) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "nonnull"(ptr addrspace(1) %res) ] at @main <stdin>:10
 ; CHECK-NEXT: Immediate UB detected: The pointer ptr 0xFFFFFFFFFFFFFFFF [dangling] violates nonnull assumption.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_poison.ll
+++ b/llvm/test/tools/llubi/assume_poison.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 poison) at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 poison) at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: The value poison violates noundef attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/assume_poison_align.ll
+++ b/llvm/test/tools/llubi/assume_poison_align.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr poison, i32 4) ] at @main
+; CHECK-NEXT: #0   call void @llvm.assume(i1 true) [ "align"(ptr poison, i32 4) ] at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Assume on poison pointer.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_dereferenceable_ub_nullary_provenance.ll
+++ b/llvm/test/tools/llubi/attribute_dereferenceable_ub_nullary_provenance.ll
@@ -15,6 +15,6 @@ define void @main() {
 ; CHECK-NEXT:   %ptr_storage = alloca i64, align 8 => ptr 0x8 [ptr_storage]
 ; CHECK-NEXT:   %p = load ptr, ptr %ptr_storage, align 8 => ptr 0xE82FEEACEEB98B3E [dangling]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee(ptr %p) at @main
+; CHECK-NEXT: #0   call void @callee(ptr %p) at @main <stdin>:11
 ; CHECK-NEXT: Immediate UB detected: The value ptr 0xE82FEEACEEB98B3E [dangling] violates dereferenceable{{(_or_null)?}}(4) attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_dereferenceable_ub_oob1.ll
+++ b/llvm/test/tools/llubi/attribute_dereferenceable_ub_oob1.ll
@@ -13,6 +13,6 @@ define void @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee(ptr %alloc) at @main
+; CHECK-NEXT: #0   call void @callee(ptr %alloc) at @main <stdin>:10
 ; CHECK-NEXT: Immediate UB detected: The value ptr 0x8 [alloc] violates dereferenceable{{(_or_null)?}}(8) attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_dereferenceable_ub_oob2.ll
+++ b/llvm/test/tools/llubi/attribute_dereferenceable_ub_oob2.ll
@@ -15,6 +15,6 @@ define void @main() {
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT:   %gep = getelementptr i8, ptr %alloc, i32 -1 => ptr 0x7 [alloc + -1]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee(ptr %gep) at @main
+; CHECK-NEXT: #0   call void @callee(ptr %gep) at @main <stdin>:11
 ; CHECK-NEXT: Immediate UB detected: The value ptr 0x7 [alloc + -1] violates dereferenceable{{(_or_null)?}}(2) attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_dereferenceable_ub_oob3.ll
+++ b/llvm/test/tools/llubi/attribute_dereferenceable_ub_oob3.ll
@@ -15,6 +15,6 @@ define void @main() {
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT:   %gep = getelementptr i8, ptr %alloc, i32 2 => ptr 0xA [alloc + 2]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee(ptr %gep) at @main
+; CHECK-NEXT: #0   call void @callee(ptr %gep) at @main <stdin>:11
 ; CHECK-NEXT: Immediate UB detected: The value ptr 0xA [alloc + 2] violates dereferenceable{{(_or_null)?}}(3) attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_dereferenceable_ub_poison.ll
+++ b/llvm/test/tools/llubi/attribute_dereferenceable_ub_poison.ll
@@ -11,6 +11,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee(ptr poison) at @main
+; CHECK-NEXT: #0   call void @callee(ptr poison) at @main <stdin>:9
 ; CHECK-NEXT: Immediate UB detected: The value poison violates dereferenceable{{(_or_null)?}}(4) attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_noundef_agg_ub.ll
+++ b/llvm/test/tools/llubi/attribute_noundef_agg_ub.ll
@@ -11,6 +11,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee({ i32, i32 } { i32 0, i32 poison }) at @main
+; CHECK-NEXT: #0   call void @callee({ i32, i32 } { i32 0, i32 poison }) at @main <stdin>:9
 ; CHECK-NEXT: Immediate UB detected: The value { i32 0, poison } violates noundef attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/attribute_noundef_ub.ll
+++ b/llvm/test/tools/llubi/attribute_noundef_ub.ll
@@ -11,6 +11,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @callee(i32 poison) at @main
+; CHECK-NEXT: #0   call void @callee(i32 poison) at @main <stdin>:9
 ; CHECK-NEXT: Immediate UB detected: The value poison violates noundef attribute.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/br_poison.ll
+++ b/llvm/test/tools/llubi/br_poison.ll
@@ -10,6 +10,6 @@ exit:
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   br i1 poison, label %exit, label %exit at @main
+; CHECK-NEXT: #0   br i1 poison, label %exit, label %exit at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: Branch on poison condition.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/call_mismatched_signature.ll
+++ b/llvm/test/tools/llubi/call_mismatched_signature.ll
@@ -11,6 +11,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @foo() at @main
+; CHECK-NEXT: #0   call void @foo() at @main <stdin>:9
 ; CHECK-NEXT: Immediate UB detected: Indirect call through a function pointer with mismatched signature. Expected: void (), Actual: i32 ()
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/call_poison.ll
+++ b/llvm/test/tools/llubi/call_poison.ll
@@ -8,6 +8,6 @@ entry:
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void poison() at @main
+; CHECK-NEXT: #0   call void poison() at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: Indirect call through poison function pointer.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/divrem_ub1.ll
+++ b/llvm/test/tools/llubi/divrem_ub1.ll
@@ -9,6 +9,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} <2 x i32> splat (i32 10), zeroinitializer at @main
+; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} <2 x i32> splat (i32 10), zeroinitializer at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: Division by zero.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/divrem_ub2.ll
+++ b/llvm/test/tools/llubi/divrem_ub2.ll
@@ -9,6 +9,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} i32 10, poison at @main
+; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} i32 10, poison at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: Division by zero (refine RHS to 0).
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/divrem_ub3.ll
+++ b/llvm/test/tools/llubi/divrem_ub3.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} i8 -128, -1 at @main
+; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} i8 -128, -1 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Signed division overflow.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/divrem_ub4.ll
+++ b/llvm/test/tools/llubi/divrem_ub4.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} i8 poison, -1 at @main
+; CHECK-NEXT: #0 %res = {{sdiv|udiv|srem|urem}} i8 poison, -1 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Signed division overflow (refine LHS to INT_MIN).
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/indirectbr_invalid.ll
+++ b/llvm/test/tools/llubi/indirectbr_invalid.ll
@@ -13,6 +13,6 @@ exit:
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   indirectbr ptr blockaddress(@main, %bb2), [label %exit] at @main
+; CHECK-NEXT: #0   indirectbr ptr blockaddress(@main, %bb2), [label %exit] at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: Indirect branch on unlisted target BB.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/indirectbr_poison.ll
+++ b/llvm/test/tools/llubi/indirectbr_poison.ll
@@ -10,6 +10,6 @@ exit:
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   indirectbr ptr poison, [label %exit] at @main
+; CHECK-NEXT: #0   indirectbr ptr poison, [label %exit] at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: Indirect branch on poison.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/infinite_loop.ll
+++ b/llvm/test/tools/llubi/infinite_loop.ll
@@ -20,6 +20,6 @@ loop:
 ; CHECK-NEXT:   br label %loop jump to %loop
 ; CHECK-NEXT:   br label %loop jump to %loop
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   br label %loop at @main
+; CHECK-NEXT: #0   br label %loop at @main <stdin>:9
 ; CHECK-NEXT: Error: Exceeded maximum number of execution steps.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/invoke_poison.ll
+++ b/llvm/test/tools/llubi/invoke_poison.ll
@@ -15,6 +15,6 @@ exit:
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
 ; CHECK-NEXT: #0   invoke void poison()
-; CHECK-NEXT:           to label %exit unwind label %cleanup at @main
+; CHECK-NEXT:           to label %exit unwind label %cleanup at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: Indirect call through poison function pointer.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_cxx_memory_large_size.ll
+++ b/llvm/test/tools/llubi/lib_cxx_memory_large_size.ll
@@ -12,6 +12,6 @@ define i32 @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %ptr_1 = call ptr @_Znwm(i64 50) => ptr 0x10 [ptr_1]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %ptr_2 = call ptr @_Znwm(i64 100) at @main
+; CHECK-NEXT: #0   %ptr_2 = call ptr @_Znwm(i64 100) at @main <stdin>:8
 ; CHECK-NEXT: Error: Insufficient heap space.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_double_free.ll
+++ b/llvm/test/tools/llubi/lib_double_free.ll
@@ -18,6 +18,6 @@ entry:
 ; CHECK-NEXT:   %ptr = call ptr @malloc(i64 4) => ptr 0x10 [ptr]
 ; CHECK-NEXT:   call void @free(ptr %ptr)
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @free(ptr %ptr) at @main
+; CHECK-NEXT: #0   call void @free(ptr %ptr) at @main <stdin>:13
 ; CHECK-NEXT: Immediate UB detected: double-freeing a memory object allocated at 0x10.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_free_nullary_pointer.ll
+++ b/llvm/test/tools/llubi/lib_free_nullary_pointer.ll
@@ -12,6 +12,6 @@ define i32 @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %p = getelementptr i8, ptr null, i64 42 => ptr 0x2A [dangling]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @free(ptr %p) at @main
+; CHECK-NEXT: #0   call void @free(ptr %p) at @main <stdin>:8
 ; CHECK-NEXT: Immediate UB detected: freeing a pointer with nullary provenance.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_free_out_of_bound.ll
+++ b/llvm/test/tools/llubi/lib_free_out_of_bound.ll
@@ -15,6 +15,6 @@ define i32 @main() {
 ; CHECK-NEXT:   %p = call ptr @malloc(i64 4) => ptr 0x10 [p]
 ; CHECK-NEXT:   %p_oob = getelementptr i8, ptr %p, i64 8 => ptr 0x18 [p + 8]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @free(ptr %p_oob) at @main
+; CHECK-NEXT: #0   call void @free(ptr %p_oob) at @main <stdin>:10
 ; CHECK-NEXT: Immediate UB detected: freeing a pointer that does not point to the start of an allocation. Pointer address: 0x18, allocation base: 0x10.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_free_stack.ll
+++ b/llvm/test/tools/llubi/lib_free_stack.ll
@@ -12,6 +12,6 @@ define i32 @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %p = alloca i32, align 4 => ptr 0x8 [p]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   call void @free(ptr %p) at @main
+; CHECK-NEXT: #0   call void @free(ptr %p) at @main <stdin>:8
 ; CHECK-NEXT: Immediate UB detected: freeing a non-heap allocation at 0x8.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_poison_argument.ll
+++ b/llvm/test/tools/llubi/lib_poison_argument.ll
@@ -10,6 +10,6 @@ define i32 @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %1 = call i32 @puts(ptr poison) at @main
+; CHECK-NEXT: #0   %1 = call i32 @puts(ptr poison) at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: Poison argument passed to a library call at argument index 0.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_printf_not_enough_argument.ll
+++ b/llvm/test/tools/llubi/lib_printf_not_enough_argument.ll
@@ -15,6 +15,6 @@ define i32 @main() {
 ; CHECK-NEXT:   %fmt = alloca [18 x i8], align 1 => ptr 0x8 [fmt]
 ; CHECK-NEXT:   store [18 x i8] c"Ints: %d, %i, %u\0A\00", ptr %fmt, align 1
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %1 = call i32 (ptr, ...) @printf(ptr %fmt, i32 42, i32 -42) at @main
+; CHECK-NEXT: #0   %1 = call i32 (ptr, ...) @printf(ptr %fmt, i32 42, i32 -42) at @main <stdin>:10
 ; CHECK-NEXT: Immediate UB detected: Not enough arguments provided for the format string. Required argument for 'u'.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_printf_unknown_specifier.ll
+++ b/llvm/test/tools/llubi/lib_printf_unknown_specifier.ll
@@ -15,6 +15,6 @@ define i32 @main() {
 ; CHECK-NEXT:   %fmt = alloca [4 x i8], align 1 => ptr 0x8 [fmt]
 ; CHECK-NEXT:   store [4 x i8] c"%m\0A\00", ptr %fmt, align 1
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %1 = call i32 (ptr, ...) @printf(ptr %fmt, i32 0) at @main
+; CHECK-NEXT: #0   %1 = call i32 (ptr, ...) @printf(ptr %fmt, i32 0) at @main <stdin>:10
 ; CHECK-NEXT: Immediate UB detected: Unknown or unsupported format specifier 'm' in printf.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_read_nullary_string.ll
+++ b/llvm/test/tools/llubi/lib_read_nullary_string.ll
@@ -10,6 +10,6 @@ define i32 @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %1 = call i32 @puts(ptr null) at @main
+; CHECK-NEXT: #0   %1 = call i32 @puts(ptr null) at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: Invalid memory access via a pointer with nullary provenance.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/lib_uninit_string.ll
+++ b/llvm/test/tools/llubi/lib_uninit_string.ll
@@ -15,6 +15,6 @@ entry:
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %ptr = call ptr @malloc(i64 10) => ptr 0x10 [ptr]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %0 = call i32 @puts(ptr %ptr) at @main
+; CHECK-NEXT: #0   %0 = call i32 @puts(ptr %ptr) at @main <stdin>:11
 ; CHECK-NEXT: Immediate UB detected: Read uninitialized or poison memory while parsing C-string at offset 0.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/load_noundef_ub_poison.ll
+++ b/llvm/test/tools/llubi/load_noundef_ub_poison.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT:   %p = alloca i32, align 4 => ptr 0x8 [p]
 ; CHECK-NEXT:   store i32 poison, ptr %p, align 4
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %res = load i32, ptr %p, align 4, !noundef !0 at @main
+; CHECK-NEXT: #0   %res = load i32, ptr %p, align 4, !noundef !0 at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: The value loaded contains undefined bits.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/load_noundef_ub_poison_padding.ll
+++ b/llvm/test/tools/llubi/load_noundef_ub_poison_padding.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT:   %p = alloca i8, align 1 => ptr 0x8 [p]
 ; CHECK-NEXT:   store <2 x i4> <i4 1, i4 poison>, ptr %p, align 1
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %res = load i4, ptr %p, align 1, !noundef !0 at @main
+; CHECK-NEXT: #0   %res = load i4, ptr %p, align 1, !noundef !0 at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: The value loaded contains undefined bits.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/load_noundef_ub_undef.ll
+++ b/llvm/test/tools/llubi/load_noundef_ub_undef.ll
@@ -9,6 +9,6 @@ define void @main() {
 ; CHECK: Entering function: main
 ; CHECK-NEXT:   %p = alloca i32, align 4 => ptr 0x8 [p]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %res = load i32, ptr %p, align 4, !noundef !0 at @main
+; CHECK-NEXT: #0   %res = load i32, ptr %p, align 4, !noundef !0 at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: The value loaded contains undefined bits.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/loadstore_misaligned.ll
+++ b/llvm/test/tools/llubi/loadstore_misaligned.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT: %alloc = alloca [2 x i32], align 8 => ptr 0x8 [alloc]
 ; CHECK-NEXT: %gep = getelementptr inbounds [2 x i32], ptr %alloc, i64 0, i64 1 => ptr 0xC [alloc + 4]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 {{store i32 0|%res = load i32}}, ptr %gep, align 8 at @main
+; CHECK-NEXT: #0 {{store i32 0|%res = load i32}}, ptr %gep, align 8 at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: Misaligned memory access.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/loadstore_null.ll
+++ b/llvm/test/tools/llubi/loadstore_null.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 {{store i32 0|%res = load i32}}, ptr null, align 4 at @main
+; CHECK-NEXT: #0 {{store i32 0|%res = load i32}}, ptr null, align 4 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Invalid memory access via a pointer with nullary provenance.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/loadstore_oob1.ll
+++ b/llvm/test/tools/llubi/loadstore_oob1.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT: %alloc = alloca [2 x i32], align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT: %gep = getelementptr inbounds [2 x i32], ptr %alloc, i64 0, i64 2 => ptr 0x10 [alloc + 8]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   {{store i32 0|%res = load i32}}, ptr %gep, align 4 at @main
+; CHECK-NEXT: #0   {{store i32 0|%res = load i32}}, ptr %gep, align 4 at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: Memory access is out of bounds. Accessed size: 4, Address: 0x10, Object base: 0x8, Object size: 8.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/loadstore_poison.ll
+++ b/llvm/test/tools/llubi/loadstore_poison.ll
@@ -7,6 +7,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0 {{store i32 0|%res = load i32}}, ptr poison, align 4 at @main
+; CHECK-NEXT: #0 {{store i32 0|%res = load i32}}, ptr poison, align 4 at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Invalid memory access with a poison pointer.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/loadstore_uaf.ll
+++ b/llvm/test/tools/llubi/loadstore_uaf.ll
@@ -18,6 +18,6 @@ define void @main() {
 ; CHECK-NEXT: Exiting function: stack_object
 ; CHECK-NEXT:   %alloc = call ptr @stack_object() => ptr 0x8 [dangling]
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   {{store i32 0|%res = load i32}}, ptr %alloc, align 4 at @main
+; CHECK-NEXT: #0   {{store i32 0|%res = load i32}}, ptr %alloc, align 4 at @main <stdin>:11
 ; CHECK-NEXT: Immediate UB detected: Try to access a dead memory object at address 0x8.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/metadata_noundef_ub.ll
+++ b/llvm/test/tools/llubi/metadata_noundef_ub.ll
@@ -11,6 +11,6 @@ define void @main() {
 ; CHECK-NEXT:   %alloc = alloca i32, align 4 => ptr 0x8 [alloc]
 ; CHECK-NEXT:   store i32 -1, ptr %alloc, align 4
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %res = load i32, ptr %alloc, align 4, !range !0, !noundef !1 at @main
+; CHECK-NEXT: #0   %res = load i32, ptr %alloc, align 4, !range !0, !noundef !1 at @main <stdin>:7
 ; CHECK-NEXT: Immediate UB detected: The value poison violates !noundef metadata.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/stack_overflow.ll
+++ b/llvm/test/tools/llubi/stack_overflow.ll
@@ -104,15 +104,15 @@ entry:
 ; CHECK-NEXT:   %sub1 = sub i32 %n, 1 => i32 41
 ; CHECK-NEXT:   %sub2 = sub i32 %n, 2 => i32 40
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #1   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #2   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #3   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #4   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #5   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #6   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #7   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #8   %call1 = call i32 @fib(i32 %sub1) at @fib
-; CHECK-NEXT: #9   %res2 = call i32 @fib(i32 50) at @main
+; CHECK-NEXT: #0   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #1   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #2   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #3   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #4   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #5   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #6   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #7   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #8   %call1 = call i32 @fib(i32 %sub1) at @fib <stdin>:12
+; CHECK-NEXT: #9   %res2 = call i32 @fib(i32 50) at @main <stdin>:24
 ; CHECK-NEXT: Error: Maximum stack depth exceeded.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/store_dead.ll
+++ b/llvm/test/tools/llubi/store_dead.ll
@@ -15,6 +15,6 @@ define void @main() {
 ; CHECK-NEXT:   store i32 0, ptr %alloc, align 4
 ; CHECK-NEXT:   call void @llvm.lifetime.end.p0(ptr %alloc)
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   store i32 0, ptr %alloc, align 4 at @main
+; CHECK-NEXT: #0   store i32 0, ptr %alloc, align 4 at @main <stdin>:9
 ; CHECK-NEXT: Immediate UB detected: Try to access a dead memory object at address 0x8.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/switch_poison.ll
+++ b/llvm/test/tools/llubi/switch_poison.ll
@@ -11,6 +11,6 @@ exit:
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
 ; CHECK-NEXT: #0   switch i32 poison, label %exit [
-; CHECK-NEXT:   ] at @main
+; CHECK-NEXT:   ] at @main <stdin>:6
 ; CHECK-NEXT: Immediate UB detected: Switch on poison condition.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/test/tools/llubi/unreachable.ll
+++ b/llvm/test/tools/llubi/unreachable.ll
@@ -6,6 +6,6 @@ define void @main() {
 }
 ; CHECK: Entering function: main
 ; CHECK-NEXT: Stacktrace:
-; CHECK-NEXT: #0   unreachable at @main
+; CHECK-NEXT: #0   unreachable at @main <stdin>:5
 ; CHECK-NEXT: Immediate UB detected: Unreachable code.
 ; CHECK-NEXT: error: Execution of function 'main' failed.

--- a/llvm/tools/llubi/lib/CMakeLists.txt
+++ b/llvm/tools/llubi/lib/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_LINK_COMPONENTS
   Analysis
+  AsmParser
   Core
   Support
   )

--- a/llvm/tools/llubi/lib/Context.cpp
+++ b/llvm/tools/llubi/lib/Context.cpp
@@ -15,9 +15,9 @@
 
 namespace llvm::ubi {
 
-Context::Context(Module &M)
-    : Ctx(M.getContext()), M(M), DL(M.getDataLayout()),
-      TLIImpl(M.getTargetTriple()) {}
+Context::Context(Module &M, const AsmParserContext *ParserContext)
+    : Ctx(M.getContext()), M(M), ParserContext(ParserContext),
+      DL(M.getDataLayout()), TLIImpl(M.getTargetTriple()) {}
 
 Context::~Context() = default;
 

--- a/llvm/tools/llubi/lib/Context.h
+++ b/llvm/tools/llubi/lib/Context.h
@@ -12,6 +12,7 @@
 #include "Value.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/AsmParser/AsmParserContext.h"
 #include "llvm/IR/FPEnv.h"
 #include "llvm/IR/Module.h"
 #include <map>
@@ -197,6 +198,7 @@ class Context {
   // Module
   LLVMContext &Ctx;
   Module &M;
+  const AsmParserContext *ParserContext;
   const DataLayout &DL;
   const TargetLibraryInfoImpl TLIImpl;
 
@@ -250,7 +252,7 @@ class Context {
   // TODO: errno
 
 public:
-  explicit Context(Module &M);
+  explicit Context(Module &M, const AsmParserContext *ParserContext);
   Context(const Context &) = delete;
   Context(Context &&) = delete;
   Context &operator=(const Context &) = delete;
@@ -279,6 +281,8 @@ public:
   void reseed(uint32_t Seed) { Rng.seed(Seed); }
 
   LLVMContext &getContext() const { return Ctx; }
+  Module &getModule() const { return M; }
+  const AsmParserContext *getParserContext() const { return ParserContext; }
   const DataLayout &getDataLayout() const { return DL; }
   const Triple &getTargetTriple() const { return M.getTargetTriple(); }
   const TargetLibraryInfoImpl &getTLIImpl() const { return TLIImpl; }

--- a/llvm/tools/llubi/lib/ExecutorBase.cpp
+++ b/llvm/tools/llubi/lib/ExecutorBase.cpp
@@ -177,11 +177,17 @@ void ExecutorBase::dumpStackTrace() const {
   errs() << "Stacktrace:\n";
   const Frame *TheFrame = CurrentFrame;
   unsigned Index = 0;
+  const AsmParserContext *ParserContext = Ctx.getParserContext();
+  StringRef ModuleFileName = Ctx.getModule().getModuleIdentifier();
   while (TheFrame != nullptr) {
     if (TheFrame->BB) {
       Instruction &Inst = *TheFrame->PC;
       errs() << "#" << Index++ << " " << Inst << " at ";
       Inst.getFunction()->printAsOperand(errs(), /*PrintType=*/false);
+      if (ParserContext) {
+        if (auto Loc = ParserContext->getInstructionOrArgumentLocation(&Inst))
+          errs() << ' ' << ModuleFileName << ':' << Loc->Start.Line + 1;
+      }
       errs() << "\n";
     }
     TheFrame = TheFrame->LastFrame;

--- a/llvm/tools/llubi/llubi.cpp
+++ b/llvm/tools/llubi/llubi.cpp
@@ -211,7 +211,9 @@ int main(int argc, char **argv) {
 
   // Load the bitcode...
   SMDiagnostic Err;
-  std::unique_ptr<Module> Owner = parseIRFile(InputFile, Err, Context);
+  AsmParserContext ParserContext;
+  std::unique_ptr<Module> Owner =
+      parseIRFile(InputFile, Err, Context, /*Callbacks=*/{}, &ParserContext);
   Module *Mod = Owner.get();
   if (!Mod) {
     Err.print(argv[0], errs());
@@ -233,7 +235,7 @@ int main(int argc, char **argv) {
   InputArgv.insert(InputArgv.begin(), InputFile);
 
   // Initialize the execution context and set parameters.
-  ubi::Context Ctx(*Mod);
+  ubi::Context Ctx(*Mod, &ParserContext);
   Ctx.setMemoryLimit(MaxMem);
   Ctx.setVScale(VScale);
   Ctx.setMaxSteps(MaxSteps);


### PR DESCRIPTION
This patch appends `file:line number` to each frame in the stack trace. It would improve the debugging experience.

In all test files, the inputs are supplied via stdin. I think it should be okay, as I don't need to add wildcards for filenames.
