### PR TITLE
[libc++][test] Move backported algorithms to `libcxx/test/support`

### DIFF
--- a/libcxx/test/support/algorithms.h
+++ b/libcxx/test/support/algorithms.h
@@ -7,8 +7,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LIBCPP_TEST_STD_UTILITIES_MEMORY_SPECIALIZED_ALGORITHMS_DESTROY_H
-#define LIBCPP_TEST_STD_UTILITIES_MEMORY_SPECIALIZED_ALGORITHMS_DESTROY_H
+#ifndef TEST_SUPPORT_ALGORITHMS_H
+#define TEST_SUPPORT_ALGORITHMS_H
 
 #include <cstddef>
 #include <memory>
@@ -16,7 +16,9 @@
 
 #include "test_macros.h"
 
-namespace backport {
+// This file intends to provide algorithms backported from newer standard revisions.
+
+namespace util {
 
 template <class T, typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
 TEST_CONSTEXPR_CXX20 void destroy_at(T* p) {
@@ -26,22 +28,22 @@ template <class T, typename std::enable_if<std::is_array<T>::value, int>::type =
 TEST_CONSTEXPR_CXX20 void destroy_at(T* p) {
   static_assert(std::extent<T>::value > 0, "must destroy a bounded array");
   for (std::size_t i = 0; i != std::extent<T>::value; ++i)
-    backport::destroy_at(i + *p);
+    util::destroy_at(i + *p);
 }
 
 template <class Iterator>
 TEST_CONSTEXPR_CXX20 void destroy(Iterator first, Iterator last) {
   for (; first != last; ++first)
-    backport::destroy_at(std::addressof(*first));
+    util::destroy_at(std::addressof(*first));
 }
 
 template <class Iterator, class Size>
 TEST_CONSTEXPR_CXX20 Iterator destroy_n(Iterator first, Size n) {
   for (; n > 0; ++first, (void)--n)
-    backport::destroy_at(std::addressof(*first));
+    util::destroy_at(std::addressof(*first));
   return first;
 }
 
-} // namespace backport
+} // namespace util
 
-#endif // LIBCPP_TEST_STD_UTILITIES_MEMORY_SPECIALIZED_ALGORITHMS_DESTROY_H
+#endif // TEST_SUPPORT_ALGORITHMS_H


### PR DESCRIPTION
And namespace `util`. This will make helpers provided more consistently, and potentially allow us to unify test helper namespaces in the future.