### PR TITLE
[GlobalsModRef] Don't erase while iterating

### DIFF
--- a/llvm/lib/Analysis/GlobalsModRef.cpp
+++ b/llvm/lib/Analysis/GlobalsModRef.cpp
@@ -215,11 +215,8 @@ void GlobalsAAResult::DeletionCallbackHandle::deleted() {
       // remove any AllocRelatedValues for it.
       if (GAR->IndirectGlobals.erase(GV)) {
         // Remove any entries in AllocsForIndirectGlobals for this global.
-        for (auto I = GAR->AllocsForIndirectGlobals.begin(),
-                  E = GAR->AllocsForIndirectGlobals.end();
-             I != E; ++I)
-          if (I->second == GV)
-            GAR->AllocsForIndirectGlobals.erase(I);
+        GAR->AllocsForIndirectGlobals.remove_if(
+            [GV](const auto &Entry) { return Entry.second == GV; });
       }
 
       // Scan the function info we have collected and remove this global


### PR DESCRIPTION
The loop erases from AllocsForIndirectGlobals while walking it, which now hits the iterator invalidation assert in DenseMap::erase. Use remove_if instead.

Started with https://github.com/llvm/llvm-project/pull/199369.