### PR TITLE
[BPF] crash fix for memcpy with unsupported alignment

### DIFF
--- a/llvm/lib/Target/BPF/BPFSelectionDAGInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFSelectionDAGInfo.cpp
@@ -21,8 +21,17 @@ using namespace llvm;
 
 #define DEBUG_TYPE "bpf-selectiondag-info"
 
+static cl::opt<unsigned> BPFMaxStoresPerMemFunc(
+    "bpf-max-stores-per-memfunc", cl::Hidden, cl::init(128),
+    cl::desc("Set the maximum number of stores for inlined BPF memory "
+             "intrinsics"));
+
 BPFSelectionDAGInfo::BPFSelectionDAGInfo()
     : SelectionDAGGenTargetInfo(BPFGenSDNodeInfo) {}
+
+unsigned BPFSelectionDAGInfo::getCommonMaxStoresPerMemFunc() const {
+  return BPFMaxStoresPerMemFunc;
+}
 
 SDValue BPFSelectionDAGInfo::EmitTargetCodeForMemcpy(
     SelectionDAG &DAG, const SDLoc &dl, SDValue Chain, SDValue Dst, SDValue Src,
@@ -31,6 +40,10 @@ SDValue BPFSelectionDAGInfo::EmitTargetCodeForMemcpy(
   // Requires the copy size to be a constant.
   ConstantSDNode *ConstantSize = dyn_cast<ConstantSDNode>(Size);
   if (!ConstantSize)
+    return SDValue();
+
+  // BPF::MEMCPY supports alignment up to 8 bytes.
+  if (Alignment.value() > 8)
     return SDValue();
 
   unsigned CopyLen = ConstantSize->getZExtValue();

--- a/llvm/lib/Target/BPF/BPFSelectionDAGInfo.h
+++ b/llvm/lib/Target/BPF/BPFSelectionDAGInfo.h
@@ -31,7 +31,7 @@ public:
                                   MachinePointerInfo DstPtrInfo,
                                   MachinePointerInfo SrcPtrInfo) const override;
 
-  unsigned getCommonMaxStoresPerMemFunc() const { return 128; }
+  unsigned getCommonMaxStoresPerMemFunc() const;
 };
 
 } // namespace llvm

