### PR TITLE
[AtomicExpand] Don't reduce volatile idempotent atomicrmw to a fenced load.

### DIFF
--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -1699,6 +1699,10 @@ bool AtomicExpandImpl::expandAtomicCmpXchg(AtomicCmpXchgInst *CI) {
 }
 
 bool AtomicExpandImpl::isIdempotentRMW(AtomicRMWInst *RMWI) {
+  // Volatile RMWs must be preserved as-is.
+  if (RMWI->isVolatile())
+    return false;
+
   // TODO: Add floating point support.
   auto C = dyn_cast<ConstantInt>(RMWI->getValOperand());
   if (!C)

--- a/llvm/test/CodeGen/X86/atomic-idempotent.ll
+++ b/llvm/test/CodeGen/X86/atomic-idempotent.ll
@@ -951,4 +951,115 @@ define void @atomic_fsub_zero(ptr %addr) #0 {
   ret void
 }
 
+; Volatile RMWs must not be reduced to a fenced load even when the value is
+; idempotent (or-zero, xor-zero, and-allones).
+
+define i32 @or32_volatile(ptr %p) #0 {
+; X64-LABEL: or32_volatile:
+; X64:       # %bb.0:
+; X64-NEXT:    movl (%rdi), %eax
+; X64-NEXT:    .p2align 4
+; X64-NEXT:  .LBB23_1: # %atomicrmw.start
+; X64-NEXT:    # =>This Inner Loop Header: Depth=1
+; X64-NEXT:    lock cmpxchgl %eax, (%rdi)
+; X64-NEXT:    jne .LBB23_1
+; X64-NEXT:  # %bb.2: # %atomicrmw.end
+; X64-NEXT:    retq
+;
+; X86-LABEL: or32_volatile:
+; X86:       # %bb.0:
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl (%ecx), %eax
+; X86-NEXT:    .p2align 4
+; X86-NEXT:  .LBB23_1: # %atomicrmw.start
+; X86-NEXT:    # =>This Inner Loop Header: Depth=1
+; X86-NEXT:    lock cmpxchgl %eax, (%ecx)
+; X86-NEXT:    jne .LBB23_1
+; X86-NEXT:  # %bb.2: # %atomicrmw.end
+; X86-NEXT:    retl
+  %res = atomicrmw volatile or ptr %p, i32 0 seq_cst
+  ret i32 %res
+}
+
+define i32 @xor32_volatile(ptr %p) #0 {
+; X64-LABEL: xor32_volatile:
+; X64:       # %bb.0:
+; X64-NEXT:    movl (%rdi), %eax
+; X64-NEXT:    .p2align 4
+; X64-NEXT:  .LBB24_1: # %atomicrmw.start
+; X64-NEXT:    # =>This Inner Loop Header: Depth=1
+; X64-NEXT:    lock cmpxchgl %eax, (%rdi)
+; X64-NEXT:    jne .LBB24_1
+; X64-NEXT:  # %bb.2: # %atomicrmw.end
+; X64-NEXT:    retq
+;
+; X86-LABEL: xor32_volatile:
+; X86:       # %bb.0:
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl (%ecx), %eax
+; X86-NEXT:    .p2align 4
+; X86-NEXT:  .LBB24_1: # %atomicrmw.start
+; X86-NEXT:    # =>This Inner Loop Header: Depth=1
+; X86-NEXT:    lock cmpxchgl %eax, (%ecx)
+; X86-NEXT:    jne .LBB24_1
+; X86-NEXT:  # %bb.2: # %atomicrmw.end
+; X86-NEXT:    retl
+  %res = atomicrmw volatile xor ptr %p, i32 0 release
+  ret i32 %res
+}
+
+define i32 @and32_volatile(ptr %p) #0 {
+; X64-LABEL: and32_volatile:
+; X64:       # %bb.0:
+; X64-NEXT:    movl (%rdi), %eax
+; X64-NEXT:    .p2align 4
+; X64-NEXT:  .LBB25_1: # %atomicrmw.start
+; X64-NEXT:    # =>This Inner Loop Header: Depth=1
+; X64-NEXT:    lock cmpxchgl %eax, (%rdi)
+; X64-NEXT:    jne .LBB25_1
+; X64-NEXT:  # %bb.2: # %atomicrmw.end
+; X64-NEXT:    retq
+;
+; X86-LABEL: and32_volatile:
+; X86:       # %bb.0:
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-NEXT:    movl (%ecx), %eax
+; X86-NEXT:    .p2align 4
+; X86-NEXT:  .LBB25_1: # %atomicrmw.start
+; X86-NEXT:    # =>This Inner Loop Header: Depth=1
+; X86-NEXT:    lock cmpxchgl %eax, (%ecx)
+; X86-NEXT:    jne .LBB25_1
+; X86-NEXT:  # %bb.2: # %atomicrmw.end
+; X86-NEXT:    retl
+  %res = atomicrmw volatile and ptr %p, i32 -1 acq_rel
+  ret i32 %res
+}
+
+; A volatile RMW with no result use already goes through DAG lowering, which
+; preserves the volatile bit.
+define void @or32_volatile_nouse_seq_cst(ptr %p) #0 {
+; X64-LABEL: or32_volatile_nouse_seq_cst:
+; X64:       # %bb.0:
+; X64-NEXT:    lock orl $0, (%rdi)
+; X64-NEXT:    retq
+;
+; X86-GENERIC-LABEL: or32_volatile_nouse_seq_cst:
+; X86-GENERIC:       # %bb.0:
+; X86-GENERIC-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-GENERIC-NEXT:    lock orl $0, (%eax)
+; X86-GENERIC-NEXT:    retl
+;
+; X86-ATOM-LABEL: or32_volatile_nouse_seq_cst:
+; X86-ATOM:       # %bb.0:
+; X86-ATOM-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-ATOM-NEXT:    lock orl $0, (%eax)
+; X86-ATOM-NEXT:    nop
+; X86-ATOM-NEXT:    nop
+; X86-ATOM-NEXT:    nop
+; X86-ATOM-NEXT:    nop
+; X86-ATOM-NEXT:    retl
+  atomicrmw volatile or ptr %p, i32 0 seq_cst
+  ret void
+}
+
 attributes #0 = { nounwind }


### PR DESCRIPTION
lowerIdempotentRMWIntoFencedLoad replaces e.g. `atomicrmw or ptr %p, i32 0` with `fence + atomic load`. That is only valid for non-volatile RMWs.

A volatile atomicrmw is not just a volatile read: LangRef specifies that atomicrmw atomically reads, modifies, and writes back the memory location, and volatile operations may have target-specific side effects such as MMIO behavior. Even an idempotent volatile RMW can therefore have an observable write/RMW transaction that a volatile load plus fence would not preserve.

Skip the idempotent-RMW load optimization for volatile RMWs. The existing fallback expansion uses a cmpxchg loop and preserves the volatile flag.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
