### PR TITLE
[Flang][OpenMP]add semantic check for linear clause with statement function variables

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1064,7 +1064,8 @@ private:
       Symbol::Flag::OmpIsDevicePtr, Symbol::Flag::OmpHasDeviceAddr};
 
   Symbol::Flags privateDataSharingAttributeFlags{Symbol::Flag::OmpPrivate,
-      Symbol::Flag::OmpFirstPrivate, Symbol::Flag::OmpLastPrivate};
+      Symbol::Flag::OmpFirstPrivate, Symbol::Flag::OmpLastPrivate,
+      Symbol::Flag::OmpLinear};
 
   Symbol::Flags ompFlagsRequireNewSymbol{Symbol::Flag::OmpPrivate,
       Symbol::Flag::OmpLinear, Symbol::Flag::OmpFirstPrivate,
@@ -3263,6 +3264,8 @@ void OmpAttributeVisitor::CheckObjectIsPrivatizable(
     clauseName = "FIRSTPRIVATE";
   } else if (ompFlag == Symbol::Flag::OmpLastPrivate) {
     clauseName = "LASTPRIVATE";
+  } else if (ompFlag == Symbol::Flag::OmpLinear) {
+    clauseName = "LINEAR";
   }
 
   if (SymbolOrEquivalentIsInNamelist(symbol)) {

--- a/flang/test/Semantics/OpenMP/private03.f90
+++ b/flang/test/Semantics/OpenMP/private03.f90
@@ -1,7 +1,7 @@
 ! RUN: %python %S/../test_errors.py %s %flang -fopenmp
 ! OpenMP Version 4.5
 ! Variables that appear in expressions for statement function definitions
-! may not appear in private, firstprivate or lastprivate clauses.
+! may not appear in private, firstprivate, lastprivate or linear clauses.
 
 subroutine stmt_function(temp)
 
@@ -33,6 +33,14 @@ subroutine stmt_function(temp)
   t(i) = v(temp) + i - s
   end do
   !$omp end parallel do
+
+  !ERROR: Variable 'p' in statement function expression cannot be in a LINEAR clause
+  !$omp parallel do simd linear(p)
+  do i = 1, 10
+  t(i) = v(temp) + i
+  p = p + 1
+  end do
+  !$omp end parallel do simd
 
   print *, t
 


### PR DESCRIPTION
### **Description**

1. This patch adds a missing semantic check for the LINEAR clause.
2. OpenMP treats LINEAR variables similarly to PRIVATE variables. Variables used inside statement function expressions are not allowed to be privatized, but Flang was not checking this for LINEAR.
3.  The existing privatization check already handled PRIVATE, FIRSTPRIVATE, and LASTPRIVATE. This patch extends the same check to LINEAR.

Fixes : [199660](https://github.com/llvm/llvm-project/issues/199660)

### **Reproducer**
```
subroutine test()
  integer :: pi, r, f, x
  f(r) = pi * r + x
  !$omp parallel do linear(x)
  do r = 1, 10
    pi = f(r)
  end do
  !$omp end parallel do
end subroutine
```
when compiled with : `-fopenmp -fopenmp-version=45 -c`

**Observed Behavior**

` No diagnostic emitted
`

**Expected Behavior**

```
error: Variable 'x' in statement function expression cannot be in a LINEAR clause
    !$omp parallel do linear(x)
```
                             


