### PR TITLE
[libc][math] Implement double-precision acosh, asinh, atanh, cosh, sinh and tanh hyperbolic math functions

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -534,10 +534,12 @@ set(TARGET_LIBM_ENTRYPOINTS
     # math.h entrypoints
     libc.src.math.acos
     libc.src.math.acosf
+    libc.src.math.acosh
     libc.src.math.acoshf
     libc.src.math.acospif
     libc.src.math.asin
     libc.src.math.asinf
+    libc.src.math.asinh
     libc.src.math.asinhf
     libc.src.math.asinpi
     libc.src.math.asinpif
@@ -545,6 +547,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.atan2f
     libc.src.math.atan
     libc.src.math.atanf
+    libc.src.math.atanh
     libc.src.math.atanhf
     libc.src.math.canonicalize
     libc.src.math.canonicalizef
@@ -560,6 +563,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.copysignl
     libc.src.math.cos
     libc.src.math.cosf
+    libc.src.math.cosh
     libc.src.math.coshf
     libc.src.math.cospif
     libc.src.math.dfmal
@@ -746,6 +750,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.sincos
     libc.src.math.sincosf
     libc.src.math.sinf
+    libc.src.math.sinh
     libc.src.math.sinhf
     libc.src.math.sinpif
     libc.src.math.sqrt
@@ -753,6 +758,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.sqrtl
     libc.src.math.tan
     libc.src.math.tanf
+    libc.src.math.tanh
     libc.src.math.tanhf
     libc.src.math.tanpif
     libc.src.math.totalorder

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -55,6 +55,19 @@ add_header_library(
 )
 
 add_header_library(
+  acosh
+  HDRS
+    acosh.h
+  DEPENDS
+    .log
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   acoshf_utils
   HDRS
     acoshf_utils.h
@@ -155,6 +168,20 @@ add_header_library(
     libc.src.__support.FPUtil.sqrt
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
+)
+
+add_header_library(
+  asinh
+  HDRS
+    asinh.h
+  DEPENDS
+    .log
+    .log1p
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.sqrt
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
 )
 
 add_header_library(
@@ -351,6 +378,18 @@ add_header_library(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.sqrt
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
+  atanh
+  HDRS
+    atanh.h
+  DEPENDS
+    .log1p
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.macros.config
     libc.src.__support.macros.optimization
 )
 
@@ -2798,6 +2837,19 @@ add_header_library(
 )
 
 add_header_library(
+  cosh
+  HDRS
+    cosh.h
+  DEPENDS
+    .exp
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.rounding_mode
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   coshf
   HDRS
     coshf.h
@@ -5222,6 +5274,20 @@ add_header_library(
 )
 
 add_header_library(
+  sinh
+  HDRS
+    sinh.h
+  DEPENDS
+    .exp
+    .expm1
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.rounding_mode
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   sinhf
   HDRS
     sinhf.h
@@ -5369,6 +5435,18 @@ add_header_library(
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.macros.optimization
     libc.include.llvm-libc-macros.float16_macros
+)
+
+add_header_library(
+  tanh
+  HDRS
+    tanh.h
+  DEPENDS
+    .expm1
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.macros.config
+    libc.src.__support.macros.optimization
 )
 
 add_header_library(

--- a/libc/src/__support/math/acosh.h
+++ b/libc/src/__support/math/acosh.h
@@ -1,0 +1,67 @@
+//===-- Implementation header for acosh -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ACOSH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ACOSH_H
+
+#include "log.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/sqrt.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double acosh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+  uint64_t x_u = xbits.uintval();
+
+  // Handle NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // acosh(+inf) = +inf.
+  if (LIBC_UNLIKELY(xbits.is_inf()))
+    return x;
+
+  // Domain error: acosh(x) is undefined for x < 1.
+  if (LIBC_UNLIKELY(x_u < 0x3ff0000000000000ULL)) {
+    fputil::set_errno_if_required(EDOM);
+    fputil::raise_except_if_required(FE_INVALID);
+    return FPBits::quiet_nan().get_val();
+  }
+
+  // acosh(1) = 0.
+  if (LIBC_UNLIKELY(x_u == 0x3ff0000000000000ULL))
+    return 0.0;
+
+  // For large x (x >= 2^28): acosh(x) ~ log(2x) = log(x) + log(2).
+  if (LIBC_UNLIKELY(x_u >= 0x41b0000000000000ULL)) {
+    constexpr double LOG_2 = 0x1.62e42fefa39efp-1;
+    return math::log(x) + LOG_2;
+  }
+
+  // General case: acosh(x) = log(x + sqrt(x^2 - 1)).
+  double x2m1 = x * x - 1.0;
+  return math::log(x + fputil::sqrt<double>(x2m1));
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ACOSH_H

--- a/libc/src/__support/math/asinh.h
+++ b/libc/src/__support/math/asinh.h
@@ -1,0 +1,79 @@
+//===-- Implementation header for asinh -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ASINH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ASINH_H
+
+#include "log.h"
+#include "log1p.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/sqrt.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double asinh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+
+  // Handle NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // Handle +/-inf: asinh(+/-inf) = +/-inf.
+  if (LIBC_UNLIKELY(xbits.is_inf()))
+    return x;
+
+  uint64_t x_abs_u = xbits.abs().uintval();
+  double x_abs = xbits.abs().get_val();
+  bool is_neg = xbits.is_neg();
+
+  // For very small |x| (|x| <= 2^-26), asinh(x) ~ x.
+  // Use FP arithmetic to ensure FTZ/DAZ mode behavior.
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e50000000000000ULL)) {
+    // asinh(+/-0) = +/-0, preserve sign of zero exactly.
+    if (LIBC_UNLIKELY(x_abs_u == 0))
+      return x;
+    double x2 = x_abs * x_abs;
+    double result = x_abs - x2 * x_abs * (1.0 / 6.0);
+    return is_neg ? -result : result;
+  }
+
+  double result;
+  // For large |x| (|x| >= 2^28): asinh(x) ~ log(2|x|) = log(|x|) + log(2).
+  if (LIBC_UNLIKELY(x_abs_u >= 0x41b0000000000000ULL)) {
+    constexpr double LOG_2 = 0x1.62e42fefa39efp-1;
+    result = math::log(x_abs) + LOG_2;
+  } else if (x_abs_u >= 0x3fe0000000000000ULL) {
+    // |x| >= 0.5: asinh(x) = log(x + sqrt(x^2 + 1)).
+    result = math::log(x_abs + fputil::sqrt<double>(x_abs * x_abs + 1.0));
+  } else {
+    // |x| < 0.5: use log1p for better accuracy near 0.
+    // asinh(x) = log1p(x + x^2 / (1 + sqrt(1 + x^2)))
+    double x2 = x_abs * x_abs;
+    double sqrt1px2 = fputil::sqrt<double>(1.0 + x2);
+    result = math::log1p(x_abs + x2 / (1.0 + sqrt1px2));
+  }
+
+  return is_neg ? -result : result;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ASINH_H

--- a/libc/src/__support/math/atanh.h
+++ b/libc/src/__support/math/atanh.h
@@ -1,0 +1,74 @@
+//===-- Implementation header for atanh -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ATANH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ATANH_H
+
+#include "log1p.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double atanh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+  Sign sign = xbits.sign();
+  uint64_t x_abs_u = xbits.abs().uintval();
+
+  // Handle NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // |x| >= 1.
+  if (LIBC_UNLIKELY(x_abs_u >= 0x3ff0000000000000ULL)) {
+    if (x_abs_u == 0x3ff0000000000000ULL) {
+      // |x| == 1: return +/-inf with ERANGE.
+      fputil::set_errno_if_required(ERANGE);
+      fputil::raise_except_if_required(FE_DIVBYZERO);
+      return FPBits::inf(sign).get_val();
+    }
+    // |x| > 1: domain error.
+    fputil::set_errno_if_required(EDOM);
+    fputil::raise_except_if_required(FE_INVALID);
+    return FPBits::quiet_nan().get_val();
+  }
+
+  // For very small |x| (|x| <= 2^-27), atanh(x) ~ x.
+  // Use FP arithmetic to ensure FTZ/DAZ mode behavior.
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e40000000000000ULL)) {
+    // atanh(+/-0) = +/-0, preserve sign of zero exactly.
+    if (LIBC_UNLIKELY(x_abs_u == 0))
+      return x;
+    double x_abs = xbits.abs().get_val();
+    double x2 = x_abs * x_abs;
+    double result = x_abs + x2 * x_abs * (1.0 / 3.0);
+    return sign == Sign::NEG ? -result : result;
+  }
+
+  // General case: atanh(x) = 0.5 * log((1+x)/(1-x))
+  //                        = 0.5 * log1p(2x / (1-x))
+  double x_abs = xbits.abs().get_val();
+  double result = 0.5 * math::log1p(2.0 * x_abs / (1.0 - x_abs));
+  return sign == Sign::NEG ? -result : result;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ATANH_H

--- a/libc/src/__support/math/cosh.h
+++ b/libc/src/__support/math/cosh.h
@@ -1,0 +1,67 @@
+//===-- Implementation header for cosh --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_COSH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_COSH_H
+
+#include "exp.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/rounding_mode.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double cosh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+  // cosh is even, work with |x|.
+  xbits.set_sign(Sign::POS);
+  double x_abs = xbits.get_val();
+  uint64_t x_abs_u = xbits.uintval();
+
+  // Handle NaN: cosh(NaN) = NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // cosh(+/-inf) = +inf.
+  if (LIBC_UNLIKELY(xbits.is_inf()))
+    return FPBits::inf(Sign::POS).get_val();
+
+  // For very small |x| (|x| <= 2^-27), cosh(x) ~ 1.
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e40000000000000ULL))
+    return 1.0;
+
+  // For |x| >= 710, overflow.
+  if (LIBC_UNLIKELY(x_abs_u >= 0x4086340000000000ULL)) {
+    int rounding = fputil::quick_get_round();
+    if (rounding == FE_DOWNWARD || rounding == FE_TOWARDZERO)
+      return FPBits::max_normal().get_val();
+    fputil::set_errno_if_required(ERANGE);
+    fputil::raise_except_if_required(FE_OVERFLOW);
+    return FPBits::inf(Sign::POS).get_val();
+  }
+
+  // General case: cosh(x) = (exp(x) + exp(-x)) / 2.
+  double ex = math::exp(x_abs);
+  return (ex + 1.0 / ex) * 0.5;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COSH_H

