### PR TITLE
Revert "[DenseMap] Invalidate iterators on erase"

### DIFF
--- a/llvm/docs/ProgrammersManual.rst
+++ b/llvm/docs/ProgrammersManual.rst
@@ -2422,14 +2422,13 @@ that are currently inserted in the map.  ``DenseMap`` is a great way to map
 pointers to pointers, or map other small types to each other.
 
 There are several aspects of ``DenseMap`` that you should be aware of, however.
-The iterators in a ``DenseMap`` are invalidated whenever an insertion or
-erasure occurs, unlike ``map``.  Also, because ``DenseMap`` allocates space for
-a large number of key/value pairs (it starts with 64 by default), it will waste
-a lot of space if your keys or values are large.  Finally, you must implement a
-partial specialization of ``DenseMapInfo`` for the key that you want, if it
-isn't already supported.  This is required to tell ``DenseMap`` about two
-special marker values (which can never be inserted into the map) that it needs
-internally.
+The iterators in a ``DenseMap`` are invalidated whenever an insertion occurs,
+unlike ``map``.  Also, because ``DenseMap`` allocates space for a large number of
+key/value pairs (it starts with 64 by default), it will waste a lot of space if
+your keys or values are large.  Finally, you must implement a partial
+specialization of ``DenseMapInfo`` for the key that you want, if it isn't already
+supported.  This is required to tell ``DenseMap`` about two special marker values
+(which can never be inserted into the map) that it needs internally.
 
 ``DenseMap``'s ``find_as()`` method supports lookup operations using an alternate key
 type.  This is useful in cases where the normal key type is expensive to

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -128,11 +128,6 @@ Makes programs 10x faster by doing Special New Thing.
 * ``ConstantFP`` now supports vector types and is the canonical form returned by
   ``ConstantVector::getSplat(C)`` when ``C`` is a scalar ``ConstantFP``.
 
-* ``DenseMap`` and ``DenseSet`` ``erase`` now invalidates all iterators and
-  references into the container, not just the iterator for the erased element.
-  Use the new ``remove_if`` member to erase matching elements in a single pass
-  instead of erasing while iterating.
-
 ### Changes to building LLVM
 
 ### Changes to TableGen

--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -330,7 +330,6 @@ public:
     if (!TheBucket)
       return false; // not in map.
 
-    incrementEpoch();
     TheBucket->getSecond().~ValueT();
     TheBucket->getFirst() = KeyInfoT::getTombstoneKey();
     decrementNumEntries();
@@ -339,7 +338,6 @@ public:
   }
   void erase(iterator I) {
     BucketT *TheBucket = &*I;
-    incrementEpoch();
     TheBucket->getSecond().~ValueT();
     TheBucket->getFirst() = KeyInfoT::getTombstoneKey();
     decrementNumEntries();

--- a/llvm/unittests/ADT/DenseMapTest.cpp
+++ b/llvm/unittests/ADT/DenseMapTest.cpp
@@ -1153,15 +1153,4 @@ TEST(DenseMapCustomTest, RemoveIfValueDtor) {
   EXPECT_EQ(0u, CtorTester::getNumConstructed());
 }
 
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-TEST(DenseMapCustomTest, EraseInvalidatesIterators) {
-  DenseMap<int, int> M;
-  M.try_emplace(1, 10);
-  M.try_emplace(2, 20);
-  auto It = M.find(1);
-  M.erase(M.find(2));
-  EXPECT_DEATH((void)It->second, "invalid iterator access");
-}
-#endif
-
 } // namespace

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -281,15 +281,4 @@ TEST(DenseSetCustomTest, ConstTest) {
   EXPECT_TRUE(Map.contains(B));
   EXPECT_TRUE(Map.contains(C));
 }
-
-#if LLVM_ENABLE_ABI_BREAKING_CHECKS
-TEST(DenseSetCustomTest, EraseInvalidatesIterators) {
-  DenseSet<int> Set;
-  Set.insert(1);
-  Set.insert(2);
-  auto It = Set.find(1);
-  Set.erase(2);
-  EXPECT_DEATH((void)*It, "invalid iterator access");
-}
-#endif
 }


### PR DESCRIPTION
Reverts llvm/llvm-project#199369

This change is causing buildbot failures and pre-merge failures:
- https://lab.llvm.org/staging/#/builders/120/builds/18792
- https://lab.llvm.org/buildbot/#/builders/13/builds/13321
- https://lab.llvm.org/buildbot/#/builders/174/builds/36084
- https://github.com/llvm/llvm-project/pull/179926#issuecomment-3853284324