### PR TITLE
Update `memset.inline` third argument documentation

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -16803,7 +16803,7 @@ Arguments:
 """"""""""
 
 The first argument is a pointer to the destination to fill, the second
-is the byte value with which to fill it, the third argument is a constant
+is the byte value with which to fill it, the third argument is an
 integer argument specifying the number of bytes to fill, and the fourth
 is a boolean indicating a volatile access.
 

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1098,7 +1098,6 @@ def int_memset  : DefaultAttrsIntrinsic<[],
 // Memset version that is guaranteed to be inlined.
 // In particular this means that the generated code is not allowed to call any
 // external function.
-// The third argument (specifying the size) must be a constant.
 def int_memset_inline
     : DefaultAttrsIntrinsic<[],
       [llvm_anyptr_ty, llvm_i8_ty, llvm_anyint_ty, llvm_i1_ty],


### PR DESCRIPTION
Similar to `memcpy.inline`, `memset.inline`'s size argument doesn't need to be a constant. Checked by the test
Transforms/PreISelIntrinsicLowering/X86/memset-inline-non-constant-len.ll.

This cleanup was missed in 4d052a76185875bf8d8343d723a444795b87c8c5.