### PR TITLE
[llvm-mca] Fix total execution count in Average Wait times

### DIFF
--- a/llvm/docs/CommandGuide/llvm-mca.rst
+++ b/llvm/docs/CommandGuide/llvm-mca.rst
@@ -683,7 +683,7 @@ Below is the timeline view for a subset of the dot-product example located in
   0.     3     1.0    1.0    3.3       vmulps	%xmm0, %xmm1, %xmm2
   1.     3     3.3    0.7    1.0       vhaddps	%xmm2, %xmm2, %xmm3
   2.     3     5.7    0.0    0.0       vhaddps	%xmm3, %xmm3, %xmm4
-         3     3.3    0.5    1.4       <total>
+         9     3.3    0.5    1.4       <total>
 
 The timeline view is interesting because it shows instruction state changes
 during execution.  It also gives an idea of how the tool processes instructions

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A510-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A510-writeback.s
@@ -1202,7 +1202,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1248,7 +1248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1294,7 +1294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1340,7 +1340,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1386,7 +1386,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1432,7 +1432,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1478,7 +1478,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1524,7 +1524,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1570,7 +1570,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1616,7 +1616,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1662,7 +1662,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1708,7 +1708,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1754,7 +1754,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1800,7 +1800,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1846,7 +1846,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1892,7 +1892,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1938,7 +1938,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1984,7 +1984,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2030,7 +2030,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2076,7 +2076,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2122,7 +2122,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2168,7 +2168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2214,7 +2214,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2260,7 +2260,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2306,7 +2306,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2352,7 +2352,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2398,7 +2398,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2444,7 +2444,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2490,7 +2490,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2536,7 +2536,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2582,7 +2582,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2628,7 +2628,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2674,7 +2674,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2720,7 +2720,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2766,7 +2766,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2812,7 +2812,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2858,7 +2858,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2904,7 +2904,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2950,7 +2950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2996,7 +2996,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3042,7 +3042,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3088,7 +3088,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3134,7 +3134,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3180,7 +3180,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3226,7 +3226,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3272,7 +3272,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3318,7 +3318,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3364,7 +3364,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3410,7 +3410,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3456,7 +3456,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3502,7 +3502,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3548,7 +3548,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3594,7 +3594,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3640,7 +3640,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3686,7 +3686,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3732,7 +3732,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3778,7 +3778,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3824,7 +3824,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3870,7 +3870,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3916,7 +3916,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3962,7 +3962,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4008,7 +4008,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4054,7 +4054,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4100,7 +4100,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4146,7 +4146,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4192,7 +4192,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4238,7 +4238,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4284,7 +4284,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4330,7 +4330,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4376,7 +4376,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4422,7 +4422,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4468,7 +4468,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4506,7 +4506,7 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4552,7 +4552,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4598,7 +4598,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4644,7 +4644,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4690,7 +4690,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4736,7 +4736,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4782,7 +4782,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4828,7 +4828,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4874,7 +4874,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4920,7 +4920,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4962,7 +4962,7 @@ add x0, x27, 1
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4995,7 +4995,7 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5040,7 +5040,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5085,7 +5085,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5130,7 +5130,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5175,7 +5175,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5220,7 +5220,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5249,7 +5249,7 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       strh	w1, [x27, #254]!
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5282,4 +5282,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A53-carry-over.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A53-carry-over.s
@@ -80,4 +80,4 @@ add  w19, w20, w21
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       ldp	w7, w8, [x11]
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       add	w16, w17, w18
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	w19, w20, w21
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A53-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A53-writeback.s
@@ -1202,7 +1202,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1248,7 +1248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1294,7 +1294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1340,7 +1340,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1386,7 +1386,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1432,7 +1432,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1478,7 +1478,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1524,7 +1524,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1570,7 +1570,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1616,7 +1616,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1662,7 +1662,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1708,7 +1708,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1754,7 +1754,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1800,7 +1800,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1846,7 +1846,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1892,7 +1892,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1938,7 +1938,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1984,7 +1984,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2030,7 +2030,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2076,7 +2076,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2122,7 +2122,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2168,7 +2168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2214,7 +2214,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2260,7 +2260,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2306,7 +2306,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2352,7 +2352,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2398,7 +2398,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2444,7 +2444,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2490,7 +2490,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2536,7 +2536,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2582,7 +2582,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2628,7 +2628,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2674,7 +2674,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2720,7 +2720,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2766,7 +2766,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2812,7 +2812,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2858,7 +2858,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2904,7 +2904,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2950,7 +2950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2996,7 +2996,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3042,7 +3042,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3088,7 +3088,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3134,7 +3134,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3180,7 +3180,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3226,7 +3226,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3272,7 +3272,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3318,7 +3318,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3364,7 +3364,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3410,7 +3410,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3456,7 +3456,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3502,7 +3502,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3548,7 +3548,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3594,7 +3594,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3640,7 +3640,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3686,7 +3686,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3732,7 +3732,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3778,7 +3778,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3824,7 +3824,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3870,7 +3870,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3916,7 +3916,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3962,7 +3962,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4008,7 +4008,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4054,7 +4054,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4100,7 +4100,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4146,7 +4146,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4192,7 +4192,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4238,7 +4238,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4284,7 +4284,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4330,7 +4330,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4376,7 +4376,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4422,7 +4422,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4468,7 +4468,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4506,7 +4506,7 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4552,7 +4552,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4598,7 +4598,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4644,7 +4644,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4690,7 +4690,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4736,7 +4736,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4782,7 +4782,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4828,7 +4828,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4874,7 +4874,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4920,7 +4920,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4962,7 +4962,7 @@ add x0, x27, 1
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4995,7 +4995,7 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5041,7 +5041,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5087,7 +5087,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5133,7 +5133,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5179,7 +5179,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5225,7 +5225,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5254,7 +5254,7 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       strh	w1, [x27, #254]!
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5287,4 +5287,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-add-sequence.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-add-sequence.s
@@ -78,4 +78,4 @@ add      w1, w0, #4
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       add	w4, w3, #2, lsl #12
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       add	w0, w4, #3
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       add	w1, w0, #4
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-all-views.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-all-views.s
@@ -119,4 +119,4 @@ str	w0, [x21, x18, lsl #2]
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       add	x3, x3, x13
 # CHECK-NEXT: 4.     2     0.0    0.0    0.0       subs	x1, x1, #1
 # CHECK-NEXT: 5.     2     0.0    0.0    0.0       str	w0, [x21, x18, lsl #2]
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        12    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-in-order-retire.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-in-order-retire.s
@@ -119,4 +119,4 @@ add	w7, w9, w0
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       add	w3, w4, #1
 # CHECK-NEXT: 4.     2     0.0    0.0    0.0       add	w5, w6, w0
 # CHECK-NEXT: 5.     2     0.0    0.0    0.0       add	w7, w9, w0
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        12    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-load-readadv.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-load-readadv.s
@@ -828,4 +828,4 @@ ldpsw    x0, x1, [x2], #16
 # CHECK-NEXT: 151.   1     0.0    0.0    0.0       ldpsw	x0, x1, [x2, #16]!
 # CHECK-NEXT: 152.   1     0.0    0.0    0.0       add	x2, x3, #1
 # CHECK-NEXT: 153.   1     0.0    0.0    0.0       ldpsw	x0, x1, [x2], #16
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        154   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-load-store-alias.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-load-store-alias.s
@@ -99,4 +99,4 @@ ldr x3, [x10]
 # CHECK-NEXT: 3.     3     0.0    0.0    0.0       nop
 # CHECK-NEXT: 4.     3     0.0    0.0    0.0       ldr	x2, [x10]
 # CHECK-NEXT: 5.     3     0.0    0.0    0.0       ldr	x3, [x10]
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        18    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-load-store-noalias.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-load-store-noalias.s
@@ -97,4 +97,4 @@ ldr x3, [x10]
 # CHECK-NEXT: 3.     3     0.0    0.0    0.0       nop
 # CHECK-NEXT: 4.     3     0.0    0.0    0.0       ldr	x2, [x10]
 # CHECK-NEXT: 5.     3     0.0    0.0    0.0       ldr	x3, [x10]
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        18    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-out-of-order-retire.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-out-of-order-retire.s
@@ -117,4 +117,4 @@ add	w7, w9, w0
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       add	w3, w4, #1
 # CHECK-NEXT: 4.     2     0.0    0.0    0.0       add	w5, w6, w0
 # CHECK-NEXT: 5.     2     0.0    0.0    0.0       add	w7, w9, w0
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        12    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-store-readadv.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-store-readadv.s
@@ -648,4 +648,4 @@ stp      x0, x1, [x2], #16
 # CHECK-NEXT: 115.   1     0.0    0.0    0.0       stp	x0, x1, [x2, #16]!
 # CHECK-NEXT: 116.   1     0.0    0.0    0.0       add	x2, x3, #1
 # CHECK-NEXT: 117.   1     0.0    0.0    0.0       stp	x0, x1, [x2], #16
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        118   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A55-writeback.s
@@ -1202,7 +1202,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1248,7 +1248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1294,7 +1294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1340,7 +1340,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1386,7 +1386,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1432,7 +1432,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1478,7 +1478,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1524,7 +1524,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1570,7 +1570,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1616,7 +1616,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1662,7 +1662,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1708,7 +1708,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1754,7 +1754,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1800,7 +1800,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1846,7 +1846,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1892,7 +1892,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1938,7 +1938,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1984,7 +1984,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2030,7 +2030,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2076,7 +2076,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2122,7 +2122,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2168,7 +2168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2214,7 +2214,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2260,7 +2260,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2306,7 +2306,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2352,7 +2352,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2398,7 +2398,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2444,7 +2444,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2490,7 +2490,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2536,7 +2536,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2582,7 +2582,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2628,7 +2628,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2674,7 +2674,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2720,7 +2720,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2766,7 +2766,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2812,7 +2812,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2858,7 +2858,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2904,7 +2904,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2950,7 +2950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2996,7 +2996,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3042,7 +3042,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3088,7 +3088,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3134,7 +3134,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3180,7 +3180,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3226,7 +3226,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3272,7 +3272,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3318,7 +3318,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3364,7 +3364,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3410,7 +3410,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3456,7 +3456,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3502,7 +3502,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3548,7 +3548,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3594,7 +3594,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3640,7 +3640,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3686,7 +3686,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3732,7 +3732,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3778,7 +3778,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3824,7 +3824,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3870,7 +3870,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3916,7 +3916,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3962,7 +3962,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4008,7 +4008,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4054,7 +4054,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4100,7 +4100,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4146,7 +4146,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4192,7 +4192,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4238,7 +4238,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4284,7 +4284,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4330,7 +4330,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4376,7 +4376,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4422,7 +4422,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4468,7 +4468,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4506,7 +4506,7 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4552,7 +4552,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4598,7 +4598,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4644,7 +4644,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4690,7 +4690,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4736,7 +4736,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4782,7 +4782,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4828,7 +4828,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4874,7 +4874,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4920,7 +4920,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4962,7 +4962,7 @@ add x0, x27, 1
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4995,7 +4995,7 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5041,7 +5041,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5087,7 +5087,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5133,7 +5133,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5179,7 +5179,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5225,7 +5225,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5254,7 +5254,7 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       strh	w1, [x27, #254]!
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5287,4 +5287,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/A57-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/A57-writeback.s
@@ -1202,7 +1202,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1248,7 +1248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1294,7 +1294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1340,7 +1340,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.6    0.2    1.6       <total>
+# CHECK-NEXT:        10    1.6    0.2    1.6       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1386,7 +1386,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.4    1.8       <total>
+# CHECK-NEXT:        10    1.4    0.4    1.8       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1432,7 +1432,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.6    0.3    1.7       <total>
+# CHECK-NEXT:        10    1.6    0.3    1.7       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1478,7 +1478,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    2.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.6    2.1       <total>
+# CHECK-NEXT:        10    1.2    0.6    2.1       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1524,7 +1524,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    2.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.7    2.3       <total>
+# CHECK-NEXT:        10    1.8    0.7    2.3       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1570,7 +1570,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.6    0.6    2.2       <total>
+# CHECK-NEXT:        10    1.6    0.6    2.2       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1616,7 +1616,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    1.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.7    2.4       <total>
+# CHECK-NEXT:        10    2.0    0.7    2.4       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1662,7 +1662,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    1.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.7    2.4       <total>
+# CHECK-NEXT:        10    1.8    0.7    2.4       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1708,7 +1708,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    1.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.4    0.9    2.4       <total>
+# CHECK-NEXT:        10    3.4    0.9    2.4       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1754,7 +1754,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     11.0   0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     11.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.6    0.8    2.8       <total>
+# CHECK-NEXT:        10    4.6    0.8    2.8       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1800,7 +1800,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1846,7 +1846,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     26.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     26.0   0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.2   0.1    2.7       <total>
+# CHECK-NEXT:        10    13.2   0.1    2.7       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1892,7 +1892,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.3    2.4       <total>
+# CHECK-NEXT:        10    1.2    0.3    2.4       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1938,7 +1938,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    2.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.4    3.1       <total>
+# CHECK-NEXT:        10    1.0    0.4    3.1       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1984,7 +1984,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2030,7 +2030,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.8       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.8       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2076,7 +2076,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    1.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2122,7 +2122,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.2       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2168,7 +2168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     20.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     26.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     26.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.8   0.1    3.1       <total>
+# CHECK-NEXT:        10    13.8   0.1    3.1       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2214,7 +2214,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     25.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    2.8       <total>
+# CHECK-NEXT:        10    13.0   0.1    2.8       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2260,7 +2260,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     11.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     10.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     10.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.6    0.1    2.9       <total>
+# CHECK-NEXT:        10    7.6    0.1    2.9       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2306,7 +2306,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2352,7 +2352,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.4    2.9       <total>
+# CHECK-NEXT:        10    1.1    0.4    2.9       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2398,7 +2398,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2444,7 +2444,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    1.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    3.5       <total>
+# CHECK-NEXT:        10    1.0    0.7    3.5       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2490,7 +2490,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    8.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.1    0.8    3.5       <total>
+# CHECK-NEXT:        10    2.1    0.8    3.5       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2536,7 +2536,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     8.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     15.0   0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     5.2    0.5    3.5       <total>
+# CHECK-NEXT:        10    5.2    0.5    3.5       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2582,7 +2582,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     22.0   0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     29.0   0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.0   0.1    3.5       <total>
+# CHECK-NEXT:        10    15.0   0.1    3.5       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2628,7 +2628,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     20.0   0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     24.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     24.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.4   0.1    2.7       <total>
+# CHECK-NEXT:        10    13.4   0.1    2.7       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2674,7 +2674,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.6    2.9       <total>
+# CHECK-NEXT:        10    1.0    0.6    2.9       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2720,7 +2720,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.6    3.2       <total>
+# CHECK-NEXT:        10    1.0    0.6    3.2       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2766,7 +2766,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.2       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2812,7 +2812,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    9.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.7    3.6       <total>
+# CHECK-NEXT:        10    2.0    0.7    3.6       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2858,7 +2858,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    3.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.9    3.4       <total>
+# CHECK-NEXT:        10    1.4    0.9    3.4       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2904,7 +2904,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.8    3.5       <total>
+# CHECK-NEXT:        10    1.0    0.8    3.5       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2950,7 +2950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     18.0   0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     24.0   0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     12.6   0.2    3.4       <total>
+# CHECK-NEXT:        10    12.6   0.2    3.4       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2996,7 +2996,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     12.8   0.2    3.2       <total>
+# CHECK-NEXT:        10    12.8   0.2    3.2       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3042,7 +3042,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    1.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.8    0.5    3.2       <total>
+# CHECK-NEXT:        10    4.8    0.5    3.2       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3088,7 +3088,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    1.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.8    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.8    3.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3134,7 +3134,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    2.8       <total>
+# CHECK-NEXT:        10    1.0    0.7    2.8       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3180,7 +3180,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    2.6       <total>
+# CHECK-NEXT:        10    1.0    0.7    2.6       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3226,7 +3226,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.6       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.6       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3272,7 +3272,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.2       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3318,7 +3318,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     18.0   0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     17.0   0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     22.0   0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        10    11.5   0.1    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3364,7 +3364,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3410,7 +3410,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3456,7 +3456,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3502,7 +3502,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3547,7 +3547,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.1    0.9       <total>
+# CHECK-NEXT:        10    1.4    0.1    0.9       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3592,7 +3592,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.4    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3638,7 +3638,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.6    0.3    0.0       <total>
+# CHECK-NEXT:        10    1.6    0.3    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3684,7 +3684,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        10    1.2    0.4    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3730,7 +3730,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    3.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.9    0.4       <total>
+# CHECK-NEXT:        10    3.0    0.9    0.4       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3776,7 +3776,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    3.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     7.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.2    1.1    0.6       <total>
+# CHECK-NEXT:        10    4.2    1.1    0.6       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3822,7 +3822,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    3.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.6    0.9    0.6       <total>
+# CHECK-NEXT:        10    2.6    0.9    0.6       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3868,7 +3868,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     6.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    2.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     6.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.0    1.2    1.1       <total>
+# CHECK-NEXT:        10    4.0    1.2    1.1       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3914,7 +3914,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     8.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     9.0    2.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     8.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.7    1.5    1.4       <total>
+# CHECK-NEXT:        10    4.7    1.5    1.4       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3960,7 +3960,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     6.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    2.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.6    1.2    1.1       <total>
+# CHECK-NEXT:        10    3.6    1.2    1.1       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4006,7 +4006,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     10.0   0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     12.0   3.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     12.0   0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     6.4    1.9    1.5       <total>
+# CHECK-NEXT:        10    6.4    1.9    1.5       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4052,7 +4052,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     9.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   7.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     15.0   0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.4    2.4    2.0       <total>
+# CHECK-NEXT:        10    7.4    2.4    2.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4098,7 +4098,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     7.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     13.0   7.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     13.0   0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     6.8    2.0    1.6       <total>
+# CHECK-NEXT:        10    6.8    2.0    1.6       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4144,7 +4144,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     10.0   0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     10.0   0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     10.0   0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.0    1.4    1.0       <total>
+# CHECK-NEXT:        10    7.0    1.4    1.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4189,7 +4189,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4235,7 +4235,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.3    0.4       <total>
+# CHECK-NEXT:        10    1.2    0.3    0.4       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4281,7 +4281,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.7    0.6       <total>
+# CHECK-NEXT:        10    1.3    0.7    0.6       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4327,7 +4327,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    1.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.9    0.9    0.7       <total>
+# CHECK-NEXT:        10    2.9    0.9    0.7       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4373,7 +4373,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     2.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.8    0.6       <total>
+# CHECK-NEXT:        10    1.7    0.8    0.6       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4419,7 +4419,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.5       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4465,7 +4465,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.3       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4503,7 +4503,7 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     3.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 5.     1     3.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    1.3    0.8       <total>
+# CHECK-NEXT:        6     2.7    1.3    0.8       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4549,7 +4549,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    5.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.2    1.7    1.5       <total>
+# CHECK-NEXT:        10    3.2    1.7    1.5       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4595,7 +4595,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    2.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    1.1    0.7       <total>
+# CHECK-NEXT:        10    1.5    1.1    0.7       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4641,7 +4641,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.6    0.6    0.6       <total>
+# CHECK-NEXT:        10    1.6    0.6    0.6       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4687,7 +4687,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     1.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.5       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4733,7 +4733,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     6.0    6.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.4    1.2    1.0       <total>
+# CHECK-NEXT:        10    2.4    1.2    1.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4779,7 +4779,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     9.0    7.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     6.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.8    2.0    1.9       <total>
+# CHECK-NEXT:        10    3.8    2.0    1.9       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4825,7 +4825,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     10.0   7.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     9.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     5.2    2.0    1.6       <total>
+# CHECK-NEXT:        10    5.2    2.0    1.6       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4871,7 +4871,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     6.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.3    1.3    1.2       <total>
+# CHECK-NEXT:        10    4.3    1.3    1.2       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4917,7 +4917,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.5       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4959,7 +4959,7 @@ add x0, x27, 1
 # CHECK-NEXT: 5.     1     5.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     5.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 7.     1     5.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.5    1.0    0.8       <total>
+# CHECK-NEXT:        8     3.5    1.0    0.8       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4992,7 +4992,7 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        4     1.0    0.5    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5038,7 +5038,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    3.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.9    0.9    0.3       <total>
+# CHECK-NEXT:        10    1.9    0.9    0.3       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5084,7 +5084,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5130,7 +5130,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5176,7 +5176,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5222,7 +5222,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5251,7 +5251,7 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       strh	w1, [x27, #254]!
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5285,4 +5285,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     4.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.3    2.0       <total>
+# CHECK-NEXT:        4     2.0    0.3    2.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Nano-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Nano-forwarding.s
@@ -72,7 +72,7 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    0.0       adrp	x0, #6553600
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       ldr	x0, [x0, #4096]
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region - simd_mac_mla
 
@@ -103,7 +103,7 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       mla	v0.4s, v3.4s, v4.4s
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region - simd_mac_dot
 
@@ -137,7 +137,7 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK-NEXT: 0.     2     0.0    0.0    0.0       udot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       udot	v0.4s, v3.16b, v4.16b
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       sdot	v0.4s, v5.16b, v6.16b
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region - simd_mac_long
 
@@ -171,7 +171,7 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK-NEXT: 0.     2     0.0    0.0    0.0       umlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       smlal	v0.4s, v3.4h, v4.4h
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       umlsl	v0.4s, v5.4h, v6.4h
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region - simd_mac_mixed
 
@@ -209,7 +209,7 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       mls	v0.4s, v3.4s, v4.4s
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       udot	v0.4s, v5.16b, v6.16b
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       umlal	v0.4s, v7.4h, v8.4h
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region - simd_mac_mul_to_accum
 
@@ -247,7 +247,7 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       mla	v0.4s, v3.4s, v4.4s
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       smull	v1.4s, v5.4h, v6.4h
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       smlal	v1.4s, v7.4h, v8.4h
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>
 
 # CHECK:      [6] Code Region - simd_mac_size_mismatch
 
@@ -282,4 +282,4 @@ mla      v0.4h, v5.4h, v6.4h
 # CHECK-NEXT: 0.     2     0.0    0.0    0.0       mul	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       mla	v0.2s, v3.2s, v4.2s
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       mla	v0.4h, v5.4h, v6.4h
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Premium-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Premium-forwarding.s
@@ -435,7 +435,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     7.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     8.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     8.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.3    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -473,7 +473,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     7.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     8.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     8.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.3    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -517,7 +517,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     21.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     25.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     17.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    17.5   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -555,7 +555,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -593,7 +593,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -631,7 +631,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -669,7 +669,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -707,7 +707,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqrdmlah	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -745,7 +745,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -783,7 +783,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - ssra
 
@@ -821,7 +821,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -859,7 +859,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -903,7 +903,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     20.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    16.5   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -947,7 +947,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     20.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    16.5   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -985,7 +985,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -1023,7 +1023,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -1061,7 +1061,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - crc32b
 
@@ -1099,7 +1099,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 3.     2     8.0    0.0    0.0       crc32b	w0, w0, w0
-# CHECK-NEXT:        2     6.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.3    0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z saba
 
@@ -1137,7 +1137,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sadalp
 
@@ -1175,7 +1175,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z ssra
 
@@ -1213,7 +1213,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z cdot.s
 
@@ -1251,7 +1251,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cdot.d
 
@@ -1289,7 +1289,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cmla.b
 
@@ -1327,7 +1327,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z cmla.d
 
@@ -1365,7 +1365,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z sdot.s
 
@@ -1403,7 +1403,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sudot
 
@@ -1441,7 +1441,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z sdot.d
 
@@ -1479,7 +1479,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z smmla
 
@@ -1517,7 +1517,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z mla.b
 
@@ -1555,7 +1555,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z mla.d
 
@@ -1593,7 +1593,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z smlalb
 
@@ -1631,7 +1631,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sqdmlalb
 
@@ -1669,7 +1669,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqrdmlah.b
 
@@ -1707,7 +1707,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z sqrdmlah.d
 
@@ -1745,7 +1745,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z fcmla ZPmZZ
 
@@ -1783,7 +1783,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fcmla ZZZI
 
@@ -1821,7 +1821,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fmla ZPmZZ
 
@@ -1859,7 +1859,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmla ZZZI
 
@@ -1897,7 +1897,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z fmlalb ZZZ
 
@@ -1935,7 +1935,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z bfdot
 
@@ -1973,7 +1973,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z bfmmla
 
@@ -2011,7 +2011,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.0   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     12.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.5   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - bfmlalb
 
@@ -2049,7 +2049,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [43] Code Region - brkn
 
@@ -2083,7 +2083,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       brkn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       brkn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       brkn	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [44] Code Region - brkns
 
@@ -2117,7 +2117,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       brkns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       brkns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       brkns	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [45] Code Region - sel
 
@@ -2154,7 +2154,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     2.0    2.0    0.5       sel	z0.s, p15, z1.s, z2.s
 # CHECK-NEXT: 2.     2     2.5    2.5    0.5       sel	z0.s, p15, z1.s, z2.s
 # CHECK-NEXT: 3.     2     4.5    0.0    0.0       sel	z0.s, p15, z0.s, z1.s
-# CHECK-NEXT:        2     2.6    1.5    0.5       <total>
+# CHECK-NEXT:        8     2.6    1.5    0.5       <total>
 
 # CHECK:      [46] Code Region - and
 
@@ -2188,7 +2188,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       and	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       and	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       and	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - ands
 
@@ -2222,7 +2222,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       ands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       ands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       ands	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - bic
 
@@ -2256,7 +2256,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       bic	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       bic	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       bic	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - bics
 
@@ -2290,7 +2290,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       bics	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       bics	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       bics	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - eor
 
@@ -2324,7 +2324,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       eor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       eor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       eor	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - eors
 
@@ -2358,7 +2358,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       eors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       eors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       eors	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [52] Code Region - nand
 
@@ -2392,7 +2392,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nand	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nand	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nand	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - nands
 
@@ -2426,7 +2426,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nands	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - nor
 
@@ -2460,7 +2460,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nor	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - nors
 
@@ -2494,7 +2494,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nors	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - orn
 
@@ -2528,7 +2528,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       orn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       orn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       orn	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - orns
 
@@ -2562,4 +2562,4 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       orns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       orns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       orns	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Premium-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Premium-writeback.s
@@ -760,7 +760,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4h }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -796,7 +796,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.16b }, [x27], #16
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -832,7 +832,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -868,7 +868,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -904,7 +904,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -940,7 +940,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -976,7 +976,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1012,7 +1012,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1048,7 +1048,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1084,7 +1084,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1120,7 +1120,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1156,7 +1156,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1192,7 +1192,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     11.0   0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT:        1     4.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     4.2    0.2    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1228,7 +1228,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.b }[8], [x27], x28
 # CHECK-NEXT: 3.     1     25.0   0.0    0.0       ld1	{ v1.h }[0], [x27], #2
 # CHECK-NEXT: 4.     1     33.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
-# CHECK-NEXT:        1     17.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     17.0   0.2    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1264,7 +1264,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.s }[0], [x27], #4
 # CHECK-NEXT: 3.     1     25.0   0.0    0.0       ld1	{ v1.s }[0], [x27], x28
 # CHECK-NEXT: 4.     1     33.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
-# CHECK-NEXT:        1     17.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     17.0   0.2    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1300,7 +1300,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.2d }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1r	{ v1.2s }, [x27], #4
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
-# CHECK-NEXT:        1     3.0    0.2    0.2       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.2       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1336,7 +1336,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.8h }, [x27], #2
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1r	{ v1.16b }, [x27], #1
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1372,7 +1372,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1r	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -1408,7 +1408,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -1444,7 +1444,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -1480,7 +1480,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -1516,7 +1516,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 3.     1     25.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     33.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT:        1     17.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     17.0   0.2    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -1552,7 +1552,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     25.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     33.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT:        1     17.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     17.0   0.2    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -1588,7 +1588,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     18.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 4.     1     19.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT:        1     12.8   0.2    0.0       <total>
+# CHECK-NEXT:        5     12.8   0.2    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -1624,7 +1624,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -1660,7 +1660,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -1696,7 +1696,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -1732,7 +1732,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 4.     1     7.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT:        1     3.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.6    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -1768,7 +1768,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     7.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     3.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.6    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -1804,7 +1804,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     14.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
 # CHECK-NEXT: 4.     1     23.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT:        1     8.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     8.8    0.4    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -1840,7 +1840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     19.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 3.     1     28.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
 # CHECK-NEXT: 4.     1     37.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT:        1     19.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     19.0   0.2    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -1876,7 +1876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     19.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     28.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
 # CHECK-NEXT: 4.     1     37.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT:        1     19.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     19.0   0.2    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -1912,7 +1912,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
 # CHECK-NEXT: 4.     1     7.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT:        1     3.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.6    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -1948,7 +1948,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     7.0    1.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     3.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.6    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -1984,7 +1984,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     7.0    1.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     3.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.6    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2020,7 +2020,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 3.     1     8.0    3.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 4.     1     10.0   1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT:        1     5.0    1.2    0.0       <total>
+# CHECK-NEXT:        5     5.0    1.2    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2056,7 +2056,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     5.0    2.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 3.     1     10.0   4.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     13.0   2.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT:        1     6.2    1.8    0.0       <total>
+# CHECK-NEXT:        5     6.2    1.8    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2092,7 +2092,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     5.0    2.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     9.0    3.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     10.0   0.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT:        1     5.4    1.2    0.0       <total>
+# CHECK-NEXT:        5     5.4    1.2    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2128,7 +2128,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     19.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 3.     1     28.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 4.     1     37.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT:        1     19.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     19.0   0.2    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2164,7 +2164,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     19.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 3.     1     28.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 4.     1     37.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT:        1     19.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     19.0   0.2    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -2200,7 +2200,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     11.0   0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 3.     1     14.0   2.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
 # CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT:        1     10.2   0.6    0.0       <total>
+# CHECK-NEXT:        5     10.2   0.6    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -2236,7 +2236,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     5.0    2.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
 # CHECK-NEXT: 3.     1     6.0    0.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
 # CHECK-NEXT: 4.     1     9.0    2.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT:        1     4.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     4.6    1.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -2272,7 +2272,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     5.0    2.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     6.0    0.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     9.0    2.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT:        1     4.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     4.6    1.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -2308,7 +2308,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     5.0    2.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     6.0    0.0    2.0       ldp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     6.0    0.0    1.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     4.0    0.6    0.6       <total>
+# CHECK-NEXT:        5     4.0    0.6    0.6       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -2344,7 +2344,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     4.0    0.0    1.0       ldp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     2.6    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.2       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -2380,7 +2380,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       ldp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     10.0   0.0    0.0       ldpsw	x1, x2, [x27], #248
 # CHECK-NEXT: 4.     1     10.0   0.0    0.0       ldpsw	x1, x2, [x27, #248]!
-# CHECK-NEXT:        1     6.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     6.4    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -2416,7 +2416,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	d1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldr	q1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -2452,7 +2452,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	d1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldr	q1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -2488,7 +2488,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	x1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrb	w1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -2524,7 +2524,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrh	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsb	w1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsb	x1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -2560,7 +2560,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsh	w1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsh	x1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsh	w1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -2595,7 +2595,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsw	x1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    1.0       st1	{ v1.1d }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.2       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.2       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -2630,7 +2630,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.8b }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -2665,7 +2665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -2700,7 +2700,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -2735,7 +2735,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -2770,7 +2770,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -2805,7 +2805,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -2840,7 +2840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 3.     1     5.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 4.     1     6.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT:        1     3.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.4    0.4    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -2875,7 +2875,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 3.     1     5.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     3.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.4    0.4    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -2910,7 +2910,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     3.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.2    0.4    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -2946,7 +2946,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 4.     1     7.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT:        1     3.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.6    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -2982,7 +2982,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 4.     1     8.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT:        1     4.0    0.8    0.0       <total>
+# CHECK-NEXT:        5     4.0    0.8    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -3017,7 +3017,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     3.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.6    0.4    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -3053,7 +3053,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     5.0    2.0    0.0       st1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 3.     1     6.0    0.0    0.0       st1	{ v1.b }[8], [x27], #1
 # CHECK-NEXT: 4.     1     7.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT:        1     4.2    0.6    0.0       <total>
+# CHECK-NEXT:        5     4.2    0.6    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -3089,7 +3089,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -3125,7 +3125,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -3161,7 +3161,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 4.     1     6.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT:        1     3.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.6    0.4    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -3197,7 +3197,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    1.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT:        1     3.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.2    0.4    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -3233,7 +3233,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    1.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
 # CHECK-NEXT: 4.     1     6.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT:        1     3.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.6    0.4    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -3269,7 +3269,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st2	{ v1.h, v2.h }[4], [x27], #4
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -3305,7 +3305,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], #16
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -3341,7 +3341,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 3.     1     9.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 4.     1     13.0   0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT:        1     5.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     5.6    0.2    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -3377,7 +3377,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     11.0   0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 3.     1     17.0   0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 4.     1     23.0   0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     11.8   0.2    0.0       <total>
+# CHECK-NEXT:        5     11.8   0.2    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -3413,7 +3413,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     9.0    0.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     15.0   0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     19.0   0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     9.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     9.8    0.2    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -3449,7 +3449,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     11.0   0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 3.     1     15.0   0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     19.0   0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT:        1     10.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     10.6   0.2    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -3485,7 +3485,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     9.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     13.0   0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     17.0   0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT:        1     9.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     9.0    0.2    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -3521,7 +3521,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     9.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     13.0   0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 4.     1     20.0   0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT:        1     9.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     9.6    0.2    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -3557,7 +3557,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     14.0   0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 3.     1     20.0   0.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 4.     1     27.0   0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT:        1     13.8   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.8   0.2    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -3593,7 +3593,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     14.0   0.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     20.0   0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     27.0   0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     14.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     14.0   0.2    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -3629,7 +3629,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
 # CHECK-NEXT: 3.     1     21.0   0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
 # CHECK-NEXT: 4.     1     27.0   0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT:        1     14.4   0.2    0.0       <total>
+# CHECK-NEXT:        5     14.4   0.2    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -3665,7 +3665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -3701,7 +3701,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       stg	x26, [x27], #4064
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -3736,7 +3736,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stgp	x1, x2, [x27, #992]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       stp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       stp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -3771,7 +3771,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    0.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       stp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     7.0    0.0    0.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     4.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     4.0    0.2    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -3806,7 +3806,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       str	b1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       str	h1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -3841,7 +3841,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       str	q1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       str	b1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       str	h1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -3876,7 +3876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       str	q1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       str	w1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       str	x1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -3911,7 +3911,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       strb	w1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       strb	w1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       strh	w1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -3946,7 +3946,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stz2g	x26, [x27, #4064]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       stzg	x26, [x27], #4064
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       stzg	x26, [x27, #4064]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -3976,4 +3976,4 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ldr	x1, [x27], #254
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Ultra-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Ultra-forwarding.s
@@ -428,7 +428,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     7.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     8.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     8.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.3    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -466,7 +466,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     7.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     8.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     8.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.3    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -510,7 +510,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     15.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.5   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -548,7 +548,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -586,7 +586,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -624,7 +624,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -662,7 +662,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -700,7 +700,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqrdmlah	v0.8h, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqrdmlah	v0.8h, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqrdmlah	v0.8h, v1.8h, v2.8h
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -738,7 +738,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -776,7 +776,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - fcmla
 
@@ -814,7 +814,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fmla
 
@@ -858,7 +858,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     20.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    16.5   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmlal
 
@@ -902,7 +902,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     20.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    16.5   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - bfdot
 
@@ -940,7 +940,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfmmla
 
@@ -978,7 +978,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmlalb
 
@@ -1016,7 +1016,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - Z saba
 
@@ -1054,7 +1054,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - Z sabalt
 
@@ -1092,7 +1092,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sabalt	z0.h, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sabalt	z0.h, z1.b, z2.b
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       sabalt	z0.h, z0.b, z1.b
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z sadalp
 
@@ -1130,7 +1130,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z ssra
 
@@ -1168,7 +1168,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z cdot.s
 
@@ -1206,7 +1206,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z cdot.d
 
@@ -1244,7 +1244,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cmla.b
 
@@ -1282,7 +1282,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cmla.d
 
@@ -1320,7 +1320,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z sdot.s
 
@@ -1358,7 +1358,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z sudot
 
@@ -1396,7 +1396,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sdot.d
 
@@ -1434,7 +1434,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z smmla
 
@@ -1472,7 +1472,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     11.5   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.3    0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z mla.b
 
@@ -1510,7 +1510,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z mla.d
 
@@ -1548,7 +1548,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z smlalb
 
@@ -1586,7 +1586,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     12.0   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     9.8    0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z sqdmlalb
 
@@ -1624,7 +1624,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sqrdmlah.b
 
@@ -1662,7 +1662,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqrdmlah.d
 
@@ -1700,7 +1700,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z fcmla ZPmZZ
 
@@ -1738,7 +1738,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z fcmla ZZZI
 
@@ -1776,7 +1776,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fmla ZPmZZ
 
@@ -1814,7 +1814,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fmla ZZZI
 
@@ -1852,7 +1852,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmlalb ZZZ
 
@@ -1890,7 +1890,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z bfdot
 
@@ -1928,7 +1928,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     13.5   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.3   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z bfmmla
 
@@ -1966,7 +1966,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.0   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     12.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.5   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - bfmlalb
 
@@ -2004,7 +2004,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - brkn
 
@@ -2038,7 +2038,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       brkn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       brkn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       brkn	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [43] Code Region - brkns
 
@@ -2072,7 +2072,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       brkns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       brkns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       brkns	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [44] Code Region - sel
 
@@ -2109,7 +2109,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     1.0    1.0    1.0       sel	z0.s, p15, z1.s, z2.s
 # CHECK-NEXT: 2.     2     1.0    1.0    1.0       sel	z0.s, p15, z1.s, z2.s
 # CHECK-NEXT: 3.     2     3.0    0.0    0.0       sel	z0.s, p15, z0.s, z1.s
-# CHECK-NEXT:        2     1.5    0.8    0.8       <total>
+# CHECK-NEXT:        8     1.5    0.8    0.8       <total>
 
 # CHECK:      [45] Code Region - and
 
@@ -2143,7 +2143,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       and	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       and	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       and	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - ands
 
@@ -2177,7 +2177,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       ands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       ands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       ands	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - bic
 
@@ -2211,7 +2211,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       bic	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       bic	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       bic	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - bics
 
@@ -2245,7 +2245,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       bics	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       bics	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       bics	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - eor
 
@@ -2279,7 +2279,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       eor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       eor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       eor	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - eors
 
@@ -2313,7 +2313,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       eors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       eors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       eors	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - nand
 
@@ -2347,7 +2347,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nand	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nand	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nand	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [52] Code Region - nands
 
@@ -2381,7 +2381,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nands	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nands	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - nor
 
@@ -2415,7 +2415,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nor	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nor	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - nors
 
@@ -2449,7 +2449,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       nors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       nors	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       nors	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - orn
 
@@ -2483,7 +2483,7 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       orn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       orn	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       orn	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - orns
 
@@ -2517,4 +2517,4 @@ orns p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 0.     2     2.5    0.5    0.0       orns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 1.     2     3.5    0.0    0.0       orns	p0.b, p15/z, p1.b, p0.b
 # CHECK-NEXT: 2.     2     4.5    0.0    0.0       orns	p0.b, p15/z, p1.b, p0.b
-# CHECK-NEXT:        2     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.5    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Ultra-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Cortex/C1Ultra-writeback.s
@@ -1222,7 +1222,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1268,7 +1268,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1314,7 +1314,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1360,7 +1360,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1406,7 +1406,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1452,7 +1452,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1498,7 +1498,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1544,7 +1544,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1590,7 +1590,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1636,7 +1636,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     5.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.2       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.2       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1682,7 +1682,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     5.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.5       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.5       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1728,7 +1728,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.5       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.5       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1774,7 +1774,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     10.0   0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     11.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.3    0.1    2.4       <total>
+# CHECK-NEXT:        10    4.3    0.1    2.4       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1820,7 +1820,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     24.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     25.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.1   0.1    2.0       <total>
+# CHECK-NEXT:        10    13.1   0.1    2.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1866,7 +1866,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     24.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     25.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.1   0.1    2.0       <total>
+# CHECK-NEXT:        10    13.1   0.1    2.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1912,7 +1912,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1958,7 +1958,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -2004,7 +2004,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2050,7 +2050,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.6       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.6       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2096,7 +2096,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2142,7 +2142,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2188,7 +2188,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     32.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     33.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     17.1   0.1    3.0       <total>
+# CHECK-NEXT:        10    17.1   0.1    3.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2234,7 +2234,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     32.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     33.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     17.1   0.1    3.0       <total>
+# CHECK-NEXT:        10    17.1   0.1    3.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2280,7 +2280,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     18.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     18.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     19.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     12.9   0.1    3.0       <total>
+# CHECK-NEXT:        10    12.9   0.1    3.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2326,7 +2326,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2372,7 +2372,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2418,7 +2418,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.1       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.1       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2464,7 +2464,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.5       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.5       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2510,7 +2510,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.5       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.5       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2556,7 +2556,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     12.0   0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     20.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     21.0   0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.9    0.1    3.5       <total>
+# CHECK-NEXT:        10    7.9    0.1    3.5       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2602,7 +2602,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     28.0   0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     36.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     37.0   0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     19.1   0.1    3.5       <total>
+# CHECK-NEXT:        10    19.1   0.1    3.5       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2648,7 +2648,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     28.0   0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     36.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     37.0   0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     19.1   0.1    3.5       <total>
+# CHECK-NEXT:        10    19.1   0.1    3.5       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2694,7 +2694,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2740,7 +2740,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2786,7 +2786,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2832,7 +2832,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.2       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.2       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2878,7 +2878,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.3       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.3       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2924,7 +2924,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.3       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.3       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2970,7 +2970,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     32.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     33.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     17.1   0.1    3.0       <total>
+# CHECK-NEXT:        10    17.1   0.1    3.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -3016,7 +3016,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     32.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     33.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     17.1   0.1    3.0       <total>
+# CHECK-NEXT:        10    17.1   0.1    3.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3062,7 +3062,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     11.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     11.0   0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     12.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     8.7    0.1    3.0       <total>
+# CHECK-NEXT:        10    8.7    0.1    3.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3108,7 +3108,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3154,7 +3154,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    3.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    3.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3200,7 +3200,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.8       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.8       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3246,7 +3246,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    1.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     4.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3292,7 +3292,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     10.0   0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     10.0   0.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     11.0   0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.3    0.1    0.8       <total>
+# CHECK-NEXT:        10    7.3    0.1    0.8       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3338,7 +3338,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3384,7 +3384,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3430,7 +3430,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3476,7 +3476,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3522,7 +3522,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3567,7 +3567,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.8       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.8       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3612,7 +3612,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3657,7 +3657,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3702,7 +3702,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3747,7 +3747,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3792,7 +3792,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3837,7 +3837,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3882,7 +3882,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     6.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        10    3.5    0.2    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3927,7 +3927,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.5    0.2    0.0       <total>
+# CHECK-NEXT:        10    3.5    0.2    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3972,7 +3972,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.3    0.2    0.0       <total>
+# CHECK-NEXT:        10    3.3    0.2    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4018,7 +4018,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     6.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     7.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.9    0.3    0.0       <total>
+# CHECK-NEXT:        10    3.9    0.3    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4064,7 +4064,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     8.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.1    0.4    0.0       <total>
+# CHECK-NEXT:        10    4.1    0.4    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4109,7 +4109,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.7    0.2    0.0       <total>
+# CHECK-NEXT:        10    3.7    0.2    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4155,7 +4155,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     6.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     6.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     7.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.3    0.3    0.6       <total>
+# CHECK-NEXT:        10    4.3    0.3    0.6       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4201,7 +4201,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4247,7 +4247,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4293,7 +4293,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4339,7 +4339,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4385,7 +4385,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4431,7 +4431,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4477,7 +4477,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4523,7 +4523,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 9.     1     6.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.5    0.2    0.7       <total>
+# CHECK-NEXT:        10    3.5    0.2    0.7       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4569,7 +4569,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    2.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     8.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.1    0.4    1.4       <total>
+# CHECK-NEXT:        10    4.1    0.4    1.4       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4615,7 +4615,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.3    0.2    1.2       <total>
+# CHECK-NEXT:        10    3.3    0.2    1.2       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4661,7 +4661,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     6.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.7    0.2    1.1       <total>
+# CHECK-NEXT:        10    3.7    0.2    1.1       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4707,7 +4707,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4753,7 +4753,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    1.4       <total>
+# CHECK-NEXT:        10    3.1    0.1    1.4       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4799,7 +4799,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     13.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     13.0   0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     14.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.5    1.0    2.3       <total>
+# CHECK-NEXT:        10    7.5    1.0    2.3       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4845,7 +4845,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     9.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     13.0   4.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     14.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     6.9    1.0    2.1       <total>
+# CHECK-NEXT:        10    6.9    1.0    2.1       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4891,7 +4891,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     14.0   0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     14.0   0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     15.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     9.1    1.1    2.2       <total>
+# CHECK-NEXT:        10    9.1    1.1    2.2       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4937,7 +4937,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4983,7 +4983,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    4.0       stg	x26, [x27], #4064
 # CHECK-NEXT: 9.     1     5.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    2.3       <total>
+# CHECK-NEXT:        10    3.1    0.1    2.3       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -5028,7 +5028,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.3    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.3    0.1    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5074,7 +5074,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     7.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     6.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     7.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    4.5    0.1    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5119,7 +5119,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5164,7 +5164,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5209,7 +5209,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5254,7 +5254,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.1    0.1    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5299,7 +5299,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       stzg	x26, [x27, #4064]!
 # CHECK-NEXT: 9.     1     5.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.4    0.1    0.0       <total>
+# CHECK-NEXT:        10    3.4    0.1    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5333,4 +5333,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.5    0.3    2.0       <total>
+# CHECK-NEXT:        4     2.5    0.3    2.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/HiSilicon/tsv110-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/HiSilicon/tsv110-forwarding.s
@@ -46,7 +46,7 @@ madd x0, x0, x0, x0
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       add	x0, x0, x1
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       add	x0, x0, x1
 # CHECK-NEXT: 3.     1     7.0    0.0    0.0       add	x0, x0, x1
-# CHECK-NEXT:        1     4.8    0.3    0.0       <total>
+# CHECK-NEXT:        4     4.8    0.3    0.0       <total>
 
 # CHECK:      [1] Code Region - madd bypass
 
@@ -80,4 +80,4 @@ madd x0, x0, x0, x0
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     1     7.0    0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        4     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/HiSilicon/tsv110-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/HiSilicon/tsv110-writeback.s
@@ -750,7 +750,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2s }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4h }, [x27], #8
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -786,7 +786,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.16b }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -822,7 +822,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -858,7 +858,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -894,7 +894,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -930,7 +930,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -966,7 +966,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1002,7 +1002,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1038,7 +1038,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1074,7 +1074,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1110,7 +1110,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1146,7 +1146,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1182,7 +1182,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT:        1     2.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.2    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1218,7 +1218,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld1	{ v1.b }[8], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld1	{ v1.h }[0], [x27], #2
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1254,7 +1254,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld1	{ v1.s }[0], [x27], #4
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld1	{ v1.s }[0], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1290,7 +1290,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1r	{ v1.2d }, [x27], #8
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1r	{ v1.2s }, [x27], #4
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1326,7 +1326,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1r	{ v1.8h }, [x27], #2
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1r	{ v1.16b }, [x27], #1
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1362,7 +1362,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1r	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1r	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -1398,7 +1398,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -1434,7 +1434,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -1470,7 +1470,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -1506,7 +1506,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -1542,7 +1542,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -1578,7 +1578,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     13.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 4.     1     13.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT:        1     9.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     9.4    0.2    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -1614,7 +1614,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -1650,7 +1650,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -1686,7 +1686,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -1722,7 +1722,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -1758,7 +1758,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -1794,7 +1794,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     7.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
 # CHECK-NEXT: 4.     1     13.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT:        1     4.6    0.6    0.0       <total>
