### PR TITLE
[ConstantHoisting] Avoid DenseMap reference invalidated by insertion

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstantHoisting.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstantHoisting.cpp
@@ -268,12 +268,14 @@ static void findBestInsertionSet(DominatorTree &DT, BlockFrequencyInfo &BFI,
       std::pair<SetVector<BasicBlock *>, BlockFrequency>;
 
   // InsertPtsMap is a map from a BB to the best insertion points for the
-  // subtree of BB (subtree not including the BB itself).
+  // subtree of BB (subtree not including the BB itself). Pre-populate every
+  // node so that loop below only uses find().
   DenseMap<BasicBlock *, InsertPtsCostPair> InsertPtsMap;
-  InsertPtsMap.reserve(Orders.size() + 1);
+  for (BasicBlock *Node : Orders)
+    InsertPtsMap.try_emplace(Node);
   for (BasicBlock *Node : llvm::reverse(Orders)) {
     bool NodeInBBs = BBs.count(Node);
-    auto &[InsertPts, InsertPtsFreq] = InsertPtsMap[Node];
+    auto &[InsertPts, InsertPtsFreq] = InsertPtsMap.find(Node)->second;
 
     // Return the optimal insert points in BBs.
     if (Node == Entry) {
@@ -289,7 +291,7 @@ static void findBestInsertionSet(DominatorTree &DT, BlockFrequencyInfo &BFI,
     BasicBlock *Parent = DT.getNode(Node)->getIDom()->getBlock();
     // Initially, ParentInsertPts is empty and ParentPtsFreq is 0. Every child
     // will update its parent's ParentInsertPts and ParentPtsFreq.
-    auto &[ParentInsertPts, ParentPtsFreq] = InsertPtsMap[Parent];
+    auto &[ParentInsertPts, ParentPtsFreq] = InsertPtsMap.find(Parent)->second;
     // Choose to insert in Node or in subtree of Node.
     // Don't hoist to EHPad because we may not find a proper place to insert
     // in EHPad.


### PR DESCRIPTION
Fix https://reviews.llvm.org/D28962 : DenseMap does not promise to keep
references stable across insertion. This happens to work today because
we don't do bucket eviction.

Pre-populate every node up front.