--- a/libc/src/__support/math/sinh.h
+++ b/libc/src/__support/math/sinh.h
@@ -1,0 +1,88 @@
+//===-- Implementation header for sinh --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SINH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SINH_H
+
+#include "exp.h"
+#include "expm1.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/rounding_mode.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double sinh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+  bool is_neg = xbits.is_neg();
+  // Work with |x|.
+  xbits.set_sign(Sign::POS);
+  double x_abs = xbits.get_val();
+  uint64_t x_abs_u = xbits.uintval();
+
+  // Handle NaN: sinh(NaN) = NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // sinh(+/-inf) = +/-inf.
+  if (LIBC_UNLIKELY(xbits.is_inf()))
+    return x;
+
+  // For very small |x| (|x| <= 2^-26), sinh(x) ~ x.
+  // Use FP arithmetic to ensure FTZ/DAZ mode behavior.
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e50000000000000ULL)) {
+    // sinh(+/-0) = +/-0, preserve sign of zero exactly.
+    if (LIBC_UNLIKELY(x_abs_u == 0))
+      return x;
+    double x2 = x_abs * x_abs;
+    double result = x_abs + x2 * x_abs * (1.0 / 6.0);
+    return is_neg ? -result : result;
+  }
+
+  // For |x| >= 710, overflow.
+  if (LIBC_UNLIKELY(x_abs_u >= 0x4086340000000000ULL)) {
+    int rounding = fputil::quick_get_round();
+    if ((rounding == FE_DOWNWARD && !is_neg) ||
+        (rounding == FE_UPWARD && is_neg) || rounding == FE_TOWARDZERO)
+      return is_neg ? -FPBits::max_normal().get_val()
+                    : FPBits::max_normal().get_val();
+    fputil::set_errno_if_required(ERANGE);
+    fputil::raise_except_if_required(FE_OVERFLOW);
+    return x + (is_neg ? -FPBits::inf().get_val() : FPBits::inf().get_val());
+  }
+
+  double result;
+  if (x_abs_u < 0x3ff0000000000000ULL) {
+    // |x| < 1: use expm1 to avoid catastrophic cancellation.
+    // sinh(x) = expm1(x)/2 + expm1(x)/(2*(1+expm1(x)))
+    double em1 = math::expm1(x_abs);
+    result = em1 / 2.0 + em1 / (2.0 * (1.0 + em1));
+  } else {
+    // |x| >= 1: sinh(x) = (exp(x) - exp(-x)) / 2.
+    double ex = math::exp(x_abs);
+    result = (ex - 1.0 / ex) * 0.5;
+  }
+
+  return is_neg ? -result : result;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SINH_H

