### PR TITLE
[lit][NFC] remove future statements for mandatory features in Python 3

### DIFF
--- a/llvm/utils/lit/lit/LitConfig.py
+++ b/llvm/utils/lit/lit/LitConfig.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import inspect
 import os
 import enum

--- a/llvm/utils/lit/lit/ShUtil.py
+++ b/llvm/utils/lit/lit/ShUtil.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import itertools
 
 import lit.util

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, annotations
+from __future__ import annotations
 
 import os
 import pathlib

--- a/llvm/utils/lit/lit/formats/base.py
+++ b/llvm/utils/lit/lit/formats/base.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 
 import lit.Test

--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import json
 import math
 import os

--- a/llvm/utils/lit/lit/formats/shtest.py
+++ b/llvm/utils/lit/lit/formats/shtest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import lit.TestRunner
 import lit.util
 

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import errno
 import itertools
 import math

--- a/llvm/utils/lit/tests/Inputs/check_path.py
+++ b/llvm/utils/lit/tests/Inputs/check_path.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-control-chars.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-format/external_shell/write-control-chars.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import sys
 
 print("a line with \x1b[2;30;41mcontrol characters\x1b[0m.")

--- a/llvm/utils/lit/tests/Inputs/shtest-not/print_environment.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-not/print_environment.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 

--- a/llvm/utils/lit/tests/Inputs/shtest-timeout/short.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-timeout/short.py
@@ -1,4 +1,3 @@
 # RUN: %{python} %s
-from __future__ import print_function
 
 print("short program")


### PR DESCRIPTION
This patch removes future statements from lit for features that are mandatory in Python 3.0 and later.

Specifically, it removes future statements for [`absolute_import`](https://docs.python.org/3/library/__future__.html#future__.absolute_import) and [`print_function`](https://docs.python.org/3/library/__future__.html#future__.print_function), since both became mandatory in Python 3.0.
