### PR TITLE
[VPlan] Add missing maybe_unsused to OpTy (NFC).

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -465,7 +465,7 @@ Type *llvm::computeScalarTypeForInstruction(unsigned Opcode,
                                                         Type *ExpectedTy) {
     if (!ExpectedTy || Operands.size() <= Idx)
       return;
-    Type *OpTy = getScalarTypeOrInfer(Operands[Idx]);
+    [[maybe_unused]] Type *OpTy = getScalarTypeOrInfer(Operands[Idx]);
     assert((!OpTy || OpTy == ExpectedTy) &&
            "different types inferred for different operands");
   };


### PR DESCRIPTION
This fixes a warning when building w/o assertions.

https://lab.llvm.org/buildbot/#/builders/228/builds/76