### PR TITLE
[LLD][COFF] Gate second-dot section-name stripping on MinGW

### DIFF
--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -840,8 +840,10 @@ void Writer::run() {
                << "': " << toString(std::move(e));
 }
 
-static StringRef getOutputSectionName(StringRef name) {
+static StringRef getOutputSectionName(StringRef name, bool isMinGW) {
   StringRef s = name.split('$').first;
+  if (!isMinGW)
+    return s;
 
   // Treat a later period as a separator for MinGW, for sections like
   // ".ctors.01234".
@@ -1155,7 +1157,7 @@ void Writer::createSections() {
   // contributes to .text, for example. See PE/COFF spec 3.2.
   for (auto it : partialSections) {
     PartialSection *pSec = it.second;
-    StringRef name = getOutputSectionName(pSec->name);
+    StringRef name = getOutputSectionName(pSec->name, ctx.config.mingw);
     uint32_t outChars = pSec->characteristics;
 
     if (name == ".CRT") {

--- a/lld/test/COFF/ctors_dtors_priority.s
+++ b/lld/test/COFF/ctors_dtors_priority.s
@@ -3,6 +3,10 @@
 # RUN: lld-link -lldmingw -entry:main %t.obj -out:%t.exe
 # RUN: llvm-objdump -s %t.exe | FileCheck %s
 
+## In MSVC mode the second-dot stripping must NOT apply.
+# RUN: lld-link -force:unresolved -entry:main %t.obj -out:%t.msvc.exe
+# RUN: llvm-readobj --section-headers %t.msvc.exe | FileCheck %s --check-prefix=MSVC
+
 .globl main
 main:
   nop
@@ -43,3 +47,10 @@ main:
 # __DTOR_LIST__ pointing at 0x140002038.
 # CHECK-NEXT: Contents of section .data:
 # CHECK-NEXT: 140003000 10200040 01000000 38200040 01000000
+
+# MSVC: Name: .ctors (
+# MSVC: Name: .dtors (
+# MSVC: Name: .ctors.0
+# MSVC: Name: .ctors.0
+# MSVC: Name: .dtors.0
+# MSVC: Name: .dtors.0


### PR DESCRIPTION
The comment in getOutputSectionName has always called the second-dot
stripping "for MinGW" (e.g. .ctors.NNNN), but the code applied it on
every target. This hiddes a split-dwarf bug #199616.

Take an isMinGW gate and skip the stripping when it is false.