### PR TITLE
[ORC] Avoid iterator invalidation when erasing image info symbols

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MachOPlatform.cpp
@@ -1124,8 +1124,8 @@ Error MachOPlatform::MachOPlatformPlugin::processObjCImageInfo(
         return E;
 
     // __objc_imageinfo is valid. Delete the block.
-    for (auto *S : ObjCImageInfo->symbols())
-      G.removeDefinedSymbol(*S);
+    while (ObjCImageInfo->symbols_size() != 0)
+      G.removeDefinedSymbol(**ObjCImageInfo->symbols().begin());
     G.removeBlock(ObjCImageInfoBlock);
   } else {
     LLVM_DEBUG({


### PR DESCRIPTION
processObjCImageInfo iterated the section's DenseSet of symbols while calling removeDefinedSymbol, which erases from that same set. Re-fetch begin() each iteration so the iterator is always fresh.

Started with https://github.com/llvm/llvm-project/pull/199369.