### PR TITLE
[X86] SimplifyDemandedBitsForTargetNode - add X86ISD::BZHI handling

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45905,6 +45905,68 @@ bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
 
     break;
   }
+  case X86ISD::BZHI: {
+    SDValue Op0 = Op.getOperand(0);
+    SDValue Op1 = Op.getOperand(1);
+
+    // If the index's max value is less than BitWidth, bits above it
+    // are not demanded from the source.
+    auto SimplifySrcDemandedBits = [&](uint64_t MaxIdx) -> bool {
+      if (MaxIdx < BitWidth) {
+        APInt DemandedSrc =
+            OriginalDemandedBits & APInt::getLowBitsSet(BitWidth, MaxIdx);
+        if (SimplifyDemandedBits(Op0, DemandedSrc, Known, TLO, Depth + 1))
+          return true;
+      }
+      return false;
+    };
+
+    if (auto *Cst1 = dyn_cast<ConstantSDNode>(Op1)) {
+      uint64_t Val = Cst1->getZExtValue();
+      uint64_t Masked = Val & 0xFF;
+
+      if (SimplifySrcDemandedBits(Masked))
+        return true;
+
+      // Known bits: exact index, so bits above Masked are known zero.
+      if (Masked < BitWidth) {
+        Known.Zero.setBits(Masked, BitWidth);
+        Known.One.clearBits(Masked, BitWidth);
+      }
+
+      if (Masked != Val) {
+        SDLoc DL(Op);
+        return TLO.CombineTo(
+            Op, TLO.DAG.getNode(X86ISD::BZHI, DL, VT, Op0,
+                                TLO.DAG.getConstant(Masked, DL, VT)));
+      }
+    } else {
+      KnownBits Known1;
+      APInt DemandedMask(APInt::getLowBitsSet(BitWidth, 8));
+      if (SimplifyDemandedBits(Op1, DemandedMask, Known1, TLO, Depth + 1))
+        return true;
+
+      KnownBits Known1Trunc = Known1.trunc(8);
+      uint64_t MinValue = Known1Trunc.getMinValue().getZExtValue();
+      uint64_t MaxValue = Known1Trunc.getMaxValue().getZExtValue();
+
+      if (SimplifySrcDemandedBits(MaxValue))
+        return true;
+
+      // Known bits: adjust based on control range.
+      if (MinValue >= BitWidth) {
+        // BZHI is a no-op, Known from Op0 is valid as-is.
+      } else if (MaxValue < BitWidth) {
+        Known.Zero.setBits(MaxValue, BitWidth);
+        Known.One.clearBits(MaxValue, BitWidth);
+        Known.One.clearBits(MinValue, MaxValue);
+      } else {
+        Known.One.clearAllBits();
+      }
+    }
+
+    break;
+  }
   case X86ISD::PDEP: {
     SDValue Op0 = Op.getOperand(0);
     SDValue Op1 = Op.getOperand(1);

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -46027,6 +46027,68 @@ bool X86TargetLowering::SimplifyDemandedBitsForTargetNode(
 
     break;
   }
+  case X86ISD::BZHI: {
+    SDValue Op0 = Op.getOperand(0);
+    SDValue Op1 = Op.getOperand(1);
+
+    // If the index's max value is less than BitWidth, bits above it
+    // are not demanded from the source.
+    auto SimplifySrcDemandedBits = [&](uint64_t MaxIdx) -> bool {
+      if (MaxIdx < BitWidth) {
+        APInt DemandedSrc =
+            OriginalDemandedBits & APInt::getLowBitsSet(BitWidth, MaxIdx);
+        if (SimplifyDemandedBits(Op0, DemandedSrc, Known, TLO, Depth + 1))
+          return true;
+      }
+      return false;
+    };
+
+    if (auto *Cst1 = dyn_cast<ConstantSDNode>(Op1)) {
+      uint64_t Val = Cst1->getZExtValue();
+      uint64_t Masked = Val & 0xFF;
+
+      if (SimplifySrcDemandedBits(Masked))
+        return true;
+
+      // Known bits: exact index, so bits above Masked are known zero.
+      if (Masked < BitWidth) {
+        Known.Zero.setBits(Masked, BitWidth);
+        Known.One.clearBits(Masked, BitWidth);
+      }
+
+      if (Masked != Val) {
+        SDLoc DL(Op);
+        return TLO.CombineTo(
+            Op, TLO.DAG.getNode(X86ISD::BZHI, DL, VT, Op0,
+                                TLO.DAG.getConstant(Masked, DL, VT)));
+      }
+    } else {
+      KnownBits Known1;
+      APInt DemandedMask(APInt::getLowBitsSet(BitWidth, 8));
+      if (SimplifyDemandedBits(Op1, DemandedMask, Known1, TLO, Depth + 1))
+        return true;
+
+      KnownBits Known1Trunc = Known1.trunc(8);
+      uint64_t MinValue = Known1Trunc.getMinValue().getZExtValue();
+      uint64_t MaxValue = Known1Trunc.getMaxValue().getZExtValue();
+
+      if (SimplifySrcDemandedBits(MaxValue))
+        return true;
+
+      // Known bits: adjust based on control range.
+      if (MinValue >= BitWidth) {
+        // BZHI is a no-op, Known from Op0 is valid as-is.
+      } else if (MaxValue < BitWidth) {
+        Known.Zero.setBits(MaxValue, BitWidth);
+        Known.One.clearBits(MaxValue, BitWidth);
+        Known.One.clearBits(MinValue, MaxValue);
+      } else {
+        Known.One.clearAllBits();
+      }
+    }
+
+    break;
+  }
   case X86ISD::VPMADD52L:
   case X86ISD::VPMADD52H: {
     KnownBits KnownOp0, KnownOp1, KnownOp2;

--- a/llvm/test/CodeGen/X86/combine-bzhi.ll
+++ b/llvm/test/CodeGen/X86/combine-bzhi.ll
@@ -81,3 +81,92 @@ define i64 @test_bzhi64_range(i64 %arg) nounwind readnone {
   %4 = tail call i64 @llvm.x86.bmi.bzhi.64(i64 30064771240, i64 %3)
   ret i64 %4
 }
+define i32 @test_bzhi32_control_upper_bits(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: test_bzhi32_control_upper_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    bzhil %esi, %edi, %eax
+; CHECK-NEXT:    retq
+  %control = or i32 %b, 256
+  %result = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %a, i32 %control)
+  ret i32 %result
+}
+
+define i64 @test_bzhi64_control_upper_bits(i64 %a, i64 %b) nounwind {
+; CHECK-LABEL: test_bzhi64_control_upper_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    bzhiq %rsi, %rdi, %rax
+; CHECK-NEXT:    retq
+  %control = or i64 %b, 256
+  %result = tail call i64 @llvm.x86.bmi.bzhi.64(i64 %a, i64 %control)
+  ret i64 %result
+}
+
+; Constant control 0x110 (272) — low 8 bits are 0x10 (16), upper bits are junk.
+; Should simplify to bzhi(a, 16), which keeps low 16 bits.
+define i32 @test_bzhi32_constant_control_upper_bits(i32 %a) nounwind {
+; CHECK-LABEL: test_bzhi32_constant_control_upper_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movl $16, %eax
+; CHECK-NEXT:    bzhil %eax, %edi, %eax
+; CHECK-NEXT:    retq
+  %result = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %a, i32 272)
+  ret i32 %result
+}
+
+define i64 @test_bzhi64_constant_control_upper_bits(i64 %a) nounwind {
+; CHECK-LABEL: test_bzhi64_constant_control_upper_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    movl $16, %eax
+; CHECK-NEXT:    bzhiq %rax, %rdi, %rax
+; CHECK-NEXT:    retq
+  %result = tail call i64 @llvm.x86.bmi.bzhi.64(i64 %a, i64 272)
+  ret i64 %result
+}
+
+define i32 @test_bzhi32_src_upper_bits(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: test_bzhi32_src_upper_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andl $15, %esi
+; CHECK-NEXT:    bzhil %esi, %edi, %eax
+; CHECK-NEXT:    retq
+  %src = or i32 %a, 65536
+  %control = and i32 %b, 15
+  %result = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %src, i32 %control)
+  ret i32 %result
+}
+
+define i64 @test_bzhi64_src_upper_bits(i64 %a, i64 %b) nounwind {
+; CHECK-LABEL: test_bzhi64_src_upper_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andl $15, %esi
+; CHECK-NEXT:    bzhiq %rsi, %rdi, %rax
+; CHECK-NEXT:    retq
+  %src = or i64 %a, 65536
+  %control = and i64 %b, 15
+  %result = tail call i64 @llvm.x86.bmi.bzhi.64(i64 %src, i64 %control)
+  ret i64 %result
+}
+
+define i32 @test_bzhi32_known_bits(i32 %a, i32 %b) nounwind {
+; CHECK-LABEL: test_bzhi32_known_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andl $7, %esi
+; CHECK-NEXT:    bzhil %esi, %edi, %eax
+; CHECK-NEXT:    retq
+  %control = and i32 %b, 7
+  %bzhi = tail call i32 @llvm.x86.bmi.bzhi.32(i32 %a, i32 %control)
+  %result = and i32 %bzhi, 127
+  ret i32 %result
+}
+
+define i64 @test_bzhi64_known_bits(i64 %a, i64 %b) nounwind {
+; CHECK-LABEL: test_bzhi64_known_bits:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    andl $7, %esi
+; CHECK-NEXT:    bzhiq %rsi, %rdi, %rax
+; CHECK-NEXT:    retq
+  %control = and i64 %b, 7
+  %bzhi = tail call i64 @llvm.x86.bmi.bzhi.64(i64 %a, i64 %control)
+  %result = and i64 %bzhi, 127
+  ret i64 %result
+}


### PR DESCRIPTION
This PR implements `X86ISD::BZHI` handling for `SimplifyDemandedBitsForTargetNode`. Specifically, it captures the following:

- Only the bottom 8 bits of the mask (second operand) are required
- Based off the known bits of the mask, we can tweak the src DemandedBits - as well as the incoming DemandedBits mask, if the 8 bit mask is known to be less than bitwidth (getMaxValue.ult(BitWidth)) then bits above getMaxValue are not demanded.

The known bits calculation is logically identical to what is performed in `computeKnownBits`. 

Resolves https://github.com/llvm/llvm-project/issues/177369