--- a/libc/src/__support/math/tanh.h
+++ b/libc/src/__support/math/tanh.h
@@ -1,0 +1,68 @@
+//===-- Implementation header for tanh --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_TANH_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_TANH_H
+
+#include "expm1.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE double tanh(double x) {
+  using FPBits = fputil::FPBits<double>;
+  FPBits xbits(x);
+  bool is_neg = xbits.is_neg();
+  // Work with |x|.
+  xbits.set_sign(Sign::POS);
+  double x_abs = xbits.get_val();
+  uint64_t x_abs_u = xbits.uintval();
+
+  // Handle NaN: tanh(NaN) = NaN.
+  if (LIBC_UNLIKELY(xbits.is_nan())) {
+    if (xbits.is_signaling_nan()) {
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+    return x;
+  }
+
+  // For very small |x| (|x| <= 2^-27), tanh(x) ~ x.
+  // Use x - x^3/3 to ensure FP operations are performed (for FTZ/DAZ modes).
+  if (LIBC_UNLIKELY(x_abs_u <= 0x3e40000000000000ULL)) {
+    // tanh(+/-0) = +/-0, preserve sign of zero exactly.
+    if (LIBC_UNLIKELY(x_abs_u == 0))
+      return x;
+    double x2 = x_abs * x_abs;
+    double result = x_abs - x2 * x_abs * (1.0 / 3.0);
+    return is_neg ? -result : result;
+  }
+
+  // For |x| >= 20, tanh(x) ~ sign(x) * 1.
+  // (e^40 - 1)/(e^40 + 1) rounds to 1 in double precision.
+  if (LIBC_UNLIKELY(x_abs_u >= 0x4034000000000000ULL)) {
+    // tanh(+/-inf) = +/-1.
+    return is_neg ? -1.0 : 1.0;
+  }
+
+  // General case: tanh(x) = expm1(2x) / (expm1(2x) + 2).
+  double e2xm1 = math::expm1(2.0 * x_abs);
+  double result = e2xm1 / (e2xm1 + 2.0);
+  return is_neg ? -result : result;
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_TANH_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3632,6 +3632,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  cosh
+  SRCS
+    cosh.cpp
+  HDRS
+    ../cosh.h
+  DEPENDS
+    libc.src.__support.math.cosh
+)
+
+add_entrypoint_object(
   coshf
   SRCS
     coshf.cpp
@@ -3649,6 +3659,16 @@ add_entrypoint_object(
     ../coshf16.h
   DEPENDS
     libc.src.__support.math.coshf16
+)
+
+add_entrypoint_object(
+  sinh
+  SRCS
+    sinh.cpp
+  HDRS
+    ../sinh.h
+  DEPENDS
+    libc.src.__support.math.sinh
 )
 
 add_entrypoint_object(
@@ -3672,6 +3692,16 @@ add_entrypoint_object(
 )
 
 add_entrypoint_object(
+  tanh
+  SRCS
+    tanh.cpp
+  HDRS
+    ../tanh.h
+  DEPENDS
+    libc.src.__support.math.tanh
+)
+
+add_entrypoint_object(
   tanhf
   SRCS
     tanhf.cpp
@@ -3689,6 +3719,16 @@ add_entrypoint_object(
     ../tanhf16.h
   DEPENDS
     libc.src.__support.math.tanhf16
+)
+
+add_entrypoint_object(
+  acosh
+  SRCS
+    acosh.cpp
+  HDRS
+    ../acosh.h
+  DEPENDS
+    libc.src.__support.math.acosh
 )
 
 add_entrypoint_object(
@@ -3720,6 +3760,16 @@ add_entrypoint_object(
     ../acospif.h
   DEPENDS
     libc.src.__support.math.acospif
+)
+
+add_entrypoint_object(
+  asinh
+  SRCS
+    asinh.cpp
+  HDRS
+    ../asinh.h
+  DEPENDS
+    libc.src.__support.math.asinh
 )
 
 add_entrypoint_object(
@@ -3771,6 +3821,16 @@ add_entrypoint_object(
   DEPENDS
     libc.src.errno.errno
     libc.src.__support.math.asinpif16
+)
+
+add_entrypoint_object(
+  atanh
+  SRCS
+    atanh.cpp
+  HDRS
+    ../atanh.h
+  DEPENDS
+    libc.src.__support.math.atanh
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/acosh.cpp
+++ b/libc/src/math/generic/acosh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision acosh implementation -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/acosh.h"
+#include "src/__support/math/acosh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, acosh, (double x)) { return math::acosh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/asinh.cpp
+++ b/libc/src/math/generic/asinh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision asinh implementation -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/asinh.h"
+#include "src/__support/math/asinh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, asinh, (double x)) { return math::asinh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/atanh.cpp
+++ b/libc/src/math/generic/atanh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision atanh implementation -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/atanh.h"
+#include "src/__support/math/atanh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, atanh, (double x)) { return math::atanh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/cosh.cpp
+++ b/libc/src/math/generic/cosh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision cosh implementation ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/cosh.h"
+#include "src/__support/math/cosh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, cosh, (double x)) { return math::cosh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/sinh.cpp
+++ b/libc/src/math/generic/sinh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision sinh implementation ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/sinh.h"
+#include "src/__support/math/sinh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, sinh, (double x)) { return math::sinh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/tanh.cpp
+++ b/libc/src/math/generic/tanh.cpp
@@ -1,0 +1,16 @@
+//===-- Double-precision tanh implementation ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/tanh.h"
+#include "src/__support/math/tanh.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(double, tanh, (double x)) { return math::tanh(x); }
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -4623,6 +4623,18 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  cosh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    cosh_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.math.cosh
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   coshf_test
   SUITE
     libc-math-smoke-tests
@@ -4646,6 +4658,18 @@ add_fp_unittest(
     libc.hdr.fenv_macros
     libc.src.math.coshf16
     libc.src.__support.FPUtil.cast
+)
+
+add_fp_unittest(
+  sinh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    sinh_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.math.sinh
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(
@@ -4675,6 +4699,17 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  tanh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    tanh_test.cpp
+  DEPENDS
+    libc.src.math.tanh
+    libc.src.__support.FPUtil.fp_bits
+)
+
+add_fp_unittest(
   tanhf_test
   SUITE
     libc-math-smoke-tests
@@ -4697,6 +4732,18 @@ add_fp_unittest(
     libc.hdr.fenv_macros
     libc.src.math.tanhf16
     libc.src.__support.FPUtil.cast
+)
+
+add_fp_unittest(
+  atanh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    atanh_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.math.atanh
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(
@@ -4732,6 +4779,17 @@ add_fp_unittest(
     atanpif16_test.cpp
   DEPENDS
     libc.src.math.atanpif16
+)
+
+add_fp_unittest(
+  asinh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    asinh_test.cpp
+  DEPENDS
+    libc.src.math.asinh
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(
@@ -4791,6 +4849,18 @@ add_fp_unittest(
   DEPENDS
     libc.hdr.errno_macros
     libc.src.math.asinpif16
+)
+
+add_fp_unittest(
+  acosh_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    acosh_test.cpp
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.src.math.acosh
+    libc.src.__support.FPUtil.fp_bits
 )
 
 add_fp_unittest(

--- a/libc/test/src/math/smoke/acosh_test.cpp
+++ b/libc/test/src/math/smoke/acosh_test.cpp
@@ -1,0 +1,66 @@
+//===-- Unittests for acosh -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/acosh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcAcoshTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcAcoshTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::acosh(sNaN), FE_INVALID);
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::acosh(aNaN));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::acosh(inf));
+  EXPECT_MATH_ERRNO(0);
+
+  // acosh(x) for x < 1 is a domain error.
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::acosh(0.0), FE_INVALID);
+  EXPECT_MATH_ERRNO(EDOM);
+
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::acosh(-1.0), FE_INVALID);
+  EXPECT_MATH_ERRNO(EDOM);
+
+  // acosh(1) = 0.
+  EXPECT_FP_EQ_ALL_ROUNDING(0.0, LIBC_NAMESPACE::acosh(1.0));
+  EXPECT_MATH_ERRNO(0);
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcAcoshTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  // acosh(x) for x < 1 is still a domain error in FTZ mode.
+  EXPECT_FP_IS_NAN(LIBC_NAMESPACE::acosh(min_denormal));
+  EXPECT_FP_IS_NAN(LIBC_NAMESPACE::acosh(max_denormal));
+}
+
+TEST_F(LlvmLibcAcoshTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  EXPECT_FP_IS_NAN(LIBC_NAMESPACE::acosh(min_denormal));
+  EXPECT_FP_IS_NAN(LIBC_NAMESPACE::acosh(max_denormal));
+}
+
+TEST_F(LlvmLibcAcoshTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  EXPECT_FP_IS_NAN(LIBC_NAMESPACE::acosh(min_denormal));
+  EXPECT_FP_IS_NAN(LIBC_NAMESPACE::acosh(max_denormal));
+}
+
+#endif

--- a/libc/test/src/math/smoke/asinh_test.cpp
+++ b/libc/test/src/math/smoke/asinh_test.cpp
@@ -1,0 +1,57 @@
+//===-- Unittests for asinh -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/asinh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcAsinhTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcAsinhTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::asinh(sNaN), FE_INVALID);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::asinh(aNaN));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::asinh(inf));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_inf, LIBC_NAMESPACE::asinh(neg_inf));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(0.0, LIBC_NAMESPACE::asinh(0.0));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::asinh(neg_zero));
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcAsinhTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::asinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::asinh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcAsinhTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::asinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::asinh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcAsinhTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::asinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::asinh(neg_min_denormal));
+}
+
+#endif

--- a/libc/test/src/math/smoke/atanh_test.cpp
+++ b/libc/test/src/math/smoke/atanh_test.cpp
@@ -1,0 +1,75 @@
+//===-- Unittests for atanh -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/atanh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcAtanhTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcAtanhTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::atanh(sNaN), FE_INVALID);
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::atanh(aNaN));
+  EXPECT_MATH_ERRNO(0);
+
+  // atanh(+/-1) = +/-inf with ERANGE/FE_DIVBYZERO.
+  EXPECT_FP_EQ_WITH_EXCEPTION(inf, LIBC_NAMESPACE::atanh(1.0), FE_DIVBYZERO);
+  EXPECT_MATH_ERRNO(ERANGE);
+
+  EXPECT_FP_EQ_WITH_EXCEPTION(neg_inf, LIBC_NAMESPACE::atanh(-1.0),
+                              FE_DIVBYZERO);
+  EXPECT_MATH_ERRNO(ERANGE);
+
+  // atanh(x) for |x| > 1 is a domain error.
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::atanh(2.0), FE_INVALID);
+  EXPECT_MATH_ERRNO(EDOM);
+
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::atanh(inf), FE_INVALID);
+  EXPECT_MATH_ERRNO(EDOM);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(0.0, LIBC_NAMESPACE::atanh(0.0));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::atanh(neg_zero));
+  EXPECT_MATH_ERRNO(0);
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcAtanhTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::atanh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::atanh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcAtanhTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::atanh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::atanh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcAtanhTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::atanh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::atanh(neg_min_denormal));
+}
+
+#endif

