### PR TITLE
[libclc] Use generic spirv*-unknown-unknown clang triple for SPIR-V targets

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -123,18 +123,8 @@ foreach( tool IN ITEMS opt llvm-link )
   endif()
 endforeach()
 
-# Determine the clang target triple. Vulkan and SPIR-V backend targets use the
-# triple directly; other SPIR-V targets fall back to the legacy SPIR target.
+# Determine the clang target triple.
 set(clang_triple ${LIBCLC_TARGET})
-if(LIBCLC_TARGET_ARCH IN_LIST LIBCLC_ARCHS_SPIRV)
-  if(NOT LIBCLC_TARGET_OS STREQUAL vulkan AND NOT LIBCLC_USE_SPIRV_BACKEND)
-    if(LIBCLC_TARGET_ARCH STREQUAL spirv)
-      set(clang_triple spir--)
-    else()
-      set(clang_triple spir64--)
-    endif()
-  endif()
-endif()
 
 # Address space values.
 set(private_addrspace_val 0)

--- a/libclc/README.md
+++ b/libclc/README.md
@@ -60,9 +60,9 @@ cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release
 #### Configure for SPIR-V targets
 ```
 cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release \
-  -DRUNTIMES_spirv32-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
-  -DRUNTIMES_spirv64-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
-  -DLLVM_RUNTIME_TARGETS="spirv32-mesa-mesa3d;spirv64-mesa-mesa3d"
+  -DRUNTIMES_spirv32-unknown-unknown_LLVM_ENABLE_RUNTIMES=libclc \
+  -DRUNTIMES_spirv64-unknown-unknown_LLVM_ENABLE_RUNTIMES=libclc \
+  -DLLVM_RUNTIME_TARGETS="spirv32-unknown-unknown;spirv64-unknown-unknown"
 ```
 
 To build multiple targets, pass them as a semicolon-separated list in

--- a/libclc/README.md
+++ b/libclc/README.md
@@ -60,9 +60,9 @@ cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release
 #### Configure for SPIR-V targets
 ```
 cmake ../llvm -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release \
-  -DRUNTIMES_spirv-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
+  -DRUNTIMES_spirv32-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
   -DRUNTIMES_spirv64-mesa-mesa3d_LLVM_ENABLE_RUNTIMES=libclc \
-  -DLLVM_RUNTIME_TARGETS="spirv-mesa-mesa3d;spirv64-mesa-mesa3d"
+  -DLLVM_RUNTIME_TARGETS="spirv32-mesa-mesa3d;spirv64-mesa-mesa3d"
 ```
 
 To build multiple targets, pass them as a semicolon-separated list in


### PR DESCRIPTION
spirv-diff shows only numbering change to spirv64-unknown-unknown/libclc.spv. No change in `llvm-spirv -to-text` outputs. llvm-diff shows no change on reverse-translated bitcode files.

Also fixes a bug that spirv32-unknown-unknown was incorrectly using 64-bit triple.

Update README.md to use the generic target triple for SPIR-V targets.