+# CHECK-NEXT:        5     4.6    0.6    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -1830,7 +1830,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -1866,7 +1866,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -1902,7 +1902,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -1938,7 +1938,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -1974,7 +1974,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2010,7 +2010,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2046,7 +2046,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2082,7 +2082,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2118,7 +2118,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2154,7 +2154,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -2190,7 +2190,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 3.     1     6.0    1.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT:        1     5.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     5.0    0.4    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -2226,7 +2226,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -2262,7 +2262,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -2298,7 +2298,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    1.0       ldp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     1.0    0.8    0.2       <total>
+# CHECK-NEXT:        5     1.0    0.8    0.2       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -2334,7 +2334,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ldp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ldp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ldp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -2370,7 +2370,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ldp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ldpsw	x1, x2, [x27], #248
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -2406,7 +2406,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldr	s1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27], #254
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldr	q1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -2442,7 +2442,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldr	s1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldr	q1, [x27, #254]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -2478,7 +2478,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldr	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	x1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldrb	w1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -2514,7 +2514,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldrh	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldrsb	w1, [x27], #254
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldrsb	x1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -2550,7 +2550,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldrsh	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldrsh	x1, [x27], #254
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldrsh	w1, [x27, #254]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -2585,7 +2585,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldrsw	x1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.1d }, [x27], #8
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -2620,7 +2620,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8b }, [x27], #8
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -2655,7 +2655,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -2691,7 +2691,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -2727,7 +2727,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -2763,7 +2763,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -2799,7 +2799,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -2835,7 +2835,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -2871,7 +2871,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -2907,7 +2907,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -2943,7 +2943,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -2979,7 +2979,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -3015,7 +3015,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -3050,7 +3050,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    2.0       st1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 3.     1     3.0    0.0    1.0       st1	{ v1.b }[8], [x27], #1
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.6       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.6       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -3085,7 +3085,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -3121,7 +3121,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -3157,7 +3157,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -3193,7 +3193,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -3229,7 +3229,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -3265,7 +3265,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[4], [x27], #4
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -3301,7 +3301,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -3332,7 +3332,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT:        1     1.7    0.3    0.0       <total>
+# CHECK-NEXT:        3     1.7    0.3    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -3368,7 +3368,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -3404,7 +3404,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -3440,7 +3440,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -3476,7 +3476,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -3512,7 +3512,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -3548,7 +3548,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -3584,7 +3584,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -3620,7 +3620,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    1.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.2       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -3656,7 +3656,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -3690,7 +3690,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       st4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
-# CHECK-NEXT:        1     2.0    0.3    0.0       <total>
+# CHECK-NEXT:        4     2.0    0.3    0.0       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -3719,7 +3719,7 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       stp	s1, s2, [x27], #248
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       stp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     1.5    1.0    0.0       <total>
+# CHECK-NEXT:        2     1.5    1.0    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -3755,7 +3755,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       stp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     5.0    1.0    0.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     3.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     3.0    1.0    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -3790,7 +3790,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27], #254
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       str	h1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -3825,7 +3825,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       str	q1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       str	h1, [x27, #254]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -3860,7 +3860,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       str	q1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	w1, [x27], #254
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       str	x1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -3895,7 +3895,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       strb	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       strb	w1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       strh	w1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -3951,4 +3951,4 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ldr	x1, [x27], #254
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N1-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N1-forwarding.s
@@ -120,7 +120,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     11.9   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.9   0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - fmadd
 
@@ -164,7 +164,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmul	d0, d0, d0
 # CHECK-NEXT: 4.     2     19.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     23.5   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     15.7   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.7   0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - smaddl
 
@@ -202,7 +202,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     7.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     8.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     7.4    0.1    0.0       <total>
+# CHECK-NEXT:        8     7.4    0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -240,7 +240,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - mla
 
@@ -278,7 +278,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - sadalp
 
@@ -316,7 +316,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - ssra
 
@@ -354,7 +354,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - fmla
 
@@ -398,7 +398,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       fadd	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT: 4.     2     16.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     20.5   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     13.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    13.5   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - fmlal
 
@@ -442,7 +442,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       fadd	v0.2d, v0.2d, v0.2d
 # CHECK-NEXT: 4.     2     22.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     27.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     18.3   0.1    0.0       <total>
+# CHECK-NEXT:        12    18.3   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - crc32
 
@@ -480,7 +480,7 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       crc32cb	w0, w0, w1
 # CHECK-NEXT: 2.     2     6.5    0.0    0.0       crc32cb	w0, w0, w1
 # CHECK-NEXT: 3.     2     8.0    0.0    0.0       crc32cb	w0, w0, w0
-# CHECK-NEXT:        2     6.1    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.1    0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - smulh
 
@@ -518,4 +518,4 @@ smulh x0, x0, x0
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       smulh	x0, x0, x1
 # CHECK-NEXT: 2.     2     18.5   0.0    0.0       smulh	x0, x0, x1
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       smulh	x0, x0, x0
-# CHECK-NEXT:        2     16.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.4   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N1-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N1-writeback.s
@@ -1202,7 +1202,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1248,7 +1248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1294,7 +1294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1340,7 +1340,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.4    1.5       <total>
+# CHECK-NEXT:        10    1.1    0.4    1.5       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1386,7 +1386,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.5       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1432,7 +1432,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.5       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1478,7 +1478,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.8       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.8       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1524,7 +1524,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1570,7 +1570,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1616,7 +1616,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1662,7 +1662,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1708,7 +1708,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1754,7 +1754,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     5.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.4    2.1       <total>
+# CHECK-NEXT:        10    1.8    0.4    2.1       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1800,7 +1800,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     21.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     21.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.0   0.1    2.5       <total>
+# CHECK-NEXT:        10    11.0   0.1    2.5       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1846,7 +1846,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     21.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     21.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.0   0.1    2.5       <total>
+# CHECK-NEXT:        10    11.0   0.1    2.5       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1892,7 +1892,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1938,7 +1938,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1984,7 +1984,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2030,7 +2030,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2076,7 +2076,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2122,7 +2122,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2168,7 +2168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     21.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     21.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.0   0.1    2.5       <total>
+# CHECK-NEXT:        10    11.0   0.1    2.5       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2214,7 +2214,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     21.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     21.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.0   0.1    2.5       <total>
+# CHECK-NEXT:        10    11.0   0.1    2.5       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2260,7 +2260,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     10.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     9.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     9.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     7.4    0.1    2.5       <total>
+# CHECK-NEXT:        10    7.4    0.1    2.5       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2306,7 +2306,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2352,7 +2352,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2398,7 +2398,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    1.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.6    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.6    2.5       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2444,7 +2444,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    1.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.5       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.5       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2490,7 +2490,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.5       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.5       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2536,7 +2536,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     10.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     9.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.6    0.6    2.5       <total>
+# CHECK-NEXT:        10    3.6    0.6    2.5       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2582,7 +2582,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     12.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     17.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     16.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     8.6    0.2    2.4       <total>
+# CHECK-NEXT:        10    8.6    0.2    2.4       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2628,7 +2628,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     12.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     17.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     16.0   0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     8.6    0.2    2.4       <total>
+# CHECK-NEXT:        10    8.6    0.2    2.4       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2674,7 +2674,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2720,7 +2720,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2766,7 +2766,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2812,7 +2812,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    1.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.6       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.6       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2858,7 +2858,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.8       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.8       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2904,7 +2904,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.8       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.8       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2950,7 +2950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     11.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     17.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     15.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     8.2    0.2    2.8       <total>
+# CHECK-NEXT:        10    8.2    0.2    2.8       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2996,7 +2996,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     11.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     17.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     15.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     8.2    0.2    2.8       <total>
+# CHECK-NEXT:        10    8.2    0.2    2.8       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3042,7 +3042,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.7    2.3       <total>
+# CHECK-NEXT:        10    1.7    0.7    2.3       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3088,7 +3088,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3134,7 +3134,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3180,7 +3180,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.8    1.8       <total>
+# CHECK-NEXT:        10    1.0    0.8    1.8       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3226,7 +3226,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    1.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3272,7 +3272,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.2       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3318,7 +3318,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3364,7 +3364,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.5       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.5       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3410,7 +3410,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3456,7 +3456,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3502,7 +3502,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3547,7 +3547,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.2    0.8       <total>
+# CHECK-NEXT:        10    1.3    0.2    0.8       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3593,7 +3593,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3639,7 +3639,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3685,7 +3685,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3731,7 +3731,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3777,7 +3777,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3823,7 +3823,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3869,7 +3869,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    1.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    0.2       <total>
+# CHECK-NEXT:        10    1.0    1.0    0.2       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3915,7 +3915,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    0.3       <total>
+# CHECK-NEXT:        10    1.0    1.0    0.3       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3961,7 +3961,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    0.2       <total>
+# CHECK-NEXT:        10    1.0    1.0    0.2       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4007,7 +4007,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    0.2       <total>
+# CHECK-NEXT:        10    1.0    0.7    0.2       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4053,7 +4053,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.8    0.3       <total>
+# CHECK-NEXT:        10    1.0    0.8    0.3       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4099,7 +4099,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    0.2       <total>
+# CHECK-NEXT:        10    1.0    0.7    0.2       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4145,7 +4145,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    0.8       <total>
+# CHECK-NEXT:        10    1.0    0.7    0.8       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4191,7 +4191,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4237,7 +4237,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.1       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.1       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4283,7 +4283,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.2       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4329,7 +4329,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.3       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4375,7 +4375,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.2       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4421,7 +4421,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4467,7 +4467,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4505,7 +4505,7 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 5.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    1.5       <total>
+# CHECK-NEXT:        6     1.0    0.7    1.5       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4551,7 +4551,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.9    1.5       <total>
+# CHECK-NEXT:        10    1.0    0.9    1.5       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4597,7 +4597,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    1.5       <total>
+# CHECK-NEXT:        10    1.0    0.7    1.5       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4643,7 +4643,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    0.7       <total>
+# CHECK-NEXT:        10    1.0    1.0    0.7       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4689,7 +4689,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     1.0    1.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    0.5       <total>
+# CHECK-NEXT:        10    1.0    1.0    0.5       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4735,7 +4735,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    1.1       <total>
+# CHECK-NEXT:        10    1.0    1.0    1.1       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4781,7 +4781,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    2.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    2.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4827,7 +4827,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    1.8       <total>
+# CHECK-NEXT:        10    1.0    1.0    1.8       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4873,7 +4873,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    1.4       <total>
+# CHECK-NEXT:        10    1.0    1.0    1.4       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4919,7 +4919,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    1.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    1.0       <total>
+# CHECK-NEXT:        10    1.0    1.0    1.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4961,7 +4961,7 @@ add x0, x27, 1
 # CHECK-NEXT: 5.     1     1.0    1.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     1.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 7.     1     1.0    1.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    1.0    0.8       <total>
+# CHECK-NEXT:        8     1.0    1.0    0.8       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4994,7 +4994,7 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        4     1.0    0.5    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5040,7 +5040,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.7    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.7    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5086,7 +5086,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5132,7 +5132,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5178,7 +5178,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5224,7 +5224,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5253,7 +5253,7 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       strh	w1, [x27, #254]!
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5287,4 +5287,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     4.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.3    2.0       <total>
+# CHECK-NEXT:        4     2.0    0.3    2.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-forwarding.s
@@ -344,7 +344,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     6.6    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.6    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -382,7 +382,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     6.6    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.6    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -426,7 +426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     17.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     21.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     14.9   0.1    0.0       <total>
+# CHECK-NEXT:        12    14.9   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -464,7 +464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -502,7 +502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -540,7 +540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -578,7 +578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -616,7 +616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sqrdmlah	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.6   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -654,7 +654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -692,7 +692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - ssra
 
@@ -730,7 +730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -768,7 +768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -812,7 +812,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     17.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     21.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     14.6   0.1    0.0       <total>
+# CHECK-NEXT:        12    14.6   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -856,7 +856,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     22.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     24.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     29.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     20.4   0.1    0.0       <total>
+# CHECK-NEXT:        12    20.4   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -894,7 +894,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -932,7 +932,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.6   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -970,7 +970,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - crc32b
 
@@ -1008,7 +1008,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       crc32b	w0, w0, w0
-# CHECK-NEXT:        2     6.6    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.6    0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z saba
 
@@ -1046,7 +1046,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sadalp
 
@@ -1084,7 +1084,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z ssra
 
@@ -1122,7 +1122,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z cdot.s
 
@@ -1160,7 +1160,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cdot.d
 
@@ -1198,7 +1198,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cmla.b
 
@@ -1236,7 +1236,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z cmla.d
 
@@ -1274,7 +1274,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z sdot.s
 
@@ -1312,7 +1312,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sudot
 
@@ -1350,7 +1350,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z sdot.d
 
@@ -1388,7 +1388,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z smmla
 
@@ -1426,7 +1426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z mla.b
 
@@ -1464,7 +1464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z mla.d
 
@@ -1502,7 +1502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z smlalb
 
@@ -1540,7 +1540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sqdmlalb
 
@@ -1578,7 +1578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqrdmlah.b
 
@@ -1616,7 +1616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z sqrdmlah.d
 
@@ -1654,7 +1654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z fcmla ZPmZZ
 
@@ -1692,7 +1692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     12.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.6   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fcmla ZZZI
 
@@ -1730,7 +1730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     12.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.6   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fmla ZPmZZ
 
@@ -1768,7 +1768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmla ZZZI
 
@@ -1806,7 +1806,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z fmlalb ZZZ
 
@@ -1844,7 +1844,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z bfdot
 
@@ -1882,7 +1882,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z bfmmla
 
@@ -1920,7 +1920,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     13.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.6   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - bfmlalb
 
@@ -1958,4 +1958,4 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     9.5    0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     10.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N2-writeback.s
@@ -1222,7 +1222,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1268,7 +1268,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1314,7 +1314,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1360,7 +1360,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1406,7 +1406,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1452,7 +1452,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1498,7 +1498,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1544,7 +1544,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1590,7 +1590,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1636,7 +1636,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.2    2.2       <total>
+# CHECK-NEXT:        10    1.3    0.2    2.2       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1682,7 +1682,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1728,7 +1728,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1774,7 +1774,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     8.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.4    2.6       <total>
+# CHECK-NEXT:        10    2.3    0.4    2.6       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1820,7 +1820,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1866,7 +1866,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1912,7 +1912,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1958,7 +1958,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -2004,7 +2004,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2050,7 +2050,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.2    0.1    3.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2096,7 +2096,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.4    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.4    3.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2142,7 +2142,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.2    3.0       <total>
+# CHECK-NEXT:        10    1.2    0.2    3.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2188,7 +2188,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     22.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     29.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.0   0.1    3.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2234,7 +2234,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2280,7 +2280,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.3   0.1    3.0       <total>
+# CHECK-NEXT:        10    11.3   0.1    3.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2326,7 +2326,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2372,7 +2372,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2418,7 +2418,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.4    0.1    3.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2464,7 +2464,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2510,7 +2510,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2556,7 +2556,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     7.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     13.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     13.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.6    0.3    3.0       <total>
+# CHECK-NEXT:        10    4.6    0.3    3.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2602,7 +2602,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2648,7 +2648,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2694,7 +2694,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2740,7 +2740,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2786,7 +2786,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2832,7 +2832,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.2       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2878,7 +2878,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2924,7 +2924,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2970,7 +2970,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -3016,7 +3016,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3062,7 +3062,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     7.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     6.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     6.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     5.4    0.3    3.0       <total>
+# CHECK-NEXT:        10    5.4    0.3    3.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3108,7 +3108,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3154,7 +3154,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3200,7 +3200,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.4    2.6       <total>
+# CHECK-NEXT:        10    1.2    0.4    2.6       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3246,7 +3246,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    1.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.2    2.0       <total>
+# CHECK-NEXT:        10    1.2    0.2    2.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3292,7 +3292,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     5.0    4.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     6.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.5    1.2       <total>
+# CHECK-NEXT:        10    2.3    0.5    1.2       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3338,7 +3338,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3384,7 +3384,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3430,7 +3430,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3476,7 +3476,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3522,7 +3522,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3567,7 +3567,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.2    0.1    0.8       <total>
+# CHECK-NEXT:        10    2.2    0.1    0.8       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3612,7 +3612,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3657,7 +3657,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3702,7 +3702,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3747,7 +3747,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.3    0.1    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3792,7 +3792,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.2    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3837,7 +3837,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.2    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3883,7 +3883,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3929,7 +3929,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3975,7 +3975,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4021,7 +4021,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4067,7 +4067,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4113,7 +4113,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4159,7 +4159,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.3    0.6       <total>
+# CHECK-NEXT:        10    1.3    0.3    0.6       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4205,7 +4205,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4251,7 +4251,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.4    0.1    1.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4297,7 +4297,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.3    0.1    1.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4343,7 +4343,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.2    1.0       <total>
+# CHECK-NEXT:        10    1.2    0.2    1.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4389,7 +4389,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.2    1.0       <total>
+# CHECK-NEXT:        10    1.3    0.2    1.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4435,7 +4435,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4481,7 +4481,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4527,7 +4527,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 9.     1     1.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.3    1.0       <total>
+# CHECK-NEXT:        10    1.2    0.3    1.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4573,7 +4573,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.9       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.9       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4619,7 +4619,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.7       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.7       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4665,7 +4665,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4711,7 +4711,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4757,7 +4757,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.9       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.9       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4803,7 +4803,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    1.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.8    2.1       <total>
+# CHECK-NEXT:        10    1.1    0.8    2.1       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4849,7 +4849,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    1.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.6    1.9       <total>
+# CHECK-NEXT:        10    1.0    0.6    1.9       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4895,7 +4895,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.7    2.0       <total>
+# CHECK-NEXT:        10    1.2    0.7    2.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4941,7 +4941,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4987,7 +4987,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    1.0       stg	x26, [x27], #4064
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.5    1.3       <total>
+# CHECK-NEXT:        10    1.1    0.5    1.3       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -5032,7 +5032,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5078,7 +5078,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.6    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.6    0.1    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5123,7 +5123,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5168,7 +5168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5213,7 +5213,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5258,7 +5258,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5303,7 +5303,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       stzg	x26, [x27, #4064]!
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5337,4 +5337,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.3    2.0       <total>
+# CHECK-NEXT:        4     2.3    0.3    2.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-forwarding.s
@@ -358,7 +358,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     6.6    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.6    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -396,7 +396,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     6.6    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.6    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -440,7 +440,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     17.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     21.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     14.9   0.1    0.0       <total>
+# CHECK-NEXT:        12    14.9   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -478,7 +478,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -516,7 +516,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -554,7 +554,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -592,7 +592,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -630,7 +630,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sqrdmlah	v0.8h, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sqrdmlah	v0.8h, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sqrdmlah	v0.8h, v1.8h, v2.8h
-# CHECK-NEXT:        2     11.1   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.1   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -668,7 +668,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sqdmlal2
 
@@ -706,7 +706,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sqdmlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sqdmlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sqdmlal2	v0.4s, v1.8h, v2.8h
-# CHECK-NEXT:        2     11.1   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.1   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - sadalp
 
@@ -744,7 +744,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -782,7 +782,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -826,7 +826,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     17.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     21.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     14.6   0.1    0.0       <total>
+# CHECK-NEXT:        12    14.6   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -870,7 +870,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     20.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     24.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     17.3   0.1    0.0       <total>
+# CHECK-NEXT:        12    17.3   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -908,7 +908,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -946,7 +946,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.6   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -984,7 +984,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - crc32
 
@@ -1043,7 +1043,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 8.     2     16.0   0.0    0.0       crc32ch	w0, w0, w16
 # CHECK-NEXT: 9.     2     16.5   0.0    0.0       crc32cw	w0, w0, w23
 # CHECK-NEXT: 10.    2     17.0   0.0    0.0       crc32cx	w0, w0, x5
-# CHECK-NEXT:        2     12.9   0.0    0.0       <total>
+# CHECK-NEXT:        22    12.9   0.0    0.0       <total>
 
 # CHECK:      [18] Code Region - Z saba
 
@@ -1081,7 +1081,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sabalt
 
@@ -1119,7 +1119,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sabalt	z0.h, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       sabalt	z0.h, z1.b, z2.b
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sabalt	z0.h, z0.b, z1.b
-# CHECK-NEXT:        2     11.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.6   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z sadalp
 
@@ -1157,7 +1157,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z ssra
 
@@ -1195,7 +1195,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cdot.s
 
@@ -1233,7 +1233,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cdot.d
 
@@ -1271,7 +1271,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z cmla.b
 
@@ -1309,7 +1309,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z cmla.d
 
@@ -1347,7 +1347,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sdot.s
 
@@ -1385,7 +1385,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z sudot
 
@@ -1423,7 +1423,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z sdot.d
 
@@ -1461,7 +1461,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z smmla
 
@@ -1499,7 +1499,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     10.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.4   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z mla.b
 
@@ -1537,7 +1537,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z mla.d
 
@@ -1575,7 +1575,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z smlalb
 
@@ -1613,7 +1613,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqdmlalb
 
@@ -1651,7 +1651,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z sqrdmlah.b
 
@@ -1689,7 +1689,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z sqrdmlah.d
 
@@ -1727,7 +1727,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fcmla ZPmZZ
 
@@ -1765,7 +1765,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fcmla ZZZI
 
@@ -1803,7 +1803,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmla ZPmZZ
 
@@ -1841,7 +1841,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z fmla ZZZI
 
@@ -1879,7 +1879,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z fmlalb ZZZ
 
@@ -1917,7 +1917,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z bfdot
 
@@ -1955,7 +1955,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - Z bfmmla
 
@@ -1993,7 +1993,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     13.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.6   0.1    0.0       <total>
 
 # CHECK:      [43] Code Region - bfmlalb
 
@@ -2031,4 +2031,4 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.4   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.4   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/N3-writeback.s
@@ -1222,7 +1222,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1268,7 +1268,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1314,7 +1314,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1360,7 +1360,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1406,7 +1406,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1452,7 +1452,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1498,7 +1498,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1544,7 +1544,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1590,7 +1590,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1636,7 +1636,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.2    2.2       <total>
+# CHECK-NEXT:        10    1.3    0.2    2.2       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1682,7 +1682,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1728,7 +1728,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.5       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.5       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1774,7 +1774,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     8.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.4    2.6       <total>
+# CHECK-NEXT:        10    2.3    0.4    2.6       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1820,7 +1820,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1866,7 +1866,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1912,7 +1912,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.1    2.4       <total>
+# CHECK-NEXT:        10    2.0    0.1    2.4       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1958,7 +1958,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -2004,7 +2004,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2050,7 +2050,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.1    0.1    2.6       <total>
+# CHECK-NEXT:        10    2.1    0.1    2.6       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2096,7 +2096,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2142,7 +2142,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2188,7 +2188,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2234,7 +2234,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2280,7 +2280,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     16.0   0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.3   0.1    2.8       <total>
+# CHECK-NEXT:        10    11.3   0.1    2.8       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2326,7 +2326,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2372,7 +2372,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2418,7 +2418,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    8.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.1    2.4       <total>
+# CHECK-NEXT:        10    1.4    0.1    2.4       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2464,7 +2464,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    8.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.4       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.4       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2510,7 +2510,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    8.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.6       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.6       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2556,7 +2556,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     9.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     15.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     5.4    0.3    3.4       <total>
+# CHECK-NEXT:        10    5.4    0.3    3.4       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2602,7 +2602,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2648,7 +2648,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2694,7 +2694,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2740,7 +2740,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2786,7 +2786,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2832,7 +2832,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.4    2.8       <total>
+# CHECK-NEXT:        10    1.1    0.4    2.8       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2878,7 +2878,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2924,7 +2924,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2970,7 +2970,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -3016,7 +3016,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3062,7 +3062,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     7.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     6.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     6.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     5.4    0.3    3.0       <total>
+# CHECK-NEXT:        10    5.4    0.3    3.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3108,7 +3108,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3154,7 +3154,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3200,7 +3200,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     1.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    2.6       <total>
+# CHECK-NEXT:        10    1.0    0.5    2.6       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3246,7 +3246,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    1.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     2.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.4    2.0       <total>
+# CHECK-NEXT:        10    1.1    0.4    2.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3292,7 +3292,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3338,7 +3338,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3384,7 +3384,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3430,7 +3430,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3476,7 +3476,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3522,7 +3522,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3567,7 +3567,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.2    0.1    0.8       <total>
+# CHECK-NEXT:        10    2.2    0.1    0.8       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3612,7 +3612,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3657,7 +3657,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3702,7 +3702,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3747,7 +3747,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3792,7 +3792,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3837,7 +3837,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3883,7 +3883,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3929,7 +3929,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3975,7 +3975,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -4021,7 +4021,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4067,7 +4067,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4113,7 +4113,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4158,7 +4158,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.3    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.3    0.2    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4203,7 +4203,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4248,7 +4248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4293,7 +4293,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4338,7 +4338,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4383,7 +4383,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4428,7 +4428,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4473,7 +4473,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4519,7 +4519,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.2    0.3    0.4       <total>
+# CHECK-NEXT:        10    1.2    0.3    0.4       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4565,7 +4565,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.8       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.8       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4611,7 +4611,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4657,7 +4657,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.2       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4703,7 +4703,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4749,7 +4749,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.2       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.2       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4795,7 +4795,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    1.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    1.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4841,7 +4841,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.8       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.8       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4887,7 +4887,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.4       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.4       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4933,7 +4933,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4979,7 +4979,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       stg	x26, [x27], #4064
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.4    0.0       <total>
+# CHECK-NEXT:        10    1.1    0.4    0.0       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -5024,7 +5024,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5069,7 +5069,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5114,7 +5114,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5159,7 +5159,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     2.0    0.0    1.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.2       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.2       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5204,7 +5204,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.2       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.2       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5249,7 +5249,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5294,7 +5294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       stzg	x26, [x27, #4064]!
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5328,4 +5328,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.3    2.0       <total>
+# CHECK-NEXT:        4     2.3    0.3    2.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-clear-upper-regs.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-clear-upper-regs.s
@@ -125,7 +125,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    0.5       ldr	w0, [sp]
 # CHECK-NEXT: 1.     4     5.3    0.0    0.0       add	x0, x0, x0
-# CHECK-NEXT:        4     3.3    0.6    0.3       <total>
+# CHECK-NEXT:        8     3.3    0.6    0.3       <total>
 
 # CHECK:      [1] Code Region - FPR8-bit
 
@@ -202,7 +202,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	b0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       fadd	d0, d0, d0
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [2] Code Region - FPR16-bit
 
@@ -279,7 +279,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	h0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       fadd	d0, d0, d0
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [3] Code Region - FPR32-bit
 
@@ -356,7 +356,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	s0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       fadd	d0, d0, d0
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [4] Code Region - SIMD64-bit-b
 
@@ -433,7 +433,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.8b }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [5] Code Region - SIMD64-bit-h
 
@@ -510,7 +510,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.4h }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	v0.8h, v0.8h, v0.8h
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [6] Code Region - SIMD64-bit-s
 
@@ -587,7 +587,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.2s }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	v0.4s, v0.4s, v0.4s
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [7] Code Region - SIMD64-bit-d
 
@@ -664,7 +664,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.1d }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	v0.2d, v0.2d, v0.2d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [8] Code Region - ins
 
@@ -741,7 +741,7 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     7.0    0.3    0.0       mov	v0.b[0], v1.b[1]
 # CHECK-NEXT: 1.     4     9.0    0.0    0.0       add	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:        4     8.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.0    0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - lanewise-load
 
