### PR TITLE
[LifetimeSafety] Fix use-after-scope from #198784

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety/Checker.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/Checker.cpp
@@ -356,8 +356,11 @@ public:
 
     // We iterate in reverse order (from most recent to oldest) to find
     // the first declaration in each file.
-    for (const FunctionDecl *Redecl :
-         llvm::reverse(llvm::to_vector(FDef->redecls())))
+
+    // Store in temporary variable to manually extend lifetime
+    auto redecls = llvm::to_vector(FDef->redecls());
+
+    for (const FunctionDecl *Redecl : llvm::reverse(redecls))
       AddCrossTUDecl(Redecl);
 
     return Targets;


### PR DESCRIPTION
This fixes a use-after-scope introduced by #198784 (reported in https://github.com/llvm/llvm-project/pull/198784#issuecomment-4530043621), by manually extending the lifetime.

AFAIK clang is built using C++17 [*], hence C++23 P2718R0's lifetime extension in range-based for loops does not apply.

[*] "Unless otherwise documented, LLVM subprojects are written using standard C++17 code" (https://llvm.org/docs/CodingStandards.html#c-standard-versions)