### PR TITLE
[LifetimeSafety] Avoid assert on variadic placement new

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety/FactsGenerator.h
@@ -76,6 +76,8 @@ private:
 
   void handlePointerArithmetic(const BinaryOperator *BO);
 
+  void handlePlacementNew(const CXXNewExpr *NE, OriginList *NewList);
+
   void handleCXXCtorInitializer(const CXXCtorInitializer *CII);
 
   void handleLifetimeEnds(const CFGLifetimeEnds &LifetimeEnds);

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -633,6 +633,10 @@ void FactsGenerator::VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
 
 void FactsGenerator::handlePlacementNew(const CXXNewExpr *NE,
                                         OriginList *NewList) {
+  // Check if we have a placement new where the second argument is void*, to
+  // avoid flowing from non-pointer parameters, such as std::nothrow.
+  // And that the placement parameter num is 1,
+  // that is to mostly limit to standard library placement new.
   if (NE->getNumPlacementArgs() != 1)
     return;
 
@@ -667,10 +671,6 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   OriginList *NewList = getOriginsList(*NE);
   const Expr *Init = NE->getInitializer();
 
-  // Check if we have a placement new where the second argument is void*, to
-  // avoid flowing from non-pointer parameters, such as std::nothrow.
-  // And that the placement parameter num is 1,
-  // that is to mostly limit to standard library placement new.
   if (NE->getNumPlacementArgs() == 1) {
     handlePlacementNew(NE, NewList);
   } else {

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -631,6 +631,38 @@ void FactsGenerator::VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
       Dst->getOuterOriginID(), Src->getOuterOriginID(), /*Kill=*/true));
 }
 
+void FactsGenerator::handlePlacementNew(const CXXNewExpr *NE,
+                                        OriginList *NewList) {
+  if (NE->getNumPlacementArgs() != 1)
+    return;
+
+  const FunctionDecl *OperatorNew = NE->getOperatorNew();
+  if (OperatorNew->getNumParams() <= 1)
+    return;
+
+  const auto *Arg =
+      OperatorNew->getParamDecl(1)->getType()->getAs<PointerType>();
+  if (!Arg || !Arg->isVoidPointerType())
+    return;
+
+  // Use the placement argument before the implicit conversion to void*, so
+  // inner origins are still available.
+  const Expr *PlacementArg = NE->getPlacementArg(0);
+  if (const auto *ICE = dyn_cast<ImplicitCastExpr>(PlacementArg);
+      ICE && ICE->getCastKind() == CK_BitCast &&
+      PlacementArg->getType()->isVoidPointerType())
+    PlacementArg = ICE->getSubExpr();
+  OriginList *PlacementList = getOriginsList(*PlacementArg);
+  // FIXME: General placement arguments need separate handling to overwrite
+  // the right origins.
+
+  // The pointer returned by placement new comes from the placement
+  // argument.
+  if (PlacementList)
+    CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
+        NewList->getOuterOriginID(), PlacementList->getOuterOriginID(), true));
+}
+
 void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   OriginList *NewList = getOriginsList(*NE);
   const Expr *Init = NE->getInitializer();
