### PR TITLE
[libc][math] Add missing math function entries dfmal,dfmaf128 to math.yaml

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -373,6 +373,23 @@ functions:
     arguments:
       - type: long double
       - type: long double
+  - name: dfmaf128
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: float128
+      - type: float128
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: dfmal
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: long double
+      - type: long double
+      - type: long double
   - name: dmulf128
     standards:
       - llvm_libc_ext


### PR DESCRIPTION
Part of https://github.com/llvm/llvm-project/issues/199266

Added missing math function entries to `libc/include/math.yaml`:

-  dfmaf128
-  dfmal

@Sukumarsawant
