### PR TITLE
[SPIR-V] Recognize reqd_sub_group_size metadata for SubgroupSize

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -605,6 +605,9 @@ void SPIRVAsmPrinter::outputExecutionMode(const Module &M) {
     if (MDNode *Node = F.getMetadata("work_group_size_hint"))
       outputExecutionModeFromMDNode(FReg, Node,
                                     SPIRV::ExecutionMode::LocalSizeHint, 3, 1);
+    if (MDNode *Node = F.getMetadata("reqd_sub_group_size"))
+      outputExecutionModeFromMDNode(FReg, Node,
+                                    SPIRV::ExecutionMode::SubgroupSize, 0, 0);
     if (MDNode *Node = F.getMetadata("intel_reqd_sub_group_size"))
       outputExecutionModeFromMDNode(FReg, Node,
                                     SPIRV::ExecutionMode::SubgroupSize, 0, 0);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -2627,7 +2627,8 @@ static void collectReqs(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,
       MAI.Reqs.getAndAddRequirements(
           SPIRV::OperandCategory::ExecutionModeOperand,
           SPIRV::ExecutionMode::LocalSizeHint, ST);
-    if (F.getMetadata("intel_reqd_sub_group_size"))
+    if (F.getMetadata("intel_reqd_sub_group_size") ||
+        F.getMetadata("reqd_sub_group_size"))
       MAI.Reqs.getAndAddRequirements(
           SPIRV::OperandCategory::ExecutionModeOperand,
           SPIRV::ExecutionMode::SubgroupSize, ST);

--- a/llvm/test/CodeGen/SPIRV/transcoding/ReqdSubgroupSize.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/ReqdSubgroupSize.ll
@@ -1,14 +1,19 @@
-;; Check translation of intel_reqd_sub_group_size metadata to SubgroupSize
-;; execution mode and back. The IR is producded from the following OpenCL C code:
-;; kernel __attribute__((intel_reqd_sub_group_size(8)))
-;; void foo() {}
+;; Check translation of (intel_)reqd_sub_group_size metadata to SubgroupSize
+;; execution mode.
 
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV: OpCapability SubgroupDispatch
-; CHECK-SPIRV: OpEntryPoint Kernel %[[#kernel:]] "foo"
-; CHECK-SPIRV: OpExecutionMode %[[#kernel]] SubgroupSize 8
+; CHECK-SPIRV: OpEntryPoint Kernel %[[#bar_kernel:]] "bar"
+; CHECK-SPIRV: OpEntryPoint Kernel %[[#foo_kernel:]] "foo"
+; CHECK-SPIRV: OpExecutionMode %[[#bar_kernel]] SubgroupSize 8
+; CHECK-SPIRV: OpExecutionMode %[[#foo_kernel]] SubgroupSize 8
+
+define spir_kernel void @bar() !reqd_sub_group_size !0 {
+entry:
+  ret void
+}
 
 define spir_kernel void @foo() !intel_reqd_sub_group_size !0 {
 entry:


### PR DESCRIPTION
Recognize function metadata without a vendor prefix for the `SubgroupSize` Execution Mode, alongside the existing vendor-prefixed metadata.  `SubgroupSize` is a core SPIR-V feature, so representing it using vendor-prefixed metadata was misleading.

Relates to https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3742