### PR TITLE
[lit] Add __slots__ to hot shell-execution objects

### DIFF
--- a/llvm/utils/lit/lit/ShellEnvironment.py
+++ b/llvm/utils/lit/lit/ShellEnvironment.py
@@ -19,6 +19,18 @@ kDevNull = "/dev/null"
 class ShellCommandResult(object):
     """Captures the result of an individual command."""
 
+    # TODO(prasoon054): Replace __slots__ with @dataclass(slots=True)
+    # once the minimum Python version is bumped to 3.10.
+    # https://github.com/llvm/llvm-project/issues/200531
+    __slots__ = (
+        "command",
+        "stdout",
+        "stderr",
+        "exitCode",
+        "timeoutReached",
+        "outputFiles",
+    )
+
     def __init__(
         self, command, stdout, stderr, exitCode, timeoutReached, outputFiles=[]
     ):
@@ -43,6 +55,11 @@ class ShellEnvironment(object):
     Environment variables are not implemented, but cwd tracking is. In addition,
     we maintain a dir stack for pushd/popd.
     """
+
+    # TODO(prasoon054): Replace __slots__ with @dataclass(slots=True)
+    # once the minimum Python version is bumped to 3.10.
+    # https://github.com/llvm/llvm-project/issues/200531
+    __slots__ = ("cwd", "env", "umask", "dirStack", "ulimit", "normalize_slashes")
 
     def __init__(self, cwd, env, umask=-1, ulimit=None, normalize_slashes=False):
         self.cwd = cwd

--- a/llvm/utils/lit/lit/builtin_commands/diff.py
+++ b/llvm/utils/lit/lit/builtin_commands/diff.py
@@ -11,6 +11,20 @@ import util
 
 
 class DiffFlags:
+    # TODO(prasoon054): Replace __slots__ with @dataclass(slots=True)
+    # once the minimum Python version is bumped to 3.10.
+    # https://github.com/llvm/llvm-project/issues/200531
+    __slots__ = (
+        "ignore_all_space",
+        "ignore_space_change",
+        "ignore_matching_lines",
+        "ignore_matching_lines_regex",
+        "unified_diff",
+        "num_context_lines",
+        "recursive_diff",
+        "strip_trailing_cr",
+    )
+
     def __init__(self):
         self.ignore_all_space = False
         self.ignore_space_change = False


### PR DESCRIPTION
`ShellCommand`, `ShellEnvironment` and `DiffFlags` classes are
instantiated per commad / per diff. `__slots__` drops the per-instance
`__dict__`, lowering memory and speeding attribute access. (`__slots__` 
not `@dataclass(slots=True)` to keep Python 3.8 support.)

**Baseline:**
| Stage | Metric (Runtime / Peak RSS) |
| :--- | :--- |
| **CodeGen-X86** | 99.310s / 51872 kB |
| **llvm-transforms** | 51.457s / 66928 kB |

**Changes made here:**
| Stage | Metric (Runtime / Peak RSS) |
| :--- | :--- |
| **CodeGen-X86** | 98.708s / 51872 kB |
| **llvm-transforms** | 51.496s / 66824 kB |

This PR is part of the "GSoC 2026: Improving lit" project.