### PR TITLE
ids-check: Update the workflow and script

### DIFF
--- a/.github/workflows/ids-check.yml
+++ b/.github/workflows/ids-check.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'llvm'
     name: Check LLVM_ABI annotations with ids
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
           repository: compnerd/ids
           path: ${{ github.workspace }}/ids
-          ref: b3bf35dd13d7ff244a6a6d106fe58d0eedb5743e # main
+          ref: 6d9b77c89107743159fccaea109e8feb81959844 # main, pinned at the --main-file landing
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -46,7 +46,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y clang-19 ninja-build libclang-19-dev
+          # Pull a recent clang from LLVM's apt repo so idt's parser stays in
+          # sync with the C++ language features used by current LLVM source.
+          sudo install -d -m 0755 /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt update
+          # oprofile provides opagent.h, used by llvm/ExecutionEngine/OProfileWrapper.h
+          sudo apt install -y clang-22 lld-22 ninja-build libclang-22-dev oprofile
           pip install --require-hashes -r ${{ github.workspace }}/llvm-project/llvm/utils/git/requirements.txt
 
       - name: Configure and build minimal LLVM for use by ids
@@ -54,33 +63,53 @@ jobs:
           cmake -B ${{ github.workspace }}/llvm-project/build/ \
                 -S ${{ github.workspace }}/llvm-project/llvm/ \
                 -D CMAKE_BUILD_TYPE=Release \
-                -D CMAKE_C_COMPILER=clang \
-                -D CMAKE_CXX_COMPILER=clang++ \
+                -D CMAKE_C_COMPILER=clang-22 \
+                -D CMAKE_CXX_COMPILER=clang++-22 \
                 -D LLVM_ENABLE_PROJECTS=clang \
                 -D LLVM_TARGETS_TO_BUILD="host" \
+                -D LLVM_INCLUDE_TESTS=OFF \
+                -D LLVM_INCLUDE_BENCHMARKS=OFF \
                 -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+                -D CMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
                 -G Ninja
-          cd ${{ github.workspace }}/llvm-project/build/
-          ninja -t targets all | grep "CommonTableGen: phony$" | grep -v "/" | sed 's/:.*//'
 
