### PR TITLE
[MC][COFF][AArch64] Add helper symbols for large SECREL addends

### DIFF
--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -129,6 +129,8 @@ class llvm::WinCOFFWriter {
 
   using symbol_map = DenseMap<MCSymbol const *, COFFSymbol *>;
   using section_map = DenseMap<MCSection const *, COFFSection *>;
+  using section_offset_map =
+      DenseMap<std::pair<MCSection const *, uint64_t>, COFFSymbol *>;
 
   using symbol_list = DenseSet<COFFSymbol *>;
 
@@ -141,11 +143,13 @@ class llvm::WinCOFFWriter {
   // Maps used during object file creation.
   section_map SectionMap;
   symbol_map SymbolMap;
+  section_offset_map SecRelSymbolMap;
 
   symbol_list WeakDefaults;
 
   bool UseBigObj;
   bool UseOffsetLabels = false;
+  unsigned SecRelSymbolCount = 0;
 
 public:
   enum DwoMode {
@@ -168,6 +172,7 @@ public:
 private:
   MCContext &getContext() const { return OWriter.getContext(); }
   COFFSymbol *createSymbol(StringRef Name);
+  COFFSymbol *getOrCreateSecRelSymbol(const MCSymbol &Sym, uint64_t Offset);
   COFFSymbol *getOrCreateCOFFSymbol(const MCSymbol &Sym);
   COFFSection *createSection(StringRef Name);
 
@@ -248,6 +253,33 @@ COFFSymbol *WinCOFFWriter::getOrCreateCOFFSymbol(const MCSymbol &Sym) {
   COFFSymbol *&Ret = SymbolMap[&Sym];
   if (!Ret)
     Ret = createSymbol(Sym.getName());
+  return Ret;
+}
+
+COFFSymbol *WinCOFFWriter::getOrCreateSecRelSymbol(const MCSymbol &Sym,
+                                                   uint64_t Offset) {
+  MCSection *TargetSection = &Sym.getSection();
+  assert(SectionMap.contains(TargetSection) &&
+         "Section must already have been defined in executePostLayoutBinding!");
+
+  COFFSymbol *&Ret = SecRelSymbolMap[{TargetSection, Offset}];
+  if (Ret)
+    return Ret;
+
+  COFFSection *Section = SectionMap[TargetSection];
+  std::string Name;
+  if (Sym.isTemporary() && !Sym.getName().empty() &&
+      Offset == Asm->getSymbolOffset(Sym))
+    Name = Sym.getName().str();
+  else
+    Name =
+        (Twine("$L") + Section->Name + "_secrel_" + Twine(++SecRelSymbolCount))
+            .str();
+
+  Ret = createSymbol(Name);
+  Ret->Section = Section;
+  Ret->Data.StorageClass = COFF::IMAGE_SYM_CLASS_LABEL;
+  Ret->Data.Value = Offset;
   return Ret;
 }
 
@@ -806,7 +838,9 @@ void WinCOFFWriter::reset() {
   Strings.clear();
   SectionMap.clear();
   SymbolMap.clear();
+  SecRelSymbolMap.clear();
   WeakDefaults.clear();
+  SecRelSymbolCount = 0;
 }
 
 void WinCOFFWriter::executePostLayoutBinding() {
@@ -886,9 +920,40 @@ void WinCOFFWriter::recordRelocation(const MCFragment &F, const MCFixup &Fixup,
 
   Reloc.Data.SymbolTableIndex = 0;
   Reloc.Data.VirtualAddress = Asm->getFragmentOffset(F);
+  Reloc.Data.Type = OWriter.TargetObjectWriter->getRelocType(
+      getContext(), Target, Fixup, Target.getSubSym(), Asm->getBackend());
 
-  // Turn relocations for temporary symbols into section relocations.
-  if (A.isTemporary() && !SymbolMap[&A]) {
+  bool IsArm64SecRel12 = false;
+  if (COFF::isAnyArm64(Header.Machine)) {
+    switch (Reloc.Data.Type) {
+    case COFF::IMAGE_REL_ARM64_SECREL_HIGH12A:
+    case COFF::IMAGE_REL_ARM64_SECREL_LOW12A:
+    case COFF::IMAGE_REL_ARM64_SECREL_LOW12L:
+      IsArm64SecRel12 = true;
+      break;
+    }
+  }
+
+  bool NeedsSecRelSymbol = false;
+  bool UseSectionSymbol = A.isTemporary() && !SymbolMap.lookup(&A);
+  uint64_t SecRelSymbolOffset = 0;
+  if (IsArm64SecRel12 && A.isInSection()) {
+    uint64_t SecRelFixedValue = FixedValue;
+    if (UseSectionSymbol)
+      SecRelFixedValue += Asm->getSymbolOffset(A);
+    NeedsSecRelSymbol = !isUInt<12>(SecRelFixedValue);
+    SecRelSymbolOffset = Asm->getSymbolOffset(A) + FixedValue;
+  }
+
+  if (NeedsSecRelSymbol) {
+    if (!isUInt<32>(SecRelSymbolOffset)) {
+      getContext().reportError(Fixup.getLoc(),
+                               "relocation addend out of range");
+      return;
+    }
+    Reloc.Symb = getOrCreateSecRelSymbol(A, SecRelSymbolOffset);
+    FixedValue = 0;
+  } else if (UseSectionSymbol) {
     MCSection *TargetSection = &A.getSection();
     assert(
         SectionMap.contains(TargetSection) &&
@@ -920,8 +985,6 @@ void WinCOFFWriter::recordRelocation(const MCFragment &F, const MCFixup &Fixup,
   ++Reloc.Symb->Relocations;
 
   Reloc.Data.VirtualAddress += Fixup.getOffset();
-  Reloc.Data.Type = OWriter.TargetObjectWriter->getRelocType(
-      getContext(), Target, Fixup, Target.getSubSym(), Asm->getBackend());
 
   // The *_REL32 relocations are relative to the end of the relocation,
   // not to the start.

--- a/llvm/test/MC/AArch64/coff-secrel-hi12.s
+++ b/llvm/test/MC/AArch64/coff-secrel-hi12.s
@@ -1,0 +1,90 @@
+// RUN: llvm-mc -triple aarch64-windows -filetype obj -o %t.obj %s
+// RUN: llvm-mc -triple arm64ec-windows -filetype obj -o %t-ec.obj %s
+// RUN: llvm-readobj -r --syms %t.obj | FileCheck %s
+// RUN: llvm-readobj -r --syms %t-ec.obj | FileCheck %s
+// RUN: llvm-objdump --no-print-imm-hex -d %t.obj | FileCheck %s --check-prefix=DISASM
+// RUN: llvm-objdump --no-print-imm-hex -d %t-ec.obj | FileCheck %s --check-prefix=DISASM
+
+  .bss
+  .zero 0xff0
+.Lsmall:
+  .long 0
+  .zero 28
+.Llarge:
+  .long 0
+large:
+  .long 0
+
+  .text
+f:
+  add x0, x0, :secrel_hi12:.Lsmall
+  add x0, x0, :secrel_lo12:.Lsmall
+  add x1, x1, :secrel_hi12:.Lsmall+16
+  add x1, x1, :secrel_lo12:.Lsmall+16
+  add x2, x2, :secrel_hi12:.Llarge
+  add x2, x2, :secrel_lo12:.Llarge
+  ldr w3, [x3, :secrel_lo12:.Llarge+4]
+  add x4, x4, :secrel_hi12:large
+  add x4, x4, :secrel_lo12:large
+  add x5, x5, :secrel_hi12:.Lsmall+4
+  add x5, x5, :secrel_lo12:.Lsmall+4
+  add x6, x6, :secrel_hi12:large+128
+  add x6, x6, :secrel_lo12:large+128
+  ret
+
+// CHECK:      Relocations [
+// CHECK:        Section ({{[0-9]+}}) .text {
+// CHECK-NEXT:     0x0 IMAGE_REL_ARM64_SECREL_HIGH12A .bss (
+// CHECK-NEXT:     0x4 IMAGE_REL_ARM64_SECREL_LOW12A .bss (
+// CHECK-NEXT:     0x8 IMAGE_REL_ARM64_SECREL_HIGH12A $L.bss_secrel_1 (
+// CHECK-NEXT:     0xC IMAGE_REL_ARM64_SECREL_LOW12A $L.bss_secrel_1 (
+// CHECK-NEXT:     0x10 IMAGE_REL_ARM64_SECREL_HIGH12A .Llarge (
+// CHECK-NEXT:     0x14 IMAGE_REL_ARM64_SECREL_LOW12A .Llarge (
+// CHECK-NEXT:     0x18 IMAGE_REL_ARM64_SECREL_LOW12L $L.bss_secrel_2 (
+// CHECK-NEXT:     0x1C IMAGE_REL_ARM64_SECREL_HIGH12A large (
+// CHECK-NEXT:     0x20 IMAGE_REL_ARM64_SECREL_LOW12A large (
+// CHECK-NEXT:     0x24 IMAGE_REL_ARM64_SECREL_HIGH12A .bss (
+// CHECK-NEXT:     0x28 IMAGE_REL_ARM64_SECREL_LOW12A .bss (
+// CHECK-NEXT:     0x2C IMAGE_REL_ARM64_SECREL_HIGH12A large (
+// CHECK-NEXT:     0x30 IMAGE_REL_ARM64_SECREL_LOW12A large (
+// CHECK-NEXT:   }
+
+// CHECK:      Symbol {
+// CHECK:        Name: large
+// CHECK-NEXT:   Value: 4116
+// CHECK-NEXT:   Section: .bss
+// CHECK:        StorageClass: Static
+
+// CHECK:      Symbol {
+// CHECK:        Name: $L.bss_secrel_1
+// CHECK-NEXT:   Value: 4096
+// CHECK-NEXT:   Section: .bss
+// CHECK:        StorageClass: Label
+
+// CHECK:      Symbol {
+// CHECK:        Name: .Llarge
+// CHECK-NEXT:   Value: 4112
+// CHECK-NEXT:   Section: .bss
+// CHECK:        StorageClass: Label
+
+// CHECK:      Symbol {
+// CHECK:        Name: $L.bss_secrel_2
+// CHECK-NEXT:   Value: 4116
+// CHECK-NEXT:   Section: .bss
+// CHECK:        StorageClass: Label
+
+// DISASM-LABEL: <f>:
+// DISASM-NEXT:    add x0, x0, #4080, lsl #12
+// DISASM-NEXT:    add x0, x0, #4080
+// DISASM-NEXT:    add x1, x1, #0, lsl #12
+// DISASM-NEXT:    add x1, x1, #0
+// DISASM-NEXT:    add x2, x2, #0, lsl #12
+// DISASM-NEXT:    add x2, x2, #0
+// DISASM-NEXT:    ldr w3, [x3]
+// DISASM-NEXT:    add x4, x4, #0, lsl #12
+// DISASM-NEXT:    add x4, x4, #0
+// DISASM-NEXT:    add x5, x5, #4084, lsl #12
+// DISASM-NEXT:    add x5, x5, #4084
+// DISASM-NEXT:    add x6, x6, #128, lsl #12
+// DISASM-NEXT:    add x6, x6, #128
+// DISASM-NEXT:    ret


### PR DESCRIPTION
## Summary

Create helper label symbols for ARM64 COFF SECREL HI12/LO12 relocations when the byte offset cannot fit in the 12-bit instruction addend.

This is the MC-side follow-up to #200060: with LLD now handling small SECREL_HIGH12A byte addends correctly, this patch only handles the remaining large-addend case that needs a helper symbol.

Fixes #199581.

AI assistance: Claude (Anthropic), Codex (OpenAI).

## Tests

`llvm/test/MC/AArch64/coff-secrel-hi12.s`, run for both `aarch64-windows` and `arm64ec-windows`, covers:

- Temporary symbol, offset in range (`.Lsmall`, `.Lsmall+4`): emitted as a `.bss` section relocation with the offset baked into the imm12; no helper symbol.
- Temporary symbol, offset out of range (`.Lsmall+16`, `.Llarge`, `.Llarge+4`): a helper label symbol is created at the exact section offset and the imm12 is cleared.
- Non-temporary symbol, offset in range (`large`, `large+128`): relocation against the symbol with the addend in the imm12; no helper symbol.

`ninja -C build check-llvm-mc`