### PR TITLE
[AMDGPU] Fix ELF note emission to include null terminator

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -821,6 +821,7 @@ void AMDGPUTargetELFStreamer::EmitNote(
   S.emitValue(DescSZ, 4);                    // descz
   S.emitInt32(NoteType);                     // type
   S.emitBytes(Name);                         // name
+  S.emitInt8(0);                             // null terminator
   S.emitValueToAlignment(Align(4), 0, 1, 0); // padding 0
   EmitDesc(S);                               // desc
   S.emitValueToAlignment(Align(4), 0, 1, 0); // padding 0

--- a/llvm/test/CodeGen/AMDGPU/elf-note-null-terminator.ll
+++ b/llvm/test/CodeGen/AMDGPU/elf-note-null-terminator.ll
@@ -1,0 +1,33 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -filetype=obj < %s | llvm-readelf -n - | FileCheck --check-prefix=NOTE-AMDGPU %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a -filetype=obj < %s | llvm-readelf -x .note - | FileCheck --check-prefix=HEX-AMDGPU %s
+; RUN: llc -mtriple=amdgcn-amd-unknown -mcpu=gfx90a -filetype=obj < %s | llvm-readelf -n - | FileCheck --check-prefix=NOTE-AMD %s
+; RUN: llc -mtriple=amdgcn-amd-unknown -mcpu=gfx90a -filetype=obj < %s | llvm-readelf -x .note - | FileCheck --check-prefix=HEX-AMD %s
+
+; Verify ELF notes have explicit null terminators after the name field.
+; Tests both "AMDGPU" (NoteNameV3, 7 bytes with null) and "AMD" (NoteNameV2, 4 bytes with null).
+
+; Check "AMDGPU" note is parseable (used in amdhsa triple)
+; NOTE-AMDGPU-NOT: Unknown note type
+; NOTE-AMDGPU: AMDGPU
+; NOTE-AMDGPU: NT_AMDGPU_METADATA
+
+; Check hex shows explicit null: "AMDGPU" (6 bytes) + null = namesz of 7
+; HEX-AMDGPU: Hex dump of section '.note':
+; HEX-AMDGPU-NEXT: 0x00000000 07000000 {{[0-9a-f]+}} {{[0-9a-f]+}} 414d4447
+; HEX-AMDGPU-NEXT: 0x00000010 5055{{00}}
+
+; Check "AMD" note is parseable (used in unknown triple)
+; NOTE-AMD-NOT: Unknown note type
+; NOTE-AMD: AMD
+; NOTE-AMD: NT_AMD_HSA_ISA_NAME
+
+; Check hex shows explicit null: "AMD" (3 bytes) + null = namesz of 4
+; HEX-AMD: Hex dump of section '.note':
+; HEX-AMD: 04000000 {{[0-9a-f]+}} {{[0-9a-f]+}} 414d44{{00}}
+
+define amdgpu_kernel void @test_note() {
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"amdhsa_code_object_version", i32 400}


### PR DESCRIPTION
Fixes https://github.com/ROCm/llvm-project/issues/2336
The `AMDGPUTargetELFStreamer::EmitNote()` function claims the note name includes a null terminator (NameSZ = Name.size() + 1) but only emits the string bytes via `emitBytes(Name)`, relying on alignment padding to provide the null byte. Works for most situations but breaks with 8-byte names where padding lands exactly at the boundary.

Fix: Explicitly emit null terminator with `S.emitInt8(0)` after `emitBytes(Name)`.

### Tested:

Verified with 7-byte name **"TESTBUG"** and 8-byte name **"TESTBUG8"**:

**7-byte name ("TESTBUG"):**
- Before fix: `readelf` shows "Unknown note type" (null from padding works by luck)
- After fix: Correctly parses `NT_AMDGPU_METADATA`

**8-byte name ("TESTBUG8"):**
- Before fix: Complete parse failure - reader expects 9 bytes, gets 8 + padding at wrong offset
- After fix: `readelf` correctly parses note with explicit null terminator

Both cases now emit the null terminator explicitly via `S.emitInt8(0)` instead of relying on alignment padding.