### PR TITLE
[MLIR] Fix TypeID anonymous namespace check to handle GCC's __PRETTY_FUNCTION__ format

### DIFF
--- a/mlir/lib/Support/TypeID.cpp
+++ b/mlir/lib/Support/TypeID.cpp
@@ -30,12 +30,14 @@ struct ImplicitTypeIDRegistry {
     // Perform a heuristic check to see if this type is in an anonymous
     // namespace. String equality is not valid for anonymous types, so we try to
     // abort whenever we see them.
+    // Check all known anonymous-namespace markers unconditionally:
+    //   Clang : "(anonymous namespace)"
+    //   GCC   : "{anonymous}"
+    //   MSVC  : "anonymous-namespace"
 #ifndef NDEBUG
-#if defined(_MSC_VER)
-    if (typeName.contains("anonymous-namespace")) {
-#else
-    if (typeName.contains("anonymous namespace")) {
-#endif
+    if (typeName.contains("anonymous namespace") ||
+        typeName.contains("{anonymous}") ||
+        typeName.contains("anonymous-namespace")) {
       std::string errorStr;
       {
         llvm::raw_string_ostream errorOS(errorStr);


### PR DESCRIPTION
The anonymous namespace detection in `FallbackTypeIDResolver::registerImplicitTypeID` only checked for Clang's `(anonymous namespace)` and MSVC's `anonymous-namespace` formats. GCC produces `{anonymous}` in `__PRETTY_FUNCTION__`, silently bypassing the check.