### PR TITLE
[CIR] Split RecordType into StructType/UnionType

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -358,7 +358,7 @@ def CIR_DynamicCastOp : CIR_Op<"dyn_cast"> {
   );
 
   let results = (outs
-    CIR_PtrToAnyOf<[CIR_VoidType, CIRRecordType]>:$result
+    CIR_PtrToAnyOf<[CIR_VoidType, CIR_StructType, CIR_UnionType]>:$result
   );
 
   let assemblyFormat = [{

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -358,7 +358,7 @@ def CIR_DynamicCastOp : CIR_Op<"dyn_cast"> {
   );
 
   let results = (outs
-    CIR_PtrToAnyOf<[CIR_VoidType, CIR_RecordType]>:$result
+    CIR_PtrToAnyOf<[CIR_VoidType, CIRRecordType]>:$result
   );
 
   let assemblyFormat = [{
@@ -4420,7 +4420,7 @@ def CIR_CopyOp : CIR_Op<"copy",[
     /// record type. Otherwise returns the full type size.
     unsigned getCopySizeInBytes(const mlir::DataLayout &dl) {
       if (getSkipTailPadding())
-        return mlir::cast<cir::RecordType>(getType().getPointee())
+        return mlir::cast<cir::StructType>(getType().getPointee())
             .computeStructDataSize(dl);
       return dl.getTypeSize(getType().getPointee());
     }

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -78,4 +78,60 @@ namespace cir {
 #define GET_TYPEDEF_CLASSES
 #include "clang/CIR/Dialect/IR/CIROpsTypes.h.inc"
 
+namespace cir {
+
+/// C++ view class that accepts both !cir.struct and !cir.union types.
+///
+/// Follows the MLIR BaseMemRefType pattern: StructType and UnionType are the
+/// concrete tablegen types; RecordType is a hand-written view class that
+/// covers both.  Use it when code must handle either kind generically.
+///
+/// Methods that are common to both types are forwarded through dyn_cast
+/// dispatch.  Type-specific methods (getPadding, getUnionStorageType) are only
+/// available on the concrete type.
+class RecordType : public mlir::Type {
+public:
+  using mlir::Type::Type;
+
+  // Allow implicit construction from concrete record types so that
+  // functions returning cir::RecordType can return StructType/UnionType
+  // values without an explicit cast.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  RecordType(StructType t) : mlir::Type(t) {}
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  RecordType(UnionType t) : mlir::Type(t) {}
+
+  static bool classof(mlir::Type t) {
+    return mlir::isa<StructType>(t) || mlir::isa<UnionType>(t);
+  }
+
+  llvm::ArrayRef<mlir::Type> getMembers() const;
+  mlir::StringAttr getName() const;
+  bool isIncomplete() const;
+  bool isComplete() const { return !isIncomplete(); }
+  bool getPacked() const;
+  bool getPadded() const;
+
+  bool isClass() const;
+  bool isStruct() const;
+  bool isUnion() const { return mlir::isa<UnionType>(*this); }
+
+  size_t getNumElements() const { return getMembers().size(); }
+  mlir::Type getElementType(size_t idx) const { return getMembers()[idx]; }
+  std::string getKindAsStr() const;
+  std::string getPrefixedName() const;
+
+  void complete(llvm::ArrayRef<mlir::Type> members, bool packed, bool padded,
+                mlir::Type padding = {});
+  uint64_t getElementOffset(const mlir::DataLayout &dataLayout,
+                            unsigned idx) const;
+  bool isLayoutIdentical(const RecordType &other);
+
+  bool isABIConvertedRecord() const;
+  mlir::StringAttr getABIConvertedName() const;
+  void removeABIConversionNamePrefix();
+};
+
+} // namespace cir
+
 #endif // CLANG_CIR_DIALECT_IR_CIRTYPES_H

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.h
@@ -27,7 +27,8 @@
 namespace cir {
 
 namespace detail {
-struct RecordTypeStorage;
+struct StructTypeStorage;
+struct UnionTypeStorage;
 } // namespace detail
 
 bool isValidFundamentalIntWidth(unsigned width);

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -669,7 +669,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
   );
 
   // StorageClass is defined in C++ for mutability.
-  let storageClass = "RecordTypeStorage";
+  let storageClass = "StructTypeStorage";
   let genStorageClass = 0;
 
   let skipDefaultBuilders = 1;
@@ -685,7 +685,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
       "bool":$is_class
     ), [{
       return $_get($_ctxt, members, name, /*incomplete=*/false, packed, padded,
-                   is_class, /*padding=*/mlir::Type{});
+                   is_class);
     }]>,
 
     // Create an identified and incomplete struct/class type.
@@ -695,7 +695,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
     ), [{
       return $_get($_ctxt, /*members=*/llvm::ArrayRef<mlir::Type>{}, name,
                    /*incomplete=*/true, /*packed=*/false,
-                   /*padded=*/false, is_class, /*padding=*/mlir::Type{});
+                   /*padded=*/false, is_class);
     }]>,
 
     // Create an anonymous struct/class type (always complete).
@@ -706,7 +706,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
       "bool":$is_class
     ), [{
       return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
-                   packed, padded, is_class, /*padding=*/mlir::Type{});
+                   packed, padded, is_class);
     }]>
   ];
 
@@ -811,7 +811,7 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
   );
 
   // StorageClass is defined in C++ for mutability.
-  let storageClass = "RecordTypeStorage";
+  let storageClass = "UnionTypeStorage";
   let genStorageClass = 0;
 
   let skipDefaultBuilders = 1;
@@ -826,14 +826,14 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
       CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, name, /*incomplete=*/false, packed,
-                   /*padded=*/false, /*is_class=*/false, padding);
+                   padding);
     }]>,
 
     // Create an identified and incomplete union type.
     TypeBuilder<(ins "mlir::StringAttr":$name), [{
       return $_get($_ctxt, /*members=*/llvm::ArrayRef<mlir::Type>{}, name,
-                   /*incomplete=*/true, /*packed=*/false, /*padded=*/false,
-                   /*is_class=*/false, /*padding=*/mlir::Type{});
+                   /*incomplete=*/true, /*packed=*/false,
+                   /*padding=*/mlir::Type{});
     }]>,
 
     // Create an anonymous union type (always complete).
@@ -843,7 +843,7 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
       CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
-                   packed, /*padded=*/false, /*is_class=*/false, padding);
+                   packed, padding);
     }]>
   ];
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -620,59 +620,42 @@ def CIR_VoidType : CIR_Type<"Void", "void"> {
 }
 
 //===----------------------------------------------------------------------===//
-// RecordType
+// StructType
 //
-// The base type for all RecordDecls.
+// The CIR type for C/C++ struct and class declarations.
 //===----------------------------------------------------------------------===//
 
