### PR TITLE
[libclang] Add clang_ModuleCache_pruneWithCallback

### DIFF
--- a/clang/include/clang-c/BuildSystem.h
+++ b/clang/include/clang-c/BuildSystem.h
@@ -162,6 +162,41 @@ CINDEX_LINKAGE void clang_ModuleCache_prune(const char *Path,
                                             time_t PruneAfter);
 
 /**
+ * Callback invoked by \c clang_ModuleCache_pruneWithCallback() once for each
+ * file or directory removed from the module cache.
+ *
+ * \param Path the absolute path of the file or directory that was pruned.
+ * The pointer is only valid for the duration of the callback.
+ *
+ * \param UserData the opaque pointer passed to
+ * \c clang_ModuleCache_pruneWithCallback().
+ */
+typedef void (*CXModuleCachePruneCallback)(const char *Path, void *UserData);
+
+/**
+ * Variant of \c clang_ModuleCache_prune() that invokes \p Callback once for
+ * each absolute path removed from the cache. This includes pruned \c .pcm
+ * files, their companion \c .timestamp files, and any cache subdirectory that
+ * becomes empty as a result of pruning.
+ *
+ * \param Path the path to the module cache directory.
+ *
+ * \param PruneInterval the minimum time in seconds between two prune
+ * operations. If the timestamp file is newer than this, pruning is skipped.
+ *
+ * \param PruneAfter the time in seconds after which unused module files are
+ * removed.
+ *
+ * \param Callback invoked for each pruned absolute path. May be NULL, in
+ * which case this function behaves like \c clang_ModuleCache_prune().
+ *
+ * \param UserData opaque pointer passed through to \p Callback.
+ */
+CINDEX_LINKAGE void clang_ModuleCache_pruneWithCallback(
+    const char *Path, time_t PruneInterval, time_t PruneAfter,
+    CXModuleCachePruneCallback Callback, void *UserData);
+
+/**
  * @}
  */
 

--- a/clang/include/clang/Serialization/ModuleCache.h
+++ b/clang/include/clang/Serialization/ModuleCache.h
@@ -11,6 +11,7 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/FileSystem/UniqueID.h"
 
@@ -90,8 +91,13 @@ public:
 std::shared_ptr<ModuleCache> createCrossProcessModuleCache();
 
 /// Shared implementation of `ModuleCache::maybePrune()`.
+///
+/// If \p OnPrune is non-empty, it is invoked once per file or directory that
+/// is successfully removed from the cache. The path passed to \p OnPrune is
+/// absolute.
 void maybePruneImpl(StringRef Path, time_t PruneInterval, time_t PruneAfter,
-                    bool PruneTopLevel = false);
+                    bool PruneTopLevel = false,
+                    llvm::function_ref<void(StringRef)> OnPrune = {});
 
 /// Shared implementation of `ModuleCache::write()`.
 std::error_code writeImpl(StringRef Path, llvm::MemoryBufferRef Buffer,

--- a/clang/lib/Serialization/ModuleCache.cpp
+++ b/clang/lib/Serialization/ModuleCache.cpp
@@ -56,14 +56,18 @@ static void writeTimestampFile(StringRef TimestampFile) {
 }
 
 void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
-                           time_t PruneAfter, bool PruneTopLevel) {
+                           time_t PruneAfter, bool PruneTopLevel,
+                           llvm::function_ref<void(StringRef)> OnPrune) {
   if (PruneInterval <= 0 || PruneAfter <= 0)
     return;
 
   // This is a compiler-internal input/output, let's bypass the sandbox.
   auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
 
-  llvm::SmallString<128> TimestampFile(Path);
+  llvm::SmallString<256> RootPath(Path);
+  (void)llvm::sys::fs::make_absolute(RootPath);
+
+  llvm::SmallString<128> TimestampFile(RootPath);
   llvm::sys::path::append(TimestampFile, "modules.timestamp");
 
   // Try to stat() the timestamp file.
@@ -87,6 +91,11 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
   // There is a benign race condition here, if two Clang instances happen to
   // notice at the same time that the timestamp is out-of-date.
   writeTimestampFile(TimestampFile);
+
+  auto NotifyPruned = [&](StringRef RemovedPath) {
+    if (OnPrune)
+      OnPrune(RemovedPath);
+  };
 
   // Walk the entire module cache, looking for unused module files and module
   // indices.
@@ -114,14 +123,16 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
       return;
 
     // Remove the file.
-    llvm::sys::fs::remove(FilePath);
+    if (!llvm::sys::fs::remove(FilePath))
+      NotifyPruned(FilePath);
 
     // Remove the timestamp file created by implicit module builds.
     std::string TimestampFilename = FilePath.str() + ".timestamp";
-    llvm::sys::fs::remove(TimestampFilename);
+    if (!llvm::sys::fs::remove(TimestampFilename))
+      NotifyPruned(TimestampFilename);
   };
 
