### PR TITLE
Remove duplicate .pdata entries after ICF

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -129,7 +129,6 @@ struct Configuration {
   bool doGC = true;
   ICFLevel doICF = ICFLevel::None;
   bool tailMerge;
-  bool dedupPdata = true;
   bool relocatable = true;
   bool forceMultiple = false;
   bool forceMultipleRes = false;

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -129,6 +129,7 @@ struct Configuration {
   bool doGC = true;
   ICFLevel doICF = ICFLevel::None;
   bool tailMerge;
+  bool dedupPdata = true;
   bool relocatable = true;
   bool forceMultiple = false;
   bool forceMultipleRes = false;

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2027,10 +2027,6 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
         icfLevel = ICFLevel::Safe;
       } else if (s == "noicf") {
         icfLevel = ICFLevel::None;
-      } else if (s == "deduppdata") {
-        config->dedupPdata = true;
-      } else if (s == "nodeduppdata") {
-        config->dedupPdata = false;
       } else if (s == "lldtailmerge") {
         tailMerge = 2;
       } else if (s == "nolldtailmerge") {
@@ -2943,6 +2939,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
     findKeepUniqueSections(ctx);
     doICF(ctx);
   }
+
+  // Remove duplicate .pdata entries that arise after ICF folds functions.
+  if (config->machine == AMD64)
+    removeDuplicatePdataChunks(ctx);
 
   // Write the result.
   writeResult(ctx);

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2027,6 +2027,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
         icfLevel = ICFLevel::Safe;
       } else if (s == "noicf") {
         icfLevel = ICFLevel::None;
+      } else if (s == "deduppdata") {
+        config->dedupPdata = true;
+      } else if (s == "nodeduppdata") {
+        config->dedupPdata = false;
       } else if (s == "lldtailmerge") {
         tailMerge = 2;
       } else if (s == "nolldtailmerge") {

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -211,7 +211,6 @@ public:
 private:
   void calculateStubDependentSizes();
   void createSections();
-  void removeDuplicatePdataChunks();
   void createMiscChunks();
   void createImportTables();
   void appendImportThunks();
@@ -1068,7 +1067,7 @@ void Writer::calculateStubDependentSizes() {
 // entries covering the same address range. We detect this by comparing the
 // BeginAddress and EndAddress relocation targets (the first two relocations),
 // and set live = false on duplicates so they are excluded from the output.
-void Writer::removeDuplicatePdataChunks() {
+void lld::coff::removeDuplicatePdataChunks(COFFLinkerContext &ctx) {
   // Key: (beginChunk, beginValue, endChunk, endValue) identifying the range.
   struct PdataKey {
     Chunk *beginChunk;
@@ -1091,6 +1090,7 @@ void Writer::removeDuplicatePdataChunks() {
   };
 
   llvm::DenseSet<PdataKey, PdataKeyInfo> seen;
+  llvm::DenseSet<SectionChunk *> orphanXdata;
 
   for (Chunk *c : ctx.driver.getChunks()) {
     auto *sc = dyn_cast<SectionChunk>(c);
@@ -1119,31 +1119,54 @@ void Writer::removeDuplicatePdataChunks() {
       return {nullptr, 0};
     };
 
+    if (relocs[0].VirtualAddress != 0 || relocs[1].VirtualAddress != 4)
+      continue;
+
     auto [beginChunk, beginVal] = resolve(relocs[0]);
     auto [endChunk, endVal] = resolve(relocs[1]);
-    if (!beginChunk)
+    if (!beginChunk || !endChunk)
       continue;
 
     // Account for addends baked into the section data.
-    beginVal += *reinterpret_cast<const ulittle32_t *>(contents.data());
-    endVal += *reinterpret_cast<const ulittle32_t *>(contents.data() + 4);
+    beginVal += support::endian::read32le(contents.data());
+    endVal += support::endian::read32le(contents.data() + 4);
 
     PdataKey key{beginChunk, beginVal, endChunk, endVal};
     if (!seen.insert(key).second) {
-      Log(ctx) << "Removed duplicate .pdata entry in " << sc->getSectionName();
+      Warn(ctx) << "duplicate .pdata entry in " << sc->getSectionName();
       sc->live = false;
+
+      // Track the .xdata chunk referenced by the dead .pdata's
+      // UnwindInfoAddress (reloc 2) as a candidate for removal.
+      auto [xdataChunk, xdataVal] = resolve(relocs[2]);
+      if (auto *xdataSC = dyn_cast_or_null<SectionChunk>(xdataChunk))
+        orphanXdata.insert(xdataSC);
     }
+  }
+
+  // Remove orphan .xdata chunks that are no longer referenced by any live
+  // .pdata entry.
+  if (!orphanXdata.empty()) {
+    for (Chunk *c : ctx.driver.getChunks()) {
+      auto *sc = dyn_cast<SectionChunk>(c);
+      if (!sc || !sc->live)
+        continue;
+      StringRef name = sc->getSectionName().split('$').first;
+      if (name != ".pdata")
+        continue;
+      ArrayRef<coff_relocation> relocs = sc->getRelocs();
+      Symbol *sym = sc->file->getSymbol(relocs[2].SymbolTableIndex);
+      if (auto *d = dyn_cast<DefinedRegular>(sym))
+        orphanXdata.erase(dyn_cast<SectionChunk>(d->getChunk()));
+    }
+    for (SectionChunk *xdata : orphanXdata)
+      xdata->live = false;
   }
 }
 
 // Create output section objects and add them to OutputSections.
 void Writer::createSections() {
   llvm::TimeTraceScope timeScope("Output sections");
-
-  // Deduplicate .pdata COMDAT chunks whose relocation targets resolve to the
-  // same function after ICF.
-  if (ctx.config.dedupPdata)
-    removeDuplicatePdataChunks();
 
   // First, create the builtin sections.
   const uint32_t data = IMAGE_SCN_CNT_INITIALIZED_DATA;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -211,6 +211,7 @@ public:
 private:
   void calculateStubDependentSizes();
   void createSections();
+  void removeDuplicatePdataChunks();
   void createMiscChunks();
   void createImportTables();
   void appendImportThunks();
@@ -1062,9 +1063,91 @@ void Writer::calculateStubDependentSizes() {
   dataDirOffset64 = peHeaderOffset + sizeof(pe32plus_header);
 }
 
+// Mark duplicate COMDAT .pdata chunks as dead. After ICF folds identical
+// code sections, multiple .pdata COMDAT chunks may produce RUNTIME_FUNCTION
+// entries covering the same address range. We detect this by comparing the
+// BeginAddress and EndAddress relocation targets (the first two relocations),
+// and set live = false on duplicates so they are excluded from the output.
+void Writer::removeDuplicatePdataChunks() {
+  // Key: (beginChunk, beginValue, endChunk, endValue) identifying the range.
+  struct PdataKey {
+    Chunk *beginChunk;
+    uint32_t beginValue;
+    Chunk *endChunk;
+    uint32_t endValue;
+  };
+  struct PdataKeyInfo {
+    static PdataKey getEmptyKey() { return {nullptr, 0, nullptr, 0}; }
+    static PdataKey getTombstoneKey() {
+      return {nullptr, ~0u, nullptr, ~0u};
+    }
+    static unsigned getHashValue(const PdataKey &k) {
+      return llvm::hash_combine(k.beginChunk, k.beginValue, k.endChunk,
+                                k.endValue);
+    }
+    static bool isEqual(const PdataKey &lhs, const PdataKey &rhs) {
+      return lhs.beginChunk == rhs.beginChunk &&
+             lhs.beginValue == rhs.beginValue &&
+             lhs.endChunk == rhs.endChunk && lhs.endValue == rhs.endValue;
+    }
+  };
+
+  llvm::DenseSet<PdataKey, PdataKeyInfo> seen;
+
+  for (Chunk *c : ctx.driver.getChunks()) {
+    auto *sc = dyn_cast<SectionChunk>(c);
+    if (!sc || !sc->live || !sc->isCOMDAT())
+      continue;
+    StringRef name = sc->getSectionName().split('$').first;
+    if (name != ".pdata")
+      continue;
+
+    ArrayRef<coff_relocation> relocs = sc->getRelocs();
+    if (relocs.size() != 3)
+      continue;
+
+    ArrayRef<uint8_t> contents = sc->getContents();
+    if (contents.size() != 12)
+      continue;
+
+    // Resolve the BeginAddress (reloc 0) and EndAddress (reloc 1) targets.
+    auto resolve = [&](const coff_relocation &rel)
+        -> std::pair<Chunk *, uint32_t> {
+      Symbol *sym = sc->file->getSymbol(rel.SymbolTableIndex);
+      if (auto *d = dyn_cast<DefinedRegular>(sym))
+        return {d->getChunk(), d->getValue()};
+      if (auto *d = dyn_cast<Defined>(sym))
+        return {d->getChunk(), 0};
+      return {nullptr, 0};
+    };
+
+    auto [beginChunk, beginVal] = resolve(relocs[0]);
+    auto [endChunk, endVal] = resolve(relocs[1]);
+    if (!beginChunk)
+      continue;
+
+    // Account for addends baked into the section data.
+    beginVal += *reinterpret_cast<const ulittle32_t *>(contents.data());
+    endVal += *reinterpret_cast<const ulittle32_t *>(contents.data() + 4);
+
+    PdataKey key{beginChunk, beginVal, endChunk, endVal};
+    if (!seen.insert(key).second) {
+      Log(ctx) << "Removed duplicate .pdata entry in "
+               << sc->getSectionName();
+      sc->live = false;
+    }
+  }
+}
+
 // Create output section objects and add them to OutputSections.
 void Writer::createSections() {
   llvm::TimeTraceScope timeScope("Output sections");
+
+  // Deduplicate .pdata COMDAT chunks whose relocation targets resolve to the
+  // same function after ICF.
+  if (ctx.config.dedupPdata)
+    removeDuplicatePdataChunks();
+
   // First, create the builtin sections.
   const uint32_t data = IMAGE_SCN_CNT_INITIALIZED_DATA;
   const uint32_t bss = IMAGE_SCN_CNT_UNINITIALIZED_DATA;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1078,17 +1078,15 @@ void Writer::removeDuplicatePdataChunks() {
   };
   struct PdataKeyInfo {
     static PdataKey getEmptyKey() { return {nullptr, 0, nullptr, 0}; }
-    static PdataKey getTombstoneKey() {
-      return {nullptr, ~0u, nullptr, ~0u};
-    }
+    static PdataKey getTombstoneKey() { return {nullptr, ~0u, nullptr, ~0u}; }
     static unsigned getHashValue(const PdataKey &k) {
       return llvm::hash_combine(k.beginChunk, k.beginValue, k.endChunk,
                                 k.endValue);
     }
     static bool isEqual(const PdataKey &lhs, const PdataKey &rhs) {
       return lhs.beginChunk == rhs.beginChunk &&
-             lhs.beginValue == rhs.beginValue &&
-             lhs.endChunk == rhs.endChunk && lhs.endValue == rhs.endValue;
+             lhs.beginValue == rhs.beginValue && lhs.endChunk == rhs.endChunk &&
+             lhs.endValue == rhs.endValue;
     }
   };
 
@@ -1111,8 +1109,8 @@ void Writer::removeDuplicatePdataChunks() {
       continue;
 
     // Resolve the BeginAddress (reloc 0) and EndAddress (reloc 1) targets.
-    auto resolve = [&](const coff_relocation &rel)
-        -> std::pair<Chunk *, uint32_t> {
+    auto resolve =
+        [&](const coff_relocation &rel) -> std::pair<Chunk *, uint32_t> {
       Symbol *sym = sc->file->getSymbol(rel.SymbolTableIndex);
       if (auto *d = dyn_cast<DefinedRegular>(sym))
         return {d->getChunk(), d->getValue()};
@@ -1132,8 +1130,7 @@ void Writer::removeDuplicatePdataChunks() {
 
     PdataKey key{beginChunk, beginVal, endChunk, endVal};
     if (!seen.insert(key).second) {
-      Log(ctx) << "Removed duplicate .pdata entry in "
-               << sc->getSectionName();
+      Log(ctx) << "Removed duplicate .pdata entry in " << sc->getSectionName();
       sc->live = false;
     }
   }

--- a/lld/COFF/Writer.h
+++ b/lld/COFF/Writer.h
@@ -21,6 +21,7 @@ static const int pageSize = 4096;
 class COFFLinkerContext;
 
 void writeResult(COFFLinkerContext &ctx);
+void removeDuplicatePdataChunks(COFFLinkerContext &ctx);
 
 class PartialSection {
 public:

--- a/lld/test/COFF/duplicate-pdata-entry.s
+++ b/lld/test/COFF/duplicate-pdata-entry.s
@@ -15,9 +15,9 @@
 #
 # When ICF is enabled, helper_b folds into helper_a, making the two .pdata
 # entries duplicates. Only one survives = 12 bytes = 0xC.
-# RUN: lld-link %t.obj -dll -noentry -out:%t.dll -verbose 2>&1 | FileCheck --check-prefix=ICF-VERBOSE %s
+# RUN: lld-link %t.obj -dll -noentry -out:%t.dll 2>&1 | FileCheck --check-prefix=WARN %s
 # RUN: llvm-readobj --sections %t.dll | FileCheck --check-prefix=ICF %s
-# ICF-VERBOSE: Removed duplicate .pdata entry in .pdata$parent_b
+# WARN: warning: duplicate .pdata entry in .pdata$parent_b
 # ICF:      Name: .pdata
 # ICF-NEXT: VirtualSize: 0xC
 #
@@ -27,12 +27,6 @@
 # RUN: llvm-readobj --sections %t_noicf.dll | FileCheck --check-prefix=NOICF %s
 # NOICF:      Name: .pdata
 # NOICF-NEXT: VirtualSize: 0x18
-#
-# With /opt:nodeduppdata: deduplication is disabled, duplicates remain = 0x18.
-# RUN: lld-link %t.obj -dll -noentry -out:%t_nodedup.dll -opt:nodeduppdata
-# RUN: llvm-readobj --sections %t_nodedup.dll | FileCheck --check-prefix=NODEDUP %s
-# NODEDUP:      Name: .pdata
-# NODEDUP-NEXT: VirtualSize: 0x18
 
 --- !COFF
 header:

--- a/lld/test/COFF/duplicate-pdata-entry.s
+++ b/lld/test/COFF/duplicate-pdata-entry.s
@@ -13,15 +13,15 @@
 #
 # RUN: yaml2obj %s -o %t.obj
 #
-# With ICF: helper_b folds into helper_a, making the two .pdata entries
-# duplicates. Only one survives = 12 bytes = 0xC.
+# When ICF is enabled, helper_b folds into helper_a, making the two .pdata
+# entries duplicates. Only one survives = 12 bytes = 0xC.
 # RUN: lld-link %t.obj -dll -noentry -out:%t.dll -verbose 2>&1 | FileCheck --check-prefix=ICF-VERBOSE %s
 # RUN: llvm-readobj --sections %t.dll | FileCheck --check-prefix=ICF %s
 # ICF-VERBOSE: Removed duplicate .pdata entry in .pdata$parent_b
 # ICF:      Name: .pdata
 # ICF-NEXT: VirtualSize: 0xC
 #
-# Without ICF: both helpers remain distinct, so both .pdata entries are
+# Without ICF, both helpers remain distinct, so both .pdata entries are
 # unique = 24 bytes = 0x18.
 # RUN: lld-link %t.obj -dll -noentry -out:%t_noicf.dll -opt:noicf
 # RUN: llvm-readobj --sections %t_noicf.dll | FileCheck --check-prefix=NOICF %s

--- a/lld/test/COFF/duplicate-pdata-entry.s
+++ b/lld/test/COFF/duplicate-pdata-entry.s
@@ -1,0 +1,224 @@
+# REQUIRES: x86
+#
+# Test that duplicate COMDAT .pdata entries are removed in createSections.
+#
+# Each .pdata COMDAT section is exactly 12 bytes (one RUNTIME_FUNCTION) with
+# 3 IMAGE_REL_AMD64_ADDR32NB relocations at offsets 0, 4, 8 for BeginAddress,
+# EndAddress, and UnwindInfoAddress respectively.
+#
+# removeDuplicatePdataChunks() identifies duplicates by comparing the resolved
+# BeginAddress and EndAddress (relocs 0 and 1 plus their in-section addends).
+# When ICF folds helper_b into helper_a, both .pdata entries resolve to the
+# same [begin, end) range and the duplicate is removed.
+#
+# RUN: yaml2obj %s -o %t.obj
+#
+# With ICF: helper_b folds into helper_a, making the two .pdata entries
+# duplicates. Only one survives = 12 bytes = 0xC.
+# RUN: lld-link %t.obj -dll -noentry -out:%t.dll -verbose 2>&1 | FileCheck --check-prefix=ICF-VERBOSE %s
+# RUN: llvm-readobj --sections %t.dll | FileCheck --check-prefix=ICF %s
+# ICF-VERBOSE: Removed duplicate .pdata entry in .pdata$parent_b
+# ICF:      Name: .pdata
+# ICF-NEXT: VirtualSize: 0xC
+#
+# Without ICF: both helpers remain distinct, so both .pdata entries are
+# unique = 24 bytes = 0x18.
+# RUN: lld-link %t.obj -dll -noentry -out:%t_noicf.dll -opt:noicf
+# RUN: llvm-readobj --sections %t_noicf.dll | FileCheck --check-prefix=NOICF %s
+# NOICF:      Name: .pdata
+# NOICF-NEXT: VirtualSize: 0x18
+#
+# With /opt:nodeduppdata: deduplication is disabled, duplicates remain = 0x18.
+# RUN: lld-link %t.obj -dll -noentry -out:%t_nodedup.dll -opt:nodeduppdata
+# RUN: llvm-readobj --sections %t_nodedup.dll | FileCheck --check-prefix=NODEDUP %s
+# NODEDUP:      Name: .pdata
+# NODEDUP-NEXT: VirtualSize: 0x18
+
+--- !COFF
+header:
+  Machine:         IMAGE_FILE_MACHINE_AMD64
+  Characteristics: []
+sections:
+  # .text$parent_a (17 bytes) - kept alive via export, not ICF-foldable
+  - Name:            '.text$parent_a'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     4883EC28B80200000048FFC04883C428C3
+  # .text$parent_b (20 bytes) - different from parent_a
+  - Name:            '.text$parent_b'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     4883EC30B80300000048FFC848FFC04883C430C3
+  # .text$helper (14 bytes) - helper_a, identical to helper_b
+  - Name:            '.text$helper'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     4883EC20B8010000004883C420C3
+  # .text$helper (14 bytes) - helper_b, identical to helper_a (ICF folds this)
+  - Name:            '.text$helper'
+    Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
+    Alignment:       16
+    SectionData:     4883EC20B8010000004883C420C3
+  # .xdata for helper_a
+  - Name:            .xdata
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     '0104010034010000'
+  # .xdata for helper_b (different unwind info, e.g. different frame register)
+  - Name:            .xdata
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     '0104010054010000'
+  # .pdata$parent_a - 12-byte RUNTIME_FUNCTION, 3 relocs, associative to parent_a
+  # BeginAddress addend = 0, EndAddress addend = 0x0E (function size 14)
+  - Name:            '.pdata$parent_a'
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     '000000000E00000000000000'
+    Relocations:
+      - VirtualAddress:  0
+        SymbolName:      helper_a
+        Type:            IMAGE_REL_AMD64_ADDR32NB
+      - VirtualAddress:  4
+        SymbolName:      helper_a
+        Type:            IMAGE_REL_AMD64_ADDR32NB
+      - VirtualAddress:  8
+        SymbolName:      xdata_sym
+        Type:            IMAGE_REL_AMD64_ADDR32NB
+  # .pdata$parent_b - 12-byte RUNTIME_FUNCTION, 3 relocs, associative to parent_b
+  # Same begin/end as parent_a after ICF, but different UnwindInfoAddress.
+  # removeDuplicatePdataChunks() only checks begin/end, so this is still a dup.
+  - Name:            '.pdata$parent_b'
+    Characteristics: [ IMAGE_SCN_CNT_INITIALIZED_DATA, IMAGE_SCN_LNK_COMDAT, IMAGE_SCN_MEM_READ ]
+    Alignment:       4
+    SectionData:     '000000000E00000000000000'
+    Relocations:
+      - VirtualAddress:  0
+        SymbolName:      helper_b
+        Type:            IMAGE_REL_AMD64_ADDR32NB
+      - VirtualAddress:  4
+        SymbolName:      helper_b
+        Type:            IMAGE_REL_AMD64_ADDR32NB
+      - VirtualAddress:  8
+        SymbolName:      xdata_b_sym
+        Type:            IMAGE_REL_AMD64_ADDR32NB
+  # .drectve - export parent_a and parent_b (keeps them and their assoc alive)
+  - Name:            .drectve
+    Characteristics: [ IMAGE_SCN_LNK_INFO, IMAGE_SCN_LNK_REMOVE ]
+    SectionData:     202D6578706F72743A706172656E745F61202D6578706F72743A706172656E745F62
+symbols:
+  - Name:            '.text$parent_a'
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          17
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        1111111111
+      Number:          1
+      Selection:       IMAGE_COMDAT_SELECT_ANY
+  - Name:            parent_a
+    Value:           0
+    SectionNumber:   1
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+  - Name:            '.text$parent_b'
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          20
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        2222222222
+      Number:          2
+      Selection:       IMAGE_COMDAT_SELECT_ANY
+  - Name:            parent_b
+    Value:           0
+    SectionNumber:   2
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+  - Name:            '.text$helper'
+    Value:           0
+    SectionNumber:   3
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          14
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        3333333333
+      Number:          3
+      Selection:       IMAGE_COMDAT_SELECT_ANY
+  - Name:            helper_a
+    Value:           0
+    SectionNumber:   3
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+  - Name:            '.text$helper'
+    Value:           0
+    SectionNumber:   4
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          14
+      NumberOfRelocations: 0
+      NumberOfLinenumbers: 0
+      CheckSum:        3333333333
+      Number:          4
+      Selection:       IMAGE_COMDAT_SELECT_ANY
+  - Name:            helper_b
+    Value:           0
+    SectionNumber:   4
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_FUNCTION
+    StorageClass:    IMAGE_SYM_CLASS_EXTERNAL
+  - Name:            xdata_sym
+    Value:           0
+    SectionNumber:   5
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+  - Name:            xdata_b_sym
+    Value:           0
+    SectionNumber:   6
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+  - Name:            '.pdata$parent_a'
+    Value:           0
+    SectionNumber:   7
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          12
+      NumberOfRelocations: 3
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          1
+      Selection:       IMAGE_COMDAT_SELECT_ASSOCIATIVE
+  - Name:            '.pdata$parent_b'
+    Value:           0
+    SectionNumber:   8
+    SimpleType:      IMAGE_SYM_TYPE_NULL
+    ComplexType:     IMAGE_SYM_DTYPE_NULL
+    StorageClass:    IMAGE_SYM_CLASS_STATIC
+    SectionDefinition:
+      Length:          12
+      NumberOfRelocations: 3
+      NumberOfLinenumbers: 0
+      CheckSum:        0
+      Number:          2
+      Selection:       IMAGE_COMDAT_SELECT_ASSOCIATIVE
+...


### PR DESCRIPTION
MSVC 2015 generates per-function COMDAT .pdata sections (12 bytes each)
with different $-suffixed names. Each .pdata section is associative to
its parent function's COMDAT and contains a RUNTIME_FUNCTION entry that
may reference a different (helper) function via relocations. When ICF
folds identical helper functions, multiple .pdata entries end up with
the same BeginAddress and EndAddress, producing duplicates. Because the
.pdata section names differ, ICF does not fold these chunks directly.

These duplicate entries cause some external post-processing tools to
assert or fail, as they expect each function to have at most one
RUNTIME_FUNCTION entry in the .pdata table.

Add removeDuplicatePdataChunks() in Writer::createSections() to detect
and remove these duplicates by comparing the resolved BeginAddress and
EndAddress relocation targets. Duplicate entries are marked as dead
(live = false) so they are excluded from the output.

This is guarded by a new /opt:deduppdata option (on by default).
Use /opt:nodeduppdata to disable.
