### PR TITLE
[Github] Pin container image reference in libc-shared-tests

### DIFF
--- a/.github/workflows/libc-shared-tests.yml
+++ b/.github/workflows/libc-shared-tests.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/libc-ubuntu-24.04:70cbd7591abe'
+      image: 'ghcr.io/llvm/libc-ubuntu-24.04:latest@sha256:a902fb53bdad5e4a4bb6c11b6584e717a7b3d6e886f1ea58e11f95e46226249c'
     strategy:
       fail-fast: false # If one arch fails, let the other finish
       matrix:
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/libc-ubuntu-24.04:70cbd7591abe'
+      image: 'ghcr.io/llvm/libc-ubuntu-24.04:latest@sha256:a902fb53bdad5e4a4bb6c11b6584e717a7b3d6e886f1ea58e11f95e46226249c'
     strategy:
       fail-fast: false # If one arch fails, let the other finish
       matrix:


### PR DESCRIPTION
Pinned to the image used in the last successful workflow run.

Introduced in c32de3e3759c3368978535e4ff4fb83323219fb0.