### PR TITLE
[NFC] Add null terminator assert to CodeViewRecordIO::mapStringZ

### DIFF
--- a/llvm/lib/DebugInfo/CodeView/CodeViewRecordIO.cpp
+++ b/llvm/lib/DebugInfo/CodeView/CodeViewRecordIO.cpp
@@ -209,6 +209,7 @@ Error CodeViewRecordIO::mapEncodedInteger(APSInt &Value, const Twine &Comment) {
 
 Error CodeViewRecordIO::mapStringZ(StringRef &Value, const Twine &Comment) {
   if (isStreaming()) {
+    assert(Value.data()[Value.size()] == '\0' && "Expected null terminator.");
     auto NullTerminatedString = StringRef(Value.data(), Value.size() + 1);
     emitComment(Comment);
     Streamer->emitBytes(NullTerminatedString);


### PR DESCRIPTION
mapStringZ assumes that there's a null terminator past the end of Value (I suppose the name hints at this too). This doesn't seem very nice to me, but at least we can add an assert to check that the assumption holds.