### PR TITLE
[BPF] cli option to allow libcalls

### DIFF
--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -43,6 +43,11 @@ static cl::opt<unsigned> BPFMinimumJumpTableEntries(
     "bpf-min-jump-table-entries", cl::init(13), cl::Hidden,
     cl::desc("Set minimum number of entries to use a jump table on BPF"));
 
+static cl::opt<bool> BPFAllowsLibcalls(
+    "bpf-allows-libcalls", cl::Hidden, cl::init(false),
+    cl::desc("Allow libcalls instead of rejecting unsupported built-in "
+             "functions"));
+
 static void fail(const SDLoc &DL, SelectionDAG &DAG, const Twine &Msg,
                  SDValue Val = {}) {
   std::string Str;
@@ -601,9 +606,10 @@ SDValue BPFTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
   } else if (ExternalSymbolSDNode *E = dyn_cast<ExternalSymbolSDNode>(Callee)) {
     Callee = DAG.getTargetExternalSymbol(E->getSymbol(), PtrVT, 0);
     StringRef Sym = E->getSymbol();
-    if (Sym != BPF_TRAP && Sym != "__multi3" && Sym != "__divti3" &&
-        Sym != "__modti3" && Sym != "__udivti3" && Sym != "__umodti3" &&
-        Sym != "memcpy" && Sym != "memset" && Sym != "memmove")
+    if (!BPFAllowsLibcalls && Sym != BPF_TRAP && Sym != "__multi3" &&
+        Sym != "__divti3" && Sym != "__modti3" && Sym != "__udivti3" &&
+        Sym != "__umodti3" && Sym != "memcpy" && Sym != "memset" &&
+        Sym != "memmove")
       fail(
           CLI.DL, DAG,
           Twine("A call to built-in function '" + Sym + "' is not supported."));

--- a/llvm/test/CodeGen/BPF/libcall-non-whitelisted.ll
+++ b/llvm/test/CodeGen/BPF/libcall-non-whitelisted.ll
@@ -1,0 +1,14 @@
+; RUN: not llc < %s -mtriple=bpfel 2>&1 | FileCheck %s --check-prefix=ERR
+; RUN: llc < %s -mtriple=bpfel -bpf-allows-libcalls | FileCheck %s --check-prefix=LIBCALL
+
+; `uitofp i128` lowers to the non-whitelisted libcall `__floatuntidf`.
+define dso_local double @accept_non_whitelisted_libcall(i128 %x) local_unnamed_addr {
+entry:
+  %conv = uitofp i128 %x to double
+  ret double %conv
+}
+
+; ERR: A call to built-in function '__floatuntidf' is not supported.
+
+; LIBCALL-LABEL: accept_non_whitelisted_libcall:
+; LIBCALL:       call __floatuntidf


### PR DESCRIPTION
This is the follow up PR for PR #199541 

### --bpf-allows-libcalls
Second, an opt-in flag to allow additional libcalls beyond the currently whitelisted ones. 

Today BPF rejects unsupported libcalls here:

```c++
if (Sym != BPF_TRAP && Sym != "__multi3" && Sym != "__divti3" &&
    Sym != "__modti3" && Sym != "__udivti3" &&
    Sym != "__umodti3" && Sym != "memcpy" &&
    Sym != "memset" && Sym != "memmove")
  fail(
      CLI.DL, DAG,
      Twine("A call to built-in function '" + Sym +
            "' is not supported."));
```

With the new flag enabled, this error path is skipped so VM/runtime environments can provide their own libcall implementations.

For VM runtimes using the BPF backend, libcalls are useful because they create an interface between normal compiler-generated code and runtime-specific optimization. We have already explored this model for u128 arithmetic, where libcalls allow normal Rust code to stay unchanged while the runtime can provide optimized behavior:

https://blueshift.gg/research/accelerating-u128-math-with-libcalls-and-jit-intrinsics

The same idea applies to memory operations. Users can continue writing normal Rust like `ptr::copy_nonoverlapping`, while the runtime can choose an implementation tailored to its execution environment.

This new option is opt-in and disabled by default, so existing kernel projects and current BPF behavior remain unchanged.