### PR TITLE
[AMDGPU] Added min operation for MCExprs

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -2568,6 +2568,9 @@ As part of the AMDGPU MC layer, AMDGPU provides the following target-specific
      ``max(arg, ...)``   1 or more         Variadic signed operation that returns the maximum
                                            value of all its arguments.
 
+     ``min(arg, ...)``   1 or more         Variadic signed operation that returns the minimum
+                                           value of all its arguments
+
      ``or(arg, ...)``    1 or more         Variadic signed operation that returns the bitwise-or
                                            result of all its arguments.
 

--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -9344,7 +9344,8 @@ void AMDGPUAsmParser::onBeginOfFile() {
 /// Parse AMDGPU specific expressions.
 ///
 ///  expr ::= or(expr, ...) |
-///           max(expr, ...)
+///           max(expr, ...) |
+///           min(expr, ...)
 ///
 bool AMDGPUAsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc) {
   using AGVK = AMDGPUMCExpr::VariantKind;
@@ -9353,6 +9354,7 @@ bool AMDGPUAsmParser::parsePrimaryExpr(const MCExpr *&Res, SMLoc &EndLoc) {
     StringRef TokenId = getTokenStr();
     AGVK VK = StringSwitch<AGVK>(TokenId)
                   .Case("max", AGVK::AGVK_Max)
+                  .Case("min", AGVK::AGVK_Min)
                   .Case("or", AGVK::AGVK_Or)
                   .Case("extrasgprs", AGVK::AGVK_ExtraSGPRs)
                   .Case("totalnumvgprs", AGVK::AGVK_TotalNumVGPRs)

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -499,7 +499,7 @@ static void targetOpKnownBitsMapHelper(const MCExpr *Expr, KnownBitsMap &KBM,
     KnownBits KB = KBM[AGVK->getSubExpr(0)];
     for (const MCExpr *Arg : AGVK->getArgs()) {
       knownBitsMapHelper(Arg, KBM, Depth + 1);
-      KB = KnownBits::umax(KB, KBM[Arg]);
+      KB = KnownBits::smax(KB, KBM[Arg]);
     }
     KBM[Expr] = std::move(KB);
     return;
@@ -509,7 +509,7 @@ static void targetOpKnownBitsMapHelper(const MCExpr *Expr, KnownBitsMap &KBM,
     KnownBits KB = KBM[AGVK->getSubExpr(0)];
     for (const MCExpr *Arg : AGVK->getArgs()) {
       knownBitsMapHelper(Arg, KBM, Depth + 1);
-      KB = KnownBits::umin(KB, KBM[Arg]);
+      KB = KnownBits::smin(KB, KBM[Arg]);
     }
     KBM[Expr] = std::move(KB);
     return;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.cpp
@@ -65,6 +65,9 @@ void AMDGPUMCExpr::printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const {
   case AGVK_Max:
     OS << "max(";
     break;
+  case AGVK_Min:
+    OS << "min(";
+    break;
   case AGVK_ExtraSGPRs:
     OS << "extrasgprs(";
     break;
@@ -103,6 +106,8 @@ static int64_t op(AMDGPUMCExpr::VariantKind Kind, int64_t Arg1, int64_t Arg2) {
     return std::max(Arg1, Arg2);
   case AMDGPUMCExpr::AGVK_Or:
     return Arg1 | Arg2;
+  case AMDGPUMCExpr::AGVK_Min:
+    return std::min(Arg1, Arg2);
   }
 }
 
@@ -495,6 +500,16 @@ static void targetOpKnownBitsMapHelper(const MCExpr *Expr, KnownBitsMap &KBM,
     for (const MCExpr *Arg : AGVK->getArgs()) {
       knownBitsMapHelper(Arg, KBM, Depth + 1);
       KB = KnownBits::umax(KB, KBM[Arg]);
+    }
+    KBM[Expr] = std::move(KB);
+    return;
+  }
+  case AMDGPUMCExpr::VariantKind::AGVK_Min: {
+    knownBitsMapHelper(AGVK->getSubExpr(0), KBM, Depth + 1);
+    KnownBits KB = KBM[AGVK->getSubExpr(0)];
+    for (const MCExpr *Arg : AGVK->getArgs()) {
+      knownBitsMapHelper(Arg, KBM, Depth + 1);
+      KB = KnownBits::umin(KB, KBM[Arg]);
     }
     KBM[Expr] = std::move(KB);
     return;

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -26,8 +26,9 @@ enum class LitModifier { None, Lit, Lit64 };
 ///   - max
 ///   - min
 ///
-/// \note If the 'or'/'max'/'min' operations are provided only a single argument, the
-/// operation will act as a no-op and simply resolve as the provided argument.
+/// \note If the 'or'/'max'/'min' operations are provided only a single
+/// argument, the operation will act as a no-op and simply resolve as the
+/// provided argument.
 ///
 class AMDGPUMCExpr : public MCTargetExpr {
 public:
@@ -87,10 +88,10 @@ public:
                                        MCContext &Ctx) {
     return create(VariantKind::AGVK_Max, Args, Ctx);
   }
-  static const AMDGPUMCExpr *createMin(ArrayRef<const MCExpr *> Args, 
-                                      MCContext &Ctx) {
+  static const AMDGPUMCExpr *createMin(ArrayRef<const MCExpr *> Args,
+                                       MCContext &Ctx) {
     return create(VariantKind::AGVK_Min, Args, Ctx);
-                                      }
+  }
 
   static const AMDGPUMCExpr *createExtraSGPRs(const MCExpr *VCCUsed,
                                               const MCExpr *FlatScrUsed,

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -24,8 +24,9 @@ enum class LitModifier { None, Lit, Lit64 };
 /// operations are:
 ///   - (bitwise) or
 ///   - max
+///   - min
 ///
-/// \note If the 'or'/'max' operations are provided only a single argument, the
+/// \note If the 'or'/'max'/'min' operations are provided only a single argument, the
 /// operation will act as a no-op and simply resolve as the provided argument.
 ///
 class AMDGPUMCExpr : public MCTargetExpr {
@@ -41,6 +42,7 @@ public:
     AGVK_InstPrefSize,
     AGVK_Lit,
     AGVK_Lit64,
+    AGVK_Min,
   };
 
   // Relocation specifiers.
@@ -85,6 +87,10 @@ public:
                                        MCContext &Ctx) {
     return create(VariantKind::AGVK_Max, Args, Ctx);
   }
+  static const AMDGPUMCExpr *createMin(ArrayRef<const MCExpr *> Args, 
+                                      MCContext &Ctx) {
+    return create(VariantKind::AGVK_Min, Args, Ctx);
+                                      }
 
   static const AMDGPUMCExpr *createExtraSGPRs(const MCExpr *VCCUsed,
                                               const MCExpr *FlatScrUsed,

--- a/llvm/test/MC/AMDGPU/mcexpr_amd.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd.s
@@ -17,7 +17,6 @@
 // OBJDUMP-NEXT: 000000000000000a l       *ABS*  0000000000000000 max_literals
 // OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 max_with_max_sym
 // OBJDUMP-NEXT: 000000000000000f l       *ABS*  0000000000000000 max
-// OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 neg_one
 // OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 max_neg_numbers
 // OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 max_neg_number
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_with_subexpr
@@ -29,6 +28,24 @@
 // OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 max_expr_one_min
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 max_expr_two_min
 // OBJDUMP-NEXT: 0000000000989680 l       *ABS*  0000000000000000 max_expr_three_min
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 min_expression_all
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 min_expression_two
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 min_expression_one
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 min_literals
+// OBJDUMP-NEXT: 0000000000000000 l       *ABS*  0000000000000000 min_with_min_sym
+// OBJDUMP-NEXT: 0000000000000000 l       *ABS*  0000000000000000 min
+// OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 neg_one
+// OBJDUMP-NEXT: fffffffffffffffb l       *ABS*  0000000000000000 min_neg_numbers
+// OBJDUMP-NEXT: ffffffffffffffff l       *ABS*  0000000000000000 min_neg_number
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 min_with_subexpr
+// OBJDUMP-NEXT: 0000000000000004 l       *ABS*  0000000000000000 min_as_subexpr
+// OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 min_recursive_subexpr
+// OBJDUMP-NEXT: 7fffffffffffffff l       *ABS*  0000000000000000 min_expr_one_max
+// OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 min_expr_two_max
+// OBJDUMP-NEXT: ffffffffff676980 l       *ABS*  0000000000000000 min_expr_three_max
+// OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 min_expr_one_min
+// OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 min_expr_two_min
+// OBJDUMP-NEXT: 8000000000000000 l       *ABS*  0000000000000000 min_expr_three_min
 // OBJDUMP-NEXT: 0000000000000007 l       *ABS*  0000000000000000 or_expression_all
 // OBJDUMP-NEXT: 0000000000000003 l       *ABS*  0000000000000000 or_expression_two
 // OBJDUMP-NEXT: 0000000000000001 l       *ABS*  0000000000000000 or_expression_one
@@ -97,6 +114,49 @@
 .set max_expr_two_min, max(i64_min, three)
 .set max_expr_three_min, max(i64_min, three, 10000000)
 
+// ASM: .set min_expression_all, min(1, 2, five, 3, four)
+// ASM: .set min_expression_two, 1
+// ASM: .set min_expression_one, 3
+// ASM: .set min_literals, 1
+// ASM: .set min_with_min_sym, min(min, 4, 3, 1, 2)
+
+.set min_expression_all, min(one, two, five, three, four)
+.set min_expression_two, min(one, three)
+.set min_expression_one, min(three)
+.set min_literals, min(1,2,3,4,5,6,7,8,9,10)
+.set min_with_min_sym, min(min, 4, 3, one, two)
+
+// ASM: .set min_neg_numbers, -5
+// ASM: .set min_neg_number, -1
+
+.set neg_one, -1
+.set min_neg_numbers, min(-5, -4, -3, -2, neg_one)
+.set min_neg_number, min(neg_one)
+
+// ASM: .set min_with_subexpr, 3
+// ASM: .set min_as_subexpr, 1+min(4, 3, five)
+// ASM: .set min_recursive_subexpr, min(min(1, four), 3, min_expression_all)
+
+.set min_with_subexpr, min(((one | 3) << 3) / 8)
+.set min_as_subexpr, 1 + min(4, 3, five)
+.set min_recursive_subexpr, min(min(one, four), three, min_expression_all)
+
+// ASM: .set min_expr_one_max, 9223372036854775807
+// ASM: .set min_expr_two_max, 3
+// ASM: .set min_expr_three_max, -10000000
+
+.set min_expr_one_max, min(i64_max)
+.set min_expr_two_max, min(i64_max, three)
+.set min_expr_three_max, min(i64_max, three, -10000000)
+
+// ASM: .set min_expr_one_min, -9223372036854775808
+// ASM: .set min_expr_two_min, min(-9223372036854775808, five)
+// ASM: .set min_expr_three_min, min(-9223372036854775808, five, 10000000)
+
+.set min_expr_one_min, min(i64_min)
+.set min_expr_two_min, min(i64_min, five)
+.set min_expr_three_min, min(i64_min, five, 10000000)
+
 // ASM: .set or_expression_all, or(1, 2, five, 3, four)
 // ASM: .set or_expression_two, 3
 // ASM: .set or_expression_one, 1
@@ -127,4 +187,5 @@
 .set four, 4
 .set five, 5
 .set max, 0xF
+.set min, 0x0
 .set or, 0xFF

--- a/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
+++ b/llvm/test/MC/AMDGPU/mcexpr_amd_err.s
@@ -8,6 +8,10 @@
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: empty max expression
 // ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
 
+.set min_empty, min()
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: empty min expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set or_empty, or()
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: empty or expression
 // ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
@@ -40,6 +44,10 @@
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unexpected token in or expression
 // ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
 
+.set min_expression_one, min(four,five
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: unexpected token in min expression
+// ASM: :[[@LINE-2]]:{{[0-9]+}}: error: missing expression
+
 .set max_no_lparen, max four, five)
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
 
@@ -47,6 +55,9 @@
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
 
 .set max_rparen_only, max)
+// ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
+
+.set min_no_lparen, min four, five)
 // ASM: :[[@LINE-1]]:{{[0-9]+}}: error: expected newline
 
 .set four, 4

--- a/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
@@ -1,0 +1,109 @@
+//===- llvm/unittests/MC/AMDGPU/AMDGPUMCExprTest.cpp ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUTargetMachine.h"
+#include "AMDGPUUnitTests.h"
+#include "GCNSubtarget.h"
+#include "SIProgramInfo.h"
+#include "MCTargetDesc/AMDGPUMCExpr.h"
+#include "Utils/AMDGPUPALMetadata.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+class AMDGPUMCExprTest : public AMDGPUTestBase {
+
+protected:
+  std::unique_ptr<GCNTargetMachine> TM;
+  std::unique_ptr<LLVMContext> LLVMCtx;
+  std::unique_ptr<GCNSubtarget> ST;
+  std::unique_ptr<MachineModuleInfo> MMI;
+  std::unique_ptr<MachineFunction> MF;
+  std::unique_ptr<Module> M;
+  AMDGPUPALMetadata MD;
+
+  AMDGPUMCExprTest() {
+    
+    TM = createAMDGPUTargetMachine("amdgcn--amdpal", "gfx1010", "");
+
+    LLVMCtx = std::make_unique<LLVMContext>();
+    M = std::make_unique<Module>("Module", *LLVMCtx);
+    M->setDataLayout(TM->createDataLayout());
+    auto *FType = FunctionType::get(Type::getVoidTy(*LLVMCtx), false);
+    auto *F = Function::Create(FType, GlobalValue::ExternalLinkage, "Test", *M);
+    MMI = std::make_unique<MachineModuleInfo>(TM.get());
+
+    ST = std::make_unique<GCNSubtarget>(TM->getTargetTriple(),
+                                        TM->getTargetCPU(),
+                                        TM->getTargetFeatureString(), *TM);
+
+    MF = std::make_unique<MachineFunction>(*F, *TM, *ST, MMI->getContext(), 1);
+  }
+};
+//Next two tests showcases the folding of foldAMDGPUMCExpr function that uses KnownBits to simplify expressions as much as possible
+// max(((external_unknown & 0) | 0x8000000000000000), 5)
+TEST_F(AMDGPUMCExprTest, MaxFoldKnownBitsSignedness){
+  MCContext &Ctx = MF->getContext();
+
+  // Set up the unknown/undefined part of the expression
+  MCSymbol *Sym = Ctx.getOrCreateSymbol("external_unknown");
+  const MCExpr *SymRef = MCSymbolRefExpr::create(Sym, Ctx);
+
+  // Set up the rest of the expression
+  const MCExpr *Masked = MCBinaryExpr::createAnd(
+      SymRef, MCConstantExpr::create(0, Ctx),Ctx);
+  const MCExpr *SignBit = AMDGPUMCExpr::createOr({
+      Masked, MCConstantExpr::create(INT64_MIN, Ctx)}, Ctx);
+  const MCExpr *MaxExpr = AMDGPUMCExpr::createMax({
+      SignBit, MCConstantExpr::create(5, Ctx)}, Ctx);
+  
+  // running evaluateAsAbsolute will fail since external_unknown is undefined.
+  int64_t RuntimeRst;
+  EXPECT_FALSE(MaxExpr->evaluateAsAbsolute(RuntimeRst));
+
+  // fold expression and then running evaluateAsAbsolute should now succeed with the correct rst
+  const MCExpr *Folded = AMDGPU::foldAMDGPUMCExpr(MaxExpr, Ctx);
+  int64_t FoldedVal;
+  ASSERT_TRUE(Folded->evaluateAsAbsolute(FoldedVal));
+  EXPECT_EQ(FoldedVal, int64_t{5});
+}
+
+// min(((external_unknown & 0) | 0x8000000000000000), 5)
+TEST_F(AMDGPUMCExprTest, MinFolddKnownBitsSignedness){
+  MCContext &Ctx = MF->getContext();
+
+  // Set up the unknown/undefined part of the expression
+  MCSymbol *Sym = Ctx.getOrCreateSymbol("external_unknown");
+  const MCExpr *SymRef = MCSymbolRefExpr::create(Sym, Ctx);
+
+  // Set up the rest of the expression
+  const MCExpr *Masked = MCBinaryExpr::createAnd(
+      SymRef, MCConstantExpr::create(0, Ctx),Ctx);
+  const MCExpr *SignBit = AMDGPUMCExpr::createOr({
+      Masked, MCConstantExpr::create(INT64_MIN, Ctx)}, Ctx);
+  const MCExpr *MinExpr = AMDGPUMCExpr::createMin({
+      SignBit, MCConstantExpr::create(5, Ctx)}, Ctx);
+
+  // running evaluateAsAbsolute will fail since external_unknown is undefined.
+  int64_t AbsoluteRst;
+  EXPECT_FALSE(MinExpr->evaluateAsAbsolute(AbsoluteRst));
+
+  // fold expression and then running evaluateAsAbsolute should now succeed with the correct rst
+  const MCExpr *Folded = AMDGPU::foldAMDGPUMCExpr(MinExpr, Ctx);
+  int64_t FoldedVal;
+  ASSERT_TRUE(Folded->evaluateAsAbsolute(FoldedVal));
+  EXPECT_EQ(FoldedVal, INT64_MIN);
+}

--- a/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
@@ -11,16 +11,10 @@
 #include "AMDGPUTargetMachine.h"
 #include "AMDGPUUnitTests.h"
 #include "GCNSubtarget.h"
-#include "SIProgramInfo.h"
-#include "Utils/AMDGPUPALMetadata.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
-#include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
-#include "llvm/MC/MCTargetOptions.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Target/TargetMachine.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
@@ -34,7 +28,6 @@ protected:
   std::unique_ptr<MachineModuleInfo> MMI;
   std::unique_ptr<MachineFunction> MF;
   std::unique_ptr<Module> M;
-  AMDGPUPALMetadata MD;
 
   AMDGPUMCExprTest() {
 
@@ -85,7 +78,7 @@ TEST_F(AMDGPUMCExprTest, MaxFoldKnownBitsSignedness) {
 }
 
 // min(((external_unknown & 0) | 0x8000000000000000), 5)
-TEST_F(AMDGPUMCExprTest, MinFolddKnownBitsSignedness) {
+TEST_F(AMDGPUMCExprTest, MinFoldKnownBitsSignedness) {
   MCContext &Ctx = MF->getContext();
 
   // Set up the unknown/undefined part of the expression

--- a/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUMCExprTest.cpp
@@ -1,4 +1,5 @@
-//===- llvm/unittests/MC/AMDGPU/AMDGPUMCExprTest.cpp ---------------------------===//
+//===- llvm/unittests/MC/AMDGPU/AMDGPUMCExprTest.cpp
+//---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/AMDGPUMCExpr.h"
 #include "AMDGPUTargetMachine.h"
 #include "AMDGPUUnitTests.h"
 #include "GCNSubtarget.h"
 #include "SIProgramInfo.h"
-#include "MCTargetDesc/AMDGPUMCExpr.h"
 #include "Utils/AMDGPUPALMetadata.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/MC/MCContext.h"
@@ -36,7 +37,7 @@ protected:
   AMDGPUPALMetadata MD;
 
   AMDGPUMCExprTest() {
-    
+
     TM = createAMDGPUTargetMachine("amdgcn--amdpal", "gfx1010", "");
 
     LLVMCtx = std::make_unique<LLVMContext>();
@@ -53,9 +54,10 @@ protected:
     MF = std::make_unique<MachineFunction>(*F, *TM, *ST, MMI->getContext(), 1);
   }
 };
-//Next two tests showcases the folding of foldAMDGPUMCExpr function that uses KnownBits to simplify expressions as much as possible
-// max(((external_unknown & 0) | 0x8000000000000000), 5)
-TEST_F(AMDGPUMCExprTest, MaxFoldKnownBitsSignedness){
+// Next two tests showcases the folding of foldAMDGPUMCExpr function that uses
+// KnownBits to simplify expressions as much as possible
+//  max(((external_unknown & 0) | 0x8000000000000000), 5)
+TEST_F(AMDGPUMCExprTest, MaxFoldKnownBitsSignedness) {
   MCContext &Ctx = MF->getContext();
 
   // Set up the unknown/undefined part of the expression
@@ -63,18 +65,19 @@ TEST_F(AMDGPUMCExprTest, MaxFoldKnownBitsSignedness){
   const MCExpr *SymRef = MCSymbolRefExpr::create(Sym, Ctx);
 
   // Set up the rest of the expression
-  const MCExpr *Masked = MCBinaryExpr::createAnd(
-      SymRef, MCConstantExpr::create(0, Ctx),Ctx);
-  const MCExpr *SignBit = AMDGPUMCExpr::createOr({
-      Masked, MCConstantExpr::create(INT64_MIN, Ctx)}, Ctx);
-  const MCExpr *MaxExpr = AMDGPUMCExpr::createMax({
-      SignBit, MCConstantExpr::create(5, Ctx)}, Ctx);
-  
+  const MCExpr *Masked =
+      MCBinaryExpr::createAnd(SymRef, MCConstantExpr::create(0, Ctx), Ctx);
+  const MCExpr *SignBit = AMDGPUMCExpr::createOr(
+      {Masked, MCConstantExpr::create(INT64_MIN, Ctx)}, Ctx);
+  const MCExpr *MaxExpr =
+      AMDGPUMCExpr::createMax({SignBit, MCConstantExpr::create(5, Ctx)}, Ctx);
+
   // running evaluateAsAbsolute will fail since external_unknown is undefined.
   int64_t RuntimeRst;
   EXPECT_FALSE(MaxExpr->evaluateAsAbsolute(RuntimeRst));
 
-  // fold expression and then running evaluateAsAbsolute should now succeed with the correct rst
+  // fold expression and then running evaluateAsAbsolute should now succeed with
+  // the correct result
   const MCExpr *Folded = AMDGPU::foldAMDGPUMCExpr(MaxExpr, Ctx);
   int64_t FoldedVal;
   ASSERT_TRUE(Folded->evaluateAsAbsolute(FoldedVal));
@@ -82,7 +85,7 @@ TEST_F(AMDGPUMCExprTest, MaxFoldKnownBitsSignedness){
 }
 
 // min(((external_unknown & 0) | 0x8000000000000000), 5)
-TEST_F(AMDGPUMCExprTest, MinFolddKnownBitsSignedness){
+TEST_F(AMDGPUMCExprTest, MinFolddKnownBitsSignedness) {
   MCContext &Ctx = MF->getContext();
 
   // Set up the unknown/undefined part of the expression
@@ -90,18 +93,19 @@ TEST_F(AMDGPUMCExprTest, MinFolddKnownBitsSignedness){
   const MCExpr *SymRef = MCSymbolRefExpr::create(Sym, Ctx);
 
   // Set up the rest of the expression
-  const MCExpr *Masked = MCBinaryExpr::createAnd(
-      SymRef, MCConstantExpr::create(0, Ctx),Ctx);
-  const MCExpr *SignBit = AMDGPUMCExpr::createOr({
-      Masked, MCConstantExpr::create(INT64_MIN, Ctx)}, Ctx);
-  const MCExpr *MinExpr = AMDGPUMCExpr::createMin({
-      SignBit, MCConstantExpr::create(5, Ctx)}, Ctx);
+  const MCExpr *Masked =
+      MCBinaryExpr::createAnd(SymRef, MCConstantExpr::create(0, Ctx), Ctx);
+  const MCExpr *SignBit = AMDGPUMCExpr::createOr(
+      {Masked, MCConstantExpr::create(INT64_MIN, Ctx)}, Ctx);
+  const MCExpr *MinExpr =
+      AMDGPUMCExpr::createMin({SignBit, MCConstantExpr::create(5, Ctx)}, Ctx);
 
   // running evaluateAsAbsolute will fail since external_unknown is undefined.
   int64_t AbsoluteRst;
   EXPECT_FALSE(MinExpr->evaluateAsAbsolute(AbsoluteRst));
 
-  // fold expression and then running evaluateAsAbsolute should now succeed with the correct rst
+  // fold expression and then running evaluateAsAbsolute should now succeed with
+  // the correct result
   const MCExpr *Folded = AMDGPU::foldAMDGPUMCExpr(MinExpr, Ctx);
   int64_t FoldedVal;
   ASSERT_TRUE(Folded->evaluateAsAbsolute(FoldedVal));

--- a/llvm/unittests/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/unittests/Target/AMDGPU/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_target_unittest(AMDGPUTests
+  AMDGPUMCExprTest.cpp
   AMDGPUUnitTests.cpp
   CSETest.cpp
   DwarfRegMappings.cpp


### PR DESCRIPTION
The min operation is needed in MC Expressions for a future change that caps the max number of registers used for indirect calls.