### PR TITLE
[Compiler-rt][test] Fix circular link dependency between builtins and libc

### DIFF
--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -107,7 +107,9 @@ else:
     if config.target_os == "Haiku":
         config.substitutions.append(("%librt ", base_lib + " -lroot "))
     else:
-        config.substitutions.append(("%librt ", base_lib + " -lc -lm "))
+        config.substitutions.append(
+            ("%librt ", "-lm -Wl,--start-group " + base_lib + " -lc -Wl,--end-group ")
+        )
 
 builtins_test_crt = get_required_attr(config, "builtins_test_crt")
 if builtins_test_crt:


### PR DESCRIPTION
Currently, the link order is `libclang_rt.builtins.a -lc -lm`. Builtins are scanned first after which symbols like `abort` are unresolved references that are resolved through libc.a. However, resolving the references to these symbols further lead to undefined references to `_aeabi_uldivmod` etc. that can only resolved through builtins. 
Reversing the order also wont fix the issue because `libc.a` introduces `__aeabi_uldivmod` which is resolved by builtins but it introduces `abort` which can only be resolved libc.a. 

This patch fixes this by wrapping the archives in a linker group (--start-group/--end-group), which instructs the linker to rescan all archives in the group until no new symbols can be resolved.

This error is exposed only when bfd like linkers are used.