--- a/libc/test/src/math/smoke/cosh_test.cpp
+++ b/libc/test/src/math/smoke/cosh_test.cpp
@@ -1,0 +1,72 @@
+//===-- Unittests for cosh ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/cosh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcCoshTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcCoshTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::cosh(sNaN), FE_INVALID);
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::cosh(aNaN));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::cosh(inf));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::cosh(neg_inf));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(1.0, LIBC_NAMESPACE::cosh(0.0));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(1.0, LIBC_NAMESPACE::cosh(-0.0));
+  EXPECT_MATH_ERRNO(0);
+}
+
+TEST_F(LlvmLibcCoshTest, Overflow) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(inf, LIBC_NAMESPACE::cosh(0x1.0p10), FE_OVERFLOW);
+  EXPECT_MATH_ERRNO(ERANGE);
+
+  EXPECT_FP_EQ_WITH_EXCEPTION(inf, LIBC_NAMESPACE::cosh(-0x1.0p10),
+                              FE_OVERFLOW);
+  EXPECT_MATH_ERRNO(ERANGE);
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcCoshTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(min_denormal));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(max_denormal));
+}
+
+TEST_F(LlvmLibcCoshTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(min_denormal));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(max_denormal));
+}
+
+TEST_F(LlvmLibcCoshTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(min_denormal));
+  EXPECT_FP_EQ(1.0, LIBC_NAMESPACE::cosh(max_denormal));
+}
+
+#endif

