### PR TITLE
[AtomicExpand] Preserve volatile in widenPartwordAtomicRMW.

### DIFF
--- a/llvm/lib/CodeGen/AtomicExpandPass.cpp
+++ b/llvm/lib/CodeGen/AtomicExpandPass.cpp
@@ -1142,6 +1142,7 @@ AtomicRMWInst *AtomicExpandImpl::widenPartwordAtomicRMW(AtomicRMWInst *AI) {
       Op, PMV.AlignedAddr, NewOperand, PMV.AlignedAddrAlignment,
       AI->getOrdering(), AI->getSyncScopeID());
 
+  NewAI->setVolatile(AI->isVolatile());
   copyMetadataForAtomic(*NewAI, *AI);
 
   Value *FinalOldResult = extractMaskedValue(Builder, NewAI, PMV);

--- a/llvm/test/Transforms/AtomicExpand/RISCV/atomicrmw-widen-volatile.ll
+++ b/llvm/test/Transforms/AtomicExpand/RISCV/atomicrmw-widen-volatile.ll
@@ -1,0 +1,41 @@
+; RUN: opt -S -mtriple=riscv32 -mattr=+a -passes='require<libcall-lowering-info>,atomic-expand' %s | FileCheck %s
+
+; Check that widenPartwordAtomicRMW preserves the volatile bit.
+
+define i8 @test_atomicrmw_and_i8_volatile(ptr %p) {
+; CHECK-LABEL: @test_atomicrmw_and_i8_volatile(
+; CHECK:         atomicrmw volatile and ptr {{.*}}, i32 {{.*}} seq_cst, align 4
+  %r = atomicrmw volatile and ptr %p, i8 15 seq_cst, align 1
+  ret i8 %r
+}
+
+define i8 @test_atomicrmw_or_i8_volatile(ptr %p) {
+; CHECK-LABEL: @test_atomicrmw_or_i8_volatile(
+; CHECK:         atomicrmw volatile or ptr {{.*}}, i32 {{.*}} seq_cst, align 4
+  %r = atomicrmw volatile or ptr %p, i8 15 seq_cst, align 1
+  ret i8 %r
+}
+
+define i8 @test_atomicrmw_xor_i8_volatile(ptr %p) {
+; CHECK-LABEL: @test_atomicrmw_xor_i8_volatile(
+; CHECK:         atomicrmw volatile xor ptr {{.*}}, i32 {{.*}} seq_cst, align 4
+  %r = atomicrmw volatile xor ptr %p, i8 15 seq_cst, align 1
+  ret i8 %r
+}
+
+; Ensure the non-volatile case is not promoted to volatile.
+define i8 @test_atomicrmw_and_i8_nonvolatile(ptr %p) {
+; CHECK-LABEL: @test_atomicrmw_and_i8_nonvolatile(
+; CHECK-NOT:     atomicrmw volatile
+; CHECK:         atomicrmw and ptr {{.*}}, i32 {{.*}} seq_cst, align 4
+  %r = atomicrmw and ptr %p, i8 15 seq_cst, align 1
+  ret i8 %r
+}
+
+; Also exercise i16 widening.
+define i16 @test_atomicrmw_and_i16_volatile(ptr %p) {
+; CHECK-LABEL: @test_atomicrmw_and_i16_volatile(
+; CHECK:         atomicrmw volatile and ptr {{.*}}, i32 {{.*}} seq_cst, align 4
+  %r = atomicrmw volatile and ptr %p, i16 15 seq_cst, align 2
+  ret i16 %r
+}


### PR DESCRIPTION
widenPartwordAtomicRMW widens a sub-word atomicrmw to the target's
minimum cmpxchg size by calling CreateAtomicRMW, which has no
IsVolatile parameter, and didn't copy isVolatile() from the original.
Every other expansion path in this file already does.  Affects targets
whose MinCmpXchgSizeInBits exceeds the value width (RISC-V without
Zabha, LoongArch base, SPARC, AMDGPU, etc.).

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
