### PR TITLE
[lldb-dap][NFC] Use GetStringValue helper

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -95,14 +95,7 @@ static std::string GetStringFromStructuredData(lldb::SBStructuredData &data,
   if (!keyValue)
     return std::string();
 
-  const size_t length = keyValue.GetStringValue(nullptr, 0);
-
-  if (length == 0)
-    return std::string();
-
-  std::string str(length + 1, 0);
-  keyValue.GetStringValue(&str[0], length + 1);
-  return str;
+  return GetStringValue(keyValue);
 }
 
 static uint64_t GetUintFromStructuredData(lldb::SBStructuredData &data,

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -9,6 +9,7 @@
 #include "JSONUtils.h"
 #include "DAP.h"
 #include "ExceptionBreakpoint.h"
+#include "LLDBUtils.h"
 #include "Protocol/ProtocolBase.h"
 #include "Protocol/ProtocolRequests.h"
 #include "lldb/API/SBAddress.h"
@@ -456,13 +457,9 @@ static void FilterAndGetValueForKey(const lldb::SBStructuredData data,
   case lldb::eStructuredDataTypeBoolean:
     out.try_emplace(key_utf8, value.GetBooleanValue());
     break;
-  case lldb::eStructuredDataTypeString: {
-    // Get the string size before reading
-    const size_t str_length = value.GetStringValue(nullptr, 0);
-    std::string str(str_length + 1, 0);
-    value.GetStringValue(&str[0], str_length);
-    out.try_emplace(key_utf8, llvm::json::fixUTF8(str));
-  } break;
+  case lldb::eStructuredDataTypeString:
+    out.try_emplace(key_utf8, llvm::json::fixUTF8(GetStringValue(value)));
+    break;
   case lldb::eStructuredDataTypeDictionary: {
     lldb::SBStream contents;
     value.GetAsJSON(contents);

--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -48,12 +48,9 @@ static bool RunLLDBCommands(lldb::SBDebugger &debugger, llvm::StringRef prefix,
 
     // Get the current prompt from settings.
     if (const lldb::SBStructuredData prompt = debugger.GetSetting("prompt")) {
-      const size_t prompt_length = prompt.GetStringValue(nullptr, 0);
-
-      if (prompt_length != 0) {
-        prompt_string.resize(prompt_length + 1);
-        prompt.GetStringValue(prompt_string.data(), prompt_string.length());
-      }
+      std::string tmp_prompt = GetStringValue(prompt);
+      if (!tmp_prompt.empty())
+        prompt_string = std::move(tmp_prompt);
     }
   }
 
@@ -179,29 +176,17 @@ uint64_t MakeDAPFrameID(lldb::SBFrame &frame) {
 
 lldb::StopDisassemblyType
 GetStopDisassemblyDisplay(lldb::SBDebugger &debugger) {
-  lldb::StopDisassemblyType result =
-      lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo;
   lldb::SBStructuredData string_result =
       debugger.GetSetting("stop-disassembly-display");
-  const size_t result_length = string_result.GetStringValue(nullptr, 0);
-  if (result_length > 0) {
-    std::string result_string(result_length, '\0');
-    string_result.GetStringValue(result_string.data(), result_length + 1);
-
-    result =
-        llvm::StringSwitch<lldb::StopDisassemblyType>(result_string)
-            .Case("never", lldb::StopDisassemblyType::eStopDisassemblyTypeNever)
-            .Case("always",
-                  lldb::StopDisassemblyType::eStopDisassemblyTypeAlways)
-            .Case("no-source",
-                  lldb::StopDisassemblyType::eStopDisassemblyTypeNoSource)
-            .Case("no-debuginfo",
-                  lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo)
-            .Default(
-                lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo);
-  }
-
-  return result;
+  return llvm::StringSwitch<lldb::StopDisassemblyType>(
+             GetStringValue(string_result))
+      .Case("never", lldb::StopDisassemblyType::eStopDisassemblyTypeNever)
+      .Case("always", lldb::StopDisassemblyType::eStopDisassemblyTypeAlways)
+      .Case("no-source",
+            lldb::StopDisassemblyType::eStopDisassemblyTypeNoSource)
+      .Case("no-debuginfo",
+            lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo)
+      .Default(lldb::StopDisassemblyType::eStopDisassemblyTypeNoDebugInfo);
 }
 
 llvm::Error ToError(const lldb::SBError &error, bool show_user) {


### PR DESCRIPTION
I noticed some inconsistency in working with `SBStructuredData.GetStringValue` (e.g. use `length + 1` or `length`), so it would be better to remove that code duplication and use common helper (`GetStringValue`) to do this routine.