### PR TITLE
[DSE] Restrict partial-overlap store merging to matching orderings.

### DIFF
--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -773,6 +773,22 @@ tryToMergePartialOverlappingStores(StoreInst *KillingI, StoreInst *DeadI,
                                    const DataLayout &DL, BatchAAResults &AA,
                                    DominatorTree *DT) {
 
+  // The merge erases KillingI and writes its bytes via DeadI. For that to be
+  // safe:
+  //   - KillingI must be deletable (not volatile, ordering at most unordered),
+  //   - DeadI must be safe to rewrite (likewise), and
+  //   - Their orderings must match, so the bytes originally written by
+  //     KillingI keep the same atomicity after they are folded into DeadI.
+  // This allows merging two simple stores or two unordered-atomic stores with
+  // matching ordering, while leaving volatile and ordered-atomic stores in
+  // place.
+  if (KillingI && DeadI) {
+    if (!KillingI->isUnordered() || !DeadI->isUnordered())
+      return nullptr;
+    if (KillingI->getOrdering() != DeadI->getOrdering())
+      return nullptr;
+  }
+
   if (DeadI && isa<ConstantInt>(DeadI->getValueOperand()) &&
       DL.typeSizeEqualsStoreSize(DeadI->getValueOperand()->getType()) &&
       KillingI && isa<ConstantInt>(KillingI->getValueOperand()) &&

--- a/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/DeadStoreElimination.cpp
@@ -772,61 +772,60 @@ tryToMergePartialOverlappingStores(StoreInst *KillingI, StoreInst *DeadI,
                                    int64_t KillingOffset, int64_t DeadOffset,
                                    const DataLayout &DL, BatchAAResults &AA,
                                    DominatorTree *DT) {
+  assert(KillingI);
+  assert(DeadI);
+
+  // If the store we find is:
+  //   a) partially overwritten by the store to 'Loc'
+  //   b) the killing store is fully contained in the dead one and
+  //   c) they both have a constant value
+  //   d) none of the two stores need padding
+  // Merge the two stores, replacing the dead store's value with a
+  // merge of both values.
+  //
+  // TODO: Deal with other constant types (vectors, etc), and probably
+  // some mem intrinsics (if needed)
+  if (!isa<ConstantInt>(DeadI->getValueOperand()) ||
+      !DL.typeSizeEqualsStoreSize(DeadI->getValueOperand()->getType()) ||
+      !isa<ConstantInt>(KillingI->getValueOperand()) ||
+      !DL.typeSizeEqualsStoreSize(KillingI->getValueOperand()->getType()) ||
+      !memoryIsNotModifiedBetween(DeadI, KillingI, AA, DL, DT))
+    return nullptr;
 
   // The merge erases KillingI and writes its bytes via DeadI. For that to be
   // safe:
   //   - KillingI must be deletable (not volatile, ordering at most unordered),
-  //   - DeadI must be safe to rewrite (likewise), and
-  //   - Their orderings must match, so the bytes originally written by
+  //   - DeadI must be safe to rewrite, and
+  //   - their orderings must match, so the bytes originally written by
   //     KillingI keep the same atomicity after they are folded into DeadI.
   // This allows merging two simple stores or two unordered-atomic stores with
   // matching ordering, while leaving volatile and ordered-atomic stores in
   // place.
-  if (KillingI && DeadI) {
-    if (!KillingI->isUnordered() || !DeadI->isUnordered())
-      return nullptr;
-    if (KillingI->getOrdering() != DeadI->getOrdering())
-      return nullptr;
-  }
+  if (!KillingI->isUnordered() || !DeadI->isUnordered() ||
+      KillingI->getOrdering() != DeadI->getOrdering())
+    return nullptr;
 
-  if (DeadI && isa<ConstantInt>(DeadI->getValueOperand()) &&
-      DL.typeSizeEqualsStoreSize(DeadI->getValueOperand()->getType()) &&
-      KillingI && isa<ConstantInt>(KillingI->getValueOperand()) &&
-      DL.typeSizeEqualsStoreSize(KillingI->getValueOperand()->getType()) &&
-      memoryIsNotModifiedBetween(DeadI, KillingI, AA, DL, DT)) {
-    // If the store we find is:
-    //   a) partially overwritten by the store to 'Loc'
-    //   b) the killing store is fully contained in the dead one and
-    //   c) they both have a constant value
-    //   d) none of the two stores need padding
-    // Merge the two stores, replacing the dead store's value with a
-    // merge of both values.
-    // TODO: Deal with other constant types (vectors, etc), and probably
-    // some mem intrinsics (if needed)
+  APInt DeadValue = cast<ConstantInt>(DeadI->getValueOperand())->getValue();
+  APInt KillingValue =
+      cast<ConstantInt>(KillingI->getValueOperand())->getValue();
+  unsigned KillingBits = KillingValue.getBitWidth();
+  assert(DeadValue.getBitWidth() > KillingValue.getBitWidth());
+  KillingValue = KillingValue.zext(DeadValue.getBitWidth());
 
-    APInt DeadValue = cast<ConstantInt>(DeadI->getValueOperand())->getValue();
-    APInt KillingValue =
-        cast<ConstantInt>(KillingI->getValueOperand())->getValue();
-    unsigned KillingBits = KillingValue.getBitWidth();
-    assert(DeadValue.getBitWidth() > KillingValue.getBitWidth());
-    KillingValue = KillingValue.zext(DeadValue.getBitWidth());
-
-    // Offset of the smaller store inside the larger store
-    unsigned BitOffsetDiff = (KillingOffset - DeadOffset) * 8;
-    unsigned LShiftAmount =
-        DL.isBigEndian() ? DeadValue.getBitWidth() - BitOffsetDiff - KillingBits
-                         : BitOffsetDiff;
-    APInt Mask = APInt::getBitsSet(DeadValue.getBitWidth(), LShiftAmount,
-                                   LShiftAmount + KillingBits);
-    // Clear the bits we'll be replacing, then OR with the smaller
-    // store, shifted appropriately.
-    APInt Merged = (DeadValue & ~Mask) | (KillingValue << LShiftAmount);
-    LLVM_DEBUG(dbgs() << "DSE: Merge Stores:\n  Dead: " << *DeadI
-                      << "\n  Killing: " << *KillingI
-                      << "\n  Merged Value: " << Merged << '\n');
-    return ConstantInt::get(DeadI->getValueOperand()->getType(), Merged);
-  }
-  return nullptr;
+  // Offset of the smaller store inside the larger store
+  unsigned BitOffsetDiff = (KillingOffset - DeadOffset) * 8;
+  unsigned LShiftAmount =
+      DL.isBigEndian() ? DeadValue.getBitWidth() - BitOffsetDiff - KillingBits
+                       : BitOffsetDiff;
+  APInt Mask = APInt::getBitsSet(DeadValue.getBitWidth(), LShiftAmount,
+                                 LShiftAmount + KillingBits);
+  // Clear the bits we'll be replacing, then OR with the smaller
+  // store, shifted appropriately.
+  APInt Merged = (DeadValue & ~Mask) | (KillingValue << LShiftAmount);
+  LLVM_DEBUG(dbgs() << "DSE: Merge Stores:\n  Dead: " << *DeadI
+                    << "\n  Killing: " << *KillingI
+                    << "\n  Merged Value: " << Merged << '\n');
+  return ConstantInt::get(DeadI->getValueOperand()->getType(), Merged);
 }
 
 // Returns true if \p I is an intrinsic that does not read or write memory.

--- a/llvm/test/Transforms/DeadStoreElimination/merge-stores.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/merge-stores.ll
@@ -5,7 +5,7 @@ target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f3
 define void @byte_by_byte_replacement(ptr %ptr) {
 ; CHECK-LABEL: @byte_by_byte_replacement(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i32 202050057, ptr [[PTR:%.*]]
+; CHECK-NEXT:    store i32 202050057, ptr [[PTR:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -30,7 +30,7 @@ entry:
 define void @word_replacement(ptr %ptr) {
 ; CHECK-LABEL: @word_replacement(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 8106482645252179720, ptr [[PTR:%.*]]
+; CHECK-NEXT:    store i64 8106482645252179720, ptr [[PTR:%.*]], align 8
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -51,7 +51,7 @@ entry:
 define void @differently_sized_replacements(ptr %ptr) {
 ; CHECK-LABEL: @differently_sized_replacements(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 578437695752307201, ptr [[PTR:%.*]]
+; CHECK-NEXT:    store i64 578437695752307201, ptr [[PTR:%.*]], align 8
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -73,7 +73,7 @@ entry:
 define void @multiple_replacements_to_same_byte(ptr %ptr) {
 ; CHECK-LABEL: @multiple_replacements_to_same_byte(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 579005069522043393, ptr [[PTR:%.*]]
+; CHECK-NEXT:    store i64 579005069522043393, ptr [[PTR:%.*]], align 8
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -94,7 +94,7 @@ entry:
 define void @merged_merges(ptr %ptr) {
 ; CHECK-LABEL: @merged_merges(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 579005069572506113, ptr [[PTR:%.*]]
+; CHECK-NEXT:    store i64 579005069572506113, ptr [[PTR:%.*]], align 8
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -141,7 +141,7 @@ entry:
 define void @foo(ptr nocapture %u) {
 ; CHECK-LABEL: @foo(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    store i64 42, ptr [[U:%.*]], align 8
+; CHECK-NEXT:    store i64 42, ptr [[U:%.*]], align 8, !tbaa [[TBAA0:![0-9]+]], !noalias [[META3:![0-9]+]], !nontemporal [[META6:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -154,8 +154,8 @@ entry:
 
 define void @PR34074(ptr %x, ptr %y) {
 ; CHECK-LABEL: @PR34074(
-; CHECK-NEXT:    store i64 42, ptr %y
-; CHECK-NEXT:    store i32 4, ptr %x
+; CHECK-NEXT:    store i64 42, ptr [[Y:%.*]], align 8
+; CHECK-NEXT:    store i32 4, ptr [[X:%.*]], align 4
 ; CHECK-NEXT:    ret void
 ;
   store i64 42, ptr %y          ; independent store
@@ -176,6 +176,50 @@ define void @PR36129(ptr %P, ptr %Q) {
   store i32 1, ptr %P, align 4
   store i32 2, ptr %Q, align 4
   store i8 3, ptr %P, align 1
+  ret void
+}
+
+; Partial-overlap store merging erases the killing store and folds its bytes
+; into the preceding (wider) dead store. It is only valid when both stores
+; have matching atomic ordering, so the killing store is safely deletable and
+; its bytes keep the same atomicity after being folded into the dead store.
+
+define void @killing_store_volatile(ptr %p) {
+; CHECK-LABEL: @killing_store_volatile(
+; CHECK-NEXT:    store i32 0, ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr i8, ptr [[P]], i64 2
+; CHECK-NEXT:    store volatile i16 -1, ptr [[P2]], align 2
+; CHECK-NEXT:    ret void
+;
+  store i32 0, ptr %p, align 4
+  %p2 = getelementptr i8, ptr %p, i64 2
+  store volatile i16 -1, ptr %p2, align 2
+  ret void
+}
+
+define void @killing_store_atomic_monotonic(ptr %p) {
+; CHECK-LABEL: @killing_store_atomic_monotonic(
+; CHECK-NEXT:    store i32 0, ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr i8, ptr [[P]], i64 2
+; CHECK-NEXT:    store atomic i16 -1, ptr [[P2]] monotonic, align 2
+; CHECK-NEXT:    ret void
+;
+  store i32 0, ptr %p, align 4
+  %p2 = getelementptr i8, ptr %p, i64 2
+  store atomic i16 -1, ptr %p2 monotonic, align 2
+  ret void
+}
+
+define void @killing_store_atomic_unordered(ptr %p) {
+; CHECK-LABEL: @killing_store_atomic_unordered(
+; CHECK-NEXT:    store i32 0, ptr [[P:%.*]], align 4
+; CHECK-NEXT:    [[P2:%.*]] = getelementptr i8, ptr [[P]], i64 2
+; CHECK-NEXT:    store atomic i16 -1, ptr [[P2]] unordered, align 2
+; CHECK-NEXT:    ret void
+;
+  store i32 0, ptr %p, align 4
+  %p2 = getelementptr i8, ptr %p, i64 2
+  store atomic i16 -1, ptr %p2 unordered, align 2
   ret void
 }
 


### PR DESCRIPTION
Partial-overlap store merging folds the later killing store into the
earlier dead store and erases the killing store. That is invalid if the
killing store is volatile or has stronger-than-unordered atomic ordering,
because erasing it drops an observable write. It is also invalid if the
killing and dead stores have different atomic orderings, because the
bytes originally written by the killing store would inherit the dead
store's atomicity after the merge -- silently dropping (or adding)
atomicity for those bytes.

Require both stores to be unordered (i.e. non-volatile with ordering at
most unordered) and to share the same ordering. This preserves the
existing fold for two simple stores or two unordered-atomic stores
(e.g. simple.ll's test43a) while leaving volatile, ordered-atomic, and
atomicity-mismatched cases in place.

This bug was found by a large run of Opus 4.7 looking for bugs in LLVM.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
