### PR TITLE
Reland "[APFloat] Add exp functions for single and double using exp/expf implementations from LLVM libc." (#197440)

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -700,6 +700,10 @@ endif()
 
 set(LLVM_ENABLE_Z3_SOLVER_DEFAULT "${Z3_FOUND}")
 
+include(FindLibcCommonUtils)
+if(NOT TARGET llvm-libc-common-utilities)
+  message(FATAL_ERROR "LLVM libc is not found at ${libc_path}.")
+endif()
 
 if( LLVM_TARGETS_TO_BUILD STREQUAL "all" )
   set( LLVM_TARGETS_TO_BUILD ${LLVM_ALL_TARGETS} )

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1760,6 +1760,10 @@ inline APFloat maximumnum(const APFloat &A, const APFloat &B) {
   return A < B ? B : A;
 }
 
+/// Implement IEEE 754-2019 exp functions
+LLVM_READONLY
+APFloat exp(const APFloat &X, RoundingMode RM = APFloat::rmNearestTiesToEven);
+
 inline raw_ostream &operator<<(raw_ostream &OS, const APFloat &V) {
   V.print(OS);
   return OS;

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -29,6 +29,19 @@
 #include <cstring>
 #include <limits.h>
 
+/// Shared headers from LLVM libc
+/// Make sure to add ${LLVM_SOURCE_DIR}/../libc to include directories.
+///
+/// Notes: So far it looks like APFloat does not check errnos or floating-point
+/// exceptions after calling the math functions, so we will configure LLVM libc
+/// math functions to skip setting errnos and floating-point exceptions
+/// explicitly.  We also put them in a separate namespace so that the symbols
+/// do not clash with other libc math builds just in case.
+#define LIBC_NAMESPACE __llvm_libc_apfloat
+#define LIBC_MATH (LIBC_MATH_NO_ERRNO | LIBC_MATH_NO_EXCEPT)
+
+#include "shared/math.h"
+
 #define APFLOAT_DISPATCH_ON_SEMANTICS(METHOD_CALL)                             \
   do {                                                                         \
     if (usesLayout<IEEEFloat>(getSemantics()))                                 \
@@ -6078,6 +6091,24 @@ APFloat::Storage &APFloat::Storage::operator=(APFloat::Storage &&RHS) {
     new (this) Storage(std::move(RHS));
   }
   return *this;
+}
+
+// TODO: Support other rounding modes when LLVM libc math implement static
+// roundings.
+APFloat exp(const APFloat &X, RoundingMode rounding_mode) {
+  if (rounding_mode == APFloatBase::rmNearestTiesToEven) {
+    if (APFloat::SemanticsToEnum(X.getSemantics()) ==
+        APFloatBase::S_IEEEsingle) {
+      float result = LIBC_NAMESPACE::shared::expf(X.convertToFloat());
+      return APFloat(result);
+    }
+    if (APFloat::SemanticsToEnum(X.getSemantics()) ==
+        APFloatBase::S_IEEEdouble) {
+      double result = LIBC_NAMESPACE::shared::exp(X.convertToDouble());
+      return APFloat(result);
+    }
+  }
+  llvm_unreachable("Unexpected semantics");
 }
 
 } // namespace llvm

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -399,7 +399,12 @@ endif()
 target_include_directories(LLVMSupport
   PRIVATE
   ${LLVM_THIRD_PARTY_DIR}/siphash/include
+  ${LLVM_SOURCE_DIR}/../libc
 )
+
+if(NOT MSVC)
+  target_compile_options(LLVMSupport PRIVATE "-Wno-c99-extensions") # _Complex warnings.
+endif()
 
 # SupportLSP depends on Support and therefore must be included afterwards.
 add_subdirectory(LSP)

--- a/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULibCalls.cpp
@@ -1870,7 +1870,7 @@ bool AMDGPULibCalls::evaluateScalarMathFunc(const FuncInfo &FInfo,
     return true;
 
   case AMDGPULibFunc::EI_EXP:
-    Res0 = APFloat{exp(opr0)};
+    Res0 = APFloat{std::exp(opr0)};
     return true;
 
   case AMDGPULibFunc::EI_EXP2:

--- a/llvm/unittests/ADT/APFloatTest.cpp
+++ b/llvm/unittests/ADT/APFloatTest.cpp
@@ -10228,4 +10228,62 @@ TEST(APFloatTest, DecimalStringPreservesInexactStatus) {
   EXPECT_EQ(F.bitcastToAPInt(), Expected.bitcastToAPInt());
 }
 
+TEST(APFloatTest, expf) {
+  // exp(+-0) = 1.
+  EXPECT_EQ(1.0f, llvm::exp(APFloat(0.0f)).convertToFloat());
+  EXPECT_EQ(1.0f, llvm::exp(APFloat(-0.0f)).convertToFloat());
+  // exp(+Inf) = +Inf.
+  EXPECT_EQ(std::numeric_limits<float>::infinity(),
+            llvm::exp(APFloat::getInf(APFloat::IEEEsingle(), false))
+                .convertToFloat());
+  // exp(-Inf) = 0.
+  EXPECT_EQ(
+      0.0f,
+      llvm::exp(APFloat::getInf(APFloat::IEEEsingle(), true)).convertToFloat());
+  // exp(NaN) = NaN.
+  EXPECT_TRUE(llvm::exp(APFloat::getNaN(APFloat::IEEEsingle())).isNaN());
+  // exp(1)
+  EXPECT_EQ(0x1.5bf0a8p1f, llvm::exp(APFloat(1.0f)).convertToFloat());
+  // exp(float max)
+  EXPECT_EQ(std::numeric_limits<float>::infinity(),
+            llvm::exp(APFloat::getLargest(APFloat::IEEEsingle(), false))
+                .convertToFloat());
+  // exp(min_denormal)
+  EXPECT_EQ(1.0f, llvm::exp(APFloat::getSmallest(APFloat::IEEEsingle(), false))
+                      .convertToFloat());
+  // exp(-1)
+  EXPECT_EQ(0x1.78b564p-2f, llvm::exp(APFloat(-1.0f)).convertToFloat());
+  // exp(-90)
+  EXPECT_EQ(0x1.1d85p-130f, llvm::exp(APFloat(-90.0f)).convertToFloat());
+}
+
+TEST(APFloatTest, exp) {
+  // exp(+-0) = 1.
+  EXPECT_EQ(1.0, llvm::exp(APFloat(0.0)).convertToDouble());
+  EXPECT_EQ(1.0, llvm::exp(APFloat(-0.0)).convertToDouble());
+  // exp(+Inf) = +Inf.
+  EXPECT_EQ(std::numeric_limits<double>::infinity(),
+            llvm::exp(APFloat::getInf(APFloat::IEEEdouble(), false))
+                .convertToDouble());
+  // exp(-Inf) = 0.
+  EXPECT_EQ(0.0, llvm::exp(APFloat::getInf(APFloat::IEEEdouble(), true))
+                     .convertToDouble());
+  // exp(NaN) = NaN.
+  EXPECT_TRUE(llvm::exp(APFloat::getNaN(APFloat::IEEEdouble())).isNaN());
+  // exp(1)
+  EXPECT_EQ(0x1.5bf0a8b145769p1, llvm::exp(APFloat(1.0)).convertToDouble());
+  // exp(float max)
+  EXPECT_EQ(std::numeric_limits<double>::infinity(),
+            llvm::exp(APFloat::getLargest(APFloat::IEEEdouble(), false))
+                .convertToDouble());
+  // exp(min_denormal)
+  EXPECT_EQ(1.0, llvm::exp(APFloat::getSmallest(APFloat::IEEEdouble(), false))
+                     .convertToDouble());
+  // exp(-1)
+  EXPECT_EQ(0x1.78b56362cef38p-2, llvm::exp(APFloat(-1.0)).convertToDouble());
+  // exp(-710)
+  EXPECT_EQ(0x1.9c017e9459e18p-1025,
+            llvm::exp(APFloat(-710.0)).convertToDouble());
+}
+
 } // namespace


### PR DESCRIPTION
This reverts commit 1565f096d868f479f075fce3792db7b908cab9aa.

**Fixes applied on LLVM libc side:**
- gcc 7, 8, 9 compatibility:
  - https://github.com/llvm/llvm-project/pull/197476
  - https://github.com/llvm/llvm-project/pull/197868
- Add gcc's versions to LLVM libc-shared-tests precommit CI: https://github.com/llvm/llvm-project/pull/199300

**Original commits messages:**

Discourse RFC: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450

- The implementation in LLVM libc is free-standing header-only: https://github.com/llvm/llvm-project/issues/147386
- expf / exp implementation in LLVM libc is correctly rounded for all rounding modes.
- Only support default rounding modes for now. Other rounding modes will wait for proper static rounding implementations in LLVM libc.
- No cmake build dependency between LLVM and LLVM libc, only requires LLVM libc source presents in llvm-project/libc folder.