### PR TITLE
[clang] Enable GNU __attribute__((init_priority(...))) on z/OS.

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -535,10 +535,6 @@ def TargetWindowsArm64EC : TargetSpec {
   let CustomCode = [{ Target.getTriple().isWindowsArm64EC() }];
 }
 
-def TargetSupportsInitPriority : TargetSpec {
-  let CustomCode = [{ !Target.getTriple().isOSzOS() }];
-}
-
 class TargetSpecificSpelling<TargetSpec target, list<Spelling> spellings> {
   TargetSpec Target = target;
   list<Spelling> Spellings = spellings;
@@ -3323,7 +3319,7 @@ def WorkGroupSizeHint :  InheritableAttr {
   let Documentation = [Undocumented];
 }
 
-def InitPriority : InheritableAttr, TargetSpecificAttr<TargetSupportsInitPriority> {
+def InitPriority : InheritableAttr {
   let Spellings = [GCC<"init_priority", /*AllowInC*/0>];
   let Args = [UnsignedArgument<"Priority">];
   let Subjects = SubjectList<[Var], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -158,7 +158,7 @@ On MachO platforms, this attribute also does not control the order of initializa
 across translation units, where it only affects the order within a single TU.
 
 This attribute is only supported for C++ and Objective-C++ and is ignored in
-other language modes. Currently, this attribute is not implemented on z/OS.
+other language modes.
   }];
 }
 

--- a/clang/test/SemaCXX/init-priority-attr.cpp
+++ b/clang/test/SemaCXX/init-priority-attr.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 // RUN: %clang_cc1 -fsyntax-only -DSYSTEM -verify %s
+// RUN: %clang_cc1 -fsyntax-only -DNOERROR -Wno-error=init-priority-reserved -verify %s
 
 #if defined(SYSTEM)
 #5 "init-priority-attr.cpp" 3 // system header
@@ -26,15 +27,21 @@ extern Two koo[];
 
 Two foo __attribute__((init_priority(101))) ( 5, 6 );
 
+Two loo __attribute__((init_priority(65535))) ( 5, 6 );
+
 Two goo __attribute__((init_priority(2,3))) ( 5, 6 ); // expected-error {{'init_priority' attribute takes one argument}}
 
 Two coo[2]  __attribute__((init_priority(100)));
 #if !defined(SYSTEM)
-// expected-error@-2 {{'init_priority' 100 is reserved for internal use}}
-#endif
+#if !defined(NOERROR)
+  // expected-error@-3 {{requested 'init_priority' 100 is reserved for internal use}}
+#else  // defined(NOERROR)
+  // expected-warning@-5 {{requested 'init_priority' 100 is reserved for internal use}}
+#endif // !defined(NOERROR)
+#endif // !defined(SYSTEM)
+Two zoo[2]  __attribute__((init_priority(-1))); // expected-error {{'init_priority' attribute requires integer constant between 0 and 65535 inclusive}}
 
-Two boo[2]  __attribute__((init_priority(65536)));
-// expected-error@-1 {{'init_priority' attribute requires integer constant between 0 and 65535 inclusive}}
+Two boo[2]  __attribute__((init_priority(65536))); // expected-error {{'init_priority' attribute requires integer constant between 0 and 65535 inclusive}}
 
 Two koo[4]  __attribute__((init_priority(1.13))); // expected-error {{'init_priority' attribute requires an integer constant}}
 

--- a/clang/test/SemaCXX/init-priority-attr.cpp
+++ b/clang/test/SemaCXX/init-priority-attr.cpp
@@ -1,8 +1,5 @@
-// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -verify %s
-// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -DSYSTEM -verify %s
-// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -DNOERROR -Wno-error=init-priority-reserved -verify %s
-// RUN: %clang_cc1 -triple=s390x-none-zos -fsyntax-only -verify=unknown %s
-// RUN: %clang_cc1 -triple=s390x-none-zos -fsyntax-only -DSYSTEM -verify=unknown-system %s
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -DSYSTEM -verify %s
 
 #if defined(SYSTEM)
 #5 "init-priority-attr.cpp" 3 // system header
