### PR TITLE
[AArch64] Pass APInts by reference when evaluating them for adjustments (NFCI)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -3747,13 +3747,13 @@ static bool isLegalArithImmed(uint64_t C) {
   return IsLegal;
 }
 
-bool isLegalCmpImmed(APInt C) {
+bool isLegalCmpImmed(const APInt &C) {
   // Works for negative immediates too, as it can be written as an ADDS
   // instruction with a negated immediate.
   return isLegalArithImmed(C.abs().getZExtValue());
 }
 
-unsigned numberOfInstrToLoadImm(APInt C) {
+unsigned numberOfInstrToLoadImm(const APInt &C) {
   uint64_t Imm = C.getZExtValue();
   SmallVector<AArch64_IMM::ImmInsnModel> Insn;
   AArch64_IMM::expandMOVImm(Imm, 32, Insn);
@@ -4218,7 +4218,8 @@ static unsigned getCmpOperandFoldingProfit(SDValue Op, bool AllowExtend) {
 // emitComparison() converts comparison with one or negative one to comparison
 // with 0. Note that this only works for signed comparisons because of how ANDS
 // works.
-static bool shouldBeAdjustedToZero(SDValue LHS, APInt C, ISD::CondCode &CC) {
+static bool shouldBeAdjustedToZero(SDValue LHS, const APInt &C,
+                                   ISD::CondCode &CC) {
   // Only works for ANDS and AND.
   if (LHS.getOpcode() != ISD::AND && LHS.getOpcode() != AArch64ISD::ANDS)
     return false;
@@ -16107,7 +16108,7 @@ static SDValue ConstantBuildVector(SDValue Op, SelectionDAG &DAG,
   APInt UndefBits(VT.getSizeInBits(), 0);
   BuildVectorSDNode *BVN = cast<BuildVectorSDNode>(Op.getNode());
   if (resolveBuildVector(BVN, DefBits, UndefBits)) {
-    auto TryMOVIWithBits = [&](APInt DefBits) {
+    auto TryMOVIWithBits = [&](const APInt &DefBits) {
       SDValue NewOp;
       if ((NewOp =
                tryAdvSIMDModImm64(AArch64ISD::MOVIedit, Op, DAG, DefBits)) ||
@@ -16141,7 +16142,7 @@ static SDValue ConstantBuildVector(SDValue Op, SelectionDAG &DAG,
       return R;
 
     // See if a fneg of the constant can be materialized with a MOVI, etc
-    auto TryWithFNeg = [&](APInt DefBits, MVT FVT) {
+    auto TryWithFNeg = [&](const APInt &DefBits, MVT FVT) {
       // FNegate each sub-element of the constant
       assert(VT.getSizeInBits() % FVT.getScalarSizeInBits() == 0);
       APInt Neg = APInt::getHighBitsSet(FVT.getSizeInBits(), 1)
@@ -20736,7 +20737,7 @@ static SDValue performMulCombine(SDNode *N, SelectionDAG &DAG,
   // Can the const C be decomposed into (1+2^M1)*(1+2^N1), eg:
   // C = 45 is equal to (1+4)*(1+8), we don't decompose it into (1+2)*(16-1) as
   // the (2^N - 1) can't be execused via a single instruction.
-  auto isPowPlusPlusConst = [](APInt C, APInt &M, APInt &N) {
+  auto isPowPlusPlusConst = [](const APInt &C, APInt &M, APInt &N) {
     unsigned BitWidth = C.getBitWidth();
     for (unsigned i = 1; i < BitWidth / 2; i++) {
       APInt Rem;
@@ -20754,7 +20755,7 @@ static SDValue performMulCombine(SDNode *N, SelectionDAG &DAG,
   // Can the const C be decomposed into (2^M + 1) * 2^N + 1), eg:
   // C = 11 is equal to (1+4)*2+1, we don't decompose it into (1+2)*4-1 as
   // the (2^N - 1) can't be execused via a single instruction.
-  auto isPowPlusPlusOneConst = [](APInt C, APInt &M, APInt &N) {
+  auto isPowPlusPlusOneConst = [](const APInt &C, APInt &M, APInt &N) {
     APInt CVMinus1 = C - 1;
     if (CVMinus1.isNegative())
       return false;
@@ -20771,7 +20772,7 @@ static SDValue performMulCombine(SDNode *N, SelectionDAG &DAG,
 
   // Can the const C be decomposed into (1 - (1 - 2^M) * 2^N), eg:
   // C = 29 is equal to 1 - (1 - 2^3) * 2^2.
-  auto isPowMinusMinusOneConst = [](APInt C, APInt &M, APInt &N) {
+  auto isPowMinusMinusOneConst = [](const APInt &C, APInt &M, APInt &N) {
     APInt CVMinus1 = C - 1;
     if (CVMinus1.isNegative())
       return false;
@@ -27584,7 +27585,7 @@ static SDValue reassociateCSELOperandsForCSE(SDNode *N, SelectionDAG &DAG) {
   // in signed/unsigned wrap for signed/unsigned comparisons, respectively.
   // Since such comparisons are trivially true/false, we should not encounter
   // them here but check for them nevertheless to be on the safe side.
-  auto CheckedFold = [&](bool Check, APInt NewCmpConst,
+  auto CheckedFold = [&](bool Check, const APInt &NewCmpConst,
                          AArch64CC::CondCode NewCC) {
     auto ExpectedOp = DAG.getConstant(-NewCmpConst, SDLoc(CmpOpConst),
                                       CmpOpConst->getValueType(0));


### PR DESCRIPTION
We do not want to be copying these every single comparison.

I do not have merge permissions.