### PR TITLE
Auto-label LifetimeSafety issues with `clang:temporal-safety`

### DIFF
--- a/.github/new-issues-labeler.yml
+++ b/.github/new-issues-labeler.yml
@@ -7,6 +7,9 @@
 'clang-tidy':
   - '/\bclang-tidy/i'
 
+'clang:temporal-safety':
+  - '/LifetimeSafety/'
+
 'libc++':
   - '/libc[+x]{2}(?!\-)/i'
 

--- a/.github/new-issues-labeler.yml
+++ b/.github/new-issues-labeler.yml
@@ -8,7 +8,7 @@
   - '/\bclang-tidy/i'
 
 'clang:temporal-safety':
-  - '/LifetimeSafety/'
+  - '/LifetimeSafety/i'
 
 'libc++':
   - '/libc[+x]{2}(?!\-)/i'


### PR DESCRIPTION
cc: @usx95