### PR TITLE
[Clang][Driver] Reenable test on UBSan/HWAsan

### DIFF
--- a/clang/test/Driver/crash-ir-repro.cpp
+++ b/clang/test/Driver/crash-ir-repro.cpp
@@ -1,11 +1,6 @@
 // RUN: %clang -S -emit-llvm -o %t.ll %s
 // RUN: not %crash_opt %clang -S -DCRASH %s -o %t.ll 2>&1 | FileCheck %s
 
-// TODO(boomanaiden154): This test case causes clang to raise a signal when
-// running under ubsan, but not in normal build configurations. This should
-// be fixed.
-// UNSUPPORTED: ubsan, hwasan
-
 // CHECK: Preprocessed source(s) and associated run script(s) are located at:
 // CHECK-NEXT: clang: note: diagnostic msg: {{.*}}.cpp
 // CHECK-NEXT: clang: note: diagnostic msg: {{.*}}.sh


### PR DESCRIPTION
It passes locally, presumably due to
15488a7f78ce7b9ae3c06b031134e5cb339b335c fixing the behavior here.