### PR TITLE
[libc][NFC] Add few options to allow users to skip building and running some tests.

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -22,6 +22,9 @@ function(_get_common_test_compile_options output_var c_test flags)
   # EXPECT_DEATH and ASSERT_DEATH might be quite slow.  LIBC_TEST_SKIP_DEATH_TESTS
   # will make those tests no-op to reduce the overall test time.
   if(LIBC_TEST_SKIP_DEATH_TESTS)
+    if(LIBC_CMAKE_VERBOSE_LOGGING)
+      message(STATUS "LIBC_TEST_SKIP_DEATH_TESTS is set.  EXPECT_DEATH/ASSERT_DEATH are no-op.")
+    endif()
     list(APPEND compile_options "-DLIBC_TEST_SKIP_DEATH_TESTS")
   endif()
 

--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -19,6 +19,12 @@ function(_get_common_test_compile_options output_var c_test flags)
       ${config_flags}
       ${arch_flags})
 
+  # EXPECT_DEATH and ASSERT_DEATH might be quite slow.  LIBC_TEST_SKIP_DEATH_TESTS
+  # will make those tests no-op to reduce the overall test time.
+  if(LIBC_TEST_SKIP_DEATH_TESTS)
+    list(APPEND compile_options "-DLIBC_TEST_SKIP_DEATH_TESTS")
+  endif()
+
   if(LLVM_LIBC_COMPILER_IS_GCC_COMPATIBLE)
     list(APPEND compile_options "-fpie")
 

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -27,14 +27,14 @@ configure_lit_site_cfg(
 )
 
 add_custom_target(check-libc-build)
-add_lit_testsuite(check-libc-lit
+add_lit_testsuite(check-libc
   "Running libc tests via lit"
   ${LIBC_BUILD_DIR}/test
 )
-add_dependencies(check-libc-lit check-libc-build)
+add_dependencies(check-libc check-libc-build)
 
 if (TARGET check-hdrgen)
-  add_dependencies(check-libc-lit check-hdrgen)
+  add_dependencies(check-libc check-hdrgen)
 endif()
 
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
@@ -42,14 +42,6 @@ if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
 endif()
 if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
   add_dependencies(check-libc-build libc-hermetic-tests-build)
-endif()
-
-add_custom_target(check-libc)
-if(LIBC_TEST_CHECK_LIBC_BUILD_ONLY)
-  message(STATUS "check-libc target will now only build all the tests.  Use ninja check-libc-lit to run all the tests.")
-  add_dependencies(check-libc check-libc-build)
-else()
-  add_dependencies(check-libc check-libc-lit)
 endif()
 
 add_subdirectory(UnitTest)

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -26,20 +26,30 @@ configure_lit_site_cfg(
   "CMAKE_CROSSCOMPILING_EMULATOR"
 )
 
-add_lit_testsuite(check-libc
+add_custom_target(check-libc-build)
+add_lit_testsuite(check-libc-lit
   "Running libc tests via lit"
   ${LIBC_BUILD_DIR}/test
 )
+add_dependencies(check-libc-lit check-libc-build)
 
 if (TARGET check-hdrgen)
   add_dependencies(check-libc check-hdrgen)
 endif()
 
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)
-  add_dependencies(check-libc libc-unit-tests-build)
+  add_dependencies(check-libc-build libc-unit-tests-build)
 endif()
 if(LIBC_ENABLE_HERMETIC_TESTS AND NOT LIBC_TEST_UNIT_TEST_ONLY)
-  add_dependencies(check-libc libc-hermetic-tests-build)
+  add_dependencies(check-libc-build libc-hermetic-tests-build)
+endif()
+
+add_custom_target(check-libc)
+if(LIBC_TEST_CHECK_LIBC_BUILD_ONLY)
+  message(STATUS "check-libc target will now only build all the tests.  Use ninja check-libc-lit to run all the tests.")
+  add_dependencies(check-libc check-libc-build)
+else()
+  add_dependencies(check-libc check-libc-lit)
 endif()
 
 add_subdirectory(UnitTest)

--- a/libc/test/CMakeLists.txt
+++ b/libc/test/CMakeLists.txt
@@ -34,7 +34,7 @@ add_lit_testsuite(check-libc-lit
 add_dependencies(check-libc-lit check-libc-build)
 
 if (TARGET check-hdrgen)
-  add_dependencies(check-libc check-hdrgen)
+  add_dependencies(check-libc-lit check-hdrgen)
 endif()
 
 if(LIBC_ENABLE_UNITTESTS AND NOT LIBC_TEST_HERMETIC_TEST_ONLY)

--- a/libc/test/UnitTest/LibcTest.h
+++ b/libc/test/UnitTest/LibcTest.h
@@ -495,10 +495,19 @@ CString libc_make_test_file_path_func(const char *file_name);
 #define ASSERT_EXITS(FUNC, EXIT)                                               \
   LIBC_TEST_PROCESS_(testProcessExits, FUNC, EXIT, return)
 
+#ifdef LIBC_TEST_SKIP_DEATH_TESTS
+
+#define EXPECT_DEATH(FUNC, SIG)
+#define ASSERT_DEATH(FUNC, SIG)
+
+#else
+
 #define EXPECT_DEATH(FUNC, SIG)                                                \
   LIBC_TEST_PROCESS_(testProcessKilled, FUNC, SIG, )
 #define ASSERT_DEATH(FUNC, SIG)                                                \
   LIBC_TEST_PROCESS_(testProcessKilled, FUNC, SIG, return)
+
+#endif // LIBC_TEST_SKIP_DEATH_TESTS
 
 #endif // ENABLE_SUBPROCESS_TESTS
 

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -1,5 +1,15 @@
 add_custom_target(libc-shared-tests)
 
+# Shared math tests include the entire math library headers into a single file
+# so it might take some time to compile the tests.  We do have dedicated
+# precommit CIs to build and test shared tests.  So we provide a cmake option
+# LIBC_TEST_SKIP_SHARED_TESTS to reduce redundant testings and reduce test time
+# for other precommit CIs.
+if(LIBC_TEST_SKIP_SHARED_TESTS)
+  if(LIBC_CMAKE_VERBOSE_LOGGING)
+    message(STATUS "LIBC_TEST_SKIP_SHARED_MATH_TESTS is set.  Skipping libc-shared-tests.")
+  endif()
+else()
 add_fp_unittest(
   shared_math_test
   SUITE
@@ -802,6 +812,7 @@ add_fp_unittest(
     libc.src.__support.math.totalordermagf16
     libc.src.__support.math.totalordermagl
 )
+endif() # LIBC_TEST_SKIP_SHARED_MATH_TESTS
 
 add_fp_unittest(
   shared_str_to_num_test


### PR DESCRIPTION
These options will be used to reduce redundancy and time for precommit CIs:
- LIBC_TEST_SKIP_DEATH_TESTS
- LIBC_TEST_SKIP_SHARED_MATH_TESTS
- LIBC_TEST_CHECK_LIBC_BUILD_ONLY