### PR TITLE
[WebAssembly] Add f16x8.demote_f32x4_zero to wasm_simd128.h.

### DIFF
--- a/clang/lib/Headers/wasm_simd128.h
+++ b/clang/lib/Headers/wasm_simd128.h
@@ -2019,6 +2019,14 @@ wasm_f32x4_promote_low_f16x8(v128_t __a) {
       __f32x4);
 }
 
+static __inline__ v128_t __FP16_FN_ATTRS
+wasm_f16x8_demote_f32x4_zero(v128_t __a) {
+  return (v128_t) __builtin_convertvector(
+      __builtin_shufflevector((__f32x4)__a, (__f32x4){0, 0, 0, 0}, 0, 1, 2, 3,
+                              4, 5, 6, 7),
+      __f16x8);
+}
+
 static __inline__ v128_t __FP16_FN_ATTRS wasm_f16x8_relaxed_madd(v128_t __a,
                                                                  v128_t __b,
                                                                  v128_t __c) {

--- a/cross-project-tests/intrinsic-header-tests/wasm_simd128.c
+++ b/cross-project-tests/intrinsic-header-tests/wasm_simd128.c
@@ -1039,6 +1039,12 @@ v128_t test_f32x4_promote_low_f16x8(v128_t a) {
   return wasm_f32x4_promote_low_f16x8(a);
 }
 
+// CHECK-LABEL: test_f16x8_demote_f32x4_zero:
+// CHECK: f16x8.demote_f32x4_zero{{$}}
+v128_t test_f16x8_demote_f32x4_zero(v128_t a) {
+  return wasm_f16x8_demote_f32x4_zero(a);
+}
+
 // CHECK-LABEL: test_i8x16_shuffle:
 // CHECK: i8x16.shuffle 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
 // 0{{$}}


### PR DESCRIPTION
Missing header intrinsic.