### PR TITLE
[DirectX] Implement lowering of llvm.dx.resource.samplebias to the SampleBias DXIL Op

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -888,7 +888,8 @@ def SampleBias : DXILOp<61, sampleBias> {
                    Int32Ty, Int32Ty, Int32Ty, FloatTy, FloatTy];
   let result = OverloadTy;
   let overloads =
-      [Overloads<DXIL1_0,
+      [Overloads<DXIL1_0, [ResRetHalfTy, ResRetFloatTy]>,
+       Overloads<DXIL1_7,
                  [ResRetHalfTy, ResRetFloatTy, ResRetInt16Ty, ResRetInt32Ty]>];
   let stages = [Stages<DXIL1_0, [library, pixel]>,
                 Stages<DXIL1_6, [library, pixel, compute, amplification, mesh,

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -880,6 +880,22 @@ def CBufferLoadLegacy : DXILOp<59, cbufferLoadLegacy> {
   let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
 }
 
+def SampleBias : DXILOp<61, sampleBias> {
+  let Doc = "samples a texture after applying the input bias to the mip level";
+  // Handle, Sampler, Coord0, Coord1, Coord2, Coord3,
+  // Offset0, Offset1, Offset2, Bias, Clamp
+  let arguments = [HandleTy, HandleTy, FloatTy, FloatTy, FloatTy, FloatTy,
+                   Int32Ty, Int32Ty, Int32Ty, FloatTy, FloatTy];
+  let result = OverloadTy;
+  let overloads =
+      [Overloads<DXIL1_0,
+                 [ResRetHalfTy, ResRetFloatTy, ResRetInt16Ty, ResRetInt32Ty]>];
+  let stages = [Stages<DXIL1_0, [library, pixel]>,
+                Stages<DXIL1_6, [library, pixel, compute, amplification, mesh,
+                                 node]>];
+  let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
+}
+
 def TextureLoad : DXILOp<66, textureLoad> {
   let Doc = "reads from a texture resource";
   // Handle, MipLevelOrSampleCount, Coord0, Coord1, Coord2, Offset0, Offset1, Offset2

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -608,6 +608,18 @@ public:
     }
   }
 
+  /// Copy offsets into the argument list at the given index, unless
+  /// the offsets are known to be zero (i.e., a null constant).
+  static void extractNonZeroOffsets(IRBuilder<> &IRB,
+                                    MutableArrayRef<Value *> Args,
+                                    unsigned ArgIdx, Value *Offsets,
+                                    unsigned MaxElements) {
+    auto *COff = dyn_cast<Constant>(Offsets);
+    bool OffsetsAreZero = COff && COff->isNullValue();
+    if (!OffsetsAreZero)
+      extractElementsIntoArgs(IRB, Args, ArgIdx, Offsets, MaxElements);
+  }
+
   [[nodiscard]] bool lowerTextureLoad(Function &F) {
     IRBuilder<> &IRB = OpBuilder.getIRB();
     Type *Int32Ty = IRB.getInt32Ty();
@@ -630,8 +642,7 @@ public:
 
       // Copy coordinates and offsets into Args.
       extractElementsIntoArgs(IRB, Args, 2, Coords, 3);
-      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
-        extractElementsIntoArgs(IRB, Args, 5, Offsets, 3);
+      extractNonZeroOffsets(IRB, Args, 5, Offsets, 3);
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
           OpCode::TextureLoad, Args, CI->getName(), NewRetTy);
@@ -671,11 +682,9 @@ public:
                                    UndefF, UndefF,  UndefI, UndefI,
                                    UndefI, Bias,    Clamp};
 
-      // Copy coordinates into Args[2..5].
+      // Copy coordinates and offsets into Args.
       extractElementsIntoArgs(IRB, Args, 2, Coords, 4);
-      // Copy offsets into Args[6..8] if non-zero.
-      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
-        extractElementsIntoArgs(IRB, Args, 6, Offsets, 3);
+      extractNonZeroOffsets(IRB, Args, 6, Offsets, 3);
 
       Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
           OpCode::SampleBias, Args, CI->getName(), NewRetTy);

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -644,6 +644,50 @@ public:
     });
   }
 