@@ -28,42 +25,25 @@ extern Two koo[];
 // unknown-system-no-diagnostics
 
 Two foo __attribute__((init_priority(101))) ( 5, 6 );
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
-
-Two loo __attribute__((init_priority(65535))) ( 5, 6 );
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 
 Two goo __attribute__((init_priority(2,3))) ( 5, 6 ); // expected-error {{'init_priority' attribute takes one argument}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 
 Two coo[2]  __attribute__((init_priority(100)));
 #if !defined(SYSTEM)
-#if !defined(NOERROR)
-  // expected-error@-3 {{requested 'init_priority' 100 is reserved for internal use}}
-#else  // defined(NOERROR)
-  // expected-warning@-5 {{requested 'init_priority' 100 is reserved for internal use}}
-#endif // !defined(NOERROR)
-  // unknown-warning@-7 {{unknown attribute 'init_priority' ignored}}
-#endif // !defined(SYSTEM)
+// expected-error@-2 {{'init_priority' 100 is reserved for internal use}}
+#endif
 
-Two zoo[2]  __attribute__((init_priority(-1))); // expected-error {{'init_priority' attribute requires integer constant between 0 and 65535 inclusive}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
-
-Two boo[2]  __attribute__((init_priority(65536))); // expected-error {{'init_priority' attribute requires integer constant between 0 and 65535 inclusive}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
+Two boo[2]  __attribute__((init_priority(65536)));
+// expected-error@-1 {{'init_priority' attribute requires integer constant between 0 and 65535 inclusive}}
 
 Two koo[4]  __attribute__((init_priority(1.13))); // expected-error {{'init_priority' attribute requires an integer constant}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 
 Two func()  __attribute__((init_priority(1001))); // expected-error {{'init_priority' attribute only applies to variables}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 
 int i  __attribute__((init_priority(1001))); // expected-error {{can only use 'init_priority' attribute on file-scope definitions of objects of class type}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 
 int main() {
   Two foo __attribute__((init_priority(1001))); // expected-error {{can only use 'init_priority' attribute on file-scope definitions of objects of class type}}
-// unknown-warning@-1 {{unknown attribute 'init_priority' ignored}}
 }
 
 struct S1 {} s1;

--- a/libcxx/src/iostream_init.h
+++ b/libcxx/src/iostream_init.h
@@ -1,2 +1,2 @@
 #pragma GCC system_header
-_LIBCPP_HIDDEN ios_base::Init __start_std_streams _LIBCPP_INIT_PRIORITY_MAX;
+_LIBCPP_HIDDEN ios_base::Init __start_std_streams __attribute__((init_priority(101)));

--- a/libcxx/src/iostream_init.h
+++ b/libcxx/src/iostream_init.h
@@ -1,2 +1,2 @@
 #pragma GCC system_header
-_LIBCPP_HIDDEN ios_base::Init __start_std_streams __attribute__((init_priority(101)));
+_LIBCPP_HIDDEN ios_base::Init __start_std_streams _LIBCPP_INIT_PRIORITY_MAX;


### PR DESCRIPTION
Enable `init_priority` on z/OS

Motivation
The recent addition of `clang/test/Sema/type-dependent-attrs.cpp` in https://github.com/llvm/llvm-project/pull/182208 started failing on z/OS. That test uses `[[gnu::init_priority(2000)]]`, and the failure exposed that init_priority support was still disabled for z/OS in `Attr.td`.

What changed

- Enabled init_priority for z/OS in `clang/include/clang/Basic/Attr.td`
- Updated `clang/test/SemaCXX/init-priority-attr.cpp` so z/OS now expects normal semantic handling for init_priority

This reverts commit 2c7e24c4b6893a93ddb2b2cca91eaf5bf7956965 and preserve any changes done after this commit.
