### PR TITLE
[Hexagon] Fix fpround fp32 -> fp16 pattern

### DIFF
--- a/llvm/lib/Target/Hexagon/HexagonPatternsHVX.td
+++ b/llvm/lib/Target/Hexagon/HexagonPatternsHVX.td
@@ -596,7 +596,7 @@ let Predicates = [UseHVXV68, UseHVXIEEEFP] in {
            (V6_vmpy_sf_sf HVF32:$Rs, HVF32:$Rt)>;
 
   def: Pat<(VecF16 (pf1<fpround> HWF32:$Vuu)),
-           (V6_vdealh (V6_vcvt_hf_sf (HiVec HvxWR:$Vuu), (LoVec HvxWR:$Vuu)))>;
+           (V6_vdealh (V6_vcvt_hf_sf (LoVec HvxWR:$Vuu), (HiVec HvxWR:$Vuu)))>;
   def: Pat<(VecPF32 (pf1<fpextend> HVF16:$Vu)),
            (V6_vcvt_sf_hf (V6_vshuffh HvxVR:$Vu))>;
 

--- a/llvm/test/CodeGen/Hexagon/autohvx/conv-fp-fp.ll
+++ b/llvm/test/CodeGen/Hexagon/autohvx/conv-fp-fp.ll
@@ -57,7 +57,7 @@ define <64 x half> @f2(<64 x float> %a0) #1 {
 ; CHECK-LABEL: f2:
 ; CHECK:       // %bb.0: // %b0
 ; CHECK-NEXT:    {
-; CHECK-NEXT:     v0.hf = vcvt(v1.sf,v0.sf)
+; CHECK-NEXT:     v0.hf = vcvt(v0.sf,v1.sf)
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
 ; CHECK-NEXT:     v0.h = vdeal(v0.h)


### PR DESCRIPTION
The pattern was passing hi and lo in the wrong order to `vcvt` causing the final output after `vdeal` to be incorrect.