@@ -818,4 +818,4 @@ add v0.16b, v0.16b, v0.16b
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     15.8   0.3    0.0       ld1	{ v0.b }[0], [sp]
 # CHECK-NEXT: 1.     4     23.5   0.0    0.0       add	v0.16b, v0.16b, v0.16b
-# CHECK-NEXT:        4     19.6   0.1    0.0       <total>
+# CHECK-NEXT:        8     19.6   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-forwarding.s
@@ -267,7 +267,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     7.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     7.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     7.0    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -305,7 +305,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     7.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     7.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     7.0    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -349,7 +349,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     15.3   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.3   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -387,7 +387,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sadalp
 
@@ -425,7 +425,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - sdot
 
@@ -463,7 +463,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - smmla
 
@@ -501,7 +501,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - mla
 
@@ -539,7 +539,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -577,7 +577,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - ssra
 
@@ -615,7 +615,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - fcmla
 
@@ -653,7 +653,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fmla
 
@@ -697,7 +697,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.0   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmlal
 
@@ -741,7 +741,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     21.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     23.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     28.5   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     20.0   0.1    0.0       <total>
+# CHECK-NEXT:        12    20.0   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - bfdot
 
@@ -779,7 +779,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfmmla
 
@@ -817,7 +817,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmlalb
 
@@ -855,7 +855,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - crc32
 
@@ -914,7 +914,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 8.     2     16.5   0.0    0.0       crc32ch	w0, w0, w16
 # CHECK-NEXT: 9.     2     17.5   0.0    0.0       crc32cw	w0, w0, w23
 # CHECK-NEXT: 10.    2     18.5   0.0    0.0       crc32cx	w0, w0, x5
-# CHECK-NEXT:        2     13.7   0.0    0.0       <total>
+# CHECK-NEXT:        22    13.7   0.0    0.0       <total>
 
 # CHECK:      [17] Code Region - Z sdot.s
 
@@ -952,7 +952,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z sudot
 
@@ -990,7 +990,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sdot.d
 
@@ -1028,7 +1028,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z smmla
 
@@ -1066,7 +1066,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z mla.d
 
@@ -1104,7 +1104,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     21.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.0   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z mad.d
 
@@ -1142,7 +1142,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       mad	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     21.0   0.0    0.0       mad	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.0   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z msb.d
 
@@ -1180,7 +1180,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.0   0.0    0.0       msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     16.0   0.0    0.0       msb	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     21.0   0.0    0.0       msb	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     15.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.0   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z fcmla ZPmZZ
 
@@ -1218,7 +1218,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z fcmla ZZZI
 
@@ -1256,7 +1256,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z fmla ZPmZZ
 
@@ -1294,7 +1294,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z fmla ZZZI
 
@@ -1332,7 +1332,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z bfdot
 
@@ -1370,7 +1370,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z bfmmla
 
@@ -1408,7 +1408,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - bfmlalb
 
@@ -1446,4 +1446,4 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-writeback.s
@@ -1202,7 +1202,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -1248,7 +1248,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -1294,7 +1294,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -1340,7 +1340,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -1386,7 +1386,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -1432,7 +1432,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -1478,7 +1478,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1524,7 +1524,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1570,7 +1570,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1616,7 +1616,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 9.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.1    2.1       <total>
+# CHECK-NEXT:        10    1.8    0.1    2.1       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1662,7 +1662,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 9.     1     3.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    2.2       <total>
+# CHECK-NEXT:        10    2.3    0.1    2.2       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1708,7 +1708,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.1    2.2       <total>
+# CHECK-NEXT:        10    1.7    0.1    2.2       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1754,7 +1754,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     7.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 9.     1     8.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    2.5       <total>
+# CHECK-NEXT:        10    2.7    0.1    2.5       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1800,7 +1800,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     16.7   0.1    3.0       <total>
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1846,7 +1846,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     25.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     31.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 9.     1     32.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     16.7   0.1    3.0       <total>
+# CHECK-NEXT:        10    16.7   0.1    3.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1892,7 +1892,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
 # CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    3.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1938,7 +1938,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    3.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1984,7 +1984,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    3.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    3.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -2030,7 +2030,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    3.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    3.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -2076,7 +2076,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -2122,7 +2122,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -2168,7 +2168,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -2214,7 +2214,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -2260,7 +2260,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     16.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     11.3   0.1    3.0       <total>
+# CHECK-NEXT:        10    11.3   0.1    3.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -2306,7 +2306,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -2352,7 +2352,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -2398,7 +2398,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -2444,7 +2444,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -2490,7 +2490,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -2536,7 +2536,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     9.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     15.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 9.     1     16.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     5.7    0.1    3.0       <total>
+# CHECK-NEXT:        10    5.7    0.1    3.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -2582,7 +2582,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -2628,7 +2628,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     23.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     29.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     30.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     15.5   0.1    3.0       <total>
+# CHECK-NEXT:        10    15.5   0.1    3.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -2674,7 +2674,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -2720,7 +2720,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -2766,7 +2766,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    3.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    3.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2812,7 +2812,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.1    0.4    3.2       <total>
+# CHECK-NEXT:        10    1.1    0.4    3.2       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2858,7 +2858,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2904,7 +2904,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    7.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    7.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.3       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.3       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2950,7 +2950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2996,7 +2996,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     19.0   0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
 # CHECK-NEXT: 9.     1     25.0   0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     13.0   0.1    3.0       <total>
+# CHECK-NEXT:        10    13.0   0.1    3.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -3042,7 +3042,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     5.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
 # CHECK-NEXT: 9.     1     4.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     4.6    0.1    3.0       <total>
+# CHECK-NEXT:        10    4.6    0.1    3.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -3088,7 +3088,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -3134,7 +3134,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    6.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     1.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.0    0.5    3.0       <total>
+# CHECK-NEXT:        10    1.0    0.5    3.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -3180,7 +3180,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       ldp	d1, d2, [x27], #496
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.3    2.8       <total>
+# CHECK-NEXT:        10    1.4    0.3    2.8       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -3226,7 +3226,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    1.0       ldp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     4.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    2.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    2.0       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -3272,7 +3272,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
 # CHECK-NEXT: 9.     1     4.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    1.2       <total>
+# CHECK-NEXT:        10    2.7    0.1    1.2       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -3318,7 +3318,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldr	q1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -3364,7 +3364,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldr	q1, [x27, #254]!
 # CHECK-NEXT: 9.     1     5.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    2.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    2.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -3410,7 +3410,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldrb	w1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    1.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -3456,7 +3456,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldrsb	x1, [x27], #254
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    1.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -3502,7 +3502,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       ldrsh	w1, [x27, #254]!
 # CHECK-NEXT: 9.     1     5.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     3.0    0.1    1.0       <total>
+# CHECK-NEXT:        10    3.0    0.1    1.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -3547,7 +3547,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    1.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     4.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.9    0.1    0.8       <total>
+# CHECK-NEXT:        10    2.9    0.1    0.8       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -3592,7 +3592,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -3637,7 +3637,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -3682,7 +3682,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -3727,7 +3727,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.1    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.1    0.1    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -3772,7 +3772,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -3817,7 +3817,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    0.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -3862,7 +3862,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.9    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.9    0.2    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -3907,7 +3907,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.9    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.9    0.2    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -3952,7 +3952,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.7    0.2    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -3998,7 +3998,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.2    0.3    0.0       <total>
+# CHECK-NEXT:        10    2.2    0.3    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -4044,7 +4044,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.4    0.0       <total>
+# CHECK-NEXT:        10    1.8    0.4    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -4089,7 +4089,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.9    0.2    0.0       <total>
+# CHECK-NEXT:        10    1.9    0.2    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -4135,7 +4135,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.1    0.3    0.6       <total>
+# CHECK-NEXT:        10    2.1    0.3    0.6       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -4181,7 +4181,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -4227,7 +4227,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -4273,7 +4273,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    1.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -4319,7 +4319,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.9    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.9    0.1    1.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -4365,7 +4365,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.7    0.1    1.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -4411,7 +4411,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -4457,7 +4457,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    1.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    1.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -4494,7 +4494,7 @@ add x0, x27, 1
 # CHECK-NEXT: 3.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.3    1.2       <total>
+# CHECK-NEXT:        6     1.8    0.3    1.2       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -4540,7 +4540,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    3.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
 # CHECK-NEXT: 9.     1     4.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.3    1.4       <total>
+# CHECK-NEXT:        10    2.3    0.3    1.4       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -4586,7 +4586,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    3.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.2    1.2       <total>
+# CHECK-NEXT:        10    1.7    0.2    1.2       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -4632,7 +4632,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.1    0.2    1.1       <total>
+# CHECK-NEXT:        10    2.1    0.2    1.1       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -4678,7 +4678,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
 # CHECK-NEXT: 9.     1     2.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    1.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    1.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -4724,7 +4724,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     1.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.4    0.2    1.2       <total>
+# CHECK-NEXT:        10    1.4    0.2    1.2       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -4770,7 +4770,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 9.     1     2.0    0.0    5.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.8    0.4    2.3       <total>
+# CHECK-NEXT:        10    1.8    0.4    2.3       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -4816,7 +4816,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    5.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.9    0.4    1.9       <total>
+# CHECK-NEXT:        10    1.9    0.4    1.9       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -4862,7 +4862,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     2.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 9.     1     3.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.7    0.4    2.2       <total>
+# CHECK-NEXT:        10    1.7    0.4    2.2       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -4908,7 +4908,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     2.0    0.0    4.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     1.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 9.     1     2.0    0.0    4.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.1    2.0       <total>
+# CHECK-NEXT:        10    1.5    0.1    2.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -4950,7 +4950,7 @@ add x0, x27, 1
 # CHECK-NEXT: 5.     1     3.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 6.     1     2.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 7.     1     3.0    0.0    2.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.3    1.5       <total>
+# CHECK-NEXT:        8     2.0    0.3    1.5       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -4983,7 +4983,7 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stp	d1, d2, [x27], #496
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.0    0.3    0.0       <total>
+# CHECK-NEXT:        4     2.0    0.3    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -5028,7 +5028,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     3.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       stp	w1, w2, [x27], #248
 # CHECK-NEXT: 9.     1     3.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.3    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.3    0.1    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -5073,7 +5073,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       str	h1, [x27], #254
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -5118,7 +5118,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       str	h1, [x27, #254]!
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -5163,7 +5163,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       str	x1, [x27], #254
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -5208,7 +5208,7 @@ add x0, x27, 1
 # CHECK-NEXT: 7.     1     4.0    0.0    0.0       add	x0, x27, #1
 # CHECK-NEXT: 8.     1     3.0    0.0    0.0       strh	w1, [x27], #254
 # CHECK-NEXT: 9.     1     4.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.7    0.1    0.0       <total>
+# CHECK-NEXT:        10    2.7    0.1    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -5237,7 +5237,7 @@ add x0, x27, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       strh	w1, [x27, #254]!
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       add	x0, x27, #1
-# CHECK-NEXT:        1     1.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.5    0.5    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -5271,4 +5271,4 @@ add x0, x27, 1
 # CHECK-NEXT: 1.     1     2.0    0.0    2.0       add	x0, x27, #1
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
 # CHECK-NEXT: 3.     1     2.0    0.0    6.0       add	x0, x27, #1
-# CHECK-NEXT:        1     2.5    0.3    2.0       <total>
+# CHECK-NEXT:        4     2.5    0.3    2.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-zero-dependency.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V1-zero-dependency.s
@@ -76,4 +76,4 @@ cmp x0, #4
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     0.0    0.0    1.5       mov	x0, x1
 # CHECK-NEXT: 1.     4     1.3    1.3    0.0       cmp	x0, #4
-# CHECK-NEXT:        4     0.6    0.6    0.8       <total>
+# CHECK-NEXT:        8     0.6    0.6    0.8       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-clear-upper-regs.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-clear-upper-regs.s
@@ -128,7 +128,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ldr	b0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [1] Code Region - FPR16-bit
 
@@ -207,7 +207,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ldr	h0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [2] Code Region - FPR32-bit
 
@@ -286,7 +286,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ldr	s0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [3] Code Region - FPR64-bit
 
@@ -365,7 +365,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ldr	d0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [4] Code Region - FPR128-bit
 
@@ -444,7 +444,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ldr	q0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [5] Code Region - SIMD64-bit-b
 
@@ -523,7 +523,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ld1	{ v0.8b }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [6] Code Region - SIMD64-bit-h
 
@@ -602,7 +602,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ld1	{ v0.4h }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [7] Code Region - SIMD64-bit-s
 
@@ -681,7 +681,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ld1	{ v0.2s }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [8] Code Region - SIMD64-bit-d
 
@@ -760,7 +760,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.3       ld1	{ v0.1d }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.6       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.6       <total>
 
 # CHECK:      [9] Code Region - insr
 
@@ -839,4 +839,4 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     12.5   0.3    0.0       insr	z0.s, w0
 # CHECK-NEXT: 1.     4     18.5   0.0    0.0       add	z0.s, z0.s, z0.s
-# CHECK-NEXT:        4     15.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     15.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-forwarding.s
@@ -344,7 +344,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     6.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.8    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -382,7 +382,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     6.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.8    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -426,7 +426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     15.2   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.2   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -464,7 +464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -502,7 +502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.5   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -540,7 +540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.5   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -578,7 +578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -616,7 +616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sqrdmlah	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -654,7 +654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -692,7 +692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - ssra
 
@@ -730,7 +730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -768,7 +768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -812,7 +812,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     14.8   0.1    0.0       <total>
+# CHECK-NEXT:        12    14.8   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -856,7 +856,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     21.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     25.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     17.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    17.5   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -894,7 +894,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -932,7 +932,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     17.0   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -970,7 +970,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - crc32b
 
@@ -1008,7 +1008,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 2.     2     7.0    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 3.     2     9.0    0.0    0.0       crc32b	w0, w0, w0
-# CHECK-NEXT:        2     6.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     6.8    0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z saba
 
@@ -1046,7 +1046,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sadalp
 
@@ -1084,7 +1084,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z ssra
 
@@ -1122,7 +1122,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z cdot.s
 
@@ -1160,7 +1160,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cdot.d
 
@@ -1198,7 +1198,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cmla.b
 
@@ -1236,7 +1236,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z cmla.d
 
@@ -1274,7 +1274,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z sdot.s
 
@@ -1312,7 +1312,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sudot
 
@@ -1350,7 +1350,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     15.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z sdot.d
 
@@ -1388,7 +1388,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z smmla
 
@@ -1426,7 +1426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     14.0   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.5   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z mla.b
 
@@ -1464,7 +1464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z mla.d
 
@@ -1502,7 +1502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z smlalb
 
@@ -1540,7 +1540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sqdmlalb
 
@@ -1578,7 +1578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqrdmlah.b
 
@@ -1616,7 +1616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.0   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z sqrdmlah.d
 
@@ -1654,7 +1654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     14.5   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     22.5   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z fcmla ZPmZZ
 
@@ -1692,7 +1692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fcmla ZZZI
 
@@ -1730,7 +1730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fmla ZPmZZ
 
@@ -1768,7 +1768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmla ZZZI
 
@@ -1806,7 +1806,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z fmlalb ZZZ
 
@@ -1844,7 +1844,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.5   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z bfdot
 
@@ -1882,7 +1882,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z bfmmla
 
@@ -1920,7 +1920,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     17.0   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     16.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.0   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - bfmlalb
 
@@ -1958,4 +1958,4 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     12.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.8   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V2-writeback.s
@@ -760,7 +760,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4h }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -796,7 +796,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.16b }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -832,7 +832,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -868,7 +868,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -904,7 +904,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -940,7 +940,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -976,7 +976,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT:        1     1.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.2    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1012,7 +1012,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1048,7 +1048,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1084,7 +1084,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1120,7 +1120,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT:        1     1.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.4    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1156,7 +1156,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.4    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1192,7 +1192,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     8.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT:        1     2.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1228,7 +1228,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld1	{ v1.b }[8], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.h }[0], [x27], #2
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1264,7 +1264,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld1	{ v1.s }[0], [x27], #4
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.s }[0], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1300,7 +1300,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1r	{ v1.2d }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.2s }, [x27], #4
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1336,7 +1336,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1r	{ v1.8h }, [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.16b }, [x27], #1
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1372,7 +1372,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1r	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -1408,7 +1408,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     1.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.2    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -1444,7 +1444,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -1480,7 +1480,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -1516,7 +1516,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -1552,7 +1552,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -1588,7 +1588,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     15.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT:        1     10.8   0.2    0.0       <total>
+# CHECK-NEXT:        5     10.8   0.2    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -1624,7 +1624,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -1660,7 +1660,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -1696,7 +1696,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -1732,7 +1732,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT:        1     1.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.4    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -1768,7 +1768,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.6    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -1804,7 +1804,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     7.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
 # CHECK-NEXT: 4.     1     14.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT:        1     4.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     4.8    0.4    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -1840,7 +1840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -1876,7 +1876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -1912,7 +1912,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT:        1     1.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.4    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -1948,7 +1948,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.6    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -1984,7 +1984,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.4    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2020,7 +2020,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2056,7 +2056,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2092,7 +2092,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2128,7 +2128,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2164,7 +2164,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     13.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 3.     1     19.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 4.     1     25.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT:        1     13.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     13.0   0.2    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -2200,7 +2200,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 3.     1     5.0    0.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT:        1     4.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     4.6    0.2    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -2236,7 +2236,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -2272,7 +2272,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -2308,7 +2308,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ldp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     1.0    0.8    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.8    0.0       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -2344,7 +2344,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ldp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ldp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     1.0    0.0    1.0       ldp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     1.0    0.2    0.2       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.2       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -2380,7 +2380,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ldpsw	x1, x2, [x27], #248
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
-# CHECK-NEXT:        1     1.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -2416,7 +2416,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldr	s1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27], #254
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldr	q1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -2452,7 +2452,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldr	s1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldr	q1, [x27, #254]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -2488,7 +2488,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	x1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldrb	w1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -2524,7 +2524,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrh	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldrsb	w1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldrsb	x1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -2560,7 +2560,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsh	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldrsh	x1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldrsh	w1, [x27, #254]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -2595,7 +2595,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsw	x1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    1.0       st1	{ v1.1d }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.2       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -2630,7 +2630,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8b }, [x27], #8
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -2665,7 +2665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -2700,7 +2700,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -2735,7 +2735,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT:        1     1.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.6    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -2770,7 +2770,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -2805,7 +2805,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -2840,7 +2840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT:        1     1.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.4    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -2876,7 +2876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.2    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.6    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -2911,7 +2911,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -2947,7 +2947,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT:        1     1.4    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.6    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -2983,7 +2983,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 4.     1     2.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT:        1     1.4    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.4    1.0    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -3019,7 +3019,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.6    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -3055,7 +3055,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st1	{ v1.b }[8], [x27], #1
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT:        1     1.4    0.8    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.8    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -3091,7 +3091,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -3127,7 +3127,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st1	{ v1.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -3163,7 +3163,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -3199,7 +3199,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    1.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.8    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -3235,7 +3235,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT:        1     1.6    0.8    0.0       <total>
+# CHECK-NEXT:        5     1.6    0.8    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -3271,7 +3271,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st2	{ v1.h, v2.h }[4], [x27], #4
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -3307,7 +3307,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], #16
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -3343,7 +3343,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    3.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT:        1     1.8    0.8    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.8    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -3379,7 +3379,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 4.     1     5.0    4.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     2.4    1.8    0.0       <total>
+# CHECK-NEXT:        5     2.4    1.8    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -3415,7 +3415,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    3.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.4    1.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    1.4    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -3451,7 +3451,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    2.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT:        1     2.0    1.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    1.4    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -3487,7 +3487,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -3523,7 +3523,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.0    1.0    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -3559,7 +3559,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 3.     1     6.0    5.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 4.     1     5.0    1.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT:        1     3.0    2.0    0.0       <total>
+# CHECK-NEXT:        5     3.0    2.0    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -3595,7 +3595,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    4.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    4.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     2.8    2.0    0.0       <total>
+# CHECK-NEXT:        5     2.8    2.0    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -3631,7 +3631,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     7.0    7.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
 # CHECK-NEXT: 3.     1     9.0    2.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
 # CHECK-NEXT: 4.     1     9.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT:        1     5.4    2.2    0.0       <total>
+# CHECK-NEXT:        5     5.4    2.2    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -3667,7 +3667,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -3703,7 +3703,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    2.0       stg	x26, [x27], #4064
-# CHECK-NEXT:        1     1.2    0.4    0.4       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.4       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -3738,7 +3738,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stgp	x1, x2, [x27, #992]!
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       stp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       stp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     1.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.2    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -3773,7 +3773,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       stp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     2.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.2    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -3808,7 +3808,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       str	b1, [x27], #254
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       str	h1, [x27], #254
-# CHECK-NEXT:        1     1.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.2    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -3843,7 +3843,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       str	q1, [x27], #254
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       str	b1, [x27, #254]!
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       str	h1, [x27, #254]!
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -3878,7 +3878,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       str	q1, [x27, #254]!
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       str	w1, [x27], #254
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       str	x1, [x27], #254
-# CHECK-NEXT:        1     1.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.2    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -3913,7 +3913,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       strb	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       strb	w1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       strh	w1, [x27], #254
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -3948,7 +3948,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stz2g	x26, [x27, #4064]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stzg	x26, [x27], #4064
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       stzg	x26, [x27, #4064]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -3978,4 +3978,4 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ldr	x1, [x27], #254
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-clear-upper-regs.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-clear-upper-regs.s
@@ -133,7 +133,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	b0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [1] Code Region - FPR16-bit
 
@@ -217,7 +217,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	h0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [2] Code Region - FPR32-bit
 
@@ -301,7 +301,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	s0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [3] Code Region - FPR64-bit
 
@@ -385,7 +385,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	d0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [4] Code Region - FPR128-bit
 
@@ -469,7 +469,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ldr	q0, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [5] Code Region - SIMD64-bit-b
 
@@ -553,7 +553,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.8b }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [6] Code Region - SIMD64-bit-h
 
@@ -637,7 +637,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.4h }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [7] Code Region - SIMD64-bit-s
 
@@ -721,7 +721,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.2s }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [8] Code Region - SIMD64-bit-d
 
@@ -805,7 +805,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.3       ld1	{ v0.1d }, [sp]
 # CHECK-NEXT: 1.     4     7.3    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.3    0.6    0.6       <total>
+# CHECK-NEXT:        8     4.3    0.6    0.6       <total>
 
 # CHECK:      [9] Code Region - insr
 
@@ -889,4 +889,4 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     11.3   0.3    0.0       insr	z0.s, w0
 # CHECK-NEXT: 1.     4     16.3   0.0    0.0       add	z0.s, z0.s, z0.s
-# CHECK-NEXT:        4     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-forwarding.s
@@ -344,7 +344,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     7.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     9.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     11.0   0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     8.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.0    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -382,7 +382,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     7.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     9.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     11.0   0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     8.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.0    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -426,7 +426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     15.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.5   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -464,7 +464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -502,7 +502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -540,7 +540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -578,7 +578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -616,7 +616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       sqrdmlah	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -654,7 +654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -692,7 +692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - ssra
 
@@ -730,7 +730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -768,7 +768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -812,7 +812,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     15.2   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.2   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -856,7 +856,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     21.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     25.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     17.8   0.1    0.0       <total>
+# CHECK-NEXT:        12    17.8   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -894,7 +894,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -932,7 +932,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     23.5   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     16.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.3   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -970,7 +970,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - crc32b
 
@@ -1008,7 +1008,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 2.     2     7.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       crc32b	w0, w0, w0
-# CHECK-NEXT:        2     7.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     7.0    0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z saba
 
@@ -1046,7 +1046,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sadalp
 
@@ -1084,7 +1084,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z ssra
 
@@ -1122,7 +1122,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z cdot.s
 
@@ -1160,7 +1160,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cdot.d
 
@@ -1198,7 +1198,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cmla.b
 
@@ -1236,7 +1236,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z cmla.d
 
@@ -1274,7 +1274,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z sdot.s
 
@@ -1312,7 +1312,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sudot
 
@@ -1350,7 +1350,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z sdot.d
 
@@ -1388,7 +1388,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z smmla
 
@@ -1426,7 +1426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z mla.b
 
@@ -1464,7 +1464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z mla.d
 
@@ -1502,7 +1502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z smlalb
 
@@ -1540,7 +1540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sqdmlalb
 
@@ -1578,7 +1578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqrdmlah.b
 
@@ -1616,7 +1616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z sqrdmlah.d
 
@@ -1654,7 +1654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z fcmla ZPmZZ
 
@@ -1692,7 +1692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fcmla ZZZI
 
@@ -1730,7 +1730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fmla ZPmZZ
 
@@ -1768,7 +1768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmla ZZZI
 
@@ -1806,7 +1806,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z fmlalb ZZZ
 
@@ -1844,7 +1844,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z bfdot
 
@@ -1882,7 +1882,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z bfmmla
 
@@ -1920,7 +1920,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     23.5   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     16.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.3   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - bfmlalb
 
@@ -1958,4 +1958,4 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3-writeback.s
@@ -760,7 +760,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4h }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -796,7 +796,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.16b }, [x27], #16
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -832,7 +832,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -868,7 +868,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -904,7 +904,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -940,7 +940,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -976,7 +976,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1012,7 +1012,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1048,7 +1048,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1084,7 +1084,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1120,7 +1120,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT:        1     2.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1156,7 +1156,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1192,7 +1192,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     10.0   0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT:        1     3.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.4    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1228,7 +1228,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.b }[8], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.h }[0], [x27], #2
 # CHECK-NEXT: 4.     1     32.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
-# CHECK-NEXT:        1     16.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.6   0.2    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1264,7 +1264,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.s }[0], [x27], #4
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.s }[0], [x27], x28
 # CHECK-NEXT: 4.     1     32.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
-# CHECK-NEXT:        1     16.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.6   0.2    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1300,7 +1300,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.2d }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.2s }, [x27], #4
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1336,7 +1336,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.8h }, [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.16b }, [x27], #1
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1372,7 +1372,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -1408,7 +1408,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -1444,7 +1444,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -1480,7 +1480,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -1516,7 +1516,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -1552,7 +1552,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -1588,7 +1588,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     17.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 4.     1     17.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT:        1     12.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     12.0   0.2    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -1624,7 +1624,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -1660,7 +1660,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -1696,7 +1696,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -1732,7 +1732,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -1768,7 +1768,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -1804,7 +1804,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     8.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
 # CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT:        1     5.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     5.2    0.2    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -1840,7 +1840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -1876,7 +1876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -1912,7 +1912,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -1948,7 +1948,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -1984,7 +1984,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2020,7 +2020,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2056,7 +2056,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT:        1     1.2    0.8    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.8    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2092,7 +2092,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.4    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2128,7 +2128,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2164,7 +2164,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -2200,7 +2200,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 3.     1     8.0    0.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
 # CHECK-NEXT: 4.     1     8.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT:        1     6.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     6.6    0.2    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -2236,7 +2236,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -2272,7 +2272,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -2308,7 +2308,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    1.0       ldp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     1.2    0.2    0.2       <total>
+# CHECK-NEXT:        5     1.2    0.2    0.2       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -2344,7 +2344,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     3.0    0.0    1.0       ldp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     2.2    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.2       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -2380,7 +2380,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldpsw	x1, x2, [x27], #248
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
-# CHECK-NEXT:        1     2.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.4    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -2416,7 +2416,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldr	q1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -2452,7 +2452,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldr	q1, [x27, #254]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -2488,7 +2488,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	x1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrb	w1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -2524,7 +2524,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrh	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsb	w1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsb	x1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -2560,7 +2560,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsh	w1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsh	x1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsh	w1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -2595,7 +2595,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsw	x1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    1.0       st1	{ v1.1d }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
-# CHECK-NEXT:        1     2.8    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.2       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -2630,7 +2630,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8b }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -2665,7 +2665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -2700,7 +2700,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -2735,7 +2735,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -2770,7 +2770,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -2805,7 +2805,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -2840,7 +2840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT:        1     1.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.4    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -2875,7 +2875,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.4    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -2910,7 +2910,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -2946,7 +2946,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT:        1     2.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.6    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -2982,7 +2982,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.8    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -3017,7 +3017,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.4    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -3053,7 +3053,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.b }[8], [x27], #1
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT:        1     2.6    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.6    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -3089,7 +3089,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -3125,7 +3125,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -3161,7 +3161,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -3197,7 +3197,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.6    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -3233,7 +3233,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    2.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT:        1     2.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.6    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -3269,7 +3269,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[4], [x27], #4
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -3305,7 +3305,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -3341,7 +3341,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 4.     1     5.0    3.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT:        1     2.4    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.4    0.8    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -3377,7 +3377,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    3.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 4.     1     8.0    4.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     3.6    1.6    0.0       <total>
+# CHECK-NEXT:        5     3.6    1.6    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -3413,7 +3413,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    3.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.8    1.2    0.0       <total>
+# CHECK-NEXT:        5     2.8    1.2    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -3449,7 +3449,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    3.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     6.0    2.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT:        1     3.2    1.2    0.0       <total>
+# CHECK-NEXT:        5     3.2    1.2    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -3485,7 +3485,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     5.0    2.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT:        1     2.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.6    1.0    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -3521,7 +3521,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT:        1     2.4    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.4    1.0    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -3557,7 +3557,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    4.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 3.     1     9.0    5.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 4.     1     8.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT:        1     4.6    2.0    0.0       <total>
+# CHECK-NEXT:        5     4.6    2.0    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -3593,7 +3593,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     6.0    5.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     6.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     9.0    4.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     4.6    2.2    0.0       <total>
+# CHECK-NEXT:        5     4.6    2.2    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -3629,7 +3629,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     9.0    9.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
 # CHECK-NEXT: 3.     1     11.0   1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
 # CHECK-NEXT: 4.     1     11.0   0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT:        1     6.6    2.4    0.0       <total>
+# CHECK-NEXT:        5     6.6    2.4    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -3665,7 +3665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     5.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT:        1     3.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.6    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -3701,7 +3701,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    2.0       stg	x26, [x27], #4064
-# CHECK-NEXT:        1     2.6    0.4    0.4       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.4       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -3736,7 +3736,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stgp	x1, x2, [x27, #992]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       stp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -3771,7 +3771,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       stp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     3.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.2    0.2    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -3806,7 +3806,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	h1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -3841,7 +3841,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       str	q1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       str	h1, [x27, #254]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -3876,7 +3876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       str	q1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	w1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	x1, [x27], #254
-# CHECK-NEXT:        1     2.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.4    0.2    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -3911,7 +3911,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       strb	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       strb	w1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       strh	w1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -3946,7 +3946,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stz2g	x26, [x27, #4064]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stzg	x26, [x27], #4064
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       stzg	x26, [x27, #4064]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -3976,4 +3976,4 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ldr	x1, [x27], #254
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-clear-upper-regs.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-clear-upper-regs.s
@@ -131,7 +131,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ldr	b0, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [1] Code Region - FPR16-bit
 
@@ -213,7 +213,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ldr	h0, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [2] Code Region - FPR32-bit
 
@@ -295,7 +295,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ldr	s0, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [3] Code Region - FPR64-bit
 
@@ -377,7 +377,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ldr	d0, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [4] Code Region - FPR128-bit
 
@@ -459,7 +459,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ldr	q0, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [5] Code Region - SIMD64-bit-b
 
@@ -541,7 +541,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ld1	{ v0.8b }, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [6] Code Region - SIMD64-bit-h
 
@@ -623,7 +623,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ld1	{ v0.4h }, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [7] Code Region - SIMD64-bit-s
 
@@ -705,7 +705,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ld1	{ v0.2s }, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [8] Code Region - SIMD64-bit-d
 
@@ -787,7 +787,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.3    1.3    1.5       ld1	{ v0.1d }, [sp]
 # CHECK-NEXT: 1.     4     7.5    0.3    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.4    0.8    0.8       <total>
+# CHECK-NEXT:        8     4.4    0.8    0.8       <total>
 
 # CHECK:      [9] Code Region - insr
 
@@ -869,4 +869,4 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     11.3   0.3    0.0       insr	z0.s, w0
 # CHECK-NEXT: 1.     4     16.3   0.0    0.0       add	z0.s, z0.s, z0.s
-# CHECK-NEXT:        4     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-forwarding.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-forwarding.s
@@ -344,7 +344,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     7.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     9.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     11.0   0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     8.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.0    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -382,7 +382,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     7.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     9.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     11.0   0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     8.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     8.0    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -426,7 +426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     15.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.5   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -464,7 +464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -502,7 +502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -540,7 +540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -578,7 +578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -616,7 +616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       sqrdmlah	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -654,7 +654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -692,7 +692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - ssra
 
@@ -730,7 +730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -768,7 +768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -812,7 +812,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     18.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     22.0   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     15.2   0.1    0.0       <total>
+# CHECK-NEXT:        12    15.2   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -856,7 +856,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     21.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     25.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     17.8   0.1    0.0       <total>
+# CHECK-NEXT:        12    17.8   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -894,7 +894,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -932,7 +932,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     23.5   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     16.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.3   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -970,7 +970,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - crc32b
 
@@ -1008,7 +1008,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 2.     2     7.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       crc32b	w0, w0, w0
-# CHECK-NEXT:        2     7.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     7.0    0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - Z saba
 
@@ -1046,7 +1046,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - Z sadalp
 
@@ -1084,7 +1084,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z ssra
 
@@ -1122,7 +1122,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z cdot.s
 
@@ -1160,7 +1160,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z cdot.d
 
@@ -1198,7 +1198,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z cmla.b
 
@@ -1236,7 +1236,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z cmla.d
 
@@ -1274,7 +1274,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z sdot.s
 
@@ -1312,7 +1312,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z sudot
 
@@ -1350,7 +1350,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z sdot.d
 
@@ -1388,7 +1388,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z smmla
 
@@ -1426,7 +1426,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     11.5   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     14.5   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     10.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.8   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z mla.b
 
@@ -1464,7 +1464,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z mla.d
 
@@ -1502,7 +1502,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z smlalb
 
@@ -1540,7 +1540,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     13.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.3   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sqdmlalb
 
@@ -1578,7 +1578,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z sqrdmlah.b
 
@@ -1616,7 +1616,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z sqrdmlah.d
 
@@ -1654,7 +1654,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z fcmla ZPmZZ
 
@@ -1692,7 +1692,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z fcmla ZZZI
 
@@ -1730,7 +1730,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z fmla ZPmZZ
 
@@ -1768,7 +1768,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z fmla ZZZI
 
@@ -1806,7 +1806,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z fmlalb ZZZ
 
@@ -1844,7 +1844,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z bfdot
 
@@ -1882,7 +1882,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z bfmmla
 
@@ -1920,7 +1920,7 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     23.5   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     16.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.3   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - bfmlalb
 
@@ -1958,4 +1958,4 @@ bfmlalb z0.s, z0.h, z1.h
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-writeback.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Neoverse/V3AE-writeback.s
@@ -760,7 +760,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4h }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -796,7 +796,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.16b }, [x27], #16
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -832,7 +832,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -868,7 +868,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -904,7 +904,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -940,7 +940,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -976,7 +976,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1012,7 +1012,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1048,7 +1048,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1084,7 +1084,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1120,7 +1120,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT:        1     2.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1156,7 +1156,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1192,7 +1192,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     10.0   0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT:        1     3.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     3.8    0.4    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1228,7 +1228,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.b }[8], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.h }[0], [x27], #2
 # CHECK-NEXT: 4.     1     32.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
-# CHECK-NEXT:        1     16.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.6   0.2    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1264,7 +1264,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.s }[0], [x27], #4
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.s }[0], [x27], x28
 # CHECK-NEXT: 4.     1     32.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
-# CHECK-NEXT:        1     16.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.6   0.2    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1300,7 +1300,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.2d }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.2s }, [x27], #4
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1336,7 +1336,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.8h }, [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.16b }, [x27], #1
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1372,7 +1372,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1r	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -1408,7 +1408,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -1444,7 +1444,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -1480,7 +1480,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -1516,7 +1516,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -1552,7 +1552,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -1588,7 +1588,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     17.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 4.     1     17.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT:        1     12.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     12.0   0.2    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -1624,7 +1624,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -1660,7 +1660,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -1696,7 +1696,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -1732,7 +1732,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -1768,7 +1768,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -1804,7 +1804,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     9.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
 # CHECK-NEXT: 4.     1     16.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT:        1     5.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     5.8    0.4    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -1840,7 +1840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -1876,7 +1876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -1912,7 +1912,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -1948,7 +1948,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -1984,7 +1984,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2020,7 +2020,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    1.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    1.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT:        1     2.2    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.8    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2056,7 +2056,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    2.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT:        1     1.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     1.6    1.0    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2092,7 +2092,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT:        1     2.4    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.4    1.0    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2128,7 +2128,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2164,7 +2164,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -2200,7 +2200,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 3.     1     10.0   2.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
 # CHECK-NEXT: 4.     1     10.0   0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT:        1     7.4    0.6    0.0       <total>
