### PR TITLE
[clang-tidy] Fix locationless diagnostic in modernize-avoid-c-arrays

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/AvoidCArraysCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/AvoidCArraysCheck.cpp
@@ -116,7 +116,8 @@ void AvoidCArraysCheck::registerMatchers(MatchFinder *Finder) {
 
   Finder->addMatcher(
       templateArgumentLoc(hasTypeLoc(
-          typeLoc(hasType(arrayType())).bind("template_arg_array_typeloc"))),
+          typeLoc(hasValidBeginLoc(), hasType(arrayType()))
+              .bind("template_arg_array_typeloc"))),
       this);
 }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -542,6 +542,11 @@ Changes in existing checks
   positives on project headers that use the same name as a standard library
   header.
 
+- Fixed :doc:`modernize-avoid-c-arrays
+  <clang-tidy/checks/modernize/avoid-c-arrays>` check to avoid emitting a
+  locationless diagnostic on ``= default`` special members of classes inheriting
+  from template types with array parameters (e.g. ``unique_ptr<T[]>``).
+
 - Improved :doc:`modernize-pass-by-value
   <clang-tidy/checks/modernize/pass-by-value>` check by adding `IgnoreMacros`
   option to suppress warnings in macros.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-c-arrays.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-c-arrays.cpp
@@ -59,6 +59,23 @@ using k2 = int[];
 
 unique_ptr<k2> dk2;
 
+// Defaulted special members in a class inheriting from unique_ptr<T[]> should
+// not produce a locationless diagnostic (https://github.com/llvm/llvm-project/issues/199692).
+template <typename T>
+struct wrapper : unique_ptr<T[]> {
+  wrapper() = default;
+  ~wrapper() = default;
+  wrapper(wrapper &&) = default;
+  wrapper &operator=(wrapper &&) = default;
+};
+// no diagnostic expected: the T[] above is inside compiler-synthesized code
+
+void testDefaultedSpecialMembers() {
+  wrapper<int> w1;
+  wrapper<int> w2(std::move(w1));
+  w1 = std::move(w2);
+}
+
 // Some header
 extern "C" {
 


### PR DESCRIPTION
The `templateArgumentLoc` matcher added by #132924 lacks a `hasValidBeginLoc()` guard, causing it to match array type template arguments inside compiler-synthesized `= default` special member bodies. These AST nodes have no valid source location, so the emitted diagnostic has no file/line/column, cannot be suppressed with NOLINT, and causes `--warnings-as-errors` to fail unconditionally.

**Reproducer:**

```cpp
template <typename T> struct mock_unique_ptr { T *p; };

template <typename T>
struct wrapper : mock_unique_ptr<T[]> {
  wrapper() = default;           // any defaulted special member triggers it
  wrapper(wrapper &&) = default;
};

void f() { wrapper<int> w; }    // instantiation required
```

**Fix:** Add `hasValidBeginLoc()` to the `templateArgumentLoc` matcher, consistent with the primary `typeLoc` matcher which already has this guard.

Related: #132260, #40517