--- a/libc/test/src/math/smoke/sinh_test.cpp
+++ b/libc/test/src/math/smoke/sinh_test.cpp
@@ -1,0 +1,75 @@
+//===-- Unittests for sinh ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/errno_macros.h"
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/sinh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcSinhTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcSinhTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::sinh(sNaN), FE_INVALID);
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::sinh(aNaN));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(inf, LIBC_NAMESPACE::sinh(inf));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_inf, LIBC_NAMESPACE::sinh(neg_inf));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(0.0, LIBC_NAMESPACE::sinh(0.0));
+  EXPECT_MATH_ERRNO(0);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::sinh(neg_zero));
+  EXPECT_MATH_ERRNO(0);
+}
+
+TEST_F(LlvmLibcSinhTest, Overflow) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(inf, LIBC_NAMESPACE::sinh(0x1.0p10), FE_OVERFLOW);
+  EXPECT_MATH_ERRNO(ERANGE);
+
+  EXPECT_FP_EQ_WITH_EXCEPTION(neg_inf, LIBC_NAMESPACE::sinh(-0x1.0p10),
+                              FE_OVERFLOW);
+  EXPECT_MATH_ERRNO(ERANGE);
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcSinhTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::sinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcSinhTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::sinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcSinhTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::sinh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::sinh(neg_min_denormal));
+}
+
+#endif

