### PR TITLE
[libc++] Update the GCC head version to 17

### DIFF
--- a/libcxx/utils/ci/docker/docker-compose.yml
+++ b/libcxx/utils/ci/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: ../../../.. # monorepo root
       dockerfile: libcxx/utils/ci/docker/linux-builder-base.dockerfile
       args:
-        GCC_HEAD_VERSION: 16
+        GCC_HEAD_VERSION: 17
         LLVM_HEAD_VERSION: 23
 
   libcxx-linux-builder:


### PR DESCRIPTION
GCC released a new version, so we should bump the versions installed in the CI so we can upgrade.
