### PR TITLE
[X86] FixupInstTuning: ProcessShiftLeftToAdd should return true after mutating.

### DIFF
--- a/llvm/lib/Target/X86/X86FixupInstTuning.cpp
+++ b/llvm/lib/Target/X86/X86FixupInstTuning.cpp
@@ -304,7 +304,7 @@ bool X86FixupInstTuningImpl::processInstruction(
       MI.addOperand(MI.getOperand(NumOperands - 2));
     }
     LLVM_DEBUG(dbgs() << "     With: " << MI);
-    return false;
+    return true;
   };
 
   // `vpermq ymm, ymm, 0x44` -> `vinserti128 ymm, ymm, xmm, 1`


### PR DESCRIPTION
I think this is almost NFC, though it should affect some of the
compilation statistics like "number of instrs changed by X pass".

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
