### PR TITLE
[clang] Fix @tparam warnings for concept template parameters

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -448,6 +448,9 @@ Improvements to Clang's diagnostics
 - Fixed bug in ``-Wdocumentation`` so that it correctly handles explicit
   function template instantiations (#64087).
 
+- Fixed concept template parameters not being recognized in ``-Wdocumentation``
+  when mentioned in tparam comments. (#GH64087)
+
 - ``-Wunused-but-set-variable`` now diagnoses file-scope variables with
   internal linkage (``static`` storage class) that are assigned but never used.
   This new coverage is added under the subgroup ``-Wunused-but-set-global``,

--- a/clang/include/clang/AST/Comment.h
+++ b/clang/include/clang/AST/Comment.h
@@ -1044,7 +1044,9 @@ struct DeclInfo {
     TypedefKind,
 
     /// An enumeration or scoped enumeration.
-    EnumKind
+    EnumKind,
+
+    ConceptKind
   };
 
   /// What kind of template specialization \c CommentDecl is.

--- a/clang/lib/AST/Comment.cpp
+++ b/clang/lib/AST/Comment.cpp
@@ -350,6 +350,12 @@ void DeclInfo::fill() {
   case Decl::Enum:
     Kind = EnumKind;
     break;
+  case Decl::Concept:
+    const ConceptDecl *Concept = cast<ConceptDecl>(CommentDecl);
+    Kind = ConceptKind;
+    TemplateKind = Template;
+    TemplateParameters = Concept->getTemplateParameters();
+    break;
   }
 
   // If the type is a typedef / using to something we consider a function,

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -319,7 +319,6 @@ void Sema::actOnTParamCommandParamNameArg(TParamCommandComment *Command,
 
   const TemplateParameterList *TemplateParameters =
       ThisDeclInfo->TemplateParameters;
-
   SmallVector<unsigned, 2> Position;
   if (resolveTParamReference(Arg, TemplateParameters, &Position)) {
     Command->setPosition(copyArray(ArrayRef(Position)));

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -317,12 +317,7 @@ void Sema::actOnTParamCommandParamNameArg(TParamCommandComment *Command,
     return;
   }
 
-  const TemplateParameterList *TemplateParameters;
-  if (const auto *Concept =
-          dyn_cast_or_null<ConceptDecl>(ThisDeclInfo->CommentDecl))
-    TemplateParameters = Concept->getTemplateParameters();
-  else
-    TemplateParameters = ThisDeclInfo->TemplateParameters;
+  const TemplateParameterList *TemplateParameters = ThisDeclInfo->TemplateParameters;
 
   SmallVector<unsigned, 2> Position;
   if (resolveTParamReference(Arg, TemplateParameters, &Position)) {
@@ -862,8 +857,7 @@ bool Sema::isTemplateOrSpecialization() {
     return false;
   if (!ThisDeclInfo->IsFilled)
     inspectThisDecl();
-  return ThisDeclInfo->getTemplateKind() != DeclInfo::NotTemplate ||
-         isa<ConceptDecl>(ThisDeclInfo->CommentDecl);
+  return ThisDeclInfo->getTemplateKind() != DeclInfo::NotTemplate;
 }
 
 bool Sema::isExplicitFunctionTemplateInstantiation() {

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -317,7 +317,8 @@ void Sema::actOnTParamCommandParamNameArg(TParamCommandComment *Command,
     return;
   }
 
-  const TemplateParameterList *TemplateParameters = ThisDeclInfo->TemplateParameters;
+  const TemplateParameterList *TemplateParameters =
+      ThisDeclInfo->TemplateParameters;
 
   SmallVector<unsigned, 2> Position;
   if (resolveTParamReference(Arg, TemplateParameters, &Position)) {

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -317,8 +317,13 @@ void Sema::actOnTParamCommandParamNameArg(TParamCommandComment *Command,
     return;
   }
 
-  const TemplateParameterList *TemplateParameters =
-      ThisDeclInfo->TemplateParameters;
+  const TemplateParameterList *TemplateParameters;
+  if (const auto *Concept =
+          dyn_cast_or_null<ConceptDecl>(ThisDeclInfo->CommentDecl))
+    TemplateParameters = Concept->getTemplateParameters();
+  else
+    TemplateParameters = ThisDeclInfo->TemplateParameters;
+
   SmallVector<unsigned, 2> Position;
   if (resolveTParamReference(Arg, TemplateParameters, &Position)) {
     Command->setPosition(copyArray(ArrayRef(Position)));
@@ -857,7 +862,8 @@ bool Sema::isTemplateOrSpecialization() {
     return false;
   if (!ThisDeclInfo->IsFilled)
     inspectThisDecl();
-  return ThisDeclInfo->getTemplateKind() != DeclInfo::NotTemplate;
+  return ThisDeclInfo->getTemplateKind() != DeclInfo::NotTemplate ||
+         isa<ConceptDecl>(ThisDeclInfo->CommentDecl);
 }
 
 bool Sema::isExplicitFunctionTemplateInstantiation() {

--- a/clang/lib/Index/CommentToXML.cpp
+++ b/clang/lib/Index/CommentToXML.cpp
@@ -894,7 +894,7 @@ void CommentASTToXMLConverter::visitFullComment(const FullComment *C) {
       Result << "<Enum";
       break;
     case DeclInfo::ConceptKind:
-      RootEndTag = "</Concept";
+      RootEndTag = "</Concept>";
       Result << "<Concept";
       break;
     }

--- a/clang/lib/Index/CommentToXML.cpp
+++ b/clang/lib/Index/CommentToXML.cpp
@@ -893,6 +893,10 @@ void CommentASTToXMLConverter::visitFullComment(const FullComment *C) {
       RootEndTag = "</Enum>";
       Result << "<Enum";
       break;
+    case DeclInfo::ConceptKind:
+      RootEndTag = "</Concept";
+      Result << "<Concept";
+      break;
     }
 
     {

--- a/clang/test/Sema/warn-documentation.cpp
+++ b/clang/test/Sema/warn-documentation.cpp
@@ -1547,7 +1547,7 @@ void foo(){}
 
 #if __cplusplus >= 202002L
 /// @tparam T Derived class.
-/// @tparam TBase Base CRTP class.
+/// @tparam TBase Base class.
 template <typename T, typename TBase>
 concept bar = true;
 #endif

--- a/clang/test/Sema/warn-documentation.cpp
+++ b/clang/test/Sema/warn-documentation.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -std=c++11 -fsyntax-only -Wdocumentation -Wdocumentation-pedantic -verify %s
 // RUN: %clang_cc1 -std=c++14 -fsyntax-only -Wdocumentation -Wdocumentation-pedantic -verify %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -Wdocumentation -Wdocumentation-pedantic -verify %s
 
 // This file contains lots of corner cases, so ensure that XML we generate is not invalid.
 // RUN: c-index-test -test-load-source all -comments-xml-schema=%S/../../bindings/xml/comment-xml-schema.rng %s | FileCheck %s -check-prefix=WRONG
@@ -1543,6 +1544,13 @@ namespace GH64087
 /// @tparam T type
 template <typename T>
 void foo(){}
+
+#if __cplusplus >= 202002L
+/// @tparam T Derived class.
+/// @tparam TBase Base CRTP class.
+template <typename T, typename TBase>
+concept bar = true;
+#endif
 
 template void foo<bool>();
 } // namespace GH64087


### PR DESCRIPTION
`-Wdocumentation` would warn on `@tparam` commands for concepts even if the named
parameter existed. This patch fixes that by adding concept support to `comment::DeclInfo` when its
properties are filled from the associated comment's decl.

Fixes #64087