### PR TITLE
[libc][math] Add missing math.yaml entries for acospif and atan2f16

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -40,6 +40,12 @@ functions:
     arguments:
       - type: _Float16
     guard: LIBC_TYPES_HAS_FLOAT16
+  - name: acospif
+    standards:
+      - stdc
+    return_type: float
+    arguments:
+      - type: float
   - name: acospif16
     standards:
       - stdc
@@ -133,6 +139,14 @@ functions:
       - type: float128
       - type: float128
     guard: LIBC_TYPES_HAS_FLOAT128
+  - name: atan2f16
+    standards:
+      - stdc
+    return_type: _Float16
+    arguments:
+      - type: _Float16
+      - type: _Float16
+    guard: LIBC_TYPES_HAS_FLOAT16
   - name: atanf
     standards:
       - stdc
@@ -153,7 +167,7 @@ functions:
     arguments:
       - type: float
   - name: atanhf16
-    standatds:
+    standards:
       - stdc
     return_type: _Float16
     arguments:


### PR DESCRIPTION
Part of #199266

This PR adds missing `math.yaml` entries for `acospif` and `atan2f16`.