+  [[nodiscard]] bool lowerSampleBias(Function &F, bool HasClamp) {
+    IRBuilder<> &IRB = OpBuilder.getIRB();
+    Type *Int32Ty = IRB.getInt32Ty();
+    Type *FloatTy = IRB.getFloatTy();
+
+    return replaceFunction(F, [&](CallInst *CI) -> Error {
+      IRB.SetInsertPoint(CI);
+
+      Value *Handle =
+          createTmpHandleCast(CI->getArgOperand(0), OpBuilder.getHandleType());
+      Value *Sampler =
+          createTmpHandleCast(CI->getArgOperand(1), OpBuilder.getHandleType());
+      Value *Coords = CI->getArgOperand(2);
+      Value *Bias = CI->getArgOperand(3);
+      Value *Offsets = CI->getArgOperand(4);
+      Value *Clamp = HasClamp ? CI->getArgOperand(5) : UndefValue::get(FloatTy);
+
+      Type *OldTy = CI->getType();
+      Type *NewRetTy = OpBuilder.getResRetType(OldTy->getScalarType());
+
+      Value *UndefF = UndefValue::get(FloatTy);
+      Value *UndefI = UndefValue::get(Int32Ty);
+      // Args: Handle, Sampler, Coord0..3, Offset0..2, Bias, Clamp
+      std::array<Value *, 11> Args{Handle, Sampler, UndefF, UndefF,
+                                   UndefF, UndefF,  UndefI, UndefI,
+                                   UndefI, Bias,    Clamp};
+
+      // Copy coordinates into Args[2..5].
+      extractElementsIntoArgs(IRB, Args, 2, Coords, 4);
+      // Copy offsets into Args[6..8] if non-zero.
+      if (auto *C = dyn_cast<Constant>(Offsets); !C || !C->isNullValue())
+        extractElementsIntoArgs(IRB, Args, 6, Offsets, 3);
+
+      Expected<CallInst *> OpCall = OpBuilder.tryCreateOp(
+          OpCode::SampleBias, Args, CI->getName(), NewRetTy);
+      if (Error E = OpCall.takeError())
+        return E;
+      if (Error E = replaceResRetUses(CI, *OpCall, /*HasCheckBit=*/false))
+        return E;
+
+      return Error::success();
+    });
+  }
+
   [[nodiscard]] bool lowerRawBufferLoad(Function &F) {
     const DataLayout &DL = F.getDataLayout();
     IRBuilder<> &IRB = OpBuilder.getIRB();
@@ -1060,6 +1104,12 @@ public:
         break;
       case Intrinsic::dx_resource_load_level:
         HasErrors |= lowerTextureLoad(F);
+        break;
+      case Intrinsic::dx_resource_samplebias:
+        HasErrors |= lowerSampleBias(F, /*HasClamp=*/false);
+        break;
+      case Intrinsic::dx_resource_samplebias_clamp:
+        HasErrors |= lowerSampleBias(F, /*HasClamp=*/true);
         break;
       case Intrinsic::dx_resource_store_typedbuffer:
         HasErrors |= lowerBufferStore(F, /*IsRaw=*/false);

--- a/llvm/test/CodeGen/DirectX/SampleBias.ll
+++ b/llvm/test/CodeGen/DirectX/SampleBias.ll
@@ -1,0 +1,51 @@
+; RUN: opt -S -dxil-op-lower %s | FileCheck %s
+
+target triple = "dxil-pc-shadermodel6.6-pixel"
+
+declare void @use_float4(<4 x float>)
+
+; CHECK-LABEL: define void @samplebias_texture2d_float4(
+define void @samplebias_texture2d_float4(<2 x float> %coords, float %bias) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; CHECK-LABEL: define void @samplebias_texture2d_with_clamp(
+define void @samplebias_texture2d_with_clamp(<2 x float> %coords, float %bias, float %clamp) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float %clamp)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.clamp.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> zeroinitializer, float %clamp)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}

--- a/llvm/test/CodeGen/DirectX/SampleBias.ll
+++ b/llvm/test/CodeGen/DirectX/SampleBias.ll
@@ -1,11 +1,10 @@
 ; RUN: opt -S -dxil-op-lower %s | FileCheck %s
 
-target triple = "dxil-pc-shadermodel6.7-pixel"
+target triple = "dxil-pc-shadermodel6.6-pixel"
 
 declare void @use_float4(<4 x float>)
 declare void @use_float(float)
 declare void @use_half4(<4 x half>)
