### PR TITLE
Reland "[libc] Enable baremetal float printf using modular format"

### DIFF
--- a/libc/config/baremetal/config.json
+++ b/libc/config/baremetal/config.json
@@ -13,9 +13,6 @@
     "LIBC_CONF_PRINTF_DISABLE_FIXED_POINT": {
       "value": true
     },
-    "LIBC_CONF_PRINTF_DISABLE_FLOAT": {
-      "value": true
-    },
     "LIBC_CONF_PRINTF_DISABLE_INDEX_MODE": {
       "value": true
     },
@@ -32,6 +29,9 @@
       "value": true
     },
     "LIBC_COPT_PRINTF_DISABLE_BITINT": {
+      "value": true
+    },
+    "LIBC_CONF_PRINTF_MODULAR": {
       "value": true
     }
   },


### PR DESCRIPTION
Reverts llvm/llvm-project#199114

#199118 fixed the issue uncovered in the Fuchsia CI build.