--- a/llvm/test/CodeGen/BPF/libcall-memcpy-threshold.ll
+++ b/llvm/test/CodeGen/BPF/libcall-memcpy-threshold.ll
@@ -1,0 +1,28 @@
+; RUN: llc < %s -mtriple=bpfel -verify-machineinstrs -bpf-max-stores-per-memfunc=1 | FileCheck %s --check-prefix=LIBCALL
+
+; StoresNumEstimate = alignTo(16, 8) >> 3 = 2, which is greater than the
+; getCommonMaxStoresPerMemFunc() value of 1 from -bpf-max-stores-per-memfunc.
+; That prevents inline expansion and lets the generic memcpy libcall path fire.
+define dso_local void @small_copy(ptr nocapture %dst, ptr nocapture readonly %src) local_unnamed_addr {
+entry:
+  tail call void @llvm.memcpy.p0.p0.i64(ptr align 8 %dst, ptr align 8 %src, i64 16, i1 false)
+  ret void
+}
+
+; StoresNumEstimate = alignTo(16, 16) >> 4 = 1, so the threshold still allows
+; inline expansion here. The memcpy must still avoid BPF::MEMCPY because BPF
+; only supports alignment up to 8 bytes.
+define dso_local void @align16_copy(ptr nocapture %dst, ptr nocapture readonly %src) local_unnamed_addr {
+entry:
+  tail call void @llvm.memcpy.p0.p0.i64(ptr align 16 %dst, ptr align 16 %src, i64 16, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i64(ptr nocapture writeonly, ptr nocapture readonly, i64, i1 immarg)
+
+; LIBCALL-LABEL: small_copy:
+; LIBCALL:       r3 = 16
+; LIBCALL:       call memcpy
+; LIBCALL-LABEL: align16_copy:
+; LIBCALL:       r3 = 16
+; LIBCALL:       call memcpy


### PR DESCRIPTION
### Summary
BPF only has scalar load/store opcodes up to 8 bytes and `memcpy` with 16 byte alignment crashes with `llvm_unreachable("unsupported memcpy alignment");` in `BPFInstrInfo::expandMEMCPY`

### Issue
The crash can be reproduced from Rust code like:

```rust
#[no_mangle]
pub extern "C" fn entry(src: *const u128) -> u64 {
    let mut dst = [0u128; 2];
    unsafe { ptr::copy_nonoverlapping(src, dst.as_mut_ptr(), 2) };
    let _ = black_box(dst);
    0
}
```

This produces a `memcpy` with 16-byte alignment and `BPFSelectionDAGInfo::EmitTargetCodeForMemcpy` emit the `BPFISD::MEMCPY` pseudo for 16-byte alignment. That pseudo later reaches `expandMEMCPY` during the Post-RA pseudo expansion pass and hits:
```
llvm_unreachable("unsupported memcpy alignment");
```

The crash report looks like:
```
= note: PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/
        and include the crash backtrace and instructions to reproduce the bug.
        Stack dump:
        0. Running pass 'Function Pass Manager' on module 'linked_module'.
        1. Running pass 'Post-RA pseudo instruction expansion pass' on function '@entry'
```
### Fix
Return `SDValue()` in `BPFSelectionDAGInfo::EmitTargetCodeForMemcpy` when the alignment is larger than 8 bytes. LLVM then naturally falls back to the existing libcall path and emits `call memcpy` instead of creating a pseudo instruction that cannot be expanded later.

Since `memcpy`, `memset`, and `memmove` are now whitelisted, I think this fallback behavior is the right fix: unsupported target expansion should decline and use the existing libcall path instead of crashing.

### Opt-in controls around libcalls
I also want to use this chance to introduce two opt-in controls around libcalls for VM/runtime use cases built on top of the BPF backend (both controls are opt-in and disabled by default, so existing kernel projects and current BPF behavior remain unchanged), 

### --bpf-max-stores-per-memfunc
First, an opt-in flag to control over `BPFSelectionDAGInfo::getCommonMaxStoresPerMemFunc()`.

Today, the target memory expansion path uses:

```c++
if (StoresNumEstimate > getCommonMaxStoresPerMemFunc())
  return SDValue();
```

This threshold controls whether `EmitTargetCodeForMemcpy` continues emitting the BPF memory pseudo(which is later expanded with load/store ops) or falls back to the libcall path.

Currently this value is effectively fixed at 128, which means most constant-size memory operations are expanded into inline load/store sequences. Exposing the threshold gives VM/runtime users a way to allow more memory operations to fall through to libcalls, while keeping the current default behavior unchanged.

### --bpf-allows-libcalls (PR #199542 )
Second, an opt-in flag to allow additional libcalls beyond the currently whitelisted ones. 

Today BPF rejects unsupported libcalls here:

```c++
if (Sym != BPF_TRAP && Sym != "__multi3" && Sym != "__divti3" &&
    Sym != "__modti3" && Sym != "__udivti3" &&
    Sym != "__umodti3" && Sym != "memcpy" &&
    Sym != "memset" && Sym != "memmove")
  fail(
      CLI.DL, DAG,
      Twine("A call to built-in function '" + Sym +
            "' is not supported."));
```

With the new flag enabled, _this error path is skipped_ so VM/runtime environments can provide their own libcall implementations.

For VM runtimes using the BPF backend, libcalls are useful because they create an interface between normal compiler-generated code and runtime-specific optimization. We have already explored this model for u128 arithmetic, where libcalls allow normal Rust code to stay unchanged while the runtime can provide optimized behavior:

https://blueshift.gg/research/accelerating-u128-math-with-libcalls-and-jit-intrinsics

The same idea applies to memory operations. Users can continue writing normal Rust like `ptr::copy_nonoverlapping`, while the runtime can choose an implementation tailored to its execution environment.

Both controls are opt-in and disabled by default, so existing kernel projects and current BPF behavior remain unchanged.