@@ -640,30 +672,7 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   // And that the placement parameter num is 1,
   // that is to mostly limit to standard library placement new.
   if (NE->getNumPlacementArgs() == 1) {
-    const FunctionDecl *OperatorNew = NE->getOperatorNew();
-    if (OperatorNew->getNumParams() > 1) {
-      if (const auto *Arg =
-              OperatorNew->getParamDecl(1)->getType()->getAs<PointerType>();
-          Arg && Arg->isVoidPointerType()) {
-        // Use the placement argument before the implicit conversion to void*,
-        // so inner origins are still available.
-        const Expr *PlacementArg = NE->getPlacementArg(0);
-        if (const auto *ICE = dyn_cast<ImplicitCastExpr>(PlacementArg);
-            ICE && ICE->getCastKind() == CK_BitCast &&
-            PlacementArg->getType()->isVoidPointerType())
-          PlacementArg = ICE->getSubExpr();
-        OriginList *PlacementList = getOriginsList(*PlacementArg);
-        // FIXME: General placement arguments need separate handling to
-        // overwrite the right origins.
-
-        // The pointer returned by placement new comes from the placement
-        // argument.
-        if (PlacementList)
-          CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
-              NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
-              true));
-      }
-    }
+    handlePlacementNew(NE, NewList);
   } else {
     const Loan *L = createLoan(FactMgr, NE);
     CurrentBlockFacts.push_back(

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -633,10 +633,10 @@ void FactsGenerator::VisitArraySubscriptExpr(const ArraySubscriptExpr *ASE) {
 
 void FactsGenerator::handlePlacementNew(const CXXNewExpr *NE,
                                         OriginList *NewList) {
-  // Check if we have a placement new where the second argument is void*, to
-  // avoid flowing from non-pointer parameters, such as std::nothrow.
-  // And that the placement parameter num is 1,
-  // that is to mostly limit to standard library placement new.
+  // Model only the standard single-argument placement new form, where the
+  // placement argument corresponds to a void* allocation-function parameter.
+  // Other placement forms, such as std::nothrow, are not modeled as providing
+  // storage for the returned pointer.
   if (NE->getNumPlacementArgs() != 1)
     return;
 

--- a/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
+++ b/clang/lib/Analysis/LifetimeSafety/FactsGenerator.cpp
@@ -640,28 +640,29 @@ void FactsGenerator::VisitCXXNewExpr(const CXXNewExpr *NE) {
   // And that the placement parameter num is 1,
   // that is to mostly limit to standard library placement new.
   if (NE->getNumPlacementArgs() == 1) {
-    if (const auto *Arg = NE->getOperatorNew()
-                              ->getParamDecl(1)
-                              ->getType()
-                              ->getAs<PointerType>();
-        Arg && Arg->isVoidPointerType()) {
-      // Use the placement argument before the implicit conversion to void*, so
-      // inner origins are still available.
-      const Expr *PlacementArg = NE->getPlacementArg(0);
-      if (const auto *ICE = dyn_cast<ImplicitCastExpr>(PlacementArg);
-          ICE && ICE->getCastKind() == CK_BitCast &&
-          PlacementArg->getType()->isVoidPointerType())
-        PlacementArg = ICE->getSubExpr();
-      OriginList *PlacementList = getOriginsList(*PlacementArg);
-      // FIXME: General placement arguments need separate handling to overwrite
-      // the right origins.
+    const FunctionDecl *OperatorNew = NE->getOperatorNew();
+    if (OperatorNew->getNumParams() > 1) {
+      if (const auto *Arg =
+              OperatorNew->getParamDecl(1)->getType()->getAs<PointerType>();
+          Arg && Arg->isVoidPointerType()) {
+        // Use the placement argument before the implicit conversion to void*,
+        // so inner origins are still available.
+        const Expr *PlacementArg = NE->getPlacementArg(0);
+        if (const auto *ICE = dyn_cast<ImplicitCastExpr>(PlacementArg);
+            ICE && ICE->getCastKind() == CK_BitCast &&
+            PlacementArg->getType()->isVoidPointerType())
+          PlacementArg = ICE->getSubExpr();
+        OriginList *PlacementList = getOriginsList(*PlacementArg);
+        // FIXME: General placement arguments need separate handling to
+        // overwrite the right origins.
 
-      // The pointer returned by placement new comes from the placement
-      // argument.
-      if (PlacementList)
-        CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
-            NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
-            true));
+        // The pointer returned by placement new comes from the placement
+        // argument.
+        if (PlacementList)
+          CurrentBlockFacts.push_back(FactMgr.createFact<OriginFlowFact>(
+              NewList->getOuterOriginID(), PlacementList->getOuterOriginID(),
+              true));
+      }
     }
   } else {
     const Loan *L = createLoan(FactMgr, NE);

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2982,6 +2982,17 @@ void placement_new_heap_then_delete_use_after_free() {
   (void)*p;                  // expected-note {{later used here}}
 }
 
+struct PlacementArg {};
+
+struct VariadicPlacementNew {
+  void *operator new(decltype(sizeof(0)), ...);
+};
+
+void variadic_placement_new() {
+  PlacementArg arg;
+  (void)new (arg) VariadicPlacementNew;
+}
+
 int* foo(int* x [[clang::lifetimebound]], int* y [[clang::lifetimebound]]);
 
 void placement_new_delete_result_of_lifetimebound_call() {

--- a/clang/test/Sema/warn-lifetime-safety.cpp
+++ b/clang/test/Sema/warn-lifetime-safety.cpp
@@ -2985,7 +2985,7 @@ void placement_new_heap_then_delete_use_after_free() {
 struct PlacementArg {};
 
 struct VariadicPlacementNew {
-  void *operator new(decltype(sizeof(0)), ...);
+  void *operator new(std::size_t, ...);
 };
 
 void variadic_placement_new() {


### PR DESCRIPTION
Avoid assuming that a placement allocation function has a second `ParmVarDecl` before checking whether that parameter is `void*`. Variadic `operator new(size_t, ...)` can have a placement argument matched by the ellipsis instead.

As of AI Usage: Codex is used to help rephrase part of the new comments.

Closes https://github.com/llvm/llvm-project/issues/199584