--- a/libc/test/src/math/smoke/tanh_test.cpp
+++ b/libc/test/src/math/smoke/tanh_test.cpp
@@ -1,0 +1,57 @@
+//===-- Unittests for tanh ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hdr/math_macros.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/math/tanh.h"
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using LlvmLibcTanhTest = LIBC_NAMESPACE::testing::FPTest<double>;
+
+TEST_F(LlvmLibcTanhTest, SpecialNumbers) {
+  EXPECT_FP_EQ_WITH_EXCEPTION(aNaN, LIBC_NAMESPACE::tanh(sNaN), FE_INVALID);
+
+  EXPECT_FP_EQ_ALL_ROUNDING(aNaN, LIBC_NAMESPACE::tanh(aNaN));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(1.0, LIBC_NAMESPACE::tanh(inf));
+  EXPECT_FP_EQ_ALL_ROUNDING(-1.0, LIBC_NAMESPACE::tanh(neg_inf));
+
+  EXPECT_FP_EQ_ALL_ROUNDING(0.0, LIBC_NAMESPACE::tanh(0.0));
+  EXPECT_FP_EQ_ALL_ROUNDING(neg_zero, LIBC_NAMESPACE::tanh(neg_zero));
+}
+
+#ifdef LIBC_TEST_FTZ_DAZ
+
+using namespace LIBC_NAMESPACE::testing;
+
+TEST_F(LlvmLibcTanhTest, FTZMode) {
+  ModifyMXCSR mxcsr(FTZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::tanh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::tanh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcTanhTest, DAZMode) {
+  ModifyMXCSR mxcsr(DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::tanh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::tanh(neg_min_denormal));
+}
+
+TEST_F(LlvmLibcTanhTest, FTZDAZMode) {
+  ModifyMXCSR mxcsr(FTZ | DAZ);
+
+  const double neg_min_denormal = FPBits::min_subnormal(Sign::NEG).get_val();
+  EXPECT_FP_EQ(0.0, LIBC_NAMESPACE::tanh(min_denormal));
+  EXPECT_FP_EQ(neg_zero, LIBC_NAMESPACE::tanh(neg_min_denormal));
+}
+
+#endif


### PR DESCRIPTION
Add generic double-precision implementations for the six hyperbolic math functions: `acosh`, `asinh`, `atanh`, `cosh`, `sinh`, `tanh`.