-  for (llvm::sys::fs::directory_iterator Dir(Path, EC), DirEnd;
+  for (llvm::sys::fs::directory_iterator Dir(RootPath, EC), DirEnd;
        Dir != DirEnd && !EC; Dir.increment(EC)) {
     // If we don't have a directory, try to prune it as a file in the root.
     if (!llvm::sys::fs::is_directory(Dir->path())) {
@@ -139,8 +150,10 @@ void clang::maybePruneImpl(StringRef Path, time_t PruneInterval,
     // itself.
     if (llvm::sys::fs::directory_iterator(Dir->path(), EC) ==
             llvm::sys::fs::directory_iterator() &&
-        !EC)
-      llvm::sys::fs::remove(Dir->path());
+        !EC) {
+      if (!llvm::sys::fs::remove(Dir->path()))
+        NotifyPruned(Dir->path());
+    }
   }
 }
 

--- a/clang/tools/libclang/BuildSystem.cpp
+++ b/clang/tools/libclang/BuildSystem.cpp
@@ -158,3 +158,22 @@ void clang_ModuleCache_prune(const char *Path, time_t PruneInterval,
     clang::maybePruneImpl(Path, PruneInterval, PruneAfter,
                           /*PruneTopLevel=*/true);
 }
+
+void clang_ModuleCache_pruneWithCallback(const char *Path, time_t PruneInterval,
+                                         time_t PruneAfter,
+                                         CXModuleCachePruneCallback Callback,
+                                         void *UserData) {
+  if (!Path)
+    return;
+  llvm::function_ref<void(StringRef)> OnPrune;
+  llvm::SmallString<256> Buffer;
+  auto Trampoline = [&](StringRef Pruned) {
+    Buffer.assign(Pruned.begin(), Pruned.end());
+    Buffer.push_back('\0');
+    Callback(Buffer.data(), UserData);
+  };
+  if (Callback)
+    OnPrune = Trampoline;
+  clang::maybePruneImpl(Path, PruneInterval, PruneAfter,
+                        /*PruneTopLevel=*/true, OnPrune);
+}

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -460,6 +460,7 @@ LLVM_21 {
 LLVM_23 {
   global:
     clang_ModuleCache_prune;
+    clang_ModuleCache_pruneWithCallback;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol

--- a/clang/unittests/libclang/LibclangTest.cpp
+++ b/clang/unittests/libclang/LibclangTest.cpp
@@ -10,6 +10,7 @@
 #include "clang-c/BuildSystem.h"
 #include "clang-c/Index.h"
 #include "clang-c/Rewrite.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Debug.h"
@@ -358,68 +359,105 @@ TEST(libclang, ModuleMapDescriptor) {
   clang_ModuleMapDescriptor_dispose(MMD);
 }
 
-TEST(libclang, ModuleCache_prune) {
+// Builds a fake module cache layout used by the prune tests:
+//   <CacheDir>/modules.timestamp        (old, so the prune interval passes)
+//   <CacheDir>/Bar.pcm                  (old access time, will be pruned)
+//   <CacheDir>/ABCDEF/                  (subdir, removed when emptied)
+//   <CacheDir>/ABCDEF/Foo.pcm           (old access time, will be pruned)
+//   <CacheDir>/123456/                  (subdir, must survive)
+//   <CacheDir>/123456/Fresh.pcm         (recent access time, must survive)
+class ModuleCachePruneTest : public ::testing::Test {
+protected:
   llvm::SmallString<256> CacheDir;
-  ASSERT_FALSE(
-      llvm::sys::fs::createUniqueDirectory("libclang-module-cache", CacheDir));
+  llvm::SmallString<256> SubDir;
+  llvm::SmallString<256> PCMFile;
+  llvm::SmallString<256> RootPCMFile;
+  llvm::SmallString<256> FreshSubDir;
+  llvm::SmallString<256> FreshPCMFile;
 
-  auto writeFile = [](const llvm::Twine &Path, llvm::StringRef Content = "") {
+  void SetUp() override {
+    ASSERT_FALSE(llvm::sys::fs::createUniqueDirectory("libclang-module-cache",
+                                                      CacheDir));
+
+    SubDir = CacheDir;
+    llvm::sys::path::append(SubDir, "ABCDEF");
+    ASSERT_FALSE(llvm::sys::fs::create_directory(SubDir));
+
+    PCMFile = SubDir;
+    llvm::sys::path::append(PCMFile, "Foo.pcm");
+    ASSERT_NO_FATAL_FAILURE(writeFileWithOldAccessTime(PCMFile));
+
+    RootPCMFile = CacheDir;
+    llvm::sys::path::append(RootPCMFile, "Bar.pcm");
+    ASSERT_NO_FATAL_FAILURE(writeFileWithOldAccessTime(RootPCMFile));
+
+    // A recently-accessed .pcm in its own subdir. Pruning must leave both the
+    // file and its containing directory alone.
+    FreshSubDir = CacheDir;
+    llvm::sys::path::append(FreshSubDir, "123456");
+    ASSERT_FALSE(llvm::sys::fs::create_directory(FreshSubDir));
+
+    FreshPCMFile = FreshSubDir;
+    llvm::sys::path::append(FreshPCMFile, "Fresh.pcm");
+    ASSERT_NO_FATAL_FAILURE(writeFile(FreshPCMFile));
+
+    llvm::SmallString<256> ModulesTimestamp(CacheDir);
+    llvm::sys::path::append(ModulesTimestamp, "modules.timestamp");
+    ASSERT_NO_FATAL_FAILURE(writeFileWithOldAccessTime(ModulesTimestamp));
+  }
+
+  void TearDown() override { llvm::sys::fs::remove_directories(CacheDir); }
+
+private:
+  static void writeFile(const llvm::Twine &Path) {
     std::error_code EC;
     llvm::raw_fd_ostream OS(Path.str(), EC);
     ASSERT_FALSE(EC);
-    OS << Content;
-  };
+  }
 
-  auto setOldAccessTime = [](const llvm::Twine &Path) {
+  static void writeFileWithOldAccessTime(const llvm::Twine &Path) {
+    ASSERT_NO_FATAL_FAILURE(writeFile(Path));
     int FD;
-    std::error_code EC = llvm::sys::fs::openFileForReadWrite(
-        Path, FD, llvm::sys::fs::CD_OpenExisting, llvm::sys::fs::OF_None);
-    ASSERT_FALSE(EC);
-    // Set the access time to be old enough to get pruned.
+    ASSERT_FALSE(llvm::sys::fs::openFileForReadWrite(
+        Path, FD, llvm::sys::fs::CD_OpenExisting, llvm::sys::fs::OF_None));
     time_t OldTime = time(nullptr) - 86400;
-    EC = llvm::sys::fs::setLastAccessAndModificationTime(
-        FD, llvm::sys::toTimePoint(OldTime));
-    ASSERT_FALSE(EC);
+    ASSERT_FALSE(llvm::sys::fs::setLastAccessAndModificationTime(
+        FD, llvm::sys::toTimePoint(OldTime)));
     ::close(FD);
-  };
+  }
+};
 
-  // Create a subdirectory with a .pcm file and a .timestamp file.
-  llvm::SmallString<256> SubDir(CacheDir);
-  llvm::sys::path::append(SubDir, "ABCDEF");
-  ASSERT_FALSE(llvm::sys::fs::create_directory(SubDir));
-
-  llvm::SmallString<256> PCMFile(SubDir);
-  llvm::sys::path::append(PCMFile, "Foo.pcm");
-  writeFile(PCMFile, "fake pcm");
-
-  // Also create a .pcm file in the root of the cache directory.
-  llvm::SmallString<256> RootPCMFile(CacheDir);
-  llvm::sys::path::append(RootPCMFile, "Bar.pcm");
-  writeFile(RootPCMFile, "fake pcm");
-
-  setOldAccessTime(PCMFile);
-  setOldAccessTime(RootPCMFile);
-
-  // Create the modules.timestamp file with an old modification time so the
-  // prune interval check passes.
-  llvm::SmallString<256> ModulesTimestamp(CacheDir);
-  llvm::sys::path::append(ModulesTimestamp, "modules.timestamp");
-  writeFile(ModulesTimestamp);
-  setOldAccessTime(ModulesTimestamp);
-
-  // Verify the files exist before pruning.
-  EXPECT_TRUE(llvm::sys::fs::exists(PCMFile));
-  EXPECT_TRUE(llvm::sys::fs::exists(RootPCMFile));
-
+TEST_F(ModuleCachePruneTest, Prune) {
   clang_ModuleCache_prune(CacheDir.c_str(), /*PruneInterval=*/1,
                           /*PruneAfter=*/1);
-
-  // The old .pcm files should have been removed from both the subdirectory
-  // and the root.
   EXPECT_FALSE(llvm::sys::fs::exists(PCMFile));
   EXPECT_FALSE(llvm::sys::fs::exists(RootPCMFile));
+  EXPECT_TRUE(llvm::sys::fs::exists(FreshPCMFile));
+}
 
-  llvm::sys::fs::remove_directories(CacheDir);
+TEST_F(ModuleCachePruneTest, PruneWithCallback) {
+  std::vector<std::string> Pruned;
+  auto Callback = +[](const char *Path, void *UserData) {
+    static_cast<std::vector<std::string> *>(UserData)->emplace_back(Path);
+  };
+
+  clang_ModuleCache_pruneWithCallback(CacheDir.c_str(), /*PruneInterval=*/1,
+                                      /*PruneAfter=*/1, Callback, &Pruned);
+
+  for (const auto &P : Pruned)
+    EXPECT_TRUE(llvm::sys::path::is_absolute(P)) << P;
+  auto contains = [&](llvm::StringRef Needle) {
+    return llvm::is_contained(Pruned, Needle);
+  };
+  EXPECT_TRUE(contains(PCMFile));
+  EXPECT_TRUE(contains(RootPCMFile));
+  EXPECT_TRUE(contains(SubDir));
+
+  // The recently-accessed .pcm and its directory must survive, and the
+  // callback must not report them.
+  EXPECT_TRUE(llvm::sys::fs::exists(FreshPCMFile));
+  EXPECT_FALSE(contains(FreshPCMFile));
+  EXPECT_FALSE(contains(FreshSubDir));
 }
 
 TEST_F(LibclangParseTest, GlobalOptions) {


### PR DESCRIPTION
clang_ModuleCache_pruneWithCallback takes a callback that is invoked for each PCM that gets pruned. This is to support build systems that would like to clean up additional data when PCMs are removed from disk.