### PR TITLE
[flang][OpenMP] Fix copyprivate crash with unlimited polymorphic pointer

### DIFF
--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -1179,9 +1179,13 @@ void TypeInfo::typeScan(mlir::Type ty) {
     typeScan(pty.getEleTy());
   } else {
     // The scan ends when reaching any built-in, record or boxproc type.
+    // A `none` element type is reached for unlimited polymorphic entities
+    // (e.g. `class(*)`), which are always inside a box; the copy is then
+    // performed through the descriptor, so no scalar type info is needed.
     assert(ty.isIntOrIndexOrFloat() || mlir::isa<mlir::ComplexType>(ty) ||
            mlir::isa<fir::LogicalType>(ty) || mlir::isa<fir::RecordType>(ty) ||
-           mlir::isa<fir::BoxProcType>(ty));
+           mlir::isa<fir::BoxProcType>(ty) ||
+           (inBox && mlir::isa<mlir::NoneType>(ty)));
   }
 }
 

--- a/flang/test/Lower/OpenMP/copyprivate6.f90
+++ b/flang/test/Lower/OpenMP/copyprivate6.f90
@@ -1,0 +1,26 @@
+! Test lowering of COPYPRIVATE with an unlimited polymorphic pointer.
+! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+
+! Testcase from: https://github.com/llvm/llvm-project/issues/198770
+
+! CHECK-LABEL: func.func private @_copy_ref_class_ptr_none(
+! CHECK-SAME:    %arg0: [[TYPE:!fir.ref<!fir.class<!fir.ptr<none>>>]],
+! CHECK-SAME:    %arg1: [[TYPE]]) attributes {llvm.linkage = #llvm.linkage<internal>} {
+! CHECK:   %[[DST:.*]]:2 = hlfir.declare %arg0 {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_copy_ref_class_ptr_none_dst"}
+! CHECK:   %[[SRC:.*]]:2 = hlfir.declare %arg1 {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_copy_ref_class_ptr_none_src"}
+! CHECK:   %[[LD:.*]] = fir.load %[[SRC]]#0 : [[TYPE]]
+! CHECK:   fir.store %[[LD]] to %[[DST]]#0 : [[TYPE]]
+! CHECK:   return
+! CHECK: }
+
+! CHECK-LABEL: func.func @_QQmain()
+! CHECK: omp.single copyprivate(%{{.*}} -> @_copy_ref_class_ptr_none : !fir.ref<!fir.class<!fir.ptr<none>>>) {
+! CHECK:   omp.terminator
+! CHECK: }
+
+class(*), pointer, save :: aa
+!$omp threadprivate(aa)
+!$omp single
+!$omp end single copyprivate(aa)
+end
+


### PR DESCRIPTION
Lowering a copyprivate clause whose list item is an unlimited polymorphic pointer (class(*), pointer) crashed in TypeInfo::typeScan. The scan descends through the fir.class box and the fir.ptr, reaching a `none` element type, which the terminal assertion did not allow.

Fixes #198770