### PR TITLE
[lit][NFC] remove new-style class opt-ins

### DIFF
--- a/llvm/utils/lit/lit/LitConfig.py
+++ b/llvm/utils/lit/lit/LitConfig.py
@@ -12,7 +12,7 @@ import lit.util
 from lit.DiffUpdater import diff_test_updater
 
 # LitConfig must be a new style class for properties to work
-class LitConfig(object):
+class LitConfig:
     """LitConfig - Configuration data for a 'lit' test runner instance, shared
     across all tests.
 

--- a/llvm/utils/lit/lit/ShellEnvironment.py
+++ b/llvm/utils/lit/lit/ShellEnvironment.py
@@ -16,7 +16,7 @@ kAvoidDevNull = kIsWindows
 kDevNull = "/dev/null"
 
 
-class ShellCommandResult(object):
+class ShellCommandResult:
     """Captures the result of an individual command."""
 
     def __init__(
@@ -36,7 +36,7 @@ class InternalShellError(Exception):
         self.message = message
 
 
-class ShellEnvironment(object):
+class ShellEnvironment:
 
     """Mutable shell environment containing things like CWD and env vars.
 

--- a/llvm/utils/lit/lit/Test.py
+++ b/llvm/utils/lit/lit/Test.py
@@ -8,7 +8,7 @@ from lit.TestTimes import read_test_times
 # Test result codes.
 
 
-class ResultCode(object):
+class ResultCode:
     """Test result codes."""
 
     # All result codes (including user-defined ones) in declaration order
@@ -59,7 +59,7 @@ XPASS = ResultCode("XPASS", "Unexpectedly Passed", True)
 # Test metric values.
 
 
-class MetricValue(object):
+class MetricValue:
     def format(self):
         """
         format() -> str
@@ -149,7 +149,7 @@ def toMetricValue(value):
 # Test results.
 
 
-class Result(object):
+class Result:
     """Wrapper for the results of executing an individual test."""
 
     def __init__(

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -77,7 +77,7 @@ def buildPdbgCommand(msg, cmd):
     return res
 
 
-class TimeoutHelper(object):
+class TimeoutHelper:
     """
     Object used to helper manage enforcing a timeout in
     _executeShCmd(). It is passed through recursive calls
@@ -1070,7 +1070,7 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
 def _caching_re_compile(r):
     return re.compile(r)
 
-class ExpandableScriptDirective(object):
+class ExpandableScriptDirective:
     """
     Common interface for lit directives for which any lit substitutions must be
     expanded to produce the shell script.  It includes directives (e.g., 'RUN:')
@@ -1434,7 +1434,7 @@ def applySubstitutions(script, substitutions, conditions={}, recursion_limit=Non
     return output
 
 
-class ParserKind(object):
+class ParserKind:
     """
     An enumeration representing the style of an integrated test keyword or
     command.
@@ -1492,7 +1492,7 @@ class ParserKind(object):
         }[value]
 
 
-class IntegratedTestKeywordParser(object):
+class IntegratedTestKeywordParser:
     """A parser for LLVM/Clang style integrated test scripts.
 
     keyword: The keyword to parse for. It must end in either '.' or ':'.

--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 
-class TestingConfig(object):
+class TestingConfig:
     """
     TestingConfig - Information on the tests inside a suite.
     """

--- a/llvm/utils/lit/lit/display.py
+++ b/llvm/utils/lit/lit/display.py
@@ -29,7 +29,7 @@ def create_display(opts, tests, total_tests, workers):
     return Display(opts, tests, header, progress_bar)
 
 
-class ProgressPredictor(object):
+class ProgressPredictor:
     def __init__(self, tests):
         self.completed = 0
         self.time_elapsed = 0.0
@@ -71,7 +71,7 @@ class ProgressPredictor(object):
         return 0
 
 
-class NopDisplay(object):
+class NopDisplay:
     def print_header(self):
         pass
 
@@ -92,7 +92,7 @@ def shouldPrintInfo(infoOption, test):
     return False
 
 
-class Display(object):
+class Display:
     def __init__(
         self,
         opts: Namespace,

--- a/llvm/utils/lit/lit/formats/base.py
+++ b/llvm/utils/lit/lit/formats/base.py
@@ -5,7 +5,7 @@ import lit.Test
 import lit.util
 
 
-class TestFormat(object):
+class TestFormat:
     def getTestsForPath(self, testSuite, path_in_suite, litConfig, localConfig):
         """
         Given the path to a test in the test suite, generates the Lit tests associated

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -24,7 +24,7 @@ def user_is_root():
     return False
 
 
-class LLVMConfig(object):
+class LLVMConfig:
     def __init__(self, lit_config, config):
         self.lit_config = lit_config
         self.config = config

--- a/llvm/utils/lit/lit/llvm/subst.py
+++ b/llvm/utils/lit/lit/llvm/subst.py
@@ -7,7 +7,7 @@ expr = re.compile(r"^(\\)?((\| )?)\W+b(\S+)\\b\W*$")
 wordifier = re.compile(r"(\W*)(\b[^\b]+\b)")
 
 
-class FindTool(object):
+class FindTool:
     def __init__(self, name):
         self.name = name
 
@@ -26,7 +26,7 @@ class FindTool(object):
         return command
 
 
-class ToolSubst(object):
+class ToolSubst:
     """String-like class used to build regex substitution patterns for llvm
     tools.
 

--- a/llvm/utils/lit/lit/reports.py
+++ b/llvm/utils/lit/lit/reports.py
@@ -17,7 +17,7 @@ def by_suite_and_test_path(test):
     return (test.suite.name, id(test.suite), test.path_in_suite)
 
 
-class Report(object):
+class Report:
     def __init__(self, output_file):
         self.output_file = output_file
         # Set by the option parser later.

--- a/llvm/utils/lit/lit/run.py
+++ b/llvm/utils/lit/lit/run.py
@@ -24,7 +24,7 @@ class TimeoutError(Exception):
     pass
 
 
-class Run(object):
+class Run:
     """A concrete, configured testing run."""
 
     def __init__(


### PR DESCRIPTION
In Python 3.0 and later it is no longer necessary to explicitly derive from `object` to opt into "new-style" classes, they are the default.

Since the current minimum Python version is 3.8, this is no longer required. This patch removes `object` from the base class lists of all affected classes in lit.