### PR TITLE
[X86] with vbmi prefer byte over word permutes

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -18953,8 +18953,16 @@ static SDValue lowerVECTOR_SHUFFLE(SDValue Op, const X86Subtarget &Subtarget,
   // wider element types. We cap this to not form integers or floating point
   // elements wider than 64 bits. It does not seem beneficial to form i128
   // integers to handle flipping the low and high halves of AVX 256-bit vectors.
+
+  // When VBMI is available, byte permutes (vpermi2b) are faster than word
+  // permutes (vpermi2w). Don't widen byte shuffles in that case: 512-bit
+  // requires VBMI, 256/128-bit also require VLX.
+  bool HasVBMIBytePermute = VT.getScalarSizeInBits() == 8 &&
+                            Subtarget.hasVBMI() &&
+                            (VT.getSizeInBits() == 512 || Subtarget.hasVLX());
+
   SmallVector<int, 16> WidenedMask;
-  if (VT.getScalarSizeInBits() < 64 && !Is1BitVector &&
+  if (VT.getScalarSizeInBits() < 64 && !Is1BitVector && !HasVBMIBytePermute &&
       !canCombineAsMaskOperation(V1, Subtarget) &&
       !canCombineAsMaskOperation(V2, Subtarget) &&
       canWidenShuffleElements(OrigMask, Zeroable, V2IsZero, WidenedMask)) {

--- a/llvm/test/CodeGen/X86/avx512vbmi-intrinsics.ll
+++ b/llvm/test/CodeGen/X86/avx512vbmi-intrinsics.ll
@@ -177,3 +177,24 @@ define <64 x i8>@test_int_x86_avx512_maskz_vpermt2var_qi_512(<64 x i8> %x0, <64 
   %3 = select <64 x i1> %2, <64 x i8> %1, <64 x i8> zeroinitializer
   ret <64 x i8> %3
 }
+
+; With VBMI this should use a (more efficient) byte permute, not a word permute.
+define <64 x i8> @vbmi_prefer_byte_permute(<64 x i8> %a, <64 x i8> %b) {
+; X86-LABEL: vbmi_prefer_byte_permute:
+; X86:       # %bb.0:
+; X86-NEXT:    vmovdqa64 {{.*#+}} zmm2 = [0,1,64,65,2,3,66,67,4,5,68,69,6,7,70,71,8,9,72,73,10,11,74,75,12,13,76,77,14,15,78,79,16,17,80,81,18,19,82,83,20,21,84,85,22,23,86,87,24,25,88,89,26,27,90,91,28,29,92,93,30,31,94,95]
+; X86-NEXT:    # encoding: [0x62,0xf1,0xfd,0x48,0x6f,0x15,A,A,A,A]
+; X86-NEXT:    # fixup A - offset: 6, value: {{\.?LCPI[0-9]+_[0-9]+}}, kind: FK_Data_4
+; X86-NEXT:    vpermt2b %zmm1, %zmm2, %zmm0 # encoding: [0x62,0xf2,0x6d,0x48,0x7d,0xc1]
+; X86-NEXT:    retl # encoding: [0xc3]
+;
+; X64-LABEL: vbmi_prefer_byte_permute:
+; X64:       # %bb.0:
+; X64-NEXT:    vmovdqa64 {{.*#+}} zmm2 = [0,1,64,65,2,3,66,67,4,5,68,69,6,7,70,71,8,9,72,73,10,11,74,75,12,13,76,77,14,15,78,79,16,17,80,81,18,19,82,83,20,21,84,85,22,23,86,87,24,25,88,89,26,27,90,91,28,29,92,93,30,31,94,95]
+; X64-NEXT:    # encoding: [0x62,0xf1,0xfd,0x48,0x6f,0x15,A,A,A,A]
+; X64-NEXT:    # fixup A - offset: 6, value: {{\.?LCPI[0-9]+_[0-9]+}}, kind: reloc_riprel_4byte
+; X64-NEXT:    vpermt2b %zmm1, %zmm2, %zmm0 # encoding: [0x62,0xf2,0x6d,0x48,0x7d,0xc1]
+; X64-NEXT:    retq # encoding: [0xc3]
+  %res = shufflevector <64 x i8> %a, <64 x i8> %b, <64 x i32> <i32 0, i32 1, i32 64, i32 65, i32 2, i32 3, i32 66, i32 67, i32 4, i32 5, i32 68, i32 69, i32 6, i32 7, i32 70, i32 71, i32 8, i32 9, i32 72, i32 73, i32 10, i32 11, i32 74, i32 75, i32 12, i32 13, i32 76, i32 77, i32 14, i32 15, i32 78, i32 79, i32 16, i32 17, i32 80, i32 81, i32 18, i32 19, i32 82, i32 83, i32 20, i32 21, i32 84, i32 85, i32 22, i32 23, i32 86, i32 87, i32 24, i32 25, i32 88, i32 89, i32 26, i32 27, i32 90, i32 91, i32 28, i32 29, i32 92, i32 93, i32 30, i32 31, i32 94, i32 95>
+  ret <64 x i8> %res
+}

--- a/llvm/test/CodeGen/X86/avx512vbmivl-intrinsics.ll
+++ b/llvm/test/CodeGen/X86/avx512vbmivl-intrinsics.ll
@@ -353,3 +353,37 @@ define <32 x i8>@test_int_x86_avx512_maskz_vpermt2var_qi_256(<32 x i8> %x0, <32 
   %3 = select <32 x i1> %2, <32 x i8> %1, <32 x i8> zeroinitializer
   ret <32 x i8> %3
 }
+
+
+; With VBMI+VL this should use a (more efficient) byte permute, not a word permute.
+define <32 x i8> @vbmi_prefer_byte_permute_256(<32 x i8> %a, <32 x i8> %b) {
+; X86-LABEL: vbmi_prefer_byte_permute_256:
+; X86:       # %bb.0:
+; X86-NEXT:    vmovdqa {{.*#+}} ymm2 = [0,1,32,33,2,3,34,35,4,5,36,37,6,7,38,39,8,9,40,41,10,11,42,43,12,13,44,45,14,15,46,47]
+; X86-NEXT:    # EVEX TO VEX Compression encoding: [0xc5,0xfd,0x6f,0x15,A,A,A,A]
+; X86-NEXT:    # fixup A - offset: 4, value: {{\.?LCPI[0-9]+_[0-9]+}}, kind: FK_Data_4
+; X86-NEXT:    vpermt2b %ymm1, %ymm2, %ymm0 # encoding: [0x62,0xf2,0x6d,0x28,0x7d,0xc1]
+; X86-NEXT:    retl # encoding: [0xc3]
+;
+; X64-LABEL: vbmi_prefer_byte_permute_256:
+; X64:       # %bb.0:
+; X64-NEXT:    vmovdqa {{.*#+}} ymm2 = [0,1,32,33,2,3,34,35,4,5,36,37,6,7,38,39,8,9,40,41,10,11,42,43,12,13,44,45,14,15,46,47]
+; X64-NEXT:    # EVEX TO VEX Compression encoding: [0xc5,0xfd,0x6f,0x15,A,A,A,A]
+; X64-NEXT:    # fixup A - offset: 4, value: {{\.?LCPI[0-9]+_[0-9]+}}, kind: reloc_riprel_4byte
+; X64-NEXT:    vpermt2b %ymm1, %ymm2, %ymm0 # encoding: [0x62,0xf2,0x6d,0x28,0x7d,0xc1]
+; X64-NEXT:    retq # encoding: [0xc3]
+  %res = shufflevector <32 x i8> %a, <32 x i8> %b, <32 x i32> <i32 0, i32 1, i32 32, i32 33, i32 2, i32 3, i32 34, i32 35, i32 4, i32 5, i32 36, i32 37, i32 6, i32 7, i32 38, i32 39, i32 8, i32 9, i32 40, i32 41, i32 10, i32 11, i32 42, i32 43, i32 12, i32 13, i32 44, i32 45, i32 14, i32 15, i32 46, i32 47>
+  ret <32 x i8> %res
+}
+
+; For 128-bit vectors with VBMI+VL a byte permute is more efficient than a word permute,
+; but vpunpcklwd is an instruction for this exact pattern.
+define <16 x i8> @vbmi_prefer_byte_permute_128(<16 x i8> %a, <16 x i8> %b) {
+; CHECK-LABEL: vbmi_prefer_byte_permute_128:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vpunpcklwd %xmm1, %xmm0, %xmm0 # EVEX TO VEX Compression encoding: [0xc5,0xf9,0x61,0xc1]
+; CHECK-NEXT:    # xmm0 = xmm0[0],xmm1[0],xmm0[1],xmm1[1],xmm0[2],xmm1[2],xmm0[3],xmm1[3]
+; CHECK-NEXT:    ret{{[l|q]}} # encoding: [0xc3]
+  %res = shufflevector <16 x i8> %a, <16 x i8> %b, <16 x i32> <i32 0,  i32 1, i32 16, i32 17, i32 2, i32 3, i32 18, i32 19, i32 4, i32 5, i32 20, i32 21, i32 6, i32 7, i32 22, i32 23>
+  ret <16 x i8> %res
+}

--- a/llvm/test/CodeGen/X86/vector-shuffle-512-v64.ll
+++ b/llvm/test/CodeGen/X86/vector-shuffle-512-v64.ll
@@ -1953,26 +1953,28 @@ define <512 x i8> @PR153457(<512 x i8> %a0, <512 x i8> %a1) nounwind {
 ; AVX512VBMI-NEXT:    vpermi2b %zmm0, %zmm6, %zmm1
 ; AVX512VBMI-NEXT:    vmovdqa64 {{.*#+}} zmm6 = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,0,64,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,56,57,58,59,60,61,62,63]
 ; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm0, %zmm6
-; AVX512VBMI-NEXT:    vinserti32x4 $1, %xmm7, %zmm2, %zmm0
-; AVX512VBMI-NEXT:    vpshufb {{.*#+}} zmm0 = zmm0[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63]
-; AVX512VBMI-NEXT:    vpmovsxbw {{.*#+}} zmm2 = [0,1,2,3,33,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,20,21,22,23,24,25,26,27,28,29,30,31]
-; AVX512VBMI-NEXT:    vpermi2w %zmm7, %zmm3, %zmm2
+; AVX512VBMI-NEXT:    vmovdqa64 {{.*#+}} zmm0 = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,65,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63]
+; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm2, %zmm0
+; AVX512VBMI-NEXT:    vmovdqa64 {{.*#+}} zmm2 = [0,1,2,3,4,5,6,7,66,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63]
+; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm3, %zmm2
 ; AVX512VBMI-NEXT:    vmovdqa64 {{.*#+}} zmm3 = [67,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,68,u,u,u,u,u,u,u]
 ; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm4, %zmm3
-; AVX512VBMI-NEXT:    vinserti32x4 $3, %xmm7, %zmm5, %zmm4
-; AVX512VBMI-NEXT:    vpshufb {{.*#+}} zmm4 = zmm4[u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,53,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
-; AVX512VBMI-NEXT:    vbroadcasti64x4 {{.*#+}} zmm5 = [16,17,18,19,35,0,0,0,8,9,10,11,12,13,14,15,16,17,18,19,35,0,0,0,8,9,10,11,12,13,14,15]
+; AVX512VBMI-NEXT:    vbroadcasti64x4 {{.*#+}} zmm4 = [32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,69,0,0,0,0,0,0,0,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,69,0,0,0,0,0,0,0,24,25,26,27,28,29,30,31]
+; AVX512VBMI-NEXT:    # zmm4 = mem[0,1,2,3,0,1,2,3]
+; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm5, %zmm4
+; AVX512VBMI-NEXT:    vbroadcasti64x4 {{.*#+}} zmm5 = [32,33,34,35,36,37,38,39,70,0,0,0,0,0,0,0,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,70,0,0,0,0,0,0,0,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]
 ; AVX512VBMI-NEXT:    # zmm5 = mem[0,1,2,3,0,1,2,3]
-; AVX512VBMI-NEXT:    vpermi2w %zmm7, %zmm8, %zmm5
-; AVX512VBMI-NEXT:    vinserti64x4 $1, %ymm7, %zmm1, %zmm1
-; AVX512VBMI-NEXT:    vpshufb {{.*#+}} zmm1 = zmm1[u,u,u,u,u,u,u,u,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,39,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u,u]
+; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm8, %zmm5
+; AVX512VBMI-NEXT:    vbroadcasti64x4 {{.*#+}} zmm8 = [71,0,0,0,0,0,0,0,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,71,0,0,0,0,0,0,0,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31]
+; AVX512VBMI-NEXT:    # zmm8 = mem[0,1,2,3,0,1,2,3]
+; AVX512VBMI-NEXT:    vpermi2b %zmm7, %zmm1, %zmm8
 ; AVX512VBMI-NEXT:    vmovdqa64 %zmm5, 320(%rdi)
 ; AVX512VBMI-NEXT:    vmovdqa64 %zmm4, 256(%rdi)
+; AVX512VBMI-NEXT:    vmovdqa64 %zmm8, 384(%rdi)
 ; AVX512VBMI-NEXT:    vmovdqa64 %zmm3, 192(%rdi)
 ; AVX512VBMI-NEXT:    vmovdqa64 %zmm2, 128(%rdi)
 ; AVX512VBMI-NEXT:    vmovdqa64 %zmm0, 64(%rdi)
 ; AVX512VBMI-NEXT:    vmovdqa64 %zmm6, (%rdi)
-; AVX512VBMI-NEXT:    vmovdqa64 %zmm1, 384(%rdi)
 ; AVX512VBMI-NEXT:    movq %rbp, %rsp
 ; AVX512VBMI-NEXT:    popq %rbp
 ; AVX512VBMI-NEXT:    vzeroupper


### PR DESCRIPTION
Reported as https://github.com/rust-lang/rust/issues/156946.

When vbmi is available, byte permutes are better than word permutes

- https://uops.info/html-instr/VPERMI2W_ZMM_ZMM_ZMM.html
- https://uops.info/html-instr/VPERMI2B_ZMM_ZMM_ZMM.html

On Emerald Rapids:

```diff
     Measurements
         Latencies
-            Latency operand 1 → 1: 7
-            Latency operand 2 → 1: 7
-            Latency operand 3 → 1: 7
+            Latency operand 1 → 1: 5
+            Latency operand 2 → 1: 4
+            Latency operand 3 → 1: 4
         Throughput
             Computed from the port usage: 2.00
             Measured (loop): 2.00
             Measured (unrolled): 2.00
         Number of μops
             Executed: 3
-            Retire slots: 5
-            Decoded (MITE): 5
+            Retire slots: 3
+            Decoded (MITE): 3
             Microcode Sequencer (MS): 0
-            Requires the complex decoder (1 other instruction can be decoded with simple decoders in the same cycle)
+            Requires the complex decoder (3 other instructions can be decoded with simple decoders in the same cycle)
         Port usage: 1*p05+2*p5
```

So prevent the conversion from a byte permute to a word permute in that case. See https://rust.godbolt.org/z/4cMGaqWq4 for the output of the added tests before this change.

Marking this as ready for review in the sense that I need some help. 

The change I made has the desired effect on the test cases, but for 

- `CodeGen/X86/vector-fshr-rot-256.ll`
- `CodeGen/X86/vector-replicaton-i1-mask.ll`
- `CodeGen/X86/vector-shuffle-256-v32.ll` 

The backend enters an infinite loop, and I'm not really sure how to debug/fix that. Also it's perhaps an indication that my fix is not the right one?