### PR TITLE
[Clang][CodeGen] Track EH cleanup depth for guarded init and pop correctly

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -661,6 +661,7 @@ Bug Fixes in This Version
 - Fixed a crash when ``#embed`` is used with C++ modules (#GH195350)
 - Fixed an issue where ``__typeof_unqual`` and ``__typeof_unqual__`` were rejected as a declaration specifier in block scope in C++.
 - Fixed crash when checking for overflow for unary operator that can't overflow (#GH170072)
+- Fixed a crash (``Instruction does not dominate all uses`` / broken module) when a block literal capturing variables with non-trivial destructors is used to initialize a block-scope ``static`` or ``thread_local`` variable. The captures' destructors were emitted outside the guarded initialization region, producing invalid IR. (#GH188058)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -216,8 +216,15 @@ void CodeGenFunction::EmitCXXGlobalVarDeclInit(const VarDecl &D,
     }
     bool NeedsDtor =
         D.needsDestruction(getContext()) == QualType::DK_cxx_destructor;
-    if (PerformInit)
+    if (PerformInit) {
+      // The initializer may push cleanups that are lifetime-extended to the
+      // enclosing scope (e.g. destructors for block-literal captures). Bound
+      // them here so they run as part of this initialization instead of
+      // escaping to the enclosing function, where the on-stack storage they
+      // reference may not dominate (e.g. under a guarded local-static init).
+      RunCleanupsScope Scope(*this);
       EmitDeclInit(*this, D, DeclAddr);
+    }
     if (D.getType().isConstantStorage(getContext(), true, !NeedsDtor))
       EmitDeclInvariant(*this, D, DeclPtr);
     else

--- a/clang/test/CodeGen/block-static-cleanup.cpp
+++ b/clang/test/CodeGen/block-static-cleanup.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -std=c++20 -fblocks -emit-llvm -o - %s
+
+struct S {
+  ~S();
+};
+
+void test() {
+  S s1, s2;
+
+  static const int i = ^(void) {
+    (void)s1;
+    (void)s2;
+    return 0;
+  }();
+}


### PR DESCRIPTION
Fixes this github issue: https://github.com/llvm/llvm-project/issues/188058

### Scope EmitDeclInit cleanups with RunCleanupsScope

Clang crashes with an LLVM IR verification error when a block literal that captures variables with non-trivial destructors is used to initialize a block-scope static (or thread_local) variable:


```
struct S { ~S(); };

void test() {
  S s1, s2;
  static const int i = ^{ (void)s1; (void)s2; return 0; }();
}
```

```
Instruction does not dominate all uses!
  %block.captured = getelementptr ... %block ...
  call void @_ZN1SD1Ev(ptr ... %block.captured)
fatal error: error in backend: Broken module found, compilation aborted!
```

**Root cause:** A block's captures are destroyed at the end of the enclosing scope, not the full-expression, so their destructors are pushed as lifetime-extended cleanups (_pushLifetimeExtendedDestroy_). The full-expression cleanup scope in _EmitScalarExpr_ doesn't run them — it promotes them to the enclosing scope. In the guarded local-static path, _EmitGuardedInit_ emits the initializer without any enclosing cleanup scope, so the promoted capture destructors escape to function exit and are emitted on a path where the on-stack block doesn't dominate, producing invalid IR.

**Fix:** Wrap the _EmitDeclInit_ call in _EmitCXXGlobalVarDeclInit_ in a _RunCleanupsScope_. This bounds the initializer's cleanups to the initialization region — where the block storage dominates — and balances them in one place, fixing both the Itanium and Microsoft guarded-init paths without touching either _EmitGuardedInit_.