-declare void @use_int4(<4 x i32>)
 
 ; Test basic SampleBias on a Texture2D with float4 result.
 ; CHECK-LABEL: define void @samplebias_texture2d_float4(
@@ -19,7 +18,14 @@ define void @samplebias_texture2d_float4(<2 x float> %coords, float %bias) {
 
   ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
   %data = call <4 x float>
       @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
           target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
@@ -43,7 +49,14 @@ define void @samplebias_texture2d_with_clamp(<2 x float> %coords, float %bias, f
 
   ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float %clamp)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float %clamp)
   %data = call <4 x float>
       @llvm.dx.resource.samplebias.clamp.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
           target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
@@ -55,7 +68,7 @@ define void @samplebias_texture2d_with_clamp(<2 x float> %coords, float %bias, f
   ret void
 }
 
-; Test SampleBias with non-zero offsets on a Texture2D.
+; Test SampleBias with constant non-zero offsets on a Texture2D.
 ; CHECK-LABEL: define void @samplebias_texture2d_with_offset(
 define void @samplebias_texture2d_with_offset(<2 x float> %coords, float %bias) {
   %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
@@ -67,12 +80,52 @@ define void @samplebias_texture2d_with_offset(<2 x float> %coords, float %bias) 
 
   ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 1, i32 -2, i32 undef, float %bias, float undef)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 1, i32 -2, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
   %data = call <4 x float>
       @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
           target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
           target("dx.Sampler", 0) %sampler,
           <2 x float> %coords, float %bias, <2 x i32> <i32 1, i32 -2>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleBias with dynamic (non-constant) offsets on a Texture2D.
+; CHECK-LABEL: define void @samplebias_texture2d_with_dynamic_offset(
+define void @samplebias_texture2d_with_dynamic_offset(<2 x float> %coords, float %bias, <2 x i32> %offsets) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[OFF0:.*]] = extractelement <2 x i32> %offsets, i64 0
+  ; CHECK: %[[OFF1:.*]] = extractelement <2 x i32> %offsets, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 %[[OFF0]], i32 %[[OFF1]], i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> %offsets)
 
   ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
   call void @use_float4(<4 x float> %data)
@@ -91,7 +144,14 @@ define void @samplebias_texture2d_with_offset_and_clamp(<2 x float> %coords, flo
 
   ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 3, i32 -1, i32 undef, float %bias, float %clamp)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 3, i32 -1, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float %clamp)
   %data = call <4 x float>
       @llvm.dx.resource.samplebias.clamp.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
           target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
