### PR TITLE
[libc][math] Temporarily disable exception tests for NextAfter and NextToward tests on Windows.

### DIFF
--- a/libc/test/src/math/smoke/NextAfterTest.h
+++ b/libc/test/src/math/smoke/NextAfterTest.h
@@ -14,6 +14,7 @@
 #include "src/__support/CPP/bit.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/macros/properties/os.h"
 #include "src/__support/sign.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"
@@ -23,12 +24,24 @@
 
 using LIBC_NAMESPACE::Sign;
 
+// TODO: https://github.com/llvm/llvm-project/issues/199738
+// The exceptions setup seem to be flaky on Windows with clang-cl and need
+// further investigation.
+#ifdef LIBC_TARGET_OS_IS_WINDOWS
+
+#define ASSERT_FP_EQ_WITH_EXCEPTION(result, expected, expected_exception)      \
+  ASSERT_FP_EQ(result, expected);
+
+#else
+
 // TODO: Strengthen errno,exception checks and remove these assert macros
 // after new matchers/test fixtures are added
 #define ASSERT_FP_EQ_WITH_EXCEPTION(result, expected, expected_exception)      \
   ASSERT_FP_EQ(result, expected);                                              \
   ASSERT_FP_EXCEPTION(expected_exception);                                     \
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT)
+
+#endif // LIBC_TARGET_OS_IS_WINDOWS
 
 #define ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected)                          \
   ASSERT_FP_EQ_WITH_EXCEPTION(result, expected, FE_UNDERFLOW)

--- a/libc/test/src/math/smoke/NextTowardTest.h
+++ b/libc/test/src/math/smoke/NextTowardTest.h
@@ -14,6 +14,7 @@
 #include "src/__support/CPP/bit.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/macros/properties/os.h"
 #include "test/UnitTest/FEnvSafeTest.h"
 #include "test/UnitTest/FPMatcher.h"
 #include "test/UnitTest/Test.h"
@@ -22,12 +23,24 @@
 
 using LIBC_NAMESPACE::Sign;
 
+// TODO: https://github.com/llvm/llvm-project/issues/199738
+// The exceptions setup seem to be flaky on Windows with clang-cl and need
+// further investigation.
+#ifdef LIBC_TARGET_OS_IS_WINDOWS
+
+#define ASSERT_FP_EQ_WITH_EXCEPTION(result, expected, expected_exception)      \
+  ASSERT_FP_EQ(result, expected);
+
+#else
+
 // TODO: Strengthen errno,exception checks and remove these assert macros
 // after new matchers/test fixtures are added
 #define ASSERT_FP_EQ_WITH_EXCEPTION(result, expected, expected_exception)      \
   ASSERT_FP_EQ(result, expected);                                              \
   ASSERT_FP_EXCEPTION(expected_exception);                                     \
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT)
+
+#endif // LIBC_TARGET_OS_IS_WINDOWS
 
 #define ASSERT_FP_EQ_WITH_UNDERFLOW(result, expected)                          \
   ASSERT_FP_EQ_WITH_EXCEPTION(result, expected, FE_UNDERFLOW)


### PR DESCRIPTION
They are a bit flaky on Windows.
See https://github.com/llvm/llvm-project/issues/199738