### PR TITLE
[compiler-rt][ARM] Add missing SUPERSEDES for optimized FP comparison sources

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -524,6 +524,8 @@ set(thumb1_base_SOURCES
   ${GENERIC_SOURCES}
 )
 set_special_properties(arm/adddf3.S SUPERSEDES subdf3.c PROVIDES subdf3)
+set_special_properties(arm/cmpdf2.S SUPERSEDES comparedf2.c PROVIDES comparedf2)
+set_special_properties(arm/cmpsf2.S SUPERSEDES arm/comparesf2.S PROVIDES comparesf2)
 
 if(COMPILER_RT_ARM_OPTIMIZED_FP)
   set(thumb1_base_SOURCES


### PR DESCRIPTION
PR #179924 and #179925 added optimized assembly implementations for ARM double-precision and single-precision FP comparisons (arm/cmpdf2.S, arm/gedf2.S, arm/unorddf2.S, arm/cmpsf2.S, arm/gesf2.S, arm/unordsf2.S) but only added SUPERSEDES annotations for the thumb1 variants. The arm variants were missing these annotations, causing both the generic and optimized implementations to be included in libclang_rt.builtins.a.

For double-precision, the archive contains:
  - comparedf2.c.obj (pos 28): defines __unorddf2, __aeabi_dcmpun, ...
  - divdc3.c.obj (pos 32): defines __divdc3; refs __aeabi_dcmpun
  - unorddf2.S.obj (pos 126): defines __unorddf2, __aeabi_dcmpun
  - aeabi_dcmp.S.obj (pos 158): defines __aeabi_dcmpeq; refs __eqdf2

When linking divdc3_test.c, the linker loads divdc3.c.obj which introduces __aeabi_dcmpun as undefined. BFD-like linkers (GNU ld, ELD) continue scanning forward and resolve __aeabi_dcmpun from unorddf2.S.obj (pos 126). Later, aeabi_dcmp.S.obj introduces __eqdf2 as undefined, which is resolved by comparedf2.c.obj (pos 28) on the next pass. Since both comparedf2.c.obj and unorddf2.S.obj define __unorddf2, the linker reports a duplicate symbol error.

lld does not encounter this because of the difference in the way it resolves symbol references. This causes comparedf2.c.obj (pos 28) to be selected first for __aeabi_dcmpun, making unorddf2.S.obj unnecessary.

The same pattern exists for single-precision where arm/comparesf2.S and arm/unordsf2.S both define __unordsf2 and __aeabi_fcmpun.

The fix adds SUPERSEDES annotations so that the generic implementations (comparedf2.c for double-precision and arm/comparesf2.S for single- precision) are removed from the source list when the optimized assembly replacements are present. The assembly files together provide all symbols that the generic implementations define.

The surrounding code was reviewed, and this PR was developed with the assistance of AI.