@@ -113,7 +173,14 @@ define void @samplebias_texture1d_float4(float %coord, float %bias) {
       @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
           i32 0, i32 0, i32 1, i32 0, ptr null)
 
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %coord, float undef, float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %coord, float undef, float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
   %data = call <4 x float>
       @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_1t.tdx.Sampler_0t.f32.i32(
           target("dx.Texture", <4 x float>, 0, 0, 0, 1) %texture,
@@ -138,7 +205,14 @@ define void @samplebias_texture3d_float4(<3 x float> %coords, float %bias) {
   ; CHECK: %[[COORD0:.*]] = extractelement <3 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <3 x float> %coords, i64 1
   ; CHECK: %[[COORD2:.*]] = extractelement <3 x float> %coords, i64 2
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float %[[COORD2]], float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float %[[COORD2]], float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
   %data = call <4 x float>
       @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_4t.tdx.Sampler_0t.v3f32.v3i32(
           target("dx.Texture", <4 x float>, 0, 0, 0, 4) %texture,
@@ -162,7 +236,14 @@ define void @samplebias_texture2d_scalar(<2 x float> %coords, float %bias) {
 
   ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32
+  ; CHECK-SAME: @dx.op.sampleBias.f32(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
   %data = call float
       @llvm.dx.resource.samplebias.f32.tdx.Texture_f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
           target("dx.Texture", float, 0, 0, 0, 2) %texture,
@@ -186,7 +267,14 @@ define void @samplebias_texture2d_half4(<2 x float> %coords, float %bias) {
 
   ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
   ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f16 @dx.op.sampleBias.f16(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f16
+  ; CHECK-SAME: @dx.op.sampleBias.f16(i32 61,
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: %dx.types.Handle %{{[^,]*}},
+  ; CHECK-SAME: float %[[COORD0]], float %[[COORD1]], float undef, float undef,
+  ; CHECK-SAME: i32 undef, i32 undef, i32 undef,
+  ; CHECK-SAME: float %bias,
+  ; CHECK-SAME: float undef)
   %data = call <4 x half>
       @llvm.dx.resource.samplebias.v4f16.tdx.Texture_v4f16_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
           target("dx.Texture", <4 x half>, 0, 0, 0, 2) %texture,
@@ -195,29 +283,5 @@ define void @samplebias_texture2d_half4(<2 x float> %coords, float %bias) {
 
   ; CHECK: extractvalue %dx.types.ResRet.f16 %[[SAMPLE]], 0
   call void @use_half4(<4 x half> %data)
-  ret void
-}
-
-; Test SampleBias with integer result type on a Texture2D (requires SM 6.7).
-; CHECK-LABEL: define void @samplebias_texture2d_int4(
-define void @samplebias_texture2d_int4(<2 x float> %coords, float %bias) {
-  %texture = call target("dx.Texture", <4 x i32>, 0, 0, 0, 2)
-      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4i32_0_0_0_2t(
-          i32 0, i32 6, i32 1, i32 0, ptr null)
-  %sampler = call target("dx.Sampler", 0)
-      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
-          i32 0, i32 0, i32 1, i32 0, ptr null)
-
-  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
-  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
-  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.i32 @dx.op.sampleBias.i32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
-  %data = call <4 x i32>
-      @llvm.dx.resource.samplebias.v4i32.tdx.Texture_v4i32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
-          target("dx.Texture", <4 x i32>, 0, 0, 0, 2) %texture,
-          target("dx.Sampler", 0) %sampler,
-          <2 x float> %coords, float %bias, <2 x i32> zeroinitializer)
-
-  ; CHECK: extractvalue %dx.types.ResRet.i32 %[[SAMPLE]], 0
-  call void @use_int4(<4 x i32> %data)
   ret void
 }

--- a/llvm/test/CodeGen/DirectX/SampleBias.ll
+++ b/llvm/test/CodeGen/DirectX/SampleBias.ll
@@ -1,9 +1,13 @@
 ; RUN: opt -S -dxil-op-lower %s | FileCheck %s
 
-target triple = "dxil-pc-shadermodel6.6-pixel"
+target triple = "dxil-pc-shadermodel6.7-pixel"
 
 declare void @use_float4(<4 x float>)
+declare void @use_float(float)
+declare void @use_half4(<4 x half>)
+declare void @use_int4(<4 x i32>)
 
+; Test basic SampleBias on a Texture2D with float4 result.
 ; CHECK-LABEL: define void @samplebias_texture2d_float4(
 define void @samplebias_texture2d_float4(<2 x float> %coords, float %bias) {
   %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
@@ -27,6 +31,7 @@ define void @samplebias_texture2d_float4(<2 x float> %coords, float %bias) {
   ret void
 }
 
+; Test SampleBias with clamp on a Texture2D.
 ; CHECK-LABEL: define void @samplebias_texture2d_with_clamp(
 define void @samplebias_texture2d_with_clamp(<2 x float> %coords, float %bias, float %clamp) {
   %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
@@ -47,5 +52,172 @@ define void @samplebias_texture2d_with_clamp(<2 x float> %coords, float %bias, f
 
   ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
   call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleBias with non-zero offsets on a Texture2D.
+; CHECK-LABEL: define void @samplebias_texture2d_with_offset(
+define void @samplebias_texture2d_with_offset(<2 x float> %coords, float %bias) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 1, i32 -2, i32 undef, float %bias, float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> <i32 1, i32 -2>)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleBias with both offset and clamp on a Texture2D.
+; CHECK-LABEL: define void @samplebias_texture2d_with_offset_and_clamp(
+define void @samplebias_texture2d_with_offset_and_clamp(<2 x float> %coords, float %bias, float %clamp) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_2t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 3, i32 -1, i32 undef, float %bias, float %clamp)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.clamp.v4f32.tdx.Texture_v4f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> <i32 3, i32 -1>, float %clamp)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleBias on a Texture1D (scalar coordinate, scalar offset).
+; CHECK-LABEL: define void @samplebias_texture1d_float4(
+define void @samplebias_texture1d_float4(float %coord, float %bias) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 1)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_1t(
+          i32 0, i32 3, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %coord, float undef, float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_1t.tdx.Sampler_0t.f32.i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 1) %texture,
+          target("dx.Sampler", 0) %sampler,
+          float %coord, float %bias, i32 0)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleBias on a Texture3D (3-component coordinates).
+; CHECK-LABEL: define void @samplebias_texture3d_float4(
+define void @samplebias_texture3d_float4(<3 x float> %coords, float %bias) {
+  %texture = call target("dx.Texture", <4 x float>, 0, 0, 0, 4)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f32_0_0_0_4t(
+          i32 0, i32 4, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <3 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <3 x float> %coords, i64 1
+  ; CHECK: %[[COORD2:.*]] = extractelement <3 x float> %coords, i64 2
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float %[[COORD2]], float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  %data = call <4 x float>
+      @llvm.dx.resource.samplebias.v4f32.tdx.Texture_v4f32_0_0_0_4t.tdx.Sampler_0t.v3f32.v3i32(
+          target("dx.Texture", <4 x float>, 0, 0, 0, 4) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <3 x float> %coords, float %bias, <3 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float4(<4 x float> %data)
+  ret void
+}
+
+; Test SampleBias with a scalar return type on a Texture2D.
+; CHECK-LABEL: define void @samplebias_texture2d_scalar(
+define void @samplebias_texture2d_scalar(<2 x float> %coords, float %bias) {
+  %texture = call target("dx.Texture", float, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_f32_0_0_0_2t(
+          i32 0, i32 1, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  %data = call float
+      @llvm.dx.resource.samplebias.f32.tdx.Texture_f32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", float, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f32 %[[SAMPLE]], 0
+  call void @use_float(float %data)
+  ret void
+}
+
+; Test SampleBias with half-precision result type on a Texture2D.
+; CHECK-LABEL: define void @samplebias_texture2d_half4(
+define void @samplebias_texture2d_half4(<2 x float> %coords, float %bias) {
+  %texture = call target("dx.Texture", <4 x half>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4f16_0_0_0_2t(
+          i32 0, i32 5, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.f16 @dx.op.sampleBias.f16(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  %data = call <4 x half>
+      @llvm.dx.resource.samplebias.v4f16.tdx.Texture_v4f16_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x half>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.f16 %[[SAMPLE]], 0
+  call void @use_half4(<4 x half> %data)
+  ret void
+}
+
+; Test SampleBias with integer result type on a Texture2D (requires SM 6.7).
+; CHECK-LABEL: define void @samplebias_texture2d_int4(
+define void @samplebias_texture2d_int4(<2 x float> %coords, float %bias) {
+  %texture = call target("dx.Texture", <4 x i32>, 0, 0, 0, 2)
+      @llvm.dx.resource.handlefrombinding.tdx.Texture_v4i32_0_0_0_2t(
+          i32 0, i32 6, i32 1, i32 0, ptr null)
+  %sampler = call target("dx.Sampler", 0)
+      @llvm.dx.resource.handlefrombinding.tdx.Sampler_0t(
+          i32 0, i32 0, i32 1, i32 0, ptr null)
+
+  ; CHECK: %[[COORD0:.*]] = extractelement <2 x float> %coords, i64 0
+  ; CHECK: %[[COORD1:.*]] = extractelement <2 x float> %coords, i64 1
+  ; CHECK: %[[SAMPLE:.*]] = call %dx.types.ResRet.i32 @dx.op.sampleBias.i32(i32 61, %dx.types.Handle %{{.*}}, %dx.types.Handle %{{.*}}, float %[[COORD0]], float %[[COORD1]], float undef, float undef, i32 undef, i32 undef, i32 undef, float %bias, float undef)
+  %data = call <4 x i32>
+      @llvm.dx.resource.samplebias.v4i32.tdx.Texture_v4i32_0_0_0_2t.tdx.Sampler_0t.v2f32.v2i32(
+          target("dx.Texture", <4 x i32>, 0, 0, 0, 2) %texture,
+          target("dx.Sampler", 0) %sampler,
+          <2 x float> %coords, float %bias, <2 x i32> zeroinitializer)
+
+  ; CHECK: extractvalue %dx.types.ResRet.i32 %[[SAMPLE]], 0
+  call void @use_int4(<4 x i32> %data)
   ret void
 }


### PR DESCRIPTION
Fixes #192548

This PR implements the lowering of the `llvm.dx.resource.samplebias` intrinsic to the `SampleBias` DXIL Op.

Although I reckon that other `lowerSample*` functions in `DXILOpLowering.cpp` will have shared logic, this is the first one to be implemented. Consolidating common logic between future `lowerSample*` functions can be left to a later PR implementing the second or other `lowerSample*` function.

Assisted-by: Claude Opus 4.6