-def CIR_RecordType : CIR_Type<"Record", "record", [
+def CIR_StructType : CIR_Type<"Struct", "struct", [
     DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
     DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>,
     MutableType,
 ]> {
-  let summary = "CIR record type";
+  let summary = "CIR struct/class type";
   let description = [{
-    Each unique clang::RecordDecl is mapped to a `cir.record` and any object in
-    C/C++ that has a struct or class type will have a `cir.record` in CIR.
+    Each unique clang::RecordDecl with struct or class kind is mapped to a
+    `cir.struct` type.  Any object in C/C++ that has a struct or class type
+    will have a `!cir.struct` in CIR.
 
-    There are three possible formats for this type:
+    There are three possible formats:
 
-     - Identified and complete records: unique name and a known body.
-     - Identified and incomplete records: unique name and unknown body.
-     - Anonymous records: no name and a known body.
+     - Identified and complete: unique name and a known body.
+     - Identified and incomplete: unique name and unknown body.
+     - Anonymous: no name and a known body.
 
-    Identified records are uniqued by their name, and anonymous records are
-    uniqued by their body. This means that two anonymous records with the same
-    body will be the same type, and two identified records with the same name
-    will be the same type. Attempting to build a record with an existing name,
-    but a different body will result in an error.
+    The optional `class` keyword distinguishes C++ class declarations from
+    plain struct declarations.  Both are semantically identical; the keyword
+    preserves the original source spelling.
 
-    Each record type will have a `RecordKind` that is either `Class`, `Struct`,
-    or `Union`, depending on the C/C++ type that it is representing. Note that
-    `Class` and `Struct` are semantically identical, but the kind preserves the
-    keyword that was used to declare the type in the original source code.
-
-    A few examples:
+    Examples:
 
     ```
-        !rec_complete = !cir.record<struct "complete" {!u8i}>
-        !rec_incomplete = !cir.record<struct "incomplete" incomplete>
-        !anonymous_struct = !cir.record<struct {!u8i}>
-        !rec_p1 = !cir.record<struct "p1" packed {!u8i, !u8i}>
-        !rec_p2 = !cir.record<struct "p2" padded {!u8i, !u8i}>
-        !rec_p3 = !cir.record<struct "p3" packed padded {!s32i, !u8i, !u8i}>
-    ```
-
-    Incomplete records are mutable, meaning they can be later completed with a
-    body automatically updating in place every type in the code that uses the
-    incomplete record. Mutability allows for recursive types to be represented,
-    meaning the record can have members that refer to itself. This is useful for
-    representing recursive records and is implemented through a special syntax.
-    In the example below, the `Node` record has a member that is a pointer to a
-    `Node` record:
-
-    ```
-        !s = !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>}>
+        !rec_complete = !cir.struct<"complete" {!u8i}>
+        !rec_class    = !cir.struct<class "MyClass" {!s32i}>
+        !rec_incomplete = !cir.struct<"incomplete" incomplete>
+        !anonymous    = !cir.struct<{!u8i}>
+        !rec_packed   = !cir.struct<"p1" packed {!u8i, !u8i}>
+        !rec_padded   = !cir.struct<"p2" padded {!u8i, !u8i}>
+        !recursive    = !cir.struct<"Node" {!cir.ptr<!cir.struct<"Node">>}>
     ```
   }];
 
@@ -682,7 +665,8 @@ def CIR_RecordType : CIR_Type<"Record", "record", [
     "bool":$incomplete,
     "bool":$packed,
     "bool":$padded,
-    "RecordType::RecordKind":$kind
+    "bool":$is_class,
+    OptionalParameter<"mlir::Type">:$padding
   );
 
   // StorageClass is defined in C++ for mutability.
@@ -693,85 +677,71 @@ def CIR_RecordType : CIR_Type<"Record", "record", [
   let genVerifyDecl = 1;
 
   let builders = [
-    // Create an identified and complete record type.
+    // Create an identified and complete struct/class type.
     TypeBuilder<(ins
       "llvm::ArrayRef<mlir::Type>":$members,
       "mlir::StringAttr":$name,
       "bool":$packed,
       "bool":$padded,
-      "RecordKind":$kind
+      "bool":$is_class,
+      CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, name, /*incomplete=*/false, packed, padded,
-                   kind);
+                   is_class, padding);
     }]>,
 
-    // Create an identified and incomplete record type.
+    // Create an identified and incomplete struct/class type.
     TypeBuilder<(ins
       "mlir::StringAttr":$name,
-      "RecordKind":$kind
+      "bool":$is_class
     ), [{
-      return $_get($_ctxt, /*members=*/llvm::ArrayRef<Type>{}, name,
-                         /*incomplete=*/true, /*packed=*/false,
-                         /*padded=*/false, kind);
+      return $_get($_ctxt, /*members=*/llvm::ArrayRef<mlir::Type>{}, name,
+                   /*incomplete=*/true, /*packed=*/false,
+                   /*padded=*/false, is_class, /*padding=*/mlir::Type{});
     }]>,
 
-    // Create an anonymous record type (always complete).
+    // Create an anonymous struct/class type (always complete).
     TypeBuilder<(ins
       "llvm::ArrayRef<mlir::Type>":$members,
       "bool":$packed,
       "bool":$padded,
-      "RecordKind":$kind
+      "bool":$is_class,
+      CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
-                      packed, padded, kind);
-    }]>];
+                   packed, padded, is_class, padding);
+    }]>
+  ];
 
   let extraClassDeclaration = [{
     using Base::verifyInvariants;
 
-    enum RecordKind : uint32_t { Class, Struct, Union };
-
-    bool isClass() const { return getKind() == RecordKind::Class; };
-    bool isStruct() const { return getKind() == RecordKind::Struct; };
-    bool isUnion() const { return getKind() == RecordKind::Union; };
-    bool isComplete() const { return !isIncomplete(); };
+    bool isClass() const { return getIsClass(); }
+    bool isStruct() const { return !getIsClass(); }
+    bool isComplete() const { return !isIncomplete(); }
     bool isIncomplete() const;
 
-    mlir::Type getLargestMember(const mlir::DataLayout &dataLayout) const;
-
-    /// Tail-padding member for a padded union (last member appended by
-    /// lowerUnion).  Empty type when the record is not padded.
-    mlir::Type getPadding() const;
-
-    size_t getNumElements() const { return getMembers().size(); };
-    std::string getKindAsStr() {
-      switch (getKind()) {
-      case RecordKind::Class:
-        return "class";
-      case RecordKind::Union:
-        return "union";
-      case RecordKind::Struct:
-        return "struct";
-      }
-      llvm_unreachable("Invalid value for RecordType::getKind()");
+    size_t getNumElements() const { return getMembers().size(); }
+    std::string getKindAsStr() const {
+      return getIsClass() ? "class" : "struct";
     }
-    mlir::Type getElementType(size_t idx) {
+    mlir::Type getElementType(size_t idx) const {
       return getMembers()[idx];
     }
-    std::string getPrefixedName() {
+    std::string getPrefixedName() const {
       return getKindAsStr() + "." + getName().getValue().str();
     }
 
     void complete(llvm::ArrayRef<mlir::Type> members, bool packed,
-                  bool isPadded);
+                  bool isPadded, mlir::Type padding = {});
 
     uint64_t getElementOffset(const mlir::DataLayout &dataLayout,
-              unsigned idx) const;
+                              unsigned idx) const;
 
-    bool isLayoutIdentical(const RecordType &other);
+    bool isLayoutIdentical(const StructType &other);
 
     // Checks the name of this record to check if it is a 'after' (or during)
-    // ABI converison.
+    // ABI conversion.
     bool isABIConvertedRecord() const;
 
     // Get the version of this record's name for use during cxx-abi conversion.
@@ -784,15 +754,12 @@ def CIR_RecordType : CIR_Type<"Record", "record", [
     // a conflict in RecordStorage because two types will have the same hash.
     void removeABIConversionNamePrefix();
 
-    bool isSized() const {
-      return isComplete();
-    }
+    bool isSized() const { return isComplete(); }
 
-    /// Returns the data size (excluding tail padding) for struct types.
+    /// Returns the data size (excluding tail padding) for this struct type.
     unsigned computeStructDataSize(const mlir::DataLayout &dataLayout) const;
 
   private:
-
     static constexpr char abi_conversion_prefix[] = "__post_abi_";
     unsigned computeStructSize(const mlir::DataLayout &dataLayout) const;
     uint64_t computeStructAlignment(const mlir::DataLayout &dataLayout) const;
@@ -802,8 +769,143 @@ def CIR_RecordType : CIR_Type<"Record", "record", [
   let hasCustomAssemblyFormat = 1;
 }
 
-// Note CIRRecordType is used instead of CIR_RecordType
-// because of tablegen conflicts.
+//===----------------------------------------------------------------------===//
+// UnionType
+//
+// The CIR type for C/C++ union declarations.
+//===----------------------------------------------------------------------===//
+
+def CIR_UnionType : CIR_Type<"Union", "union", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>,
+    MutableType,
+]> {
+  let summary = "CIR union type";
+  let description = [{
+    Each unique clang::RecordDecl with union kind is mapped to a `cir.union`
+    type.  Any object in C/C++ that has a union type will have a `!cir.union`
+    in CIR.
+
+    There are three possible formats:
+
+     - Identified and complete: unique name and a known body.
+     - Identified and incomplete: unique name and unknown body.
+     - Anonymous: no name and a known body.
+
+    Padded unions carry an explicit tail-padding type to ensure the LLVM struct
+    that models the union has the correct byte size.
+
+    Examples:
+
+    ```
+        !u_complete   = !cir.union<"U" {!s32i, !u8i}>
+        !u_incomplete = !cir.union<"U" incomplete>
+        !u_anonymous  = !cir.union<{!s32i, !u8i}>
+        !u_padded     = !cir.union<"U" padded {!s32i, !u8i}, padding = {!u8i}>
+    ```
+  }];
+
+  let parameters = (ins
+    OptionalArrayRefParameter<"mlir::Type">:$members,
+    OptionalParameter<"mlir::StringAttr">:$name,
+    "bool":$incomplete,
+    "bool":$packed,
+    "bool":$padded,
+    OptionalParameter<"mlir::Type">:$padding
+  );
+
+  // StorageClass is defined in C++ for mutability.
+  let storageClass = "RecordTypeStorage";
+  let genStorageClass = 0;
+
+  let skipDefaultBuilders = 1;
+  let genVerifyDecl = 1;
+
+  let builders = [
+    // Create an identified and complete union type.
+    TypeBuilder<(ins
+      "llvm::ArrayRef<mlir::Type>":$members,
+      "mlir::StringAttr":$name,
+      "bool":$packed,
+      "bool":$padded,
+      CArg<"mlir::Type", "{}">:$padding
+    ), [{
+      return $_get($_ctxt, members, name, /*incomplete=*/false, packed, padded,
+                   /*is_class=*/false, padding);
+    }]>,
+
+    // Create an identified and incomplete union type.
+    TypeBuilder<(ins "mlir::StringAttr":$name), [{
+      return $_get($_ctxt, /*members=*/llvm::ArrayRef<mlir::Type>{}, name,
+                   /*incomplete=*/true, /*packed=*/false, /*padded=*/false,
+                   /*is_class=*/false, /*padding=*/mlir::Type{});
+    }]>,
+
+    // Create an anonymous union type (always complete).
+    TypeBuilder<(ins
+      "llvm::ArrayRef<mlir::Type>":$members,
+      "bool":$packed,
+      "bool":$padded,
+      CArg<"mlir::Type", "{}">:$padding
+    ), [{
+      return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
+                   packed, padded, /*is_class=*/false, padding);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    using Base::verifyInvariants;
+
+    bool isUnion() const { return true; }
+    bool isComplete() const { return !isIncomplete(); }
+    bool isIncomplete() const;
+
+    size_t getNumElements() const { return getMembers().size(); }
+    std::string getKindAsStr() const { return "union"; }
+    mlir::Type getElementType(size_t idx) const {
+      return getMembers()[idx];
+    }
+    std::string getPrefixedName() const {
+      return "union." + getName().getValue().str();
+    }
+
+    /// Returns the highest-alignment variant of the union (the member used as
+    /// the storage type when lowering to LLVM IR).  Returns a null type for
+    /// empty unions.
+    mlir::Type getUnionStorageType(const mlir::DataLayout &dataLayout) const;
+
+    void complete(llvm::ArrayRef<mlir::Type> members, bool packed,
+                  bool isPadded, mlir::Type padding = {});
+
+    uint64_t getElementOffset(const mlir::DataLayout &, unsigned) const {
+      return 0;
+    }
+
+    bool isLayoutIdentical(const UnionType &other);
+
+    // Checks the name of this record to check if it is a 'after' (or during)
+    // ABI conversion.
+    bool isABIConvertedRecord() const;
+
+    // Get the version of this record's name for use during cxx-abi conversion.
+    mlir::StringAttr getABIConvertedName() const;
+
+    // This function should only be called after the CXXABILowering pass.
+    void removeABIConversionNamePrefix();
+
+    bool isSized() const { return isComplete(); }
+
+  private:
+    static constexpr char abi_conversion_prefix[] = "__post_abi_";
+  public:
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
+// CIRRecordType: tablegen constraint matching either !cir.struct or !cir.union.
+// Note: CIRRecordType is used instead of CIR_StructType / CIR_UnionType in op
+// definitions so a single constraint covers both record kinds.
 def CIRRecordType : Type<
   CPred<"::mlir::isa<::cir::RecordType>($_self)">, "CIR record type">;
 
@@ -853,7 +955,8 @@ def CIR_CatchTokenType : CIR_Type<"CatchToken", "catch_token"> {
 
 def CIR_AnyType : AnyTypeOf<[
   CIR_VoidType, CIR_BoolType, CIR_ArrayType, CIR_VectorType, CIR_IntType,
-  CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_RecordType,
+  CIR_AnyFloatType, CIR_PointerType, CIR_FuncType, CIR_StructType,
+  CIR_UnionType,
   CIR_ComplexType, CIR_VPtrType, CIR_DataMemberType, CIR_MethodType,
   CIR_EhTokenType, CIR_CleanupTokenType, CIR_CatchTokenType
 ]>;

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -798,7 +798,7 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
         !u_complete   = !cir.union<"U" {!s32i, !u8i}>
         !u_incomplete = !cir.union<"U" incomplete>
         !u_anonymous  = !cir.union<{!s32i, !u8i}>
-        !u_padded     = !cir.union<"U" padded {!s32i, !u8i}, padding = {!u8i}>
+        !u_padded     = !cir.union<"U" {!s32i, !u8i}, padding = {!u8i}>
     ```
   }];
 
@@ -826,7 +826,7 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
       CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, name, /*incomplete=*/false, packed,
-                   /*padded=*/!!padding, /*is_class=*/false, padding);
+                   /*padded=*/false, /*is_class=*/false, padding);
     }]>,
 
     // Create an identified and incomplete union type.
@@ -843,7 +843,7 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
       CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
-                   packed, /*padded=*/!!padding, /*is_class=*/false, padding);
+                   packed, /*padded=*/false, /*is_class=*/false, padding);
     }]>
   ];
 
@@ -855,7 +855,8 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
     bool isIncomplete() const;
 
     /// Returns true when this union carries a tail-padding type.
-    /// Derived from getPadding() — a union is padded iff it has a padding type.
+    /// Derived from getPadding(): a union is padded iff it has a non-null
+    /// padding type.
     bool getPadded() const;
 
     size_t getNumElements() const { return getMembers().size(); }

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -665,8 +665,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
     "bool":$incomplete,
     "bool":$packed,
     "bool":$padded,
-    "bool":$is_class,
-    OptionalParameter<"mlir::Type">:$padding
+    "bool":$is_class
   );
 
   // StorageClass is defined in C++ for mutability.
@@ -683,11 +682,10 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
       "mlir::StringAttr":$name,
       "bool":$packed,
       "bool":$padded,
-      "bool":$is_class,
-      CArg<"mlir::Type", "{}">:$padding
+      "bool":$is_class
     ), [{
       return $_get($_ctxt, members, name, /*incomplete=*/false, packed, padded,
-                   is_class, padding);
+                   is_class, /*padding=*/mlir::Type{});
     }]>,
 
     // Create an identified and incomplete struct/class type.
@@ -705,11 +703,10 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
       "llvm::ArrayRef<mlir::Type>":$members,
       "bool":$packed,
       "bool":$padded,
-      "bool":$is_class,
-      CArg<"mlir::Type", "{}">:$padding
+      "bool":$is_class
     ), [{
       return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
-                   packed, padded, is_class, padding);
+                   packed, padded, is_class, /*padding=*/mlir::Type{});
     }]>
   ];
 
@@ -733,7 +730,7 @@ def CIR_StructType : CIR_Type<"Struct", "struct", [
     }
 
     void complete(llvm::ArrayRef<mlir::Type> members, bool packed,
-                  bool isPadded, mlir::Type padding = {});
+                  bool isPadded);
 
     uint64_t getElementOffset(const mlir::DataLayout &dataLayout,
                               unsigned idx) const;
@@ -810,7 +807,6 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
     OptionalParameter<"mlir::StringAttr">:$name,
     "bool":$incomplete,
     "bool":$packed,
-    "bool":$padded,
     OptionalParameter<"mlir::Type">:$padding
   );
 
@@ -827,11 +823,10 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
       "llvm::ArrayRef<mlir::Type>":$members,
       "mlir::StringAttr":$name,
       "bool":$packed,
-      "bool":$padded,
       CArg<"mlir::Type", "{}">:$padding
     ), [{
-      return $_get($_ctxt, members, name, /*incomplete=*/false, packed, padded,
-                   /*is_class=*/false, padding);
+      return $_get($_ctxt, members, name, /*incomplete=*/false, packed,
+                   /*padded=*/!!padding, /*is_class=*/false, padding);
     }]>,
 
     // Create an identified and incomplete union type.
@@ -845,11 +840,10 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
     TypeBuilder<(ins
       "llvm::ArrayRef<mlir::Type>":$members,
       "bool":$packed,
-      "bool":$padded,
       CArg<"mlir::Type", "{}">:$padding
     ), [{
       return $_get($_ctxt, members, mlir::StringAttr{}, /*incomplete=*/false,
-                   packed, padded, /*is_class=*/false, padding);
+                   packed, /*padded=*/!!padding, /*is_class=*/false, padding);
     }]>
   ];
 
@@ -859,6 +853,10 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
     bool isUnion() const { return true; }
     bool isComplete() const { return !isIncomplete(); }
     bool isIncomplete() const;
+
+    /// Returns true when this union carries a tail-padding type.
+    /// Derived from getPadding() — a union is padded iff it has a padding type.
+    bool getPadded() const;
 
     size_t getNumElements() const { return getMembers().size(); }
     std::string getKindAsStr() const { return "union"; }
@@ -875,7 +873,7 @@ def CIR_UnionType : CIR_Type<"Union", "union", [
     mlir::Type getUnionStorageType(const mlir::DataLayout &dataLayout) const;
 
     void complete(llvm::ArrayRef<mlir::Type> members, bool packed,
-                  bool isPadded, mlir::Type padding = {});
+                  mlir::Type padding = {});
 
     uint64_t getElementOffset(const mlir::DataLayout &, unsigned) const {
       return 0;

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -22,11 +22,11 @@ namespace cir {
 namespace detail {
 
 //===----------------------------------------------------------------------===//
-// CIR RecordTypeStorage
+// CIR StructTypeStorage
 //===----------------------------------------------------------------------===//
 
-/// Type storage for CIR record types.
-struct RecordTypeStorage : public mlir::TypeStorage {
+/// Type storage for CIR struct/class types.
+struct StructTypeStorage : public mlir::TypeStorage {
   struct KeyTy {
     llvm::ArrayRef<mlir::Type> members;
     mlir::StringAttr name;
@@ -34,13 +34,11 @@ struct RecordTypeStorage : public mlir::TypeStorage {
     bool packed;
     bool padded;
     bool is_class;
-    mlir::Type padding;
 
     KeyTy(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-          bool incomplete, bool packed, bool padded, bool is_class,
-          mlir::Type padding)
+          bool incomplete, bool packed, bool padded, bool is_class)
         : members(members), name(name), incomplete(incomplete), packed(packed),
-          padded(padded), is_class(is_class), padding(padding) {}
+          padded(padded), is_class(is_class) {}
   };
 
   llvm::ArrayRef<mlir::Type> members;
@@ -49,68 +47,133 @@ struct RecordTypeStorage : public mlir::TypeStorage {
   bool packed;
   bool padded;
   bool is_class;
-  mlir::Type padding;
 
-  RecordTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                    bool incomplete, bool packed, bool padded, bool is_class,
-                    mlir::Type padding)
+  StructTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
+                    bool incomplete, bool packed, bool padded, bool is_class)
       : members(members), name(name), incomplete(incomplete), packed(packed),
-        padded(padded), is_class(is_class), padding(padding) {
+        padded(padded), is_class(is_class) {
     assert((name || !incomplete) && "Incomplete records must have a name");
   }
 
   KeyTy getAsKey() const {
-    return KeyTy(members, name, incomplete, packed, padded, is_class, padding);
+    return KeyTy(members, name, incomplete, packed, padded, is_class);
   }
 
   bool operator==(const KeyTy &key) const {
     if (name)
       return (name == key.name) && (is_class == key.is_class);
-    return std::tie(members, name, incomplete, packed, padded, is_class,
-                    padding) == std::tie(key.members, key.name, key.incomplete,
-                                         key.packed, key.padded, key.is_class,
-                                         key.padding);
+    return std::tie(members, name, incomplete, packed, padded, is_class) ==
+           std::tie(key.members, key.name, key.incomplete, key.packed,
+                    key.padded, key.is_class);
   }
 
   static llvm::hash_code hashKey(const KeyTy &key) {
     if (key.name)
       return llvm::hash_combine(key.name, key.is_class);
     return llvm::hash_combine(key.members, key.incomplete, key.packed,
-                              key.padded, key.is_class, key.padding);
+                              key.padded, key.is_class);
   }
 
-  static RecordTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
+  static StructTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
                                       const KeyTy &key) {
-    return new (allocator.allocate<RecordTypeStorage>()) RecordTypeStorage(
-        allocator.copyInto(key.members), key.name, key.incomplete, key.packed,
-        key.padded, key.is_class, key.padding);
+    return new (allocator.allocate<StructTypeStorage>())
+        StructTypeStorage(allocator.copyInto(key.members), key.name,
+                          key.incomplete, key.packed, key.padded, key.is_class);
   }
 
-  /// Mutates the members and attributes an identified record.
-  ///
-  /// Once a record is mutated, it is marked as complete, preventing further
-  /// mutations.  Anonymous records are always complete and cannot be mutated.
-  /// This method does not fail if a mutation of a complete record does not
-  /// change the record.
+  /// Mutates the members and attributes of an identified struct/class.
   llvm::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
                              llvm::ArrayRef<mlir::Type> members, bool packed,
-                             bool padded, mlir::Type padding) {
-    // Anonymous records cannot mutate.
+                             bool padded) {
     if (!name)
       return llvm::failure();
 
-    // Mutation of complete records are allowed if they change nothing.
     if (!incomplete)
-      return mlir::success(
-          (this->members == members) && (this->packed == packed) &&
-          (this->padded == padded) && (this->padding == padding));
+      return mlir::success((this->members == members) &&
+                           (this->packed == packed) &&
+                           (this->padded == padded));
 
-    // Mutate incomplete record.
     this->members = allocator.copyInto(members);
     this->packed = packed;
     this->padded = padded;
-    this->padding = padding;
+    incomplete = false;
+    return llvm::success();
+  }
+};
 
+//===----------------------------------------------------------------------===//
+// CIR UnionTypeStorage
+//===----------------------------------------------------------------------===//
+
+/// Type storage for CIR union types.
+struct UnionTypeStorage : public mlir::TypeStorage {
+  struct KeyTy {
+    llvm::ArrayRef<mlir::Type> members;
+    mlir::StringAttr name;
+    bool incomplete;
+    bool packed;
+    mlir::Type padding;
+
+    KeyTy(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
+          bool incomplete, bool packed, mlir::Type padding)
+        : members(members), name(name), incomplete(incomplete), packed(packed),
+          padding(padding) {}
+  };
+
+  llvm::ArrayRef<mlir::Type> members;
+  mlir::StringAttr name;
+  bool incomplete;
+  bool packed;
+  mlir::Type padding;
+
+  UnionTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
+                   bool incomplete, bool packed, mlir::Type padding)
+      : members(members), name(name), incomplete(incomplete), packed(packed),
+        padding(padding) {
+    assert((name || !incomplete) && "Incomplete records must have a name");
+  }
+
+  KeyTy getAsKey() const {
+    return KeyTy(members, name, incomplete, packed, padding);
+  }
+
+  bool operator==(const KeyTy &key) const {
+    if (name)
+      return name == key.name;
+    return std::tie(members, name, incomplete, packed, padding) ==
+           std::tie(key.members, key.name, key.incomplete, key.packed,
+                    key.padding);
+  }
+
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    if (key.name)
+      return llvm::hash_combine(key.name);
+    return llvm::hash_combine(key.members, key.incomplete, key.packed,
+                              key.padding);
+  }
+
+  static UnionTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
+                                     const KeyTy &key) {
+    return new (allocator.allocate<UnionTypeStorage>())
+        UnionTypeStorage(allocator.copyInto(key.members), key.name,
+                         key.incomplete, key.packed, key.padding);
+  }
+
+  /// Mutates the members and attributes of an identified union.
+  llvm::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
+                             llvm::ArrayRef<mlir::Type> members, bool packed,
+                             mlir::Type padding) {
+    if (!name)
+      return llvm::failure();
+
+    if (!incomplete)
+      return mlir::success((this->members == members) &&
+                           (this->packed == packed) &&
+                           (this->padding == padding));
+
+    this->members = allocator.copyInto(members);
+    this->packed = packed;
+    this->padding = padding;
     incomplete = false;
     return llvm::success();
   }

--- a/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypesDetails.h
@@ -33,13 +33,14 @@ struct RecordTypeStorage : public mlir::TypeStorage {
     bool incomplete;
     bool packed;
     bool padded;
-    RecordType::RecordKind kind;
+    bool is_class;
+    mlir::Type padding;
 
     KeyTy(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-          bool incomplete, bool packed, bool padded,
-          RecordType::RecordKind kind)
+          bool incomplete, bool packed, bool padded, bool is_class,
+          mlir::Type padding)
         : members(members), name(name), incomplete(incomplete), packed(packed),
-          padded(padded), kind(kind) {}
+          padded(padded), is_class(is_class), padding(padding) {}
   };
 
   llvm::ArrayRef<mlir::Type> members;
@@ -47,65 +48,68 @@ struct RecordTypeStorage : public mlir::TypeStorage {
   bool incomplete;
   bool packed;
   bool padded;
-  RecordType::RecordKind kind;
+  bool is_class;
+  mlir::Type padding;
 
   RecordTypeStorage(llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                    bool incomplete, bool packed, bool padded,
-                    RecordType::RecordKind kind)
+                    bool incomplete, bool packed, bool padded, bool is_class,
+                    mlir::Type padding)
       : members(members), name(name), incomplete(incomplete), packed(packed),
-        padded(padded), kind(kind) {
+        padded(padded), is_class(is_class), padding(padding) {
     assert((name || !incomplete) && "Incomplete records must have a name");
   }
 
   KeyTy getAsKey() const {
-    return KeyTy(members, name, incomplete, packed, padded, kind);
+    return KeyTy(members, name, incomplete, packed, padded, is_class, padding);
   }
 
   bool operator==(const KeyTy &key) const {
     if (name)
-      return (name == key.name) && (kind == key.kind);
-    return std::tie(members, name, incomplete, packed, padded, kind) ==
-           std::tie(key.members, key.name, key.incomplete, key.packed,
-                    key.padded, key.kind);
+      return (name == key.name) && (is_class == key.is_class);
+    return std::tie(members, name, incomplete, packed, padded, is_class,
+                    padding) == std::tie(key.members, key.name, key.incomplete,
+                                         key.packed, key.padded, key.is_class,
+                                         key.padding);
   }
 
   static llvm::hash_code hashKey(const KeyTy &key) {
     if (key.name)
-      return llvm::hash_combine(key.name, key.kind);
+      return llvm::hash_combine(key.name, key.is_class);
     return llvm::hash_combine(key.members, key.incomplete, key.packed,
-                              key.padded, key.kind);
+                              key.padded, key.is_class, key.padding);
   }
 
   static RecordTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
                                       const KeyTy &key) {
-    return new (allocator.allocate<RecordTypeStorage>())
-        RecordTypeStorage(allocator.copyInto(key.members), key.name,
-                          key.incomplete, key.packed, key.padded, key.kind);
+    return new (allocator.allocate<RecordTypeStorage>()) RecordTypeStorage(
+        allocator.copyInto(key.members), key.name, key.incomplete, key.packed,
+        key.padded, key.is_class, key.padding);
   }
 
   /// Mutates the members and attributes an identified record.
   ///
   /// Once a record is mutated, it is marked as complete, preventing further
-  /// mutations. Anonymous records are always complete and cannot be mutated.
+  /// mutations.  Anonymous records are always complete and cannot be mutated.
   /// This method does not fail if a mutation of a complete record does not
   /// change the record.
   llvm::LogicalResult mutate(mlir::TypeStorageAllocator &allocator,
                              llvm::ArrayRef<mlir::Type> members, bool packed,
-                             bool padded) {
+                             bool padded, mlir::Type padding) {
     // Anonymous records cannot mutate.
     if (!name)
       return llvm::failure();
 
     // Mutation of complete records are allowed if they change nothing.
     if (!incomplete)
-      return mlir::success((this->members == members) &&
-                           (this->packed == packed) &&
-                           (this->padded == padded));
+      return mlir::success(
+          (this->members == members) && (this->packed == packed) &&
+          (this->padded == padded) && (this->padding == padding));
 
     // Mutate incomplete record.
     this->members = allocator.copyInto(members);
     this->packed = packed;
     this->padded = padded;
+    this->padding = padding;
 
     incomplete = false;
     return llvm::success();

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -134,7 +134,7 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
               // here, we just need to find eltSize that is greater then the
               // required offset. The same is true for the similar union type
               // check below
-              if (!mlir::isa<cir::UnionType>(recordTy))
+              if (!recordTy.isUnion())
                 pos = (pos + alignMask) & ~alignMask;
               assert(offset >= 0);
               if (offset < pos + eltSize) {
@@ -143,7 +143,7 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
                 return elts[i];
               }
               // No need to update pos here, see the comment above.
-              if (!mlir::isa<cir::UnionType>(recordTy))
+              if (!recordTy.isUnion())
                 pos += eltSize;
             }
             llvm_unreachable("offset was not found within the record");
@@ -194,8 +194,7 @@ cir::RecordType clang::CIRGen::CIRGenBuilderTy::getCompleteRecordType(
   if (name.empty())
     return getAnonRecordTy(members, packed, padded);
 
-  return getCompleteNamedRecordType(members, packed, padded, mlir::Type{},
-                                    name);
+  return getCompleteNamedRecordType(members, packed, padded, name);
 }
 
 mlir::Attribute clang::CIRGen::CIRGenBuilderTy::getConstRecordOrZeroAttr(

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.cpp
@@ -134,7 +134,7 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
               // here, we just need to find eltSize that is greater then the
               // required offset. The same is true for the similar union type
               // check below
-              if (!recordTy.isUnion())
+              if (!mlir::isa<cir::UnionType>(recordTy))
                 pos = (pos + alignMask) & ~alignMask;
               assert(offset >= 0);
               if (offset < pos + eltSize) {
@@ -143,7 +143,7 @@ void CIRGenBuilderTy::computeGlobalViewIndicesFromFlatOffset(
                 return elts[i];
               }
               // No need to update pos here, see the comment above.
-              if (!recordTy.isUnion())
+              if (!mlir::isa<cir::UnionType>(recordTy))
                 pos += eltSize;
             }
             llvm_unreachable("offset was not found within the record");
@@ -194,7 +194,8 @@ cir::RecordType clang::CIRGen::CIRGenBuilderTy::getCompleteRecordType(
   if (name.empty())
     return getAnonRecordTy(members, packed, padded);
 
-  return getCompleteNamedRecordType(members, packed, padded, name);
+  return getCompleteNamedRecordType(members, packed, padded, mlir::Type{},
+                                    name);
 }
 
 mlir::Attribute clang::CIRGen::CIRGenBuilderTy::getConstRecordOrZeroAttr(

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -179,20 +179,15 @@ public:
   }
 
   /// Get a CIR record kind from a AST declaration tag.
-  cir::RecordType::RecordKind getRecordKind(const clang::TagTypeKind kind) {
-    switch (kind) {
-    case clang::TagTypeKind::Class:
-      return cir::RecordType::Class;
-    case clang::TagTypeKind::Struct:
-      return cir::RecordType::Struct;
-    case clang::TagTypeKind::Union:
-      return cir::RecordType::Union;
-    case clang::TagTypeKind::Interface:
-      llvm_unreachable("interface records are NYI");
-    case clang::TagTypeKind::Enum:
-      llvm_unreachable("enums are not records");
-    }
-    llvm_unreachable("Unsupported record kind");
+  /// Returns true if the tag kind represents a C++ class (as opposed to a
+  /// plain struct).
+  static bool tagKindIsClass(const clang::TagTypeKind kind) {
+    return kind == clang::TagTypeKind::Class;
+  }
+
+  /// Returns true if the tag kind is a union.
+  static bool tagKindIsUnion(const clang::TagTypeKind kind) {
+    return kind == clang::TagTypeKind::Union;
   }
 
   /// Get a CIR named record type.
@@ -201,14 +196,15 @@ public:
   /// it with a different set of attributes, this method will crash.
   cir::RecordType getCompleteNamedRecordType(llvm::ArrayRef<mlir::Type> members,
                                              bool packed, bool padded,
+                                             mlir::Type padding,
                                              llvm::StringRef name) {
     const auto nameAttr = getStringAttr(name);
-    auto kind = cir::RecordType::RecordKind::Struct;
     assert(!cir::MissingFeatures::astRecordDeclAttr());
 
-    // Create or get the record.
-    auto type =
-        getType<cir::RecordType>(members, nameAttr, packed, padded, kind);
+    // Create or get the struct type (named anonymous struct helper — always
+    // struct, never class or union at this call site).
+    auto type = cir::StructType::get(getContext(), members, nameAttr, packed,
+                                     padded, /*is_class=*/false, padding);
 
     // If we found an existing type, verify that either it is incomplete or
     // it matches the requested attributes.
@@ -218,7 +214,7 @@ public:
 
     // Complete an incomplete record or ensure the existing complete record
     // matches the requested attributes.
-    type.complete(members, packed, padded);
+    type.complete(members, packed, padded, padding);
 
     return type;
   }
@@ -228,16 +224,16 @@ public:
                                         bool padded = false,
                                         llvm::StringRef name = "");
 
-  /// Get an incomplete CIR struct type. If we have a complete record
+  /// Get an incomplete CIR record type. If we have a complete record
   /// declaration, we may create an incomplete type and then add the
   /// members, so \p rd here may be complete.
   cir::RecordType getIncompleteRecordTy(llvm::StringRef name,
                                         const clang::RecordDecl *rd) {
     const mlir::StringAttr nameAttr = getStringAttr(name);
-    cir::RecordType::RecordKind kind = cir::RecordType::RecordKind::Struct;
-    if (rd)
-      kind = getRecordKind(rd->getTagKind());
-    return getType<cir::RecordType>(nameAttr, kind);
+    if (rd && tagKindIsUnion(rd->getTagKind()))
+      return cir::UnionType::get(getContext(), nameAttr);
+    bool is_class = rd && tagKindIsClass(rd->getTagKind());
+    return cir::StructType::get(getContext(), nameAttr, is_class);
   }
 
   //
@@ -437,12 +433,12 @@ public:
   // Fetch the type representing a pointer to unsigned int8 values.
   cir::PointerType getUInt8PtrTy() { return typeCache.uInt8PtrTy; }
 
-  /// Get a CIR anonymous record type.
-  cir::RecordType getAnonRecordTy(llvm::ArrayRef<mlir::Type> members,
+  /// Get a CIR anonymous struct type.
+  cir::StructType getAnonRecordTy(llvm::ArrayRef<mlir::Type> members,
                                   bool packed = false, bool padded = false) {
     assert(!cir::MissingFeatures::astRecordDeclAttr());
-    auto kind = cir::RecordType::RecordKind::Struct;
-    return getType<cir::RecordType>(members, packed, padded, kind);
+    return cir::StructType::get(getContext(), members, packed, padded,
+                                /*is_class=*/false);
   }
 
   //===--------------------------------------------------------------------===//

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -196,7 +196,6 @@ public:
   /// it with a different set of attributes, this method will crash.
   cir::RecordType getCompleteNamedRecordType(llvm::ArrayRef<mlir::Type> members,
                                              bool packed, bool padded,
-                                             mlir::Type padding,
                                              llvm::StringRef name) {
     const auto nameAttr = getStringAttr(name);
     assert(!cir::MissingFeatures::astRecordDeclAttr());
@@ -204,7 +203,7 @@ public:
     // Create or get the struct type (named anonymous struct helper — always
     // struct, never class or union at this call site).
     auto type = cir::StructType::get(getContext(), members, nameAttr, packed,
-                                     padded, /*is_class=*/false, padding);
+                                     padded, /*is_class=*/false);
 
     // If we found an existing type, verify that either it is incomplete or
     // it matches the requested attributes.
@@ -214,7 +213,7 @@ public:
 
     // Complete an incomplete record or ensure the existing complete record
     // matches the requested attributes.
-    type.complete(members, packed, padded, padding);
+    type.complete(members, packed, padded);
 
     return type;
   }

--- a/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltinX86.cpp
@@ -208,8 +208,8 @@ emitEncodeKey(mlir::MLIRContext *context, CIRGenBuilderTy &builder,
   llvm::SmallVector<mlir::Type> members{builder.getUInt32Ty()};
   llvm::append_range(members,
                      llvm::SmallVector<mlir::Type>(vecOutputCount, resVector));
-  cir::RecordType resRecord = cir::RecordType::get(
-      context, members, false, false, cir::RecordType::RecordKind::Struct);
+  cir::StructType resRecord = cir::StructType::get(
+      context, members, /*packed=*/false, /*padded=*/false, /*is_class=*/false);
 
   mlir::Value outputPtr =
       builder.createBitcast(outputOperand, cir::PointerType::get(resVector));
@@ -2217,9 +2217,9 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
     mlir::Type randTy = cast<cir::PointerType>(ops[0].getType()).getPointee();
     llvm::SmallVector<mlir::Type, 2> resultTypes = {randTy,
                                                     builder.getUInt32Ty()};
-    cir::RecordType resRecord =
-        cir::RecordType::get(&getMLIRContext(), resultTypes, false, false,
-                             cir::RecordType::RecordKind::Struct);
+    cir::StructType resRecord =
+        cir::StructType::get(&getMLIRContext(), resultTypes, /*packed=*/false,
+                             /*padded=*/false, /*is_class=*/false);
 
     mlir::Value call =
         builder.emitIntrinsicCallOp(loc, intrinsicName, resRecord);
@@ -2286,9 +2286,10 @@ CIRGenFunction::emitX86BuiltinExpr(unsigned builtinID, const CallExpr *expr) {
 
     auto resVector = cir::VectorType::get(builder.getBoolTy(), numElts);
 
-    cir::RecordType resRecord =
-        cir::RecordType::get(&getMLIRContext(), {resVector, resVector}, false,
-                             false, cir::RecordType::RecordKind::Struct);
+    cir::StructType resRecord =
+        cir::StructType::get(&getMLIRContext(), {resVector, resVector},
+                             /*packed=*/false, /*padded=*/false,
+                             /*is_class=*/false);
 
     mlir::Value call = builder.emitIntrinsicCallOp(
         getLoc(expr->getExprLoc()), intrinsicName, resRecord,

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -559,7 +559,7 @@ Address CIRGenFunction::getAddrOfBitFieldStorage(LValue base,
   auto rec = cast<cir::RecordType>(base.getAddress().getElementType());
   cir::GetMemberOp sea = getBuilder().createGetMember(
       loc, fieldPtr, base.getPointer(), field->getName(),
-      rec.isUnion() ? field->getFieldIndex() : index);
+      mlir::isa<cir::UnionType>(rec) ? field->getFieldIndex() : index);
   CharUnits offset = CharUnits::fromQuantity(
       rec.getElementOffset(cgm.getDataLayout().layout, index));
   return Address(sea, base.getAlignment().alignmentAtOffset(offset));

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -712,7 +712,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
       std::string baseIdentifier = getRecordTypeName(rd, ".base");
       baseTy = builder.getCompleteNamedRecordType(
           baseLowering.fieldTypes, baseLowering.packed, baseLowering.padded,
-          baseLowering.unionPadding, baseIdentifier);
+          baseIdentifier);
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work

--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -196,9 +196,15 @@ struct CIRRecordLowering final {
   void fillOutputFields();
 
   void appendPaddingBytes(CharUnits size) {
-    if (!size.isZero()) {
-      fieldTypes.push_back(getByteArrayType(size));
-      padded = true;
+    if (size.isZero())
+      return;
+    mlir::Type padTy = getByteArrayType(size);
+    padded = true;
+    if (recordDecl->isUnion()) {
+      assert(!unionPadding && "at most one union tail-padding type");
+      unionPadding = padTy;
+    } else {
+      fieldTypes.push_back(padTy);
     }
   }
 
@@ -212,6 +218,7 @@ struct CIRRecordLowering final {
   std::vector<MemberInfo> members;
   // Output fields, consumed by CIRGenTypes::computeRecordLayout
   llvm::SmallVector<mlir::Type, 16> fieldTypes;
+  mlir::Type unionPadding;
   llvm::DenseMap<const FieldDecl *, CIRGenBitFieldInfo> bitFields;
   llvm::DenseMap<const FieldDecl *, unsigned> fieldIdxMap;
   llvm::DenseMap<const CXXRecordDecl *, unsigned> nonVirtualBases;
@@ -705,7 +712,7 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
       std::string baseIdentifier = getRecordTypeName(rd, ".base");
       baseTy = builder.getCompleteNamedRecordType(
           baseLowering.fieldTypes, baseLowering.packed, baseLowering.padded,
-          baseIdentifier);
+          baseLowering.unionPadding, baseIdentifier);
       // TODO(cir): add something like addRecordTypeName
 
       // BaseTy and Ty must agree on their packedness for getCIRFieldNo to work
@@ -719,7 +726,8 @@ CIRGenTypes::computeRecordLayout(const RecordDecl *rd, cir::RecordType *ty) {
   // signifies that the type is no longer opaque and record layout is complete,
   // but we may need to recursively layout rd while laying D out as a base type.
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  ty->complete(lowering.fieldTypes, lowering.packed, lowering.padded);
+  ty->complete(lowering.fieldTypes, lowering.packed, lowering.padded,
+               lowering.unionPadding);
 
   // Queue ABI metadata for the module-level cir.record_layouts attribute.
   if (ty->getName()) {

--- a/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRAttrs.cpp
@@ -205,7 +205,7 @@ ConstRecordAttr::verify(function_ref<InFlightDiagnostic()> emitError,
                         mlir::Type type, ArrayAttr members) {
   auto sTy = mlir::dyn_cast_if_present<cir::RecordType>(type);
   if (!sTy)
-    return emitError() << "expected !cir.record type";
+    return emitError() << "expected !cir.struct or !cir.union type";
 
   if (sTy.getMembers().size() != members.size())
     return emitError() << "number of elements must match";
@@ -765,7 +765,7 @@ LogicalResult cir::VTableAttr::verify(
     mlir::ArrayAttr data) {
   auto sTy = mlir::dyn_cast_if_present<cir::RecordType>(type);
   if (!sTy)
-    return emitError() << "expected !cir.record type result";
+    return emitError() << "expected !cir.struct or !cir.union type result";
   if (sTy.getMembers().empty() || data.empty())
     return emitError() << "expected record type with one or more subtype";
 

--- a/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDataLayout.cpp
@@ -46,11 +46,10 @@ llvm::Align CIRDataLayout::getAlignment(mlir::Type ty, bool useABIAlign) const {
 llvm::TypeSize CIRDataLayout::getTypeSizeInBits(mlir::Type ty) const {
   assert(cir::isSized(ty) && "Cannot getTypeInfo() on a type that is unsized!");
 
-  if (auto recordTy = llvm::dyn_cast<cir::RecordType>(ty)) {
-    // FIXME(cir): CIR record's data layout implementation doesn't do a good job
-    // of handling unions particularities. We should have a separate union type.
-    return recordTy.getTypeSizeInBits(layout, {});
-  }
+  if (auto structTy = llvm::dyn_cast<cir::StructType>(ty))
+    return structTy.getTypeSizeInBits(layout, {});
+  if (auto unionTy = llvm::dyn_cast<cir::UnionType>(ty))
+    return unionTy.getTypeSizeInBits(layout, {});
 
   // FIXME(cir): This does not account for different address spaces, and relies
   // on CIR's data layout to give the proper ABI-specific type width.

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -312,7 +312,7 @@ template <typename Op> static LogicalResult verifyArrayCtorDtor(Op op) {
     if (!recTy)
       return op.emitOpError(
           "when 'num_elements' is present, 'addr' must be a pointer to a "
-          "!cir.record type");
+          "!cir.struct or !cir.union type");
 
     if (expectedEltPtrTy != ptrTy)
       return op.emitOpError("when 'num_elements' is present, 'addr' type must "
@@ -330,8 +330,8 @@ template <typename Op> static LogicalResult verifyArrayCtorDtor(Op op) {
 
     auto recTy = mlir::dyn_cast<cir::RecordType>(innerEltTy);
     if (!recTy)
-      return op.emitOpError(
-          "the block argument type must be a pointer to a !cir.record type");
+      return op.emitOpError("the block argument type must be a pointer to a "
+                            "!cir.struct or !cir.union type");
 
     if (expectedEltPtrTy.getPointee() != innerEltTy)
       return op.emitOpError(
@@ -3218,10 +3218,9 @@ LogicalResult cir::CopyOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::GetRuntimeMemberOp::verify() {
-  auto recordTy = mlir::cast<RecordType>(getAddr().getType().getPointee());
   cir::DataMemberType memberPtrTy = getMember().getType();
 
-  if (recordTy != memberPtrTy.getClassTy())
+  if (getAddr().getType().getPointee() != memberPtrTy.getClassTy())
     return emitError() << "record type does not match the member pointer type";
   if (getType().getPointee() != memberPtrTy.getMemberTy())
     return emitError() << "result type does not match the member pointer type";
@@ -3302,13 +3301,13 @@ LogicalResult cir::GetMemberOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::ExtractMemberOp::verify() {
-  auto recordTy = mlir::cast<cir::RecordType>(getRecord().getType());
-  if (recordTy.getKind() == cir::RecordType::Union)
+  if (mlir::isa<cir::UnionType>(getRecord().getType()))
     return emitError()
            << "cir.extract_member currently does not support unions";
-  if (recordTy.getMembers().size() <= getIndex())
+  auto structTy = mlir::cast<cir::StructType>(getRecord().getType());
+  if (structTy.getMembers().size() <= getIndex())
     return emitError() << "member index out of bounds";
-  if (recordTy.getMembers()[getIndex()] != getType())
+  if (structTy.getMembers()[getIndex()] != getType())
     return emitError() << "member type mismatch";
   return mlir::success();
 }
@@ -3318,12 +3317,12 @@ LogicalResult cir::ExtractMemberOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult cir::InsertMemberOp::verify() {
-  auto recordTy = mlir::cast<cir::RecordType>(getRecord().getType());
-  if (recordTy.getKind() == cir::RecordType::Union)
+  if (mlir::isa<cir::UnionType>(getRecord().getType()))
     return emitError() << "cir.insert_member currently does not support unions";
-  if (recordTy.getMembers().size() <= getIndex())
+  auto structTy = mlir::cast<cir::StructType>(getRecord().getType());
+  if (structTy.getMembers().size() <= getIndex())
     return emitError() << "member index out of bounds";
-  if (recordTy.getMembers()[getIndex()] != getValue().getType())
+  if (structTy.getMembers()[getIndex()] != getValue().getType())
     return emitError() << "member type mismatch";
   // The op trait already checks that the types of $result and $record match.
   return mlir::success();

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -365,9 +365,6 @@ Type UnionType::parse(mlir::AsmParser &parser) {
   if (parser.parseOptionalKeyword("packed").succeeded())
     packed = true;
 
-  // "padded" is accepted for backward compatibility but derived from padding.
-  (void)parser.parseOptionalKeyword("padded");
-
   bool incomplete = true;
   llvm::SmallVector<mlir::Type> members;
   if (parseRecordBody(parser, incomplete, members).failed())
@@ -417,7 +414,7 @@ Type UnionType::parse(mlir::AsmParser &parser) {
 
 void UnionType::print(mlir::AsmPrinter &printer) const {
   printRecordBody(printer, *this, getName(), /*hasClassPrefix=*/false,
-                  getPacked(), getPadded(), isIncomplete(), getMembers(),
+                  getPacked(), /*isPadded=*/false, isIncomplete(), getMembers(),
                   getPadding());
 }
 
@@ -438,7 +435,7 @@ mlir::StringAttr UnionType::getName() const { return getImpl()->name; }
 bool UnionType::isIncomplete() const { return getImpl()->incomplete; }
 bool UnionType::getIncomplete() const { return getImpl()->incomplete; }
 bool UnionType::getPacked() const { return getImpl()->packed; }
-bool UnionType::getPadded() const { return !!getPadding(); }
+bool UnionType::getPadded() const { return static_cast<bool>(getPadding()); }
 mlir::Type UnionType::getPadding() const { return getImpl()->padding; }
 
 bool UnionType::isABIConvertedRecord() const {
@@ -462,7 +459,7 @@ void UnionType::removeABIConversionNamePrefix() {
 void UnionType::complete(ArrayRef<Type> members, bool packed,
                          mlir::Type padding) {
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  if (mutate(members, packed, /*padded=*/!!padding, padding).failed())
+  if (mutate(members, packed, /*padded=*/false, padding).failed())
     llvm_unreachable("failed to complete union");
 }
 
@@ -539,6 +536,8 @@ void RecordType::complete(ArrayRef<Type> members, bool packed, bool padded,
                           mlir::Type padding) {
   if (auto s = mlir::dyn_cast<StructType>(*this))
     return s.complete(members, packed, padded);
+  // For unions, padded is derived from padding; assert the caller is consistent.
+  assert((!padded || padding) && "padded=true requires a non-null padding type");
   return mlir::cast<UnionType>(*this).complete(members, packed, padding);
 }
 uint64_t RecordType::getElementOffset(const mlir::DataLayout &dataLayout,

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -127,6 +127,67 @@ void CIRDialect::printType(Type type, DialectAsmPrinter &os) const {
 // StructType
 //===----------------------------------------------------------------------===//
 
+// Shared helpers for StructType and UnionType parse/print.
+
+/// Parse "incomplete" or "{type, type, ...}", writing results into
+/// \p incomplete and \p members.  Returns failure if member parsing fails.
+static mlir::ParseResult
+parseRecordBody(mlir::AsmParser &parser, bool &incomplete,
+                llvm::SmallVector<mlir::Type> &members) {
+  assert(incomplete && "caller must pre-initialize incomplete to true");
+  if (parser.parseOptionalKeyword("incomplete").succeeded())
+    return mlir::success();
+  incomplete = false;
+  return parser.parseCommaSeparatedList(
+      AsmParser::Delimiter::Braces, [&parser, &members]() {
+        return parser.parseType(members.emplace_back());
+      });
+}
+
+/// Print a complete CIR record body:
+///   '<' ['class '] [name] ['packed '] ['padded '] body '>'
+/// where body is "incomplete" or "{members[, padding = {type}]}".
+/// RecordTy must be a mutable MLIR type (StructType or UnionType).
+template <typename RecordTy>
+static void printRecordBody(mlir::AsmPrinter &printer, RecordTy self,
+                            mlir::StringAttr name, bool hasClassPrefix,
+                            bool isPacked, bool isPadded, bool isIncomplete,
+                            llvm::ArrayRef<mlir::Type> members,
+                            mlir::Type padding = {}) {
+  printer << '<';
+  if (hasClassPrefix)
+    printer << "class ";
+  if (name)
+    printer << name;
+
+  FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrintGuard =
+      printer.tryStartCyclicPrint(self);
+  if (failed(cyclicPrintGuard)) {
+    printer << '>';
+    return;
+  }
+
+  if (hasClassPrefix || name)
+    printer << ' ';
+  if (isPacked)
+    printer << "packed ";
+  if (isPadded)
+    printer << "padded ";
+  if (isIncomplete) {
+    printer << "incomplete";
+  } else {
+    printer << "{";
+    llvm::interleaveComma(members, printer);
+    printer << "}";
+    if (padding) {
+      printer << ", padding = {";
+      printer.printType(padding);
+      printer << '}';
+    }
+  }
+  printer << '>';
+}
+
 /// Parse the body of a !cir.struct<...> type.
 Type StructType::parse(mlir::AsmParser &parser) {
   FailureOr<AsmParser::CyclicParseReset> cyclicParseGuard;
@@ -173,15 +234,8 @@ Type StructType::parse(mlir::AsmParser &parser) {
 
   bool incomplete = true;
   llvm::SmallVector<mlir::Type> members;
-  if (parser.parseOptionalKeyword("incomplete").failed()) {
-    incomplete = false;
-    const auto delimiter = AsmParser::Delimiter::Braces;
-    const auto parseElementFn = [&parser, &members]() {
-      return parser.parseType(members.emplace_back());
-    };
-    if (parser.parseCommaSeparatedList(delimiter, parseElementFn).failed())
-      return {};
-  }
+  if (parseRecordBody(parser, incomplete, members).failed())
+    return {};
 
   if (parser.parseGreater())
     return {};
@@ -213,35 +267,8 @@ Type StructType::parse(mlir::AsmParser &parser) {
 }
 
 void StructType::print(mlir::AsmPrinter &printer) const {
-  FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrintGuard;
-  printer << '<';
-
-  if (isClass())
-    printer << "class ";
-
-  if (getName())
-    printer << getName();
-
-  cyclicPrintGuard = printer.tryStartCyclicPrint(*this);
-  if (failed(cyclicPrintGuard)) {
-    printer << '>';
-    return;
-  }
-
-  if (isClass() || getName())
-    printer << ' ';
-  if (getPacked())
-    printer << "packed ";
-  if (getPadded())
-    printer << "padded ";
-  if (isIncomplete()) {
-    printer << "incomplete";
-  } else {
-    printer << "{";
-    llvm::interleaveComma(getMembers(), printer);
-    printer << "}";
-  }
-  printer << '>';
+  printRecordBody(printer, *this, getName(), isClass(), getPacked(),
+                  getPadded(), isIncomplete(), getMembers());
 }
 
 mlir::LogicalResult
@@ -343,15 +370,8 @@ Type UnionType::parse(mlir::AsmParser &parser) {
 
   bool incomplete = true;
   llvm::SmallVector<mlir::Type> members;
-  if (parser.parseOptionalKeyword("incomplete").failed()) {
-    incomplete = false;
-    const auto delimiter = AsmParser::Delimiter::Braces;
-    const auto parseElementFn = [&parser, &members]() {
-      return parser.parseType(members.emplace_back());
-    };
-    if (parser.parseCommaSeparatedList(delimiter, parseElementFn).failed())
-      return {};
-  }
+  if (parseRecordBody(parser, incomplete, members).failed())
+    return {};
 
   // Optional tail-padding slot: ", padding = { <type> }".
   if (!incomplete && parser.parseOptionalComma().succeeded()) {
@@ -396,37 +416,9 @@ Type UnionType::parse(mlir::AsmParser &parser) {
 }
 
 void UnionType::print(mlir::AsmPrinter &printer) const {
-  FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrintGuard;
-  printer << '<';
-
-  if (getName())
-    printer << getName();
-
-  cyclicPrintGuard = printer.tryStartCyclicPrint(*this);
-  if (failed(cyclicPrintGuard)) {
-    printer << '>';
-    return;
-  }
-
-  if (getName())
-    printer << ' ';
-  if (getPacked())
-    printer << "packed ";
-  if (getPadded())
-    printer << "padded ";
-  if (isIncomplete()) {
-    printer << "incomplete";
-  } else {
-    printer << "{";
-    llvm::interleaveComma(getMembers(), printer);
-    printer << "}";
-    if (mlir::Type pad = getPadding()) {
-      printer << ", padding = {";
-      printer.printType(pad);
-      printer << '}';
-    }
-  }
-  printer << '>';
+  printRecordBody(printer, *this, getName(), /*hasClassPrefix=*/false,
+                  getPacked(), getPadded(), isIncomplete(), getMembers(),
+                  getPadding());
 }
 
 mlir::LogicalResult

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -109,13 +109,9 @@ Type CIRDialect::parseType(DialectAsmParser &parser) const {
   if (parseResult.has_value())
     return genType;
 
-  // Type is not tablegen'd: try to parse as a raw C++ type.
-  return StringSwitch<function_ref<Type()>>(mnemonic)
-      .Case("record", [&] { return RecordType::parse(parser); })
-      .Default([&] {
-        parser.emitError(typeLoc) << "unknown CIR type: " << mnemonic;
-        return Type();
-      })();
+  // All CIR types are now tablegen'd; nothing left to dispatch here.
+  parser.emitError(typeLoc) << "unknown CIR type: " << mnemonic;
+  return Type();
 }
 
 void CIRDialect::printType(Type type, DialectAsmPrinter &os) const {
@@ -128,40 +124,30 @@ void CIRDialect::printType(Type type, DialectAsmPrinter &os) const {
 }
 
 //===----------------------------------------------------------------------===//
-// RecordType Definitions
+// StructType
 //===----------------------------------------------------------------------===//
 
-Type RecordType::parse(mlir::AsmParser &parser) {
+/// Parse the body of a !cir.struct<...> type.
+Type StructType::parse(mlir::AsmParser &parser) {
   FailureOr<AsmParser::CyclicParseReset> cyclicParseGuard;
   const llvm::SMLoc loc = parser.getCurrentLocation();
   const mlir::Location eLoc = parser.getEncodedSourceLoc(loc);
   bool packed = false;
   bool padded = false;
-  RecordKind kind;
   mlir::MLIRContext *context = parser.getContext();
 
   if (parser.parseLess())
     return {};
 
-  // TODO(cir): in the future we should probably separate types for different
-  // source language declarations such as cir.record and cir.union
-  if (parser.parseOptionalKeyword("struct").succeeded())
-    kind = RecordKind::Struct;
-  else if (parser.parseOptionalKeyword("union").succeeded())
-    kind = RecordKind::Union;
-  else if (parser.parseOptionalKeyword("class").succeeded())
-    kind = RecordKind::Class;
-  else {
-    parser.emitError(loc, "unknown record type");
-    return {};
-  }
+  // An optional "class" keyword distinguishes class from struct.
+  bool is_class = parser.parseOptionalKeyword("class").succeeded();
 
   mlir::StringAttr name;
   parser.parseOptionalAttribute(name);
 
-  // Is a self reference: ensure referenced type was parsed.
+  // Self-reference: ensure the referenced type was already parsed.
   if (name && parser.parseOptionalGreater().succeeded()) {
-    RecordType type = getChecked(eLoc, context, name, kind);
+    StructType type = StructType::getChecked(eLoc, context, name, is_class);
     if (succeeded(parser.tryStartCyclicParse(type))) {
       parser.emitError(loc, "invalid self-reference within record");
       return {};
@@ -169,9 +155,9 @@ Type RecordType::parse(mlir::AsmParser &parser) {
     return type;
   }
 
-  // Is a named record definition: ensure name has not been parsed yet.
+  // Named definition: ensure name has not been parsed yet.
   if (name) {
-    RecordType type = getChecked(eLoc, context, name, kind);
+    StructType type = StructType::getChecked(eLoc, context, name, is_class);
     cyclicParseGuard = parser.tryStartCyclicParse(type);
     if (failed(cyclicParseGuard)) {
       parser.emitError(loc, "record already defined");
@@ -185,7 +171,6 @@ Type RecordType::parse(mlir::AsmParser &parser) {
   if (parser.parseOptionalKeyword("padded").succeeded())
     padded = true;
 
-  // Parse record members or lack thereof.
   bool incomplete = true;
   llvm::SmallVector<mlir::Type> members;
   if (parser.parseOptionalKeyword("incomplete").failed()) {
@@ -201,21 +186,25 @@ Type RecordType::parse(mlir::AsmParser &parser) {
   if (parser.parseGreater())
     return {};
 
-  // Try to create the proper record type.
-  ArrayRef<mlir::Type> membersRef(members); // Needed for template deduction.
+  ArrayRef<mlir::Type> membersRef(members);
   mlir::Type type = {};
-  if (name && incomplete) { // Identified & incomplete
-    type = getChecked(eLoc, context, name, kind);
-  } else if (!name && !incomplete) { // Anonymous & complete
-    type = getChecked(eLoc, context, membersRef, packed, padded, kind);
-  } else if (!incomplete) { // Identified & complete
-    type = getChecked(eLoc, context, membersRef, name, packed, padded, kind);
-    // If the record has a self-reference, its type already exists in a
-    // incomplete state. In this case, we must complete it.
-    if (mlir::cast<RecordType>(type).isIncomplete())
-      mlir::cast<RecordType>(type).complete(membersRef, packed, padded);
+  if (name && incomplete) {
+    type = StructType::getChecked(eLoc, context, name, is_class);
+  } else if (!name && !incomplete) {
+    type = StructType::getChecked(eLoc, context, membersRef, packed, padded,
+                                  is_class, mlir::Type{});
+    if (!type)
+      return {};
+  } else if (!incomplete) {
+    type = StructType::getChecked(eLoc, context, membersRef, name, packed,
+                                  padded, is_class, mlir::Type{});
+    if (!type)
+      return {};
+    if (auto structTy = mlir::dyn_cast<StructType>(type))
+      if (structTy.isIncomplete())
+        structTy.complete(membersRef, packed, padded);
     assert(!cir::MissingFeatures::astRecordDeclAttr());
-  } else { // anonymous & incomplete
+  } else {
     parser.emitError(loc, "anonymous records must be complete");
     return {};
   }
@@ -223,41 +212,28 @@ Type RecordType::parse(mlir::AsmParser &parser) {
   return type;
 }
 
-void RecordType::print(mlir::AsmPrinter &printer) const {
+void StructType::print(mlir::AsmPrinter &printer) const {
   FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrintGuard;
   printer << '<';
 
-  switch (getKind()) {
-  case RecordKind::Struct:
-    printer << "struct ";
-    break;
-  case RecordKind::Union:
-    printer << "union ";
-    break;
-  case RecordKind::Class:
+  if (isClass())
     printer << "class ";
-    break;
-  }
 
   if (getName())
     printer << getName();
 
-  // Current type has already been printed: print as self reference.
   cyclicPrintGuard = printer.tryStartCyclicPrint(*this);
   if (failed(cyclicPrintGuard)) {
     printer << '>';
     return;
   }
 
-  // Type not yet printed: continue printing the entire record.
-  printer << ' ';
-
+  if (isClass() || getName())
+    printer << ' ';
   if (getPacked())
     printer << "packed ";
-
   if (getPadded())
     printer << "padded ";
-
   if (isIncomplete()) {
     printer << "incomplete";
   } else {
@@ -265,103 +241,359 @@ void RecordType::print(mlir::AsmPrinter &printer) const {
     llvm::interleaveComma(getMembers(), printer);
     printer << "}";
   }
-
   printer << '>';
 }
 
 mlir::LogicalResult
-RecordType::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
+StructType::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
                    llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                   bool incomplete, bool packed, bool padded,
-                   RecordType::RecordKind kind) {
+                   bool incomplete, bool packed, bool padded, bool is_class,
+                   mlir::Type padding) {
   if (name && name.getValue().empty())
     return emitError() << "identified records cannot have an empty name";
+  if (padding)
+    return emitError() << "padding is not supported on struct/class types";
   return mlir::success();
 }
 
-::llvm::ArrayRef<mlir::Type> RecordType::getMembers() const {
+// Accessors are hand-written because genStorageClass = 0 suppresses generated
+// implementations.
+llvm::ArrayRef<mlir::Type> StructType::getMembers() const {
   return getImpl()->members;
 }
+mlir::StringAttr StructType::getName() const { return getImpl()->name; }
+bool StructType::isIncomplete() const { return getImpl()->incomplete; }
+bool StructType::getIncomplete() const { return getImpl()->incomplete; }
+bool StructType::getPacked() const { return getImpl()->packed; }
+bool StructType::getPadded() const { return getImpl()->padded; }
+bool StructType::getIsClass() const { return getImpl()->is_class; }
+mlir::Type StructType::getPadding() const { return getImpl()->padding; }
 
-bool RecordType::isIncomplete() const { return getImpl()->incomplete; }
-
-mlir::StringAttr RecordType::getName() const { return getImpl()->name; }
-
-bool RecordType::getIncomplete() const { return getImpl()->incomplete; }
-
-bool RecordType::getPacked() const { return getImpl()->packed; }
-
-bool RecordType::getPadded() const { return getImpl()->padded; }
-
-cir::RecordType::RecordKind RecordType::getKind() const {
-  return getImpl()->kind;
-}
-bool RecordType::isABIConvertedRecord() const {
+bool StructType::isABIConvertedRecord() const {
   return getName() && getName().getValue().starts_with(abi_conversion_prefix);
 }
 
-mlir::StringAttr RecordType::getABIConvertedName() const {
+mlir::StringAttr StructType::getABIConvertedName() const {
   assert(!isABIConvertedRecord());
-
   return StringAttr::get(getContext(),
                          abi_conversion_prefix + getName().getValue());
 }
 
-void RecordType::removeABIConversionNamePrefix() {
+void StructType::removeABIConversionNamePrefix() {
   mlir::StringAttr recordName = getName();
-
   if (recordName && recordName.getValue().starts_with(abi_conversion_prefix))
     getImpl()->name = mlir::StringAttr::get(
         recordName.getValue().drop_front(sizeof(abi_conversion_prefix) - 1),
         recordName.getType());
 }
 
-void RecordType::complete(ArrayRef<Type> members, bool packed, bool padded) {
+void StructType::complete(ArrayRef<Type> members, bool packed, bool padded,
+                          mlir::Type padding) {
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  if (mutate(members, packed, padded).failed())
-    llvm_unreachable("failed to complete record");
+  if (mutate(members, packed, padded, padding).failed())
+    llvm_unreachable("failed to complete struct");
 }
 
-/// Return the largest member of in the type.
-///
-/// Recurses into union members never returning a union as the largest member.
-Type RecordType::getLargestMember(const ::mlir::DataLayout &dataLayout) const {
-  assert(isUnion() && "Only call getLargestMember on unions");
-  llvm::ArrayRef<Type> members = getMembers();
-  if (members.empty())
-    return {};
-
-  // If the union is padded, we need to ignore the last member,
-  // which is the padding.
-  auto endIt = getPadded() ? std::prev(members.end()) : members.end();
-  if (endIt == members.begin())
-    return {};
-  return *std::max_element(members.begin(), endIt, [&](Type lhs, Type rhs) {
-    return dataLayout.getTypeABIAlignment(lhs) <
-               dataLayout.getTypeABIAlignment(rhs) ||
-           (dataLayout.getTypeABIAlignment(lhs) ==
-                dataLayout.getTypeABIAlignment(rhs) &&
-            dataLayout.getTypeSize(lhs) < dataLayout.getTypeSize(rhs));
-  });
+bool StructType::isLayoutIdentical(const StructType &other) {
+  if (getImpl() == other.getImpl())
+    return true;
+  if (getPacked() != other.getPacked())
+    return false;
+  return getMembers() == other.getMembers();
 }
 
-mlir::Type RecordType::getPadding() const {
-  if (!getPadded())
+//===----------------------------------------------------------------------===//
+// UnionType
+//===----------------------------------------------------------------------===//
+
+Type UnionType::parse(mlir::AsmParser &parser) {
+  FailureOr<AsmParser::CyclicParseReset> cyclicParseGuard;
+  const llvm::SMLoc loc = parser.getCurrentLocation();
+  const mlir::Location eLoc = parser.getEncodedSourceLoc(loc);
+  bool packed = false;
+  bool padded = false;
+  mlir::Type padding;
+  mlir::MLIRContext *context = parser.getContext();
+
+  if (parser.parseLess())
     return {};
+
+  mlir::StringAttr name;
+  parser.parseOptionalAttribute(name);
+
+  // Self-reference.
+  if (name && parser.parseOptionalGreater().succeeded()) {
+    UnionType type = UnionType::getChecked(eLoc, context, name);
+    if (succeeded(parser.tryStartCyclicParse(type))) {
+      parser.emitError(loc, "invalid self-reference within record");
+      return {};
+    }
+    return type;
+  }
+
+  // Named definition.
+  if (name) {
+    UnionType type = UnionType::getChecked(eLoc, context, name);
+    cyclicParseGuard = parser.tryStartCyclicParse(type);
+    if (failed(cyclicParseGuard)) {
+      parser.emitError(loc, "record already defined");
+      return {};
+    }
+  }
+
+  if (parser.parseOptionalKeyword("packed").succeeded())
+    packed = true;
+
+  if (parser.parseOptionalKeyword("padded").succeeded())
+    padded = true;
+
+  bool incomplete = true;
+  llvm::SmallVector<mlir::Type> members;
+  if (parser.parseOptionalKeyword("incomplete").failed()) {
+    incomplete = false;
+    const auto delimiter = AsmParser::Delimiter::Braces;
+    const auto parseElementFn = [&parser, &members]() {
+      return parser.parseType(members.emplace_back());
+    };
+    if (parser.parseCommaSeparatedList(delimiter, parseElementFn).failed())
+      return {};
+  }
+
+  // Optional tail-padding slot: ", padding = { <type> }".
+  if (!incomplete && parser.parseOptionalComma().succeeded()) {
+    if (parser.parseKeyword("padding").failed())
+      return {};
+    if (parser.parseEqual().failed())
+      return {};
+    if (parser.parseLBrace().failed())
+      return {};
+    if (parser.parseType(padding).failed())
+      return {};
+    if (parser.parseRBrace().failed())
+      return {};
+  }
+
+  if (parser.parseGreater())
+    return {};
+
+  ArrayRef<mlir::Type> membersRef(members);
+  mlir::Type type = {};
+  if (name && incomplete) {
+    type = UnionType::getChecked(eLoc, context, name);
+  } else if (!name && !incomplete) {
+    type = UnionType::getChecked(eLoc, context, membersRef, packed, padded,
+                                 padding);
+    if (!type)
+      return {};
+  } else if (!incomplete) {
+    type = UnionType::getChecked(eLoc, context, membersRef, name, packed,
+                                 padded, padding);
+    if (!type)
+      return {};
+    if (auto unionTy = mlir::dyn_cast<UnionType>(type))
+      if (unionTy.isIncomplete())
+        unionTy.complete(membersRef, packed, padded, padding);
+    assert(!cir::MissingFeatures::astRecordDeclAttr());
+  } else {
+    parser.emitError(loc, "anonymous records must be complete");
+    return {};
+  }
+
+  return type;
+}
+
+void UnionType::print(mlir::AsmPrinter &printer) const {
+  FailureOr<AsmPrinter::CyclicPrintReset> cyclicPrintGuard;
+  printer << '<';
+
+  if (getName())
+    printer << getName();
+
+  cyclicPrintGuard = printer.tryStartCyclicPrint(*this);
+  if (failed(cyclicPrintGuard)) {
+    printer << '>';
+    return;
+  }
+
+  if (getName())
+    printer << ' ';
+  if (getPacked())
+    printer << "packed ";
+  if (getPadded())
+    printer << "padded ";
+  if (isIncomplete()) {
+    printer << "incomplete";
+  } else {
+    printer << "{";
+    llvm::interleaveComma(getMembers(), printer);
+    printer << "}";
+    if (mlir::Type pad = getPadding()) {
+      printer << ", padding = {";
+      printer.printType(pad);
+      printer << '}';
+    }
+  }
+  printer << '>';
+}
+
+mlir::LogicalResult
+UnionType::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
+                  llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
+                  bool incomplete, bool packed, bool padded,
+                  mlir::Type padding) {
+  if (name && name.getValue().empty())
+    return emitError() << "identified records cannot have an empty name";
+  if (padding && !padded)
+    return emitError() << "padded keyword required when padding is set";
+  if (padded && !padding)
+    return emitError() << "padded unions must specify a padding type";
+  return mlir::success();
+}
+
+// Accessors.
+llvm::ArrayRef<mlir::Type> UnionType::getMembers() const {
+  return getImpl()->members;
+}
+mlir::StringAttr UnionType::getName() const { return getImpl()->name; }
+bool UnionType::isIncomplete() const { return getImpl()->incomplete; }
+bool UnionType::getIncomplete() const { return getImpl()->incomplete; }
+bool UnionType::getPacked() const { return getImpl()->packed; }
+bool UnionType::getPadded() const { return getImpl()->padded; }
+mlir::Type UnionType::getPadding() const { return getImpl()->padding; }
+
+bool UnionType::isABIConvertedRecord() const {
+  return getName() && getName().getValue().starts_with(abi_conversion_prefix);
+}
+
+mlir::StringAttr UnionType::getABIConvertedName() const {
+  assert(!isABIConvertedRecord());
+  return StringAttr::get(getContext(),
+                         abi_conversion_prefix + getName().getValue());
+}
+
+void UnionType::removeABIConversionNamePrefix() {
+  mlir::StringAttr recordName = getName();
+  if (recordName && recordName.getValue().starts_with(abi_conversion_prefix))
+    getImpl()->name = mlir::StringAttr::get(
+        recordName.getValue().drop_front(sizeof(abi_conversion_prefix) - 1),
+        recordName.getType());
+}
+
+void UnionType::complete(ArrayRef<Type> members, bool packed, bool padded,
+                         mlir::Type padding) {
+  assert(!cir::MissingFeatures::astRecordDeclAttr());
+  if (mutate(members, packed, padded, padding).failed())
+    llvm_unreachable("failed to complete union");
+}
+
+mlir::Type
+UnionType::getUnionStorageType(const mlir::DataLayout &dataLayout) const {
   llvm::ArrayRef<mlir::Type> members = getMembers();
   if (members.empty())
     return {};
-  return members.back();
+  return *std::max_element(
+      members.begin(), members.end(), [&](mlir::Type lhs, mlir::Type rhs) {
+        return dataLayout.getTypeABIAlignment(lhs) <
+                   dataLayout.getTypeABIAlignment(rhs) ||
+               (dataLayout.getTypeABIAlignment(lhs) ==
+                    dataLayout.getTypeABIAlignment(rhs) &&
+                dataLayout.getTypeSize(lhs) < dataLayout.getTypeSize(rhs));
+      });
 }
 
-bool RecordType::isLayoutIdentical(const RecordType &other) {
+bool UnionType::isLayoutIdentical(const UnionType &other) {
   if (getImpl() == other.getImpl())
     return true;
-
-  if (getPacked() != other.getPacked())
-    return false;
-
   return getMembers() == other.getMembers();
+}
+
+//===----------------------------------------------------------------------===//
+// RecordType view-class method implementations
+//===----------------------------------------------------------------------===//
+
+llvm::ArrayRef<mlir::Type> RecordType::getMembers() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.getMembers();
+  return mlir::cast<UnionType>(*this).getMembers();
+}
+mlir::StringAttr RecordType::getName() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.getName();
+  return mlir::cast<UnionType>(*this).getName();
+}
+bool RecordType::isIncomplete() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.isIncomplete();
+  return mlir::cast<UnionType>(*this).isIncomplete();
+}
+bool RecordType::getPacked() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.getPacked();
+  return mlir::cast<UnionType>(*this).getPacked();
+}
+bool RecordType::getPadded() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.getPadded();
+  return mlir::cast<UnionType>(*this).getPadded();
+}
+bool RecordType::isClass() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.isClass();
+  return false;
+}
+bool RecordType::isStruct() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.isStruct();
+  return false;
+}
+std::string RecordType::getKindAsStr() const {
+  if (mlir::isa<UnionType>(*this))
+    return "union";
+  return mlir::cast<StructType>(*this).getKindAsStr();
+}
+std::string RecordType::getPrefixedName() const {
+  return getKindAsStr() + "." + getName().getValue().str();
+}
+void RecordType::complete(ArrayRef<Type> members, bool packed, bool padded,
+                          mlir::Type padding) {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.complete(members, packed, padded, padding);
+  return mlir::cast<UnionType>(*this).complete(members, packed, padded,
+                                               padding);
+}
+uint64_t RecordType::getElementOffset(const mlir::DataLayout &dataLayout,
+                                      unsigned idx) const {
+  if (mlir::isa<UnionType>(*this))
+    return 0;
+  return mlir::cast<StructType>(*this).getElementOffset(dataLayout, idx);
+}
+bool RecordType::isLayoutIdentical(const RecordType &other) {
+  if (auto s = mlir::dyn_cast<StructType>(*this)) {
+    if (auto so = mlir::dyn_cast<StructType>(other))
+      return s.isLayoutIdentical(so);
+    return false;
+  }
+  if (auto u = mlir::dyn_cast<UnionType>(*this)) {
+    if (auto uo = mlir::dyn_cast<UnionType>(other))
+      return u.isLayoutIdentical(uo);
+    return false;
+  }
+  return false;
+}
+bool RecordType::isABIConvertedRecord() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.isABIConvertedRecord();
+  return mlir::cast<UnionType>(*this).isABIConvertedRecord();
+}
+mlir::StringAttr RecordType::getABIConvertedName() const {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.getABIConvertedName();
+  return mlir::cast<UnionType>(*this).getABIConvertedName();
+}
+void RecordType::removeABIConversionNamePrefix() {
+  if (auto s = mlir::dyn_cast<StructType>(*this))
+    return s.removeABIConversionNamePrefix();
+  return mlir::cast<UnionType>(*this).removeABIConversionNamePrefix();
 }
 
 //===----------------------------------------------------------------------===//
@@ -385,53 +617,49 @@ PointerType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
 }
 
 llvm::TypeSize
-RecordType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
+StructType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
                               mlir::DataLayoutEntryListRef params) const {
-  if (isUnion()) {
-    mlir::Type largest = getLargestMember(dataLayout);
-    if (!largest)
-      return llvm::TypeSize::getFixed(0);
-    // `getLargestMember` returns the highest-aligned variant (which dictates
-    // the union's alignment), not necessarily the largest by size.  When the
-    // union is `padded` -- i.e., its highest-aligned variant is strictly
-    // smaller than its layout size, as happens for any union containing both
-    // a small high-alignment scalar and a larger low-alignment array (e.g.,
-    // `union { char[16]; size_t; }`) -- `lowerUnion` appended a trailing
-    // byte-array member to extend the highest-aligned variant up to the
-    // layout size, and `LowerToLLVM` mirrors this by emitting the union as
-    // `{largest, padding}`.  Include that padding here so `getTypeSize`
-    // reports the same size `LowerToLLVM` produces; otherwise a parent
-    // record containing the union gets a spurious tail-padding member added
-    // by `insertPadding`, making `sizeof(parent)` and array GEPs off by the
-    // missing bytes.
-    llvm::TypeSize size = dataLayout.getTypeSizeInBits(largest);
-    if (mlir::Type tailPad = getPadding())
-      size += dataLayout.getTypeSizeInBits(tailPad);
-    return size;
-  }
-
   auto recordSize = static_cast<uint64_t>(computeStructSize(dataLayout));
   return llvm::TypeSize::getFixed(recordSize * 8);
 }
 
 uint64_t
-RecordType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
+StructType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
                             ::mlir::DataLayoutEntryListRef params) const {
-  if (isUnion()) {
-    mlir::Type largest = getLargestMember(dataLayout);
-    if (!largest)
-      return 1;
-    return dataLayout.getTypeABIAlignment(largest);
-  }
-
   // Packed structures always have an ABI alignment of 1.
   if (getPacked())
     return 1;
   return computeStructAlignment(dataLayout);
 }
 
+llvm::TypeSize
+UnionType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
+                             mlir::DataLayoutEntryListRef params) const {
+  mlir::Type storage = getUnionStorageType(dataLayout);
+  if (!storage)
+    return llvm::TypeSize::getFixed(0);
+  // The padding field holds enough bytes to bring the total up to the AST
+  // layout size (set by lowerUnion from the ASTRecordLayout).  Include it so
+  // getTypeSize agrees with the {storage, padding} LLVM struct that
+  // LowerToLLVM emits; without it a containing record adds spurious tail
+  // padding via insertPadding, making sizeof and array GEPs wrong.
+  llvm::TypeSize size = dataLayout.getTypeSizeInBits(storage);
+  if (mlir::Type pad = getPadding())
+    size += dataLayout.getTypeSizeInBits(pad);
+  return size;
+}
+
+uint64_t
+UnionType::getABIAlignment(const ::mlir::DataLayout &dataLayout,
+                           ::mlir::DataLayoutEntryListRef params) const {
+  mlir::Type storage = getUnionStorageType(dataLayout);
+  if (!storage)
+    return 1;
+  return dataLayout.getTypeABIAlignment(storage);
+}
+
 unsigned
-RecordType::computeStructSize(const mlir::DataLayout &dataLayout) const {
+StructType::computeStructSize(const mlir::DataLayout &dataLayout) const {
   assert(isComplete() && "Cannot get layout of incomplete records");
 
   // This is a similar algorithm to LLVM's StructLayout.
@@ -445,12 +673,12 @@ RecordType::computeStructSize(const mlir::DataLayout &dataLayout) const {
         (getPacked() ? 1 : dataLayout.getTypeABIAlignment(ty));
 
     // Add padding to the struct size to align it to the abi alignment of the
-    // element type before than adding the size of the element.
+    // element type before adding the size of the element.
     recordSize = llvm::alignTo(recordSize, tyAlign);
     recordSize += dataLayout.getTypeSize(ty);
 
-    // The alignment requirement of a struct is equal to the strictest alignment
-    // requirement of its elements.
+    // The alignment requirement of a struct is equal to the strictest
+    // alignment requirement of its elements.
     recordAlignment = std::max(tyAlign, recordAlignment);
   }
 
@@ -461,7 +689,7 @@ RecordType::computeStructSize(const mlir::DataLayout &dataLayout) const {
 }
 
 unsigned
-RecordType::computeStructDataSize(const mlir::DataLayout &dataLayout) const {
+StructType::computeStructDataSize(const mlir::DataLayout &dataLayout) const {
   assert(isComplete() && "Cannot get layout of incomplete records");
 
   // Compute the data size (excluding tail padding) for this record type. For
@@ -485,27 +713,23 @@ RecordType::computeStructDataSize(const mlir::DataLayout &dataLayout) const {
 
 // We also compute the alignment as part of computeStructSize, but this is more
 // efficient. Ideally, we'd like to compute both at once and cache the result,
-// but that's implemented yet.
+// but that's not implemented yet.
 // TODO(CIR): Implement a way to cache the result.
 uint64_t
-RecordType::computeStructAlignment(const mlir::DataLayout &dataLayout) const {
+StructType::computeStructAlignment(const mlir::DataLayout &dataLayout) const {
   assert(isComplete() && "Cannot get layout of incomplete records");
 
-  // This is a similar algorithm to LLVM's StructLayout.
   uint64_t recordAlignment = 1;
   for (mlir::Type ty : getMembers())
     recordAlignment =
         std::max(dataLayout.getTypeABIAlignment(ty), recordAlignment);
-
   return recordAlignment;
 }
 
-uint64_t RecordType::getElementOffset(const ::mlir::DataLayout &dataLayout,
+uint64_t StructType::getElementOffset(const ::mlir::DataLayout &dataLayout,
                                       unsigned idx) const {
   assert(idx < getMembers().size() && "access not valid");
-
-  // All union elements are at offset zero.
-  if (isUnion() || idx == 0)
+  if (idx == 0)
     return 0;
 
   assert(isComplete() && "Cannot get layout of incomplete records");
@@ -513,26 +737,17 @@ uint64_t RecordType::getElementOffset(const ::mlir::DataLayout &dataLayout,
   llvm::ArrayRef<mlir::Type> members = getMembers();
 
   unsigned offset = 0;
-
   for (mlir::Type ty :
        llvm::make_range(members.begin(), std::next(members.begin(), idx))) {
-    // This matches LLVM since it uses the ABI instead of preferred alignment.
     const llvm::Align tyAlign =
         llvm::Align(getPacked() ? 1 : dataLayout.getTypeABIAlignment(ty));
-
-    // Add padding if necessary to align the data element properly.
     offset = llvm::alignTo(offset, tyAlign);
-
-    // Consume space for this data item
     offset += dataLayout.getTypeSize(ty);
   }
 
-  // Account for padding, if necessary, for the alignment of the field whose
-  // offset we are calculating.
   const llvm::Align tyAlign = llvm::Align(
       getPacked() ? 1 : dataLayout.getTypeABIAlignment(members[idx]));
   offset = llvm::alignTo(offset, tyAlign);
-
   return offset;
 }
 
@@ -857,8 +1072,8 @@ static mlir::Type getMethodLayoutType(mlir::MLIRContext *ctx) {
   // TODO: consider member function pointer layout in other ABIs
   auto voidPtrTy = cir::PointerType::get(cir::VoidType::get(ctx));
   mlir::Type fields[2]{voidPtrTy, voidPtrTy};
-  return cir::RecordType::get(ctx, fields, /*packed=*/false,
-                              /*padded=*/false, cir::RecordType::Struct);
+  return cir::StructType::get(ctx, fields, /*packed=*/false,
+                              /*padded=*/false, /*is_class=*/false);
 }
 
 llvm::TypeSize
@@ -870,7 +1085,7 @@ MethodType::getTypeSizeInBits(const mlir::DataLayout &dataLayout,
 uint64_t
 MethodType::getABIAlignment(const mlir::DataLayout &dataLayout,
                             mlir::DataLayoutEntryListRef params) const {
-  return cast<cir::RecordType>(getMethodLayoutType(getContext()))
+  return cast<cir::StructType>(getMethodLayoutType(getContext()))
       .getABIAlignment(dataLayout, params);
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -192,12 +192,12 @@ Type StructType::parse(mlir::AsmParser &parser) {
     type = StructType::getChecked(eLoc, context, name, is_class);
   } else if (!name && !incomplete) {
     type = StructType::getChecked(eLoc, context, membersRef, packed, padded,
-                                  is_class, mlir::Type{});
+                                  is_class);
     if (!type)
       return {};
   } else if (!incomplete) {
     type = StructType::getChecked(eLoc, context, membersRef, name, packed,
-                                  padded, is_class, mlir::Type{});
+                                  padded, is_class);
     if (!type)
       return {};
     if (auto structTy = mlir::dyn_cast<StructType>(type))
@@ -247,12 +247,9 @@ void StructType::print(mlir::AsmPrinter &printer) const {
 mlir::LogicalResult
 StructType::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
                    llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                   bool incomplete, bool packed, bool padded, bool is_class,
-                   mlir::Type padding) {
+                   bool incomplete, bool packed, bool padded, bool is_class) {
   if (name && name.getValue().empty())
     return emitError() << "identified records cannot have an empty name";
-  if (padding)
-    return emitError() << "padding is not supported on struct/class types";
   return mlir::success();
 }
 
@@ -267,7 +264,6 @@ bool StructType::getIncomplete() const { return getImpl()->incomplete; }
 bool StructType::getPacked() const { return getImpl()->packed; }
 bool StructType::getPadded() const { return getImpl()->padded; }
 bool StructType::getIsClass() const { return getImpl()->is_class; }
-mlir::Type StructType::getPadding() const { return getImpl()->padding; }
 
 bool StructType::isABIConvertedRecord() const {
   return getName() && getName().getValue().starts_with(abi_conversion_prefix);
@@ -287,10 +283,9 @@ void StructType::removeABIConversionNamePrefix() {
         recordName.getType());
 }
 
-void StructType::complete(ArrayRef<Type> members, bool packed, bool padded,
-                          mlir::Type padding) {
+void StructType::complete(ArrayRef<Type> members, bool packed, bool padded) {
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  if (mutate(members, packed, padded, padding).failed())
+  if (mutate(members, packed, padded, /*padding=*/mlir::Type{}).failed())
     llvm_unreachable("failed to complete struct");
 }
 
@@ -311,7 +306,6 @@ Type UnionType::parse(mlir::AsmParser &parser) {
   const llvm::SMLoc loc = parser.getCurrentLocation();
   const mlir::Location eLoc = parser.getEncodedSourceLoc(loc);
   bool packed = false;
-  bool padded = false;
   mlir::Type padding;
   mlir::MLIRContext *context = parser.getContext();
 
@@ -344,8 +338,8 @@ Type UnionType::parse(mlir::AsmParser &parser) {
   if (parser.parseOptionalKeyword("packed").succeeded())
     packed = true;
 
-  if (parser.parseOptionalKeyword("padded").succeeded())
-    padded = true;
+  // "padded" is accepted for backward compatibility but derived from padding.
+  (void)parser.parseOptionalKeyword("padded");
 
   bool incomplete = true;
   llvm::SmallVector<mlir::Type> members;
@@ -381,18 +375,17 @@ Type UnionType::parse(mlir::AsmParser &parser) {
   if (name && incomplete) {
     type = UnionType::getChecked(eLoc, context, name);
   } else if (!name && !incomplete) {
-    type = UnionType::getChecked(eLoc, context, membersRef, packed, padded,
-                                 padding);
+    type = UnionType::getChecked(eLoc, context, membersRef, packed, padding);
     if (!type)
       return {};
   } else if (!incomplete) {
-    type = UnionType::getChecked(eLoc, context, membersRef, name, packed,
-                                 padded, padding);
+    type =
+        UnionType::getChecked(eLoc, context, membersRef, name, packed, padding);
     if (!type)
       return {};
     if (auto unionTy = mlir::dyn_cast<UnionType>(type))
       if (unionTy.isIncomplete())
-        unionTy.complete(membersRef, packed, padded, padding);
+        unionTy.complete(membersRef, packed, padding);
     assert(!cir::MissingFeatures::astRecordDeclAttr());
   } else {
     parser.emitError(loc, "anonymous records must be complete");
@@ -439,14 +432,9 @@ void UnionType::print(mlir::AsmPrinter &printer) const {
 mlir::LogicalResult
 UnionType::verify(function_ref<mlir::InFlightDiagnostic()> emitError,
                   llvm::ArrayRef<mlir::Type> members, mlir::StringAttr name,
-                  bool incomplete, bool packed, bool padded,
-                  mlir::Type padding) {
+                  bool incomplete, bool packed, mlir::Type padding) {
   if (name && name.getValue().empty())
     return emitError() << "identified records cannot have an empty name";
-  if (padding && !padded)
-    return emitError() << "padded keyword required when padding is set";
-  if (padded && !padding)
-    return emitError() << "padded unions must specify a padding type";
   return mlir::success();
 }
 
@@ -458,7 +446,7 @@ mlir::StringAttr UnionType::getName() const { return getImpl()->name; }
 bool UnionType::isIncomplete() const { return getImpl()->incomplete; }
 bool UnionType::getIncomplete() const { return getImpl()->incomplete; }
 bool UnionType::getPacked() const { return getImpl()->packed; }
-bool UnionType::getPadded() const { return getImpl()->padded; }
+bool UnionType::getPadded() const { return !!getPadding(); }
 mlir::Type UnionType::getPadding() const { return getImpl()->padding; }
 
 bool UnionType::isABIConvertedRecord() const {
@@ -479,10 +467,10 @@ void UnionType::removeABIConversionNamePrefix() {
         recordName.getType());
 }
 
-void UnionType::complete(ArrayRef<Type> members, bool packed, bool padded,
+void UnionType::complete(ArrayRef<Type> members, bool packed,
                          mlir::Type padding) {
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  if (mutate(members, packed, padded, padding).failed())
+  if (mutate(members, packed, /*padded=*/!!padding, padding).failed())
     llvm_unreachable("failed to complete union");
 }
 
@@ -504,7 +492,8 @@ UnionType::getUnionStorageType(const mlir::DataLayout &dataLayout) const {
 bool UnionType::isLayoutIdentical(const UnionType &other) {
   if (getImpl() == other.getImpl())
     return true;
-  return getMembers() == other.getMembers();
+  return getMembers() == other.getMembers() &&
+         getPadding() == other.getPadding();
 }
 
 //===----------------------------------------------------------------------===//
@@ -557,9 +546,8 @@ std::string RecordType::getPrefixedName() const {
 void RecordType::complete(ArrayRef<Type> members, bool packed, bool padded,
                           mlir::Type padding) {
   if (auto s = mlir::dyn_cast<StructType>(*this))
-    return s.complete(members, packed, padded, padding);
-  return mlir::cast<UnionType>(*this).complete(members, packed, padded,
-                                               padding);
+    return s.complete(members, packed, padded);
+  return mlir::cast<UnionType>(*this).complete(members, packed, padding);
 }
 uint64_t RecordType::getElementOffset(const mlir::DataLayout &dataLayout,
                                       unsigned idx) const {

--- a/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRTypes.cpp
@@ -312,7 +312,7 @@ void StructType::removeABIConversionNamePrefix() {
 
 void StructType::complete(ArrayRef<Type> members, bool packed, bool padded) {
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  if (mutate(members, packed, padded, /*padding=*/mlir::Type{}).failed())
+  if (mutate(members, packed, padded).failed())
     llvm_unreachable("failed to complete struct");
 }
 
@@ -435,7 +435,7 @@ mlir::StringAttr UnionType::getName() const { return getImpl()->name; }
 bool UnionType::isIncomplete() const { return getImpl()->incomplete; }
 bool UnionType::getIncomplete() const { return getImpl()->incomplete; }
 bool UnionType::getPacked() const { return getImpl()->packed; }
-bool UnionType::getPadded() const { return static_cast<bool>(getPadding()); }
+bool UnionType::getPadded() const { return getPadding() ? true : false; }
 mlir::Type UnionType::getPadding() const { return getImpl()->padding; }
 
 bool UnionType::isABIConvertedRecord() const {
@@ -459,7 +459,7 @@ void UnionType::removeABIConversionNamePrefix() {
 void UnionType::complete(ArrayRef<Type> members, bool packed,
                          mlir::Type padding) {
   assert(!cir::MissingFeatures::astRecordDeclAttr());
-  if (mutate(members, packed, /*padded=*/false, padding).failed())
+  if (mutate(members, packed, padding).failed())
     llvm_unreachable("failed to complete union");
 }
 
@@ -536,8 +536,9 @@ void RecordType::complete(ArrayRef<Type> members, bool packed, bool padded,
                           mlir::Type padding) {
   if (auto s = mlir::dyn_cast<StructType>(*this))
     return s.complete(members, packed, padded);
-  // For unions, padded is derived from padding; assert the caller is consistent.
-  assert((!padded || padding) && "padded=true requires a non-null padding type");
+  // Unions derive padded from padding; assert the caller is consistent.
+  assert((!padded || padding) &&
+         "padded=true requires a non-null padding type");
   return mlir::cast<UnionType>(*this).complete(members, packed, padding);
 }
 uint64_t RecordType::getElementOffset(const mlir::DataLayout &dataLayout,

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -847,8 +847,7 @@ class CIRABITypeConverter : public mlir::TypeConverter {
         if (mlir::Type pad = u.getPadding())
           loweredPadding = convertType(pad);
         return cir::UnionType::get(type.getContext(), converted,
-                                   type.getPacked(), type.getPadded(),
-                                   loweredPadding);
+                                   type.getPacked(), loweredPadding);
       }
       auto s = mlir::cast<cir::StructType>(type);
       return cir::StructType::get(type.getContext(), converted,

--- a/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CXXABILowering.cpp
@@ -441,7 +441,10 @@ static mlir::TypedAttr lowerInitialValue(const LowerModule *lowerModule,
   }
 
   if (auto recordTy = mlir::dyn_cast<cir::RecordType>(ty)) {
-    auto convertedTy = mlir::cast<cir::RecordType>(tc.convertType(recordTy));
+    auto convertedTy =
+        mlir::dyn_cast<cir::RecordType>(tc.convertType(recordTy));
+    if (!convertedTy)
+      return {};
 
     if (auto recVal = mlir::dyn_cast_if_present<cir::ZeroAttr>(initVal))
       return cir::ZeroAttr::get(convertedTy);
@@ -837,10 +840,21 @@ class CIRABITypeConverter : public mlir::TypeConverter {
     // Unnamed record types can't be referred to recursively, so we can just
     // convert this one. It also doesn't have uniqueness problems, so we can
     // just do a conversion on it.
-    if (!type.getName())
-      return cir::RecordType::get(
-          type.getContext(), convertRecordMemberTypes(type), type.getPacked(),
-          type.getPadded(), type.getKind());
+    if (!type.getName()) {
+      llvm::SmallVector<mlir::Type> converted = convertRecordMemberTypes(type);
+      if (auto u = mlir::dyn_cast<cir::UnionType>(type)) {
+        mlir::Type loweredPadding;
+        if (mlir::Type pad = u.getPadding())
+          loweredPadding = convertType(pad);
+        return cir::UnionType::get(type.getContext(), converted,
+                                   type.getPacked(), type.getPadded(),
+                                   loweredPadding);
+      }
+      auto s = mlir::cast<cir::StructType>(type);
+      return cir::StructType::get(type.getContext(), converted,
+                                  type.getPacked(), type.getPadded(),
+                                  s.getIsClass());
+    }
 
     assert(!type.isIncomplete() || type.getMembers().empty());
 
@@ -853,8 +867,14 @@ class CIRABITypeConverter : public mlir::TypeConverter {
     SmallVectorImpl<cir::RecordType> &recursiveStack =
         getCurrentThreadRecursiveStack();
 
-    auto convertedType = cir::RecordType::get(
-        type.getContext(), type.getABIConvertedName(), type.getKind());
+    cir::RecordType convertedType;
+    if (mlir::isa<cir::UnionType>(type))
+      convertedType =
+          cir::UnionType::get(type.getContext(), type.getABIConvertedName());
+    else
+      convertedType =
+          cir::StructType::get(type.getContext(), type.getABIConvertedName(),
+                               mlir::cast<cir::StructType>(type).getIsClass());
 
     // This type has already been converted, just return it.
     if (convertedType.isComplete())
@@ -873,8 +893,12 @@ class CIRABITypeConverter : public mlir::TypeConverter {
 
     SmallVector<mlir::Type> convertedMembers = convertRecordMemberTypes(type);
 
-    convertedType.complete(convertedMembers, type.getPacked(),
-                           type.getPadded());
+    mlir::Type loweredPadding;
+    if (auto u = mlir::dyn_cast<cir::UnionType>(type))
+      if (mlir::Type pad = u.getPadding())
+        loweredPadding = convertType(pad);
+    convertedType.complete(convertedMembers, type.getPacked(), type.getPadded(),
+                           loweredPadding);
     addConvertedRecordType(convertedType);
     return convertedType;
   }
@@ -925,7 +949,10 @@ public:
       return cir::FuncType::get(loweredInputTypes, loweredReturnType,
                                 /*isVarArg=*/type.getVarArg());
     });
-    addConversion([&](cir::RecordType type) -> mlir::Type {
+    addConversion([&](cir::StructType type) -> mlir::Type {
+      return convertRecordType(type);
+    });
+    addConversion([&](cir::UnionType type) -> mlir::Type {
       return convertRecordType(type);
     });
   }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -2380,9 +2380,9 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
 
   // Create the fatbin wrapper struct:
   //    struct { int magic; int version; void *fatbin; void *unused; };
-  auto fatbinWrapperType = RecordType::get(
+  auto fatbinWrapperType = cir::StructType::get(
       &getContext(), {intTy, intTy, voidPtrTy, voidPtrTy},
-      /*packed=*/false, /*padded=*/false, RecordType::RecordKind::Struct);
+      /*packed=*/false, /*padded=*/false, /*is_class=*/false);
   std::string fatbinWrapperName =
       addUnderscoredPrefix(cudaPrefix, "_fatbin_wrapper");
   GlobalOp fatbinWrapper = GlobalOp::create(

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerItaniumCXXABI.cpp
@@ -186,9 +186,9 @@ mlir::Type LowerItaniumCXXABI::lowerMethodType(
 
   // Note that clang CodeGen emits struct{ptrdiff_t, ptrdiff_t} for member
   // function pointers. Let's follow this approach.
-  return cir::RecordType::get(type.getContext(), {ptrdiffCIRTy, ptrdiffCIRTy},
+  return cir::StructType::get(type.getContext(), {ptrdiffCIRTy, ptrdiffCIRTy},
                               /*packed=*/false, /*padded=*/false,
-                              cir::RecordType::Struct);
+                              /*is_class=*/false);
 }
 
 mlir::TypedAttr LowerItaniumCXXABI::lowerDataMemberConstant(
@@ -217,10 +217,7 @@ mlir::TypedAttr LowerItaniumCXXABI::lowerMethodConstant(
     const mlir::TypeConverter &typeConverter) const {
   cir::IntType ptrdiffCIRTy = getPtrDiffCIRTy(lm);
 
-  // lowerMethodType returns the CIR type used to represent the method pointer
-  // in an ABI-specific way. That's why lowerMethodType returns cir::RecordType
-  // here.
-  auto loweredMethodTy = mlir::cast<cir::RecordType>(
+  auto loweredMethodTy = mlir::cast<cir::StructType>(
       lowerMethodType(attr.getType(), typeConverter));
 
   auto zero = cir::IntAttr::get(ptrdiffCIRTy, 0);

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2033,7 +2033,7 @@ mlir::LogicalResult CIRToLLVMConstantOpLowering::matchAndRewrite(
     rewriter.replaceOp(op, lowerCirAttrAsValue(op, op.getValue(), rewriter,
                                                getTypeConverter()));
     return mlir::success();
-  } else if (auto recTy = mlir::dyn_cast<cir::RecordType>(op.getType())) {
+  } else if (mlir::isa<cir::RecordType>(op.getType())) {
     if (mlir::isa<cir::ZeroAttr, cir::UndefAttr>(attr)) {
       mlir::Value initVal =
           lowerCirAttrAsValue(op, attr, rewriter, typeConverter);
@@ -3288,42 +3288,43 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
     auto varArg = type.isVarArg();
     return mlir::LLVM::LLVMFunctionType::get(result, arguments, varArg);
   });
-  converter.addConversion([&](cir::RecordType type) -> mlir::Type {
-    // Convert struct members.
+  converter.addConversion([&](cir::StructType type) -> mlir::Type {
     llvm::SmallVector<mlir::Type> llvmMembers;
-    switch (type.getKind()) {
-    case cir::RecordType::Class:
-    case cir::RecordType::Struct:
-      for (mlir::Type ty : type.getMembers())
-        llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, ty));
-      break;
-    // Unions are lowered as only the largest member.
-    case cir::RecordType::Union:
-      if (type.getMembers().empty())
-        break;
-      if (auto largestMember = type.getLargestMember(dataLayout))
-        llvmMembers.push_back(
-            convertTypeForMemory(converter, dataLayout, largestMember));
-      if (type.getPadded()) {
-        auto last = *type.getMembers().rbegin();
-        llvmMembers.push_back(
-            convertTypeForMemory(converter, dataLayout, last));
-      }
-      break;
-    }
+    for (mlir::Type ty : type.getMembers())
+      llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, ty));
 
-    // Record has a name: lower as an identified record.
     mlir::LLVM::LLVMStructType llvmStruct;
     if (type.getName()) {
       llvmStruct = mlir::LLVM::LLVMStructType::getIdentified(
           type.getContext(), type.getPrefixedName());
       if (llvmStruct.setBody(llvmMembers, type.getPacked()).failed())
         llvm_unreachable("Failed to set body of record");
-    } else { // Record has no name: lower as literal record.
+    } else {
       llvmStruct = mlir::LLVM::LLVMStructType::getLiteral(
           type.getContext(), llvmMembers, type.getPacked());
     }
+    return llvmStruct;
+  });
+  // Unions are lowered as only the largest member.
+  converter.addConversion([&](cir::UnionType type) -> mlir::Type {
+    llvm::SmallVector<mlir::Type> llvmMembers;
+    if (!type.getMembers().empty())
+      if (auto storage = type.getUnionStorageType(dataLayout))
+        llvmMembers.push_back(
+            convertTypeForMemory(converter, dataLayout, storage));
+    if (mlir::Type pad = type.getPadding())
+      llvmMembers.push_back(convertTypeForMemory(converter, dataLayout, pad));
 
+    mlir::LLVM::LLVMStructType llvmStruct;
+    if (type.getName()) {
+      llvmStruct = mlir::LLVM::LLVMStructType::getIdentified(
+          type.getContext(), type.getPrefixedName());
+      if (llvmStruct.setBody(llvmMembers, type.getPacked()).failed())
+        llvm_unreachable("Failed to set body of record");
+    } else {
+      llvmStruct = mlir::LLVM::LLVMStructType::getLiteral(
+          type.getContext(), llvmMembers, type.getPacked());
+    }
     return llvmStruct;
   });
   converter.addConversion([&](cir::VoidType type) -> mlir::Type {
@@ -3772,34 +3773,30 @@ mlir::LogicalResult CIRToLLVMGetMemberOpLowering::matchAndRewrite(
     cir::GetMemberOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   mlir::Type llResTy = getTypeConverter()->convertType(op.getType());
-  const auto recordTy =
-      mlir::cast<cir::RecordType>(op.getAddrTy().getPointee());
-  assert(recordTy && "expected record type");
+  mlir::Type pointee = op.getAddrTy().getPointee();
 
-  switch (recordTy.getKind()) {
-  case cir::RecordType::Class:
-  case cir::RecordType::Struct: {
-    // Since the base address is a pointer to an aggregate, the first offset
-    // is always zero. The second offset tell us which member it will access.
-    llvm::SmallVector<mlir::LLVM::GEPArg, 2> offset{0, op.getIndex()};
-    const mlir::Type elementTy = getTypeConverter()->convertType(recordTy);
-    // Struct member accesses are always inbounds and nuw: the base pointer
-    // is valid and the member offset is a positive, constant offset within
-    // the struct layout, so it cannot wrap. This matches LLVM's
-    // IRBuilder::CreateStructGEP.
-    mlir::LLVM::GEPNoWrapFlags flags =
-        mlir::LLVM::GEPNoWrapFlags::inbounds | mlir::LLVM::GEPNoWrapFlags::nuw;
-    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
-        op, llResTy, elementTy, adaptor.getAddr(), offset, flags);
-    return mlir::success();
-  }
-  case cir::RecordType::Union:
+  if (mlir::isa<cir::UnionType>(pointee)) {
     // Union members share the address space, so we just need a bitcast to
     // conform to type-checking.
     rewriter.replaceOpWithNewOp<mlir::LLVM::BitcastOp>(op, llResTy,
                                                        adaptor.getAddr());
     return mlir::success();
   }
+
+  auto structTy = mlir::cast<cir::StructType>(pointee);
+  // Since the base address is a pointer to an aggregate, the first offset
+  // is always zero. The second offset tells us which member it will access.
+  llvm::SmallVector<mlir::LLVM::GEPArg, 2> offset{0, op.getIndex()};
+  const mlir::Type elementTy = getTypeConverter()->convertType(structTy);
+  // Struct member accesses are always inbounds and nuw: the base pointer
+  // is valid and the member offset is a positive, constant offset within
+  // the struct layout, so it cannot wrap. This matches LLVM's
+  // IRBuilder::CreateStructGEP.
+  mlir::LLVM::GEPNoWrapFlags flags =
+      mlir::LLVM::GEPNoWrapFlags::inbounds | mlir::LLVM::GEPNoWrapFlags::nuw;
+  rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
+      op, llResTy, elementTy, adaptor.getAddr(), offset, flags);
+  return mlir::success();
 }
 
 mlir::LogicalResult CIRToLLVMExtractMemberOpLowering::matchAndRewrite(
@@ -3807,33 +3804,24 @@ mlir::LogicalResult CIRToLLVMExtractMemberOpLowering::matchAndRewrite(
     mlir::ConversionPatternRewriter &rewriter) const {
   std::int64_t indices[1] = {static_cast<std::int64_t>(op.getIndex())};
 
-  mlir::Type recordTy = op.getRecord().getType();
-  auto cirRecordTy = mlir::cast<cir::RecordType>(recordTy);
-  switch (cirRecordTy.getKind()) {
-  case cir::RecordType::Struct:
-  case cir::RecordType::Class:
-    rewriter.replaceOpWithNewOp<mlir::LLVM::ExtractValueOp>(
-        op, adaptor.getRecord(), indices);
-    return mlir::success();
-
-  case cir::RecordType::Union:
+  if (mlir::isa<cir::UnionType>(op.getRecord().getType())) {
     op.emitError("cir.extract_member cannot extract member from a union");
     return mlir::failure();
   }
-  llvm_unreachable("Unexpected record kind");
+
+  rewriter.replaceOpWithNewOp<mlir::LLVM::ExtractValueOp>(
+      op, adaptor.getRecord(), indices);
+  return mlir::success();
 }
 
 mlir::LogicalResult CIRToLLVMInsertMemberOpLowering::matchAndRewrite(
     cir::InsertMemberOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   std::int64_t indecies[1] = {static_cast<std::int64_t>(op.getIndex())};
-  mlir::Type recordTy = op.getRecord().getType();
 
-  if (auto cirRecordTy = mlir::dyn_cast<cir::RecordType>(recordTy)) {
-    if (cirRecordTy.getKind() == cir::RecordType::Union) {
-      op.emitError("cir.update_member cannot update member of a union");
-      return mlir::failure();
-    }
+  if (mlir::isa<cir::UnionType>(op.getRecord().getType())) {
+    op.emitError("cir.update_member cannot update member of a union");
+    return mlir::failure();
   }
 
   rewriter.replaceOpWithNewOp<mlir::LLVM::InsertValueOp>(

--- a/clang/test/CIR/CodeGen/bitfield-union.c
+++ b/clang/test/CIR/CodeGen/bitfield-union.c
@@ -11,7 +11,7 @@ typedef union {
   int z : 8;
 } demo;
 
-// CIR:  !rec_demo = !cir.record<union "demo" {!s32i, !u8i, !u8i}>
+// CIR:  !rec_demo = !cir.union<"demo" {!s32i, !u8i, !u8i}>
 // LLVM: %union.demo = type { i32 }
 // OGCG: %union.demo = type { i32 }
 
@@ -22,7 +22,7 @@ typedef union {
   int z : 2;
 } zero_bit;
 
-// CIR:  !rec_zero_bit = !cir.record<union "zero_bit" {!s32i, !u8i, !u8i}>
+// CIR:  !rec_zero_bit = !cir.union<"zero_bit" {!s32i, !u8i, !u8i}>
 // LLVM: %union.zero_bit = type { i32 }
 // OGCG: %union.zero_bit = type { i32 }
 

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -12,7 +12,7 @@ typedef struct {
   unsigned still_more_bits : 7;
 } A;
 
-// CIR-DAG:  !rec_A = !cir.record<struct "A" packed padded {!s8i, !s8i, !s8i, !u16i, !cir.array<!u8i x 3>}>
+// CIR-DAG:  !rec_A = !cir.struct<"A" packed padded {!s8i, !s8i, !s8i, !u16i, !cir.array<!u8i x 3>}>
 // CIR-DAG:  #bfi_more_bits = #cir.bitfield_info<name = "more_bits", storage_type = !u16i, size = 4, offset = 3, is_signed = false>
 // LLVM-DAG: %struct.A = type <{ i8, i8, i8, i16, [3 x i8] }>
 // OGCG-DAG: %struct.A = type <{ i8, i8, i8, i16, [3 x i8] }>
@@ -23,7 +23,7 @@ typedef struct {
   int c;
 } D;
 
-// CIR-DAG:  !rec_D = !cir.record<struct "D" {!u16i, !s32i}>
+// CIR-DAG:  !rec_D = !cir.struct<"D" {!u16i, !s32i}>
 // LLVM-DAG: %struct.D = type { i16, i32 }
 // OGCG-DAG: %struct.D = type { i16, i32 }
 
@@ -36,7 +36,7 @@ typedef struct {
   unsigned f; // type other than int above, not a bitfield
 } S;
 // CIR-DAG:  #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u64i, size = 17, offset = 32, is_signed = true>
-// CIR-DAG:  !rec_S = !cir.record<struct "S" {!u64i, !u16i, !u32i}>
+// CIR-DAG:  !rec_S = !cir.struct<"S" {!u64i, !u16i, !u32i}>
 // LLVM-DAG: %struct.S = type { i64, i16, i32 }
 // OGCG-DAG: %struct.S = type { i64, i16, i32 }
 
@@ -45,7 +45,7 @@ typedef struct {
   unsigned b;
 } T;
 
-// CIR-DAG:  !rec_T = !cir.record<struct "T" {!u8i, !u32i}>
+// CIR-DAG:  !rec_T = !cir.struct<"T" {!u8i, !u32i}>
 // LLVM-DAG: %struct.T = type { i8, i32 }
 // OGCG-DAG: %struct.T = type { i8, i32 }
 
@@ -67,7 +67,7 @@ typedef struct {
     int l: 14;
 } U;
 
-// CIR-DAG:  !rec_U = !cir.record<struct "U" packed {!s8i, !s8i, !s8i, !u8i, !u64i}>
+// CIR-DAG:  !rec_U = !cir.struct<"U" packed {!s8i, !s8i, !s8i, !u8i, !u64i}>
 // LLVM-DAG: %struct.U = type <{ i8, i8, i8, i8, i64 }>
 // OGCG-DAG: %struct.U = type <{ i8, i8, i8, i8, i64 }>
 
@@ -77,7 +77,7 @@ typedef struct{
     int c: 30;
 } Clip;
 
-// CIR-DAG: !rec_Clip = !cir.record<struct "Clip" {!cir.array<!u8i x 3>, !s8i, !u32i}>
+// CIR-DAG: !rec_Clip = !cir.struct<"Clip" {!cir.array<!u8i x 3>, !s8i, !u32i}>
 // LLVM-DAG: %struct.Clip = type { [3 x i8], i8, i32 }
 // OGCG-DAG: %struct.Clip = type { [3 x i8], i8, i32 }
 

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -13,7 +13,7 @@ typedef struct {
   int e : 15;
   unsigned f; // type other than int above, not a bitfield
 } S;
-// CIR-DAG:  !rec_S = !cir.record<struct "S" {!u64i, !u16i, !u32i}>
+// CIR-DAG:  !rec_S = !cir.struct<"S" {!u64i, !u16i, !u32i}>
 // CIR-DAG:  #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u64i, size = 17, offset = 32, is_signed = true>
 // LLVM-DAG: %struct.S = type { i64, i16, i32 }
 // OGCG-DAG: %struct.S = type { i64, i16, i32 }
@@ -23,7 +23,7 @@ typedef struct {
   unsigned b;
 } T;
 
-// CIR-DAG:  !rec_T = !cir.record<struct "T" {!u8i, !u32i}>
+// CIR-DAG:  !rec_T = !cir.struct<"T" {!u8i, !u32i}>
 // LLVM-DAG: %struct.T = type { i8, i32 }
 // OGCG-DAG: %struct.T = type { i8, i32 }
 

--- a/clang/test/CIR/CodeGen/bitfields_be.c
+++ b/clang/test/CIR/CodeGen/bitfields_be.c
@@ -11,7 +11,7 @@ typedef struct {
     int c : 17;
 } S;
 
-// CIR:  !rec_S = !cir.record<struct "S" {!u32i}>
+// CIR:  !rec_S = !cir.struct<"S" {!u32i}>
 // LLVM: %struct.S = type { i32 }
 // OGCG: %struct.S = type { i32 }
 void def() {

--- a/clang/test/CIR/CodeGen/class.cpp
+++ b/clang/test/CIR/CodeGen/class.cpp
@@ -5,10 +5,10 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=OGCG --input-file=%t.ll %s
 
-// CIR: !rec_IncompleteC = !cir.record<class "IncompleteC" incomplete>
-// CIR: !rec_Base = !cir.record<class "Base" {!s32i}>
-// CIR: !rec_CompleteC = !cir.record<class "CompleteC" {!s32i, !s8i}>
-// CIR: !rec_Derived = !cir.record<class "Derived" {!rec_Base, !s32i}>
+// CIR: !rec_IncompleteC = !cir.struct<class "IncompleteC" incomplete>
+// CIR: !rec_Base = !cir.struct<class "Base" {!s32i}>
+// CIR: !rec_CompleteC = !cir.struct<class "CompleteC" {!s32i, !s8i}>
+// CIR: !rec_Derived = !cir.struct<class "Derived" {!rec_Base, !s32i}>
 
 // Note: LLVM and OGCG do not emit the type for incomplete classes.
 

--- a/clang/test/CIR/CodeGen/cleanup.cpp
+++ b/clang/test/CIR/CodeGen/cleanup.cpp
@@ -5,7 +5,7 @@ struct Struk {
   ~Struk();
 };
 
-// CHECK: !rec_Struk = !cir.record<struct "Struk" padded {!u8i}>
+// CHECK: !rec_Struk = !cir.struct<"Struk" padded {!u8i}>
 
 // CHECK: cir.func{{.*}} @_ZN5StrukD1Ev(!cir.ptr<!rec_Struk> {{.*}})
 

--- a/clang/test/CIR/CodeGen/constant-inits.cpp
+++ b/clang/test/CIR/CodeGen/constant-inits.cpp
@@ -102,8 +102,8 @@ void function() {
 }
 
 // Anonymous struct type definitions for bitfields
-// CIR-DAG: !rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i, !u8i}>
-// CIR-DAG: !rec_anon_struct1 = !cir.record<struct  {!u8i, !u8i, !cir.array<!u8i x 2>}>
+// CIR-DAG: !rec_anon_struct = !cir.struct<{!u8i, !u8i, !u8i, !u8i}>
+// CIR-DAG: !rec_anon_struct1 = !cir.struct<{!u8i, !u8i, !cir.array<!u8i x 2>}>
 
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE1e = #cir.zero : !rec_empty
 // CIR-DAG: cir.global "private" constant internal dso_local @_ZZ8functionvE1s = #cir.const_record<{#cir.int<0> : !s32i, #cir.int<-1> : !s32i}> : !rec_simple

--- a/clang/test/CIR/CodeGen/coro-task.cpp
+++ b/clang/test/CIR/CodeGen/coro-task.cpp
@@ -121,15 +121,15 @@ co_invoke_fn co_invoke;
 
 }} // namespace folly::coro
 
-// CIR-DAG: ![[VoidTask:.*]] = !cir.record<struct "folly::coro::Task<void>" padded {!u8i}>
-// CIR-DAG: ![[IntTask:.*]] = !cir.record<struct "folly::coro::Task<int>" padded {!u8i}>
-// CIR-DAG: ![[VoidPromisse:.*]] = !cir.record<struct "folly::coro::Task<void>::promise_type" padded {!u8i}>
-// CIR-DAG: ![[IntPromisse:.*]] = !cir.record<struct "folly::coro::Task<int>::promise_type" padded {!u8i}>
-// CIR-DAG: ![[StdString:.*]] = !cir.record<struct "std::string" padded {!u8i}>
-// CIR-DAG: ![[CoroHandleVoid:.*]] = !cir.record<struct "std::coroutine_handle<void>" padded {!u8i}>
-// CIR-DAG: ![[CoroHandlePromiseVoid:rec_.*]]  = !cir.record<struct "std::coroutine_handle<folly::coro::Task<void>::promise_type>" padded {!u8i}>
-// CIR-DAG: ![[CoroHandlePromiseInt:rec_.*]] = !cir.record<struct "std::coroutine_handle<folly::coro::Task<int>::promise_type>" padded {!u8i}>
-// CIR-DAG: ![[SuspendAlways:.*]] = !cir.record<struct "std::suspend_always" padded {!u8i}>
+// CIR-DAG: ![[VoidTask:.*]] = !cir.struct<"folly::coro::Task<void>" padded {!u8i}>
+// CIR-DAG: ![[IntTask:.*]] = !cir.struct<"folly::coro::Task<int>" padded {!u8i}>
+// CIR-DAG: ![[VoidPromisse:.*]] = !cir.struct<"folly::coro::Task<void>::promise_type" padded {!u8i}>
+// CIR-DAG: ![[IntPromisse:.*]] = !cir.struct<"folly::coro::Task<int>::promise_type" padded {!u8i}>
+// CIR-DAG: ![[StdString:.*]] = !cir.struct<"std::string" padded {!u8i}>
+// CIR-DAG: ![[CoroHandleVoid:.*]] = !cir.struct<"std::coroutine_handle<void>" padded {!u8i}>
+// CIR-DAG: ![[CoroHandlePromiseVoid:rec_.*]]  = !cir.struct<"std::coroutine_handle<folly::coro::Task<void>::promise_type>" padded {!u8i}>
+// CIR-DAG: ![[CoroHandlePromiseInt:rec_.*]] = !cir.struct<"std::coroutine_handle<folly::coro::Task<int>::promise_type>" padded {!u8i}>
+// CIR-DAG: ![[SuspendAlways:.*]] = !cir.struct<"std::suspend_always" padded {!u8i}>
 
 // OGCG-DAG: %[[VoidPromisse:"struct.folly::coro::Task<void>::promise_type"]] = type { i8 }
 // OGCG-DAG: %[[VoidTask:"struct.folly::coro::Task"]] = type { i8 }

--- a/clang/test/CIR/CodeGen/ctor.cpp
+++ b/clang/test/CIR/CodeGen/ctor.cpp
@@ -10,7 +10,7 @@ void baz() {
   Struk s;
 }
 
-// CHECK: !rec_Struk = !cir.record<struct "Struk" {!s32i}>
+// CHECK: !rec_Struk = !cir.struct<"Struk" {!s32i}>
 
 // Note: In the absence of the '-mconstructor-aliases' option, we emit two
 //       constructors here. The handling of constructor aliases is currently

--- a/clang/test/CIR/CodeGen/cxx-abi-lowering-string-array.cpp
+++ b/clang/test/CIR/CodeGen/cxx-abi-lowering-string-array.cpp
@@ -20,7 +20,7 @@ const S g = { &B::y, "abc" };
 
 const S *get() { return &g; }
 
-// CIR: !rec_S = !cir.record<struct "S" {!s64i, !cir.array<!s8i x 32>}>
+// CIR: !rec_S = !cir.struct<"S" {!s64i, !cir.array<!s8i x 32>}>
 // CIR: cir.global {{.*}} @_ZL1g = #cir.const_record<{
 // CIR-SAME: #cir.int<4> : !s64i,
 // CIR-SAME: #cir.const_array<"abc" : !cir.array<!s8i x 3>, trailing_zeros> : !cir.array<!s8i x 32>

--- a/clang/test/CIR/CodeGen/destructors.cpp
+++ b/clang/test/CIR/CodeGen/destructors.cpp
@@ -16,7 +16,7 @@ out_of_line_destructor::~out_of_line_destructor() {
     some_function();
 }
 
-// CIR: !rec_out_of_line_destructor = !cir.record<struct "out_of_line_destructor" {!s32i}>
+// CIR: !rec_out_of_line_destructor = !cir.struct<"out_of_line_destructor" {!s32i}>
 
 // CIR: cir.func {{.*}} @_ZN22out_of_line_destructorD2Ev(%{{.+}}: !cir.ptr<!rec_out_of_line_destructor>
 // CIR:   cir.call @_Z13some_functionv() nothrow : () -> () 

--- a/clang/test/CIR/CodeGen/dumb-record.cpp
+++ b/clang/test/CIR/CodeGen/dumb-record.cpp
@@ -5,8 +5,8 @@ struct SimpleStruct {
   float b;
 } simple;
 // CHECK: Layout: <CIRecordLayout
-// CHECK: CIR Type:!cir.record<struct "SimpleStruct" {!cir.int<s, 32>, !cir.float}>
-// CHECK: NonVirtualBaseCIRType:!cir.record<struct "SimpleStruct" {!cir.int<s, 32>, !cir.float}>
+// CHECK: CIR Type:!cir.struct<"SimpleStruct" {!cir.int<s, 32>, !cir.float}>
+// CHECK: NonVirtualBaseCIRType:!cir.struct<"SimpleStruct" {!cir.int<s, 32>, !cir.float}>
 // CHECK: IsZeroInitializable:1
 // CHECK:   BitFields:[
 // CHECK: ]>
@@ -15,8 +15,8 @@ struct Empty {
 } empty;
 
 // CHECK: Layout: <CIRecordLayout
-// CHECK:  CIR Type:!cir.record<struct "Empty" padded {!cir.int<u, 8>}>
-// CHECK:  NonVirtualBaseCIRType:!cir.record<struct "Empty" padded {!cir.int<u, 8>}>
+// CHECK:  CIR Type:!cir.struct<"Empty" padded {!cir.int<u, 8>}>
+// CHECK:  NonVirtualBaseCIRType:!cir.struct<"Empty" padded {!cir.int<u, 8>}>
 // CHECK:  IsZeroInitializable:1
 // CHECK:  BitFields:[
 // CHECK:  ]>
@@ -30,8 +30,8 @@ struct BitfieldsInOrder {
 } bitfield_order;
 
 // CHECK: Layout: <CIRecordLayout
-// CHECK:  CIR Type:!cir.record<struct "BitfieldsInOrder" {!cir.int<s, 8>, !cir.int<u, 8>, !cir.int<u, 32>}>
-// CHECK:  NonVirtualBaseCIRType:!cir.record<struct "BitfieldsInOrder" {!cir.int<s, 8>, !cir.int<u, 8>, !cir.int<u, 32>}>
+// CHECK:  CIR Type:!cir.struct<"BitfieldsInOrder" {!cir.int<s, 8>, !cir.int<u, 8>, !cir.int<u, 32>}>
+// CHECK:  NonVirtualBaseCIRType:!cir.struct<"BitfieldsInOrder" {!cir.int<s, 8>, !cir.int<u, 8>, !cir.int<u, 32>}>
 // CHECK:  IsZeroInitializable:1
 // CHECK:  BitFields:[
 // CHECK-NEXT:   <CIRBitFieldInfo name:bit offset:0 size:8 isSigned:0 storageSize:8 storageOffset:1 volatileOffset:0 volatileStorageSize:0 volatileStorageOffset:0>

--- a/clang/test/CIR/CodeGen/dynamic-cast.cpp
+++ b/clang/test/CIR/CodeGen/dynamic-cast.cpp
@@ -13,8 +13,8 @@ struct Base {
 
 struct Derived : Base {};
 
-// CIR-BEFORE-DAG: !rec_Base = !cir.record
-// CIR-BEFORE-DAG: !rec_Derived = !cir.record
+// CIR-BEFORE-DAG: !rec_Base = !cir.struct
+// CIR-BEFORE-DAG: !rec_Derived = !cir.struct
 // CIR-BEFORE-DAG: #dyn_cast_info__ZTI4Base__ZTI7Derived = #cir.dyn_cast_info<src_rtti = #cir.global_view<@_ZTI4Base> : !cir.ptr<!u8i>, dest_rtti = #cir.global_view<@_ZTI7Derived> : !cir.ptr<!u8i>, runtime_func = @__dynamic_cast, bad_cast_func = @__cxa_bad_cast, offset_hint = #cir.int<0> : !s64i>
 
 Derived *ptr_cast(Base *b) {

--- a/clang/test/CIR/CodeGen/empty-union.c
+++ b/clang/test/CIR/CodeGen/empty-union.c
@@ -4,13 +4,13 @@
 
 // Empty union (no padding, size 0 in CIR)
 union Empty {};
-// CIR: !rec_Empty = !cir.record<union "Empty" {}>
+// CIR: !rec_Empty = !cir.union<"Empty" {}>
 // LLVM: %union.Empty = type {}
 // OGCG: %union.Empty = type {}
 
 // Aligned empty union (size 0, alignment 16)
 union EmptyAligned {} __attribute__((aligned(16)));
-// CIR: !rec_EmptyAligned = !cir.record<union "EmptyAligned" {}>
+// CIR: !rec_EmptyAligned = !cir.union<"EmptyAligned" {}>
 // LLVM: %union.EmptyAligned = type {}
 // OGCG: %union.EmptyAligned = type {}
 

--- a/clang/test/CIR/CodeGen/empty-union.cpp
+++ b/clang/test/CIR/CodeGen/empty-union.cpp
@@ -5,13 +5,13 @@
 // Padding-only union: CIR has no storage member and stores size in padding
 // field, so getUnionStorageType() is null and getABIAlignment returns 1.
 union Empty {};
-// CIR: !rec_Empty = !cir.union<"Empty" padded {}, padding = {!u8i}>
+// CIR: !rec_Empty = !cir.union<"Empty" {}, padding = {!u8i}>
 // LLVM-DAG: %union.Empty = type { i8 }
 // OGCG-DAG: %union.Empty = type { i8 }
 
 // Aligned empty union (should have aligned integer member in CIR)
 union alignas(16) EmptyAligned {};
-// CIR: !rec_EmptyAligned = !cir.union<"EmptyAligned" padded {}, padding = {!cir.array<!u8i x 16>}>
+// CIR: !rec_EmptyAligned = !cir.union<"EmptyAligned" {}, padding = {!cir.array<!u8i x 16>}>
 // LLVM-DAG: %union.EmptyAligned = type { [16 x i8] }
 // OGCG-DAG: %union.EmptyAligned = type { [16 x i8] }
 

--- a/clang/test/CIR/CodeGen/empty-union.cpp
+++ b/clang/test/CIR/CodeGen/empty-union.cpp
@@ -2,17 +2,16 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o - | FileCheck %s --check-prefix=LLVM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o - | FileCheck %s --check-prefix=OGCG
 
-// Padding-only union: CIR keeps only a tail pad member, so
-// getLargestMember() is null and getABIAlignment must not call
-// getTypeABIAlignment on null.
+// Padding-only union: CIR has no storage member and stores size in padding
+// field, so getUnionStorageType() is null and getABIAlignment returns 1.
 union Empty {};
-// CIR: !rec_Empty = !cir.record<union "Empty" padded {!u8i}>
+// CIR: !rec_Empty = !cir.union<"Empty" padded {}, padding = {!u8i}>
 // LLVM-DAG: %union.Empty = type { i8 }
 // OGCG-DAG: %union.Empty = type { i8 }
 
 // Aligned empty union (should have aligned integer member in CIR)
 union alignas(16) EmptyAligned {};
-// CIR: !rec_EmptyAligned = !cir.record<union "EmptyAligned" padded {!cir.array<!u8i x 16>}>
+// CIR: !rec_EmptyAligned = !cir.union<"EmptyAligned" padded {}, padding = {!cir.array<!u8i x 16>}>
 // LLVM-DAG: %union.EmptyAligned = type { [16 x i8] }
 // OGCG-DAG: %union.EmptyAligned = type { [16 x i8] }
 
@@ -27,8 +26,8 @@ struct WrapEmpty {
   int s;
 };
 WrapEmpty w;
-// CIR:      !rec_OuterWithEmpty = !cir.record<union "OuterWithEmpty" {!rec_Empty, !s32i}>
-// CIR:      !rec_WrapEmpty = !cir.record<struct "WrapEmpty" {!rec_OuterWithEmpty, !s32i}>
+// CIR:      !rec_OuterWithEmpty = !cir.union<"OuterWithEmpty" {!rec_Empty, !s32i}>
+// CIR:      !rec_WrapEmpty = !cir.struct<"WrapEmpty" {!rec_OuterWithEmpty, !s32i}>
 // CIR:      cir.global external @w = #cir.zero : !rec_WrapEmpty {alignment = 4 : i64}
 // LLVM-DAG: %struct.WrapEmpty = type { %union.OuterWithEmpty, i32 }
 // LLVM-DAG: %union.OuterWithEmpty = type { i32 }

--- a/clang/test/CIR/CodeGen/finegrain-bitfield-access.cpp
+++ b/clang/test/CIR/CodeGen/finegrain-bitfield-access.cpp
@@ -13,7 +13,7 @@ struct S1 {
   unsigned f5:8;
 };
 
-// CIR-DAG: !rec_S1 = !cir.record<struct "S1" {!u8i, !u8i, !u16i}>
+// CIR-DAG: !rec_S1 = !cir.struct<"S1" {!u8i, !u8i, !u16i}>
 // LLVM-DAG: %struct.S1 = type { i8, i8, i16 }
 // OGCG-DAG: %struct.S1 = type { i8, i8, i16 }
 
@@ -23,7 +23,7 @@ struct S2 {
   unsigned long f3:6;
 };
 
-// CIR-DAG: !rec_S2 = !cir.record<struct "S2" padded {!u16i, !u16i, !u8i, !cir.array<!u8i x 3>}>
+// CIR-DAG: !rec_S2 = !cir.struct<"S2" padded {!u16i, !u16i, !u8i, !cir.array<!u8i x 3>}>
 // LLVM-DAG: %struct.S2 = type { i16, i16, i8, [3 x i8] }
 // OGCG-DAG: %struct.S2 = type { i16, i16, i8, [3 x i8] }
 
@@ -33,7 +33,7 @@ struct S3 {
   unsigned long f3:32;
 };
 
-// CIR-DAG: !rec_S3 = !cir.record<struct "S3" {!u32i, !u32i}>
+// CIR-DAG: !rec_S3 = !cir.struct<"S3" {!u32i, !u32i}>
 // LLVM-DAG: %struct.S3 = type { i32, i32 }
 // OGCG-DAG: %struct.S3 = type { i32, i32 }
 

--- a/clang/test/CIR/CodeGen/forward-decls.cpp
+++ b/clang/test/CIR/CodeGen/forward-decls.cpp
@@ -9,7 +9,7 @@
 // Forward declaration of the record is never defined, so it is created as
 // an incomplete struct in CIR and will remain as such.
 
-// CHECK1: ![[INC_STRUCT:.+]] = !cir.record<struct "IncompleteStruct" incomplete>
+// CHECK1: ![[INC_STRUCT:.+]] = !cir.struct<"IncompleteStruct" incomplete>
 struct IncompleteStruct;
 // CHECK1: testIncompleteStruct(%arg0: !cir.ptr<![[INC_STRUCT]]>
 void testIncompleteStruct(struct IncompleteStruct *s) {};
@@ -24,7 +24,7 @@ void testIncompleteStruct(struct IncompleteStruct *s) {};
 // Foward declaration of the struct is followed by usage, then definition.
 // This means it will initially be created as incomplete, then completed.
 
-// CHECK2: ![[COMPLETE:.+]] = !cir.record<struct "ForwardDeclaredStruct" {!s32i}>
+// CHECK2: ![[COMPLETE:.+]] = !cir.struct<"ForwardDeclaredStruct" {!s32i}>
 // CHECK2: testForwardDeclaredStruct(%arg0: !cir.ptr<![[COMPLETE]]>
 struct ForwardDeclaredStruct;
 void testForwardDeclaredStruct(struct ForwardDeclaredStruct *fds) {};
@@ -42,7 +42,7 @@ struct ForwardDeclaredStruct {
 // Struct is initially forward declared since the self-reference is generated
 // first. Then, once the type is fully generated, it is completed.
 
-// CHECK3: ![[STRUCT:.+]] = !cir.record<struct "RecursiveStruct" {!s32i, !cir.ptr<!cir.record<struct "RecursiveStruct">>}>
+// CHECK3: ![[STRUCT:.+]] = !cir.struct<"RecursiveStruct" {!s32i, !cir.ptr<!cir.struct<"RecursiveStruct">>}>
 struct RecursiveStruct {
   int value;
   struct RecursiveStruct *next;
@@ -67,8 +67,8 @@ void testRecursiveStruct(struct RecursiveStruct *arg) {
 // in recursive type, each struct is expanded until there are no more recursive
 // types, or all the recursive types are self references.
 
-// CHECK4: ![[B:.+]] = !cir.record<struct "StructNodeB" {!s32i, !cir.ptr<!cir.record<struct "StructNodeA" {!s32i, !cir.ptr<!cir.record<struct "StructNodeB">>}
-// CHECK4: ![[A:.+]] = !cir.record<struct "StructNodeA" {!s32i, !cir.ptr<![[B]]>}>
+// CHECK4: ![[B:.+]] = !cir.struct<"StructNodeB" {!s32i, !cir.ptr<!cir.struct<"StructNodeA" {!s32i, !cir.ptr<!cir.struct<"StructNodeB">>}
+// CHECK4: ![[A:.+]] = !cir.struct<"StructNodeA" {!s32i, !cir.ptr<![[B]]>}>
 struct StructNodeB;
 struct StructNodeA {
   int value;
@@ -96,12 +96,12 @@ void testIndirectSelfReference(struct StructNodeA arg) {
 // RUN: FileCheck --check-prefix=CHECK5 --input-file=%t/complex_struct.cir %s
 
 // A sizeable complex struct just to double check that stuff is working.
-// CHECK5: !cir.record<struct "anon.0" {!cir.ptr<!cir.record<struct "A" {!cir.record<struct "anon.0">, !cir.record<struct "B" {!cir.ptr<!cir.record<struct "B">>, !cir.record<struct "C" {!cir.ptr<!cir.record<struct "A">>, !cir.ptr<!cir.record<struct "B">>, !cir.ptr<!cir.record<struct "C">>}>, !cir.record<union "anon.1" {!cir.ptr<!cir.record<struct "A">>, !cir.record<struct "anon.2" {!cir.ptr<!cir.record<struct "B">>}>}>}>}>>}>
-// CHECK5: !cir.record<struct "C" {!cir.ptr<!cir.record<struct "A" {!rec_anon2E0, !cir.record<struct "B" {!cir.ptr<!cir.record<struct "B">>, !cir.record<struct "C">, !cir.record<union "anon.1" {!cir.ptr<!cir.record<struct "A">>, !cir.record<struct "anon.2" {!cir.ptr<!cir.record<struct "B">>}>}>}>}>>, !cir.ptr<!cir.record<struct "B" {!cir.ptr<!cir.record<struct "B">>, !cir.record<struct "C">, !cir.record<union "anon.1" {!cir.ptr<!cir.record<struct "A" {!rec_anon2E0, !cir.record<struct "B">}>>, !cir.record<struct "anon.2" {!cir.ptr<!cir.record<struct "B">>}>}>}>>, !cir.ptr<!cir.record<struct "C">>}>
-// CHECK5: !cir.record<struct "anon.2" {!cir.ptr<!cir.record<struct "B" {!cir.ptr<!cir.record<struct "B">>, !rec_C, !cir.record<union "anon.1" {!cir.ptr<!cir.record<struct "A" {!rec_anon2E0, !cir.record<struct "B">}>>, !cir.record<struct "anon.2">}>}>>}>
-// CHECK5: !cir.record<union "anon.1" {!cir.ptr<!cir.record<struct "A" {!rec_anon2E0, !cir.record<struct "B" {!cir.ptr<!cir.record<struct "B">>, !rec_C, !cir.record<union "anon.1">}>}>>, !rec_anon2E2}>
-// CHECK5: !cir.record<struct "B" {!cir.ptr<!cir.record<struct "B">>, !rec_C, !rec_anon2E1}>
-// CHECK5: !cir.record<struct "A" {!rec_anon2E0, !rec_B}>
+// CHECK5: !cir.struct<"anon.0" {!cir.ptr<!cir.struct<"A" {!cir.struct<"anon.0">, !cir.struct<"B" {!cir.ptr<!cir.struct<"B">>, !cir.struct<"C" {!cir.ptr<!cir.struct<"A">>, !cir.ptr<!cir.struct<"B">>, !cir.ptr<!cir.struct<"C">>}>, !cir.union<"anon.1" {!cir.ptr<!cir.struct<"A">>, !cir.struct<"anon.2" {!cir.ptr<!cir.struct<"B">>}>}>}>}>>}>
+// CHECK5: !cir.struct<"C" {!cir.ptr<!cir.struct<"A" {!rec_anon2E0, !cir.struct<"B" {!cir.ptr<!cir.struct<"B">>, !cir.struct<"C">, !cir.union<"anon.1" {!cir.ptr<!cir.struct<"A">>, !cir.struct<"anon.2" {!cir.ptr<!cir.struct<"B">>}>}>}>}>>, !cir.ptr<!cir.struct<"B" {!cir.ptr<!cir.struct<"B">>, !cir.struct<"C">, !cir.union<"anon.1" {!cir.ptr<!cir.struct<"A" {!rec_anon2E0, !cir.struct<"B">}>>, !cir.struct<"anon.2" {!cir.ptr<!cir.struct<"B">>}>}>}>>, !cir.ptr<!cir.struct<"C">>}>
+// CHECK5: !cir.struct<"anon.2" {!cir.ptr<!cir.struct<"B" {!cir.ptr<!cir.struct<"B">>, !rec_C, !cir.union<"anon.1" {!cir.ptr<!cir.struct<"A" {!rec_anon2E0, !cir.struct<"B">}>>, !cir.struct<"anon.2">}>}>>}>
+// CHECK5: !cir.union<"anon.1" {!cir.ptr<!cir.struct<"A" {!rec_anon2E0, !cir.struct<"B" {!cir.ptr<!cir.struct<"B">>, !rec_C, !cir.union<"anon.1">}>}>>, !rec_anon2E2}>
+// CHECK5: !cir.struct<"B" {!cir.ptr<!cir.struct<"B">>, !rec_C, !rec_anon2E1}>
+// CHECK5: !cir.struct<"A" {!rec_anon2E0, !rec_B}>
 struct A {
   struct {
     struct A *a1;

--- a/clang/test/CIR/CodeGen/global-dtor-union-narrowed.cpp
+++ b/clang/test/CIR/CodeGen/global-dtor-union-narrowed.cpp
@@ -23,7 +23,7 @@ S g;
 // The dtor region must bitcast `@g`'s narrowed pointer back to `!rec_S`
 // before the dtor call.
 
-// CIR: !rec_S = !cir.record<struct "S"
+// CIR: !rec_S = !cir.struct<"S"
 // CIR: cir.global external @g = #cir.zero : ![[NARROW_TY:rec_anon_struct[0-9]*]] dtor {
 // CIR:   %[[ADDR:.+]] = cir.get_global @g : !cir.ptr<![[NARROW_TY]]>
 // CIR:   %[[CAST:.+]] = cir.cast bitcast %[[ADDR]] : !cir.ptr<![[NARROW_TY]]> -> !cir.ptr<!rec_S>

--- a/clang/test/CIR/CodeGen/inline-cxx-func.cpp
+++ b/clang/test/CIR/CodeGen/inline-cxx-func.cpp
@@ -13,7 +13,7 @@ struct S {
   }
 };
 
-// CIR: !rec_S = !cir.record<struct "S" {!s32i}>
+// CIR: !rec_S = !cir.struct<"S" {!s32i}>
 // LLVM: %struct.S = type { i32 }
 // OGCG: %struct.S = type { i32 }
 

--- a/clang/test/CIR/CodeGen/member-functions.cpp
+++ b/clang/test/CIR/CodeGen/member-functions.cpp
@@ -6,7 +6,7 @@ struct C {
   void f2(int a, int b);
 };
 
-// CIR: !rec_C = !cir.record<struct "C" padded {!u8i}>
+// CIR: !rec_C = !cir.struct<"C" padded {!u8i}>
 
 void C::f() {}
 

--- a/clang/test/CIR/CodeGen/mms-bitfields.c
+++ b/clang/test/CIR/CodeGen/mms-bitfields.c
@@ -10,7 +10,7 @@ struct s1 {
   long long f64 : 30;
 } s1;
 
-// CIR-DAG: !rec_s1 = !cir.record<struct "s1" {!s32i, !s64i}>
+// CIR-DAG: !rec_s1 = !cir.struct<"s1" {!s32i, !s64i}>
 // LLVM-DAG: %struct.s1 = type { i32, i64 }
 // OGCG-DAG: %struct.s1 = type { i32, i64 }
 
@@ -20,7 +20,7 @@ struct s2 {
     int c : 30;
 } Clip;
 
-// CIR-DAG: !rec_s2 = !cir.record<struct "s2" {!s32i, !s8i, !s32i}>
+// CIR-DAG: !rec_s2 = !cir.struct<"s2" {!s32i, !s8i, !s32i}>
 // LLVM-DAG: %struct.s2 = type { i32, i8, i32 }
 // OGCG-DAG: %struct.s2 = type { i32, i8, i32 }
 
@@ -30,7 +30,7 @@ struct s3 {
     int c : 14;
 } zero_bit;
 
-// CIR-DAG:  !rec_s3 = !cir.record<struct "s3" {!s32i, !s32i}>
+// CIR-DAG:  !rec_s3 = !cir.struct<"s3" {!s32i, !s32i}>
 // LLVM-DAG: %struct.s3 = type { i32, i32 }
 // OGCG-DAG: %struct.s3 = type { i32, i32 }
 
@@ -45,7 +45,7 @@ struct Inner {
 
 #pragma pack (pop)
 
-// CIR-DAG: !rec_Inner = !cir.record<struct "Inner" {!u32i, !u32i}>
+// CIR-DAG: !rec_Inner = !cir.struct<"Inner" {!u32i, !u32i}>
 // LLVM-DAG: %struct.Inner = type { i32, i32 }
 // OGCG-DAG: %struct.Inner = type { i32, i32 }
 
@@ -67,8 +67,8 @@ union HEADER {
 
 #pragma pack(pop)
 
-// CIR-DAG: !rec_A = !cir.record<struct "A" {!s32i, !s32i, !s32i}>
-// CIR-DAG: !rec_HEADER = !cir.record<union "HEADER" {!rec_A}>
+// CIR-DAG: !rec_A = !cir.struct<"A" {!s32i, !s32i, !s32i}>
+// CIR-DAG: !rec_HEADER = !cir.union<"HEADER" {!rec_A}>
 // LLVM-DAG: %struct.A = type { i32, i32, i32 }
 // LLVM-DAG: %union.HEADER = type { %struct.A }
 // OGCG-DAG: %struct.A = type { i32, i32, i32 }

--- a/clang/test/CIR/CodeGen/multi-vtable.cpp
+++ b/clang/test/CIR/CodeGen/multi-vtable.cpp
@@ -30,12 +30,12 @@ void Mother::MotherKey() {}
 void Father::FatherKey() {}
 void Child::MotherKey() {}
 
-// CIR-DAG: [[MOTHER_VTABLE_TYPE:.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-// CIR-DAG: [[FATHER_VTABLE_TYPE:.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
-// CIR-DAG: [[CHILD_VTABLE_TYPE:.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
-// CIR-DAG: !rec_Father = !cir.record<class "Father" {!cir.vptr}
-// CIR-DAG: !rec_Mother = !cir.record<class "Mother" {!cir.vptr}
-// CIR-DAG: !rec_Child = !cir.record<class "Child" {!rec_Mother, !rec_Father}
+// CIR-DAG: [[MOTHER_VTABLE_TYPE:.*]] = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
+// CIR-DAG: [[FATHER_VTABLE_TYPE:.*]] = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 3>}>
+// CIR-DAG: [[CHILD_VTABLE_TYPE:.*]] = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
+// CIR-DAG: !rec_Father = !cir.struct<class "Father" {!cir.vptr}
+// CIR-DAG: !rec_Mother = !cir.struct<class "Mother" {!cir.vptr}
+// CIR-DAG: !rec_Child = !cir.struct<class "Child" {!rec_Mother, !rec_Father}
 
 // Child vtable
 

--- a/clang/test/CIR/CodeGen/no-proto-fn-ptr-global-init.c
+++ b/clang/test/CIR/CodeGen/no-proto-fn-ptr-global-init.c
@@ -9,10 +9,10 @@
 // The initializer must use the struct field's function-pointer type (not the
 // FuncOp's no-prototype type) so CIR stays valid after the replacement.
 
-// CHECK: !{{[^ ]+}} = !cir.record<struct "S1" {!cir.ptr<!cir.func<()>>, !s32i, !s32i}>
-// CHECK: !{{[^ ]+}} = !cir.record<struct "S2" {!cir.ptr<!cir.func<(...)>>, !s32i, !s32i}>
-// CHECK: !{{[^ ]+}} = !cir.record<struct "S3" {!cir.ptr<!cir.func<(...)>>, !s32i, !s32i}>
-// CHECK: !{{[^ ]+}} = !cir.record<struct "S4" {!cir.ptr<!cir.func<(...)>>, !s32i, !s32i}>
+// CHECK: !{{[^ ]+}} = !cir.struct<"S1" {!cir.ptr<!cir.func<()>>, !s32i, !s32i}>
+// CHECK: !{{[^ ]+}} = !cir.struct<"S2" {!cir.ptr<!cir.func<(...)>>, !s32i, !s32i}>
+// CHECK: !{{[^ ]+}} = !cir.struct<"S3" {!cir.ptr<!cir.func<(...)>>, !s32i, !s32i}>
+// CHECK: !{{[^ ]+}} = !cir.struct<"S4" {!cir.ptr<!cir.func<(...)>>, !s32i, !s32i}>
 
 struct S1 {
   void (*fn_ptr)(void);

--- a/clang/test/CIR/CodeGen/no-unique-address.cpp
+++ b/clang/test/CIR/CodeGen/no-unique-address.cpp
@@ -29,8 +29,8 @@ struct Outer {
 // [[no_unique_address]] field, allowing 'extra' to overlap with
 // Middle's tail padding.
 
-// CIR: !rec_Middle2Ebase = !cir.record<struct "Middle.base" packed {!rec_Base, !s8i}>
-// CIR: !rec_Outer = !cir.record<struct "Outer" padded {!rec_Middle2Ebase, !s8i,
+// CIR: !rec_Middle2Ebase = !cir.struct<"Middle.base" packed {!rec_Base, !s8i}>
+// CIR: !rec_Outer = !cir.struct<"Outer" padded {!rec_Middle2Ebase, !s8i,
 
 // CIR-LABEL: cir.func {{.*}} @_ZN5OuterC2ERK6Middlec(
 // CIR:         %[[THIS:.*]] = cir.load %{{.+}} : !cir.ptr<!cir.ptr<!rec_Outer>>, !cir.ptr<!rec_Outer>
@@ -98,10 +98,10 @@ struct OuterFinal {
 
 OuterFinal of;
 
-// CIR-NUA-DAG: !rec_FinalForNUA = !cir.record<struct "FinalForNUA" {!s32i, !s8i}>
-// CIR-NUA-DAG: !rec_UnionForNUA = !cir.record<union "UnionForNUA" {!s32i, !s64i}>
-// CIR-NUA-DAG: !rec_OuterFinal = !cir.record<struct "OuterFinal" {!rec_FinalForNUA, !s8i}>
-// CIR-NUA-DAG: !rec_OuterUnion = !cir.record<struct "OuterUnion" {!rec_UnionForNUA, !s32i}>
+// CIR-NUA-DAG: !rec_FinalForNUA = !cir.struct<"FinalForNUA" {!s32i, !s8i}>
+// CIR-NUA-DAG: !rec_UnionForNUA = !cir.union<"UnionForNUA" {!s32i, !s64i}>
+// CIR-NUA-DAG: !rec_OuterFinal = !cir.struct<"OuterFinal" {!rec_FinalForNUA, !s8i}>
+// CIR-NUA-DAG: !rec_OuterUnion = !cir.struct<"OuterUnion" {!rec_UnionForNUA, !s32i}>
 // CIR-NUA-DAG: cir.global external @ou = #cir.zero : !rec_OuterUnion
 // CIR-NUA-DAG: cir.global external @of = #cir.zero : !rec_OuterFinal
 

--- a/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
+++ b/clang/test/CIR/CodeGen/nonzeroinit-struct.cpp
@@ -21,13 +21,13 @@ struct Trivial {
     decltype(&Other::x) ptr;
 };
 
-// CIR-BEFORE-DAG: !rec_Other = !cir.record<struct "Other" {!s32i}>
-// CIR-BEFORE-DAG: !rec_Trivial = !cir.record<struct "Trivial" {!s32i, !cir.double, !cir.data_member<!s32i in !rec_Other>}>
-// CIR-BEFORE-DAG: !rec_WithMemPtr = !cir.record<struct "WithMemPtr" {!s32i, !cir.double, !cir.method<!cir.func<(!cir.ptr<!rec_Other>, !s32i, !cir.float)> in !rec_Other>}>
-// CIR-AFTER-DAG: !rec_Other = !cir.record<struct "Other" {!s32i}>
-// CIR-AFTER-DAG: !rec_Trivial = !cir.record<struct "Trivial" {!s32i, !cir.double, !s64i}>
-// CIR-AFTER-DAG: !rec_anon_struct = !cir.record<struct  {!s64i, !s64i}>
-// CIR-AFTER-DAG: !rec_WithMemPtr = !cir.record<struct "WithMemPtr" {!s32i, !cir.double, !rec_anon_struct}>
+// CIR-BEFORE-DAG: !rec_Other = !cir.struct<"Other" {!s32i}>
+// CIR-BEFORE-DAG: !rec_Trivial = !cir.struct<"Trivial" {!s32i, !cir.double, !cir.data_member<!s32i in !rec_Other>}>
+// CIR-BEFORE-DAG: !rec_WithMemPtr = !cir.struct<"WithMemPtr" {!s32i, !cir.double, !cir.method<!cir.func<(!cir.ptr<!rec_Other>, !s32i, !cir.float)> in !rec_Other>}>
+// CIR-AFTER-DAG: !rec_Other = !cir.struct<"Other" {!s32i}>
+// CIR-AFTER-DAG: !rec_Trivial = !cir.struct<"Trivial" {!s32i, !cir.double, !s64i}>
+// CIR-AFTER-DAG: !rec_anon_struct = !cir.struct<{!s64i, !s64i}>
+// CIR-AFTER-DAG: !rec_WithMemPtr = !cir.struct<"WithMemPtr" {!s32i, !cir.double, !rec_anon_struct}>
 
 // LLVM-DAG: %struct.WithMemPtr = type { i32, double, { i64, i64 } }
 // LLVM-DAG: %struct.Trivial = type { i32, double, i64 }

--- a/clang/test/CIR/CodeGen/paren-list-agg-init.cpp
+++ b/clang/test/CIR/CodeGen/paren-list-agg-init.cpp
@@ -19,7 +19,7 @@ template <typename T>
 concept SameAsChar = (bool)IsInt<T>();
 
 // LLVM-DAG: [[STRUCT_A:%.*]] = type { i8, double }
-// CIR-DAG: ![[STRUCT_A:.*]] = !cir.record<struct "A" {!s8i, !cir.double}>
+// CIR-DAG: ![[STRUCT_A:.*]] = !cir.struct<"A" {!s8i, !cir.double}>
 struct A {
   char i;
   double j;
@@ -29,20 +29,20 @@ struct A {
 };
 
 // LLVM-DAG: [[STRUCT_B:%.*]] = type { [[STRUCT_A]], i32 }
-// CIR-DAG: ![[STRUCT_B:.*]] = !cir.record<struct "B" {![[STRUCT_A]], !s32i}>
+// CIR-DAG: ![[STRUCT_B:.*]] = !cir.struct<"B" {![[STRUCT_A]], !s32i}>
 struct B {
   A a;
   int b;
 };
 
 // LLVM-DAG: [[STRUCT_C:%.*]] = type <{ [[STRUCT_B]], [[STRUCT_A]], i32, [4 x i8] }>
-// CIR-DAG: ![[STRUCT_C:.*]] = !cir.record<struct "C" packed padded {![[STRUCT_B]], ![[STRUCT_A]], !s32i, !cir.array<!u8i x 4>}>
+// CIR-DAG: ![[STRUCT_C:.*]] = !cir.struct<"C" packed padded {![[STRUCT_B]], ![[STRUCT_A]], !s32i, !cir.array<!u8i x 4>}>
 struct C : public B, public A {
   int c;
 };
 
 // LLVM-DAG: [[STRUCT_D:%.*]] = type { [[STRUCT_A]], [[STRUCT_A]], i8, [[STRUCT_A]] }
-// CIR-DAG: ![[STRUCT_D:.*]] = !cir.record<struct "D" {![[STRUCT_A]], ![[STRUCT_A]], !u8i, ![[STRUCT_A]]}>
+// CIR-DAG: ![[STRUCT_D:.*]] = !cir.struct<"D" {![[STRUCT_A]], ![[STRUCT_A]], !u8i, ![[STRUCT_A]]}>
 struct D {
   A a;
   A b = A{2, 2.0};
@@ -51,14 +51,14 @@ struct D {
 };
 
 // LLVM-DAG: [[STRUCT_E:%.*]] = type { i32, ptr }
-// CIR-DAG: ![[STRUCT_E:.*]] = !cir.record<struct "E" {!s32i, !cir.ptr<!s8i>}>
+// CIR-DAG: ![[STRUCT_E:.*]] = !cir.struct<"E" {!s32i, !cir.ptr<!s8i>}>
 struct E {
   int a;
   const char* fn = __builtin_FUNCTION();
   ~E() {};
 };
 
-// CIR-DAG: ![[STRUCT_F:.*]] = !cir.record<struct "F" padded {!u8i}>
+// CIR-DAG: ![[STRUCT_F:.*]] = !cir.struct<"F" padded {!u8i}>
 struct F {
   F (int i = 1);
   F (const F &f) = delete;
@@ -66,7 +66,7 @@ struct F {
 };
 
 // LLVM-DAG: [[STRUCT_G:%.*]] = type <{ i32, [4 x i8] }>
-// CIR-DAG: ![[STRUCT_G:.*]] = !cir.record<struct "G" packed padded {!s32i, !cir.array<!u8i x 4>}>
+// CIR-DAG: ![[STRUCT_G:.*]] = !cir.struct<"G" packed padded {!s32i, !cir.array<!u8i x 4>}>
 struct G {
   int a;
   F f;
@@ -74,7 +74,7 @@ struct G {
 
 // LLVM-DAG: [[UNION_U:%.*]] = type { [[STRUCT_A]] }
 // LLVM-DAG: [[STR:@.*]] = private {{.*}}constant [6 x i8] {{.*}}foo18{{.*}}, align 1
-// CIR-DAG: ![[UNION_U:.*]] = !cir.record<union "U" {!u8i, ![[STRUCT_A]], !s8i}>
+// CIR-DAG: ![[UNION_U:.*]] = !cir.union<"U" {!u8i, ![[STRUCT_A]], !s8i}>
 union U {
   unsigned : 1;
   A a;
@@ -84,7 +84,7 @@ union U {
 
 namespace gh61145 {
   // LLVM-DAG: [[STRUCT_VEC:%.*Vec.*]] = type { i8 }
-  // CIR-DAG: ![[STRUCT_VEC:.*]] = !cir.record<struct "gh61145::Vec" padded {!u8i}>
+  // CIR-DAG: ![[STRUCT_VEC:.*]] = !cir.struct<"gh61145::Vec" padded {!u8i}>
   struct Vec {
     Vec();
     Vec(Vec&&);
@@ -92,13 +92,13 @@ namespace gh61145 {
   };
 
   // LLVM-DAG: [[STRUCT_S1:%.*]] = type { i8 }
-  // CIR-DAG: ![[STRUCT_S1:.*]] = !cir.record<struct "gh61145::S1" padded {!u8i}>
+  // CIR-DAG: ![[STRUCT_S1:.*]] = !cir.struct<"gh61145::S1" padded {!u8i}>
   struct S1 {
     Vec v;
   };
 
   // LLVM-DAG: [[STRUCT_S2:%.*]] = type { i8, i8 }
-  // CIR-DAG: ![[STRUCT_S2:.*]] = !cir.record<struct "gh61145::S2" padded {!u8i, !s8i}>
+  // CIR-DAG: ![[STRUCT_S2:.*]] = !cir.struct<"gh61145::S2" padded {!u8i, !s8i}>
   struct S2 {
     Vec v;
     char c;
@@ -107,7 +107,7 @@ namespace gh61145 {
 
 namespace gh62266 {
   // LLVM-DAG: [[STRUCT_H:%.*H.*]] = type { i32, i32 }
-  // CIR-DAG: ![[STRUCT_H:.*]] = !cir.record<struct "gh62266::H<2>" {!s32i, !s32i}>
+  // CIR-DAG: ![[STRUCT_H:.*]] = !cir.struct<"gh62266::H<2>" {!s32i, !s32i}>
   template <int J>
   struct H {
     int i;
@@ -117,7 +117,7 @@ namespace gh62266 {
 
 namespace gh61567 {
   // LLVM-DAG: [[STRUCT_I:%.*I.*]] = type { i32, ptr }
-  // CIR-DAG: ![[STRUCT_I:.*]] = !cir.record<struct "gh61567::I" {!s32i, !cir.ptr<!s32i>}>
+  // CIR-DAG: ![[STRUCT_I:.*]] = !cir.struct<"gh61567::I" {!s32i, !cir.ptr<!s32i>}>
   struct I {
     int a;
     int&& r = 2;

--- a/clang/test/CIR/CodeGen/record-type-metadata.cpp
+++ b/clang/test/CIR/CodeGen/record-type-metadata.cpp
@@ -17,10 +17,10 @@ void takesAligned(Aligned a) {}
 void takesNTD(NonTrivialDtor n) {}
 
 // Record types should NOT contain ABI metadata keywords.
-// CIR-DAG: !rec_Trivial = !cir.record<struct "Trivial" {!s32i, !s32i}>
-// CIR-DAG: !rec_Empty = !cir.record<struct "Empty" padded {!u8i}>
-// CIR-DAG: !rec_Aligned = !cir.record<struct "Aligned" padded {!s32i, !s32i, !cir.array<!u8i x 8>}>
-// CIR-DAG: !rec_NonTrivialDtor = !cir.record<class "NonTrivialDtor" {!s32i}>
+// CIR-DAG: !rec_Trivial = !cir.struct<"Trivial" {!s32i, !s32i}>
+// CIR-DAG: !rec_Empty = !cir.struct<"Empty" padded {!u8i}>
+// CIR-DAG: !rec_Aligned = !cir.struct<"Aligned" padded {!s32i, !s32i, !cir.array<!u8i x 8>}>
+// CIR-DAG: !rec_NonTrivialDtor = !cir.struct<class "NonTrivialDtor" {!s32i}>
 
 // ABI metadata lives in module-level cir.record_layouts attribute.
 // CIR-DAG: Trivial = #cir.record_layout<arg_passing_kind = can_pass_in_regs, has_trivial_dtor = true, record_align = 4>

--- a/clang/test/CIR/CodeGen/record-with-padded-union.cpp
+++ b/clang/test/CIR/CodeGen/record-with-padded-union.cpp
@@ -15,8 +15,8 @@ struct SSO {
 };
 
 // Inner union's tail padding must not bleed into the outer record.
-// CIR: !rec_anon{{.*}} = !cir.record<union "anon{{.*}}" padded {!cir.array<!s8i x 16>, !u64i, !cir.array<!u8i x 8>}>
-// CIR: !rec_SSO = !cir.record<struct "SSO" {!cir.ptr<!s8i>, !u64i, !rec_anon{{.*}}}>
+// CIR: !rec_anon{{.*}} = !cir.union<"anon{{.*}}" padded {!cir.array<!s8i x 16>, !u64i}, padding = {!cir.array<!u8i x 8>}>
+// CIR: !rec_SSO = !cir.struct<"SSO" {!cir.ptr<!s8i>, !u64i, !rec_anon{{.*}}}>
 
 // LLVM: %struct.SSO = type { ptr, i64, %union.anon{{.*}} }
 // LLVM: %union.anon{{.*}} = type { i64, [8 x i8] }

--- a/clang/test/CIR/CodeGen/record-with-padded-union.cpp
+++ b/clang/test/CIR/CodeGen/record-with-padded-union.cpp
@@ -15,7 +15,7 @@ struct SSO {
 };
 
 // Inner union's tail padding must not bleed into the outer record.
-// CIR: !rec_anon{{.*}} = !cir.union<"anon{{.*}}" padded {!cir.array<!s8i x 16>, !u64i}, padding = {!cir.array<!u8i x 8>}>
+// CIR: !rec_anon{{.*}} = !cir.union<"anon{{.*}}" {!cir.array<!s8i x 16>, !u64i}, padding = {!cir.array<!u8i x 8>}>
 // CIR: !rec_SSO = !cir.struct<"SSO" {!cir.ptr<!s8i>, !u64i, !rec_anon{{.*}}}>
 
 // LLVM: %struct.SSO = type { ptr, i64, %union.anon{{.*}} }

--- a/clang/test/CIR/CodeGen/record-zero-init-padding.c
+++ b/clang/test/CIR/CodeGen/record-zero-init-padding.c
@@ -35,10 +35,10 @@ void test_zero_init_padding(void) {
 }
 
 // Type definitions for anonymous structs with padding
-// CIR-DAG: !rec_anon_struct = !cir.record<struct  {!s8i, !u8i, !s16i, !cir.array<!u8i x 4>, !s64i}>
-// CIR-DAG: !rec_anon_struct1 = !cir.record<struct  {!s32i, !s8i, !cir.array<!u8i x 3>}>
-// CIR-DAG: !rec_anon_struct2 = !cir.record<struct  {!u8i, !cir.array<!u8i x 3>, !s32i}>
-// CIR-DAG: !rec_anon_struct3 = !cir.record<struct  {!s8i, !cir.array<!u8i x 3>, !s32i}>
+// CIR-DAG: !rec_anon_struct = !cir.struct<{!s8i, !u8i, !s16i, !cir.array<!u8i x 4>, !s64i}>
+// CIR-DAG: !rec_anon_struct1 = !cir.struct<{!s32i, !s8i, !cir.array<!u8i x 3>}>
+// CIR-DAG: !rec_anon_struct2 = !cir.struct<{!u8i, !cir.array<!u8i x 3>, !s32i}>
+// CIR-DAG: !rec_anon_struct3 = !cir.struct<{!s8i, !cir.array<!u8i x 3>, !s32i}>
 
 // paf: char + 3 bytes padding + int -> uses !rec_anon_struct3
 // CIR-DAG: cir.global "private" constant internal dso_local @test_zero_init_padding.paf = #cir.const_record<{

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -7,19 +7,19 @@
 
 // For LLVM IR checks, the structs are defined before the variables, so these
 // checks are at the top.
-// CIR-DAG: !rec_IncompleteS = !cir.record<struct "IncompleteS" incomplete>
-// CIR-DAG: !rec_CompleteS = !cir.record<struct "CompleteS" {!s32i, !s8i}>
-// CIR-DAG: !rec_OuterS = !cir.record<struct "OuterS" {!rec_InnerS, !s32i}>  
-// CIR-DAG: !rec_InnerS = !cir.record<struct "InnerS" {!s32i, !s8i}>
-// CIR-DAG: !rec_PackedS = !cir.record<struct "PackedS" packed {!s32i, !s8i}>
-// CIR-DAG: !rec_PackedAndPaddedS = !cir.record<struct "PackedAndPaddedS" packed padded {!s32i, !s8i, !u8i}>
-// CIR-DAG: !rec_NodeS = !cir.record<struct "NodeS" {!cir.ptr<!cir.record<struct "NodeS">>}>
-// CIR-DAG: !rec_RightS = !cir.record<struct "RightS" {!cir.ptr<!cir.record<struct "LeftS" {!cir.ptr<!cir.record<struct "RightS">>}>>}>
-// CIR-DAG: !rec_LeftS = !cir.record<struct "LeftS" {!cir.ptr<!rec_RightS>}>
-// CIR-DAG: !rec_CycleEnd = !cir.record<struct "CycleEnd" {!cir.ptr<!cir.record<struct "CycleStart" {!cir.ptr<!cir.record<struct "CycleMiddle" {!cir.ptr<!cir.record<struct "CycleEnd">>}>>}>>}>
-// CIR-DAG: !rec_CycleMiddle = !cir.record<struct "CycleMiddle" {!cir.ptr<!rec_CycleEnd>}>
-// CIR-DAG: !rec_CycleStart = !cir.record<struct "CycleStart" {!cir.ptr<!rec_CycleMiddle>}>
-// CIR-DAG: !rec_IncompleteArray = !cir.record<struct "IncompleteArray" {!cir.array<!s32i x 0>}>
+// CIR-DAG: !rec_IncompleteS = !cir.struct<"IncompleteS" incomplete>
+// CIR-DAG: !rec_CompleteS = !cir.struct<"CompleteS" {!s32i, !s8i}>
+// CIR-DAG: !rec_OuterS = !cir.struct<"OuterS" {!rec_InnerS, !s32i}>  
+// CIR-DAG: !rec_InnerS = !cir.struct<"InnerS" {!s32i, !s8i}>
+// CIR-DAG: !rec_PackedS = !cir.struct<"PackedS" packed {!s32i, !s8i}>
+// CIR-DAG: !rec_PackedAndPaddedS = !cir.struct<"PackedAndPaddedS" packed padded {!s32i, !s8i, !u8i}>
+// CIR-DAG: !rec_NodeS = !cir.struct<"NodeS" {!cir.ptr<!cir.struct<"NodeS">>}>
+// CIR-DAG: !rec_RightS = !cir.struct<"RightS" {!cir.ptr<!cir.struct<"LeftS" {!cir.ptr<!cir.struct<"RightS">>}>>}>
+// CIR-DAG: !rec_LeftS = !cir.struct<"LeftS" {!cir.ptr<!rec_RightS>}>
+// CIR-DAG: !rec_CycleEnd = !cir.struct<"CycleEnd" {!cir.ptr<!cir.struct<"CycleStart" {!cir.ptr<!cir.struct<"CycleMiddle" {!cir.ptr<!cir.struct<"CycleEnd">>}>>}>>}>
+// CIR-DAG: !rec_CycleMiddle = !cir.struct<"CycleMiddle" {!cir.ptr<!rec_CycleEnd>}>
+// CIR-DAG: !rec_CycleStart = !cir.struct<"CycleStart" {!cir.ptr<!rec_CycleMiddle>}>
+// CIR-DAG: !rec_IncompleteArray = !cir.struct<"IncompleteArray" {!cir.array<!s32i x 0>}>
 // LLVM-DAG: %struct.CompleteS = type { i32, i8 }
 // LLVM-DAG: %struct.OuterS = type { %struct.InnerS, i32 }
 // LLVM-DAG: %struct.InnerS = type { i32, i8 }

--- a/clang/test/CIR/CodeGen/template-specialization.cpp
+++ b/clang/test/CIR/CodeGen/template-specialization.cpp
@@ -13,7 +13,7 @@ class Templ<T, int>{};
 
 Templ<int, int> t;
 
-// CIR: !rec_Templ3Cint2C_int3E = !cir.record<class "Templ<int, int>" padded {!u8i}>
+// CIR: !rec_Templ3Cint2C_int3E = !cir.struct<class "Templ<int, int>" padded {!u8i}>
 // CIR: cir.global external @t = #cir.zero : !rec_Templ3Cint2C_int3E
 
 // LLVM: %"class.Templ<int, int>" = type { i8 }

--- a/clang/test/CIR/CodeGen/three-way-cmp.cpp
+++ b/clang/test/CIR/CodeGen/three-way-cmp.cpp
@@ -14,8 +14,8 @@
 
 // BEFORE: #cmpinfo_partial_ltn1eq0gt1unn127 = #cir.cmp3way_info<partial, lt = -1, eq = 0, gt = 1, unordered = -127>
 // BEFORE: #cmpinfo_strong_ltn1eq0gt1 = #cir.cmp3way_info<strong, lt = -1, eq = 0, gt = 1>
-// BEFORE: !rec_std3A3A__13A3Apartial_ordering = !cir.record<class "std::__1::partial_ordering" {!s8i}>
-// BEFORE: !rec_std3A3A__13A3Astrong_ordering = !cir.record<class "std::__1::strong_ordering" {!s8i}>
+// BEFORE: !rec_std3A3A__13A3Apartial_ordering = !cir.struct<class "std::__1::partial_ordering" {!s8i}>
+// BEFORE: !rec_std3A3A__13A3Astrong_ordering = !cir.struct<class "std::__1::strong_ordering" {!s8i}>
 
 auto three_way_strong(int x, int y) {
   return x <=> y;

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -31,7 +31,7 @@ union U3 {
   int i;
 } __attribute__((packed));
 
-// CIR:  !rec_U3 = !cir.union<"U3" packed padded {!cir.array<!s8i x 5>, !s32i}, padding = {!u8i}>
+// CIR:  !rec_U3 = !cir.union<"U3" packed {!cir.array<!s8i x 5>, !s32i}, padding = {!u8i}>
 // LLVM: %union.U3 = type <{ i32, i8 }>
 // OGCG: %union.U3 = type <{ i32, i8 }>
 
@@ -40,7 +40,7 @@ union U4 {
   int i;
 };
 
-// CIR:  !rec_U4 = !cir.union<"U4" padded {!cir.array<!s8i x 5>, !s32i}, padding = {!cir.array<!u8i x 4>}>
+// CIR:  !rec_U4 = !cir.union<"U4" {!cir.array<!s8i x 5>, !s32i}, padding = {!cir.array<!u8i x 4>}>
 // LLVM: %union.U4 = type { i32, [4 x i8] }
 // OGCG: %union.U4 = type { i32, [4 x i8] }
 

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -10,7 +10,7 @@ union U1 {
   char c;
 };
 
-// CIR:  !rec_U1 = !cir.record<union "U1" {!s32i, !s8i}>
+// CIR:  !rec_U1 = !cir.union<"U1" {!s32i, !s8i}>
 // LLVM: %union.U1 = type { i32 }
 // OGCG: %union.U1 = type { i32 }
 
@@ -22,7 +22,7 @@ union U2 {
   double d;
 };
 
-// CIR:  !rec_U2 = !cir.record<union "U2" {!s8i, !s16i, !s32i, !cir.float, !cir.double}>
+// CIR:  !rec_U2 = !cir.union<"U2" {!s8i, !s16i, !s32i, !cir.float, !cir.double}>
 // LLVM: %union.U2 = type { double }
 // OGCG: %union.U2 = type { double }
 
@@ -31,7 +31,7 @@ union U3 {
   int i;
 } __attribute__((packed));
 
-// CIR:  !rec_U3 = !cir.record<union "U3" packed padded {!cir.array<!s8i x 5>, !s32i, !u8i}>
+// CIR:  !rec_U3 = !cir.union<"U3" packed padded {!cir.array<!s8i x 5>, !s32i}, padding = {!u8i}>
 // LLVM: %union.U3 = type <{ i32, i8 }>
 // OGCG: %union.U3 = type <{ i32, i8 }>
 
@@ -40,7 +40,7 @@ union U4 {
   int i;
 };
 
-// CIR:  !rec_U4 = !cir.record<union "U4" padded {!cir.array<!s8i x 5>, !s32i, !cir.array<!u8i x 4>}>
+// CIR:  !rec_U4 = !cir.union<"U4" padded {!cir.array<!s8i x 5>, !s32i}, padding = {!cir.array<!u8i x 4>}>
 // LLVM: %union.U4 = type { i32, [4 x i8] }
 // OGCG: %union.U4 = type { i32, [4 x i8] }
 

--- a/clang/test/CIR/CodeGen/union.cpp
+++ b/clang/test/CIR/CodeGen/union.cpp
@@ -13,7 +13,7 @@ union U {
   float f;
   double d;
 };
-// CIR: !rec_U = !cir.record<union "U" {!cir.bool, !s16i, !s32i, !cir.float, !cir.double}>
+// CIR: !rec_U = !cir.union<"U" {!cir.bool, !s16i, !s32i, !cir.float, !cir.double}>
 // LLVM: %union.U = type { double }
 // OGCG: %union.U = type { double }
 

--- a/clang/test/CIR/CodeGen/var_arg.c
+++ b/clang/test/CIR/CodeGen/var_arg.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
 // RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
 
-// CIR: !rec___va_list_tag = !cir.record<struct "__va_list_tag" {!u32i, !u32i, !cir.ptr<!void>, !cir.ptr<!void>}
+// CIR: !rec___va_list_tag = !cir.struct<"__va_list_tag" {!u32i, !u32i, !cir.ptr<!void>, !cir.ptr<!void>}
 // LLVM: %struct.__va_list_tag = type { i32, i32, ptr, ptr }
 // OGCG: %struct.__va_list_tag = type { i32, i32, ptr, ptr }
 

--- a/clang/test/CIR/CodeGen/variable-template-specialization.cpp
+++ b/clang/test/CIR/CodeGen/variable-template-specialization.cpp
@@ -16,7 +16,7 @@ template<> int var_template<0>;
 template<> int var_template<1> = 1;
 template<> some_struct var_template<2>;
 
-// CIR: !rec_some_struct = !cir.record<struct "some_struct" {!s32i}>
+// CIR: !rec_some_struct = !cir.struct<"some_struct" {!s32i}>
 // CIR: cir.global external @_Z12var_templateILi0EE = #cir.int<0> : !s32i
 // CIR: cir.global external @_Z12var_templateILi1EE = #cir.int<1> : !s32i
 // CIR: cir.global external @_Z12var_templateILi2EE = #cir.zero : !rec_some_struct

--- a/clang/test/CIR/CodeGen/vbase.cpp
+++ b/clang/test/CIR/CodeGen/vbase.cpp
@@ -25,9 +25,9 @@ void g() {
   df.f();
 }
 
-// CIR: !rec_Base = !cir.record<class "Base" {!cir.vptr}>
-// CIR: !rec_Derived = !cir.record<class "Derived" {!rec_Base}>
-// CIR: !rec_DerivedFinal = !cir.record<class "DerivedFinal" {!rec_Base}>
+// CIR: !rec_Base = !cir.struct<class "Base" {!cir.vptr}>
+// CIR: !rec_Derived = !cir.struct<class "Derived" {!rec_Base}>
+// CIR: !rec_DerivedFinal = !cir.struct<class "DerivedFinal" {!rec_Base}>
 
 // LLVM: %class.Derived = type { %class.Base }
 // LLVM: %class.Base = type { ptr }

--- a/clang/test/CIR/CodeGen/virtual-function-calls.cpp
+++ b/clang/test/CIR/CodeGen/virtual-function-calls.cpp
@@ -13,8 +13,8 @@ struct A {
 // This should initialize the vtable pointer.
 A::A() {}
 
-// CIR: !rec_A = !cir.record<struct "A" {!cir.vptr}>
-// CIR: !rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
+// CIR: !rec_A = !cir.struct<"A" {!cir.vptr}>
+// CIR: !rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 3>}>
 
 // CIR: cir.global "private" external @_ZTV1A : !rec_anon_struct
 

--- a/clang/test/CIR/CodeGen/vtable-emission.cpp
+++ b/clang/test/CIR/CodeGen/vtable-emission.cpp
@@ -15,7 +15,7 @@ struct S {
 
 void S::key() {}
 
-// CHECK-DAG: !rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
+// CHECK-DAG: !rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
 
 // The definition of the key function should result in the vtable being emitted.
 // CHECK:      cir.global "private" external @_ZTV1S = #cir.vtable<{

--- a/clang/test/CIR/CodeGen/vtable-nyi-nonconvertible-functype.cpp
+++ b/clang/test/CIR/CodeGen/vtable-nyi-nonconvertible-functype.cpp
@@ -5,10 +5,10 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
 // RUN: FileCheck --check-prefix=LLVM,OGCG --input-file=%t.ll %s
 
-// CIR-DAG: !rec_Param2 = !cir.record<struct "Param2" incomplete>
-// CIR-DAG: !rec_Ret1 = !cir.record<struct "Ret1" incomplete>
-// CIR-DAG: !rec_S1 = !cir.record<struct "S1" {!cir.vptr}>
-// CIR-DAG: !rec_S2 = !cir.record<struct "S2" {!cir.vptr}>
+// CIR-DAG: !rec_Param2 = !cir.struct<"Param2" incomplete>
+// CIR-DAG: !rec_Ret1 = !cir.struct<"Ret1" incomplete>
+// CIR-DAG: !rec_S1 = !cir.struct<"S1" {!cir.vptr}>
+// CIR-DAG: !rec_S2 = !cir.struct<"S2" {!cir.vptr}>
 // LLVMCIR-DAG: %struct.Ret1 = type {}
 // LLVMCIR-DAG: %struct.Param2 = type {}
 

--- a/clang/test/CIR/CodeGen/vtt.cpp
+++ b/clang/test/CIR/CodeGen/vtt.cpp
@@ -46,17 +46,17 @@ void f(D *d) {}
 // Trigger vtable and VTT emission for D.
 void D::y() {}
 
-// CIR-COMMON: !rec_A2Ebase = !cir.record<struct "A.base" packed {!cir.vptr, !s32i}>
-// CIR-COMMON: !rec_B2Ebase = !cir.record<struct "B.base" packed {!cir.vptr, !s32i}>
-// CIR-COMMON: !rec_C2Ebase = !cir.record<struct "C.base" {!cir.vptr, !s64i}>
-// CIR-COMMON: !rec_A = !cir.record<class "A" packed padded {!cir.vptr, !s32i, !cir.array<!u8i x 4>}>
-// CIR-COMMON: !rec_B = !cir.record<class "B" packed padded {!cir.vptr, !s32i, !cir.array<!u8i x 4>, !rec_A2Ebase, !cir.array<!u8i x 4>}>
-// CIR-COMMON: !rec_C = !cir.record<class "C" {!cir.vptr, !s64i, !rec_A2Ebase}>
-// CIR-COMMON: !rec_D = !cir.record<class "D" {!rec_B2Ebase, !rec_C2Ebase, !s64i, !rec_A2Ebase}>
+// CIR-COMMON: !rec_A2Ebase = !cir.struct<"A.base" packed {!cir.vptr, !s32i}>
+// CIR-COMMON: !rec_B2Ebase = !cir.struct<"B.base" packed {!cir.vptr, !s32i}>
+// CIR-COMMON: !rec_C2Ebase = !cir.struct<"C.base" {!cir.vptr, !s64i}>
+// CIR-COMMON: !rec_A = !cir.struct<class "A" packed padded {!cir.vptr, !s32i, !cir.array<!u8i x 4>}>
+// CIR-COMMON: !rec_B = !cir.struct<class "B" packed padded {!cir.vptr, !s32i, !cir.array<!u8i x 4>, !rec_A2Ebase, !cir.array<!u8i x 4>}>
+// CIR-COMMON: !rec_C = !cir.struct<class "C" {!cir.vptr, !s64i, !rec_A2Ebase}>
+// CIR-COMMON: !rec_D = !cir.struct<class "D" {!rec_B2Ebase, !rec_C2Ebase, !s64i, !rec_A2Ebase}>
 
-// CIR-RTTI:   ![[REC_TYPE_INFO_VTABLE:.*]]= !cir.record<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !u32i, !u32i, !cir.ptr<!u8i>, !s64i, !cir.ptr<!u8i>, !s64i}>
-// CIR-COMMON: ![[REC_D_VTABLE:.*]] = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 5>, !cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 4>}>
-// CIR-COMMON: ![[REC_B_OR_C_IN_D_VTABLE:.*]]= !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 4>}>
+// CIR-RTTI:   ![[REC_TYPE_INFO_VTABLE:.*]]= !cir.struct<{!cir.ptr<!u8i>, !cir.ptr<!u8i>, !u32i, !u32i, !cir.ptr<!u8i>, !s64i, !cir.ptr<!u8i>, !s64i}>
+// CIR-COMMON: ![[REC_D_VTABLE:.*]] = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 5>, !cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 4>}>
+// CIR-COMMON: ![[REC_B_OR_C_IN_D_VTABLE:.*]]= !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 4>}>
 
 // Vtable for D
 

--- a/clang/test/CIR/CodeGenBuiltins/X86/avx512vlvp2intersect-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/avx512vlvp2intersect-builtins.c
@@ -13,9 +13,9 @@
 
 #include <immintrin.h>
 
-// CIR: !rec_anon_struct = !cir.record<struct  {!cir.vector<8 x !cir.bool>, !cir.vector<8 x !cir.bool>}>
-// CIR: !rec_anon_struct1 = !cir.record<struct  {!cir.vector<4 x !cir.bool>, !cir.vector<4 x !cir.bool>}>
-// CIR: !rec_anon_struct2 = !cir.record<struct  {!cir.vector<2 x !cir.bool>, !cir.vector<2 x !cir.bool>}>
+// CIR: !rec_anon_struct = !cir.struct<{!cir.vector<8 x !cir.bool>, !cir.vector<8 x !cir.bool>}>
+// CIR: !rec_anon_struct1 = !cir.struct<{!cir.vector<4 x !cir.bool>, !cir.vector<4 x !cir.bool>}>
+// CIR: !rec_anon_struct2 = !cir.struct<{!cir.vector<2 x !cir.bool>, !cir.vector<2 x !cir.bool>}>
 void test_mm256_2intersect_epi32(__m256i a, __m256i b, __mmask8 *m0, __mmask8 *m1) {
   // CIR-LABEL: mm256_2intersect_epi32
   // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.vp2intersect.d.256" %{{.*}}, %{{.*}} : (!cir.vector<8 x !s32i>, !cir.vector<8 x !s32i>) -> !rec_anon_struct

--- a/clang/test/CIR/CodeGenBuiltins/X86/avx512vp2intersect-builtins.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/avx512vp2intersect-builtins.c
@@ -14,8 +14,8 @@
 #include <immintrin.h>
 
 
-// CIR: !rec_anon_struct = !cir.record<struct  {!cir.vector<16 x !cir.bool>, !cir.vector<16 x !cir.bool>}>
-// CIR: !rec_anon_struct1 = !cir.record<struct  {!cir.vector<8 x !cir.bool>, !cir.vector<8 x !cir.bool>}>
+// CIR: !rec_anon_struct = !cir.struct<{!cir.vector<16 x !cir.bool>, !cir.vector<16 x !cir.bool>}>
+// CIR: !rec_anon_struct1 = !cir.struct<{!cir.vector<8 x !cir.bool>, !cir.vector<8 x !cir.bool>}>
 void test_mm512_2intersect_epi32(__m512i a, __m512i b, __mmask16 *m0, __mmask16 *m1) {
   // CIR-LABEL: mm512_2intersect_epi32
   // CIR: %[[RES:.*]] = cir.call_llvm_intrinsic "x86.avx512.vp2intersect.d.512" %{{.*}}, %{{.*}} : (!cir.vector<16 x !s32i>, !cir.vector<16 x !s32i>) -> !rec_anon_struct

--- a/clang/test/CIR/CodeGenBuiltins/X86/keylocker.c
+++ b/clang/test/CIR/CodeGenBuiltins/X86/keylocker.c
@@ -16,10 +16,10 @@
 
 #include <x86intrin.h>
 
-// CIR: !rec_anon_struct = !cir.record<struct  {!u8i, !cir.vector<2 x !s64i>}>
-// CIR: !rec_anon_struct1 = !cir.record<struct  {!u8i, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>}>
-// CIR: !rec_anon_struct2 = !cir.record<struct  {!u32i, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>}>
-// CIR: !rec_anon_struct3 = !cir.record<struct  {!u32i, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>}>
+// CIR: !rec_anon_struct = !cir.struct<{!u8i, !cir.vector<2 x !s64i>}>
+// CIR: !rec_anon_struct1 = !cir.struct<{!u8i, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>, !cir.vector<2 x !s64i>}>
+// CIR: !rec_anon_struct2 = !cir.struct<{!u32i, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>}>
+// CIR: !rec_anon_struct3 = !cir.struct<{!u32i, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>, !cir.vector<2 x !u64i>}>
 
 unsigned char test_mm_aesenc256kl_u8(__m128i *odata, __m128i idata, const void *h) {
   // CIR-LABEL: _mm_aesenc256kl_u8

--- a/clang/test/CIR/CodeGenCXX/zero_init_bases.cpp
+++ b/clang/test/CIR/CodeGenCXX/zero_init_bases.cpp
@@ -22,10 +22,10 @@ struct VirtualInherits : virtual Base1, virtual Base2 {
 };
 
 
-// CIR: !rec_Base2 = !cir.record<struct "Base2" {!cir.float, !cir.float, !cir.float}>
-// CIR: !rec_Base1 = !cir.record<struct "Base1" {!s32i, !s32i, !s32i}>
-// CIR: !rec_Inherits = !cir.record<struct "Inherits" {!rec_Base1, !rec_Base2, !s32i, !s32i, !s32i}>
-// CIR: !rec_VirtualInherits = !cir.record<struct "VirtualInherits" packed padded {!cir.vptr, !s32i, !s32i, !s32i, !rec_Base1, !rec_Base2, !cir.array<!u8i x 4>}>
+// CIR: !rec_Base2 = !cir.struct<"Base2" {!cir.float, !cir.float, !cir.float}>
+// CIR: !rec_Base1 = !cir.struct<"Base1" {!s32i, !s32i, !s32i}>
+// CIR: !rec_Inherits = !cir.struct<"Inherits" {!rec_Base1, !rec_Base2, !s32i, !s32i, !s32i}>
+// CIR: !rec_VirtualInherits = !cir.struct<"VirtualInherits" packed padded {!cir.vptr, !s32i, !s32i, !s32i, !rec_Base1, !rec_Base2, !cir.array<!u8i x 4>}>
 //
 // LLVM: %struct.Inherits = type { %struct.Base1, %struct.Base2, i32, i32, i32 }
 // LLVM: %struct.Base1 = type { i32, i32, i32 }

--- a/clang/test/CIR/IR/array-ctor.cir
+++ b/clang/test/CIR/IR/array-ctor.cir
@@ -3,7 +3,7 @@
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SC1Ev(!cir.ptr<!rec_S>)

--- a/clang/test/CIR/IR/array-dtor.cir
+++ b/clang/test/CIR/IR/array-dtor.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s --verify-roundtrip | FileCheck %s
 
 !u8i = !cir.int<u, 8>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SD1Ev(!cir.ptr<!rec_S>)

--- a/clang/test/CIR/IR/bitfield_info.cir
+++ b/clang/test/CIR/IR/bitfield_info.cir
@@ -4,7 +4,7 @@
 !u32i = !cir.int<u, 32>
 
 
-!rec_S = !cir.record<struct "S" {!u32i}>
+!rec_S = !cir.struct<"S" {!u32i}>
 #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u32i, size = 17, offset = 15, is_signed = true>
 
 // CHECK: #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u32i, size = 17, offset = 15, is_signed = true>

--- a/clang/test/CIR/IR/construct-catch-param.cir
+++ b/clang/test/CIR/IR/construct-catch-param.cir
@@ -3,7 +3,7 @@
 !s8i = !cir.int<s, 8>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 

--- a/clang/test/CIR/IR/copy.cir
+++ b/clang/test/CIR/IR/copy.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s --verify-roundtrip | FileCheck %s
 
 !s32i = !cir.int<s, 32>
-!rec = !cir.record<struct "S" {!s32i, !cir.int<s, 8>}>
+!rec = !cir.struct<"S" {!s32i, !cir.int<s, 8>}>
 module {
   cir.func @shouldParseCopyOp(%arg0 : !cir.ptr<!s32i>, %arg1 : !cir.ptr<!s32i>) {
     cir.copy %arg0 to %arg1 : !cir.ptr<!s32i>

--- a/clang/test/CIR/IR/dynamic-cast.cir
+++ b/clang/test/CIR/IR/dynamic-cast.cir
@@ -4,8 +4,8 @@
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!rec_Base = !cir.record<struct "Base" {!cir.vptr}>
-!rec_Derived = !cir.record<struct "Derived" {!rec_Base}>
+!rec_Base = !cir.struct<"Base" {!cir.vptr}>
+!rec_Derived = !cir.struct<"Derived" {!rec_Base}>
 
 #dyn_cast_info__ZTI4Base__ZTI7Derived = #cir.dyn_cast_info<src_rtti = #cir.global_view<@_ZTI4Base> : !cir.ptr<!u8i>, dest_rtti = #cir.global_view<@_ZTI7Derived> : !cir.ptr<!u8i>, runtime_func = @__dynamic_cast, bad_cast_func = @__cxa_bad_cast, offset_hint = #cir.int<0> : !s64i>
 

--- a/clang/test/CIR/IR/func-attrs.cir
+++ b/clang/test/CIR/IR/func-attrs.cir
@@ -5,8 +5,8 @@
 !s8i = !cir.int<s, 8>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_Struct = !cir.record<struct "Struct" padded {!u8i}>
-!rec_anon_struct = !cir.record<struct  {!s64i, !s64i}>
+!rec_Struct = !cir.struct<"Struct" padded {!u8i}>
+!rec_anon_struct = !cir.struct<{!s64i, !s64i}>
 
 cir.func no_inline dso_local @Func1(%arg0: !s32i {llvm.noundef}, %arg1: !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef}) {
 // CHECK: cir.func no_inline dso_local @Func1(%arg0: !s32i {llvm.noundef}, %arg1: !cir.float {llvm.noundef}) -> (!cir.float {llvm.noundef}) {

--- a/clang/test/CIR/IR/func.cir
+++ b/clang/test/CIR/IR/func.cir
@@ -164,7 +164,7 @@ cir.func @global_dtor_with_priority() global_dtor(201) {
 
 }
 
-!rec_Foo = !cir.record<struct "Foo" {!s32i}>
+!rec_Foo = !cir.struct<"Foo" {!s32i}>
 
 cir.func @Foo_default() special_member<#cir.cxx_ctor<!rec_Foo, default>> {
   cir.return

--- a/clang/test/CIR/IR/global-init.cir
+++ b/clang/test/CIR/IR/global-init.cir
@@ -2,9 +2,9 @@
 
 !u8i = !cir.int<u, 8>
 
-!rec_NeedsCtor = !cir.record<struct "NeedsCtor" padded {!u8i}>
-!rec_NeedsDtor = !cir.record<struct "NeedsDtor" padded {!u8i}>
-!rec_NeedsCtorDtor = !cir.record<struct "NeedsCtorDtor" padded {!u8i}>
+!rec_NeedsCtor = !cir.struct<"NeedsCtor" padded {!u8i}>
+!rec_NeedsDtor = !cir.struct<"NeedsDtor" padded {!u8i}>
+!rec_NeedsCtorDtor = !cir.struct<"NeedsCtorDtor" padded {!u8i}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   cir.func private @_ZN9NeedsCtorC1Ev(!cir.ptr<!rec_NeedsCtor>)

--- a/clang/test/CIR/IR/invalid-array-structor.cir
+++ b/clang/test/CIR/IR/invalid-array-structor.cir
@@ -3,11 +3,11 @@
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func dso_local @bad_static_array_ctor_with_num_elements(%p: !cir.ptr<!cir.array<!rec_S x 10>>, %n: !u64i) {
-    // expected-error@+1 {{'cir.array.ctor' op when 'num_elements' is present, 'addr' must be a pointer to a !cir.record type}}
+    // expected-error@+1 {{'cir.array.ctor' op when 'num_elements' is present, 'addr' must be a pointer to a !cir.struct or !cir.union type}}
     cir.array.ctor %p, %n : !cir.ptr<!cir.array<!rec_S x 10>>, !u64i {
     ^bb0(%e: !cir.ptr<!cir.array<!rec_S x 10>>):
     }
@@ -19,7 +19,7 @@ module {
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SC1Ev(!cir.ptr<!rec_S>)
@@ -38,14 +38,14 @@ module {
 // -----
 
 !u8i = !cir.int<u, 8>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @construct_int(!cir.ptr<!u8i>)
 
   // Static form: addr must be a pointer to an array type.
   cir.func @bad_static_array_not_record_ctor(%p: !cir.ptr<!cir.array<!u8i x 4>>) {
-    // expected-error@+1 {{'cir.array.ctor' op the block argument type must be a pointer to a !cir.record type}}
+    // expected-error@+1 {{'cir.array.ctor' op the block argument type must be a pointer to a !cir.struct or !cir.union type}}
     cir.array.ctor %p : !cir.ptr<!cir.array<!u8i x 4>> {
     ^bb0(%e: !cir.ptr<!u8i>):
       cir.call @construct_int(%e) : (!cir.ptr<!u8i>) -> ()
@@ -58,8 +58,8 @@ module {
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
-!rec_T = !cir.record<struct "T" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
+!rec_T = !cir.struct<"T" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SC1Ev(!cir.ptr<!rec_S>)
@@ -78,8 +78,8 @@ module {
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
-!rec_T = !cir.record<struct "T" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
+!rec_T = !cir.struct<"T" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SC1Ev(!cir.ptr<!rec_S>)
@@ -99,11 +99,11 @@ module {
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func dso_local @bad_static_array_dtor_with_num_elements(%p: !cir.ptr<!cir.array<!rec_S x 10>>, %n: !u64i) {
-    // expected-error@+1 {{'cir.array.dtor' op when 'num_elements' is present, 'addr' must be a pointer to a !cir.record type}}
+    // expected-error@+1 {{'cir.array.dtor' op when 'num_elements' is present, 'addr' must be a pointer to a !cir.struct or !cir.union type}}
     cir.array.dtor %p, %n : !cir.ptr<!cir.array<!rec_S x 10>>, !u64i {
     ^bb0(%e: !cir.ptr<!cir.array<!rec_S x 10>>):
     }
@@ -114,7 +114,7 @@ module {
 // -----
 
 !u8i = !cir.int<u, 8>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SD1Ev(!cir.ptr<!rec_S>)
@@ -131,14 +131,14 @@ module {
 // -----
 
 !u8i = !cir.int<u, 8>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @destroy_int(!cir.ptr<!u8i>)
 
   // Static form: addr must be a pointer to an array type.
   cir.func @bad_static_array_not_record_dtor(%p: !cir.ptr<!cir.array<!u8i x 4>>) {
-    // expected-error@+1 {{'cir.array.dtor' op the block argument type must be a pointer to a !cir.record type}}
+    // expected-error@+1 {{'cir.array.dtor' op the block argument type must be a pointer to a !cir.struct or !cir.union type}}
     cir.array.dtor %p : !cir.ptr<!cir.array<!u8i x 4>> {
     ^bb0(%e: !cir.ptr<!u8i>):
       cir.call @destroy_int(%e) : (!cir.ptr<!u8i>) -> ()
@@ -150,8 +150,8 @@ module {
 // -----
 
 !u8i = !cir.int<u, 8>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
-!rec_T = !cir.record<struct "T" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
+!rec_T = !cir.struct<"T" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SD1Ev(!cir.ptr<!rec_S>)
@@ -169,8 +169,8 @@ module {
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
-!rec_T = !cir.record<struct "T" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
+!rec_T = !cir.struct<"T" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SD1Ev(!cir.ptr<!rec_S>)
@@ -189,8 +189,8 @@ module {
 
 !u8i = !cir.int<u, 8>
 !u64i = !cir.int<u, 64>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
-!rec_T = !cir.record<struct "T" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
+!rec_T = !cir.struct<"T" padded {!u8i}>
 
 module {
   cir.func private @_ZN1SD1Ev(!cir.ptr<!rec_S>)

--- a/clang/test/CIR/IR/invalid-cast.cir
+++ b/clang/test/CIR/IR/invalid-cast.cir
@@ -3,7 +3,7 @@
 // -----
 
 !s32i = !cir.int<s, 32>
-!rec_Foo = !cir.record<struct "Foo" {!s32i}>
+!rec_Foo = !cir.struct<"Foo" {!s32i}>
 
 module {
   cir.func no_inline dso_local @_Z7to_boolM3Fooi(%arg0: !cir.data_member<!s32i in !rec_Foo>) -> !s32i {
@@ -16,7 +16,7 @@ module {
 // -----
 
 !s32i = !cir.int<s, 32>
-!rec_Foo = !cir.record<struct "Foo" {!s32i}>
+!rec_Foo = !cir.struct<"Foo" {!s32i}>
 
 module {
   cir.func no_inline dso_local @_Z7to_boolM3Fooi(%arg0: !s32i) -> !cir.bool {

--- a/clang/test/CIR/IR/invalid-const-record.cir
+++ b/clang/test/CIR/IR/invalid-const-record.cir
@@ -1,15 +1,15 @@
 // RUN: cir-opt %s -verify-diagnostics -split-input-file
 
 !s32i = !cir.int<s, 32>
-!rec_anon_struct = !cir.record<struct  packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
+!rec_anon_struct = !cir.struct< packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
 
-// expected-error @below {{expected !cir.record type}}
+// expected-error @below {{expected !cir.struct or !cir.union type}}
 cir.global external @e = #cir.const_record<{#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.zero : !cir.array<!s32i x 8>}> : !cir.ptr<!rec_anon_struct>
 
 // -----
 
 !s32i = !cir.int<s, 32>
-!rec_anon_struct = !cir.record<struct  packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
+!rec_anon_struct = !cir.struct< packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
 
 // expected-error @below {{number of elements must match}}
 cir.global external @e = #cir.const_record<{#cir.int<1> : !s32i, #cir.zero : !cir.array<!s32i x 8>}> : !rec_anon_struct
@@ -17,7 +17,7 @@ cir.global external @e = #cir.const_record<{#cir.int<1> : !s32i, #cir.zero : !ci
 // -----
 
 !s32i = !cir.int<s, 32>
-!rec_anon_struct = !cir.record<struct  packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
+!rec_anon_struct = !cir.struct< packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
 
 // expected-error @below {{element at index 1 has type '!cir.float' but the expected type for this element is '!cir.int<s, 32>'}}
 cir.global external @e = #cir.const_record<{#cir.int<1> : !s32i, #cir.fp<2.000000e+00> : !cir.float, #cir.zero : !cir.array<!s32i x 8>}> : !rec_anon_struct

--- a/clang/test/CIR/IR/invalid-construct-catch-param.cir
+++ b/clang/test/CIR/IR/invalid-construct-catch-param.cir
@@ -3,7 +3,7 @@
 !u8i = !cir.int<u, 8>
 !s32i = !cir.int<s, 32>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 
@@ -34,7 +34,7 @@ cir.func @copy_fn_missing() {
 
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 
@@ -68,7 +68,7 @@ cir.func @copy_fn_missing_thunk_attr() {
 
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 
@@ -104,7 +104,7 @@ cir.func @copy_fn_wrong_arity() {
 !u8i = !cir.int<u, 8>
 !s32i = !cir.int<s, 32>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 
@@ -141,7 +141,7 @@ cir.func @copy_fn_non_void_return() {
 !u8i = !cir.int<u, 8>
 !s32i = !cir.int<s, 32>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 
@@ -179,7 +179,7 @@ cir.func @copy_fn_first_arg_mismatch() {
 !u8i = !cir.int<u, 8>
 !s32i = !cir.int<s, 32>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 
@@ -216,7 +216,7 @@ cir.func @copy_fn_second_arg_mismatch() {
 
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module {
 

--- a/clang/test/CIR/IR/invalid-data-member.cir
+++ b/clang/test/CIR/IR/invalid-data-member.cir
@@ -4,7 +4,7 @@
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
+!struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
 
 // expected-error@+1 {{member type of a #cir.data_member attribute must match the attribute type}}
 #invalid_member_ty = #cir.data_member<0> : !cir.data_member<!u32i in !struct1>
@@ -12,7 +12,7 @@
 // -----
 
 !u16i = !cir.int<u, 16>
-!incomplete_struct = !cir.record<struct "Incomplete" incomplete>
+!incomplete_struct = !cir.struct<"Incomplete" incomplete>
 
 // expected-error@+1 {{incomplete 'cir.record' cannot be used to build a non-null data member pointer}}
 #incomplete_cls_member = #cir.data_member<0> : !cir.data_member<!u16i in !incomplete_struct>
@@ -21,7 +21,7 @@
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
+!struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
 
 // expected-error@+1 {{member index of a #cir.data_member attribute is out of range}}
 #invalid_member_ty = #cir.data_member<2> : !cir.data_member<!u32i in !struct1>
@@ -30,8 +30,8 @@
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
-!struct2 = !cir.record<struct "Struct2" {!u16i, !u32i}>
+!struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
+!struct2 = !cir.struct<"Struct2" {!u16i, !u32i}>
 
 module {
   cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {
@@ -46,7 +46,7 @@ module {
 
 !u16i = !cir.int<u, 16>
 !u32i = !cir.int<u, 32>
-!struct1 = !cir.record<struct "Struct1" {!u16i, !u32i}>
+!struct1 = !cir.struct<"Struct1" {!u16i, !u32i}>
 
 module {
   cir.func @invalid_base_type(%arg0 : !cir.data_member<!u32i in !struct1>) {

--- a/clang/test/CIR/IR/invalid-delete-array.cir
+++ b/clang/test/CIR/IR/invalid-delete-array.cir
@@ -2,7 +2,7 @@
 
 !void = !cir.void
 !u8i = !cir.int<u, 8>
-!rec_S = !cir.record<struct "S" padded {!u8i}>
+!rec_S = !cir.struct<"S" padded {!u8i}>
 
 module {
   cir.func private @_ZdaPvm(!cir.ptr<!void>)

--- a/clang/test/CIR/IR/invalid-dyn-cast.cir
+++ b/clang/test/CIR/IR/invalid-dyn-cast.cir
@@ -6,8 +6,8 @@
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!Base = !cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
-!Derived = !cir.record<struct "Derived" {!cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
+!Base = !cir.struct<"Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
+!Derived = !cir.struct<"Derived" {!cir.struct<"Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
 
 module {
   cir.global "private" constant external @_ZTI4Base : !cir.ptr<!u32i>
@@ -28,8 +28,8 @@ module {
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!Base = !cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
-!Derived = !cir.record<struct "Derived" {!cir.record<struct "Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
+!Base = !cir.struct<"Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>
+!Derived = !cir.struct<"Derived" {!cir.struct<"Base" {!cir.ptr<!cir.ptr<!cir.func<() -> !cir.int<u, 32>>>>}>}>
 
 module {
   cir.global "private" constant external @_ZTI4Base : !cir.ptr<!u8i>

--- a/clang/test/CIR/IR/invalid-struct.cir
+++ b/clang/test/CIR/IR/invalid-struct.cir
@@ -2,7 +2,7 @@
 
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
-!rec_S = !cir.record<struct "S" {!u8i, !u32i}>
+!rec_S = !cir.struct<"S" {!u8i, !u32i}>
 
 module  {
   cir.func @struct_extract_member_invalid_element_type() {
@@ -17,7 +17,7 @@ module  {
 
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
-!rec_S = !cir.record<struct "S" {!u8i, !u32i}>
+!rec_S = !cir.struct<"S" {!u8i, !u32i}>
 
 module  {
   cir.func @struct_extract_member_invalid_index_value() {
@@ -31,7 +31,7 @@ module  {
 // -----
 
 !u32i = !cir.int<u, 32>
-!rec_U = !cir.record<union "U" {!u32i}>
+!rec_U = !cir.union<"U" {!u32i}>
 
 module  {
   cir.func @extract_member_invalid_for_union() {
@@ -46,7 +46,7 @@ module  {
 
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
-!rec_S = !cir.record<struct "S" {!u8i, !u32i}>
+!rec_S = !cir.struct<"S" {!u8i, !u32i}>
 
 module  {
   cir.func @struct_insert_member_invalid_element_type() {
@@ -62,7 +62,7 @@ module  {
 
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
-!rec_S = !cir.record<struct "S" {!u8i, !u32i}>
+!rec_S = !cir.struct<"S" {!u8i, !u32i}>
 
 module  {
   cir.func @struct_extract_member_invalid_index_value() {
@@ -77,7 +77,7 @@ module  {
 // -----
 
 !u32i = !cir.int<u, 32>
-!rec_U = !cir.record<union "U" {!u32i}>
+!rec_U = !cir.union<"U" {!u32i}>
 
 module  {
   cir.func @extract_member_invalid_for_union() {

--- a/clang/test/CIR/IR/invalid-type-info.cir
+++ b/clang/test/CIR/IR/invalid-type-info.cir
@@ -2,16 +2,16 @@
 
 !u8i = !cir.int<u, 8>
 
-!rec_anon_struct = !cir.record<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+!rec_anon_struct = !cir.struct<{!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
 
-// expected-error @below {{expected !cir.record type}}
+// expected-error @below {{expected !cir.struct or !cir.union type}}
 cir.global constant external @type_info = #cir.typeinfo<{#cir.global_view<@_ZTVN10__cxxabiv120__si_class_type_infoE, [2 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTS1B> : !cir.ptr<!u8i>, #cir.global_view<@_ZTI1A> : !cir.ptr<!u8i>}> : !u8i
 
 // -----
 
 !u8i = !cir.int<u, 8>
 
-!rec_anon_struct = !cir.record<struct  {!u8i, !u8i, !u8i}>
+!rec_anon_struct = !cir.struct<{!u8i, !u8i, !u8i}>
 
 // expected-error @below {{integer or global view array attribute}}
 cir.global constant external @type_info = #cir.typeinfo<{ #cir.undef : !u8i, #cir.int<1> : !u8i, #cir.int<1> : !u8i}> : !rec_anon_struct

--- a/clang/test/CIR/IR/invalid-vtable.cir
+++ b/clang/test/CIR/IR/invalid-vtable.cir
@@ -20,11 +20,11 @@ cir.func @reference_non_vtable() {
 
 // -----
 
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
 !u8i = !cir.int<u, 8>
-!rec_anon_struct = !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 4>}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
 module {
-  // expected-error @below {{expected !cir.record type result}}
+  // expected-error @below {{expected !cir.struct or !cir.union type result}}
   cir.global external @_ZTV1S = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S3keyEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S6nonKeyEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !cir.ptr<!rec_anon_struct>
   cir.func private dso_local @_ZN1S3keyEv(%arg0: !cir.ptr<!rec_S>)
   cir.func private dso_local @_ZN1S6nonKeyEv(%arg0: !cir.ptr<!rec_S>)
@@ -32,9 +32,9 @@ module {
 
 // -----
 
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
 !u8i = !cir.int<u, 8>
-!rec_anon_struct = !cir.record<struct  {}>
+!rec_anon_struct = !cir.struct<{}>
 module {
   // expected-error @below {{expected record type with one or more subtype}}
   cir.global external @_ZTV1S = #cir.vtable<{}> : !rec_anon_struct {alignment = 8 : i64}
@@ -44,9 +44,9 @@ module {
 
 // -----
 
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
 !u8i = !cir.int<u, 8>
-!rec_anon_struct = !cir.record<struct  {!cir.ptr<!u8i>}>
+!rec_anon_struct = !cir.struct<{!cir.ptr<!u8i>}>
 module {
   // expected-error @below {{expected constant array subtype}}
   cir.global external @_ZTV1S = #cir.vtable<{#cir.ptr<null> : !cir.ptr<!u8i>}> : !rec_anon_struct {alignment = 8 : i64}
@@ -56,9 +56,9 @@ module {
 
 // -----
 
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
 !u64i = !cir.int<u, 64>
-!rec_anon_struct = !cir.record<struct  {!cir.array<!u64i x 4>}>
+!rec_anon_struct = !cir.struct<{!cir.array<!u64i x 4>}>
 module {
   // expected-error @below {{expected GlobalViewAttr or ConstPtrAttr}}
   cir.global external @_ZTV1S = #cir.vtable<{#cir.const_array<[#cir.int<1> : !u64i, #cir.int<1> : !u64i, #cir.int<3> : !u64i, #cir.int<4> : !u64i]> : !cir.array<!u64i x 4>}> : !rec_anon_struct {alignment = 8 : i64}
@@ -68,11 +68,11 @@ module {
 
 // -----
 
-!rec_Q = !cir.record<struct "Q" {!cir.vptr}>
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
-!rec_S2 = !cir.record<struct "S2" {!rec_Q, !rec_S}>
+!rec_Q = !cir.struct<"Q" {!cir.vptr}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
+!rec_S2 = !cir.struct<"S2" {!rec_Q, !rec_S}>
 !u8i = !cir.int<u, 8>
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.ptr<!u8i>}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>, !cir.ptr<!u8i>}>
 module {
   // expected-error @below {{expected constant array subtype}}
   cir.global external @_ZTV2S2 = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S3keyEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S6nonKeyEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>, #cir.ptr<null> : !cir.ptr<!u8i>}> : !rec_anon_struct {alignment = 8 : i64}
@@ -97,7 +97,7 @@ cir.func @reference_unknown_vtt() {
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
 !void = !cir.void
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
 cir.global external @_ZTV1S = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S3keyEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S6nonKeyEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !rec_anon_struct {alignment = 8 : i64}
 cir.func @reference_non_vtt() {
   // expected-error @below {{'cir.vtt.address_point' op Expected constant array in initializer for global VTT '_ZTV1S'}}
@@ -110,8 +110,8 @@ cir.func @reference_non_vtt() {
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
 !void = !cir.void
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-!rec_C = !cir.record<class "C" {!cir.vptr}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
+!rec_C = !cir.struct<class "C" {!cir.vptr}>
 cir.global linkonce_odr @_ZTT1C = #cir.const_array<[#cir.global_view<@_ZTV1C, [0 : i32, 3 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTC1C0_1B, [0 : i32, 3 : i32]> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 2> {alignment = 8 : i64}
 cir.func @reference_name_and_value(%arg0: !cir.ptr<!rec_C>, %arg1: !cir.ptr<!cir.ptr<!void>>) {
   // expected-error @below {{'cir.vtt.address_point' op should use either a symbol or value, but not both}}
@@ -124,8 +124,8 @@ cir.func @reference_name_and_value(%arg0: !cir.ptr<!rec_C>, %arg1: !cir.ptr<!cir
 !u8i = !cir.int<u, 8>
 !u32i = !cir.int<u, 32>
 !void = !cir.void
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-!rec_C = !cir.record<class "C" {!cir.vptr}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
+!rec_C = !cir.struct<class "C" {!cir.vptr}>
 cir.global linkonce_odr @_ZTT1C = #cir.const_array<[#cir.global_view<@_ZTV1C, [0 : i32, 3 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTC1C0_1B, [0 : i32, 3 : i32]> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 2> {alignment = 8 : i64}
 cir.func @bad_return_type_for_vtt_addrpoint() {
   // expected-error @below {{result type must be '!cir.ptr<!cir.ptr<!cir.void>>', but provided result type is '!cir.ptr<!cir.int<u, 8>>'}}

--- a/clang/test/CIR/IR/method-attr.cir
+++ b/clang/test/CIR/IR/method-attr.cir
@@ -2,7 +2,7 @@
 
 !void = !cir.void
 
-!rec_Foo = !cir.record<struct "Foo" {!cir.vptr}>
+!rec_Foo = !cir.struct<"Foo" {!cir.vptr}>
 !s32i = !cir.int<s, 32>
 module {
   cir.func private @_ZN3Foo2m1Ei(!s32i)

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -5,43 +5,43 @@
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-!rec_C = !cir.record<class "C" incomplete>
-!rec_S = !cir.record<struct "S" incomplete>
-!rec_U = !cir.record<union "U" incomplete>
+!rec_C = !cir.struct<class "C" incomplete>
+!rec_S = !cir.struct<"S" incomplete>
+!rec_U = !cir.union<"U" incomplete>
 
-// CHECK-DAG: !rec_C = !cir.record<class "C" incomplete>
-// CHECK-DAG: !rec_S = !cir.record<struct "S" incomplete>
-// CHECK-DAG: !rec_U = !cir.record<union "U" incomplete>
+// CHECK-DAG: !rec_C = !cir.struct<class "C" incomplete>
+// CHECK-DAG: !rec_S = !cir.struct<"S" incomplete>
+// CHECK-DAG: !rec_U = !cir.union<"U" incomplete>
 
-!rec_anon_struct = !cir.record<struct  packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
-!rec_anon_struct1 = !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
-!rec_anon_struct2 = !cir.record<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
-!rec_S1 = !cir.record<struct "S1" {!s32i, !s32i}>
-!rec_Sc = !cir.record<struct "Sc" {!u8i, !u16i, !u32i}>
+!rec_anon_struct = !cir.struct< packed {!s32i, !s32i, !cir.array<!s32i x 8>}>
+!rec_anon_struct1 = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 5>}>
+!rec_anon_struct2 = !cir.struct<{!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+!rec_S1 = !cir.struct<"S1" {!s32i, !s32i}>
+!rec_Sc = !cir.struct<"Sc" {!u8i, !u16i, !u32i}>
 
-// CHECK-DAG: !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 5>}>
-// CHECK-DAG: !cir.record<struct {!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
-// CHECK-DAG: !rec_S1 = !cir.record<struct "S1" {!s32i, !s32i}>
-// CHECK-DAG: !rec_Sc = !cir.record<struct "Sc" {!u8i, !u16i, !u32i}>
+// CHECK-DAG: !cir.struct<{!cir.array<!cir.ptr<!u8i> x 5>}>
+// CHECK-DAG: !cir.struct<{!cir.ptr<!u8i>, !cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+// CHECK-DAG: !rec_S1 = !cir.struct<"S1" {!s32i, !s32i}>
+// CHECK-DAG: !rec_Sc = !cir.struct<"Sc" {!u8i, !u16i, !u32i}>
 
 // Packed and padded structs
-!rec_P1 = !cir.record<struct "P1" packed {!s32i, !s32i}>
-!rec_P2 = !cir.record<struct "P2" padded {!u8i, !u16i, !u32i}>
-!rec_P3 = !cir.record<struct "P3" packed padded {!u8i, !u16i, !u32i}>
+!rec_P1 = !cir.struct<"P1" packed {!s32i, !s32i}>
+!rec_P2 = !cir.struct<"P2" padded {!u8i, !u16i, !u32i}>
+!rec_P3 = !cir.struct<"P3" packed padded {!u8i, !u16i, !u32i}>
 
-// CHECK-DAG: !rec_P1 = !cir.record<struct "P1" packed {!s32i, !s32i}>
-// CHECK-DAG: !rec_P2 = !cir.record<struct "P2" padded {!u8i, !u16i, !u32i}>
-// CHECK-DAG: !rec_P3 = !cir.record<struct "P3" packed padded {!u8i, !u16i, !u32i}>
+// CHECK-DAG: !rec_P1 = !cir.struct<"P1" packed {!s32i, !s32i}>
+// CHECK-DAG: !rec_P2 = !cir.struct<"P2" padded {!u8i, !u16i, !u32i}>
+// CHECK-DAG: !rec_P3 = !cir.struct<"P3" packed padded {!u8i, !u16i, !u32i}>
 
 
 // Complete a previously incomplete record
-!rec_A = !cir.record<class "A" incomplete>
-!rec_Ac = !cir.record<class "A" {!u8i, !s32i}>
-// CHECK-DAG: !rec_A = !cir.record<class "A" {!u8i, !s32i}>
+!rec_A = !cir.struct<class "A" incomplete>
+!rec_Ac = !cir.struct<class "A" {!u8i, !s32i}>
+// CHECK-DAG: !rec_A = !cir.struct<class "A" {!u8i, !s32i}>
 
 // Test recursive struct parsing/printing.
-!rec_Node = !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>}>
-// CHECK-DAG: !cir.record<struct "Node" {!cir.ptr<!cir.record<struct "Node">>}>
+!rec_Node = !cir.struct<"Node" {!cir.ptr<!cir.struct<"Node">>}>
+// CHECK-DAG: !cir.struct<"Node" {!cir.ptr<!cir.struct<"Node">>}>
 
 
 
@@ -68,8 +68,8 @@ module  {
   }
 
   cir.func @structs() {
-    %0 = cir.alloca !cir.ptr<!cir.record<struct "Sc" {!u8i, !u16i, !u32i}>>, !cir.ptr<!cir.ptr<!cir.record<struct "Sc" {!u8i, !u16i, !u32i}>>>, ["sc", init] {alignment = 8 : i64}
-    %1 = cir.alloca !cir.ptr<!cir.record<union "U" incomplete>>, !cir.ptr<!cir.ptr<!cir.record<union "U" incomplete>>>, ["u", init] {alignment = 8 : i64}
+    %0 = cir.alloca !cir.ptr<!cir.struct<"Sc" {!u8i, !u16i, !u32i}>>, !cir.ptr<!cir.ptr<!cir.struct<"Sc" {!u8i, !u16i, !u32i}>>>, ["sc", init] {alignment = 8 : i64}
+    %1 = cir.alloca !cir.ptr<!cir.union<"U" incomplete>>, !cir.ptr<!cir.ptr<!cir.union<"U" incomplete>>>, ["u", init] {alignment = 8 : i64}
     cir.return
   }
 

--- a/clang/test/CIR/IR/struct.cir
+++ b/clang/test/CIR/IR/struct.cir
@@ -33,6 +33,12 @@
 // CHECK-DAG: !rec_P2 = !cir.struct<"P2" padded {!u8i, !u16i, !u32i}>
 // CHECK-DAG: !rec_P3 = !cir.struct<"P3" packed padded {!u8i, !u16i, !u32i}>
 
+!rec_U1 = !cir.union<"U1" {!s32i, !u8i}, padding = {!u8i}>
+!rec_U2 = !cir.union<"U2" packed {!s32i}, padding = {!cir.array<!u8i x 4>}>
+
+// CHECK-DAG: !rec_U1 = !cir.union<"U1" {!s32i, !u8i}, padding = {!u8i}>
+// CHECK-DAG: !rec_U2 = !cir.union<"U2" packed {!s32i}, padding = {!cir.array<!u8i x 4>}>
+
 
 // Complete a previously incomplete record
 !rec_A = !cir.struct<class "A" incomplete>
@@ -63,7 +69,9 @@ module  {
                      %arg4: !rec_Ac,
                      %arg5: !rec_P1,
                      %arg6: !rec_P2,
-                     %arg7: !rec_P3) {
+                     %arg7: !rec_P3,
+                     %arg8: !rec_U1,
+                     %arg9: !rec_U2) {
     cir.return
   }
 

--- a/clang/test/CIR/IR/vtable-addrpt.cir
+++ b/clang/test/CIR/IR/vtable-addrpt.cir
@@ -4,8 +4,8 @@
 
 !u32i = !cir.int<u, 32>
 !u8i = !cir.int<u, 8>
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
 
 module {
   cir.global "private" external @_ZTV1S : !rec_anon_struct {alignment = 8 : i64}

--- a/clang/test/CIR/IR/vtable-attr.cir
+++ b/clang/test/CIR/IR/vtable-attr.cir
@@ -1,11 +1,11 @@
 // RUN: cir-opt %s --verify-roundtrip | FileCheck %s
 
-!rec_Q = !cir.record<struct "Q" {!cir.vptr}>
-!rec_S = !cir.record<struct "S" {!cir.vptr}>
-!rec_S2 = !cir.record<struct "S2" {!rec_Q, !rec_S}>
+!rec_Q = !cir.struct<"Q" {!cir.vptr}>
+!rec_S = !cir.struct<"S" {!cir.vptr}>
+!rec_S2 = !cir.struct<"S2" {!rec_Q, !rec_S}>
 !u8i = !cir.int<u, 8>
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>}>
-!rec_anon_struct1 = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>}>
+!rec_anon_struct1 = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 4>, !cir.array<!cir.ptr<!u8i> x 3>}>
 module {
   cir.global external @_ZTV1S = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S3keyEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S6nonKeyEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !rec_anon_struct {alignment = 8 : i64}
   // CHECK: cir.global external @_ZTV1S = #cir.vtable<{#cir.const_array<[#cir.ptr<null> : !cir.ptr<!u8i>, #cir.ptr<null> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S3keyEv> : !cir.ptr<!u8i>, #cir.global_view<@_ZN1S6nonKeyEv> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 4>}> : !rec_anon_struct {alignment = 8 : i64}

--- a/clang/test/CIR/IR/vtt-addrpoint.cir
+++ b/clang/test/CIR/IR/vtt-addrpoint.cir
@@ -5,10 +5,10 @@
 
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_A = !cir.record<struct "A" {!u8i}>
-!rec_B = !cir.record<struct "B" {!cir.vptr}>
-!rec_C = !cir.record<struct "C" {!rec_B}>
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
+!rec_A = !cir.struct<"A" {!u8i}>
+!rec_B = !cir.struct<"B" {!cir.vptr}>
+!rec_C = !cir.struct<"C" {!rec_B}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 3>}>
 module {
   cir.func private @_ZN1AC2Ev(!cir.ptr<!rec_A>)
   cir.func private @_ZN1BC2Ev(!cir.ptr<!rec_B>, !cir.ptr<!cir.ptr<!void>>)

--- a/clang/test/CIR/Lowering/struct.cir
+++ b/clang/test/CIR/Lowering/struct.cir
@@ -3,7 +3,7 @@
 
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
-!ty_S = !cir.record<struct "S" {!u8i, !s32i}>
+!ty_S = !cir.struct<"S" {!u8i, !s32i}>
 
 module {
   // CHECK-LABEL: @test_value

--- a/clang/test/CIR/Lowering/vtt-addrpoint.cir
+++ b/clang/test/CIR/Lowering/vtt-addrpoint.cir
@@ -6,10 +6,10 @@
 
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_A = !cir.record<struct "A" {!u8i}>
-!rec_B = !cir.record<struct "B" {!cir.vptr}>
-!rec_C = !cir.record<struct "C" {!rec_B}>
-!rec_anon_struct = !cir.record<struct  {!cir.array<!cir.ptr<!u8i> x 3>}>
+!rec_A = !cir.struct<"A" {!u8i}>
+!rec_B = !cir.struct<"B" {!cir.vptr}>
+!rec_C = !cir.struct<"C" {!rec_B}>
+!rec_anon_struct = !cir.struct<{!cir.array<!cir.ptr<!u8i> x 3>}>
 module {
   cir.func private @_ZN1AC2Ev(!cir.ptr<!rec_A>)
   cir.func private @_ZN1BC2Ev(!cir.ptr<!rec_B>, !cir.ptr<!cir.ptr<!void>>)

--- a/clang/test/CIR/Transforms/canonicalize-cleanup-scope.cir
+++ b/clang/test/CIR/Transforms/canonicalize-cleanup-scope.cir
@@ -1,7 +1,7 @@
 // RUN: cir-opt %s -cir-canonicalize -o - | FileCheck %s
 
 !s32i = !cir.int<s, 32>
-!rec_S = !cir.record<struct "S" {!s32i}>
+!rec_S = !cir.struct<"S" {!s32i}>
 
 module {
 

--- a/clang/test/CIR/Transforms/cxx-abi-lowering-attrs.cir
+++ b/clang/test/CIR/Transforms/cxx-abi-lowering-attrs.cir
@@ -3,9 +3,9 @@
 
 !u8i = !cir.int<u, 8>
 !s32i = !cir.int<s, 32>
-!rec_Other = !cir.record<struct "Other" padded {!u8i}>
-!rec_Struct = !cir.record<struct "Struct" {!cir.data_member<!s32i in !rec_Other>}>
-// CHECK: !rec_Struct = !cir.record<struct "Struct" {!s64i}>
+!rec_Other = !cir.struct<"Other" padded {!u8i}>
+!rec_Struct = !cir.struct<"Struct" {!cir.data_member<!s32i in !rec_Other>}>
+// CHECK: !rec_Struct = !cir.struct<"Struct" {!s64i}>
 
 !dmp = !cir.data_member<!s32i in !rec_Other>
 !dmp_ptr = !cir.ptr<!cir.data_member<!s32i in !rec_Other>>

--- a/clang/test/CIR/Transforms/eh-abi-lowering-construct-catch-invalid.cir
+++ b/clang/test/CIR/Transforms/eh-abi-lowering-construct-catch-invalid.cir
@@ -7,7 +7,7 @@
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 
@@ -17,7 +17,7 @@ cir.global constant linkonce_odr @_ZTI1E
     = #cir.typeinfo<{
         #cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]>
             : !cir.ptr<!u8i>}>
-    : !cir.record<struct  {!cir.ptr<!u8i>}>
+    : !cir.struct<{!cir.ptr<!u8i>}>
 
 cir.func private @_Z8mayThrowv()
 cir.func private @_ZN1EC1ERKS_(!cir.ptr<!rec_E>, !cir.ptr<!rec_E>)
@@ -65,7 +65,7 @@ cir.func @bad_kind() {
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 
@@ -75,7 +75,7 @@ cir.global constant linkonce_odr @_ZTI1E
     = #cir.typeinfo<{
         #cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]>
             : !cir.ptr<!u8i>}>
-    : !cir.record<struct  {!cir.ptr<!u8i>}>
+    : !cir.struct<{!cir.ptr<!u8i>}>
 
 cir.func private @_Z8mayThrowv()
 
@@ -118,7 +118,7 @@ cir.func @copy_fn_no_body() {
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 
@@ -128,7 +128,7 @@ cir.global constant linkonce_odr @_ZTI1E
     = #cir.typeinfo<{
         #cir.global_view<@_ZTVN10__cxxabiv117__class_type_infoE, [2 : i32]>
             : !cir.ptr<!u8i>}>
-    : !cir.record<struct  {!cir.ptr<!u8i>}>
+    : !cir.struct<{!cir.ptr<!u8i>}>
 
 cir.func private @_Z8mayThrowv()
 cir.func private @_ZN1EC1ERKS_(!cir.ptr<!rec_E>, !cir.ptr<!rec_E>)

--- a/clang/test/CIR/Transforms/eh-abi-lowering-construct-catch.cir
+++ b/clang/test/CIR/Transforms/eh-abi-lowering-construct-catch.cir
@@ -22,8 +22,8 @@
 !u32i = !cir.int<u, 32>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_E = !cir.record<struct "E" padded {!u8i}>
-!rec_anon_struct = !cir.record<struct  {!cir.ptr<!u8i>, !cir.ptr<!u8i>}>
+!rec_E = !cir.struct<"E" padded {!u8i}>
+!rec_anon_struct = !cir.struct<{!cir.ptr<!u8i>, !cir.ptr<!u8i>}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 

--- a/clang/test/CIR/Transforms/eh-abi-lowering-itanium.cir
+++ b/clang/test/CIR/Transforms/eh-abi-lowering-itanium.cir
@@ -9,8 +9,8 @@
 !u32i = !cir.int<u, 32>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
-!rec_exception = !cir.record<struct "std::exception" {!s32i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
+!rec_exception = !cir.struct<"std::exception" {!s32i}>
 
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-eh.cir
@@ -3,8 +3,8 @@
 
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
-!rec_NonTrivial = !cir.record<struct "NonTrivial" padded {!u8i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
+!rec_NonTrivial = !cir.struct<"NonTrivial" padded {!u8i}>
 #false = #cir.bool<false> : !cir.bool
 #true = #cir.bool<true> : !cir.bool
 

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-multi-exit.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-multi-exit.cir
@@ -2,7 +2,7 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
 
 // Test that a cleanup scope with break that branches through cleanup is
 // properly flattened with a destination slot and switch dispatch.

--- a/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
+++ b/clang/test/CIR/Transforms/flatten-cleanup-scope-simple.cir
@@ -2,7 +2,7 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
 
 // Test basic cleanup scope flattening with normal cleanup.
 // The body yields to cleanup, cleanup yields to continue.

--- a/clang/test/CIR/Transforms/flatten-preserve-attrs.cir
+++ b/clang/test/CIR/Transforms/flatten-preserve-attrs.cir
@@ -2,7 +2,7 @@
 // RUN: FileCheck --input-file=%t.cir %s
 
 !s32i = !cir.int<s, 32>
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
 
 // Test that argument attributes on a cir.call are preserved on the resulting
 // cir.try_call after flattening.

--- a/clang/test/CIR/Transforms/flatten-throwing-in-cleanup.cir
+++ b/clang/test/CIR/Transforms/flatten-throwing-in-cleanup.cir
@@ -3,7 +3,7 @@
 
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
 
 // Test that a throwing call in an EH cleanup region is replaced with
 // cir.try_call that unwinds to a terminate block.

--- a/clang/test/CIR/Transforms/flatten-try-op.cir
+++ b/clang/test/CIR/Transforms/flatten-try-op.cir
@@ -4,8 +4,8 @@
 !s32i = !cir.int<s, 32>
 !u8i = !cir.int<u, 8>
 !void = !cir.void
-!rec_SomeClass = !cir.record<struct "SomeClass" {!s32i}>
-!rec_exception = !cir.record<struct "std::exception" {!s32i}>
+!rec_SomeClass = !cir.struct<"SomeClass" {!s32i}>
+!rec_exception = !cir.struct<"std::exception" {!s32i}>
 
 // Test a simple try with no handlers and no throwing calls.
 cir.func @test_try_no_handlers() {

--- a/clang/test/CIR/Transforms/pure-ptr-arithmetic.cir
+++ b/clang/test/CIR/Transforms/pure-ptr-arithmetic.cir
@@ -7,9 +7,9 @@
 !u8i = !cir.int<u, 8>
 !void = !cir.void
 
-!rec_S = !cir.record<struct "S" {!s32i, !s32i}>
-!rec_Base = !cir.record<struct "Base" {!u8i}>
-!rec_Derived = !cir.record<struct "Derived" {!rec_Base, !s32i}>
+!rec_S = !cir.struct<"S" {!s32i, !s32i}>
+!rec_Base = !cir.struct<"Base" {!u8i}>
+!rec_Derived = !cir.struct<"Derived" {!rec_Base, !s32i}>
 
 module {
 

--- a/clang/unittests/CIR/PointerLikeTest.cpp
+++ b/clang/unittests/CIR/PointerLikeTest.cpp
@@ -161,11 +161,14 @@ protected:
   }
 
   // Structures and unions are accessed in the same way, so use a common test.
-  void testRecordType(mlir::Type ty1, mlir::Type ty2,
-                      cir::RecordType::RecordKind kind) {
-    // Build the structure pointer type.
-    cir::RecordType structTy =
-        cir::RecordType::get(&context, getUniqueRecordName("S"), kind);
+  void testRecordType(mlir::Type ty1, mlir::Type ty2, bool is_union) {
+    // Build the structure/union type.
+    cir::RecordType structTy;
+    if (is_union)
+      structTy = cir::UnionType::get(&context, getUniqueRecordName("S"));
+    else
+      structTy = cir::StructType::get(&context, getUniqueRecordName("S"),
+                                      /*is_class=*/false);
     structTy.complete({ty1, ty2}, false, false);
     mlir::Type ptrTy = cir::PointerType::get(structTy);
 
@@ -223,11 +226,11 @@ protected:
   }
 
   void testStructType(mlir::Type ty1, mlir::Type ty2) {
-    testRecordType(ty1, ty2, cir::RecordType::RecordKind::Struct);
+    testRecordType(ty1, ty2, /*is_union=*/false);
   }
 
   void testUnionType(mlir::Type ty1, mlir::Type ty2) {
-    testRecordType(ty1, ty2, cir::RecordType::RecordKind::Union);
+    testRecordType(ty1, ty2, /*is_union=*/true);
   }
 
   // This is testing a case like this:
@@ -246,8 +249,8 @@ protected:
     // type.
     mlir::Type ptrTy = cir::PointerType::get(ty);
     cir::RecordType structTy =
-        cir::RecordType::get(&context, getUniqueRecordName("S"),
-                             cir::RecordType::RecordKind::Struct);
+        cir::StructType::get(&context, getUniqueRecordName("S"),
+                             /*is_class=*/false);
     structTy.complete({ptrTy, ptrTy}, false, false);
     mlir::Type structPptrTy = cir::PointerType::get(structTy);
 
@@ -355,8 +358,9 @@ TEST_F(CIROpenACCPointerLikeTest, testPointerToArrayMember) {
 
 TEST_F(CIROpenACCPointerLikeTest, testPointerToStructMember) {
   mlir::Type i32Ty = cir::IntType::get(&context, 32, true);
-  cir::RecordType structTy = cir::RecordType::get(
-      &context, getUniqueRecordName("S"), cir::RecordType::RecordKind::Struct);
+  cir::RecordType structTy =
+      cir::StructType::get(&context, getUniqueRecordName("S"),
+                           /*is_class=*/false);
   structTy.complete({i32Ty, i32Ty}, false, false);
   testPointerToMemberType(structTy, mlir::acc::VariableTypeCategory::composite);
 }

--- a/clang/unittests/CIR/RecordTypeMetadataTest.cpp
+++ b/clang/unittests/CIR/RecordTypeMetadataTest.cpp
@@ -62,8 +62,7 @@ TEST_F(RecordLayoutAttrTest, HighAlignment) {
 
 TEST_F(RecordLayoutAttrTest, RecordTypeUnchanged) {
   IntType i32 = IntType::get(&context, 32, true);
-  auto ty =
-      RecordType::get(&context, getName("Foo"), RecordType::RecordKind::Struct);
+  auto ty = StructType::get(&context, getName("Foo"), /*is_class=*/false);
   ty.complete({i32, i32}, /*packed=*/false, /*padded=*/false);
   EXPECT_TRUE(ty.isComplete());
   EXPECT_EQ(ty.getMembers().size(), 2u);

--- a/clang/unittests/CIR/UnionTypeSizeTest.cpp
+++ b/clang/unittests/CIR/UnionTypeSizeTest.cpp
@@ -32,7 +32,7 @@ protected:
 
 TEST_F(UnionTypeSizeTest, SizeInBitsNotBytes) {
   IntType i32 = IntType::get(&context, 32, true);
-  auto ty = RecordType::get(&context, getName("U"), RecordType::Union);
+  auto ty = UnionType::get(&context, getName("U"));
   ty.complete({i32}, /*packed=*/false, /*padded=*/false);
 
   OpBuilder builder(&context);
@@ -49,7 +49,7 @@ TEST_F(UnionTypeSizeTest, SizeInBitsNotBytes) {
 TEST_F(UnionTypeSizeTest, MultiMemberUnion) {
   IntType i32 = IntType::get(&context, 32, true);
   IntType i64 = IntType::get(&context, 64, true);
-  auto ty = RecordType::get(&context, getName("U2"), RecordType::Union);
+  auto ty = UnionType::get(&context, getName("U2"));
   ty.complete({i32, i64}, /*packed=*/false, /*padded=*/false);
 
   OpBuilder builder(&context);
@@ -64,7 +64,7 @@ TEST_F(UnionTypeSizeTest, MultiMemberUnion) {
 }
 
 TEST_F(UnionTypeSizeTest, EmptyUnion) {
-  auto ty = RecordType::get(&context, getName("Empty"), RecordType::Union);
+  auto ty = UnionType::get(&context, getName("Empty"));
   ty.complete({}, /*packed=*/false, /*padded=*/false);
 
   OpBuilder builder(&context);

--- a/clang/unittests/CIR/UnionTypeSizeTest.cpp
+++ b/clang/unittests/CIR/UnionTypeSizeTest.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Unit tests for union RecordType::getTypeSizeInBits.
+// Unit tests for UnionType: getTypeSizeInBits and isLayoutIdentical.
 //
 //===----------------------------------------------------------------------===//
 
@@ -33,7 +33,7 @@ protected:
 TEST_F(UnionTypeSizeTest, SizeInBitsNotBytes) {
   IntType i32 = IntType::get(&context, 32, true);
   auto ty = UnionType::get(&context, getName("U"));
-  ty.complete({i32}, /*packed=*/false, /*padded=*/false);
+  ty.complete({i32}, /*packed=*/false, /*padding=*/mlir::Type{});
 
   OpBuilder builder(&context);
   auto loc = builder.getUnknownLoc();
@@ -50,7 +50,7 @@ TEST_F(UnionTypeSizeTest, MultiMemberUnion) {
   IntType i32 = IntType::get(&context, 32, true);
   IntType i64 = IntType::get(&context, 64, true);
   auto ty = UnionType::get(&context, getName("U2"));
-  ty.complete({i32, i64}, /*packed=*/false, /*padded=*/false);
+  ty.complete({i32, i64}, /*packed=*/false, /*padding=*/mlir::Type{});
 
   OpBuilder builder(&context);
   auto loc = builder.getUnknownLoc();
@@ -65,7 +65,7 @@ TEST_F(UnionTypeSizeTest, MultiMemberUnion) {
 
 TEST_F(UnionTypeSizeTest, EmptyUnion) {
   auto ty = UnionType::get(&context, getName("Empty"));
-  ty.complete({}, /*packed=*/false, /*padded=*/false);
+  ty.complete({}, /*packed=*/false, /*padding=*/mlir::Type{});
 
   OpBuilder builder(&context);
   auto loc = builder.getUnknownLoc();
@@ -76,4 +76,34 @@ TEST_F(UnionTypeSizeTest, EmptyUnion) {
   EXPECT_EQ(size.getFixedValue(), 0u);
 
   module->erase();
+}
+
+TEST_F(UnionTypeSizeTest, IsLayoutIdenticalNoPadding) {
+  IntType i32 = IntType::get(&context, 32, true);
+  auto ty1 = UnionType::get(&context, getName("Ua"));
+  ty1.complete({i32}, /*packed=*/false, /*padding=*/mlir::Type{});
+  auto ty2 = UnionType::get(&context, getName("Ub"));
+  ty2.complete({i32}, /*packed=*/false, /*padding=*/mlir::Type{});
+  EXPECT_TRUE(ty1.isLayoutIdentical(ty2));
+}
+
+TEST_F(UnionTypeSizeTest, IsLayoutIdenticalDifferentPadding) {
+  IntType i32 = IntType::get(&context, 32, true);
+  IntType i8 = IntType::get(&context, 8, false);
+  IntType i16 = IntType::get(&context, 16, false);
+  auto ty1 = UnionType::get(&context, getName("Upad1"));
+  ty1.complete({i32}, /*packed=*/false, /*padding=*/i8);
+  auto ty2 = UnionType::get(&context, getName("Upad2"));
+  ty2.complete({i32}, /*packed=*/false, /*padding=*/i16);
+  EXPECT_FALSE(ty1.isLayoutIdentical(ty2));
+}
+
+TEST_F(UnionTypeSizeTest, IsLayoutIdenticalSamePadding) {
+  IntType i32 = IntType::get(&context, 32, true);
+  IntType i8 = IntType::get(&context, 8, false);
+  auto ty1 = UnionType::get(&context, getName("Upad3"));
+  ty1.complete({i32}, /*packed=*/false, /*padding=*/i8);
+  auto ty2 = UnionType::get(&context, getName("Upad4"));
+  ty2.complete({i32}, /*packed=*/false, /*padding=*/i8);
+  EXPECT_TRUE(ty1.isLayoutIdentical(ty2));
 }


### PR DESCRIPTION
Union tail padding was stored as the last element of the `members` array with a `padded = true` flag.  Every pass touching `RecordType` had to special-case unions: skip the last member when iterating, call `getLargestMember()` to find the storage type, check `isUnion()` before almost every layout query.  This spread union-specific logic across `CIRTypes.cpp`, `LowerToLLVM.cpp`, `CXXABILowering.cpp`, `CIRGenRecordLayoutBuilder.cpp`, and `CIRGenExpr.cpp`.

This PR moves union tail padding to a dedicated `padding` field on `RecordTypeStorage` and introduces two C++ view classes: `UnionType` and `StructType`, both subclassing `RecordType` via `classof`-based dispatch.  `mlir::dyn_cast<UnionType>` and `mlir::isa<StructType>` work naturally.

`UnionType` owns the union-specific API: `getPadding()` returns the tail-padding type (null if none), and `getUnionStorageType(DataLayout)` returns the highest-alignment variant.  `RecordType::getLargestMember()` and the old `RecordType::getPadding()` (which returned the last member) are removed.

The CIR text syntax for padded unions changes from `union "Name" padded {members..., padType}` to `union "Name" padded {members...}, padding = {padType}`, separating padding from the member list.

`CIRGenRecordLayoutBuilder::appendPaddingBytes` now routes union tail padding to a new `unionPadding` field instead of appending to `fieldTypes`.  `LowerToLLVM` and `CXXABILowering` use the new `UnionType` API directly.