### PR TITLE
[CodeGenPrepare] splitMergedValStore: don't split atomic stores.

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -8589,8 +8589,8 @@ static bool splitMergedValStore(StoreInst &SI, const DataLayout &DL,
   if (!DL.typeSizeEqualsStoreSize(SplitStoreType))
     return false;
 
-  // Don't split the store if it is volatile.
-  if (SI.isVolatile())
+  // Don't split the store if it is volatile or atomic.
+  if (!SI.isSimple())
     return false;
 
   // Match the following patterns:

--- a/llvm/test/Transforms/CodeGenPrepare/X86/split-store-alignment.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/split-store-alignment.ll
@@ -126,23 +126,3 @@ define void @volatile_store_no_split(ptr %p, i32 %lo, float %hi) {
   ret void
 }
 
-define void @plain_store_is_split(ptr %p, i32 %lo, float %hi) {
-; CHECK-LABEL: @plain_store_is_split(
-; CHECK-NEXT:    [[HI_I:%.*]] = bitcast float [[HI:%.*]] to i32
-; CHECK-NEXT:    [[LO64:%.*]] = zext i32 [[LO:%.*]] to i64
-; CHECK-NEXT:    [[HI64:%.*]] = zext i32 [[HI_I]] to i64
-; CHECK-NEXT:    [[HISHL:%.*]] = shl i64 [[HI64]], 32
-; CHECK-NEXT:    [[MERGED:%.*]] = or i64 [[LO64]], [[HISHL]]
-; CHECK-NEXT:    store i32 [[LO]], ptr [[P:%.*]], align 8
-; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i32, ptr [[P]], i32 1
-; CHECK-NEXT:    store i32 [[HI_I]], ptr [[TMP1]], align 4
-; CHECK-NEXT:    ret void
-;
-  %hi_i = bitcast float %hi to i32
-  %lo64 = zext i32 %lo to i64
-  %hi64 = zext i32 %hi_i to i64
-  %hishl = shl i64 %hi64, 32
-  %merged = or i64 %lo64, %hishl
-  store i64 %merged, ptr %p, align 8
-  ret void
-}

--- a/llvm/test/Transforms/CodeGenPrepare/X86/split-store-alignment.ll
+++ b/llvm/test/Transforms/CodeGenPrepare/X86/split-store-alignment.ll
@@ -66,3 +66,83 @@ define void @split_store_align8(float %x, ptr %p) {
   store i64 %o, ptr %p, align 8
   ret void
 }
+
+; Atomic and volatile stores are observable and must not be split.
+
+define void @atomic_store_no_split(ptr %p, i32 %lo, float %hi) {
+; CHECK-LABEL: @atomic_store_no_split(
+; CHECK-NEXT:    [[HI_I:%.*]] = bitcast float [[HI:%.*]] to i32
+; CHECK-NEXT:    [[LO64:%.*]] = zext i32 [[LO:%.*]] to i64
+; CHECK-NEXT:    [[HI64:%.*]] = zext i32 [[HI_I]] to i64
+; CHECK-NEXT:    [[HISHL:%.*]] = shl i64 [[HI64]], 32
+; CHECK-NEXT:    [[MERGED:%.*]] = or i64 [[LO64]], [[HISHL]]
+; CHECK-NEXT:    store atomic i64 [[MERGED]], ptr [[P:%.*]] seq_cst, align 8
+; CHECK-NEXT:    ret void
+;
+  %hi_i = bitcast float %hi to i32
+  %lo64 = zext i32 %lo to i64
+  %hi64 = zext i32 %hi_i to i64
+  %hishl = shl i64 %hi64, 32
+  %merged = or i64 %lo64, %hishl
+  store atomic i64 %merged, ptr %p seq_cst, align 8
+  ret void
+}
+
+define void @atomic_store_unordered_no_split(ptr %p, i32 %lo, float %hi) {
+; CHECK-LABEL: @atomic_store_unordered_no_split(
+; CHECK-NEXT:    [[HI_I:%.*]] = bitcast float [[HI:%.*]] to i32
+; CHECK-NEXT:    [[LO64:%.*]] = zext i32 [[LO:%.*]] to i64
+; CHECK-NEXT:    [[HI64:%.*]] = zext i32 [[HI_I]] to i64
+; CHECK-NEXT:    [[HISHL:%.*]] = shl i64 [[HI64]], 32
+; CHECK-NEXT:    [[MERGED:%.*]] = or i64 [[LO64]], [[HISHL]]
+; CHECK-NEXT:    store atomic i64 [[MERGED]], ptr [[P:%.*]] unordered, align 8
+; CHECK-NEXT:    ret void
+;
+  %hi_i = bitcast float %hi to i32
+  %lo64 = zext i32 %lo to i64
+  %hi64 = zext i32 %hi_i to i64
+  %hishl = shl i64 %hi64, 32
+  %merged = or i64 %lo64, %hishl
+  store atomic i64 %merged, ptr %p unordered, align 8
+  ret void
+}
+
+define void @volatile_store_no_split(ptr %p, i32 %lo, float %hi) {
+; CHECK-LABEL: @volatile_store_no_split(
+; CHECK-NEXT:    [[HI_I:%.*]] = bitcast float [[HI:%.*]] to i32
+; CHECK-NEXT:    [[LO64:%.*]] = zext i32 [[LO:%.*]] to i64
+; CHECK-NEXT:    [[HI64:%.*]] = zext i32 [[HI_I]] to i64
+; CHECK-NEXT:    [[HISHL:%.*]] = shl i64 [[HI64]], 32
+; CHECK-NEXT:    [[MERGED:%.*]] = or i64 [[LO64]], [[HISHL]]
+; CHECK-NEXT:    store volatile i64 [[MERGED]], ptr [[P:%.*]], align 8
+; CHECK-NEXT:    ret void
+;
+  %hi_i = bitcast float %hi to i32
+  %lo64 = zext i32 %lo to i64
+  %hi64 = zext i32 %hi_i to i64
+  %hishl = shl i64 %hi64, 32
+  %merged = or i64 %lo64, %hishl
+  store volatile i64 %merged, ptr %p, align 8
+  ret void
+}
+
+define void @plain_store_is_split(ptr %p, i32 %lo, float %hi) {
+; CHECK-LABEL: @plain_store_is_split(
+; CHECK-NEXT:    [[HI_I:%.*]] = bitcast float [[HI:%.*]] to i32
+; CHECK-NEXT:    [[LO64:%.*]] = zext i32 [[LO:%.*]] to i64
+; CHECK-NEXT:    [[HI64:%.*]] = zext i32 [[HI_I]] to i64
+; CHECK-NEXT:    [[HISHL:%.*]] = shl i64 [[HI64]], 32
+; CHECK-NEXT:    [[MERGED:%.*]] = or i64 [[LO64]], [[HISHL]]
+; CHECK-NEXT:    store i32 [[LO]], ptr [[P:%.*]], align 8
+; CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i32, ptr [[P]], i32 1
+; CHECK-NEXT:    store i32 [[HI_I]], ptr [[TMP1]], align 4
+; CHECK-NEXT:    ret void
+;
+  %hi_i = bitcast float %hi to i32
+  %lo64 = zext i32 %lo to i64
+  %hi64 = zext i32 %hi_i to i64
+  %hishl = shl i64 %hi64, 32
+  %merged = or i64 %lo64, %hishl
+  store i64 %merged, ptr %p, align 8
+  ret void
+}


### PR DESCRIPTION
splitMergedValStore notices when you do e.g.

    z = x | (y << 32)
    store z

and may split this up into 32-bit two stores, of x and y, depending
e.g. on the type of x and y.

It skips this optimization for volatile stores, but currently does NOT
skip it for atomics (!!).  So an atomic store can be split up into two
(non-atomic!) stores.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