+# CHECK-NEXT:        5     7.4    0.6    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -2236,7 +2236,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    2.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT:        1     2.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.6    1.0    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -2272,7 +2272,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    2.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT:        1     2.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.6    1.0    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -2308,7 +2308,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    1.0       ldp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     2.4    0.6    0.2       <total>
+# CHECK-NEXT:        5     2.4    0.6    0.2       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -2344,7 +2344,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ldp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     3.0    0.0    1.0       ldp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     2.2    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.2       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -2380,7 +2380,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldpsw	x1, x2, [x27], #248
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
-# CHECK-NEXT:        1     2.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.4    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -2416,7 +2416,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldr	q1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -2452,7 +2452,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldr	d1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldr	q1, [x27, #254]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -2488,7 +2488,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	x1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrb	w1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -2524,7 +2524,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrh	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsb	w1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsb	x1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -2560,7 +2560,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsh	w1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsh	x1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsh	w1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -2595,7 +2595,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsw	x1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    1.0       st1	{ v1.1d }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
-# CHECK-NEXT:        1     2.8    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.2       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -2630,7 +2630,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8b }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -2665,7 +2665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -2700,7 +2700,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -2735,7 +2735,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -2770,7 +2770,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -2805,7 +2805,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -2840,7 +2840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT:        1     1.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.4    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -2875,7 +2875,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.4    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -2910,7 +2910,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -2946,7 +2946,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT:        1     2.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.6    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -2982,7 +2982,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.8    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -3017,7 +3017,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.4    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -3053,7 +3053,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.b }[8], [x27], #1
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT:        1     2.6    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.6    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -3089,7 +3089,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -3125,7 +3125,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -3161,7 +3161,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -3197,7 +3197,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.6    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -3233,7 +3233,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    2.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT:        1     2.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.6    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -3269,7 +3269,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[4], [x27], #4
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -3305,7 +3305,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -3341,7 +3341,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 4.     1     5.0    3.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT:        1     2.4    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.4    0.8    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -3377,7 +3377,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    3.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 4.     1     8.0    4.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     3.6    1.6    0.0       <total>
+# CHECK-NEXT:        5     3.6    1.6    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -3413,7 +3413,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     6.0    3.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.8    1.2    0.0       <total>
+# CHECK-NEXT:        5     2.8    1.2    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -3449,7 +3449,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    3.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     6.0    2.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT:        1     3.2    1.2    0.0       <total>
+# CHECK-NEXT:        5     3.2    1.2    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -3485,7 +3485,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     5.0    2.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT:        1     2.6    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.6    1.0    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -3521,7 +3521,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT:        1     2.4    1.0    0.0       <total>
+# CHECK-NEXT:        5     2.4    1.0    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -3557,7 +3557,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     4.0    4.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 3.     1     9.0    5.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 4.     1     8.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT:        1     4.6    2.0    0.0       <total>
+# CHECK-NEXT:        5     4.6    2.0    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -3593,7 +3593,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     6.0    5.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     6.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     9.0    4.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     4.6    2.2    0.0       <total>
+# CHECK-NEXT:        5     4.6    2.2    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -3629,7 +3629,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     9.0    9.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
 # CHECK-NEXT: 3.     1     11.0   1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
 # CHECK-NEXT: 4.     1     11.0   0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT:        1     6.6    2.4    0.0       <total>
+# CHECK-NEXT:        5     6.6    2.4    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -3665,7 +3665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     5.0    1.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT:        1     3.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.6    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -3701,7 +3701,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    2.0       stg	x26, [x27], #4064
-# CHECK-NEXT:        1     2.6    0.4    0.4       <total>
+# CHECK-NEXT:        5     2.6    0.4    0.4       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -3736,7 +3736,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stgp	x1, x2, [x27, #992]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       stp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -3771,7 +3771,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       stp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     3.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.2    0.2    0.0       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -3806,7 +3806,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	h1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -3841,7 +3841,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       str	q1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27, #254]!
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       str	h1, [x27, #254]!
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -3876,7 +3876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       str	q1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	w1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	x1, [x27], #254
-# CHECK-NEXT:        1     2.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.4    0.2    0.0       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -3911,7 +3911,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       strb	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       strb	w1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       strh	w1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -3946,7 +3946,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stz2g	x26, [x27, #4064]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stzg	x26, [x27], #4064
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       stzg	x26, [x27, #4064]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -3976,4 +3976,4 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ldr	x1, [x27], #254
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Olympus/clear-upper-regs.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Olympus/clear-upper-regs.s
@@ -140,7 +140,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ldr	b0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [1] Code Region - FPR16-bit
 
@@ -231,7 +231,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ldr	h0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [2] Code Region - FPR32-bit
 
@@ -322,7 +322,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ldr	s0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [3] Code Region - FPR64-bit
 
@@ -413,7 +413,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ldr	d0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [4] Code Region - FPR128-bit
 
@@ -504,7 +504,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ldr	q0, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [5] Code Region - SIMD64-bit-b
 
@@ -595,7 +595,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ld1	{ v0.8b }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [6] Code Region - SIMD64-bit-h
 
@@ -686,7 +686,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ld1	{ v0.4h }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [7] Code Region - SIMD64-bit-s
 
@@ -777,7 +777,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ld1	{ v0.2s }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [8] Code Region - SIMD64-bit-d
 
@@ -868,7 +868,7 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     1.0    1.0    1.5       ld1	{ v0.1d }, [sp]
 # CHECK-NEXT: 1.     4     7.0    0.0    0.0       add	z0.d, z0.d, z0.d
-# CHECK-NEXT:        4     4.0    0.5    0.8       <total>
+# CHECK-NEXT:        8     4.0    0.5    0.8       <total>
 
 # CHECK:      [9] Code Region - insr
 
@@ -959,4 +959,4 @@ add z0.s, z0.s, z0.s
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     4     11.3   0.3    0.0       insr	z0.s, w0
 # CHECK-NEXT: 1.     4     16.3   0.0    0.0       add	z0.s, z0.s, z0.s
-# CHECK-NEXT:        4     13.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.8   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Olympus/forwarding-idioms.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Olympus/forwarding-idioms.s
@@ -393,7 +393,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     5.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 2.     2     6.0    0.0    0.0       madd	x0, x1, x2, x0
 # CHECK-NEXT: 3.     2     8.0    0.0    0.0       madd	x0, x0, x0, x0
-# CHECK-NEXT:        2     5.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     5.8    0.1    0.0       <total>
 
 # CHECK:      [1] Code Region - smaddl
 
@@ -431,7 +431,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     5.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 2.     2     6.0    0.0    0.0       smaddl	x0, w1, w2, x0
 # CHECK-NEXT: 3.     2     8.0    0.0    0.0       smaddl	x0, w0, w0, x0
-# CHECK-NEXT:        2     5.8    0.1    0.0       <total>
+# CHECK-NEXT:        8     5.8    0.1    0.0       <total>
 
 # CHECK:      [2] Code Region - fmadd
 
@@ -475,7 +475,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 4.     2     19.5   0.0    0.0       fmadd	d0, d1, d2, d0
 # CHECK-NEXT: 5.     2     23.5   0.0    0.0       fmadd	d0, d0, d1, d2
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    16.5   0.1    0.0       <total>
 
 # CHECK:      [3] Code Region - saba
 
@@ -513,7 +513,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       saba	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       saba	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [4] Code Region - sdot
 
@@ -551,7 +551,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       sdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       sdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [5] Code Region - smmla
 
@@ -589,7 +589,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       smmla	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       smmla	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [6] Code Region - mla
 
@@ -627,7 +627,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       mla	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       mla	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [7] Code Region - sqrdmlah
 
@@ -665,7 +665,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       sqrdmlah	v0.4s, v1.4s, v2.4s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       sqrdmlah	v0.4s, v0.4s, v1.4s
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [8] Code Region - smlal2
 
@@ -703,7 +703,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       smlal2	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       smlal2	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [9] Code Region - sadalp
 
@@ -741,7 +741,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       sadalp	v0.2d, v1.4s
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       sadalp	v0.2d, v0.4s
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [10] Code Region - ssra
 
@@ -779,7 +779,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 2.     2     14.0   0.0    0.0       ssra	v0.2d, v1.2d, #1
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       ssra	v0.2d, v0.2d, #1
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [11] Code Region - fcmla
 
@@ -817,7 +817,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fcmla	v0.2d, v1.2d, v2.2d, #90
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fcmla	v0.2d, v0.2d, v1.2d, #90
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [12] Code Region - fmla
 
@@ -861,7 +861,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 3.     2     18.0   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 4.     2     19.5   0.0    0.0       fmla	v0.2d, v1.2d, v2.2d
 # CHECK-NEXT: 5.     2     23.5   0.0    0.0       fmla	v0.2d, v0.2d, v1.2d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        12    16.5   0.1    0.0       <total>
 
 # CHECK:      [13] Code Region - fmlal
 
@@ -905,7 +905,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 4.     2     21.0   0.0    0.0       fmlal	v0.4s, v1.4h, v2.4h
 # CHECK-NEXT: 5.     2     25.0   0.0    0.0       fmlal	v0.4s, v0.4h, v1.4h
-# CHECK-NEXT:        2     17.8   0.1    0.0       <total>
+# CHECK-NEXT:        12    17.8   0.1    0.0       <total>
 
 # CHECK:      [14] Code Region - bfdot
 
@@ -943,7 +943,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [15] Code Region - bfmmla
 
@@ -981,7 +981,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       bfmmla	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     23.5   0.0    0.0       bfmmla	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     16.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.3   0.1    0.0       <total>
 
 # CHECK:      [16] Code Region - bfmlalb
 
@@ -1019,7 +1019,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       bfmlalb	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       bfmlalb	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [17] Code Region - bfdot
 
@@ -1057,7 +1057,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	v0.4s, v1.8h, v2.8h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	v0.4s, v0.8h, v1.8h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [18] Code Region - f8dot
 
@@ -1095,7 +1095,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fdot	v0.4s, v1.16b, v2.16b
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fdot	v0.4s, v0.16b, v1.16b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [19] Code Region - crc32b
 
@@ -1133,7 +1133,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     6.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 2.     2     7.5    0.0    0.0       crc32b	w0, w0, w1
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       crc32b	w0, w0, w0
-# CHECK-NEXT:        2     7.0    0.1    0.0       <total>
+# CHECK-NEXT:        8     7.0    0.1    0.0       <total>
 
 # CHECK:      [20] Code Region - Z saba
 
@@ -1171,7 +1171,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       saba	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       saba	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [21] Code Region - Z sadalp
 
@@ -1209,7 +1209,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sadalp	z0.d, p0/m, z1.s
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sadalp	z0.d, p0/m, z0.s
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [22] Code Region - Z srsra
 
@@ -1247,7 +1247,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       srsra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       srsra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       srsra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [23] Code Region - Z ssra
 
@@ -1285,7 +1285,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       ssra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       ssra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [24] Code Region - Z ursra
 
@@ -1323,7 +1323,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       ursra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       ursra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       ursra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [25] Code Region - Z usra
 
@@ -1361,7 +1361,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       usra	z0.d, z1.d, #1
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       usra	z0.d, z1.d, #1
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       usra	z0.d, z0.d, #1
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [26] Code Region - Z cdot.s
 
@@ -1399,7 +1399,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       cdot	z0.s, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cdot	z0.s, z0.b, z1.b, #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [27] Code Region - Z cdot.d
 
@@ -1437,7 +1437,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       cdot	z0.d, z1.h, z2.h, #90
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       cdot	z0.d, z0.h, z1.h, #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [28] Code Region - Z cmla.b
 
@@ -1475,7 +1475,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       cmla	z0.b, z1.b, z2.b, #90
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       cmla	z0.b, z0.b, z1.b, #90
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [29] Code Region - Z cmla.d
 
@@ -1513,7 +1513,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       cmla	z0.d, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       cmla	z0.d, z0.d, z1.d, #90
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [30] Code Region - Z sdot.s
 
@@ -1551,7 +1551,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       sdot	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [31] Code Region - Z sudot
 
@@ -1589,7 +1589,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       sdot	z0.s, z1.b, z2.b[1]
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.s, z0.b, z1.b[1]
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [32] Code Region - Z sdot.d
 
@@ -1627,7 +1627,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 2.     2     14.5   0.0    0.0       sdot	z0.d, z1.h, z2.h
 # CHECK-NEXT: 3.     2     17.5   0.0    0.0       sdot	z0.d, z0.h, z1.h
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [33] Code Region - Z smmla
 
@@ -1665,7 +1665,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     11.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 2.     2     13.0   0.0    0.0       smmla	z0.s, z1.b, z2.b
 # CHECK-NEXT: 3.     2     16.0   0.0    0.0       smmla	z0.s, z0.b, z1.b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [34] Code Region - Z mla.b
 
@@ -1703,7 +1703,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       mla	z0.b, p0/m, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       mla	z0.b, p0/m, z0.b, z1.b
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [35] Code Region - Z mla.d
 
@@ -1741,7 +1741,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       mla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       mla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [36] Code Region - Z smlalb
 
@@ -1779,7 +1779,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       smlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       smlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [37] Code Region - Z sqdmlalb
 
@@ -1817,7 +1817,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sqdmlalb	z0.d, z1.s, z2.s
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sqdmlalb	z0.d, z0.s, z1.s
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [38] Code Region - Z sqrdmlah.b
 
@@ -1855,7 +1855,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 2.     2     15.5   0.0    0.0       sqrdmlah	z0.b, z1.b, z2.b
 # CHECK-NEXT: 3.     2     19.5   0.0    0.0       sqrdmlah	z0.b, z0.b, z1.b
-# CHECK-NEXT:        2     14.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.3   0.1    0.0       <total>
 
 # CHECK:      [39] Code Region - Z sqrdmlah.d
 
@@ -1893,7 +1893,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     15.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 2.     2     18.0   0.0    0.0       sqrdmlah	z0.d, z1.d, z2.d
 # CHECK-NEXT: 3.     2     23.0   0.0    0.0       sqrdmlah	z0.d, z0.d, z1.d
-# CHECK-NEXT:        2     16.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.5   0.1    0.0       <total>
 
 # CHECK:      [40] Code Region - Z fcmla ZPmZZ
 
@@ -1931,7 +1931,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.d, p0/m, z1.d, z2.d, #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.d, p0/m, z0.d, z1.d, #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [41] Code Region - Z fcmla ZZZI
 
@@ -1969,7 +1969,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     11.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 2.     2     13.5   0.0    0.0       fcmla	z0.s, z1.s, z2.s[1], #90
 # CHECK-NEXT: 3.     2     18.5   0.0    0.0       fcmla	z0.s, z0.s, z1.s[1], #90
-# CHECK-NEXT:        2     13.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     13.0   0.1    0.0       <total>
 
 # CHECK:      [42] Code Region - Z fmla ZPmZZ
 
@@ -2007,7 +2007,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     9.0    0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       fmla	z0.d, p0/m, z1.d, z2.d
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       fmla	z0.d, p0/m, z0.d, z1.d
-# CHECK-NEXT:        2     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.5   0.1    0.0       <total>
 
 # CHECK:      [43] Code Region - Z fmla ZZZI
 
@@ -2045,7 +2045,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     9.0    0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       fmla	z0.d, z1.d, z2.d[1]
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       fmla	z0.d, z0.d, z1.d[1]
-# CHECK-NEXT:        2     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.5   0.1    0.0       <total>
 
 # CHECK:      [44] Code Region - Z fmlalb ZZZ
 
@@ -2083,7 +2083,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     9.0    0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     11.0   0.0    0.0       fmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     15.0   0.0    0.0       fmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        8     10.5   0.1    0.0       <total>
 
 # CHECK:      [45] Code Region - Z bfdot
 
@@ -2121,7 +2121,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     12.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     15.0   0.0    0.0       bfdot	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     20.0   0.0    0.0       bfdot	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     14.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     14.0   0.1    0.0       <total>
 
 # CHECK:      [46] Code Region - Z bfmmla
 
@@ -2159,7 +2159,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     13.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     17.5   0.0    0.0       bfmmla	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     23.5   0.0    0.0       bfmmla	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     16.3   0.1    0.0       <total>
+# CHECK-NEXT:        8     16.3   0.1    0.0       <total>
 
 # CHECK:      [47] Code Region - bfmlalb
 
@@ -2197,7 +2197,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       bfmlalb	z0.s, z1.h, z2.h
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       bfmlalb	z0.s, z0.h, z1.h
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [48] Code Region - fdot
 
@@ -2235,7 +2235,7 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fdot	z0.h, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fdot	z0.h, z1.b, z2.b
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fdot	z0.h, z0.b, z1.b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>
 
 # CHECK:      [49] Code Region - fmlalb
 
@@ -2273,4 +2273,4 @@ fmlalb z0.h, z0.b, z1.b
 # CHECK-NEXT: 1.     2     10.5   0.0    0.0       fmlalb	z0.h, z1.b, z2.b
 # CHECK-NEXT: 2.     2     12.5   0.0    0.0       fmlalb	z0.h, z1.b, z2.b
 # CHECK-NEXT: 3.     2     16.5   0.0    0.0       fmlalb	z0.h, z0.b, z1.b
-# CHECK-NEXT:        2     11.8   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.8   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/Olympus/writeback-loads-stores.s
+++ b/llvm/test/tools/llvm-mca/AArch64/Olympus/writeback-loads-stores.s
@@ -760,7 +760,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4h }, [x27], #8
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.4s }, [x27], #16
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [1] Code Region - G02
 
@@ -796,7 +796,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.16b }, [x27], #16
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.2d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [2] Code Region - G03
 
@@ -832,7 +832,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1	{ v1.8h }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [3] Code Region - G04
 
@@ -868,7 +868,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.0       <total>
 
 # CHECK:      [4] Code Region - G05
 
@@ -904,7 +904,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.1d, v2.1d }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [5] Code Region - G06
 
@@ -940,7 +940,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.8b, v2.8b }, [x27], x28
-# CHECK-NEXT:        1     2.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.0       <total>
 
 # CHECK:      [6] Code Region - G07
 
@@ -976,7 +976,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [7] Code Region - G08
 
@@ -1012,7 +1012,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [8] Code Region - G09
 
@@ -1048,7 +1048,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [9] Code Region - G10
 
@@ -1084,7 +1084,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [10] Code Region - G11
 
@@ -1120,7 +1120,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [11] Code Region - G12
 
@@ -1156,7 +1156,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [12] Code Region - G13
 
@@ -1192,7 +1192,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     8.0    0.0    0.0       ld1	{ v1.b }[0], [x27], #1
-# CHECK-NEXT:        1     3.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.2    0.2    0.0       <total>
 
 # CHECK:      [13] Code Region - G14
 
@@ -1228,7 +1228,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.b }[8], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.h }[0], [x27], #2
 # CHECK-NEXT: 4.     1     32.0   0.0    0.0       ld1	{ v1.h }[4], [x27], #2
-# CHECK-NEXT:        1     16.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.6   0.2    0.0       <total>
 
 # CHECK:      [14] Code Region - G15
 
@@ -1264,7 +1264,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     17.0   0.0    0.0       ld1	{ v1.s }[0], [x27], #4
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld1	{ v1.s }[0], [x27], x28
 # CHECK-NEXT: 4.     1     32.0   0.0    0.0       ld1	{ v1.d }[0], [x27], #8
-# CHECK-NEXT:        1     16.6   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.6   0.2    0.0       <total>
 
 # CHECK:      [15] Code Region - G16
 
@@ -1300,7 +1300,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.2d }, [x27], #8
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1r	{ v1.2s }, [x27], #4
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld1r	{ v1.4h }, [x27], #2
-# CHECK-NEXT:        1     2.8    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.2       <total>
 
 # CHECK:      [16] Code Region - G17
 
@@ -1336,7 +1336,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.8h }, [x27], #2
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1r	{ v1.16b }, [x27], #1
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1r	{ v1.1d }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [17] Code Region - G18
 
@@ -1372,7 +1372,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld1r	{ v1.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ld1r	{ v1.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ld1r	{ v1.8b }, [x27], x28
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [18] Code Region - G19
 
@@ -1408,7 +1408,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.2s, v2.2s }, [x27], #16
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ld2	{ v1.4h, v2.4h }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [19] Code Region - G20
 
@@ -1444,7 +1444,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], #32
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.16b, v2.16b }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.2d, v2.2d }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [20] Code Region - G21
 
@@ -1480,7 +1480,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2	{ v1.4s, v2.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2	{ v1.8h, v2.8h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [21] Code Region - G22
 
@@ -1516,7 +1516,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], #2
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld2	{ v1.b, v2.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld2	{ v1.b, v2.b }[8], [x27], x28
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [22] Code Region - G23
 
@@ -1552,7 +1552,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.h, v2.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     24.0   0.0    0.0       ld2	{ v1.h, v2.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     31.0   0.0    0.0       ld2	{ v1.s, v2.s }[0], [x27], #8
-# CHECK-NEXT:        1     16.2   0.2    0.0       <total>
+# CHECK-NEXT:        5     16.2   0.2    0.0       <total>
 
 # CHECK:      [23] Code Region - G24
 
@@ -1588,7 +1588,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     16.0   0.0    0.0       ld2	{ v1.d, v2.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     17.0   0.0    0.0       ld2r	{ v1.1d, v2.1d }, [x27], #16
 # CHECK-NEXT: 4.     1     17.0   0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], #16
-# CHECK-NEXT:        1     12.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     12.0   0.2    0.0       <total>
 
 # CHECK:      [24] Code Region - G25
 
@@ -1624,7 +1624,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.4s, v2.4s }, [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.8b, v2.8b }, [x27], #2
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], #4
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [25] Code Region - G26
 
@@ -1660,7 +1660,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld2r	{ v1.4h, v2.4h }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [26] Code Region - G27
 
@@ -1696,7 +1696,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       ld2r	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ld2r	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ld3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [27] Code Region - G28
 
@@ -1732,7 +1732,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], #48
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3	{ v1.8b, v2.8b, v3.8b }, [x27], #24
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [28] Code Region - G29
 
@@ -1768,7 +1768,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.2s, v2.2s, v3.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3	{ v1.4h, v2.4h, v3.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [29] Code Region - G30
 
@@ -1804,7 +1804,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3	{ v1.16b, v2.16b, v3.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     8.0    0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[0], [x27], #3
 # CHECK-NEXT: 4.     1     15.0   0.0    0.0       ld3	{ v1.b, v2.b, v3.b }[8], [x27], #3
-# CHECK-NEXT:        1     5.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     5.2    0.2    0.0       <total>
 
 # CHECK:      [30] Code Region - G31
 
@@ -1840,7 +1840,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], #6
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[4], [x27], #6
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.h, v2.h, v3.h }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [31] Code Region - G32
 
@@ -1876,7 +1876,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld3	{ v1.s, v2.s, v3.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], #24
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld3	{ v1.d, v2.d, v3.d }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [32] Code Region - G33
 
@@ -1912,7 +1912,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.2s, v2.2s, v3.2s }, [x27], #12
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.4h, v2.4h, v3.4h }, [x27], #6
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], #12
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [33] Code Region - G34
 
@@ -1948,7 +1948,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.16b, v2.16b, v3.16b }, [x27], #3
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [34] Code Region - G35
 
@@ -1984,7 +1984,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld3r	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld3r	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld3r	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [35] Code Region - G36
 
@@ -2020,7 +2020,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], #64
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [36] Code Region - G37
 
@@ -2056,7 +2056,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 3.     1     1.0    1.0    0.0       ld4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.6    0.0       <total>
 
 # CHECK:      [37] Code Region - G38
 
@@ -2092,7 +2092,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       ld4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.4    0.0       <total>
 
 # CHECK:      [38] Code Region - G39
 
@@ -2128,7 +2128,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], x28
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], #8
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [39] Code Region - G40
 
@@ -2164,7 +2164,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     15.0   0.0    0.0       ld4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
 # CHECK-NEXT: 3.     1     22.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], #16
 # CHECK-NEXT: 4.     1     29.0   0.0    0.0       ld4	{ v1.s, v2.s, v3.s, v4.s }[0], [x27], x28
-# CHECK-NEXT:        1     15.0   0.2    0.0       <total>
+# CHECK-NEXT:        5     15.0   0.2    0.0       <total>
 
 # CHECK:      [40] Code Region - G41
 
@@ -2200,7 +2200,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     8.0    0.0    0.0       ld4r	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], #32
 # CHECK-NEXT: 3.     1     8.0    0.0    0.0       ld4r	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #32
 # CHECK-NEXT: 4.     1     8.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #16
-# CHECK-NEXT:        1     6.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     6.6    0.2    0.0       <total>
 
 # CHECK:      [41] Code Region - G42
 
@@ -2236,7 +2236,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4r	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #4
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4r	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #8
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #4
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [42] Code Region - G43
 
@@ -2272,7 +2272,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4r	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       ld4r	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       ld4r	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [43] Code Region - G44
 
@@ -2308,7 +2308,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       ld4r	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    1.0       ldp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       ldp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     1.6    0.2    0.2       <total>
+# CHECK-NEXT:        5     1.6    0.2    0.2       <total>
 
 # CHECK:      [44] Code Region - G45
 
@@ -2344,7 +2344,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     4.0    0.0    1.0       ldp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     2.8    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.2       <total>
 
 # CHECK:      [45] Code Region - G46
 
@@ -2380,7 +2380,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       ldpsw	x1, x2, [x27], #248
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       ldpsw	x1, x2, [x27, #248]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [46] Code Region - G47
 
@@ -2416,7 +2416,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	d1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldr	q1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [47] Code Region - G48
 
@@ -2452,7 +2452,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	s1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	d1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldr	q1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [48] Code Region - G49
 
@@ -2488,7 +2488,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldr	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldr	x1, [x27, #254]!
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrb	w1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [49] Code Region - G50
 
@@ -2524,7 +2524,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrh	w1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsb	w1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsb	x1, [x27], #254
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [50] Code Region - G51
 
@@ -2560,7 +2560,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsh	w1, [x27], #254
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       ldrsh	x1, [x27], #254
 # CHECK-NEXT: 4.     1     5.0    0.0    0.0       ldrsh	w1, [x27, #254]!
-# CHECK-NEXT:        1     3.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     3.0    0.2    0.0       <total>
 
 # CHECK:      [51] Code Region - G52
 
@@ -2595,7 +2595,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       ldrsw	x1, [x27, #254]!
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.1d }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.2d }, [x27], #16
-# CHECK-NEXT:        1     2.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.8    0.2    0.0       <total>
 
 # CHECK:      [52] Code Region - G53
 
@@ -2630,7 +2630,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.4s }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8b }, [x27], #8
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.8h }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [53] Code Region - G54
 
@@ -2665,7 +2665,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.2d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2s }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.4h }, [x27], x28
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [54] Code Region - G55
 
@@ -2700,7 +2700,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       st1	{ v1.8h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.16b }, [x27], x28
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], #16
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [55] Code Region - G56
 
@@ -2735,7 +2735,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4h, v2.4h }, [x27], #16
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], #16
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [56] Code Region - G57
 
@@ -2770,7 +2770,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.1d, v2.1d }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.2d, v2.2d }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.2s, v2.2s }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [57] Code Region - G58
 
@@ -2805,7 +2805,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.8h, v2.8h }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.16b, v2.16b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [58] Code Region - G59
 
@@ -2841,7 +2841,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 3.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], #48
-# CHECK-NEXT:        1     1.8    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.4    0.0       <total>
 
 # CHECK:      [59] Code Region - G60
 
@@ -2877,7 +2877,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st1	{ v1.1d, v2.1d, v3.1d }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st1	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.4    0.0       <total>
 
 # CHECK:      [60] Code Region - G61
 
@@ -2913,7 +2913,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [61] Code Region - G62
 
@@ -2949,7 +2949,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
 # CHECK-NEXT: 4.     1     4.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], #32
-# CHECK-NEXT:        1     2.0    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.6    0.0       <total>
 
 # CHECK:      [62] Code Region - G63
 
@@ -2985,7 +2985,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st1	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st1	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
 # CHECK-NEXT: 4.     1     4.0    2.0    0.0       st1	{ v1.1d, v2.1d, v3.1d, v4.1d }, [x27], x28
-# CHECK-NEXT:        1     2.0    0.8    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.8    0.0       <total>
 
 # CHECK:      [63] Code Region - G64
 
@@ -3021,7 +3021,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       st1	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     2.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.4    0.0       <total>
 
 # CHECK:      [64] Code Region - G65
 
@@ -3057,7 +3057,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    2.0    0.0       st1	{ v1.b }[0], [x27], #1
 # CHECK-NEXT: 3.     1     4.0    0.0    0.0       st1	{ v1.b }[8], [x27], #1
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       st1	{ v1.b }[0], [x27], x28
-# CHECK-NEXT:        1     2.6    0.6    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.6    0.0       <total>
 
 # CHECK:      [65] Code Region - G66
 
@@ -3093,7 +3093,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.h }[4], [x27], #2
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st1	{ v1.h }[4], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [66] Code Region - G67
 
@@ -3129,7 +3129,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st1	{ v1.d }[0], [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st1	{ v1.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.2d, v2.2d }, [x27], #32
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [67] Code Region - G68
 
@@ -3165,7 +3165,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], #32
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st2	{ v1.8b, v2.8b }, [x27], #16
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st2	{ v1.8h, v2.8h }, [x27], #32
-# CHECK-NEXT:        1     1.8    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.2    0.0       <total>
 
 # CHECK:      [68] Code Region - G69
 
@@ -3201,7 +3201,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.2s, v2.2s }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st2	{ v1.4h, v2.4h }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st2	{ v1.4s, v2.4s }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.2    0.0       <total>
 
 # CHECK:      [69] Code Region - G70
 
@@ -3237,7 +3237,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st2	{ v1.16b, v2.16b }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st2	{ v1.b, v2.b }[0], [x27], #2
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st2	{ v1.b, v2.b }[8], [x27], #2
-# CHECK-NEXT:        1     1.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.2    0.0       <total>
 
 # CHECK:      [70] Code Region - G71
 
@@ -3273,7 +3273,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], #4
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[4], [x27], #4
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.h, v2.h }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [71] Code Region - G72
 
@@ -3309,7 +3309,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st2	{ v1.s, v2.s }[0], [x27], x28
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], #16
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st2	{ v1.d, v2.d }[0], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [72] Code Region - G73
 
@@ -3345,7 +3345,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.2s, v2.2s, v3.2s }, [x27], #24
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st3	{ v1.4h, v2.4h, v3.4h }, [x27], #24
-# CHECK-NEXT:        1     2.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     2.0    0.4    0.0       <total>
 
 # CHECK:      [73] Code Region - G74
 
@@ -3381,7 +3381,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], #48
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.16b, v2.16b, v3.16b }, [x27], #48
 # CHECK-NEXT: 4.     1     3.0    1.0    0.0       st3	{ v1.2d, v2.2d, v3.2d }, [x27], x28
-# CHECK-NEXT:        1     1.8    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.8    0.6    0.0       <total>
 
 # CHECK:      [74] Code Region - G75
 
@@ -3417,7 +3417,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.4s, v2.4s, v3.4s }, [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st3	{ v1.8b, v2.8b, v3.8b }, [x27], x28
 # CHECK-NEXT: 4.     1     2.0    1.0    0.0       st3	{ v1.8h, v2.8h, v3.8h }, [x27], x28
-# CHECK-NEXT:        1     1.2    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.4    0.0       <total>
 
 # CHECK:      [75] Code Region - G76
 
@@ -3453,7 +3453,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], #3
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[0], [x27], x28
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st3	{ v1.b, v2.b, v3.b }[8], [x27], x28
-# CHECK-NEXT:        1     1.6    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.6    0.4    0.0       <total>
 
 # CHECK:      [76] Code Region - G77
 
@@ -3489,7 +3489,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[0], [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st3	{ v1.h, v2.h, v3.h }[4], [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st3	{ v1.s, v2.s, v3.s }[0], [x27], #12
-# CHECK-NEXT:        1     1.0    0.2    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.2    0.0       <total>
 
 # CHECK:      [77] Code Region - G78
 
@@ -3525,7 +3525,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       st3	{ v1.d, v2.d, v3.d }[0], [x27], x28
 # CHECK-NEXT: 3.     1     1.0    0.0    0.0       st4	{ v1.2d, v2.2d, v3.2d, v4.2d }, [x27], #64
 # CHECK-NEXT: 4.     1     1.0    1.0    0.0       st4	{ v1.2s, v2.2s, v3.2s, v4.2s }, [x27], #32
-# CHECK-NEXT:        1     1.0    0.4    0.0       <total>
+# CHECK-NEXT:        5     1.0    0.4    0.0       <total>
 
 # CHECK:      [78] Code Region - G79
 
@@ -3561,7 +3561,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], #32
 # CHECK-NEXT: 3.     1     2.0    1.0    0.0       st4	{ v1.8h, v2.8h, v3.8h, v4.8h }, [x27], #64
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st4	{ v1.16b, v2.16b, v3.16b, v4.16b }, [x27], #64
-# CHECK-NEXT:        1     1.2    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.2    0.6    0.0       <total>
 
 # CHECK:      [79] Code Region - G80
 
@@ -3597,7 +3597,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    1.0    0.0       st4	{ v1.4h, v2.4h, v3.4h, v4.4h }, [x27], x28
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st4	{ v1.4s, v2.4s, v3.4s, v4.4s }, [x27], x28
 # CHECK-NEXT: 4.     1     1.0    0.0    0.0       st4	{ v1.8b, v2.8b, v3.8b, v4.8b }, [x27], x28
-# CHECK-NEXT:        1     1.4    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.6    0.0       <total>
 
 # CHECK:      [80] Code Region - G81
 
@@ -3633,7 +3633,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     1.0    1.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], #4
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[8], [x27], #4
 # CHECK-NEXT: 4.     1     2.0    0.0    0.0       st4	{ v1.b, v2.b, v3.b, v4.b }[0], [x27], x28
-# CHECK-NEXT:        1     1.4    0.6    0.0       <total>
+# CHECK-NEXT:        5     1.4    0.6    0.0       <total>
 
 # CHECK:      [81] Code Region - G82
 
@@ -3669,7 +3669,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], #8
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    0.0       st4	{ v1.h, v2.h, v3.h, v4.h }[4], [x27], x28
-# CHECK-NEXT:        1     2.2    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.0       <total>
 
 # CHECK:      [82] Code Region - G83
 
@@ -3705,7 +3705,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    1.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], #32
 # CHECK-NEXT: 3.     1     2.0    0.0    0.0       st4	{ v1.d, v2.d, v3.d, v4.d }[0], [x27], x28
 # CHECK-NEXT: 4.     1     3.0    0.0    3.0       stg	x26, [x27], #4064
-# CHECK-NEXT:        1     2.0    0.2    0.8       <total>
+# CHECK-NEXT:        5     2.0    0.2    0.8       <total>
 
 # CHECK:      [83] Code Region - G84
 
