### PR TITLE
[C23] [Diagnostics] No longer warn with -Wc++98-compat when using constexpr in C23

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -558,6 +558,8 @@ Improvements to Clang's diagnostics
 
 - Clang now emits error when attribute is missing closing ``]]`` followed by ``;;``. (#GH187223)
 
+- No longer warn about C++98 compatibility when using ``constexpr`` in C23.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3135,6 +3135,9 @@ def note_private_extern : Note<
   "use __attribute__((visibility(\"hidden\"))) attribute instead">;
 
 // C23 constexpr
+def warn_c23_compat_constexpr : Warning<
+  "'constexpr' specifier is incompatible with C standards before C23">,
+  InGroup<CPre23Compat>, DefaultIgnore;
 def err_c23_constexpr_not_variable : Error<
   "'constexpr' can only be used in variable declarations">;
 def err_c23_constexpr_invalid_type : Error<

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4275,8 +4275,6 @@ void Parser::ParseDeclarationSpecifiers(
 
     // constexpr, consteval, constinit specifiers
     case tok::kw_constexpr:
-      if (getLangOpts().C23)
-        Diag(Tok, diag::warn_c23_compat_keyword) << Tok.getName();
       isInvalid = DS.SetConstexprSpec(ConstexprSpecKind::Constexpr, Loc,
                                       PrevSpec, DiagID);
       break;

--- a/clang/lib/Sema/DeclSpec.cpp
+++ b/clang/lib/Sema/DeclSpec.cpp
@@ -1436,7 +1436,9 @@ void DeclSpec::Finish(Sema &S, const PrintingPolicy &Policy) {
     S.Diag(TSTLoc, diag::warn_cxx98_compat_unicode_type)
       << (TypeSpecType == TST_char16 ? "char16_t" : "char32_t");
   if (getConstexprSpecifier() == ConstexprSpecKind::Constexpr)
-    S.Diag(ConstexprLoc, diag::warn_cxx98_compat_constexpr);
+    S.Diag(ConstexprLoc, S.getLangOpts().CPlusPlus
+                             ? diag::warn_cxx98_compat_constexpr
+                             : diag::warn_c23_compat_constexpr);
   else if (getConstexprSpecifier() == ConstexprSpecKind::Consteval)
     S.Diag(ConstexprLoc, diag::warn_cxx20_compat_consteval);
   else if (getConstexprSpecifier() == ConstexprSpecKind::Constinit)

--- a/clang/test/Parser/c23-constexpr.c
+++ b/clang/test/Parser/c23-constexpr.c
@@ -1,15 +1,28 @@
-// RUN: %clang_cc1 -fsyntax-only -verify=c23 -std=c23 %s -Wpre-c2x-compat
-// RUN: %clang_cc1 -fsyntax-only -verify=c17 -std=c17 %s
+// RUN: %clang_cc1 -fsyntax-only -verify=c23 -std=c23 %s -Wpre-c23-compat
+// RUN: %clang_cc1 -fsyntax-only -verify=c17 -std=c17 %s -Wc23-compat
 
-constexpr int a = 0; // c17-error {{unknown type name 'constexpr'}} \
-                        c23-warning {{'constexpr' is incompatible with C standards before C23}}
+constexpr int a = 0; // c17-warning {{'constexpr' is a keyword in C23}} \
+                        c17-error {{unknown type name 'constexpr'}} \
+                        c23-warning {{'constexpr' specifier is incompatible with C standards before C23}}
 
 void func(int array[constexpr]); // c23-error {{expected expression}} \
                                  // c17-error {{use of undeclared}}
 
 _Atomic constexpr int b = 0; // c23-error {{constexpr variable cannot have type 'const _Atomic(int)'}} \
-                             // c23-warning {{'constexpr' is incompatible with C standards before C23}} \
+                             // c23-warning {{'constexpr' specifier is incompatible with C standards before C23}} \
                              // c17-error {{unknown type name 'constexpr'}}
 
 int static constexpr c = 1; // c17-error {{expected ';' after top level declarator}} \
-                            // c23-warning {{'constexpr' is incompatible with C standards before C23}}
+                            // c23-warning {{'constexpr' specifier is incompatible with C standards before C23}}
+
+struct constexpr {  // c23-error {{declaration of anonymous struct must be a definition}} \
+                       c23-warning {{declaration does not declare anything}}
+    int constexpr;
+};
+
+struct constexpr f(void) {  // c23-error {{declaration of anonymous struct must be a definition}}
+    typedef int constexpr;
+    struct constexpr c;
+    c.constexpr = (constexpr) 0;
+    return c;
+}  // c23-error {{expected identifier or '('}}


### PR DESCRIPTION
Also changes the generic -Wpre-c23-compat warning about using the constexpr keyword to a more specific one about using the constexpr specifier on a declaration, to match the warning in C++ mode (and warn in Sema instead of reusing a Parse warning)