### PR TITLE
[MLIR] Add a non-const ActionHandler getter to MLIRContext

### DIFF
--- a/mlir/include/mlir/IR/MLIRContext.h
+++ b/mlir/include/mlir/IR/MLIRContext.h
@@ -269,7 +269,8 @@ public:
 
   /// Return a reference to the currently registered action handler. Its target
   /// can be used to gain access to the handler's state, if any.
-  const HandlerTy &getActionHandler();
+  const HandlerTy &getActionHandler() const;
+  HandlerTy &getActionHandler();
 
   /// Return true if a valid ActionHandler is set.
   bool hasActionHandler();

--- a/mlir/include/mlir/IR/MLIRContext.h
+++ b/mlir/include/mlir/IR/MLIRContext.h
@@ -211,6 +211,7 @@ public:
   // This is effectively private given that only MLIRContext.cpp can see the
   // MLIRContextImpl type.
   MLIRContextImpl &getImpl() { return *impl; }
+  const MLIRContextImpl &getImpl() const { return *impl; }
 
   /// Returns the diagnostic engine for this context.
   DiagnosticEngine &getDiagEngine();

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -380,7 +380,11 @@ void MLIRContext::registerActionHandler(HandlerTy handler) {
   getImpl().actionHandler = std::move(handler);
 }
 
-const MLIRContext::HandlerTy &MLIRContext::getActionHandler() {
+const MLIRContext::HandlerTy &MLIRContext::getActionHandler() const {
+  return getImpl().actionHandler;
+}
+
+MLIRContext::HandlerTy &MLIRContext::getActionHandler() {
   return getImpl().actionHandler;
 }
 


### PR DESCRIPTION
#197230 added a getter for the ActionHandler, but only returns a const ref with a non-const accessor. 
Instead provide both variants: a const accessor returning a const ref and non-const one returning a mutable ref.
