### PR TITLE
[RISCV][NFC] Remove SegInstSEW for unused function

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -542,6 +542,7 @@ multiclass RVVUnitStridedSegLoadTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
+            HasSegInstSEW = true,
             ManualCodegen = [{
               return emitRVVUnitStridedSegLoadTupleBuiltin(
                   this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs,
@@ -572,6 +573,7 @@ multiclass RVVUnitStridedSegStoreTuple<string op> {
           IRName = op # nf,
           MaskedIRName = op # nf # "_mask",
           NF = nf,
+          HasSegInstSEW = true,
           HasMaskedOffOperand = false,
           ManualCodegen = [{
             return emitRVVUnitStridedSegStoreTupleBuiltin(
@@ -603,6 +605,7 @@ multiclass RVVUnitStridedSegLoadFFTuple<string op> {
             IRName = op # nf # "ff",
             MaskedIRName = op # nf # "ff_mask",
             NF = nf,
+            HasSegInstSEW = true,
             ManualCodegen = [{
       return emitRVVUnitStridedSegLoadFFTupleBuiltin(
           this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked,
@@ -633,6 +636,7 @@ multiclass RVVStridedSegLoadTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
+            HasSegInstSEW = true,
             ManualCodegen = [{
       return emitRVVStridedSegLoadTupleBuiltin(
           this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked,
@@ -663,6 +667,7 @@ multiclass RVVStridedSegStoreTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
+            HasSegInstSEW = true,
             HasMaskedOffOperand = false,
             MaskedPolicyScheme = NonePolicy,
             ManualCodegen = [{
@@ -690,6 +695,7 @@ multiclass RVVIndexedSegLoadTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
+            HasSegInstSEW = true,
             ManualCodegen = [{
       return emitRVVIndexedSegLoadTupleBuiltin(
           this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked,
@@ -716,6 +722,7 @@ multiclass RVVIndexedSegStoreTuple<string op> {
             IRName = op # nf,
             MaskedIRName = op # nf # "_mask",
             NF = nf,
+            HasSegInstSEW = true,
             HasMaskedOffOperand = false,
             MaskedPolicyScheme = NonePolicy,
             ManualCodegen = [{

--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -57,7 +57,7 @@ multiclass RVVVLEFFBuiltin<list<string> types> {
       UnMaskedPolicyScheme = HasPassthruOperand,
       ManualCodegen = [{
         return emitRVVVLEFFBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                   PolicyAttrs, IsMasked, SegInstSEW);
+                                   PolicyAttrs, IsMasked);
       }] in {
     foreach type = types in {
       def : RVVBuiltin<"v", "vPCePz", type>;
@@ -114,7 +114,7 @@ let HasMaskedOffOperand = false,
     MaskedPolicyScheme = NonePolicy,
     ManualCodegen = [{
       return emitRVVVSEMaskBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                   PolicyAttrs, IsMasked, SegInstSEW);
+                                   PolicyAttrs, IsMasked);
     }] in {
   class RVVVSEMaskBuiltin : RVVBuiltin<"m", "0PUem", "c"> {
     let Name = "vsm_v";
@@ -143,7 +143,7 @@ multiclass RVVVSSEBuiltin<list<string> types> {
       MaskedPolicyScheme = NonePolicy,
       ManualCodegen = [{
         return emitRVVVSSEBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                  PolicyAttrs, IsMasked, SegInstSEW);
+                                  PolicyAttrs, IsMasked);
       }] in {
     foreach type = types in {
       def : RVVBuiltin<"v", "0Petv", type>;
@@ -159,7 +159,7 @@ multiclass RVVIndexedStore<string op> {
       MaskedPolicyScheme = NonePolicy,
       ManualCodegen = [{
         return emitRVVIndexedStoreBuiltin(this, E, ReturnValue, ResultType, ID,
-                                          Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                          Ops, PolicyAttrs, IsMasked);
       }] in {
       foreach type = TypeList in {
         foreach eew_list = EEWList[0-2] in {
@@ -315,7 +315,7 @@ multiclass RVVPseudoUnaryBuiltin<string IR, string type_range> {
       UnMaskedPolicyScheme = HasPassthruOperand,
       ManualCodegen = [{
         return emitRVVPseudoUnaryBuiltin(this, E, ReturnValue, ResultType, ID,
-                                         Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                         Ops, PolicyAttrs, IsMasked);
       }] in {
         def : RVVBuiltin<"v", "vv", type_range>;
   }
@@ -328,7 +328,7 @@ multiclass RVVPseudoVNotBuiltin<string IR, string type_range> {
       UnMaskedPolicyScheme = HasPassthruOperand,
       ManualCodegen = [{
         return emitRVVPseudoVNotBuiltin(this, E, ReturnValue, ResultType, ID,
-                                        Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                        Ops, PolicyAttrs, IsMasked);
       }] in {
         def : RVVBuiltin<"v", "vv", type_range>;
         def : RVVBuiltin<"Uv", "UvUv", type_range>;
@@ -341,7 +341,7 @@ multiclass RVVPseudoMaskBuiltin<string IR, string type_range> {
       HasMasked = false,
       ManualCodegen = [{
         return emitRVVPseudoMaskBuiltin(this, E, ReturnValue, ResultType, ID,
-                                        Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                        Ops, PolicyAttrs, IsMasked);
       }] in {
         def : RVVBuiltin<"m", "mm", type_range>;
   }
@@ -354,7 +354,7 @@ multiclass RVVPseudoVFUnaryBuiltin<string IR, string type_range> {
       UnMaskedPolicyScheme = HasPassthruOperand,
       ManualCodegen = [{
         return emitRVVPseudoVFUnaryBuiltin(this, E, ReturnValue, ResultType, ID,
-                                           Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                           Ops, PolicyAttrs, IsMasked);
       }] in {
         def : RVVBuiltin<"v", "vv", type_range>;
   }
@@ -369,7 +369,7 @@ multiclass RVVPseudoVWCVTBuiltin<string IR, string MName, string type_range,
       UnMaskedPolicyScheme = HasPassthruOperand,
       ManualCodegen = [{
         return emitRVVPseudoVWCVTBuiltin(this, E, ReturnValue, ResultType, ID,
-                                         Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                         Ops, PolicyAttrs, IsMasked);
       }] in {
         foreach s_p = suffixes_prototypes in {
           def : RVVBuiltin<s_p[0], s_p[1], type_range>;
@@ -386,7 +386,7 @@ multiclass RVVPseudoVNCVTBuiltin<string IR, string MName, string type_range,
       UnMaskedPolicyScheme = HasPassthruOperand,
       ManualCodegen = [{
         return emitRVVPseudoVNCVTBuiltin(this, E, ReturnValue, ResultType, ID,
-                                         Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                         Ops, PolicyAttrs, IsMasked);
       }] in {
         foreach s_p = suffixes_prototypes in {
           def : RVVBuiltin<s_p[0], s_p[1], type_range>;
@@ -405,7 +405,7 @@ let HasBuiltinAlias = false, HasVL = false, HasMasked = false,
     Log2LMUL = [0], IRName = "",
     ManualCodegen = [{
       return emitRVVVlenbBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                 PolicyAttrs, IsMasked, SegInstSEW);
+                                 PolicyAttrs, IsMasked);
     }] in
 {
   def vlenb : RVVBuiltin<"", "u", "i">;
@@ -482,7 +482,7 @@ let HasBuiltinAlias = false,
     Log2LMUL = [0],
     ManualCodegen = [{
       return emitRVVVsetvliBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                   PolicyAttrs, IsMasked, SegInstSEW);
+                                   PolicyAttrs, IsMasked);
     }] in // Set XLEN type
 {
   def vsetvli : RVVBuiltin<"", "zzKzKz", "i">;
@@ -963,7 +963,7 @@ defm vssub : RVVSignedBinBuiltinSet;
 let ManualCodegen = [{
   {
     return emitRVVAveragingBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                   PolicyAttrs, IsMasked, SegInstSEW);
+                                   PolicyAttrs, IsMasked);
   }
 }] in {
   // 12.2. Vector Single-Width Averaging Add and Subtract
@@ -983,7 +983,7 @@ let ManualCodegen = [{
 let ManualCodegen = [{
   {
     return emitRVVNarrowingClipBuiltin(this, E, ReturnValue, ResultType, ID,
-                                       Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                       Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   // 12.5. Vector Narrowing Fixed-Point Clip Instructions
@@ -1008,7 +1008,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
 let ManualCodegen = [{
   {
     return emitRVVFloatingPointBuiltin(this, E, ReturnValue, ResultType, ID,
-                                       Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                       Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = true in {
@@ -1046,8 +1046,7 @@ let ManualCodegen = [{
 let ManualCodegen = [{
   {
     return emitRVVWideningFloatingPointBuiltin(
-        this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked,
-        SegInstSEW);
+        this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = true in {
@@ -1098,7 +1097,7 @@ let UnMaskedPolicyScheme = HasPolicyOperand in {
 let ManualCodegen = [{
   {
     return emitRVVFMABuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                             PolicyAttrs, IsMasked, SegInstSEW);
+                             PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = 1 in {
@@ -1126,7 +1125,7 @@ let ManualCodegen = [{
 let ManualCodegen = [{
   {
     return emitRVVWideningFMABuiltin(this, E, ReturnValue, ResultType, ID,
-                                     Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                     Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = 1 in {
@@ -1165,7 +1164,7 @@ let UnMaskedPolicyScheme = HasPassthruOperand in {
 let ManualCodegen = [{
   {
     return emitRVVFloatingUnaryBuiltin(this, E, ReturnValue, ResultType, ID,
-                                       Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                       Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = 1 in {
@@ -1372,7 +1371,7 @@ let Log2LMUL = [-3, -2, -1, 0, 1, 2],
 let ManualCodegen = [{
   {
     return emitRVVFloatingConvBuiltin(this, E, ReturnValue, ResultType, ID,
-                                      Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                       Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = 1 in {
@@ -1626,8 +1625,7 @@ defm vfredmin : RVVFloatingReductionBuiltin;
 let ManualCodegen = [{
   {
     return emitRVVFloatingReductionBuiltin(
-        this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked,
-        SegInstSEW);
+        this, E, ReturnValue, ResultType, ID, Ops, PolicyAttrs, IsMasked);
   }
 }] in {
   let HasFRMRoundModeOp = 1 in {
@@ -1792,7 +1790,7 @@ let HasMasked = false, HasVL = false, IRName = "" in {
   let Name = "vreinterpret_v", MaskedPolicyScheme = NonePolicy,
       ManualCodegen = [{
         return emitRVVReinterpretBuiltin(this, E, ReturnValue, ResultType, ID,
-                                         Ops, PolicyAttrs, IsMasked, SegInstSEW);
+                                         Ops, PolicyAttrs, IsMasked);
       }] in {
     // Reinterpret between different type under the same SEW and LMUL
     def vreinterpret_i_u : RVVBuiltin<"Uvv", "vUv", "csil", "v">;
@@ -1925,7 +1923,7 @@ let HasMasked = false, HasVL = false, IRName = "" in {
   let Name = "vget_v", MaskedPolicyScheme = NonePolicy,
       ManualCodegen = [{
         return emitRVVGetBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                 PolicyAttrs, IsMasked, SegInstSEW);
+                                 PolicyAttrs, IsMasked);
       }] in {
     foreach dst_lmul = ["(SFixedLog2LMUL:0)", "(SFixedLog2LMUL:1)", "(SFixedLog2LMUL:2)"] in {
       def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "vvKz", "csilxfdy", dst_lmul # "v">;
@@ -1941,7 +1939,7 @@ let HasMasked = false, HasVL = false, IRName = "" in {
   let Name = "vset_v", MaskedPolicyScheme = NonePolicy,
       ManualCodegen = [{
         return emitRVVSetBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                 PolicyAttrs, IsMasked, SegInstSEW);
+                                 PolicyAttrs, IsMasked);
       }] in {
     foreach dst_lmul = ["(LFixedLog2LMUL:1)", "(LFixedLog2LMUL:2)", "(LFixedLog2LMUL:3)"] in {
       def : RVVBuiltin<"v" # dst_lmul # "v", dst_lmul # "v" # dst_lmul # "vKzv", "csilxfdy">;
@@ -1960,7 +1958,7 @@ let HasMasked = false, HasVL = false, IRName = "" in {
       SupportOverloading = false,
       ManualCodegen = [{
         return emitRVVCreateBuiltin(this, E, ReturnValue, ResultType, ID, Ops,
-                                    PolicyAttrs, IsMasked, SegInstSEW);
+                                    PolicyAttrs, IsMasked);
       }] in {
 
     // Since the vcreate_v uses LFixedLog2LMUL, setting the Log2LMUL to [-3] can

--- a/clang/include/clang/Basic/riscv_vector_common.td
+++ b/clang/include/clang/Basic/riscv_vector_common.td
@@ -249,6 +249,10 @@ class RVVBuiltin<string suffix, string prototype, string type_range,
   // Set to true if the builtin is associated with tuple types.
   bit IsTuple = false;
 
+  // Set to true if the builtin has a SegInstSEW parameter. This is typically
+  // used for segment load/store instructions.
+  bit HasSegInstSEW = false;
+
   // Set to true if the builtin has a parameter that models floating-point
   // rounding mode control
   bit HasFRMRoundModeOp = false;

--- a/clang/include/clang/Support/RISCVVIntrinsicUtils.h
+++ b/clang/include/clang/Support/RISCVVIntrinsicUtils.h
@@ -407,6 +407,7 @@ private:
   // InputTypes. -1 means the return type.
   std::vector<int64_t> IntrinsicTypes;
   unsigned NF = 1;
+  bool HasSegInstSEW = false;
   Policy PolicyAttrs;
   unsigned TWiden = 0;
 
@@ -418,8 +419,8 @@ public:
                bool HasBuiltinAlias, llvm::StringRef ManualCodegen,
                const RVVTypes &Types,
                const std::vector<int64_t> &IntrinsicTypes, unsigned NF,
-               Policy PolicyAttrs, bool HasFRMRoundModeOp, unsigned TWiden,
-               bool AltFmt);
+               bool HasSegInstSEW, Policy PolicyAttrs, bool HasFRMRoundModeOp,
+               unsigned TWiden, bool AltFmt);
   ~RVVIntrinsic() = default;
 
   RVVTypePtr getOutputType() const { return OutputType; }
@@ -443,6 +444,7 @@ public:
   llvm::StringRef getManualCodegen() const { return ManualCodegen; }
   PolicyScheme getPolicyScheme() const { return Scheme; }
   unsigned getNF() const { return NF; }
+  bool hasSegInstSEW() const { return HasSegInstSEW; }
   unsigned getTWiden() const { return TWiden; }
   const std::vector<int64_t> &getIntrinsicTypes() const {
     return IntrinsicTypes;

--- a/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/RISCV.cpp
@@ -32,7 +32,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVVLEFFBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                     ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                     Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                    int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -69,7 +69,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVVSSEBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                    ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                    Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                   int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                   int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -89,10 +89,11 @@ emitRVVVSSEBuiltin(CodeGenFunction *CGF, const CallExpr *E,
   return Builder.CreateCall(F, Ops, "");
 }
 
-static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVIndexedStoreBuiltin(
-    CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
-    llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+static LLVM_ATTRIBUTE_NOINLINE Value *
+emitRVVIndexedStoreBuiltin(CodeGenFunction *CGF, const CallExpr *E,
+                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
+                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
+                           int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 4> IntrinsicTypes;
@@ -119,7 +120,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVPseudoUnaryBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                          int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                          int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -149,7 +150,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVPseudoVNotBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                          ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                          Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                         int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                         int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -179,7 +180,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVPseudoMaskBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                          ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                          Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                         int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                         int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -190,10 +191,11 @@ emitRVVPseudoMaskBuiltin(CodeGenFunction *CGF, const CallExpr *E,
   return Builder.CreateCall(F, Ops, "");
 }
 
-static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVPseudoVFUnaryBuiltin(
-    CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
-    llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+static LLVM_ATTRIBUTE_NOINLINE Value *
+emitRVVPseudoVFUnaryBuiltin(CodeGenFunction *CGF, const CallExpr *E,
+                            ReturnValueSlot ReturnValue, llvm::Type *ResultType,
+                            Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
+                            int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -220,7 +222,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVPseudoVWCVTBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                          int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                          int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 4> IntrinsicTypes;
@@ -250,7 +252,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVPseudoVNCVTBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                          int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                          int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 4> IntrinsicTypes;
@@ -282,7 +284,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVVlenbBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                     ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                     Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                    int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   LLVMContext &Context = CGM.getLLVMContext();
@@ -299,7 +301,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVVsetvliBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                       ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                       Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                      int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                      int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::Function *F = CGM.getIntrinsic(ID, {ResultType});
@@ -310,7 +312,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVVSEMaskBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                       ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                       Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                      int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                      int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -491,7 +493,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVAveragingBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                         ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                         Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                        int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                        int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -517,10 +519,11 @@ emitRVVAveragingBuiltin(CodeGenFunction *CGF, const CallExpr *E,
   return Builder.CreateCall(F, Ops, "");
 }
 
-static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVNarrowingClipBuiltin(
-    CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
-    llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+static LLVM_ATTRIBUTE_NOINLINE Value *
+emitRVVNarrowingClipBuiltin(CodeGenFunction *CGF, const CallExpr *E,
+                            ReturnValueSlot ReturnValue, llvm::Type *ResultType,
+                            Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
+                            int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -547,10 +550,11 @@ static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVNarrowingClipBuiltin(
   return Builder.CreateCall(F, Ops, "");
 }
 
-static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingPointBuiltin(
-    CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
-    llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+static LLVM_ATTRIBUTE_NOINLINE Value *
+emitRVVFloatingPointBuiltin(CodeGenFunction *CGF, const CallExpr *E,
+                            ReturnValueSlot ReturnValue, llvm::Type *ResultType,
+                            Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
+                            int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -585,7 +589,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingPointBuiltin(
 static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVWideningFloatingPointBuiltin(
     CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
     llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+    int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -688,7 +692,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVFMABuiltin(CodeGenFunction *CGF, const CallExpr *E,
                   ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                   Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                  int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                  int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -717,7 +721,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVWideningFMABuiltin(CodeGenFunction *CGF, const CallExpr *E,
                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                          int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                          int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -742,10 +746,11 @@ emitRVVWideningFMABuiltin(CodeGenFunction *CGF, const CallExpr *E,
   return Builder.CreateCall(F, Ops, "");
 }
 
-static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingUnaryBuiltin(
-    CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
-    llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+static LLVM_ATTRIBUTE_NOINLINE Value *
+emitRVVFloatingUnaryBuiltin(CodeGenFunction *CGF, const CallExpr *E,
+                            ReturnValueSlot ReturnValue, llvm::Type *ResultType,
+                            Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
+                            int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   llvm::SmallVector<llvm::Type *, 3> IntrinsicTypes;
@@ -778,10 +783,11 @@ static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingUnaryBuiltin(
   return Builder.CreateCall(F, Ops, "");
 }
 
-static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingConvBuiltin(
-    CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
-    llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+static LLVM_ATTRIBUTE_NOINLINE Value *
+emitRVVFloatingConvBuiltin(CodeGenFunction *CGF, const CallExpr *E,
+                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
+                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
+                           int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -815,7 +821,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingConvBuiltin(
 static LLVM_ATTRIBUTE_NOINLINE Value *emitRVVFloatingReductionBuiltin(
     CodeGenFunction *CGF, const CallExpr *E, ReturnValueSlot ReturnValue,
     llvm::Type *ResultType, Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-    int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+    int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
   // LLVM intrinsic
@@ -848,7 +854,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVReinterpretBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                           ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                           Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                          int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                          int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto &CGM = CGF->CGM;
 
@@ -887,7 +893,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVGetBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                   ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                   Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                  int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                  int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   auto *VecTy = cast<ScalableVectorType>(ResultType);
   if (auto *OpVecTy = dyn_cast<ScalableVectorType>(Ops[0]->getType())) {
@@ -912,7 +918,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVSetBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                   ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                   Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                  int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                  int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   if (auto *ResVecTy = dyn_cast<ScalableVectorType>(ResultType)) {
     auto *VecTy = cast<ScalableVectorType>(Ops[2]->getType());
@@ -937,7 +943,7 @@ static LLVM_ATTRIBUTE_NOINLINE Value *
 emitRVVCreateBuiltin(CodeGenFunction *CGF, const CallExpr *E,
                      ReturnValueSlot ReturnValue, llvm::Type *ResultType,
                      Intrinsic::ID ID, SmallVectorImpl<Value *> &Ops,
-                     int PolicyAttrs, bool IsMasked, unsigned SegInstSEW) {
+                     int PolicyAttrs, bool IsMasked) {
   auto &Builder = CGF->Builder;
   llvm::Value *ReturnVector = llvm::PoisonValue::get(ResultType);
   auto *VecTy = cast<ScalableVectorType>(Ops[0]->getType());

--- a/clang/lib/Support/RISCVVIntrinsicUtils.cpp
+++ b/clang/lib/Support/RISCVVIntrinsicUtils.cpp
@@ -1020,21 +1020,19 @@ std::optional<RVVTypePtr> RVVTypeCache::computeType(BasicType BT, int Log2LMUL,
 //===----------------------------------------------------------------------===//
 // RVVIntrinsic implementation
 //===----------------------------------------------------------------------===//
-RVVIntrinsic::RVVIntrinsic(StringRef NewName, StringRef Suffix,
-                           StringRef NewOverloadedName,
-                           StringRef OverloadedSuffix, StringRef IRName,
-                           bool IsMasked, bool HasMaskedOffOperand, bool HasVL,
-                           PolicyScheme Scheme, bool SupportOverloading,
-                           bool HasBuiltinAlias, StringRef ManualCodegen,
-                           const RVVTypes &OutInTypes,
-                           const std::vector<int64_t> &NewIntrinsicTypes,
-                           unsigned NF, Policy NewPolicyAttrs,
-                           bool HasFRMRoundModeOp, unsigned TWiden, bool AltFmt)
+RVVIntrinsic::RVVIntrinsic(
+    StringRef NewName, StringRef Suffix, StringRef NewOverloadedName,
+    StringRef OverloadedSuffix, StringRef IRName, bool IsMasked,
+    bool HasMaskedOffOperand, bool HasVL, PolicyScheme Scheme,
+    bool SupportOverloading, bool HasBuiltinAlias, StringRef ManualCodegen,
+    const RVVTypes &OutInTypes, const std::vector<int64_t> &NewIntrinsicTypes,
+    unsigned NF, bool HasSegInstSEW, Policy NewPolicyAttrs,
+    bool HasFRMRoundModeOp, unsigned TWiden, bool AltFmt)
     : IRName(IRName), IsMasked(IsMasked),
       HasMaskedOffOperand(HasMaskedOffOperand), HasVL(HasVL), Scheme(Scheme),
       SupportOverloading(SupportOverloading), HasBuiltinAlias(HasBuiltinAlias),
-      ManualCodegen(ManualCodegen.str()), NF(NF), PolicyAttrs(NewPolicyAttrs),
-      TWiden(TWiden) {
+      ManualCodegen(ManualCodegen.str()), NF(NF), HasSegInstSEW(HasSegInstSEW),
+      PolicyAttrs(NewPolicyAttrs), TWiden(TWiden) {
 
   // Init BuiltinName, Name and OverloadedName
   BuiltinName = NewName.str();

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -250,17 +250,19 @@ void emitCodeGenSwitchBody(const RVVIntrinsic *RVVI, raw_ostream &OS) {
     OS << "  TWiden = " << RVVI->getTWiden() << ";\n";
 
   OS << "  PolicyAttrs = " << RVVI->getPolicyAttrsBits() << ";\n";
-  unsigned IndexedLoadStorePtrIdx = getIndexedLoadStorePtrIdx(RVVI);
-  if (IndexedLoadStorePtrIdx != UnknownIndex) {
-    OS << "  {\n";
-    OS << "    auto PointeeType = E->getArg(" << IndexedLoadStorePtrIdx
-       << ")->getType()->getPointeeType();\n";
-    OS << "    SegInstSEW = "
-          "llvm::Log2_64(getContext().getTypeSize(PointeeType));\n";
-    OS << "  }\n";
-  } else {
-    OS << "  SegInstSEW = " << getSegInstLog2SEW(RVVI->getOverloadedName())
-       << ";\n";
+  if (RVVI->getManualCodegen().contains("SegInstSEW")) {
+    unsigned IndexedLoadStorePtrIdx = getIndexedLoadStorePtrIdx(RVVI);
+    if (IndexedLoadStorePtrIdx != UnknownIndex) {
+      OS << "  {\n";
+      OS << "    auto PointeeType = E->getArg(" << IndexedLoadStorePtrIdx
+         << ")->getType()->getPointeeType();\n";
+      OS << "    SegInstSEW = "
+            "llvm::Log2_64(getContext().getTypeSize(PointeeType));\n";
+      OS << "  }\n";
+    } else {
+      OS << "  SegInstSEW = " << getSegInstLog2SEW(RVVI->getOverloadedName())
+         << ";\n";
+    }
   }
 
   if (RVVI->hasManualCodegen()) {

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -250,7 +250,7 @@ void emitCodeGenSwitchBody(const RVVIntrinsic *RVVI, raw_ostream &OS) {
     OS << "  TWiden = " << RVVI->getTWiden() << ";\n";
 
   OS << "  PolicyAttrs = " << RVVI->getPolicyAttrsBits() << ";\n";
-  if (RVVI->getManualCodegen().contains("SegInstSEW")) {
+  if (RVVI->hasSegInstSEW()) {
     unsigned IndexedLoadStorePtrIdx = getIndexedLoadStorePtrIdx(RVVI);
     if (IndexedLoadStorePtrIdx != UnknownIndex) {
       OS << "  {\n";
@@ -679,6 +679,7 @@ void RVVEmitter::createRVVIntrinsics(
     StringRef IRName = R->getValueAsString("IRName");
     StringRef MaskedIRName = R->getValueAsString("MaskedIRName");
     unsigned NF = R->getValueAsInt("NF");
+    bool HasSegInstSEW = R->getValueAsBit("HasSegInstSEW");
     unsigned TWiden = R->getValueAsInt("TWiden");
     bool IsTuple = R->getValueAsBit("IsTuple");
     bool HasFRMRoundModeOp = R->getValueAsBit("HasFRMRoundModeOp");
@@ -728,8 +729,8 @@ void RVVEmitter::createRVVIntrinsics(
             Name, SuffixStr, OverloadedName, OverloadedSuffixStr, IRName,
             /*IsMasked=*/false, /*HasMaskedOffOperand=*/false, HasVL,
             UnMaskedPolicyScheme, SupportOverloading, HasBuiltinAlias,
-            ManualCodegen, *Types, IntrinsicTypes, NF, DefaultPolicy,
-            HasFRMRoundModeOp, TWiden, AltFmt));
+            ManualCodegen, *Types, IntrinsicTypes, NF, HasSegInstSEW,
+            DefaultPolicy, HasFRMRoundModeOp, TWiden, AltFmt));
         if (UnMaskedPolicyScheme != PolicyScheme::SchemeNone)
           for (auto P : SupportedUnMaskedPolicies) {
             SmallVector<PrototypeDescriptor> PolicyPrototype =
@@ -743,8 +744,8 @@ void RVVEmitter::createRVVIntrinsics(
                 Name, SuffixStr, OverloadedName, OverloadedSuffixStr, IRName,
                 /*IsMask=*/false, /*HasMaskedOffOperand=*/false, HasVL,
                 UnMaskedPolicyScheme, SupportOverloading, HasBuiltinAlias,
-                ManualCodegen, *PolicyTypes, IntrinsicTypes, NF, P,
-                HasFRMRoundModeOp, TWiden, AltFmt));
+                ManualCodegen, *PolicyTypes, IntrinsicTypes, NF, HasSegInstSEW,
+                P, HasFRMRoundModeOp, TWiden, AltFmt));
           }
         if (!HasMasked)
           continue;
@@ -755,8 +756,8 @@ void RVVEmitter::createRVVIntrinsics(
             Name, SuffixStr, OverloadedName, OverloadedSuffixStr, MaskedIRName,
             /*IsMasked=*/true, HasMaskedOffOperand, HasVL, MaskedPolicyScheme,
             SupportOverloading, HasBuiltinAlias, ManualCodegen, *MaskTypes,
-            IntrinsicTypes, NF, DefaultPolicy, HasFRMRoundModeOp, TWiden,
-            AltFmt));
+            IntrinsicTypes, NF, HasSegInstSEW, DefaultPolicy, HasFRMRoundModeOp,
+            TWiden, AltFmt));
         if (MaskedPolicyScheme == PolicyScheme::SchemeNone)
           continue;
         for (auto P : SupportedMaskedPolicies) {
@@ -770,7 +771,7 @@ void RVVEmitter::createRVVIntrinsics(
               Name, SuffixStr, OverloadedName, OverloadedSuffixStr,
               MaskedIRName, /*IsMasked=*/true, HasMaskedOffOperand, HasVL,
               MaskedPolicyScheme, SupportOverloading, HasBuiltinAlias,
-              ManualCodegen, *PolicyTypes, IntrinsicTypes, NF, P,
+              ManualCodegen, *PolicyTypes, IntrinsicTypes, NF, HasSegInstSEW, P,
               HasFRMRoundModeOp, TWiden, AltFmt));
         }
       } // End for Log2LMULList


### PR DESCRIPTION
Since SegInstSEW is only used by segment load/store, no need to keep it for other builtins.