-      - name: Configure ids
+          # Build the generated-header prerequisites that idt needs to parse
+          # LLVM source.
+          BUILD_DIR=${{ github.workspace }}/llvm-project/build
+          ninja -C "$BUILD_DIR" \
+            llvm_vcsrevision_h \
+            intrinsics_gen omp_gen acc_gen analysis_gen target_parser_gen vt_gen \
+            DllOptionsTableGen LibOptionsTableGen \
+            clang-tablegen-targets \
+            lib/ExecutionEngine/JITLink/COFFOptions.inc
+
+          # Build per-target tablegen output for every enabled target.
+          # Each enabled target exposes a top-level `<Target>CommonTableGen`
+          # phony rule (e.g. `X86CommonTableGen`); discover them from the
+          # ninja graph.
+          TABLEGEN_TARGETS=$(ninja -C "$BUILD_DIR" -t targets all \
+            | awk -F: '
+                $2 ~ /phony/ &&            # phony rules only
+                $1 !~ /\// &&              # top-level (skip nested paths)
+                $1 ~ /CommonTableGen$/ {   # per-target tablegen aggregator
+                  print $1
+                }')
+          ninja -C "$BUILD_DIR" $TABLEGEN_TARGETS
+
+      - name: Configure and build ids
         run: |
           cmake -B ${{ github.workspace }}/ids/build/ \
                 -S ${{ github.workspace }}/ids/ \
                 -D CMAKE_BUILD_TYPE=Release \
-                -D CMAKE_C_COMPILER=clang \
-                -D CMAKE_CXX_COMPILER=clang++ \
+                -D CMAKE_C_COMPILER=clang-22 \
+                -D CMAKE_CXX_COMPILER=clang++-22 \
                 -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
-                -D LLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm/ \
-                -D Clang_DIR=/usr/lib/llvm-19/lib/cmake/clang/ \
-                -D FILECHECK_EXECUTABLE=$(which FileCheck-19) \
+                -D LLVM_DIR=/usr/lib/llvm-22/lib/cmake/llvm/ \
+                -D Clang_DIR=/usr/lib/llvm-22/lib/cmake/clang/ \
+                -D FILECHECK_EXECUTABLE=$(which FileCheck-22) \
                 -D LIT_EXECUTABLE=$(which lit) \
                 -G Ninja
-
-      # TODO: Use an image with a prebuilt idt.
-      - name: Build ids
-        run: |
-          ninja -C ${{ github.workspace }}/ids/build/ all
+          ninja -C ${{ github.workspace }}/ids/build/
 
       - name: Run ids check
         env:
@@ -96,7 +125,8 @@ jobs:
             --compile-commands ${{ github.workspace }}/llvm-project/build/compile_commands.json \
             --start-rev HEAD~1 \
             --end-rev HEAD \
-            --changed-files "$CHANGED_FILES"
+            --changed-files "$CHANGED_FILES" \
+            --verbose
 
       - name: Upload results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/llvm/utils/git/ids-check-helper.py
+++ b/llvm/utils/git/ids-check-helper.py
@@ -5,29 +5,268 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
+import json
 import os
 import subprocess
 import sys
+from collections import defaultdict
+from pathlib import Path
 from typing import List, Optional
 
 """
-This script is run by GitHub actions to ensure that the code in PRs properly
-labels LLVM APIs with `LLVM_ABI` so as not to break the LLVM DLL build. It can
-also be installed as a pre-commit git hook to check ABI annotations before
-submitting. The canonical source of this script is in the LLVM source tree
-under llvm/utils/git.
+Run idt on the headers changed in a PR and (optionally) post the resulting
+LLVM_ABI annotation diff as a PR comment.
 
-This script uses the idt (Interface Diff Tool) to check for missing LLVM_ABI,
-LLVM_C_ABI, and DEMANGLE_ABI annotations in header files.
+The heavy lifting (per-category clang flags, system-header-prefix isolation,
+output filtering, the `hasBody` / out-of-line distinction) lives in
+`llvm/utils/idt/idt.cc`. This script is a thin orchestrator: it picks which
+headers to check, finds a translation unit for each (since LLVM's compile
+database doesn't list headers), and forwards the list to idt batched by
+category.
 
-You can install this script as a git hook by symlinking it to the .git/hooks
-directory:
+Usage as a git pre-commit hook:
 
-ln -s $(pwd)/llvm/utils/git/ids-check-helper.py .git/hooks/pre-commit
+    ln -s $(pwd)/llvm/utils/git/ids-check-helper.py .git/hooks/pre-commit
 
-You can control the exact path to idt and compile_commands.json with the
-following environment variables: $IDT_PATH and $COMPILE_COMMANDS_PATH.
+Environment variables `IDT_PATH` and `COMPILE_COMMANDS_PATH` may be used in
+place of the matching command-line arguments.
 """
+
+
+# Headers we skip outright. Each entry is matched against the changed-file
+# path with `startswith`, so it can be either a directory prefix (trailing /)
+# or a specific file path.
+SKIP_HEADERS = [
+    # These are not LLVM component libraries.
+    "llvm/include/llvm/HTTP/",
+    "llvm/include/llvm/Debuginfod/",
+    # These are meant to be included via `Pass.h`, not directly.
+    "llvm/include/llvm/PassAnalysisSupport.h",
+    "llvm/include/llvm/PassSupport.h",
+    # Test-only headers.
+    "llvm/include/llvm/Testing/",
+    # OProfile JIT bridge, disabled by default.
+    "llvm/include/llvm/ExecutionEngine/OProfileWrapper.h",
+    "llvm/include/llvm/ExecutionEngine/RuntimeDyld.h",
+    # PDB DIA requires Windows ATL (atlbase.h), unbuildable on Linux runners.
+    "llvm/include/llvm/DebugInfo/PDB/DIA/",
+    "llvm/include/llvm/DebugInfo/PDB/ConcreteSymbolEnumerator.h",
+    # No in-tree non-tools/non-target source #includes these headers, so we
+    # can't run idt on a TU that pulls them in.
+    "llvm/include/llvm/ExecutionEngine/Interpreter.h",
+    "llvm/include/llvm/Support/DebugLog.h",
+    "llvm/include/llvm/Support/TargetSelect.h",
+    # zOS-specific shims.
+    "llvm/include/llvm/Support/AutoConvert.h",
+    # `class LLVM_ABI DagInit` (and similar in this file) inherit from
+    # `TrailingObjects<DagInit, T1, T2>` with multiple trailing types.
+    # MSVC `__declspec(dllexport)` on the class forces instantiation of
+    # all members including `getTrailingObjects()` (no-arg), which has a
+    # `static_assert(sizeof...(TrailingTys) == 1, ...)` in its body. The
+    # build then fails with C2338. Until `TrailingObjects.h` is updated
+    # to gate the no-arg overload via SFINAE / requires-clause, skip the
+    # whole header.
+    "llvm/include/llvm/TableGen/Record.h",
+    # Pimpl classes annotated `LLVM_ABI` that hold `std::unique_ptr<T>`
+    # of a forward-declared T defined only in the matching .cpp. MSVC's
+    # class-level `__declspec(dllexport)` forces the virtual destructor
+    # to be emitted inline as part of the exported vtable, which requires
+    # T to be complete in every consuming TU. Pulling T's definition into
+    # the public header would leak the implementation, so the right move
+    # is to keep these out of the bulk pass. Long-term: teach idt to
+    # detect this pattern (unique_ptr<forward-decl> + virtual destructor)
+    # and annotate individual methods instead of the class.
+    "llvm/include/llvm/MC/MCWinCOFFObjectWriter.h",
+    # Wraps the Visual Studio "Setup Configuration" COM API. The
+    # declarations rely on `EXTERN_C` / `MAXUINT` from <windows.h>, which
+    # idt's standalone parse doesn't pull in. Same long-term fix shape as
+    # `AutoConvert.h` (zOS): guard the annotations in-source, or include
+    # the prerequisite header. Skip for now.
+    "llvm/include/llvm/WindowsDriver/MSVCSetupApi.h",
+]
+
+
+# Manual header -> source mappings for headers that don't fit the conventional
+# `llvm/include/llvm/<Subsystem>/<Bar>.h` -> `llvm/lib/<Subsystem>/<Bar>.cpp`
+# layout. Used when neither the direct mapping nor the same-subdirectory
+# grep fallback finds a workable source.
+HEADER_SOURCE_OVERRIDES = {
+    # LLVM-C headers
+    "llvm/include/llvm-c/Analysis.h": "llvm/lib/Analysis/Analysis.cpp",
+    "llvm/include/llvm-c/BitReader.h": "llvm/lib/Bitcode/Reader/BitReader.cpp",
+    "llvm/include/llvm-c/BitWriter.h": "llvm/lib/Bitcode/Writer/BitWriter.cpp",
+    "llvm/include/llvm-c/Comdat.h": "llvm/lib/IR/Comdat.cpp",
+    "llvm/include/llvm-c/Core.h": "llvm/lib/IR/Core.cpp",
+    "llvm/include/llvm-c/DebugInfo.h": "llvm/lib/IR/DebugInfo.cpp",
+    "llvm/include/llvm-c/Disassembler.h": "llvm/lib/MC/MCDisassembler/Disassembler.cpp",
+    "llvm/include/llvm-c/ErrorHandling.h": "llvm/lib/Support/ErrorHandling.cpp",
+    "llvm/include/llvm-c/ExecutionEngine.h": "llvm/lib/ExecutionEngine/ExecutionEngineBindings.cpp",
+    "llvm/include/llvm-c/IRReader.h": "llvm/lib/IRReader/IRReader.cpp",
+    "llvm/include/llvm-c/LLJIT.h": "llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp",
+    "llvm/include/llvm-c/LLJITUtils.h": "llvm/lib/ExecutionEngine/Orc/Debugging/LLJITUtilsCBindings.cpp",
+    "llvm/include/llvm-c/Linker.h": "llvm/lib/Linker/LinkModules.cpp",
+    "llvm/include/llvm-c/Object.h": "llvm/lib/Object/Object.cpp",
+    "llvm/include/llvm-c/Orc.h": "llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp",
+    "llvm/include/llvm-c/OrcEE.h": "llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp",
+    "llvm/include/llvm-c/Remarks.h": "llvm/lib/Remarks/RemarkParser.cpp",
+    "llvm/include/llvm-c/Support.h": "llvm/lib/Support/CommandLine.cpp",
+    "llvm/include/llvm-c/Target.h": "llvm/lib/Target/Target.cpp",
+    "llvm/include/llvm-c/TargetMachine.h": "llvm/lib/Target/TargetMachineC.cpp",
+    "llvm/include/llvm-c/Transforms/PassBuilder.h": "llvm/lib/Passes/PassBuilderBindings.cpp",
+    "llvm/include/llvm-c/Types.h": "llvm/lib/IR/Core.cpp",
+    "llvm/include/llvm-c/lto.h": "llvm/tools/lto/lto.cpp",
+    # Top-level llvm/ headers
+    "llvm/include/llvm/Pass.h": "llvm/lib/IR/Pass.cpp",
+    "llvm/include/llvm/PassAnalysisSupport.h": "llvm/lib/IR/Pass.cpp",
+    "llvm/include/llvm/PassRegistry.h": "llvm/lib/IR/PassRegistry.cpp",
+    "llvm/include/llvm/PassSupport.h": "llvm/lib/IR/Pass.cpp",
+    "llvm/include/llvm/InitializePasses.h": "llvm/lib/Analysis/Analysis.cpp",
+    "llvm/include/llvm/LinkAllIR.h": "llvm/lib/IR/Core.cpp",
+    "llvm/include/llvm/LinkAllPasses.h": "llvm/lib/IR/Pass.cpp",
+    # Headers under llvm/include/llvm/Target/ whose same-subdir grep fallback
+    # picks per-target sources (e.g. X86, AArch64). Redirect to lib/CodeGen/.
+    "llvm/include/llvm/Target/CGPassBuilderOption.h": "llvm/lib/CodeGen/TargetPassConfig.cpp",
+    "llvm/include/llvm/Target/TargetOptions.h": "llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp",
+    # Headers pulled in transitively by a small set of "umbrella" sources.
+    "llvm/include/llvm/ADT/ilist_node_base.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/Analysis/SimplifyQuery.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/CodeGenTypes/MachineValueType.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/Analysis.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/ConstantFolder.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/FMF.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/GenericFloatingPointPredicateUtils.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/IR/IRBuilderFolder.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm/Support/Recycler.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm-c/Error.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    "llvm/include/llvm-c/Visibility.h": "llvm/lib/CodeGen/CodeGenPrepare.cpp",
+    # DTLTO drags in Any/LTO/FormatVariadic.
+    "llvm/include/llvm/ADT/Any.h": "llvm/lib/DTLTO/DTLTO.cpp",
+    "llvm/include/llvm/LTO/Config.h": "llvm/lib/DTLTO/DTLTO.cpp",
+    "llvm/include/llvm/Support/FormatVariadicDetails.h": "llvm/lib/DTLTO/DTLTO.cpp",
+    # Orc debugging / executor-side helpers.
+    "llvm/include/llvm/DebugInfo/DWARF/LowLevel/DWARFDataExtractorSimple.h": "llvm/lib/ExecutionEngine/Orc/Debugging/DebugInfoSupport.cpp",
+    "llvm/include/llvm/ExecutionEngine/Orc/MaterializationUnit.h": "llvm/lib/ExecutionEngine/Orc/Debugging/DebugInfoSupport.cpp",
+    "llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/ExecutorBootstrapService.h": "llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp",
+    "llvm/include/llvm-c/blake3.h": "llvm/lib/ExecutionEngine/Orc/TargetProcess/ExecutorSharedMemoryMapperService.cpp",
+    "llvm/include/llvm/CodeGen/AsmPrinterHandler.h": "llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp",
+}
+
+
+# Include subdir -> lib subdir remap for cases where the names diverge.
+# ADT has no `llvm/lib/ADT/`; its few non-inline implementations live under
+# `llvm/lib/Support/`.
+INCLUDE_TO_LIB_SUBDIR = {
+    "ADT": "Support",
+}
+
+
+# Categories: each header path-fragment maps to (category-name, export-macro).
+# Order matters: more specific fragments first (Demangle before generic LLVM).
+CATEGORIES = [
+    ("Demangle", "llvm/Demangle/", "DEMANGLE_ABI"),
+    ("LLVM-C", "llvm-c/", "LLVM_C_ABI"),
+    ("LLVM", "llvm/", "LLVM_ABI"),
+]
+
+EXPORT_MACRO = {name: macro for name, _fragment, macro in CATEGORIES}
+
+# Predefines applied to every idt invocation (via `--extra-arg`).
+#
+# Why these are required: idt detects an existing annotation by inspecting
+# clang's parsed attributes (`DLLExportAttr` / `DLLImportAttr` /
+# `VisibilityAttr`). In a static LLVM build, the donor source's compile
+# command carries `-DLLVM_BUILD_STATIC`, which collapses the macro guards
+# in `Compiler.h` / `DemangleConfig.h` / `llvm-c/Visibility.h` so that
+# `LLVM_ABI` / `DEMANGLE_ABI` / `LLVM_C_ABI` all expand to *empty*. The
+# parser then sees no attribute on already-annotated declarations, and
+# idt happily prepends another copy of the macro on top.
+#
+# The fix is to make those macros expand to a real attribute regardless
+# of the donor's static-vs-dylib choice:
+#  - `-ULLVM_BUILD_STATIC` removes the kill-switch.
+#  - `-DLLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS` opens the LLVM_ABI /
+#    DEMANGLE_ABI gates.
+#  - `-DLLVM_ENABLE_LLVM_C_EXPORT_ANNOTATIONS` opens the LLVM_C_ABI gate.
+#  - `-DLLVM_EXPORTS` makes the cascade pick `dllexport` over `dllimport`
+#    (either would suffice for detection, dllexport is the symmetric
+#    choice for a "we're inside the library" parse).
+EXTRA_ARGS_COMMON = [
+    "-ULLVM_BUILD_STATIC",
+    "-DLLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS",
+    "-DLLVM_ENABLE_LLVM_C_EXPORT_ANNOTATIONS",
+    "-DLLVM_EXPORTS",
+]
+
+
+def categorize_header(path: str) -> Optional[str]:
+    """Return the category name (LLVM/LLVM-C/Demangle) for a header, or None
+    if the path doesn't fall under any known category."""
+    for name, fragment, _macro in CATEGORIES:
+        if fragment in path:
+            return name
+    return None
+
+
+def find_source_for_header(header: str) -> Optional[str]:
+    """Return a source file (relative path) that includes the given header,
+    or None if no good match.
+
+    LLVM doesn't list headers in compile_commands.json, so idt needs a
+    source TU to parse. With the `hasBody` / out-of-line distinction inside
+    idt, we can pick the conventional `Foo.cpp` partner without losing
+    coverage of `Foo.h`'s own symbols.
+
+    Resolution order:
+    1. Manual override in HEADER_SOURCE_OVERRIDES.
+    2. Direct mapping: llvm/include/llvm/Foo/Bar.h -> llvm/lib/Foo/Bar.cpp,
+       with INCLUDE_TO_LIB_SUBDIR applied (e.g. ADT -> Support).
+    3. Same-subdirectory grep: any .cpp under llvm/lib/Foo/ that
+       `#include`s the header. Constrained to the matching subdirectory
+       so we don't accidentally pick a target-specific source as a
+       generic fallback.
+    4. Bail (returns None; the header is silently skipped).
+    """
+
+    # 1. Manual override for special cases.
+    if header in HEADER_SOURCE_OVERRIDES:
+        return HEADER_SOURCE_OVERRIDES[header]
+
+    if not header.startswith("llvm/include/llvm/"):
+        return None
+
+    # 2. Direct mapping.
+    sub = header[len("llvm/include/llvm/") :]
+    first_part, _, rest = sub.partition("/")
+    remap = INCLUDE_TO_LIB_SUBDIR.get(first_part)
+    sub_remapped = f"{remap}/{rest}" if remap and rest else sub
+    for ext in (".cpp", ".cc"):
+        candidate = Path("llvm/lib") / Path(sub_remapped).with_suffix(ext)
+        if candidate.exists():
+            return str(candidate)
+
+    # 3. Same-subdirectory grep fallback.
+    lib_subdir = f"llvm/lib/{INCLUDE_TO_LIB_SUBDIR.get(first_part, first_part)}"
+    if not Path(lib_subdir).is_dir():
+        return None
+
+    inc = header.removeprefix("llvm/include/")
+    try:
+        result = subprocess.run(
+            ["git", "grep", "-l", f'#include "{inc}"', "--", lib_subdir],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0 or not result.stdout:
+        return None
+    for line in result.stdout.splitlines():
+        if line.endswith((".cpp", ".cc")):
+            return line
+
+    # 4. Bail.
+    return None
 
 
 class IdsCheckArgs:
@@ -39,7 +278,7 @@ class IdsCheckArgs:
     repo: str = ""
     token: str = ""
     issue_number: int = 0
-    verbose: bool = True
+    verbose: bool = False
 
     def __init__(self, args: argparse.Namespace) -> None:
         self.start_rev = args.start_rev
@@ -50,21 +289,16 @@ class IdsCheckArgs:
         self.repo = getattr(args, "repo", "")
         self.token = getattr(args, "token", "")
         self.issue_number = getattr(args, "issue_number", 0)
-        self.verbose = getattr(args, "verbose", True)
+        self.verbose = getattr(args, "verbose", False)
 
 
 class IdsChecker:
-    """
-    Checker for LLVM ABI annotations using the idt tool.
-    """
+    """Thin orchestrator around the idt binary."""
 
     COMMENT_TAG = "<!--LLVM IDS CHECK COMMENT-->"
     name = "ids-check"
     friendly_name = "LLVM ABI annotation checker"
     comment: dict = {}
-
-    # Macro definition used for all export macros
-    MACRO_DEFINITION = '__attribute__((visibility("default")))'
 
     @property
     def comment_tag(self) -> str:
@@ -72,9 +306,11 @@ class IdsChecker:
 
     @property
     def instructions(self) -> str:
-        # Provide basic usage instructions
-        return f"""git diff origin/main HEAD -- 'llvm/include/llvm/**/*.h' 'llvm/include/llvm-c/**/*.h' 'llvm/include/llvm/Demangle/**/*.h'
-Then run idt on the changed files with appropriate --export-macro and --include-header flags."""
+        return (
+            "Build idt from compnerd/ids, then for each changed header:\n"
+            "    idt -p build/ --main-file <matching-source.cpp> \\\n"
+            "        --apply-fixits --inplace <header>"
+        )
 
     def pr_comment_text_for_diff(self, diff: str) -> str:
         return f"""
@@ -88,12 +324,6 @@ You can test this locally with the following command:
 ``````````bash
 {self.instructions}
 ``````````
-
-:warning:
-The reproduction instructions above might return results for more than one PR
-in a stack if you are using a stacked PR workflow. You can limit the results by
-changing `origin/main` to the base branch/commit you want to compare against.
-:warning:
 
 </details>
 
@@ -130,102 +360,87 @@ View the diff from {self.name} here.
         elif create_new:
             self.comment = {"body": comment_text}
 
-    # Define the file categories and their corresponding configurations
-    FILE_CATEGORIES = [
-        {
-            "name": "LLVM headers",
-            "patterns": ["llvm/include/llvm/**/*.h"],
-            "excludes": [
-                "llvm/include/llvm/Debuginfod/",
-                "llvm/include/llvm/Demangle/",
-            ],
-            "export_macro": "LLVM_ABI",
-            "include_header": "llvm/Support/Compiler.h",
-        },
-        {
-            "name": "LLVM-C headers",
-            "patterns": ["llvm/include/llvm-c/**/*.h"],
-            "excludes": [],
-            "export_macro": "LLVM_C_ABI",
-            "include_header": "llvm-c/Visibility.h",
-        },
-        {
-            "name": "LLVM Demangle headers",
-            "patterns": ["llvm/include/llvm/Demangle/**/*.h"],
-            "excludes": [],
-            "export_macro": "DEMANGLE_ABI",
-            "include_header": "llvm/Demangle/Visibility.h",
-        },
-    ]
-
-    def filter_files_for_category(
-        self, changed_files: List[str], category: dict
-    ) -> List[str]:
-        """Filter changed files based on category patterns and excludes."""
-        filtered = []
-        for path in changed_files:
-            # Check if file matches any pattern
-            matches_pattern = False
-            for pattern in category["patterns"]:
-                # Simple pattern matching for **/*.h style patterns
-                pattern_prefix = pattern.replace("**/*.h", "")
-                if path.startswith(pattern_prefix) and path.endswith(".h"):
-                    matches_pattern = True
-                    break
-
-            if not matches_pattern:
-                continue
-
-            # Check if file should be excluded
-            excluded = False
-            for exclude in category["excludes"]:
-                if path.startswith(exclude):
-                    excluded = True
-                    break
-
-            if not excluded:
-                filtered.append(path)
-
-        return filtered
-
-    def run_idt_on_files(
+    def run_idt_for_category(
         self,
-        files: List[str],
-        category: dict,
+        category: str,
+        header_source_pairs: List[tuple],
         args: IdsCheckArgs,
         idt_path: str,
         compile_commands: str,
-    ) -> bool:
-        """Run idt tool on the given files with category-specific configuration."""
-        if not files:
-            return True
+    ) -> None:
+        """Invoke idt once per header, using the matching source as the
+        flag donor via idt's `--main-file` option. idt looks the donor up
+        in compile_commands.json, swaps its input argument for the
+        positional header, and forces `-x c++-header` — so the header is
+        parsed standalone as the translation unit.
+
+        Per-header subprocess invocation also sidesteps idt's known
+        cross-TU state issues (DiagnosticsEngine instance lifetime in
+        batched runs).
+        """
+        if not header_source_pairs:
+            return
 
         if args.verbose:
             print(
-                f"Running idt on {len(files)} {category['name']} file(s)...",
+                f"Running idt on {len(header_source_pairs)} {category} file(s)...",
                 file=sys.stderr,
             )
 
-        for file in files:
+        def fwd(p: str) -> str:
+            # Forward slashes so paths survive cl::TokenizeGNUCommandLine.
+            return p.replace("\\", "/")
+
+        # Resolve `source` to the absolute path stored in
+        # compile_commands.json so idt's CompilationDatabase lookup is
+        # exact rather than relying on suffix-matching heuristics.
+        try:
+            with open(compile_commands, "r", encoding="utf-8") as f:
+                cdb_entries = json.load(f)
+        except Exception as e:
+            print(f"  ERROR: failed to read {compile_commands}: {e}", file=sys.stderr)
+            return
+        cdb_paths = [fwd(e["file"]) for e in cdb_entries]
+
+        cdb_dir = os.path.dirname(compile_commands) or "."
+
+        for i, (header, source) in enumerate(header_source_pairs, start=1):
+            if args.verbose:
+                print(
+                    f"  [{i}/{len(header_source_pairs)}] {header} "
+                    f"(flags from {source})",
+                    file=sys.stderr,
+                )
+
+            source_norm = fwd(source)
+            donor_path = next((p for p in cdb_paths if p.endswith(source_norm)), None)
+            if donor_path is None:
+                print(
+                    f"  WARN: no compile_commands entry matching {source}; "
+                    f"skipping {header}.",
+                    file=sys.stderr,
+                )
+                continue
+
             cmd = [
                 idt_path,
                 "-p",
-                compile_commands,
+                fwd(cdb_dir),
+                f"--main-file={donor_path}",
+                f"--export-macro={EXPORT_MACRO[category]}",
                 "--apply-fixits",
                 "--inplace",
-                f"--export-macro={category['export_macro']}",
-                f"--include-header={category['include_header']}",
-                f"--extra-arg=-D{category['export_macro']}={self.MACRO_DEFINITION}",
-                "--extra-arg=-Wno-macro-redefined",
-                file,
             ]
-
-            if args.verbose:
-                print(f"Running: {' '.join(cmd)}", file=sys.stderr)
-
-            subprocess.run(cmd)
-
-        return True
+            for extra in EXTRA_ARGS_COMMON:
+                cmd.append(f"--extra-arg={extra}")
+            cmd.append(fwd(header))
+            proc = subprocess.run(cmd)
+            if proc.returncode != 0 and proc.returncode != 1:
+                print(
+                    f"  WARN: idt exited with rc={proc.returncode} on "
+                    f"{header}; continuing.",
+                    file=sys.stderr,
+                )
 
     def get_changed_files(self, args: IdsCheckArgs) -> List[str]:
         """Get list of changed files between revisions."""
@@ -295,24 +510,35 @@ View the diff from {self.name} here.
                 print("No files changed, skipping ids check", file=sys.stderr)
             return 0
 
-        # Process each category
-        any_processed = False
-        for category in self.FILE_CATEGORIES:
-            filtered_files = self.filter_files_for_category(changed_files, category)
-            if filtered_files:
-                any_processed = True
-                if not self.run_idt_on_files(
-                    filtered_files, category, args, idt_path, compile_commands
-                ):
-                    return 1
+        # Filter to relevant headers and group by category.
+        per_category = defaultdict(list)
+        for path in changed_files:
+            if not path.endswith(".h"):
+                continue
+            if not path.startswith(("llvm/include/llvm/", "llvm/include/llvm-c/")):
+                continue
+            if any(path.startswith(p) for p in SKIP_HEADERS):
+                continue
+            category = categorize_header(path)
+            if category is None:
+                continue
+            source = find_source_for_header(path)
+            if source is None:
+                if args.verbose:
+                    print(f"  Skipping {path}: no matching source", file=sys.stderr)
+                continue
+            per_category[category].append((path, source))
 
-        if not any_processed:
+        if not per_category:
             if args.verbose:
                 print(
                     "No relevant header files changed, skipping ids check",
                     file=sys.stderr,
                 )
             return 0
+
+        for category, pairs in per_category.items():
+            self.run_idt_for_category(category, pairs, args, idt_path, compile_commands)
 
         # Check for differences
         diff = self.check_for_diff()
@@ -371,7 +597,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--changed-files",
         type=str,
-        help="Comma separated list of files that have been changed",
+        help="Comma-separated list of changed files, or `@<path>` to read "
+        "the list from a response file (one path per line or "
+        "comma-separated). The `@`-prefix follows the standard "
+        "compiler/linker convention and is useful on Windows where the "
+        "inline comma-separated form can hit command-line length limits.",
     )
     parser.add_argument(
         "--idt-path",
@@ -383,19 +613,25 @@ if __name__ == "__main__":
         type=str,
         help="Path to compile_commands.json (can also be set via COMPILE_COMMANDS_PATH environment variable)",
     )
-    parser.add_argument(
-        "--verbose", action="store_true", default=True, help="Enable verbose output"
-    )
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
 
     parsed_args = parser.parse_args()
 
-    # Parse changed files if provided
-    if parsed_args.changed_files:
-        parsed_args.changed_files = [
-            f.strip() for f in parsed_args.changed_files.split(",") if f.strip()
-        ]
-    else:
-        parsed_args.changed_files = []
+    raw = parsed_args.changed_files or ""
+    if raw.startswith("@"):
+        # Response file: read its contents and treat the inline value as if
+        # it had been spelled inline.
+        with open(raw[1:], "r", encoding="utf-8") as f:
+            raw = f.read()
+
+    # Accept both comma-separated and newline-separated entries so the
+    # response-file variant is friendly to write line-by-line.
+    parsed_args.changed_files = [
+        token.strip()
+        for line in raw.splitlines()
+        for token in line.split(",")
+        if token.strip()
+    ]
 
     args = IdsCheckArgs(parsed_args)
     checker = IdsChecker()

--- a/llvm/utils/git/ids-check-helper.py
+++ b/llvm/utils/git/ids-check-helper.py
@@ -18,8 +18,9 @@ Run idt on the headers changed in a PR and (optionally) post the resulting
 LLVM_ABI annotation diff as a PR comment.
 
 The heavy lifting (per-category clang flags, system-header-prefix isolation,
-output filtering, the `hasBody` / out-of-line distinction) lives in
-`llvm/utils/idt/idt.cc`. This script is a thin orchestrator: it picks which
+output filtering, the `hasBody` / out-of-line distinction) lives in `idt`
+itself (the standalone `compnerd/ids` tool, built separately and passed
+via `--idt-path`). This script is a thin orchestrator: it picks which
 headers to check, finds a translation unit for each (since LLVM's compile
 database doesn't list headers), and forwards the list to idt batched by
 category.


### PR DESCRIPTION
In compnerd/ids#58, support was added to parse a header file using a given source file's flags. This solves many of the issues we had encountered with the `ids-check-helper.py` script and its corresponding workflow.

* Update ids to the current version, which includes the `--main-file` changes.
* Use a more recent LLVM compiler to build a subset of LLVM.
* Build a subset of LLVM targets to properly parse more header files.
* Use the `--main-file` argument when invoking `idt`.
* Add explicit overrides and exclude header lists.

This was tested on every public header in LLVM and forthcoming PRs will land the changes found with the updated script. Once all of the headers have been updated, the workflow will be re-enabled. This effort is tracked in #109483.