### PR TITLE
[libc][ci] Improve full build precommit CIs caching keys.

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -121,7 +121,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@33522472633dbd32578e909b315f5ee43ba878ce # v1.2.22
       with:
         max-size: 1G
-        key: libc_fullbuild_v2_${{ matrix.c_compiler }}
+        key: libc_fullbuild_v3_${{ matrix.target }}_${{ matrix.build_type }}_${{ matrix.c_compiler }}
         variant: sccache
 
     - name: Set reusable strings


### PR DESCRIPTION
Currently full build precommit CIs only uses c_compiler as the cache's key which will be the same for many of them listed in the matrix list. We change to use the combination of (target + build_type + c_compiler) as keys to uniquely distinguish them and the future gcc builds.