### PR TITLE
[DirectX][ObjectYAML] Fix CI build issue in DXContainerInfo.cpp

### DIFF
--- a/llvm/lib/MC/CMakeLists.txt
+++ b/llvm/lib/MC/CMakeLists.txt
@@ -84,6 +84,7 @@ add_llvm_component_library(LLVMMC
 
   DEPENDS
   intrinsics_gen
+  llvm_vcsrevision_h
   )
 
 add_subdirectory(MCParser)


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/198222, the following error was reported in CI bots:

```
[1546/5356] Building CXX object lib/MC/CMakeFiles/LLVMMC.dir/DXContainerInfo.cpp.o
FAILED: [code=1] lib/MC/CMakeFiles/LLVMMC.dir/DXContainerInfo.cpp.o
sccache /usr/bin/g++ -DLLVM_EXPORTS -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_USE_CXX11_ABI=1 -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/runner/work/circt/circt/build/lib/MC -I/home/runner/work/circt/circt/llvm/llvm/lib/MC -I/home/runner/work/circt/circt/build/include -I/home/runner/work/circt/circt/llvm/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-uninitialized -Wno-nonnull -Wno-class-memaccess -Wno-dangling-reference -Wno-redundant-move -Wno-pessimizing-move -Wno-array-bounds -Wno-stringop-overread -Wno-dangling-pointer -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17 -fPIC -UNDEBUG -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/MC/CMakeFiles/LLVMMC.dir/DXContainerInfo.cpp.o -MF lib/MC/CMakeFiles/LLVMMC.dir/DXContainerInfo.cpp.o.d -o lib/MC/CMakeFiles/LLVMMC.dir/DXContainerInfo.cpp.o -c /home/runner/work/circt/circt/llvm/llvm/lib/MC/DXContainerInfo.cpp
/home/runner/work/circt/circt/llvm/llvm/lib/MC/DXContainerInfo.cpp:14:10: fatal error: llvm/Support/VCSRevision.h: No such file or directory
   14 | #include "llvm/Support/VCSRevision.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[1547/5356] Building CXX object lib/MC/CMakeFiles/LLVMMC.dir/ConstantPools.cpp.o
[1548/5356] Building CXX object lib/MC/CMakeFiles/LLVMMC.dir/DXContainerRootSignature.cpp.o
[1549/5356] Building CXX object lib/MC/CMakeFiles/LLVMMC.dir/DXContainerPSVInfo.cpp.o
[1550/5356] Building CXX object lib/Bitcode/Reader/CMakeFiles/LLVMBitReader.dir/MetadataLoader.cpp.o
[1551/5356] Building CXX object lib/Bitcode/Reader/CMakeFiles/LLVMBitReader.dir/BitcodeReader.cpp.o
ninja: build stopped: subcommand failed.
```

This adds llvm_vcsrevision_h dependency to MC to fix that.