### PR TITLE
[DirectX] Generate compiler version part in llc

### DIFF
--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -53,6 +53,7 @@ class DXContainerGlobals : public llvm::ModulePass {
   void addResourcesForPSV(Module &M, PSVRuntimeInfo &PSV);
   void addPipelineStateValidationInfo(Module &M,
                                       SmallVector<GlobalValue *> &Globals);
+  void addCompilerVersion(Module &M, SmallVector<GlobalValue *> &Globals);
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -83,6 +84,7 @@ bool DXContainerGlobals::runOnModule(Module &M) {
   addSignature(M, Globals);
   addRootSignature(M, Globals);
   addPipelineStateValidationInfo(M, Globals);
+  addCompilerVersion(M, Globals);
   appendToCompilerUsed(M, Globals);
   return true;
 }
@@ -337,6 +339,21 @@ void DXContainerGlobals::addPipelineStateValidationInfo(
   PSV.finalize(MMI.ShaderProfile);
   PSV.write(OS);
   addSection(M, Globals, Data, "dx.psv0", "PSV0");
+}
+
+void DXContainerGlobals::addCompilerVersion(
+    Module &M, SmallVector<GlobalValue *> &Globals) {
+  dxil::ModuleMetadataInfo &MMI =
+      getAnalysis<DXILMetadataAnalysisWrapperPass>().getModuleMetadata();
+
+  if (M.debug_compile_units().empty())
+    return;
+
+  SmallString<256> Data;
+  raw_svector_ostream OS(Data);
+  mcdxbc::CompilerVersion CompilerVersion;
+  CompilerVersion.write(OS);
+  addSection(M, Globals, Data, "dx.vers", "VERS");
 }
 
 char DXContainerGlobals::ID = 0;

--- a/llvm/test/CodeGen/DirectX/ContainerData/CompilerVersion.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/CompilerVersion.ll
@@ -1,0 +1,28 @@
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s
+
+; CHECK:        - Name:            VERS
+; CHECK:          CompilerVersion:
+; CHECK-NEXT:       Major:           {{[0-9]+}}
+; CHECK-NEXT:       Minor:           {{[0-9]+}}
+; CHECK-NEXT:       IsDebugBuild:    {{true|false}}
+; CHECK-NEXT:       IsValidated:     false
+; CHECK-NEXT:       CommitCount:     {{[0-9]+}}
+; CHECK-NEXT:       ContentSizeInBytes: {{[0-9]+}}
+; CHECK-NEXT:       CommitSha:       {{.*}}
+; CHECK-NEXT:       CustomVersionString: {{.*}}
+
+target triple = "dxilv1.3-pc-shadermodel6.3-library"
+
+define float @_Z3fooff(float %a, float %b) {
+entry:
+  %add = fadd float %a, %b
+  ret float %add
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, emissionKind: FullDebug)
+!1 = !DIFile(filename: "dx-source-metadata.hlsl", directory: "C:\\")
+!2 = !{i32 2, !"Dwarf Version", i32 4}
+!3 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
This change modifies DXContainerGlobals pass to generate compiler version (VERS) part in DXContainer.
VERS part allows consumers to information about compiler version used to build shader.

When debug info PDB file creation will be implemented, VERS part should go to PDB file.