### PR TITLE
[1/1]: Fix for noassert buildbot break in #183153

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -409,8 +409,7 @@ class PrologEpilogSGPRSpillBuilder {
     if (NeedsFrameMoves) {
       const TargetRegisterClass *RC = TRI.getPhysRegBaseClass(DstReg);
       ArrayRef<int16_t> DstSplitParts = TRI.getRegSplitParts(RC, EltSize);
-      unsigned DstNumSubRegs = DstSplitParts.empty() ? 1 : DstSplitParts.size();
-      assert(NumSubRegs == DstNumSubRegs);
+      assert(NumSubRegs == (DstSplitParts.empty() ? 1 : DstSplitParts.size()));
       MCRegister CFISuperReg = getCFISuperReg();
       if (NumSubRegs == 1) {
         TFI->buildCFI(


### PR DESCRIPTION
Change-Id: I285adf09ac2df239d0ab05459f7388b6970247ad

---

**Stack**:
- #199781⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