@@ -3740,7 +3740,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stgp	x1, x2, [x27, #992]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stp	s1, s2, [x27], #248
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       stp	d1, d2, [x27], #496
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [84] Code Region - G85
 
@@ -3775,7 +3775,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       stp	d1, d2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stp	q1, q2, [x27, #992]!
 # CHECK-NEXT: 4.     1     3.0    0.0    1.0       stp	w1, w2, [x27], #248
-# CHECK-NEXT:        1     2.2    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.2    0.2    0.2       <total>
 
 # CHECK:      [85] Code Region - G86
 
@@ -3810,7 +3810,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stp	x1, x2, [x27, #496]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	h1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [86] Code Region - G87
 
@@ -3845,7 +3845,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       str	q1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       str	b1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	h1, [x27, #254]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [87] Code Region - G88
 
@@ -3880,7 +3880,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       str	q1, [x27, #254]!
 # CHECK-NEXT: 3.     1     3.0    0.0    1.0       str	w1, [x27], #254
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       str	x1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.2       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.2       <total>
 
 # CHECK:      [88] Code Region - G89
 
@@ -3915,7 +3915,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       strb	w1, [x27], #254
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       strb	w1, [x27, #254]!
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       strh	w1, [x27], #254
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [89] Code Region - G90
 
@@ -3950,7 +3950,7 @@ ldr  x2, [x1], #254
 # CHECK-NEXT: 2.     1     3.0    0.0    0.0       stz2g	x26, [x27, #4064]!
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       stzg	x26, [x27], #4064
 # CHECK-NEXT: 4.     1     4.0    0.0    0.0       stzg	x26, [x27, #4064]!
-# CHECK-NEXT:        1     2.6    0.2    0.0       <total>
+# CHECK-NEXT:        5     2.6    0.2    0.0       <total>
 
 # CHECK:      [90] Code Region - G91
 
@@ -3980,4 +3980,4 @@ ldr  x2, [x1], #254
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ldr	x1, [x27], #254
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       ldr	x2, [x1], #254
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AArch64/cortex-a55-carry-over.s
+++ b/llvm/test/tools/llvm-mca/AArch64/cortex-a55-carry-over.s
@@ -79,4 +79,4 @@ ret
 # CHECK-NEXT: 1.     2     0.0    0.0    0.0       ldp	x29, x0, [sp], #16
 # CHECK-NEXT: 2.     2     0.0    0.0    0.0       mov	w0, wzr
 # CHECK-NEXT: 3.     2     0.0    0.0    0.0       ret
-# CHECK-NEXT:        2     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/carried-over.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/carried-over.s
@@ -84,4 +84,4 @@ v_sub_u32 v5, v1, v2
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       v_sub_co_u32_e64 v5, s[0:1], v1, v2
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       v_add_u32_e32 v5, v1, v2
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       v_sub_u32_e32 v5, v1, v2
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        7     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx10-add-sequence.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx10-add-sequence.s
@@ -66,4 +66,4 @@ v_add_f32 v2, v1, v0
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       v_add_f32_e32 v0, v0, v0
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       v_add_f32_e32 v1, v1, v1
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       v_add_f32_e32 v2, v1, v0
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        3     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx10-double.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx10-double.s
@@ -200,4 +200,4 @@ v_sqrt_f64 v[4:5], v[4:5]
 # CHECK-NEXT: 25.    1     0.0    0.0    0.0       v_rcp_f64_e32 v[0:1], v[0:1]
 # CHECK-NEXT: 26.    1     0.0    0.0    0.0       v_rsq_f64_e32 v[2:3], v[2:3]
 # CHECK-NEXT: 27.    1     0.0    0.0    0.0       v_sqrt_f64_e32 v[4:5], v[4:5]
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        28    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx10-trans.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx10-trans.s
@@ -112,4 +112,4 @@ v_sqrt_f64 v[2:3], v[0:1]
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       v_rcp_f64_e32 v[0:1], v[0:1]
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       v_rsq_f64_e32 v[1:2], v[1:2]
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       v_sqrt_f64_e32 v[2:3], v[0:1]
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        7     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx11-double.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx11-double.s
@@ -200,4 +200,4 @@ v_sqrt_f64 v[4:5], v[4:5]
 # CHECK-NEXT: 25.    1     0.0    0.0    0.0       v_rcp_f64_e32 v[0:1], v[0:1]
 # CHECK-NEXT: 26.    1     0.0    0.0    0.0       v_rsq_f64_e32 v[2:3], v[2:3]
 # CHECK-NEXT: 27.    1     0.0    0.0    0.0       v_sqrt_f64_e32 v[4:5], v[4:5]
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        28    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx12-permlane16-cycles.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx12-permlane16-cycles.s
@@ -107,4 +107,4 @@ v_maximum3_f32 v17, v70, v255 /*v767*/, v1 /*v769*/
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       v_maximum3_f32 v16, v16, v219, v221
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       s_set_vgpr_msb 0x2838
 # CHECK-NEXT: 10.    1     0.0    0.0    0.0       v_maximum3_f32 v17, v70, v255, v1
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        11    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx12-pseudo-scalar-trans.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx12-pseudo-scalar-trans.s
@@ -100,4 +100,4 @@ v_s_sqrt_f16 s5, s5
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       v_s_rcp_f16 s5, s2
 # CHECK-NEXT: 8.     1     0.0    0.0    0.0       v_s_rsq_f16 s5, s4
 # CHECK-NEXT: 9.     1     0.0    0.0    0.0       v_s_sqrt_f16 s5, s5
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        10    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/AMDGPU/gfx9-retireooo.s
+++ b/llvm/test/tools/llvm-mca/AMDGPU/gfx9-retireooo.s
@@ -230,4 +230,4 @@ s_waitcnt vmcnt(0) lgkmcnt(0)
 # CHECK-NEXT: 33.    1     0.0    0.0    0.0       v_mov_b32_e32 v28, s28
 # CHECK-NEXT: 34.    1     0.0    0.0    0.0       v_mov_b32_e32 v29, s29
 # CHECK-NEXT: 35.    1     0.0    0.0    0.0       s_waitcnt vmcnt(0) lgkmcnt(0)
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        36    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/ARM/cortex-a57-carryover.s
+++ b/llvm/test/tools/llvm-mca/ARM/cortex-a57-carryover.s
@@ -82,4 +82,4 @@
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     10    5.5    2.7    0.0       pop	{r3, r4, r5, r6, r7, pc}
 # CHECK-NEXT: 1.     10    3.6    0.0    3.9       nop
-# CHECK-NEXT:        10    4.6    1.4    2.0       <total>
+# CHECK-NEXT:        20    4.6    1.4    2.0       <total>

--- a/llvm/test/tools/llvm-mca/ARM/m55-storefwd.s
+++ b/llvm/test/tools/llvm-mca/ARM/m55-storefwd.s
@@ -266,4 +266,4 @@ vstrb.8 q0, [r0, #0]
 # CHECK-NEXT: 37.    10    0.0    0.0    0.0       vstrb.8	q0, [r0]
 # CHECK-NEXT: 38.    10    0.0    0.0    0.0       vcvtb.f16.f32	q0, q2
 # CHECK-NEXT: 39.    10    0.0    0.0    0.0       vstrb.8	q0, [r0]
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        400   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/ARM/m7-negative-readadvance.s
+++ b/llvm/test/tools/llvm-mca/ARM/m7-negative-readadvance.s
@@ -72,4 +72,4 @@ vldr d0, [r1]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       add.w	r1, r1, #1
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       add.w	r1, r1, #2
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vldr	d0, [r1]
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        3     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/ARM/memcpy-ldm-stm.s
+++ b/llvm/test/tools/llvm-mca/ARM/memcpy-ldm-stm.s
@@ -63,4 +63,4 @@
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       ldm	r2!, {r3, r4, r5, r6, r12, lr}
 # CHECK-NEXT: 1.     3     18.3   0.3    0.0       stm	r0!, {r3, r4, r5, r6, r12, lr}
-# CHECK-NEXT:        3     9.7    0.7    0.0       <total>
+# CHECK-NEXT:        6     9.7    0.7    0.0       <total>

--- a/llvm/test/tools/llvm-mca/ARM/vld1-index-update.s
+++ b/llvm/test/tools/llvm-mca/ARM/vld1-index-update.s
@@ -70,4 +70,4 @@ vld1.32	{d16, d17}, [r1]!
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     5     3.0    0.2    1.6       add	r1, r1, r12
 # CHECK-NEXT: 1.     5     4.0    0.0    0.0       vld1.32	{d16, d17}, [r1]!
-# CHECK-NEXT:        5     3.5    0.1    0.8       <total>
+# CHECK-NEXT:        10    3.5    0.1    0.8       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/fpr.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/fpr.s
@@ -134,4 +134,4 @@ fcvt.s.w ft0, a0
 # CHECK-NEXT: 10.    1     0.0    0.0    0.0       fclass.s	a0, fa0
 # CHECK-NEXT: 11.    1     0.0    0.0    0.0       feq.s	a0, fa0, fa1
 # CHECK-NEXT: 12.    1     0.0    0.0    0.0       fcvt.s.w	ft0, a0
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        13    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/gpr.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/gpr.s
@@ -257,4 +257,4 @@ bext a0, a0, a0
 # CHECK-NEXT: 39.    1     0.0    0.0    0.0       bclr	a0, a0, a0
 # CHECK-NEXT: 40.    1     0.0    0.0    0.0       bexti	a0, a0, 4
 # CHECK-NEXT: 41.    1     0.0    0.0    0.0       bext	a0, a0, a0
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        42    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/Andes45/zero-reg.s
+++ b/llvm/test/tools/llvm-mca/RISCV/Andes45/zero-reg.s
@@ -94,4 +94,4 @@ sb	a5, 0x0(a1)
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       add	zero, a3, a4
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       add	a5, a3, a4
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       sb	a5, 0(a1)
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/MIPS/p8700.s
+++ b/llvm/test/tools/llvm-mca/RISCV/MIPS/p8700.s
@@ -136,4 +136,4 @@
 # CHECK-NEXT: 7.     1     1.0    1.0    12.0      j	.Lend
 # CHECK-NEXT: 8.     1     6.0    0.0    6.0       add	a7, a4, a0
 # CHECK-NEXT: 9.     1     1.0    1.0    12.0      nop
-# CHECK-NEXT:        1     3.3    0.6    5.8       <total>
+# CHECK-NEXT:        10    3.3    0.6    5.8       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/div-fdiv.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/div-fdiv.s
@@ -62,4 +62,4 @@ fdiv.s f1, f2, f3
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       div	a0, a1, a2
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       fdiv.s	ft1, ft2, ft3
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass-c.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass-c.s
@@ -154,4 +154,4 @@ c.jr a0
 # CHECK-NEXT: 17.    1     0.0    0.0    0.0       bnez	a0, .Ltmp1
 # CHECK-NEXT: 18.    1     0.0    0.0    0.0       add	a0, a0, a0
 # CHECK-NEXT: 19.    1     0.0    0.0    0.0       jr	a0
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        20    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/gpr-bypass.s
@@ -515,4 +515,4 @@ jr a0
 # CHECK-NEXT: 88.    1     0.0    0.0    0.0       lwu	a0, 0(a0)
 # CHECK-NEXT: 89.    1     0.0    0.0    0.0       addw	a0, a0, a0
 # CHECK-NEXT: 90.    1     0.0    0.0    0.0       jr	a0
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        91    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/jump.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/jump.s
@@ -75,4 +75,4 @@ ret
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       jr	a0
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       jalr	t0, a0
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       ret
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        5     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFive7/sp-bypass.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFive7/sp-bypass.s
@@ -78,4 +78,4 @@ addi t0, sp, 20
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       addi	sp, t0, 16
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       addi	sp, sp, -80
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       addi	t0, sp, 20
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        5     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-lmul-instruments.s
@@ -73,4 +73,4 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m8, tu, mu
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
@@ -71,4 +71,4 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vsetvli	zero, a0, e64, m1, tu, mu
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/disable-im.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/disable-im.s
@@ -84,4 +84,4 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 4.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m8, tu, mu
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        6     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-at-start.s
@@ -61,4 +61,4 @@ vadd.vv v12, v12, v12
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-middle.s
@@ -67,4 +67,4 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, mf8, tu, mu
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        3     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-region.s
@@ -65,4 +65,4 @@ vadd.vv v12, v12, v12
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-straddles-region.s
@@ -66,4 +66,4 @@ vadd.vv v12, v12, v12
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-lmul-instruments.s
@@ -94,4 +94,4 @@ vsub.vv v12, v12, v12
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m4, tu, mu
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       vsub.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
@@ -88,4 +88,4 @@ vdivu.vv v8, v8, v12
 # CHECK-NEXT: 5.     1     0.0    0.0    0.0       vsetvli	zero, a0, e32, m1, tu, mu
 # CHECK-NEXT: 6.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
 # CHECK-NEXT: 7.     1     0.0    0.0    0.0       vdivu.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        8     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
@@ -67,4 +67,4 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        3     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/no-vsetvli-to-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/no-vsetvli-to-start.s
@@ -66,4 +66,4 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m1, tu, mu
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        3     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
@@ -62,4 +62,4 @@ vdiv.vv v8, v8, v12
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
@@ -68,4 +68,4 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m8, tu, mu
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        3     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
@@ -66,4 +66,4 @@ vdiv.vv v8, v8, v12
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e64, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
@@ -67,4 +67,4 @@ vdiv.vv v8, v8, v12
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     0.0    0.0    0.0       vsetvli	zero, a0, e64, m1, tu, mu
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        2     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-instrument.s
@@ -71,4 +71,4 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vsetivli	zero, 8, e8, m8, tu, mu
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
@@ -68,4 +68,4 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vsetivli	zero, 8, e32, m8, tu, mu
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-instrument.s
@@ -71,4 +71,4 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vsetvli	zero, a0, e8, m8, tu, mu
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vadd.vv	v12, v12, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
@@ -68,4 +68,4 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: 1.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
 # CHECK-NEXT: 2.     1     0.0    0.0    0.0       vsetvli	zero, a0, e32, m8, tu, mu
 # CHECK-NEXT: 3.     1     0.0    0.0    0.0       vdiv.vv	v8, v8, v12
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        4     0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/SyntacoreSCR/SCR4_5-FPU.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SyntacoreSCR/SCR4_5-FPU.s
@@ -158,4 +158,4 @@ fdiv.d ft7, ft7, ft7
 # CHECK-NEXT:   13.    1     0.0    0.0    0.0       fmadd.d	ft5, ft5, ft5, ft5
 # CHECK-NEXT:   14.    1     0.0    0.0    0.0       fdiv.s	ft6, ft6, ft6
 # CHECK-NEXT:   15.    1     0.0    0.0    0.0       fdiv.d	ft7, ft7, ft7
-# CHECK-NEXT:          1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        16    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/XiangShan/gpr-bypass.s
+++ b/llvm/test/tools/llvm-mca/RISCV/XiangShan/gpr-bypass.s
@@ -524,4 +524,4 @@ jr a0
 # CHECK-NEXT: 88.    1     59.0   0.0    0.0       lwu	a0, 0(a0)
 # CHECK-NEXT: 89.    1     62.0   0.0    0.0       addw	a0, a0, a0
 # CHECK-NEXT: 90.    1     63.0   0.0    0.0       jr	a0
-# CHECK-NEXT:        1     22.7   0.0    0.0       <total>
+# CHECK-NEXT:        91    22.7   0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/RISCV/XiangShan/load-to-alu.s
+++ b/llvm/test/tools/llvm-mca/RISCV/XiangShan/load-to-alu.s
@@ -70,4 +70,4 @@ addi a2, a1, 1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       ld	a1, 0(a0)
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       addi	a2, a1, 1
-# CHECK-NEXT:        1     3.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/SystemZ/stm-lm.s
+++ b/llvm/test/tools/llvm-mca/SystemZ/stm-lm.s
@@ -70,4 +70,4 @@ lmg	%r6, %r15, 48(%r15)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     9.7    0.3    0.0       stmg	%r6, %r15, 48(%r15)
 # CHECK-NEXT: 1.     3     9.0    0.3    0.0       lmg	%r6, %r15, 48(%r15)
-# CHECK-NEXT:        3     9.3    0.3    0.0       <total>
+# CHECK-NEXT:        6     9.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/AlderlakeP/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/AlderlakeP/independent-load-stores.s
@@ -128,7 +128,7 @@
 # NOALIAS-NEXT:  7.     1     1.0    1.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     1.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     1.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     1.0    1.0    0.0       <total>
+# NOALIAS-NEXT:        10    1.0    1.0    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     12.0   0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     23.0   0.0    0.0       addq	$44, 192(%r14)
@@ -139,4 +139,4 @@
 # YESALIAS-NEXT: 7.     1     78.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     89.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     100.0  0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     50.5   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    50.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/AlderlakeP/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/AlderlakeP/zero-idioms.s
@@ -493,4 +493,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 80.    1     9.0    0.0    9.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 81.    1     11.0   1.0    7.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 82.    1     12.0   2.0    6.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     9.4    1.0    5.0       <total>
+# CHECK-NEXT:        83    9.4    1.0    5.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Atom/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Atom/zero-idioms.s
@@ -237,4 +237,4 @@ pxor   %xmm2, %xmm2
 # CHECK-NEXT: 33.    1     0.0    0.0    0.0       xorpd	%xmm1, %xmm1
 # CHECK-NEXT: 34.    1     0.0    0.0    0.0       pxor	%mm2, %mm2
 # CHECK-NEXT: 35.    1     0.0    0.0    0.0       pxor	%xmm2, %xmm2
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        36    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/clear-super-register-1.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/clear-super-register-1.s
@@ -61,4 +61,4 @@ bsf   %rax, %rcx
 # CHECK-NEXT: 1.     2     5.5    1.5    0.0       lzcntl	%ecx, %eax
 # CHECK-NEXT: 2.     2     8.5    0.0    0.0       andq	%rcx, %rax
 # CHECK-NEXT: 3.     2     9.5    0.0    0.0       bsfq	%rax, %rcx
-# CHECK-NEXT:        2     7.0    0.5    0.0       <total>
+# CHECK-NEXT:        8     7.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/clear-super-register-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/clear-super-register-2.s
@@ -66,7 +66,7 @@ addps  %xmm0, %xmm0
 # CHECK-NEXT: 0.     3     14.7   8.0    0.0       sqrtss	%xmm0, %xmm0
 # CHECK-NEXT: 1.     3     1.0    1.0    21.3      movss	(%eax), %xmm0
 # CHECK-NEXT: 2.     3     7.0    0.3    18.0      addps	%xmm0, %xmm0
-# CHECK-NEXT:        3     7.6    3.1    13.1      <total>
+# CHECK-NEXT:        9     7.6    3.1    13.1      <total>
 
 # CHECK:      [1] Code Region
 
@@ -117,4 +117,4 @@ addps  %xmm0, %xmm0
 # CHECK-NEXT: 0.     3     21.7   15.0   0.0       sqrtsd	%xmm0, %xmm0
 # CHECK-NEXT: 1.     3     1.0    1.0    35.3      movsd	(%eax), %xmm0
 # CHECK-NEXT: 2.     3     7.0    0.3    32.0      addps	%xmm0, %xmm0
-# CHECK-NEXT:        3     9.9    5.4    22.4      <total>
+# CHECK-NEXT:        9     9.9    5.4    22.4      <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-cmp.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-cmp.s
@@ -68,4 +68,4 @@ cmovae %ebx, %eax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     3.7    0.3    0.0       cmpl	%eax, %eax
 # CHECK-NEXT: 1.     3     4.0    0.0    0.0       cmovael	%ebx, %eax
-# CHECK-NEXT:        3     3.8    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.8    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-pcmpeq.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-pcmpeq.s
@@ -105,4 +105,4 @@ pcmpeqw %xmm0, %xmm0
 # CHECK-NEXT: 4.     3     3.7    0.0    12.0      pcmpeqd	%xmm0, %xmm0
 # CHECK-NEXT: 5.     3     4.3    0.0    11.0      pcmpeqq	%xmm0, %xmm0
 # CHECK-NEXT: 6.     3     5.0    0.0    10.0      pcmpeqw	%xmm0, %xmm0
-# CHECK-NEXT:        3     7.1    0.1    6.6       <total>
+# CHECK-NEXT:        21    7.1    0.1    6.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-pcmpgt.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-pcmpgt.s
@@ -106,4 +106,4 @@ pcmpgtw %xmm0, %xmm0
 # CHECK-NEXT: 4.     3     0.0    0.0    16.7      pcmpgtd	%xmm0, %xmm0
 # CHECK-NEXT: 5.     3     0.0    0.0    16.3      pcmpgtq	%xmm0, %xmm0
 # CHECK-NEXT: 6.     3     0.0    0.0    16.0      pcmpgtw	%xmm0, %xmm0
-# CHECK-NEXT:        3     4.9    0.0    9.4       <total>
+# CHECK-NEXT:        21    4.9    0.0    9.4       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-sbb-1.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-sbb-1.s
@@ -69,4 +69,4 @@ sbb %eax, %eax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     4.0    0.3    0.0       sbbl	%edx, %edx
 # CHECK-NEXT: 1.     3     6.0    0.0    0.0       sbbl	%eax, %eax
-# CHECK-NEXT:        3     5.0    0.2    0.0       <total>
+# CHECK-NEXT:        6     5.0    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-sbb-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/dependency-breaking-sbb-2.s
@@ -76,4 +76,4 @@ sbb %eax, %eax
 # CHECK-NEXT: 0.     3     5.0    0.3    0.0       imull	%edx, %eax
 # CHECK-NEXT: 1.     3     1.0    0.3    6.0       addl	%edx, %edx
 # CHECK-NEXT: 2.     3     8.0    0.0    0.0       sbbl	%eax, %eax
-# CHECK-NEXT:        3     4.7    0.2    2.0       <total>
+# CHECK-NEXT:        9     4.7    0.2    2.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/int-to-fpu-forwarding-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/int-to-fpu-forwarding-3.s
@@ -72,4 +72,4 @@ pinsrw $1, %eax, %xmm0
 # CHECK-NEXT: 0.     3     1.0    0.7    2.7       addl	%eax, %eax
 # CHECK-NEXT: 1.     3     4.3    0.0    0.0       pinsrw	$0, %eax, %xmm0
 # CHECK-NEXT: 2.     3     5.7    0.0    0.0       pinsrw	$1, %eax, %xmm0
-# CHECK-NEXT:        3     3.7    0.2    0.9       <total>
+# CHECK-NEXT:        9     3.7    0.2    0.9       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/load-store-throughput.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/load-store-throughput.s
@@ -138,7 +138,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movb	(%rcx), %bpl
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movb	(%rdx), %sil
 # CHECK-NEXT: 3.     1     2.0    0.0    4.0       movb	%dil, (%rbx)
-# CHECK-NEXT:        1     1.5    1.0    1.0       <total>
+# CHECK-NEXT:        4     1.5    1.0    1.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -235,7 +235,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movw	(%rcx), %bp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movw	(%rdx), %si
 # CHECK-NEXT: 3.     1     2.0    0.0    4.0       movw	%di, (%rbx)
-# CHECK-NEXT:        1     1.5    1.0    1.0       <total>
+# CHECK-NEXT:        4     1.5    1.0    1.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -332,7 +332,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movl	(%rcx), %ebp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movl	(%rdx), %esi
 # CHECK-NEXT: 3.     1     2.0    0.0    4.0       movl	%edi, (%rbx)
-# CHECK-NEXT:        1     1.5    1.0    1.0       <total>
+# CHECK-NEXT:        4     1.5    1.0    1.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -429,7 +429,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movq	(%rcx), %rbp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movq	(%rdx), %rsi
 # CHECK-NEXT: 3.     1     2.0    0.0    4.0       movq	%rdi, (%rbx)
-# CHECK-NEXT:        1     1.5    1.0    1.0       <total>
+# CHECK-NEXT:        4     1.5    1.0    1.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -526,7 +526,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movd	(%rcx), %mm1
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movd	(%rdx), %mm2
 # CHECK-NEXT: 3.     1     2.0    0.0    4.0       movd	%mm3, (%rbx)
-# CHECK-NEXT:        1     1.5    1.0    1.0       <total>
+# CHECK-NEXT:        4     1.5    1.0    1.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -623,4 +623,4 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movaps	(%rcx), %xmm1
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movaps	(%rdx), %xmm2
 # CHECK-NEXT: 3.     1     2.0    0.0    5.0       movaps	%xmm3, (%rbx)
-# CHECK-NEXT:        1     1.5    1.0    1.3       <total>
+# CHECK-NEXT:        4     1.5    1.0    1.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/load-throughput.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/load-throughput.s
@@ -138,7 +138,7 @@ movaps (%rbx), %xmm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movb	(%rcx), %bpl
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movb	(%rdx), %sil
 # CHECK-NEXT: 3.     1     2.0    2.0    0.0       movb	(%rbx), %dil
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        4     1.5    1.5    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -235,7 +235,7 @@ movaps (%rbx), %xmm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movw	(%rcx), %bp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movw	(%rdx), %si
 # CHECK-NEXT: 3.     1     2.0    2.0    0.0       movw	(%rbx), %di
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        4     1.5    1.5    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -332,7 +332,7 @@ movaps (%rbx), %xmm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movl	(%rcx), %ebp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movl	(%rdx), %esi
 # CHECK-NEXT: 3.     1     2.0    2.0    0.0       movl	(%rbx), %edi
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        4     1.5    1.5    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -429,7 +429,7 @@ movaps (%rbx), %xmm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movq	(%rcx), %rbp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movq	(%rdx), %rsi
 # CHECK-NEXT: 3.     1     2.0    2.0    0.0       movq	(%rbx), %rdi
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        4     1.5    1.5    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -526,7 +526,7 @@ movaps (%rbx), %xmm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movd	(%rcx), %mm1
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movd	(%rdx), %mm2
 # CHECK-NEXT: 3.     1     2.0    2.0    0.0       movd	(%rbx), %mm3
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        4     1.5    1.5    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -623,4 +623,4 @@ movaps (%rbx), %xmm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movaps	(%rcx), %xmm1
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movaps	(%rdx), %xmm2
 # CHECK-NEXT: 3.     1     2.0    2.0    0.0       movaps	(%rbx), %xmm3
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        4     1.5    1.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/one-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/one-idioms.s
@@ -94,4 +94,4 @@ pcmpeqw %xmm2, %xmm2
 # CHECK-NEXT: 4.     1     1.0    0.0    7.0       pcmpeqd	%xmm2, %xmm2
 # CHECK-NEXT: 5.     1     2.0    0.0    6.0       pcmpeqq	%xmm2, %xmm2
 # CHECK-NEXT: 6.     1     3.0    0.0    5.0       pcmpeqw	%xmm2, %xmm2
-# CHECK-NEXT:        1     2.7    0.3    3.7       <total>
+# CHECK-NEXT:        7     2.7    0.3    3.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-2.s
@@ -45,4 +45,4 @@ add    %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rbx
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     2.7    1.0    0.0       <total>
+# CHECK-NEXT:        3     2.7    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-3.s
@@ -74,4 +74,4 @@ xor %bx, %dx
 # CHECK-NEXT: 0.     3     2.3    0.3    0.0       addw	%cx, %dx
 # CHECK-NEXT: 1.     3     1.0    1.0    1.0       movw	%ax, %dx
 # CHECK-NEXT: 2.     3     1.7    0.0    0.3       xorw	%bx, %dx
-# CHECK-NEXT:        3     1.7    0.4    0.4       <total>
+# CHECK-NEXT:        9     1.7    0.4    0.4       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-4.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-4.s
@@ -75,4 +75,4 @@ add %cx, %bx
 # CHECK-NEXT: 0.     3     4.3    0.3    0.0       imulw	%ax, %bx
 # CHECK-NEXT: 1.     3     2.3    2.3    2.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     3     5.0    0.0    1.3       addw	%cx, %bx
-# CHECK-NEXT:        3     3.9    0.9    1.1       <total>
+# CHECK-NEXT:        9     3.9    0.9    1.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-6.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-6.s
@@ -77,4 +77,4 @@ lzcnt 2(%rsp), %cx
 # CHECK-NEXT: 0.     3     7.3    0.3    0.0       imull	%edx, %ecx
 # CHECK-NEXT: 1.     3     2.3    2.3    1.7       lzcntw	(%rsp), %cx
 # CHECK-NEXT: 2.     3     2.7    2.7    1.0       lzcntw	2(%rsp), %cx
-# CHECK-NEXT:        3     4.1    1.8    0.9       <total>
+# CHECK-NEXT:        9     4.1    1.8    0.9       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-7.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update-7.s
@@ -96,4 +96,4 @@ cmpl $1025, %eax
 # CHECK-NEXT: 2.     5     9.4    0.0    0.0       shll	$2, %eax
 # CHECK-NEXT: 3.     5     10.2   0.0    0.0       imull	%ecx, %eax
 # CHECK-NEXT: 4.     5     12.8   0.0    0.0       cmpl	$1025, %eax
-# CHECK-NEXT:        5     10.1   0.1    0.2       <total>
+# CHECK-NEXT:        25    10.1   0.1    0.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/partial-reg-update.s
@@ -45,4 +45,4 @@ add  %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulw	%ax, %cx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       addb	%al, %cl
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/read-advance-1.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/read-advance-1.s
@@ -46,4 +46,4 @@ mulps  (%rdi), %xmm1
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       addps	%xmm0, %xmm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       mulps	(%rdi), %xmm1
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/read-advance-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/read-advance-2.s
@@ -45,4 +45,4 @@ imull  (%rdi)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%esi
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       imull	(%rdi)
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        2     1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/read-advance-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/read-advance-3.s
@@ -45,4 +45,4 @@ add %rdx, %r8
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       addq	%rdi, %rsi
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       addq	(%rsp), %rsi
 # CHECK-NEXT: 2.     1     1.0    1.0    4.0       addq	%rdx, %r8
-# CHECK-NEXT:        1     1.0    0.7    1.3       <total>
+# CHECK-NEXT:        3     1.0    0.7    1.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-1.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-1.s
@@ -78,4 +78,4 @@ addps %xmm1, %xmm1
 # CHECK-NEXT: 0.     3     0.0    0.0    3.3       xorps	%xmm0, %xmm0
 # CHECK-NEXT: 1.     3     1.3    1.3    1.3       movaps	%xmm0, %xmm1
 # CHECK-NEXT: 2.     3     2.0    0.0    0.0       addps	%xmm1, %xmm1
-# CHECK-NEXT:        3     1.1    0.4    1.6       <total>
+# CHECK-NEXT:        9     1.1    0.4    1.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-2.s
@@ -119,4 +119,4 @@ movdqu %xmm5, %xmm0
 # CHECK-NEXT: 6.     3     5.7    0.0    0.0       movupd	%xmm3, %xmm4
 # CHECK-NEXT: 7.     3     6.3    0.0    0.0       movdqa	%xmm4, %xmm5
 # CHECK-NEXT: 8.     3     7.0    0.0    0.0       movdqu	%xmm5, %xmm0
-# CHECK-NEXT:        3     3.8    0.5    1.3       <total>
+# CHECK-NEXT:        27    3.8    0.5    1.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-3.s
@@ -104,4 +104,4 @@ movdqu %xmm5, %xmm0
 # CHECK-NEXT: 4.     3     5.7    0.0    0.0       movupd	%xmm3, %xmm4
 # CHECK-NEXT: 5.     3     6.3    0.0    0.0       movdqa	%xmm4, %xmm5
 # CHECK-NEXT: 6.     3     7.0    0.0    0.0       movdqu	%xmm5, %xmm0
-# CHECK-NEXT:        3     4.5    0.5    0.8       <total>
+# CHECK-NEXT:        21    4.5    0.5    0.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-4.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-4.s
@@ -89,4 +89,4 @@ mov %edx, %eax
 # CHECK-NEXT: 2.     3     1.7    0.0    0.7       movl	%ebx, %ecx
 # CHECK-NEXT: 3.     3     2.3    0.0    0.0       movl	%ecx, %edx
 # CHECK-NEXT: 4.     3     3.0    0.0    0.0       movl	%edx, %eax
-# CHECK-NEXT:        3     1.6    0.2    0.9       <total>
+# CHECK-NEXT:        15    1.6    0.2    0.9       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-5.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-5.s
@@ -89,4 +89,4 @@ mov %rdx, %rax
 # CHECK-NEXT: 2.     3     1.7    0.0    0.7       movq	%rbx, %rcx
 # CHECK-NEXT: 3.     3     2.3    0.0    0.0       movq	%rcx, %rdx
 # CHECK-NEXT: 4.     3     3.0    0.0    0.0       movq	%rdx, %rax
-# CHECK-NEXT:        3     1.6    0.2    0.9       <total>
+# CHECK-NEXT:        15    1.6    0.2    0.9       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-6.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/reg-move-elimination-6.s
@@ -96,4 +96,4 @@ mov %esi, %ecx
 # CHECK-NEXT: 3.     3     3.0    0.0    0.0       addq	%rcx, %rcx
 # CHECK-NEXT: 4.     3     3.3    0.0    0.0       addq	%rcx, %rcx
 # CHECK-NEXT: 5.     3     1.0    1.0    2.3       movl	%esi, %ecx
-# CHECK-NEXT:        3     1.8    0.2    1.1       <total>
+# CHECK-NEXT:        18    1.8    0.2    1.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/store-throughput.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/store-throughput.s
@@ -139,7 +139,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movb	%bpl, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movb	%sil, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movb	%dil, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -237,7 +237,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movw	%bp, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movw	%si, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movw	%di, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -335,7 +335,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movl	%ebp, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movl	%esi, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movl	%edi, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -433,7 +433,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movq	%rbp, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movq	%rsi, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movq	%rdi, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -531,7 +531,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movd	%mm1, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movd	%mm2, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movd	%mm3, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -629,4 +629,4 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movaps	%xmm1, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movaps	%xmm2, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movaps	%xmm3, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Barcelona/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Barcelona/zero-idioms.s
@@ -240,4 +240,4 @@ pxor   %xmm2, %xmm2
 # CHECK-NEXT: 32.    1     0.0    0.0    26.0      xorpd	%xmm1, %xmm1
 # CHECK-NEXT: 33.    1     26.0   0.0    0.0       pxor	%mm2, %mm2
 # CHECK-NEXT: 34.    1     0.0    0.0    27.0      pxor	%xmm2, %xmm2
-# CHECK-NEXT:        1     6.1    0.2    9.7       <total>
+# CHECK-NEXT:        35    6.1    0.2    9.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/add-sequence.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/add-sequence.s
@@ -108,4 +108,4 @@ add %eax, %edx
 # CHECK-NEXT: 0.     10    12.0   2.0    0.0       addl	%eax, %ecx
 # CHECK-NEXT: 1.     10    10.7   1.8    1.0       addl	%esi, %eax
 # CHECK-NEXT: 2.     10    12.5   1.0    0.0       addl	%eax, %edx
-# CHECK-NEXT:        10    11.7   1.6    0.3       <total>
+# CHECK-NEXT:        30    11.7   1.6    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/clear-super-register-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/clear-super-register-1.s
@@ -61,4 +61,4 @@ bsf   %rax, %rcx
 # CHECK-NEXT: 1.     2     4.0    2.0    2.5       lzcntl	%ecx, %eax
 # CHECK-NEXT: 2.     2     6.0    0.0    1.5       andq	%rcx, %rax
 # CHECK-NEXT: 3.     2     6.0    0.0    0.0       bsfq	%rax, %rcx
-# CHECK-NEXT:        2     4.8    0.6    1.0       <total>
+# CHECK-NEXT:        8     4.8    0.6    1.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/clear-super-register-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/clear-super-register-2.s
@@ -135,4 +135,4 @@ vandps %xmm4, %xmm1, %xmm0
 # CHECK-NEXT: 15.    2     29.5   18.5   0.0       vaddps	%ymm3, %ymm1, %ymm4
 # CHECK-NEXT: 16.    2     29.5   19.0   0.0       vaddps	%ymm3, %ymm1, %ymm4
 # CHECK-NEXT: 17.    2     34.5   0.0    0.0       vandps	%xmm4, %xmm1, %xmm0
-# CHECK-NEXT:        2     24.0   9.6    0.2       <total>
+# CHECK-NEXT:        36    24.0   9.6    0.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/clear-super-register-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/clear-super-register-3.s
@@ -63,7 +63,7 @@ addps  %xmm0, %xmm0
 # CHECK-NEXT: 0.     2     7.0    1.0    0.0       sqrtss	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    2.0    8.5       movss	(%eax), %xmm0
 # CHECK-NEXT: 2.     2     8.5    1.5    2.5       addps	%xmm0, %xmm0
-# CHECK-NEXT:        2     5.8    1.5    3.7       <total>
+# CHECK-NEXT:        6     5.8    1.5    3.7       <total>
 
 # CHECK:      [1] Code Region
 
@@ -111,4 +111,4 @@ addps  %xmm0, %xmm0
 # CHECK-NEXT: 0.     2     7.0    1.0    0.0       sqrtsd	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    2.0    8.5       movsd	(%eax), %xmm0
 # CHECK-NEXT: 2.     2     8.5    1.5    2.5       addps	%xmm0, %xmm0
-# CHECK-NEXT:        2     5.8    1.5    3.7       <total>
+# CHECK-NEXT:        6     5.8    1.5    3.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-cmp.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-cmp.s
@@ -84,4 +84,4 @@ cmovae %ebx, %eax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.3    1.3    1.0       cmpl	%eax, %eax
 # CHECK-NEXT: 1.     3     3.7    0.3    0.0       cmovael	%ebx, %eax
-# CHECK-NEXT:        3     2.5    0.8    0.5       <total>
+# CHECK-NEXT:        6     2.5    0.8    0.5       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-pcmpeq.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-pcmpeq.s
@@ -100,4 +100,4 @@ vpcmpeqq %xmm3, %xmm3, %xmm0
 # CHECK-NEXT: 1.     3     3.0    3.0    0.0       vpcmpeqw	%xmm1, %xmm1, %xmm2
 # CHECK-NEXT: 2.     3     2.0    2.0    1.0       vpcmpeqd	%xmm2, %xmm2, %xmm3
 # CHECK-NEXT: 3.     3     4.0    0.0    0.0       vpcmpeqq	%xmm3, %xmm3, %xmm0
-# CHECK-NEXT:        3     2.6    1.6    0.4       <total>
+# CHECK-NEXT:        12    2.6    1.6    0.4       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-pcmpgt.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-pcmpgt.s
@@ -100,4 +100,4 @@ vpcmpgtq %xmm3, %xmm3, %xmm0
 # CHECK-NEXT: 1.     3     0.0    0.0    1.3       vpcmpgtw	%xmm1, %xmm1, %xmm2
 # CHECK-NEXT: 2.     3     0.0    0.0    1.3       vpcmpgtd	%xmm2, %xmm2, %xmm3
 # CHECK-NEXT: 3.     3     1.0    1.0    0.0       vpcmpgtq	%xmm3, %xmm3, %xmm0
-# CHECK-NEXT:        3     0.3    0.3    1.0       <total>
+# CHECK-NEXT:        12    0.3    0.3    1.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-sbb-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-sbb-1.s
@@ -85,4 +85,4 @@ sbb %eax, %eax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     2.7    0.3    0.0       sbbl	%edx, %edx
 # CHECK-NEXT: 1.     3     3.7    0.0    0.0       sbbl	%eax, %eax
-# CHECK-NEXT:        3     3.2    0.2    0.0       <total>
+# CHECK-NEXT:        6     3.2    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-sbb-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dependency-breaking-sbb-2.s
@@ -93,4 +93,4 @@ sbb %eax, %eax
 # CHECK-NEXT: 0.     3     5.7    2.0    0.0       imull	%edx, %eax
 # CHECK-NEXT: 1.     3     1.7    0.7    6.7       addl	%edx, %edx
 # CHECK-NEXT: 2.     3     5.0    2.7    3.0       sbbl	%eax, %eax
-# CHECK-NEXT:        3     4.1    1.8    3.2       <total>
+# CHECK-NEXT:        9     4.1    1.8    3.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dependent-pmuld-paddd.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dependent-pmuld-paddd.s
@@ -108,4 +108,4 @@ vpaddd %xmm0, %xmm0, %xmm3
 # CHECK-NEXT: 0.     10    25.0   0.1    0.0       vpmuldq	%xmm0, %xmm0, %xmm1
 # CHECK-NEXT: 1.     10    28.7   0.0    0.0       vpaddd	%xmm1, %xmm1, %xmm0
 # CHECK-NEXT: 2.     10    30.5   0.0    0.0       vpaddd	%xmm0, %xmm0, %xmm3
-# CHECK-NEXT:        10    28.1   0.0    0.0       <total>
+# CHECK-NEXT:        30    28.1   0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/dot-product.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/dot-product.s
@@ -87,4 +87,4 @@ vhaddps  %xmm3, %xmm3, %xmm4
 # CHECK-NEXT: 0.     3     1.0    1.0    13.7      vmulps	%xmm0, %xmm1, %xmm2
 # CHECK-NEXT: 1.     3     6.0    0.7    5.7       vhaddps	%xmm2, %xmm2, %xmm3
 # CHECK-NEXT: 2.     3     16.0   0.0    0.0       vhaddps	%xmm3, %xmm3, %xmm4
-# CHECK-NEXT:        3     7.7    0.6    6.4       <total>
+# CHECK-NEXT:        9     7.7    0.6    6.4       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/hadd-read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/hadd-read-after-ld-1.s
@@ -42,4 +42,4 @@ vhaddps (%rdi), %xmm1, %xmm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vshufps	$0, %xmm0, %xmm1, %xmm1
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       vhaddps	(%rdi), %xmm1, %xmm2
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        2     1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/hadd-read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/hadd-read-after-ld-2.s
@@ -42,4 +42,4 @@ vhaddps (%rdi), %ymm1, %ymm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vshufps	$0, %xmm0, %xmm1, %xmm1
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       vhaddps	(%rdi), %ymm1, %ymm2
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        2     1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/int-to-fpu-forwarding-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/int-to-fpu-forwarding-3.s
@@ -87,4 +87,4 @@ vpinsrb $1, %eax, %xmm0, %xmm0
 # CHECK-NEXT: 0.     3     1.0    0.7    9.3       addl	%eax, %eax
 # CHECK-NEXT: 1.     3     14.3   0.0    0.0       vpinsrb	$0, %eax, %xmm0, %xmm0
 # CHECK-NEXT: 2.     3     15.7   0.0    0.0       vpinsrb	$1, %eax, %xmm0, %xmm0
-# CHECK-NEXT:        3     10.3   0.2    3.1       <total>
+# CHECK-NEXT:        9     10.3   0.2    3.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/load-store-alias.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/load-store-alias.s
@@ -106,4 +106,4 @@ vmovaps %xmm0, 48(%rdi)
 # CHECK-NEXT: 5.     1     17.0   0.0    0.0       vmovaps	%xmm0, 32(%rdi)
 # CHECK-NEXT: 6.     1     18.0   0.0    0.0       vmovaps	48(%rsi), %xmm0
 # CHECK-NEXT: 7.     1     23.0   0.0    0.0       vmovaps	%xmm0, 48(%rdi)
-# CHECK-NEXT:        1     12.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     12.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/load-store-throughput.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/load-store-throughput.s
@@ -159,7 +159,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movb	(%rcx), %bpl
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movb	(%rdx), %sil
 # CHECK-NEXT: 3.     1     3.0    1.0    3.0       movb	%dil, (%rbx)
-# CHECK-NEXT:        1     1.8    1.3    0.8       <total>
+# CHECK-NEXT:        4     1.8    1.3    0.8       <total>
 
 # CHECK:      [1] Code Region
 
@@ -277,7 +277,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movw	(%rcx), %bp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movw	(%rdx), %si
 # CHECK-NEXT: 3.     1     3.0    1.0    3.0       movw	%di, (%rbx)
-# CHECK-NEXT:        1     1.8    1.3    0.8       <total>
+# CHECK-NEXT:        4     1.8    1.3    0.8       <total>
 
 # CHECK:      [2] Code Region
 
@@ -395,7 +395,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movl	(%rcx), %ebp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movl	(%rdx), %esi
 # CHECK-NEXT: 3.     1     3.0    1.0    3.0       movl	%edi, (%rbx)
-# CHECK-NEXT:        1     1.8    1.3    0.8       <total>
+# CHECK-NEXT:        4     1.8    1.3    0.8       <total>
 
 # CHECK:      [3] Code Region
 
@@ -513,7 +513,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movq	(%rcx), %rbp
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movq	(%rdx), %rsi
 # CHECK-NEXT: 3.     1     3.0    1.0    3.0       movq	%rdi, (%rbx)
-# CHECK-NEXT:        1     1.8    1.3    0.8       <total>
+# CHECK-NEXT:        4     1.8    1.3    0.8       <total>
 
 # CHECK:      [4] Code Region
 
@@ -630,7 +630,7 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movd	(%rcx), %mm1
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movd	(%rdx), %mm2
 # CHECK-NEXT: 3.     1     4.0    2.0    1.0       movd	%mm3, (%rbx)
-# CHECK-NEXT:        1     2.0    1.5    0.3       <total>
+# CHECK-NEXT:        4     2.0    1.5    0.3       <total>
 
 # CHECK:      [5] Code Region
 
@@ -747,4 +747,4 @@ movaps %xmm3, (%rbx)
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movaps	(%rcx), %xmm1
 # CHECK-NEXT: 2.     1     2.0    2.0    0.0       movaps	(%rdx), %xmm2
 # CHECK-NEXT: 3.     1     4.0    2.0    2.0       movaps	%xmm3, (%rbx)
-# CHECK-NEXT:        1     2.0    1.5    0.5       <total>
+# CHECK-NEXT:        4     2.0    1.5    0.5       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/load-throughput.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/load-throughput.s
@@ -163,7 +163,7 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movb	(%rcx), %bpl
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       movb	(%rdx), %sil
 # CHECK-NEXT: 3.     1     3.0    3.0    0.0       movb	(%rbx), %dil
-# CHECK-NEXT:        1     2.0    2.0    0.0       <total>
+# CHECK-NEXT:        4     2.0    2.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -278,7 +278,7 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movw	(%rcx), %bp
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       movw	(%rdx), %si
 # CHECK-NEXT: 3.     1     3.0    3.0    0.0       movw	(%rbx), %di
-# CHECK-NEXT:        1     2.0    2.0    0.0       <total>
+# CHECK-NEXT:        4     2.0    2.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -393,7 +393,7 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movl	(%rcx), %ebp
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       movl	(%rdx), %esi
 # CHECK-NEXT: 3.     1     3.0    3.0    0.0       movl	(%rbx), %edi
-# CHECK-NEXT:        1     2.0    2.0    0.0       <total>
+# CHECK-NEXT:        4     2.0    2.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -508,7 +508,7 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movq	(%rcx), %rbp
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       movq	(%rdx), %rsi
 # CHECK-NEXT: 3.     1     3.0    3.0    0.0       movq	(%rbx), %rdi
-# CHECK-NEXT:        1     2.0    2.0    0.0       <total>
+# CHECK-NEXT:        4     2.0    2.0    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -624,7 +624,7 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movd	(%rcx), %mm1
 # CHECK-NEXT: 2.     1     4.0    4.0    0.0       movd	(%rdx), %mm2
 # CHECK-NEXT: 3.     1     4.0    4.0    0.0       movd	(%rbx), %mm3
-# CHECK-NEXT:        1     2.5    2.5    0.0       <total>
+# CHECK-NEXT:        4     2.5    2.5    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -740,7 +740,7 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       movaps	(%rcx), %xmm1
 # CHECK-NEXT: 2.     1     4.0    4.0    0.0       movaps	(%rdx), %xmm2
 # CHECK-NEXT: 3.     1     4.0    4.0    0.0       movaps	(%rbx), %xmm3
-# CHECK-NEXT:        1     2.5    2.5    0.0       <total>
+# CHECK-NEXT:        4     2.5    2.5    0.0       <total>
 
 # CHECK:      [6] Code Region
 
@@ -855,4 +855,4 @@ vmovaps (%rbx), %ymm3
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       vmovaps	(%rcx), %ymm1
 # CHECK-NEXT: 2.     1     3.0    3.0    0.0       vmovaps	(%rdx), %ymm2
 # CHECK-NEXT: 3.     1     3.0    3.0    0.0       vmovaps	(%rbx), %ymm3
-# CHECK-NEXT:        1     2.0    2.0    0.0       <total>
+# CHECK-NEXT:        4     2.0    2.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/memcpy-like-test.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/memcpy-like-test.s
@@ -106,4 +106,4 @@ vmovaps %xmm0, 48(%rdi)
 # CHECK-NEXT: 5.     1     9.0    1.0    0.0       vmovaps	%xmm0, 32(%rdi)
 # CHECK-NEXT: 6.     1     3.0    3.0    2.0       vmovaps	48(%rsi), %xmm0
 # CHECK-NEXT: 7.     1     10.0   1.0    0.0       vmovaps	%xmm0, 48(%rdi)
-# CHECK-NEXT:        1     5.3    1.5    0.5       <total>
+# CHECK-NEXT:        8     5.3    1.5    0.5       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/one-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/one-idioms.s
@@ -165,4 +165,4 @@ vpcmpeqw  %xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 12.    1     4.0    4.0    0.0       vpcmpeqd	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 13.    1     4.0    0.0    0.0       vpcmpeqq	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 14.    1     5.0    5.0    0.0       vpcmpeqw	%xmm3, %xmm3, %xmm5
-# CHECK-NEXT:        1     2.9    2.1    0.3       <total>
+# CHECK-NEXT:        15    2.9    2.1    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-2.s
@@ -46,4 +46,4 @@ add    %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rbx
 # CHECK-NEXT: 1.     1     6.0    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     1     8.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     5.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     5.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-3.s
@@ -92,4 +92,4 @@ xor %bx, %dx
 # CHECK-NEXT: 0.     3     3.7    0.3    0.0       addw	%cx, %dx
 # CHECK-NEXT: 1.     3     4.3    0.0    0.0       movw	%ax, %dx
 # CHECK-NEXT: 2.     3     5.0    0.0    0.0       xorw	%bx, %dx
-# CHECK-NEXT:        3     4.3    0.1    0.0       <total>
+# CHECK-NEXT:        9     4.3    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-4.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-4.s
@@ -92,4 +92,4 @@ add %cx, %bx
 # CHECK-NEXT: 0.     3     6.7    0.7    0.0       imulw	%ax, %bx
 # CHECK-NEXT: 1.     3     9.7    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     3     11.7   0.0    0.0       addw	%cx, %bx
-# CHECK-NEXT:        3     9.3    0.2    0.0       <total>
+# CHECK-NEXT:        9     9.3    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-6.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update-6.s
@@ -93,4 +93,4 @@ lzcnt 2(%rsp), %cx
 # CHECK-NEXT: 0.     3     7.7    0.3    0.0       imull	%edx, %ecx
 # CHECK-NEXT: 1.     3     7.3    0.0    0.0       lzcntw	(%rsp), %cx
 # CHECK-NEXT: 2.     3     8.7    1.0    0.0       lzcntw	2(%rsp), %cx
-# CHECK-NEXT:        3     7.9    0.4    0.0       <total>
+# CHECK-NEXT:        9     7.9    0.4    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/partial-reg-update.s
@@ -45,4 +45,4 @@ add  %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulw	%ax, %cx
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       addb	%al, %cl
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     4.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     4.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/pipes-fpu.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/pipes-fpu.s
@@ -121,4 +121,4 @@ vsqrtps     %ymm0, %ymm2
 # CHECK-NEXT: 5.     2     3.5    3.5    12.0      vsqrtps	%xmm0, %xmm2
 # CHECK-NEXT: 6.     2     19.5   19.5   0.0       vaddps	%ymm0, %ymm1, %ymm2
 # CHECK-NEXT: 7.     2     7.5    7.5    8.0       vsqrtps	%ymm0, %ymm2
-# CHECK-NEXT:        2     7.8    7.8    6.3       <total>
+# CHECK-NEXT:        16    7.8    7.8    6.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/pr37790.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/pr37790.s
@@ -44,4 +44,4 @@ stmxcsr (%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    0.5    0.0       int3
 # CHECK-NEXT: 1.     2     9.5    9.0    90.0      stmxcsr	(%rsp)
-# CHECK-NEXT:        2     5.3    4.8    45.0      <total>
+# CHECK-NEXT:        4     5.3    4.8    45.0      <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/rank.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/rank.s
@@ -122,4 +122,4 @@ add %ebx, %eax
 # CHECK-NEXT: 5.     3     10.7   1.0    0.0       addl	%edx, %esi
 # CHECK-NEXT: 6.     3     12.0   1.0    0.0       addl	%ebx, %eax
 # CHECK-NEXT: 7.     3     13.0   0.0    0.0       addl	%ebx, %eax
-# CHECK-NEXT:        3     9.9    1.1    0.3       <total>
+# CHECK-NEXT:        24    9.9    1.1    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/read-advance-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/read-advance-1.s
@@ -46,4 +46,4 @@ vmulps  (%rdi), %xmm1, %xmm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       vmulps	(%rdi), %xmm1, %xmm2
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/read-advance-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/read-advance-2.s
@@ -45,4 +45,4 @@
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%esi
 # CHECK-NEXT: 1.     1     5.0    4.0    0.0       imull	(%rdi)
-# CHECK-NEXT:        1     3.0    2.5    0.0       <total>
+# CHECK-NEXT:        2     3.0    2.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/read-advance-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/read-advance-3.s
@@ -45,4 +45,4 @@
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       addq	%rdi, %rsi
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       addq	(%rsp), %rsi
 # CHECK-NEXT: 2.     1     3.0    3.0    2.0       addq	%rdx, %r8
-# CHECK-NEXT:        1     1.7    1.3    0.7       <total>
+# CHECK-NEXT:        3     1.7    1.3    0.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-1.s
@@ -104,4 +104,4 @@ vaddps %xmm1, %xmm1, %xmm2
 # CHECK-NEXT: 0.     3     0.0    0.0    5.3       vxorps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     3     1.7    1.7    3.0       vmovaps	%xmm0, %xmm1
 # CHECK-NEXT: 2.     3     3.3    1.0    0.0       vaddps	%xmm1, %xmm1, %xmm2
-# CHECK-NEXT:        3     1.7    0.9    2.8       <total>
+# CHECK-NEXT:        9     1.7    0.9    2.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-2.s
@@ -144,4 +144,4 @@ movdqu %xmm5, %xmm0
 # CHECK-NEXT: 6.     3     4.7    0.0    0.0       movupd	%xmm3, %xmm4
 # CHECK-NEXT: 7.     3     5.3    0.0    0.0       movdqa	%xmm4, %xmm5
 # CHECK-NEXT: 8.     3     6.0    0.0    0.0       movdqu	%xmm5, %xmm0
-# CHECK-NEXT:        3     3.0    0.4    1.4       <total>
+# CHECK-NEXT:        27    3.0    0.4    1.4       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-3.s
@@ -129,4 +129,4 @@ vmovdqu %xmm5, %xmm0
 # CHECK-NEXT: 4.     3     5.7    0.0    0.0       vmovupd	%xmm3, %xmm4
 # CHECK-NEXT: 5.     3     6.3    0.0    0.0       vmovdqa	%xmm4, %xmm5
 # CHECK-NEXT: 6.     3     7.0    0.0    0.0       vmovdqu	%xmm5, %xmm0
-# CHECK-NEXT:        3     4.5    0.5    0.8       <total>
+# CHECK-NEXT:        21    4.5    0.5    0.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-4.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-4.s
@@ -115,4 +115,4 @@ mov %edx, %eax
 # CHECK-NEXT: 2.     3     4.7    0.0    0.0       movl	%ebx, %ecx
 # CHECK-NEXT: 3.     3     5.3    0.0    0.0       movl	%ecx, %edx
 # CHECK-NEXT: 4.     3     6.0    0.0    0.0       movl	%edx, %eax
-# CHECK-NEXT:        3     4.0    0.8    0.7       <total>
+# CHECK-NEXT:        15    4.0    0.8    0.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-5.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/reg-move-elimination-5.s
@@ -115,4 +115,4 @@ mov %rdx, %rax
 # CHECK-NEXT: 2.     3     4.7    0.0    0.0       movq	%rbx, %rcx
 # CHECK-NEXT: 3.     3     5.3    0.0    0.0       movq	%rcx, %rdx
 # CHECK-NEXT: 4.     3     6.0    0.0    0.0       movq	%rdx, %rax
-# CHECK-NEXT:        3     4.0    0.8    0.7       <total>
+# CHECK-NEXT:        15    4.0    0.8    0.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/register-files-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/register-files-1.s
@@ -101,4 +101,4 @@ vmulps %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     5     20.2   0.2    0.0       vaddps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     5     25.2   0.0    0.0       vmulps	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        5     22.7   0.1    0.0       <total>
+# CHECK-NEXT:        10    22.7   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/register-files-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/register-files-2.s
@@ -101,4 +101,4 @@ vmulps %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     5     14.0   0.2    0.0       vaddps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     5     15.8   0.0    0.0       vmulps	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        5     14.9   0.1    0.0       <total>
+# CHECK-NEXT:        10    14.9   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/register-files-5.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/register-files-5.s
@@ -152,4 +152,4 @@
 # CHECK-NEXT: 30.    1     24.0   11.0   0.0       vaddps	%ymm3, %ymm0, %ymm4
 # CHECK-NEXT: 31.    1     25.0   12.0   0.0       vaddps	%ymm3, %ymm0, %ymm5
 # CHECK-NEXT: 32.    1     25.0   13.0   0.0       vaddps	%ymm3, %ymm0, %ymm6
-# CHECK-NEXT:        1     15.6   11.2   0.6       <total>
+# CHECK-NEXT:        33    15.6   11.2   0.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/store-throughput.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/store-throughput.s
@@ -163,7 +163,7 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movb	%bpl, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movb	%sil, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movb	%dil, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -278,7 +278,7 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movw	%bp, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movw	%si, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movw	%di, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -393,7 +393,7 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movl	%ebp, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movl	%esi, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movl	%edi, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -508,7 +508,7 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movq	%rbp, (%rcx)
 # CHECK-NEXT: 2.     1     3.0    1.0    0.0       movq	%rsi, (%rdx)
 # CHECK-NEXT: 3.     1     4.0    1.0    0.0       movq	%rdi, (%rbx)
-# CHECK-NEXT:        1     2.5    1.0    0.0       <total>
+# CHECK-NEXT:        4     2.5    1.0    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -624,7 +624,7 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movd	%mm1, (%rcx)
 # CHECK-NEXT: 2.     1     4.0    2.0    0.0       movd	%mm2, (%rdx)
 # CHECK-NEXT: 3.     1     5.0    1.0    0.0       movd	%mm3, (%rbx)
-# CHECK-NEXT:        1     3.0    1.3    0.0       <total>
+# CHECK-NEXT:        4     3.0    1.3    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -740,7 +740,7 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    1.0    0.0       movaps	%xmm1, (%rcx)
 # CHECK-NEXT: 2.     1     4.0    2.0    0.0       movaps	%xmm2, (%rdx)
 # CHECK-NEXT: 3.     1     5.0    1.0    0.0       movaps	%xmm3, (%rbx)
-# CHECK-NEXT:        1     3.0    1.3    0.0       <total>
+# CHECK-NEXT:        4     3.0    1.3    0.0       <total>
 
 # CHECK:      [6] Code Region
 
@@ -855,4 +855,4 @@ vmovaps %ymm3, (%rbx)
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       vmovaps	%ymm1, (%rcx)
 # CHECK-NEXT: 2.     1     35.0   34.0   0.0       vmovaps	%ymm2, (%rdx)
 # CHECK-NEXT: 3.     1     36.0   2.0    0.0       vmovaps	%ymm3, (%rbx)
-# CHECK-NEXT:        1     18.5   9.8    0.0       <total>
+# CHECK-NEXT:        4     18.5   9.8    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/vbroadcast-operand-latency.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/vbroadcast-operand-latency.s
@@ -80,4 +80,4 @@ vbroadcastss (%rax), %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.3    1.3    2.3       leaq	8(%rsp,%rdi,2), %rax
 # CHECK-NEXT: 1.     3     1.7    1.0    0.0       vbroadcastss	(%rax), %ymm0
-# CHECK-NEXT:        3     1.5    1.2    1.2       <total>
+# CHECK-NEXT:        6     1.5    1.2    1.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/vec-logic-read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/vec-logic-read-after-ld-1.s
@@ -41,4 +41,4 @@ vandps (%rdi), %xmm1, %xmm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       vandps	(%rdi), %xmm1, %xmm2
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/vec-logic-read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/vec-logic-read-after-ld-2.s
@@ -41,4 +41,4 @@ vandps (%rdi), %ymm1, %ymm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vaddps	%ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       vandps	(%rdi), %ymm1, %ymm2
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/xop-super-registers-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/xop-super-registers-1.s
@@ -102,4 +102,4 @@
 # CHECK-NEXT: 3.     2     16.0   0.0    6.0       vaddps	%ymm4, %ymm5, %ymm6
 # CHECK-NEXT: 4.     2     20.0   0.0    4.0       vmulps	%ymm6, %ymm3, %ymm4
 # CHECK-NEXT: 5.     2     25.0   0.0    1.5       vaddps	%ymm4, %ymm5, %ymm0
-# CHECK-NEXT:        2     14.8   0.4    5.3       <total>
+# CHECK-NEXT:        12    14.8   0.4    5.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/xop-super-registers-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/xop-super-registers-2.s
@@ -102,4 +102,4 @@
 # CHECK-NEXT: 3.     2     8.5    0.0    6.5       vaddps	%ymm4, %ymm5, %ymm6
 # CHECK-NEXT: 4.     2     12.5   0.0    4.5       vmulps	%ymm6, %ymm3, %ymm4
 # CHECK-NEXT: 5.     2     17.5   0.0    2.0       vaddps	%ymm4, %ymm5, %ymm0
-# CHECK-NEXT:        2     9.2    0.3    5.7       <total>
+# CHECK-NEXT:        12    9.2    0.3    5.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/zero-idioms-avx-256.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/zero-idioms-avx-256.s
@@ -120,7 +120,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       vaddps	%ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     3     1.3    1.3    2.3       vxorps	%ymm1, %ymm1, %ymm1
 # CHECK-NEXT: 2.     3     2.7    0.0    0.3       vblendps	$2, %ymm1, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.7    0.8    0.9       <total>
+# CHECK-NEXT:        9     1.7    0.8    0.9       <total>
 
 # CHECK:      [1] Code Region - ZERO-IDIOM-2
 
@@ -206,7 +206,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       vaddpd	%ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     3     1.3    1.3    2.3       vxorpd	%ymm1, %ymm1, %ymm1
 # CHECK-NEXT: 2.     3     2.7    0.0    0.3       vblendpd	$2, %ymm1, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.7    0.8    0.9       <total>
+# CHECK-NEXT:        9     1.7    0.8    0.9       <total>
 
 # CHECK:      [2] Code Region - ZERO-IDIOM-3
 
@@ -285,7 +285,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       vaddps	%ymm0, %ymm1, %ymm2
 # CHECK-NEXT: 1.     3     1.0    1.0    3.0       vandnps	%ymm2, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.0    1.0    1.5       <total>
+# CHECK-NEXT:        6     1.0    1.0    1.5       <total>
 
 # CHECK:      [3] Code Region - ZERO-IDIOM-4
 
@@ -364,7 +364,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       vaddps	%ymm0, %ymm1, %ymm2
 # CHECK-NEXT: 1.     3     1.0    1.0    3.0       vandnps	%ymm2, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.0    1.0    1.5       <total>
+# CHECK-NEXT:        6     1.0    1.0    1.5       <total>
 
 # CHECK:      [4] Code Region - ZERO-IDIOM-5
 
@@ -444,4 +444,4 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     7.0    0.3    0.0       vperm2f128	$136, %ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     3     9.0    0.0    0.0       vaddps	%ymm1, %ymm1, %ymm0
-# CHECK-NEXT:        3     8.0    0.2    0.0       <total>
+# CHECK-NEXT:        6     8.0    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BdVer2/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/BdVer2/zero-idioms.s
@@ -450,4 +450,4 @@ vpxor  %xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 68.    1     0.0    0.0    6.0       vxorps	%xmm4, %xmm4, %xmm5
 # CHECK-NEXT: 69.    1     0.0    0.0    6.0       vxorpd	%xmm1, %xmm1, %xmm3
 # CHECK-NEXT: 70.    1     0.0    0.0    7.0       vpxor	%xmm3, %xmm3, %xmm5
-# CHECK-NEXT:        1     0.7    0.7    2.7       <total>
+# CHECK-NEXT:        71    0.7    0.7    2.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/Broadwell/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Broadwell/zero-idioms.s
@@ -448,4 +448,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 72.    1     0.0    0.0    3.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 73.    1     0.0    0.0    3.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 74.    1     0.0    0.0    3.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     0.8    0.2    1.9       <total>
+# CHECK-NEXT:        75    0.8    0.2    1.9       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/add-sequence.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/add-sequence.s
@@ -99,4 +99,4 @@ add %eax, %edx
 # CHECK-NEXT: 0.     10    2.5    0.4    0.0       addl	%eax, %ecx
 # CHECK-NEXT: 1.     10    2.1    0.7    0.5       addl	%esi, %eax
 # CHECK-NEXT: 2.     10    2.6    0.0    0.3       addl	%eax, %edx
-# CHECK-NEXT:        10    2.4    0.4    0.3       <total>
+# CHECK-NEXT:        30    2.4    0.4    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/bottleneck-hints-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/bottleneck-hints-1.s
@@ -99,4 +99,4 @@ add %edx, %eax
 # CHECK-NEXT: 1.     1     2.0    0.0    0.0       addl	%ebx, %ecx
 # CHECK-NEXT: 2.     1     2.0    0.0    0.0       addl	%ecx, %edx
 # CHECK-NEXT: 3.     1     3.0    0.0    0.0       addl	%edx, %eax
-# CHECK-NEXT:        1     2.0    0.3    0.0       <total>
+# CHECK-NEXT:        4     2.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/bottleneck-hints-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/bottleneck-hints-3.s
@@ -124,4 +124,4 @@ vmovaps %xmm0, 48(%rdi)
 # CHECK-NEXT: 5.     1     16.0   0.0    0.0       vmovaps	%xmm0, 32(%rdi)
 # CHECK-NEXT: 6.     1     16.0   0.0    0.0       vmovaps	48(%rsi), %xmm0
 # CHECK-NEXT: 7.     1     21.0   0.0    0.0       vmovaps	%xmm0, 48(%rdi)
-# CHECK-NEXT:        1     11.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/clear-super-register-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/clear-super-register-1.s
@@ -61,4 +61,4 @@ bsf   %rax, %rcx
 # CHECK-NEXT: 1.     2     1.5    1.0    4.5       lzcntl	%ecx, %eax
 # CHECK-NEXT: 2.     2     2.0    0.0    4.5       andq	%rcx, %rax
 # CHECK-NEXT: 3.     2     2.0    0.0    0.5       bsfq	%rax, %rcx
-# CHECK-NEXT:        2     1.8    0.4    2.4       <total>
+# CHECK-NEXT:        8     1.8    0.4    2.4       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/clear-super-register-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/clear-super-register-2.s
@@ -122,4 +122,4 @@ vandps %xmm4, %xmm1, %xmm0
 # CHECK-NEXT: 15.    2     21.0   21.0   13.5      vaddps	%ymm3, %ymm1, %ymm4
 # CHECK-NEXT: 16.    2     22.0   22.0   12.5      vaddps	%ymm3, %ymm1, %ymm4
 # CHECK-NEXT: 17.    2     24.0   0.0    11.5      vandps	%xmm4, %xmm1, %xmm0
-# CHECK-NEXT:        2     17.5   9.9    21.6      <total>
+# CHECK-NEXT:        36    17.5   9.9    21.6      <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/cmpxchg-read-advance.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/cmpxchg-read-advance.s
@@ -110,7 +110,7 @@ lock cmpxchg16b (%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rax
 # CHECK-NEXT: 1.     1     3.0    0.0    0.0       cmpxchgq	%rcx, (%rdx)
-# CHECK-NEXT:        1     2.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     2.0    0.5    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -177,7 +177,7 @@ lock cmpxchg16b (%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rcx, %rcx
 # CHECK-NEXT: 1.     1     3.0    0.0    0.0       cmpxchgq	%rcx, (%rdx)
-# CHECK-NEXT:        1     2.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     2.0    0.5    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -244,7 +244,7 @@ lock cmpxchg16b (%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rax
 # CHECK-NEXT: 1.     1     3.0    0.0    0.0       lock		cmpxchgq	%rcx, (%rdx)
-# CHECK-NEXT:        1     2.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     2.0    0.5    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -311,7 +311,7 @@ lock cmpxchg16b (%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rcx, %rcx
 # CHECK-NEXT: 1.     1     3.0    0.0    0.0       lock		cmpxchgq	%rcx, (%rdx)
-# CHECK-NEXT:        1     2.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     2.0    0.5    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -382,7 +382,7 @@ lock cmpxchg16b (%rsp)
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%eax, %eax
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       imull	%edx, %edx
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       cmpxchg8b	(%rsp)
-# CHECK-NEXT:        1     1.3    1.0    0.0       <total>
+# CHECK-NEXT:        3     1.3    1.0    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -453,7 +453,7 @@ lock cmpxchg16b (%rsp)
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%eax, %eax
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       imull	%edx, %edx
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       cmpxchg16b	(%rsp)
-# CHECK-NEXT:        1     1.3    1.0    0.0       <total>
+# CHECK-NEXT:        3     1.3    1.0    0.0       <total>
 
 # CHECK:      [6] Code Region
 
@@ -524,7 +524,7 @@ lock cmpxchg16b (%rsp)
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%ebx, %ebx
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       imull	%ecx, %ecx
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       lock		cmpxchg8b	(%rsp)
-# CHECK-NEXT:        1     1.3    1.0    0.0       <total>
+# CHECK-NEXT:        3     1.3    1.0    0.0       <total>
 
 # CHECK:      [7] Code Region
 
@@ -595,4 +595,4 @@ lock cmpxchg16b (%rsp)
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%ebx, %ebx
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       imull	%ecx, %ecx
 # CHECK-NEXT: 2.     1     1.0    0.0    0.0       lock		cmpxchg16b	(%rsp)
-# CHECK-NEXT:        1     1.3    1.0    0.0       <total>
+# CHECK-NEXT:        3     1.3    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-cmp.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-cmp.s
@@ -75,4 +75,4 @@ cmovae %ebx, %eax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       cmpl	%eax, %eax
 # CHECK-NEXT: 1.     3     2.0    0.0    0.0       cmovael	%ebx, %eax
-# CHECK-NEXT:        3     1.5    0.5    0.0       <total>
+# CHECK-NEXT:        6     1.5    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-pcmpeq.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-pcmpeq.s
@@ -90,4 +90,4 @@ vpcmpeqq %xmm3, %xmm3, %xmm0
 # CHECK-NEXT: 1.     3     1.0    1.0    0.0       vpcmpeqw	%xmm1, %xmm1, %xmm2
 # CHECK-NEXT: 2.     3     1.0    1.0    0.0       vpcmpeqd	%xmm2, %xmm2, %xmm3
 # CHECK-NEXT: 3.     3     1.0    1.0    0.0       vpcmpeqq	%xmm3, %xmm3, %xmm0
-# CHECK-NEXT:        3     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        12    1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-pcmpgt.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-pcmpgt.s
@@ -91,4 +91,4 @@ vpcmpgtq %xmm3, %xmm3, %xmm0
 # CHECK-NEXT: 1.     3     0.0    0.0    0.0       vpcmpgtw	%xmm1, %xmm1, %xmm2
 # CHECK-NEXT: 2.     3     0.0    0.0    0.0       vpcmpgtd	%xmm2, %xmm2, %xmm3
 # CHECK-NEXT: 3.     3     0.0    0.0    0.0       vpcmpgtq	%xmm3, %xmm3, %xmm0
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        12    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-sbb-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-sbb-1.s
@@ -76,4 +76,4 @@ sbb %eax, %eax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     2.0    0.3    0.0       sbbl	%edx, %edx
 # CHECK-NEXT: 1.     3     3.0    0.0    0.0       sbbl	%eax, %eax
-# CHECK-NEXT:        3     2.5    0.2    0.0       <total>
+# CHECK-NEXT:        6     2.5    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-sbb-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dependency-breaking-sbb-2.s
@@ -84,4 +84,4 @@ sbb %eax, %eax
 # CHECK-NEXT: 0.     3     2.3    1.0    0.0       imull	%edx, %eax
 # CHECK-NEXT: 1.     3     1.3    1.0    2.7       addl	%edx, %edx
 # CHECK-NEXT: 2.     3     1.7    0.0    2.7       sbbl	%eax, %eax
-# CHECK-NEXT:        3     1.8    0.7    1.8       <total>
+# CHECK-NEXT:        9     1.8    0.7    1.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dependent-pmuld-paddd.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dependent-pmuld-paddd.s
@@ -99,4 +99,4 @@ vpaddd %xmm0, %xmm0, %xmm3
 # CHECK-NEXT: 0.     10    8.0    0.1    0.0       vpmuldq	%xmm0, %xmm0, %xmm1
 # CHECK-NEXT: 1.     10    9.5    0.0    0.0       vpaddd	%xmm1, %xmm1, %xmm0
 # CHECK-NEXT: 2.     10    10.0   0.0    0.0       vpaddd	%xmm0, %xmm0, %xmm3
-# CHECK-NEXT:        10    9.2    0.0    0.0       <total>
+# CHECK-NEXT:        30    9.2    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/dot-product.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/dot-product.s
@@ -78,4 +78,4 @@ vhaddps  %xmm3, %xmm3, %xmm4
 # CHECK-NEXT: 0.     3     1.0    1.0    4.7       vmulps	%xmm0, %xmm1, %xmm2
 # CHECK-NEXT: 1.     3     2.7    0.0    2.3       vhaddps	%xmm2, %xmm2, %xmm3
 # CHECK-NEXT: 2.     3     6.0    0.0    0.0       vhaddps	%xmm3, %xmm3, %xmm4
-# CHECK-NEXT:        3     3.2    0.3    2.3       <total>
+# CHECK-NEXT:        9     3.2    0.3    2.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/hadd-read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/hadd-read-after-ld-1.s
@@ -42,4 +42,4 @@ vhaddps (%rdi), %xmm1, %xmm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vshufps	$0, %xmm0, %xmm1, %xmm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       vhaddps	(%rdi), %xmm1, %xmm2
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/hadd-read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/hadd-read-after-ld-2.s
@@ -42,4 +42,4 @@ vhaddps (%rdi), %ymm1, %ymm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vshufps	$0, %xmm0, %xmm1, %xmm1
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       vhaddps	(%rdi), %ymm1, %ymm2
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        2     1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/independent-load-stores.s
@@ -132,7 +132,7 @@
 # NOALIAS-NEXT:  7.     1     5.0    1.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     5.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     6.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     3.5    1.0    0.0       <total>
+# NOALIAS-NEXT:        10    3.5    1.0    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     7.0    0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     12.0   0.0    0.0       addq	$44, 192(%r14)
@@ -143,4 +143,4 @@
 # YESALIAS-NEXT: 7.     1     40.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     45.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     51.0   0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     26.0   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    26.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/int-to-fpu-forwarding-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/int-to-fpu-forwarding-3.s
@@ -80,4 +80,4 @@ vpinsrb $1, %eax, %xmm0, %xmm0
 # CHECK-NEXT: 0.     3     1.0    1.0    3.3       addl	%eax, %eax
 # CHECK-NEXT: 1.     3     7.0    0.0    0.0       vpinsrb	$0, %eax, %xmm0, %xmm0
 # CHECK-NEXT: 2.     3     7.0    0.0    0.0       vpinsrb	$1, %eax, %xmm0, %xmm0
-# CHECK-NEXT:        3     5.0    0.3    1.1       <total>
+# CHECK-NEXT:        9     5.0    0.3    1.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/load-store-alias.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/load-store-alias.s
@@ -97,4 +97,4 @@ vmovaps %xmm0, 48(%rdi)
 # CHECK-NEXT: 5.     1     16.0   0.0    0.0       vmovaps	%xmm0, 32(%rdi)
 # CHECK-NEXT: 6.     1     16.0   0.0    0.0       vmovaps	48(%rsi), %xmm0
 # CHECK-NEXT: 7.     1     21.0   0.0    0.0       vmovaps	%xmm0, 48(%rdi)
-# CHECK-NEXT:        1     11.0   0.1    0.0       <total>
+# CHECK-NEXT:        8     11.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/memcpy-like-test.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/memcpy-like-test.s
@@ -97,4 +97,4 @@ vmovaps %xmm0, 48(%rdi)
 # CHECK-NEXT: 5.     1     6.0    0.0    0.0       vmovaps	%xmm0, 32(%rdi)
 # CHECK-NEXT: 6.     1     1.0    1.0    0.0       vmovaps	48(%rsi), %xmm0
 # CHECK-NEXT: 7.     1     6.0    0.0    0.0       vmovaps	%xmm0, 48(%rdi)
-# CHECK-NEXT:        1     3.5    0.5    0.0       <total>
+# CHECK-NEXT:        8     3.5    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/negative-read-advance.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/negative-read-advance.s
@@ -87,4 +87,4 @@ vpinsrd $3, %ebx, %xmm8, %xmm10
 # CHECK-NEXT: 3.     1     6.0    1.0    0.0       vpinsrd	$2, %ebx, %xmm4, %xmm5
 # CHECK-NEXT: 4.     1     5.0    1.0    0.0       vpinsrd	$2, %ebx, %xmm6, %xmm7
 # CHECK-NEXT: 5.     1     5.0    2.0    0.0       vpinsrd	$3, %ebx, %xmm8, %xmm10
-# CHECK-NEXT:        1     5.0    0.8    0.0       <total>
+# CHECK-NEXT:        6     5.0    0.8    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/one-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/one-idioms.s
@@ -156,4 +156,4 @@ vpcmpeqw  %xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 12.    1     1.0    1.0    0.0       vpcmpeqd	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 13.    1     1.0    1.0    0.0       vpcmpeqq	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 14.    1     1.0    1.0    0.0       vpcmpeqw	%xmm3, %xmm3, %xmm5
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        15    1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-2.s
@@ -46,4 +46,4 @@ add    %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rbx
 # CHECK-NEXT: 1.     1     7.0    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     1     7.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     5.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     5.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-3.s
@@ -83,4 +83,4 @@ xor %bx, %dx
 # CHECK-NEXT: 0.     3     2.7    0.3    0.0       addw	%cx, %dx
 # CHECK-NEXT: 1.     3     3.3    0.0    0.0       movw	%ax, %dx
 # CHECK-NEXT: 2.     3     3.7    0.0    0.0       xorw	%bx, %dx
-# CHECK-NEXT:        3     3.2    0.1    0.0       <total>
+# CHECK-NEXT:        9     3.2    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-4.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-4.s
@@ -83,4 +83,4 @@ add %cx, %bx
 # CHECK-NEXT: 0.     3     4.7    0.3    0.0       imulw	%ax, %bx
 # CHECK-NEXT: 1.     3     7.3    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     3     7.7    0.0    0.0       addw	%cx, %bx
-# CHECK-NEXT:        3     6.6    0.1    0.0       <total>
+# CHECK-NEXT:        9     6.6    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-6.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-6.s
@@ -84,4 +84,4 @@ lzcnt 2(%rsp), %cx
 # CHECK-NEXT: 0.     3     4.7    0.3    0.0       imull	%edx, %ecx
 # CHECK-NEXT: 1.     3     4.3    0.0    0.0       lzcntw	(%rsp), %cx
 # CHECK-NEXT: 2.     3     4.7    0.0    0.0       lzcntw	2(%rsp), %cx
-# CHECK-NEXT:        3     4.6    0.1    0.0       <total>
+# CHECK-NEXT:        9     4.6    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-7.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update-7.s
@@ -102,4 +102,4 @@ cmpl $1025, %eax
 # CHECK-NEXT: 2.     5     6.2    0.0    0.8       shll	$2, %eax
 # CHECK-NEXT: 3.     5     6.8    0.0    0.0       imull	%ecx, %eax
 # CHECK-NEXT: 4.     5     9.2    0.0    0.0       cmpl	$1025, %eax
-# CHECK-NEXT:        5     7.0    0.1    0.3       <total>
+# CHECK-NEXT:        25    7.0    0.1    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/partial-reg-update.s
@@ -45,4 +45,4 @@ add  %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulw	%ax, %cx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       addb	%al, %cl
 # CHECK-NEXT: 2.     1     4.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/pipes-fpu.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/pipes-fpu.s
@@ -110,4 +110,4 @@ vsqrtps     %ymm0, %ymm2
 # CHECK-NEXT: 5.     2     29.5   29.5   0.0       vsqrtps	%xmm0, %xmm2
 # CHECK-NEXT: 6.     2     1.0    1.0    45.5      vaddps	%ymm0, %ymm1, %ymm2
 # CHECK-NEXT: 7.     2     48.5   48.5   0.0       vsqrtps	%ymm0, %ymm2
-# CHECK-NEXT:        2     10.5   10.5   23.7      <total>
+# CHECK-NEXT:        16    10.5   10.5   23.7      <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/pr37790.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/pr37790.s
@@ -44,4 +44,4 @@ stmxcsr (%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.0       int3
 # CHECK-NEXT: 1.     2     1.0    0.0    99.0      stmxcsr	(%rsp)
-# CHECK-NEXT:        2     1.0    0.5    49.5      <total>
+# CHECK-NEXT:        4     1.0    0.5    49.5      <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/rank.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/rank.s
@@ -113,4 +113,4 @@ add %ebx, %eax
 # CHECK-NEXT: 5.     3     2.0    0.0    0.0       addl	%edx, %esi
 # CHECK-NEXT: 6.     3     2.0    0.0    0.0       addl	%ebx, %eax
 # CHECK-NEXT: 7.     3     3.0    0.0    0.0       addl	%ebx, %eax
-# CHECK-NEXT:        3     2.1    0.2    0.0       <total>
+# CHECK-NEXT:        24    2.1    0.2    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/read-advance-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/read-advance-1.s
@@ -45,4 +45,4 @@ vmulps  (%rdi), %xmm1, %xmm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       vmulps	(%rdi), %xmm1, %xmm2
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/read-advance-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/read-advance-2.s
@@ -45,4 +45,4 @@
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imull	%esi
 # CHECK-NEXT: 1.     1     2.0    2.0    0.0       imull	(%rdi)
-# CHECK-NEXT:        1     1.5    1.5    0.0       <total>
+# CHECK-NEXT:        2     1.5    1.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/read-advance-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/read-advance-3.s
@@ -45,4 +45,4 @@
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       addq	%rdi, %rsi
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       addq	(%rsp), %rsi
 # CHECK-NEXT: 2.     1     2.0    2.0    2.0       addq	%rdx, %r8
-# CHECK-NEXT:        1     1.3    1.0    0.7       <total>
+# CHECK-NEXT:        3     1.3    1.0    0.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-1.s
@@ -98,4 +98,4 @@ vaddps %xmm1, %xmm1, %xmm2
 # CHECK-NEXT: 0.     3     0.0    0.0    2.7       vxorps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     3     0.0    0.0    2.7       vmovaps	%xmm0, %xmm1
 # CHECK-NEXT: 2.     3     1.0    1.0    0.0       vaddps	%xmm1, %xmm1, %xmm2
-# CHECK-NEXT:        3     0.3    0.3    1.8       <total>
+# CHECK-NEXT:        9     0.3    0.3    1.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-2.s
@@ -139,4 +139,4 @@ movdqu %xmm5, %xmm0
 # CHECK-NEXT: 6.     3     0.0    0.0    0.0       movupd	%xmm3, %xmm4
 # CHECK-NEXT: 7.     3     0.0    0.0    0.0       movdqa	%xmm4, %xmm5
 # CHECK-NEXT: 8.     3     0.0    0.0    0.0       movdqu	%xmm5, %xmm0
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        27    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-3.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-3.s
@@ -124,4 +124,4 @@ vmovdqu %xmm5, %xmm0
 # CHECK-NEXT: 4.     3     0.0    0.0    0.0       vmovupd	%xmm3, %xmm4
 # CHECK-NEXT: 5.     3     0.0    0.0    0.0       vmovdqa	%xmm4, %xmm5
 # CHECK-NEXT: 6.     3     0.0    0.0    0.0       vmovdqu	%xmm5, %xmm0
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        21    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-4.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-4.s
@@ -109,4 +109,4 @@ mov %edx, %eax
 # CHECK-NEXT: 2.     3     0.0    0.0    0.0       movl	%ebx, %ecx
 # CHECK-NEXT: 3.     3     0.0    0.0    0.0       movl	%ecx, %edx
 # CHECK-NEXT: 4.     3     0.0    0.0    0.0       movl	%edx, %eax
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        15    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-5.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-5.s
@@ -109,4 +109,4 @@ mov %rdx, %rax
 # CHECK-NEXT: 2.     3     0.0    0.0    0.0       movq	%rbx, %rcx
 # CHECK-NEXT: 3.     3     0.0    0.0    0.0       movq	%rcx, %rdx
 # CHECK-NEXT: 4.     3     0.0    0.0    0.0       movq	%rdx, %rax
-# CHECK-NEXT:        3     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        15    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-6.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/reg-move-elimination-6.s
@@ -117,4 +117,4 @@ mov %esi, %ecx
 # CHECK-NEXT: 3.     3     2.0    0.0    0.0       addq	%rcx, %rcx
 # CHECK-NEXT: 4.     3     2.0    0.0    0.0       addq	%rcx, %rcx
 # CHECK-NEXT: 5.     3     0.0    0.0    3.0       movl	%esi, %ecx
-# CHECK-NEXT:        3     1.0    0.2    1.1       <total>
+# CHECK-NEXT:        18    1.0    0.2    1.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/register-files-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/register-files-1.s
@@ -91,4 +91,4 @@ vmulps %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     5     9.0    0.2    0.0       vaddps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     5     12.0   0.0    0.0       vmulps	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        5     10.5   0.1    0.0       <total>
+# CHECK-NEXT:        10    10.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/register-files-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/register-files-2.s
@@ -92,4 +92,4 @@ vmulps %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     5     6.6    0.2    0.0       vaddps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     5     7.8    0.0    0.0       vmulps	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        5     7.2    0.1    0.0       <total>
+# CHECK-NEXT:        10    7.2    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/register-files-5.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/register-files-5.s
@@ -151,4 +151,4 @@
 # CHECK-NEXT: 30.    1     30.0   25.0   0.0       vaddps	%ymm3, %ymm0, %ymm4
 # CHECK-NEXT: 31.    1     31.0   27.0   0.0       vaddps	%ymm3, %ymm0, %ymm5
 # CHECK-NEXT: 32.    1     24.0   24.0   0.0       vaddps	%ymm3, %ymm0, %ymm6
-# CHECK-NEXT:        1     15.8   14.0   12.4      <total>
+# CHECK-NEXT:        33    15.8   14.0   12.4      <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/rmw-adc-sequence-readadvance.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/rmw-adc-sequence-readadvance.s
@@ -66,4 +66,4 @@ adc %eax, 4(%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       addl	%eax, %eax
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       adcl	%eax, 4(%rsp)
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/rmw-add-sequence-readadvance.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/rmw-add-sequence-readadvance.s
@@ -66,4 +66,4 @@ add %eax, 4(%rsp)
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       addl	%eax, %eax
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       addl	%eax, 4(%rsp)
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/stmxcsr-ldmxcsr.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/stmxcsr-ldmxcsr.s
@@ -101,4 +101,4 @@ retq
 # CHECK-NEXT: 3.     3     6.0    0.7    0.0       movl	%eax, -8(%rsp)
 # CHECK-NEXT: 4.     3     5.0    0.0    0.0       ldmxcsr	-8(%rsp)
 # CHECK-NEXT: 5.     3     1.3    1.3    2.7       retq
-# CHECK-NEXT:        3     3.2    0.7    1.3       <total>
+# CHECK-NEXT:        18    3.2    0.7    1.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/vbroadcast-operand-latency.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/vbroadcast-operand-latency.s
@@ -71,4 +71,4 @@ vbroadcastss (%rax), %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    2.7       leaq	8(%rsp,%rdi,2), %rax
 # CHECK-NEXT: 1.     3     2.0    0.0    0.0       vbroadcastss	(%rax), %ymm0
-# CHECK-NEXT:        3     1.5    0.5    1.3       <total>
+# CHECK-NEXT:        6     1.5    0.5    1.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/vec-logic-read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/vec-logic-read-after-ld-1.s
@@ -41,4 +41,4 @@ vandps (%rdi), %xmm1, %xmm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm1
 # CHECK-NEXT: 1.     1     1.0    0.0    0.0       vandps	(%rdi), %xmm1, %xmm2
-# CHECK-NEXT:        1     1.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/vec-logic-read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/vec-logic-read-after-ld-2.s
@@ -41,4 +41,4 @@ vandps (%rdi), %ymm1, %ymm2
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vaddps	%ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     1     1.0    1.0    0.0       vandps	(%rdi), %ymm1, %ymm2
-# CHECK-NEXT:        1     1.0    1.0    0.0       <total>
+# CHECK-NEXT:        2     1.0    1.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/xadd.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/xadd.s
@@ -99,7 +99,7 @@ imul %ecx, %ecx
 # CHECK-NEXT: 2.     2     5.0    0.0    7.0       addl	%ecx, %ecx
 # CHECK-NEXT: 3.     2     5.0    0.0    4.0       imull	%ecx, %ecx
 # CHECK-NEXT: 4.     2     8.0    0.0    2.0       imull	%ecx, %ecx
-# CHECK-NEXT:        2     5.0    0.1    4.0       <total>
+# CHECK-NEXT:        10    5.0    0.1    4.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -183,4 +183,4 @@ imul %ecx, %ecx
 # CHECK-NEXT: 2.     2     17.0   0.0    4.0       addl	%ecx, %ecx
 # CHECK-NEXT: 3.     2     17.0   0.0    1.0       imull	%ecx, %ecx
 # CHECK-NEXT: 4.     2     20.0   0.0    0.0       imull	%ecx, %ecx
-# CHECK-NEXT:        2     15.4   0.1    1.8       <total>
+# CHECK-NEXT:        10    15.4   0.1    1.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/xchg.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/xchg.s
@@ -87,4 +87,4 @@ imul %ecx, %ecx
 # CHECK-NEXT: 2.     2     17.0   0.0    4.0       addl	%ecx, %ecx
 # CHECK-NEXT: 3.     2     18.0   0.0    1.0       imull	%ecx, %ecx
 # CHECK-NEXT: 4.     2     20.0   0.0    0.0       imull	%ecx, %ecx
-# CHECK-NEXT:        2     15.8   0.1    1.8       <total>
+# CHECK-NEXT:        10    15.8   0.1    1.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/zero-idioms-avx-256.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/zero-idioms-avx-256.s
@@ -111,7 +111,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK-NEXT: 0.     3     1.3    1.3    0.0       vaddps	%ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     3     1.0    1.0    1.3       vxorps	%ymm1, %ymm1, %ymm1
 # CHECK-NEXT: 2.     3     1.0    0.0    1.3       vblendps	$2, %ymm1, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.1    0.8    0.9       <total>
+# CHECK-NEXT:        9     1.1    0.8    0.9       <total>
 
 # CHECK:      [1] Code Region - ZERO-IDIOM-2
 
@@ -188,7 +188,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK-NEXT: 0.     3     1.3    1.3    0.0       vaddpd	%ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     3     1.0    1.0    1.3       vxorpd	%ymm1, %ymm1, %ymm1
 # CHECK-NEXT: 2.     3     1.0    0.0    1.3       vblendpd	$2, %ymm1, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.1    0.8    0.9       <total>
+# CHECK-NEXT:        9     1.1    0.8    0.9       <total>
 
 # CHECK:      [2] Code Region - ZERO-IDIOM-3
 
@@ -258,7 +258,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       vaddps	%ymm0, %ymm1, %ymm2
 # CHECK-NEXT: 1.     3     1.0    1.0    1.0       vandnps	%ymm2, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.0    1.0    0.5       <total>
+# CHECK-NEXT:        6     1.0    1.0    0.5       <total>
 
 # CHECK:      [3] Code Region - ZERO-IDIOM-4
 
@@ -328,7 +328,7 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.0       vaddps	%ymm0, %ymm1, %ymm2
 # CHECK-NEXT: 1.     3     1.0    1.0    1.0       vandnps	%ymm2, %ymm2, %ymm3
-# CHECK-NEXT:        3     1.0    1.0    0.5       <total>
+# CHECK-NEXT:        6     1.0    1.0    0.5       <total>
 
 # CHECK:      [4] Code Region - ZERO-IDIOM-5
 
@@ -399,4 +399,4 @@ vaddps  %ymm1, %ymm1, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     3     1.0    1.0    0.7       vperm2f128	$136, %ymm0, %ymm0, %ymm1
 # CHECK-NEXT: 1.     3     1.0    0.0    0.0       vaddps	%ymm1, %ymm1, %ymm0
-# CHECK-NEXT:        3     1.0    0.5    0.3       <total>
+# CHECK-NEXT:        6     1.0    0.5    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/BtVer2/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/BtVer2/zero-idioms.s
@@ -441,4 +441,4 @@ vpxor  %xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 68.    1     0.0    0.0    0.0       vxorps	%xmm4, %xmm4, %xmm5
 # CHECK-NEXT: 69.    1     0.0    0.0    0.0       vxorpd	%xmm1, %xmm1, %xmm3
 # CHECK-NEXT: 70.    1     0.0    0.0    0.0       vpxor	%xmm3, %xmm3, %xmm5
-# CHECK-NEXT:        1     0.0    0.0    0.0       <total>
+# CHECK-NEXT:        71    0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Generic/avx512-super-registers-1.s
+++ b/llvm/test/tools/llvm-mca/X86/Generic/avx512-super-registers-1.s
@@ -87,4 +87,4 @@
 # CHECK-NEXT: 3.     2     8.5    0.0    6.0       vaddps	%xmm4, %xmm5, %xmm6
 # CHECK-NEXT: 4.     2     11.0   0.0    3.5       vmulps	%xmm6, %xmm3, %xmm4
 # CHECK-NEXT: 5.     2     16.0   0.0    2.0       vaddps	%xmm4, %xmm5, %xmm0
-# CHECK-NEXT:        2     8.3    0.3    5.0       <total>
+# CHECK-NEXT:        12    8.3    0.3    5.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Generic/avx512-super-registers-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Generic/avx512-super-registers-2.s
@@ -87,4 +87,4 @@
 # CHECK-NEXT: 3.     2     8.5    0.0    6.0       vaddps	%xmm4, %xmm5, %xmm6
 # CHECK-NEXT: 4.     2     11.0   0.0    3.5       vmulps	%xmm6, %xmm3, %xmm4
 # CHECK-NEXT: 5.     2     16.0   0.0    2.0       vaddps	%xmm4, %xmm5, %xmm0
-# CHECK-NEXT:        2     8.3    0.3    5.0       <total>
+# CHECK-NEXT:        12    8.3    0.3    5.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Generic/avx512-super-registers-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Generic/avx512-super-registers-3.s
@@ -87,4 +87,4 @@
 # CHECK-NEXT: 3.     2     8.5    0.0    6.0       vaddps	%xmm4, %xmm18, %xmm6
 # CHECK-NEXT: 4.     2     11.0   0.0    3.5       vmulps	%xmm6, %xmm19, %xmm4
 # CHECK-NEXT: 5.     2     16.0   0.0    2.0       vaddps	%xmm4, %xmm20, %xmm0
-# CHECK-NEXT:        2     8.3    0.3    5.0       <total>
+# CHECK-NEXT:        12    8.3    0.3    5.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Generic/xop-super-registers-1.s
+++ b/llvm/test/tools/llvm-mca/X86/Generic/xop-super-registers-1.s
@@ -87,4 +87,4 @@
 # CHECK-NEXT: 3.     2     8.5    0.0    6.0       vaddps	%ymm4, %ymm5, %ymm6
 # CHECK-NEXT: 4.     2     11.0   0.0    3.5       vmulps	%ymm6, %ymm3, %ymm4
 # CHECK-NEXT: 5.     2     16.0   0.0    2.0       vaddps	%ymm4, %ymm5, %ymm0
-# CHECK-NEXT:        2     8.3    0.3    5.0       <total>
+# CHECK-NEXT:        12    8.3    0.3    5.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Generic/xop-super-registers-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Generic/xop-super-registers-2.s
@@ -87,4 +87,4 @@
 # CHECK-NEXT: 3.     2     6.5    0.0    6.0       vaddps	%ymm4, %ymm5, %ymm6
 # CHECK-NEXT: 4.     2     9.0    0.0    3.5       vmulps	%ymm6, %ymm3, %ymm4
 # CHECK-NEXT: 5.     2     14.0   0.0    2.0       vaddps	%ymm4, %ymm5, %ymm0
-# CHECK-NEXT:        2     6.8    0.3    5.2       <total>
+# CHECK-NEXT:        12    6.8    0.3    5.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/Haswell/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/independent-load-stores.s
@@ -128,7 +128,7 @@
 # NOALIAS-NEXT:  7.     1     1.0    1.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     1.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     1.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     1.0    1.0    0.0       <total>
+# NOALIAS-NEXT:        10    1.0    1.0    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     7.0    0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     13.0   0.0    0.0       addq	$44, 192(%r14)
@@ -139,4 +139,4 @@
 # YESALIAS-NEXT: 7.     1     43.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     49.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     55.0   0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     28.0   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    28.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Haswell/mulx-hi-read-advance.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/mulx-hi-read-advance.s
@@ -74,7 +74,7 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxl	(%rdi), %eax, %ecx
 # CHECK-NEXT: 1.     1     8.0    0.0    0.0       addl	%eax, %eax
-# CHECK-NEXT:        1     4.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     4.5    0.5    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -137,4 +137,4 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxq	(%rdi), %rax, %rcx
 # CHECK-NEXT: 1.     1     8.0    0.0    0.0       addq	%rax, %rax
-# CHECK-NEXT:        1     4.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     4.5    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Haswell/stmxcsr-ldmxcsr.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/stmxcsr-ldmxcsr.s
@@ -97,4 +97,4 @@ retq
 # CHECK-NEXT: 3.     3     11.0   0.7    0.0       movl	%eax, -8(%rsp)
 # CHECK-NEXT: 4.     3     10.0   0.0    0.0       ldmxcsr	-8(%rsp)
 # CHECK-NEXT: 5.     3     1.3    1.3    7.7       retq
-# CHECK-NEXT:        3     5.6    0.7    3.6       <total>
+# CHECK-NEXT:        18    5.6    0.7    3.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/Haswell/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Haswell/zero-idioms.s
@@ -490,4 +490,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 80.    1     0.0    0.0    3.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 81.    1     0.0    0.0    3.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 82.    1     0.0    0.0    3.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     0.7    0.2    1.8       <total>
+# CHECK-NEXT:        83    0.7    0.2    1.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/IceLakeServer/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/IceLakeServer/independent-load-stores.s
@@ -130,7 +130,7 @@
 # NOALIAS-NEXT:  7.     1     1.0    0.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     1.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     1.0    0.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     1.0    0.5    0.0       <total>
+# NOALIAS-NEXT:        10    1.0    0.5    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     8.0    0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     14.0   0.0    0.0       addq	$44, 192(%r14)
@@ -141,4 +141,4 @@
 # YESALIAS-NEXT: 7.     1     47.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     53.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     60.0   0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     30.5   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    30.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/IceLakeServer/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/IceLakeServer/zero-idioms.s
@@ -778,4 +778,4 @@ vpxorq  %zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 136.   1     0.0    0.0    3.0       vpxorq	%ymm19, %ymm19, %ymm21
 # CHECK-NEXT: 137.   1     0.0    0.0    3.0       vpxord	%zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 138.   1     0.0    0.0    2.0       vpxorq	%zmm19, %zmm19, %zmm21
-# CHECK-NEXT:        1     0.9    0.2    2.0       <total>
+# CHECK-NEXT:        139   0.9    0.2    2.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/LunarlakeP/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/LunarlakeP/independent-load-stores.s
@@ -134,7 +134,7 @@
 # NOALIAS-NEXT:  7.     1     2.0    0.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     2.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     3.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     1.7    0.7    0.0       <total>
+# NOALIAS-NEXT:        10    1.7    0.7    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     13.0   0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     24.0   0.0    0.0       addq	$44, 192(%r14)
@@ -145,4 +145,4 @@
 # YESALIAS-NEXT: 7.     1     82.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     93.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     105.0  0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     53.0   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    53.0   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/LunarlakeP/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/LunarlakeP/zero-idioms.s
@@ -499,4 +499,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 80.    1     8.0    0.0    11.0      vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 81.    1     10.0   1.0    9.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 82.    1     10.0   1.0    9.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     9.0    0.7    5.6       <total>
+# CHECK-NEXT:        83    9.0    0.7    5.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/SLM/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/SLM/zero-idioms.s
@@ -243,4 +243,4 @@ pxor   %xmm2, %xmm2
 # CHECK-NEXT: 33.    1     9.0    9.0    0.0       xorpd	%xmm1, %xmm1
 # CHECK-NEXT: 34.    1     8.0    2.0    0.0       pxor	%mm2, %mm2
 # CHECK-NEXT: 35.    1     9.0    9.0    0.0       pxor	%xmm2, %xmm2
-# CHECK-NEXT:        1     5.1    1.9    0.6       <total>
+# CHECK-NEXT:        36    5.1    1.9    0.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/SandyBridge/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/SandyBridge/zero-idioms.s
@@ -386,4 +386,4 @@ vpxor  %xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 60.    1     0.0    0.0    8.0       vxorps	%ymm4, %ymm4, %ymm5
 # CHECK-NEXT: 61.    1     0.0    0.0    8.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 62.    1     0.0    0.0    8.0       vpxor	%xmm3, %xmm3, %xmm5
-# CHECK-NEXT:        1     1.8    0.3    7.7       <total>
+# CHECK-NEXT:        63    1.8    0.3    7.7       <total>

--- a/llvm/test/tools/llvm-mca/X86/SapphireRapids/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/SapphireRapids/independent-load-stores.s
@@ -128,7 +128,7 @@
 # NOALIAS-NEXT:  7.     1     1.0    1.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     1.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     1.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     1.0    1.0    0.0       <total>
+# NOALIAS-NEXT:        10    1.0    1.0    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     12.0   0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     23.0   0.0    0.0       addq	$44, 192(%r14)
@@ -139,4 +139,4 @@
 # YESALIAS-NEXT: 7.     1     78.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     89.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     100.0  0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     50.5   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    50.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/SapphireRapids/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/SapphireRapids/zero-idioms.s
@@ -779,4 +779,4 @@ vpxorq  %zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 136.   1     26.0   1.0    0.0       vpxorq	%ymm19, %ymm19, %ymm21
 # CHECK-NEXT: 137.   1     26.0   1.0    0.0       vpxord	%zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 138.   1     26.0   2.0    0.0       vpxorq	%zmm19, %zmm19, %zmm21
-# CHECK-NEXT:        1     14.1   2.2    3.5       <total>
+# CHECK-NEXT:        139   14.1   2.2    3.5       <total>

--- a/llvm/test/tools/llvm-mca/X86/SkylakeClient/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeClient/independent-load-stores.s
@@ -128,7 +128,7 @@
 # NOALIAS-NEXT:  7.     1     5.0    1.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     5.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     6.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     3.5    1.0    0.0       <total>
+# NOALIAS-NEXT:        10    3.5    1.0    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     8.0    0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     14.0   0.0    0.0       addq	$44, 192(%r14)
@@ -139,4 +139,4 @@
 # YESALIAS-NEXT: 7.     1     47.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     53.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     60.0   0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     30.5   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    30.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/SkylakeClient/mulx-hi-read-advance.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeClient/mulx-hi-read-advance.s
@@ -74,7 +74,7 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxl	(%rdi), %eax, %ecx
 # CHECK-NEXT: 1.     1     9.0    0.0    0.0       addl	%eax, %eax
-# CHECK-NEXT:        1     5.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     5.0    0.5    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -137,4 +137,4 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxq	(%rdi), %rax, %rcx
 # CHECK-NEXT: 1.     1     9.0    0.0    0.0       addq	%rax, %rax
-# CHECK-NEXT:        1     5.0    0.5    0.0       <total>
+# CHECK-NEXT:        2     5.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/SkylakeClient/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeClient/zero-idioms.s
@@ -490,4 +490,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 80.    1     0.0    0.0    3.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 81.    1     0.0    0.0    3.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 82.    1     0.0    0.0    4.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     0.6    0.2    2.2       <total>
+# CHECK-NEXT:        83    0.6    0.2    2.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/SkylakeServer/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeServer/independent-load-stores.s
@@ -128,7 +128,7 @@
 # NOALIAS-NEXT:  7.     1     5.0    1.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     5.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     6.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     3.5    1.0    0.0       <total>
+# NOALIAS-NEXT:        10    3.5    1.0    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     8.0    0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     14.0   0.0    0.0       addq	$44, 192(%r14)
@@ -139,4 +139,4 @@
 # YESALIAS-NEXT: 7.     1     47.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     53.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     60.0   0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     30.5   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    30.5   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/SkylakeServer/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/SkylakeServer/zero-idioms.s
@@ -776,4 +776,4 @@ vpxorq  %zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 136.   1     0.0    0.0    7.0       vpxorq	%ymm19, %ymm19, %ymm21
 # CHECK-NEXT: 137.   1     0.0    0.0    7.0       vpxord	%zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 138.   1     0.0    0.0    6.0       vpxorq	%zmm19, %zmm19, %zmm21
-# CHECK-NEXT:        1     0.9    0.2    3.1       <total>
+# CHECK-NEXT:        139   0.9    0.2    3.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-2.s
@@ -45,4 +45,4 @@ add    %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rbx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.7    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.7    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-3.s
@@ -88,4 +88,4 @@ xor %bx, %dx
 # CHECK-NEXT: 0.     6     7.0    0.2    0.0       addw	%cx, %dx
 # CHECK-NEXT: 1.     6     7.7    0.0    0.0       movw	%ax, %dx
 # CHECK-NEXT: 2.     6     8.5    0.0    0.0       xorw	%bx, %dx
-# CHECK-NEXT:        6     7.7    0.1    0.0       <total>
+# CHECK-NEXT:        18    7.7    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-4.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-4.s
@@ -91,4 +91,4 @@ add %cx, %bx
 # CHECK-NEXT: 0.     7     14.1   0.1    0.0       imulw	%ax, %bx
 # CHECK-NEXT: 1.     7     15.9   0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     7     17.6   0.0    0.0       addw	%cx, %bx
-# CHECK-NEXT:        7     15.9   0.0    0.0       <total>
+# CHECK-NEXT:        21    15.9   0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-6.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-6.s
@@ -84,4 +84,4 @@ lzcnt 2(%rsp), %cx
 # CHECK-NEXT: 0.     4     9.5    0.3    0.0       imull	%edx, %ecx
 # CHECK-NEXT: 1.     4     9.0    0.0    0.0       lzcntw	(%rsp), %cx
 # CHECK-NEXT: 2.     4     9.5    0.0    0.0       lzcntw	2(%rsp), %cx
-# CHECK-NEXT:        4     9.3    0.1    0.0       <total>
+# CHECK-NEXT:        12    9.3    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-7.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update-7.s
@@ -49,4 +49,4 @@ addq  %rcx, %rdx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rcx
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       addl	%edx, %ecx
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       addq	%rcx, %rdx
-# CHECK-NEXT:        1     4.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     4.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/partial-reg-update.s
@@ -45,4 +45,4 @@ add  %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulw	%ax, %cx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       addb	%al, %cl
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver1/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver1/zero-idioms.s
@@ -497,4 +497,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 80.    1     3.0    3.0    0.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 81.    1     3.0    3.0    0.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 82.    1     3.0    3.0    0.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     2.9    2.9    0.1       <total>
+# CHECK-NEXT:        83    2.9    2.9    0.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/mulx-hi-read-advance.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/mulx-hi-read-advance.s
@@ -77,7 +77,7 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxl	(%rdi), %eax, %ecx
 # CHECK-NEXT: 1.     1     8.0    0.0    0.0       addl	%eax, %eax
-# CHECK-NEXT:        1     4.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     4.5    0.5    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -143,4 +143,4 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxq	(%rdi), %rax, %rcx
 # CHECK-NEXT: 1.     1     8.0    0.0    0.0       addq	%rax, %rax
-# CHECK-NEXT:        1     4.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     4.5    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-2.s
@@ -45,4 +45,4 @@ add    %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rbx
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     4.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     4.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-3.s
@@ -89,4 +89,4 @@ xor %bx, %dx
 # CHECK-NEXT: 0.     6     7.0    0.2    0.0       addw	%cx, %dx
 # CHECK-NEXT: 1.     6     7.7    0.0    0.0       movw	%ax, %dx
 # CHECK-NEXT: 2.     6     8.5    0.0    0.0       xorw	%bx, %dx
-# CHECK-NEXT:        6     7.7    0.1    0.0       <total>
+# CHECK-NEXT:        18    7.7    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-4.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-4.s
@@ -92,4 +92,4 @@ add %cx, %bx
 # CHECK-NEXT: 0.     7     14.1   0.1    0.0       imulw	%ax, %bx
 # CHECK-NEXT: 1.     7     16.9   0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     7     17.6   0.0    0.0       addw	%cx, %bx
-# CHECK-NEXT:        7     16.2   0.0    0.0       <total>
+# CHECK-NEXT:        21    16.2   0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-6.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-6.s
@@ -85,4 +85,4 @@ lzcnt 2(%rsp), %cx
 # CHECK-NEXT: 0.     4     8.0    0.3    0.0       imull	%edx, %ecx
 # CHECK-NEXT: 1.     4     7.5    0.0    0.0       lzcntw	(%rsp), %cx
 # CHECK-NEXT: 2.     4     8.0    0.0    0.0       lzcntw	2(%rsp), %cx
-# CHECK-NEXT:        4     7.8    0.1    0.0       <total>
+# CHECK-NEXT:        12    7.8    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-7.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update-7.s
@@ -49,4 +49,4 @@ addq  %rcx, %rdx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rcx
 # CHECK-NEXT: 1.     1     5.0    0.0    0.0       addl	%edx, %ecx
 # CHECK-NEXT: 2.     1     6.0    0.0    0.0       addq	%rcx, %rdx
-# CHECK-NEXT:        1     4.0    0.3    0.0       <total>
+# CHECK-NEXT:        3     4.0    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/partial-reg-update.s
@@ -45,4 +45,4 @@ add  %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulw	%ax, %cx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       addb	%al, %cl
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver2/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver2/zero-idioms.s
@@ -498,4 +498,4 @@ vpxor  %ymm3, %ymm3, %ymm5
 # CHECK-NEXT: 80.    1     3.0    3.0    0.0       vxorpd	%ymm1, %ymm1, %ymm3
 # CHECK-NEXT: 81.    1     4.0    4.0    0.0       vpxor	%xmm3, %xmm3, %xmm5
 # CHECK-NEXT: 82.    1     4.0    4.0    0.0       vpxor	%ymm3, %ymm3, %ymm5
-# CHECK-NEXT:        1     3.1    3.1    0.1       <total>
+# CHECK-NEXT:        83    3.1    3.1    0.1       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/dependency-breaking-gpr.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/dependency-breaking-gpr.s
@@ -110,7 +110,7 @@ cmovael %eax, %ecx
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.5    0.5    1.5       sbbl	%eax, %eax
 # CHECK-NEXT: 1.     2     2.5    0.0    0.0       mulxl	%eax, %eax, %eax
-# CHECK-NEXT:        2     2.0    0.3    0.8       <total>
+# CHECK-NEXT:        4     2.0    0.3    0.8       <total>
 
 # CHECK:      [1] Code Region
 
@@ -187,7 +187,7 @@ cmovael %eax, %ecx
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.5    0.5    1.5       sbbq	%rax, %rax
 # CHECK-NEXT: 1.     2     2.5    0.0    0.0       mulxq	%rax, %rax, %rax
-# CHECK-NEXT:        2     2.0    0.3    0.8       <total>
+# CHECK-NEXT:        4     2.0    0.3    0.8       <total>
 
 # CHECK:      [2] Code Region
 
@@ -270,7 +270,7 @@ cmovael %eax, %ecx
 # CHECK-NEXT: 0.     2     3.0    0.5    0.0       mulxl	%eax, %eax, %eax
 # CHECK-NEXT: 1.     2     0.0    0.0    6.5       cmpl	%eax, %eax
 # CHECK-NEXT: 2.     2     6.5    0.0    0.0       cmovael	%eax, %ecx
-# CHECK-NEXT:        2     3.2    0.2    2.2       <total>
+# CHECK-NEXT:        6     3.2    0.2    2.2       <total>
 
 # CHECK:      [3] Code Region
 
@@ -353,7 +353,7 @@ cmovael %eax, %ecx
 # CHECK-NEXT: 0.     2     3.0    0.5    0.0       mulxq	%rax, %rax, %rax
 # CHECK-NEXT: 1.     2     0.0    0.0    6.5       cmpq	%rax, %rax
 # CHECK-NEXT: 2.     2     6.5    0.0    0.0       cmovaeq	%rax, %rcx
-# CHECK-NEXT:        2     3.2    0.2    2.2       <total>
+# CHECK-NEXT:        6     3.2    0.2    2.2       <total>
 
 # CHECK:      [4] Code Region
 
@@ -436,7 +436,7 @@ cmovael %eax, %ecx
 # CHECK-NEXT: 0.     2     3.0    0.5    0.0       mulxl	%eax, %eax, %eax
 # CHECK-NEXT: 1.     2     0.0    0.0    6.5       cmpw	%ax, %ax
 # CHECK-NEXT: 2.     2     6.5    0.0    0.0       cmovael	%eax, %ecx
-# CHECK-NEXT:        2     3.2    0.2    2.2       <total>
+# CHECK-NEXT:        6     3.2    0.2    2.2       <total>
 
 # CHECK:      [5] Code Region
 
@@ -519,4 +519,4 @@ cmovael %eax, %ecx
 # CHECK-NEXT: 0.     2     3.0    0.5    0.0       mulxl	%eax, %eax, %eax
 # CHECK-NEXT: 1.     2     0.0    0.0    6.5       cmpb	%al, %al
 # CHECK-NEXT: 2.     2     6.5    0.0    0.0       cmovael	%eax, %ecx
-# CHECK-NEXT:        2     3.2    0.2    2.2       <total>
+# CHECK-NEXT:        6     3.2    0.2    2.2       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/mulx-hi-read-advance.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/mulx-hi-read-advance.s
@@ -87,7 +87,7 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxl	(%rdi), %eax, %ecx
 # CHECK-NEXT: 1.     1     8.0    0.0    0.0       addl	%eax, %eax
-# CHECK-NEXT:        1     4.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     4.5    0.5    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -163,4 +163,4 @@ add %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       mulxq	(%rdi), %rax, %rcx
 # CHECK-NEXT: 1.     1     8.0    0.0    0.0       addq	%rax, %rax
-# CHECK-NEXT:        1     4.5    0.5    0.0       <total>
+# CHECK-NEXT:        2     4.5    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-avx-xmm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-avx-xmm.s
@@ -110,7 +110,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqb	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddb	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [1] Code Region
 
@@ -201,7 +201,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqw	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddw	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [2] Code Region
 
@@ -292,7 +292,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqd	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddd	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [3] Code Region
 
@@ -383,4 +383,4 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqq	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddq	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-avx-ymm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-avx-ymm.s
@@ -110,7 +110,7 @@ vpaddq %ymm0, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqb	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddb	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [1] Code Region
 
@@ -201,7 +201,7 @@ vpaddq %ymm0, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqw	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddw	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [2] Code Region
 
@@ -292,7 +292,7 @@ vpaddq %ymm0, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqd	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddd	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [3] Code Region
 
@@ -383,4 +383,4 @@ vpaddq %ymm0, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpcmpeqq	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpaddq	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-mmx.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-mmx.s
@@ -105,7 +105,7 @@ paddd %mm0, %mm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqb	%mm0, %mm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddb	%mm0, %mm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [1] Code Region
 
@@ -196,7 +196,7 @@ paddd %mm0, %mm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqw	%mm0, %mm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddw	%mm0, %mm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [2] Code Region
 
@@ -287,4 +287,4 @@ paddd %mm0, %mm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqd	%mm0, %mm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddd	%mm0, %mm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-sse-xmm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/one-idioms-sse-xmm.s
@@ -110,7 +110,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqb	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddb	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [1] Code Region
 
@@ -201,7 +201,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqw	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddw	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [2] Code Region
 
@@ -292,7 +292,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqd	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddd	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [3] Code Region
 
@@ -383,4 +383,4 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpeqq	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddq	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-2.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-2.s
@@ -45,4 +45,4 @@ add    %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rbx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-3.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-3.s
@@ -99,4 +99,4 @@ xor %bx, %dx
 # CHECK-NEXT: 0.     6     7.5    0.2    0.0       addw	%cx, %dx
 # CHECK-NEXT: 1.     6     8.5    0.0    0.0       movw	%ax, %dx
 # CHECK-NEXT: 2.     6     9.5    0.0    0.0       xorw	%bx, %dx
-# CHECK-NEXT:        6     8.5    0.1    0.0       <total>
+# CHECK-NEXT:        18    8.5    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-4.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-4.s
@@ -102,4 +102,4 @@ add %cx, %bx
 # CHECK-NEXT: 0.     7     14.7   0.1    0.0       imulw	%ax, %bx
 # CHECK-NEXT: 1.     7     17.7   0.0    0.0       lzcntw	%ax, %bx
 # CHECK-NEXT: 2.     7     18.7   0.0    0.0       addw	%cx, %bx
-# CHECK-NEXT:        7     17.0   0.0    0.0       <total>
+# CHECK-NEXT:        21    17.0   0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-6.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-6.s
@@ -95,4 +95,4 @@ lzcnt 2(%rsp), %cx
 # CHECK-NEXT: 0.     4     9.5    0.3    0.0       imull	%edx, %ecx
 # CHECK-NEXT: 1.     4     9.5    0.0    0.0       lzcntw	(%rsp), %cx
 # CHECK-NEXT: 2.     4     10.5   0.0    0.0       lzcntw	2(%rsp), %cx
-# CHECK-NEXT:        4     9.8    0.1    0.0       <total>
+# CHECK-NEXT:        12    9.8    0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-7.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update-7.s
@@ -49,4 +49,4 @@ addq  %rcx, %rdx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulq	%rax, %rcx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       addl	%edx, %ecx
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addq	%rcx, %rdx
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/partial-reg-update.s
@@ -45,4 +45,4 @@ add  %ecx, %ebx
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       imulw	%ax, %cx
 # CHECK-NEXT: 1.     1     4.0    0.0    0.0       addb	%al, %cl
 # CHECK-NEXT: 2.     1     5.0    0.0    0.0       addl	%ecx, %ebx
-# CHECK-NEXT:        1     3.3    0.3    0.0       <total>
+# CHECK-NEXT:        3     3.3    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-avx-xmm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-avx-xmm.s
@@ -407,7 +407,7 @@ vmovdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovaps	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovaps	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovaps	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -701,7 +701,7 @@ vmovdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovups	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovups	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovups	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -995,7 +995,7 @@ vmovdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovapd	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovapd	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovapd	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -1289,7 +1289,7 @@ vmovdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovupd	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovupd	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovupd	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -1583,7 +1583,7 @@ vmovdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovdqa	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovdqa	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovdqa	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -1877,4 +1877,4 @@ vmovdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovdqu	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovdqu	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovdqu	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-avx-ymm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-avx-ymm.s
@@ -407,7 +407,7 @@ vmovdqu %ymm15, %ymm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovaps	%ymm13, %ymm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovaps	%ymm14, %ymm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovaps	%ymm15, %ymm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -701,7 +701,7 @@ vmovdqu %ymm15, %ymm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovups	%ymm13, %ymm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovups	%ymm14, %ymm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovups	%ymm15, %ymm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -995,7 +995,7 @@ vmovdqu %ymm15, %ymm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovapd	%ymm13, %ymm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovapd	%ymm14, %ymm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovapd	%ymm15, %ymm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -1289,7 +1289,7 @@ vmovdqu %ymm15, %ymm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovupd	%ymm13, %ymm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovupd	%ymm14, %ymm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovupd	%ymm15, %ymm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -1583,7 +1583,7 @@ vmovdqu %ymm15, %ymm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovdqa	%ymm13, %ymm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovdqa	%ymm14, %ymm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovdqa	%ymm15, %ymm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -1877,4 +1877,4 @@ vmovdqu %ymm15, %ymm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       vmovdqu	%ymm13, %ymm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       vmovdqu	%ymm14, %ymm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       vmovdqu	%ymm15, %ymm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-gpr.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-gpr.s
@@ -337,7 +337,7 @@ xchgq %r15, %rax
 # CHECK-NEXT: 11.    10    0.0    0.0    0.0       movl	%r13d, %r14d
 # CHECK-NEXT: 12.    10    0.0    0.0    0.0       movl	%r14d, %r15d
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movl	%r15d, %eax
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        140   0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -605,7 +605,7 @@ xchgq %r15, %rax
 # CHECK-NEXT: 11.    10    0.0    0.0    0.0       movq	%r13, %r14
 # CHECK-NEXT: 12.    10    0.0    0.0    0.0       movq	%r14, %r15
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movq	%r15, %rax
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        140   0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -873,7 +873,7 @@ xchgq %r15, %rax
 # CHECK-NEXT: 11.    10    0.0    0.0    0.0       xchgl	%r13d, %r14d
 # CHECK-NEXT: 12.    10    0.0    0.0    0.0       xchgl	%r14d, %r15d
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       xchgl	%r15d, %eax
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        140   0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -1141,4 +1141,4 @@ xchgq %r15, %rax
 # CHECK-NEXT: 11.    10    0.0    0.0    0.0       xchgq	%r13, %r14
 # CHECK-NEXT: 12.    10    0.0    0.0    0.0       xchgq	%r14, %r15
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       xchgq	%r15, %rax
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        140   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-mmx.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-mmx.s
@@ -190,4 +190,4 @@ movq %mm7, %mm0
 # CHECK-NEXT: 5.     10    35.5   0.0    0.0       movq	%mm5, %mm6
 # CHECK-NEXT: 6.     10    36.1   0.0    0.0       movq	%mm6, %mm7
 # CHECK-NEXT: 7.     10    37.0   0.0    0.0       movq	%mm7, %mm0
-# CHECK-NEXT:        10    34.2   0.0    0.0       <total>
+# CHECK-NEXT:        80    34.2   0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-sse-xmm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-sse-xmm.s
@@ -407,7 +407,7 @@ movdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movaps	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       movaps	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       movaps	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [1] Code Region
 
@@ -701,7 +701,7 @@ movdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movups	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       movups	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       movups	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [2] Code Region
 
@@ -995,7 +995,7 @@ movdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movapd	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       movapd	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       movapd	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [3] Code Region
 
@@ -1289,7 +1289,7 @@ movdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movupd	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       movupd	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       movupd	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [4] Code Region
 
@@ -1583,7 +1583,7 @@ movdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movdqa	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       movdqa	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       movdqa	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>
 
 # CHECK:      [5] Code Region
 
@@ -1877,4 +1877,4 @@ movdqu %xmm15, %xmm0
 # CHECK-NEXT: 13.    10    0.0    0.0    0.0       movdqu	%xmm13, %xmm14
 # CHECK-NEXT: 14.    10    0.0    0.0    0.0       movdqu	%xmm14, %xmm15
 # CHECK-NEXT: 15.    10    0.0    0.0    0.0       movdqu	%xmm15, %xmm0
-# CHECK-NEXT:        10    0.0    0.0    0.0       <total>
+# CHECK-NEXT:        160   0.0    0.0    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-x87.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/reg-move-elimination-x87.s
@@ -201,4 +201,4 @@ fxch %st(0)
 # CHECK-NEXT: 6.     10    38.3   38.3   0.0       fxch	%st(6)
 # CHECK-NEXT: 7.     10    39.5   39.5   0.0       fxch	%st(7)
 # CHECK-NEXT: 8.     10    40.7   40.7   0.0       fxch	%st(0)
-# CHECK-NEXT:        10    37.0   37.0   0.0       <total>
+# CHECK-NEXT:        90    37.0   37.0   0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-avx-xmm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-avx-xmm.s
@@ -180,7 +180,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vxorps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vxorps	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [1] Code Region
 
@@ -271,7 +271,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vxorpd	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vxorpd	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [2] Code Region
 
@@ -362,7 +362,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vandnps	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vandnps	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [3] Code Region
 
@@ -453,7 +453,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vandnpd	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vandnpd	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [4] Code Region
 
@@ -544,7 +544,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpxor	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpxor	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [5] Code Region
 
@@ -635,7 +635,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpandn	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpandn	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [6] Code Region
 
@@ -726,7 +726,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubb	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubb	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [7] Code Region
 
@@ -817,7 +817,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubw	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubw	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [8] Code Region
 
@@ -908,7 +908,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubd	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubd	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [9] Code Region
 
@@ -999,7 +999,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubq	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubq	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [10] Code Region
 
@@ -1090,7 +1090,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubsb	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [11] Code Region
 
@@ -1181,7 +1181,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubsw	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [12] Code Region
 
@@ -1272,7 +1272,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubusb	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [13] Code Region
 
@@ -1363,7 +1363,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubusw	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%xmm1, %xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [14] Code Region
 
@@ -1454,7 +1454,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtb	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddb	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [15] Code Region
 
@@ -1545,7 +1545,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtw	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddw	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [16] Code Region
 
@@ -1636,7 +1636,7 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtd	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddd	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [17] Code Region
 
@@ -1727,4 +1727,4 @@ vpaddq %xmm0, %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtq	%xmm0, %xmm0, %xmm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddq	%xmm0, %xmm0, %xmm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-avx-ymm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-avx-ymm.s
@@ -190,7 +190,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vxorps	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vxorps	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [1] Code Region
 
@@ -281,7 +281,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vxorpd	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vxorpd	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [2] Code Region
 
@@ -372,7 +372,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vandnps	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vandnps	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [3] Code Region
 
@@ -463,7 +463,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vandnpd	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vandnpd	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [4] Code Region
 
@@ -554,7 +554,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpxor	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpxor	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [5] Code Region
 
@@ -645,7 +645,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpandn	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpandn	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [6] Code Region
 
@@ -736,7 +736,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubb	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubb	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [7] Code Region
 
@@ -827,7 +827,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubw	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubw	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [8] Code Region
 
@@ -918,7 +918,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubd	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubd	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [9] Code Region
 
@@ -1009,7 +1009,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpsubq	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpsubq	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [10] Code Region
 
@@ -1100,7 +1100,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubsb	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [11] Code Region
 
@@ -1191,7 +1191,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubsw	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [12] Code Region
 
@@ -1282,7 +1282,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubusb	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [13] Code Region
 
@@ -1373,7 +1373,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       vpsubusw	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       vpxor	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [14] Code Region
 
@@ -1464,7 +1464,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtb	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddb	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [15] Code Region
 
@@ -1555,7 +1555,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtw	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddw	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [16] Code Region
 
@@ -1646,7 +1646,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtd	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddd	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [17] Code Region
 
@@ -1737,7 +1737,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     0.0    0.0    1.0       vpcmpgtq	%ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     1.0    1.0    0.0       vpaddq	%ymm0, %ymm0, %ymm0
-# CHECK-NEXT:        2     0.5    0.5    0.5       <total>
+# CHECK-NEXT:        4     0.5    0.5    0.5       <total>
 
 # CHECK:      [18] Code Region
 
@@ -1829,7 +1829,7 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     3.0    0.5    0.0       vperm2f128	$136, %ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       vxorps	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     4.5    0.3    0.0       <total>
+# CHECK-NEXT:        4     4.5    0.3    0.0       <total>
 
 # CHECK:      [19] Code Region
 
@@ -1921,4 +1921,4 @@ vpxor %ymm1, %ymm0, %ymm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     3.0    0.5    0.0       vperm2i128	$136, %ymm0, %ymm0, %ymm0
 # CHECK-NEXT: 1.     2     6.0    0.0    0.0       vpxor	%ymm1, %ymm0, %ymm0
-# CHECK-NEXT:        2     4.5    0.3    0.0       <total>
+# CHECK-NEXT:        4     4.5    0.3    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-gpr.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-gpr.s
@@ -126,7 +126,7 @@ addq %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     10    0.0    0.0    1.5       xorl	%eax, %eax
 # CHECK-NEXT: 1.     10    1.0    1.0    0.0       addl	%eax, %eax
-# CHECK-NEXT:        10    0.5    0.5    0.8       <total>
+# CHECK-NEXT:        20    0.5    0.5    0.8       <total>
 
 # CHECK:      [1] Code Region
 
@@ -233,7 +233,7 @@ addq %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     10    0.0    0.0    1.5       xorq	%rax, %rax
 # CHECK-NEXT: 1.     10    1.0    1.0    0.0       addq	%rax, %rax
-# CHECK-NEXT:        10    0.5    0.5    0.8       <total>
+# CHECK-NEXT:        20    0.5    0.5    0.8       <total>
 
 # CHECK:      [2] Code Region
 
@@ -340,7 +340,7 @@ addq %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     10    0.0    0.0    1.5       subl	%eax, %eax
 # CHECK-NEXT: 1.     10    1.0    1.0    0.0       addl	%eax, %eax
-# CHECK-NEXT:        10    0.5    0.5    0.8       <total>
+# CHECK-NEXT:        20    0.5    0.5    0.8       <total>
 
 # CHECK:      [3] Code Region
 
@@ -447,4 +447,4 @@ addq %rax, %rax
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     10    0.0    0.0    1.5       subq	%rax, %rax
 # CHECK-NEXT: 1.     10    1.0    1.0    0.0       addq	%rax, %rax
-# CHECK-NEXT:        10    0.5    0.5    0.8       <total>
+# CHECK-NEXT:        20    0.5    0.5    0.8       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-sse-xmm.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver3/zero-idioms-sse-xmm.s
@@ -180,7 +180,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       xorps	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       xorps	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [1] Code Region
 
@@ -271,7 +271,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       xorpd	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       xorpd	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [2] Code Region
 
@@ -362,7 +362,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       andnps	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       andnps	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [3] Code Region
 
@@ -453,7 +453,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       andnpd	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       andnpd	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [4] Code Region
 
@@ -544,7 +544,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pxor	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       pxor	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [5] Code Region
 
@@ -635,7 +635,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pandn	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       pandn	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [6] Code Region
 
@@ -726,7 +726,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubb	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       psubb	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [7] Code Region
 
@@ -817,7 +817,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubw	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       psubw	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [8] Code Region
 
@@ -908,7 +908,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubd	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       psubd	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [9] Code Region
 
@@ -999,7 +999,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubq	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       psubq	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [10] Code Region
 
@@ -1090,7 +1090,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubsb	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       pxor	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [11] Code Region
 
@@ -1181,7 +1181,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubsw	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       pxor	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [12] Code Region
 
@@ -1272,7 +1272,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubusb	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       pxor	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [13] Code Region
 
@@ -1363,7 +1363,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       psubusw	%xmm1, %xmm1
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       pxor	%xmm0, %xmm1
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [14] Code Region
 
@@ -1454,7 +1454,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpgtb	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddb	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [15] Code Region
 
@@ -1545,7 +1545,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpgtw	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddw	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [16] Code Region
 
@@ -1636,7 +1636,7 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpgtd	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddd	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>
 
 # CHECK:      [17] Code Region
 
@@ -1727,4 +1727,4 @@ paddq %xmm0, %xmm0
 # CHECK:            [0]    [1]    [2]    [3]
 # CHECK-NEXT: 0.     2     1.0    1.0    0.5       pcmpgtq	%xmm0, %xmm0
 # CHECK-NEXT: 1.     2     2.0    0.0    0.0       paddq	%xmm0, %xmm0
-# CHECK-NEXT:        2     1.5    0.5    0.3       <total>
+# CHECK-NEXT:        4     1.5    0.5    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver4/independent-load-stores.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver4/independent-load-stores.s
@@ -141,7 +141,7 @@
 # NOALIAS-NEXT:  7.     1     4.0    0.0    0.0       addq	$44, 512(%r14)
 # NOALIAS-NEXT:  8.     1     5.0    1.0    0.0       addq	$44, 576(%r14)
 # NOALIAS-NEXT:  9.     1     6.0    1.0    0.0       addq	$44, 640(%r14)
-# NOALIAS-NEXT:         1     3.3    0.7    0.0       <total>
+# NOALIAS-NEXT:        10    3.3    0.7    0.0       <total>
 
 # YESALIAS-NEXT: 1.     1     7.0    0.0    0.0       addq	$44, 128(%r14)
 # YESALIAS-NEXT: 2.     1     13.0   0.0    0.0       addq	$44, 192(%r14)
@@ -152,4 +152,4 @@
 # YESALIAS-NEXT: 7.     1     42.0   0.0    0.0       addq	$44, 512(%r14)
 # YESALIAS-NEXT: 8.     1     48.0   0.0    0.0       addq	$44, 576(%r14)
 # YESALIAS-NEXT: 9.     1     54.0   0.0    0.0       addq	$44, 640(%r14)
-# YESALIAS-NEXT:        1     27.6   0.1    0.0       <total>
+# YESALIAS-NEXT:        10    27.6   0.1    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver4/partially-overlapping-group-resources.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver4/partially-overlapping-group-resources.s
@@ -88,4 +88,4 @@ vpxord zmm1, zmm1, zmm1
 # CHECK-NEXT: 0.     1     1.0    1.0    0.0       vpconflictd	zmm0, zmm3
 # CHECK-NEXT: 1.     1     3.0    3.0    3.0       kxnorw	k1, k1, k1
 # CHECK-NEXT: 2.     1     0.0    0.0    7.0       vpxord	zmm1, zmm1, zmm1
-# CHECK-NEXT:        1     1.3    1.3    3.3       <total>
+# CHECK-NEXT:        3     1.3    1.3    3.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/Znver4/zero-idioms.s
+++ b/llvm/test/tools/llvm-mca/X86/Znver4/zero-idioms.s
@@ -793,4 +793,4 @@ vpxorq  %zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 136.   1     0.0    0.0    1.0       vpxorq	%ymm19, %ymm19, %ymm21
 # CHECK-NEXT: 137.   1     0.0    0.0    1.0       vpxord	%zmm19, %zmm19, %zmm21
 # CHECK-NEXT: 138.   1     0.0    0.0    0.0       vpxorq	%zmm19, %zmm19, %zmm21
-# CHECK-NEXT:        1     0.2    0.1    1.6       <total>
+# CHECK-NEXT:        139   0.2    0.1    1.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/bextr-read-after-ld.s
+++ b/llvm/test/tools/llvm-mca/X86/bextr-read-after-ld.s
@@ -141,4 +141,4 @@ bextrl	%esi, (%rdi), %eax
 # ALL:                [0]    [1]    [2]    [3]
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       addl	%edi, %esi
 # ALL-NEXT:     1.     1     1.0    0.0    0.0       bextrl	%esi, (%rdi), %eax
-# ALL-NEXT:            1     1.0    0.5    0.0       <total>
+# ALL-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/bzhi-read-after-ld.s
+++ b/llvm/test/tools/llvm-mca/X86/bzhi-read-after-ld.s
@@ -94,4 +94,4 @@ bzhil	%esi, (%rdi), %eax
 # ALL:                [0]    [1]    [2]    [3]
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       addl	%edi, %esi
 # ALL-NEXT:     1.     1     1.0    0.0    0.0       bzhil	%esi, (%rdi), %eax
-# ALL-NEXT:            1     1.0    0.5    0.0       <total>
+# ALL-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/fma3-read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/fma3-read-after-ld-1.s
@@ -79,4 +79,4 @@ vfmadd213ps (%rdi), %xmm1, %xmm2
 # ALL:                [0]    [1]    [2]    [3]
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm1
 # ALL-NEXT:     1.     1     1.0    0.0    0.0       vfmadd213ps	(%rdi), %xmm1, %xmm2
-# ALL-NEXT:            1     1.0    0.5    0.0       <total>
+# ALL-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/fma3-read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/fma3-read-after-ld-2.s
@@ -79,4 +79,4 @@ vfmadd213ps (%rdi), %xmm1, %xmm2
 # ALL:                [0]    [1]    [2]    [3]
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm2
 # ALL-NEXT:     1.     1     1.0    0.0    0.0       vfmadd213ps	(%rdi), %xmm1, %xmm2
-# ALL-NEXT:            1     1.0    0.5    0.0       <total>
+# ALL-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/read-after-ld-1.s
@@ -184,34 +184,34 @@ vaddps  (%rax), %xmm1, %xmm1
 # ALL-NEXT:       0.     1     1.0    1.0    0.0       vdivps	%xmm0, %xmm1, %xmm1
 
 # BARCELONA-NEXT: 1.     1     9.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# BARCELONA-NEXT:        1     5.0    0.5    0.0       <total>
+# BARCELONA-NEXT:        2     5.0    0.5    0.0       <total>
 
 # BDVER2-NEXT:    1.     1     5.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# BDVER2-NEXT:           1     3.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     3.0    0.5    0.0       <total>
 
 # BDWELL-NEXT:    1.     1     7.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# BDWELL-NEXT:           1     4.0    0.5    0.0       <total>
+# BDWELL-NEXT:        2     4.0    0.5    0.0       <total>
 
 # BTVER2-NEXT:    1.     1     15.0   0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# BTVER2-NEXT:           1     8.0    0.5    0.0       <total>
+# BTVER2-NEXT:        2     8.0    0.5    0.0       <total>
 
 # HASWELL-NEXT:   1.     1     8.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# HASWELL-NEXT:          1     4.5    0.5    0.0       <total>
+# HASWELL-NEXT:        2     4.5    0.5    0.0       <total>
 
 # SANDY-NEXT:     1.     1     9.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# SANDY-NEXT:            1     5.0    0.5    0.0       <total>
+# SANDY-NEXT:        2     5.0    0.5    0.0       <total>
 
 # SKYLAKE-NEXT:   1.     1     6.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# SKYLAKE-NEXT:          1     3.5    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     3.5    0.5    0.0       <total>
 
 # ZNVER1-NEXT:    1.     1     3.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# ZNVER1-NEXT:           1     2.0    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     2.0    0.5    0.0       <total>
 
 # ZNVER2-NEXT:    1.     1     4.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# ZNVER2-NEXT:           1     2.5    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     2.5    0.5    0.0       <total>
 
 # ZNVER3-NEXT:    1.     1     5.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# ZNVER3-NEXT:           1     3.0    0.5    0.0       <total>
+# ZNVER3-NEXT:        2     3.0    0.5    0.0       <total>
 
 # ZNVER4-NEXT:    1.     1     5.0    0.0    0.0       vaddps	(%rax), %xmm1, %xmm1
-# ZNVER4-NEXT:           1     3.0    0.5    0.0       <total>
+# ZNVER4-NEXT:        2     3.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/read-after-ld-2.s
@@ -301,20 +301,20 @@ cmp     %edi, %edx
 
 # BDWELL-NEXT:  2.     10    1.0    0.4    5.7       addq	$32, %r8
 # BDWELL-NEXT:  3.     10    1.0    0.0    5.3       cmpl	%edi, %edx
-# BDWELL-NEXT:         10    1.0    0.2    3.9       <total>
+# BDWELL-NEXT:        40    1.0    0.2    3.9       <total>
 
 # HASWELL-NEXT: 2.     10    1.0    0.4    6.7       addq	$32, %r8
 # HASWELL-NEXT: 3.     10    1.0    0.0    6.3       cmpl	%edi, %edx
-# HASWELL-NEXT:        10    1.0    0.2    4.6       <total>
+# HASWELL-NEXT:        40    1.0    0.2    4.6       <total>
 
 # SKYLAKE-NEXT: 2.     10    1.0    0.1    7.0       addq	$32, %r8
 # SKYLAKE-NEXT: 3.     10    2.0    0.0    6.0       cmpl	%edi, %edx
-# SKYLAKE-NEXT:        10    1.5    0.1    4.6       <total>
+# SKYLAKE-NEXT:        40    1.5    0.1    4.6       <total>
 
 # ZNVER1-NEXT:  2.     10    1.0    0.4    6.7       addq	$32, %r8
 # ZNVER1-NEXT:  3.     10    1.0    0.0    6.3       cmpl	%edi, %edx
-# ZNVER1-NEXT:         10    1.0    0.2    4.6       <total>
+# ZNVER1-NEXT:        40    1.0    0.2    4.6       <total>
 
 # ZNVER2-NEXT:  2.     10    1.0    0.1    7.0       addq	$32, %r8
 # ZNVER2-NEXT:  3.     10    2.0    0.0    6.0       cmpl	%edi, %edx
-# ZNVER2-NEXT:         10    1.3    0.1    4.6       <total>
+# ZNVER2-NEXT:        40    1.3    0.1    4.6       <total>

--- a/llvm/test/tools/llvm-mca/X86/read-after-ld-3.s
+++ b/llvm/test/tools/llvm-mca/X86/read-after-ld-3.s
@@ -49,4 +49,4 @@ addl    (%rdi), %esi
 # ALL:                [0]    [1]    [2]    [3]
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       addl	%edi, %esi
 # ALL-NEXT:     1.     1     1.0    0.0    0.0       addl	(%rdi), %esi
-# ALL-NEXT:            1     1.0    0.5    0.0       <total>
+# ALL-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/sqrt-rsqrt-rcp-memop.s
+++ b/llvm/test/tools/llvm-mca/X86/sqrt-rsqrt-rcp-memop.s
@@ -91,28 +91,28 @@ rcpss (%rax), %xmm1
 # ALL-NEXT:       0.     1     1.0    1.0    0.0       leaq	8(%rsp,%rdi,2), %rax
 
 # BARCELONA-NEXT: 1.     1     2.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# BARCELONA-NEXT:        1     1.5    0.5    0.0       <total>
+# BARCELONA-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BDVER2-NEXT:    1.     1     3.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# BDVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # BROADWELL-NEXT: 1.     1     2.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# BROADWELL-NEXT:        1     1.5    0.5    0.0       <total>
+# BROADWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BTVER2-NEXT:    1.     1     3.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# BTVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BTVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # HASWELL-NEXT:   1.     1     2.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# HASWELL-NEXT:          1     1.5    0.5    0.0       <total>
+# HASWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # SKYLAKE-NEXT:   1.     1     2.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# SKYLAKE-NEXT:          1     1.5    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER1-NEXT:    1.     1     2.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# ZNVER1-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER2-NEXT:    1.     1     2.0    0.0    0.0       sqrtss	(%rax), %xmm1
-# ZNVER2-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ALL:            [1] Code Region - test_sqrtsd
 
@@ -176,28 +176,28 @@ rcpss (%rax), %xmm1
 # ALL-NEXT:       0.     1     1.0    1.0    0.0       leaq	8(%rsp,%rdi,2), %rax
 
 # BARCELONA-NEXT: 1.     1     2.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# BARCELONA-NEXT:        1     1.5    0.5    0.0       <total>
+# BARCELONA-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BDVER2-NEXT:    1.     1     3.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# BDVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # BROADWELL-NEXT: 1.     1     2.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# BROADWELL-NEXT:        1     1.5    0.5    0.0       <total>
+# BROADWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BTVER2-NEXT:    1.     1     3.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# BTVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BTVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # HASWELL-NEXT:   1.     1     2.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# HASWELL-NEXT:          1     1.5    0.5    0.0       <total>
+# HASWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # SKYLAKE-NEXT:   1.     1     2.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# SKYLAKE-NEXT:          1     1.5    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER1-NEXT:    1.     1     2.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# ZNVER1-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER2-NEXT:    1.     1     2.0    0.0    0.0       sqrtsd	(%rax), %xmm1
-# ZNVER2-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ALL:            [2] Code Region - test_rsqrtss
 
@@ -248,28 +248,28 @@ rcpss (%rax), %xmm1
 # ALL-NEXT:       0.     1     1.0    1.0    0.0       leaq	8(%rsp,%rdi,2), %rax
 
 # BARCELONA-NEXT: 1.     1     2.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# BARCELONA-NEXT:        1     1.5    0.5    0.0       <total>
+# BARCELONA-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BDVER2-NEXT:    1.     1     3.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# BDVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # BROADWELL-NEXT: 1.     1     2.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# BROADWELL-NEXT:        1     1.5    0.5    0.0       <total>
+# BROADWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BTVER2-NEXT:    1.     1     3.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# BTVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BTVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # HASWELL-NEXT:   1.     1     2.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# HASWELL-NEXT:          1     1.5    0.5    0.0       <total>
+# HASWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # SKYLAKE-NEXT:   1.     1     2.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# SKYLAKE-NEXT:          1     1.5    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER1-NEXT:    1.     1     2.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# ZNVER1-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER2-NEXT:    1.     1     2.0    0.0    0.0       rsqrtss	(%rax), %xmm1
-# ZNVER2-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ALL:            [3] Code Region - test_rcp
 
@@ -320,25 +320,25 @@ rcpss (%rax), %xmm1
 # ALL-NEXT:       0.     1     1.0    1.0    0.0       leaq	8(%rsp,%rdi,2), %rax
 
 # BARCELONA-NEXT: 1.     1     2.0    0.0    0.0       rcpss	(%rax), %xmm1
-# BARCELONA-NEXT:        1     1.5    0.5    0.0       <total>
+# BARCELONA-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BDVER2-NEXT:    1.     1     3.0    0.0    0.0       rcpss	(%rax), %xmm1
-# BDVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # BROADWELL-NEXT: 1.     1     2.0    0.0    0.0       rcpss	(%rax), %xmm1
-# BROADWELL-NEXT:        1     1.5    0.5    0.0       <total>
+# BROADWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # BTVER2-NEXT:    1.     1     3.0    0.0    0.0       rcpss	(%rax), %xmm1
-# BTVER2-NEXT:           1     2.0    0.5    0.0       <total>
+# BTVER2-NEXT:        2     2.0    0.5    0.0       <total>
 
 # HASWELL-NEXT:   1.     1     2.0    0.0    0.0       rcpss	(%rax), %xmm1
-# HASWELL-NEXT:          1     1.5    0.5    0.0       <total>
+# HASWELL-NEXT:        2     1.5    0.5    0.0       <total>
 
 # SKYLAKE-NEXT:   1.     1     2.0    0.0    0.0       rcpss	(%rax), %xmm1
-# SKYLAKE-NEXT:          1     1.5    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER1-NEXT:    1.     1     2.0    0.0    0.0       rcpss	(%rax), %xmm1
-# ZNVER1-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     1.5    0.5    0.0       <total>
 
 # ZNVER2-NEXT:    1.     1     2.0    0.0    0.0       rcpss	(%rax), %xmm1
-# ZNVER2-NEXT:           1     1.5    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     1.5    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/stack-engine-pop.s
+++ b/llvm/test/tools/llvm-mca/X86/stack-engine-pop.s
@@ -89,4 +89,4 @@ popq %r12
 # CHECK-NEXT: 3.     2     2.0    1.0    0.0       popq	%rdx
 # CHECK-NEXT: 4.     2     2.5    1.5    0.0       popq	%rbx
 # CHECK-NEXT: 5.     2     3.0    2.0    0.0       popq	%r12
-# CHECK-NEXT:        2     2.2    1.0    0.5       <total>
+# CHECK-NEXT:        12    2.2    1.0    0.5       <total>

--- a/llvm/test/tools/llvm-mca/X86/stack-engine-push.s
+++ b/llvm/test/tools/llvm-mca/X86/stack-engine-push.s
@@ -89,4 +89,4 @@ pushq %r12
 # CHECK-NEXT: 3.     2     4.0    1.0    0.0       pushq	%rdx
 # CHECK-NEXT: 4.     2     4.0    1.0    0.0       pushq	%rbx
 # CHECK-NEXT: 5.     2     5.0    1.0    0.0       pushq	%r12
-# CHECK-NEXT:        2     3.3    0.9    0.3       <total>
+# CHECK-NEXT:        12    3.3    0.9    0.3       <total>

--- a/llvm/test/tools/llvm-mca/X86/variable-blend-read-after-ld-1.s
+++ b/llvm/test/tools/llvm-mca/X86/variable-blend-read-after-ld-1.s
@@ -168,28 +168,28 @@ vblendvps %xmm1, (%rdi), %xmm2, %xmm3
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm1
 
 # BDVER2-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# BDVER2-NEXT:         1     1.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     1.0    0.5    0.0       <total>
 
 # BDWELL-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# BDWELL-NEXT:         1     1.0    0.5    0.0       <total>
+# BDWELL-NEXT:        2     1.0    0.5    0.0       <total>
 
 # BTVER2-NEXT:  1.     1     1.0    1.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# BTVER2-NEXT:         1     1.0    1.0    0.0       <total>
+# BTVER2-NEXT:        2     1.0    1.0    0.0       <total>
 
 # HASWELL-NEXT: 1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# HASWELL-NEXT:        1     1.0    0.5    0.0       <total>
+# HASWELL-NEXT:        2     1.0    0.5    0.0       <total>
 
 # IVY-NEXT:     1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# IVY-NEXT:            1     1.0    0.5    0.0       <total>
+# IVY-NEXT:        2     1.0    0.5    0.0       <total>
 
 # SANDY-NEXT:   1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# SANDY-NEXT:          1     1.0    0.5    0.0       <total>
+# SANDY-NEXT:        2     1.0    0.5    0.0       <total>
 
 # SKYLAKE-NEXT: 1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# SKYLAKE-NEXT:        1     1.0    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     1.0    0.5    0.0       <total>
 
 # ZNVER1-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# ZNVER1-NEXT:         1     1.0    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     1.0    0.5    0.0       <total>
 
 # ZNVER2-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# ZNVER2-NEXT:         1     1.0    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/test/tools/llvm-mca/X86/variable-blend-read-after-ld-2.s
+++ b/llvm/test/tools/llvm-mca/X86/variable-blend-read-after-ld-2.s
@@ -168,28 +168,28 @@ vblendvps %xmm1, (%rdi), %xmm2, %xmm3
 # ALL-NEXT:     0.     1     1.0    1.0    0.0       vaddps	%xmm0, %xmm0, %xmm2
 
 # BDVER2-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# BDVER2-NEXT:         1     1.0    0.5    0.0       <total>
+# BDVER2-NEXT:        2     1.0    0.5    0.0       <total>
 
 # BDWELL-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# BDWELL-NEXT:         1     1.0    0.5    0.0       <total>
+# BDWELL-NEXT:        2     1.0    0.5    0.0       <total>
 
 # BTVER2-NEXT:  1.     1     1.0    1.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# BTVER2-NEXT:         1     1.0    1.0    0.0       <total>
+# BTVER2-NEXT:        2     1.0    1.0    0.0       <total>
 
 # HASWELL-NEXT: 1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# HASWELL-NEXT:        1     1.0    0.5    0.0       <total>
+# HASWELL-NEXT:        2     1.0    0.5    0.0       <total>
 
 # IVY-NEXT:     1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# IVY-NEXT:            1     1.0    0.5    0.0       <total>
+# IVY-NEXT:        2     1.0    0.5    0.0       <total>
 
 # SANDY-NEXT:   1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# SANDY-NEXT:          1     1.0    0.5    0.0       <total>
+# SANDY-NEXT:        2     1.0    0.5    0.0       <total>
 
 # SKYLAKE-NEXT: 1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# SKYLAKE-NEXT:        1     1.0    0.5    0.0       <total>
+# SKYLAKE-NEXT:        2     1.0    0.5    0.0       <total>
 
 # ZNVER1-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# ZNVER1-NEXT:         1     1.0    0.5    0.0       <total>
+# ZNVER1-NEXT:        2     1.0    0.5    0.0       <total>
 
 # ZNVER2-NEXT:  1.     1     1.0    0.0    0.0       vblendvps	%xmm1, (%rdi), %xmm2, %xmm3
-# ZNVER2-NEXT:         1     1.0    0.5    0.0       <total>
+# ZNVER2-NEXT:        2     1.0    0.5    0.0       <total>

--- a/llvm/tools/llvm-mca/Views/TimelineView.cpp
+++ b/llvm/tools/llvm-mca/Views/TimelineView.cpp
@@ -151,7 +151,7 @@ void TimelineView::printWaitTimeEntry(formatted_raw_ostream &OS,
   AverageTime3 = (double)(Entry.CyclesSpentAfterWBAndBeforeRetire * 10) /
                  CumulativeExecutions;
 
-  OS << Executions;
+  OS << CumulativeExecutions;
   OS.PadToColumn(13);
 
   int BufferSize = PrintingTotals ? 0 : UsedBuffer[SourceIndex].second;

--- a/llvm/tools/llvm-mca/Views/TimelineView.h
+++ b/llvm/tools/llvm-mca/Views/TimelineView.h
@@ -84,7 +84,7 @@
 /// 3.	 2	1.5	0.5	1.0	vaddss  %xmm1, %xmm0, %xmm3
 /// 4.	 2	3.5	0.0	0.0	vaddss  %xmm3, %xmm2, %xmm4
 /// 5.	 2	6.5	0.0	0.0	vaddss  %xmm4, %xmm5, %xmm6
-///      2	2.4	0.6	1.6     <total>
+///      12	2.4	0.6	1.6     <total>
 ///
 /// By comparing column [2] with column [1], we get an idea about how many
 /// cycles were spent in the scheduler's queue due to data dependencies.


### PR DESCRIPTION
 Fix the [0] column for the <total> row in llvm-mca's `Average Wait times` report.
 The total row now prints the total dynamic execution count used to normalize the
 averages, instead of the per-instruction iteration count. Update the timeline
 view docs and autogenerated test expectations accordingly.