### PR TITLE
[X86][AsmParser] Fix MS inline asm label mismatch with offset operator

### DIFF
--- a/clang/test/CodeGen/ms-inline-asm.c
+++ b/clang/test/CodeGen/ms-inline-asm.c
@@ -789,6 +789,20 @@ int test_indirect_field(LARGE_INTEGER LargeInteger) {
 // CHECK-LABEL: define{{.*}} i32 @test_indirect_field(
 // CHECK: call i32 asm sideeffect inteldialect "mov eax, $1",
 
+// Test that 'offset' references to inline asm labels use the same prefix
+// as the label definition (InternalSymbolPrefix, e.g. 'L' on Darwin/COFF).
+void label_offset(void) {
+  __asm {
+    label_offset_target:
+    mov eax, offset label_offset_target
+  }
+  // CHECK-LABEL: define{{.*}} void @label_offset(
+  // CHECK: call void asm sideeffect inteldialect
+  // CHECK-SAME: {{.*}}__MSASMLABEL_.${:uid}__label_offset_target:
+  // CHECK-SAME: mov eax, offset {{.*}}__MSASMLABEL_.${:uid}__label_offset_target
+  // CHECK-SAME: "~{eax},~{dirflag},~{fpsr},~{flags}"()
+}
+
 // MS ASM containing labels must not be duplicated (PR23715).
 // CHECK: attributes [[ATTR1]] = {
 // CHECK-NOT: noduplicate

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -2314,11 +2314,16 @@ bool X86AsmParser::ParseIntelInlineAsmIdentifier(
     assert(InternalName.size() && "We should have an internal name here.");
     // Push a rewrite for replacing the identifier name with the internal name,
     // unless we are parsing the operand of an offset operator
-    if (!IsParsingOffsetOperator)
+    if (!IsParsingOffsetOperator) {
       InstInfo->AsmRewrites->emplace_back(AOK_Label, Loc, Identifier.size(),
                                           InternalName);
-    else
-      Identifier = InternalName;
+    } else {
+      // Prepend InternalSymbolPrefix to match AOK_Label rewrite.
+      MCSymbol *Sym = getContext().getOrCreateSymbol(
+          getContext().getAsmInfo().getInternalSymbolPrefix() +
+          InternalName);
+      Identifier = Sym->getName();
+    }
   } else if (Info.isKind(InlineAsmIdentifierInfo::IK_EnumVal))
     return false;
   // Create the symbol reference.


### PR DESCRIPTION
When using the 'offset' operator to reference an inline asm label in
MSVC-style inline assembly, the label reference was missing the
PrivateLabelPrefix (e.g., 'L' on COFF targets). This caused a symbol
name mismatch between the label definition and its reference:

- Label definition (via AOK_Label rewrite): L__MSASMLABEL_.0__name
- Offset reference (no rewrite): __MSASMLABEL_.0__name

This mismatch resulted in an 'undefined symbol' linker error when
using lld-link on Windows.

The fix uses getOrCreateSymbol to create the prefixed symbol so that
MC knows it is referenced, and derives the Identifier from the
symbol's name.

Fixes #132863
Assisted by: Claude Opus 4.6
